### PR TITLE
Getting ready to handle relative paths for backing files.

### DIFF
--- a/include/qcow2_disk.h
+++ b/include/qcow2_disk.h
@@ -52,7 +52,7 @@ public:
 	
 	static QCow2Header read_header(FILE* qcow2File);
 
-	QCow2Image(QCow2Header qcow2_header, FILE *qcow2File);
+	QCow2Image(QCow2Header qcow2Header, FILE *qcow2File, Bit8u* imageName);
 
 	virtual ~QCow2Image();
 	
@@ -124,7 +124,7 @@ class QCow2Disk : public imageDisk{
 
 public:
 	
-	QCow2Disk(QCow2Image::QCow2Header qcow2_header, FILE *qcow2File, Bit8u *imgName, Bit32u imgSizeK, bool isHardDisk);
+	QCow2Disk(QCow2Image::QCow2Header qcow2Header, FILE *qcow2File, Bit8u *imgName, Bit32u imgSizeK, bool isHardDisk);
 
 	virtual ~QCow2Disk();
 	

--- a/include/qcow2_disk.h
+++ b/include/qcow2_disk.h
@@ -32,7 +32,7 @@ class QCow2Image{
 
 public:
 
-	static const Bit32u magic = 0x514649FB;
+	static const Bit32u magic;
 	
 	typedef struct QCow2Header {
 		Bit32u magic;
@@ -61,6 +61,23 @@ public:
 	Bit8u write_sector(Bit32u sectnum, Bit8u* data);
 	
 private:
+
+	FILE* file;
+	QCow2Header header;
+	static const Bit64u copy_flag;
+	static const Bit64u empty_mask;
+	static const Bit32u sector_size;
+	static const Bit64u table_entry_mask;
+	Bit64u cluster_mask;
+	Bit64u cluster_size;
+	Bit64u sectors_per_cluster;
+	Bit64u disk_sectors_total;
+	Bit64u l2_mask;
+	Bit64u l2_bits;
+	Bit64u l1_bits;
+	Bit64u refcount_mask;
+	Bit64u refcount_bits;
+	QCow2Image* backing_image;
 
 	static Bit16u host_read16(Bit16u buffer);
 
@@ -101,23 +118,6 @@ private:
 	Bit8u write_refcount_table_entry(Bit64u cluster_offset, Bit64u refcount_cluster_offset);
 
 	Bit8u write_table_entry(Bit64u entry_offset, Bit64u entry_value);
-
-	FILE* file;
-	QCow2Header header;
-	static const Bit64u copy_flag = 0x8000000000000000;
-	static const Bit64u empty_mask = 0xFFFFFFFFFFFFFFFF;
-	static const Bit32u sector_size = 512;
-	static const Bit64u table_entry_mask = 0x00FFFFFFFFFFFFFF;
-	Bit64u cluster_mask;
-	Bit64u cluster_size;
-	Bit64u sectors_per_cluster;
-	Bit64u disk_sectors_total;
-	Bit64u l2_mask;
-	Bit64u l2_bits;
-	Bit64u l1_bits;
-	Bit64u refcount_mask;
-	Bit64u refcount_bits;
-	QCow2Image* backing_image;
 };
 
 class QCow2Disk : public imageDisk{

--- a/include/qcow2_disk.h
+++ b/include/qcow2_disk.h
@@ -52,7 +52,7 @@ public:
 	
 	static QCow2Header read_header(FILE* qcow2File);
 
-	QCow2Image(QCow2Header qcow2Header, FILE *qcow2File, Bit8u* imageName);
+	QCow2Image(QCow2Header qcow2Header, FILE *qcow2File, const char* imageName);
 
 	virtual ~QCow2Image();
 	

--- a/src/ints/qcow2_disk.cpp
+++ b/src/ints/qcow2_disk.cpp
@@ -25,11 +25,12 @@ using namespace std;
 
 //Public function to read a QCow2 header.
 	QCow2Image::QCow2Header QCow2Image::read_header(FILE* qcow2File){
-		QCow2Header header = QCow2Header();
-		if (1 != fseek(qcow2File, 0, SEEK_SET)){
-			clearerr(qcow2File);
+		QCow2Header header;
+		fseek(qcow2File, 0, SEEK_SET);
+		if (1 != fread(&header, sizeof header, 1, qcow2File)){
+			clearerr(qcow2File);  /*If we fail, reset the file stream's status*/
+			return QCow2Header(); /*Return an empty header*/
 		}
-		fread(&header, sizeof header, 1, qcow2File);
 		header.magic = host_read32(header.magic);
 		header.version = host_read32(header.version);
 		header.backing_file_offset = host_read64(header.backing_file_offset);

--- a/src/ints/qcow2_disk.cpp
+++ b/src/ints/qcow2_disk.cpp
@@ -23,6 +23,9 @@
 using namespace std;
 
 
+	const Bit32u QCow2Image::magic = 0x514649FB;
+
+
 //Public function to read a QCow2 header.
 	QCow2Image::QCow2Header QCow2Image::read_header(FILE* qcow2File){
 		QCow2Header header;
@@ -172,6 +175,13 @@ using namespace std;
 		}
 		return write_data(data_cluster_offset + (address & cluster_mask), data, sector_size);
 	}
+
+
+//Private constants
+	const Bit64u QCow2Image::copy_flag = 0x8000000000000000;
+	const Bit64u QCow2Image::empty_mask = 0xFFFFFFFFFFFFFFFF;
+	const Bit32u QCow2Image::sector_size = 512;
+	const Bit64u QCow2Image::table_entry_mask = 0x00FFFFFFFFFFFFFF;
 
 
 //Helper functions for endianness. QCOW format is big endian so we need different functions than those defined in mem.h.

--- a/src/ints/qcow2_disk.cpp
+++ b/src/ints/qcow2_disk.cpp
@@ -23,6 +23,7 @@
 using namespace std;
 
 
+//Public constant.
 	const Bit32u QCow2Image::magic = 0x514649FB;
 
 
@@ -177,7 +178,7 @@ using namespace std;
 	}
 
 
-//Private constants
+//Private constants.
 	const Bit64u QCow2Image::copy_flag = 0x8000000000000000;
 	const Bit64u QCow2Image::empty_mask = 0xFFFFFFFFFFFFFFFF;
 	const Bit32u QCow2Image::sector_size = 512;


### PR DESCRIPTION
Really minor changes, inlcuding passing the original file name into the QCow2Image constructor to use as a jumping off point for relative paths in backing files.

Fixed my boneheaded mistake in read_header so that we ensure an empty header is returned in failure cases.
