### PR TITLE
Compile fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -282,54 +282,6 @@ AC_ARG_ENABLE(core-inline,AC_HELP_STRING([--enable-core-inline],[Enable inlined 
   fi
 ],)
 
-# FFMPEG output
-AH_TEMPLATE(C_AVCODEC,[Define to 1 to use FFMPEG libavcodec for video capture])
-AC_ARG_ENABLE(avcodec,AC_HELP_STRING([--disable-avcodec],[Disable FFMPEG avcodec support]),,enable_ffmpeg=yes)
-if test x$enable_avcodec = xyes; then
-	CFLAGS="$CFLAGS "`pkg-config libavcodec --cflags`
-	CPPFLAGS="$CPPFLAGS "`pkg-config libavcodec --cflags`
-	LIBS="$LIBS -lavcodec -lavformat -lavutil -lswscale "`pkg-config libavcodec --libs`
-fi
-AC_CHECK_LIB(avcodec,avcodec_open2,have_ffmpeg=yes,have_ffmpeg=no,)
-AC_CHECK_HEADER(libavcodec/avcodec.h,have_avcodec_h=yes,have_avcodec_h=no,)
-if test x$enable_avcodec = xyes; then
-    if test x$have_ffmpeg = xyes; then
-        if test x$have_avcodec_h = xyes; then
-            AC_MSG_RESULT(yes)
-            AC_DEFINE(C_AVCODEC,1)
-        fi
-    fi
-fi
-
-AH_TEMPLATE(C_OPENGL,[Define to 1 to use opengl display output support])
-AC_CHECK_LIB(GL, main, have_gl_lib=yes, have_gl_lib=no , )
-AC_CHECK_LIB(opengl32, main, have_opengl32_lib=yes,have_opengl32_lib=no , )
-AC_CHECK_HEADER(GL/gl.h, have_gl_h=yes , have_gl_h=no , )
-AC_ARG_ENABLE(opengl,AC_HELP_STRING([--disable-opengl],[Disable opengl support]),,enable_opengl=yes)
-AC_MSG_CHECKING(whether opengl display output will be enabled) 
-if test x$enable_opengl = xyes; then
-case "$host" in
-    *-*-darwin*)
-       AC_MSG_RESULT(yes)
-       LIBS="$LIBS -framework OpenGL"
-       AC_DEFINE(C_OPENGL,1)
-       ;;
-    *)
-       if test x$have_gl_h = xyes -a x$have_gl_lib = xyes ; then 
-         AC_MSG_RESULT(yes)
-         LIBS="$LIBS -lGL"
-         AC_DEFINE(C_OPENGL,1)
-       elif test x$have_gl_h = xyes -a x$have_opengl32_lib = xyes ; then 
-         AC_MSG_RESULT(yes)
-         LIBS="$LIBS -lopengl32"
-         AC_DEFINE(C_OPENGL,1)
-       else
-         AC_MSG_RESULT(no)
-       fi
-       ;;
-esac
-fi
-
 dnl The target cpu checks for dynamic cores
 AH_TEMPLATE(C_TARGETCPU,[The type of cpu this target has])
 AC_MSG_CHECKING(for target cpu type) 
@@ -478,6 +430,54 @@ if test x$have_fluidsynth_lib = xyes -a x$have_fluidsynth_h = xyes ; then
   AC_DEFINE(C_FLUIDSYNTH,1)
 else
   AC_MSG_WARN([fluidsynth MIDI synthesis not available])
+fi
+
+# FFMPEG output
+AH_TEMPLATE(C_AVCODEC,[Define to 1 to use FFMPEG libavcodec for video capture])
+AC_ARG_ENABLE(avcodec,AC_HELP_STRING([--disable-avcodec],[Disable FFMPEG avcodec support]),,enable_ffmpeg=yes)
+if test x$enable_avcodec = xyes; then
+	CFLAGS="$CFLAGS "`pkg-config libavcodec --cflags`
+	CPPFLAGS="$CPPFLAGS "`pkg-config libavcodec --cflags`
+	LIBS="$LIBS -lavcodec -lavformat -lavutil -lswscale "`pkg-config libavcodec --libs`
+fi
+AC_CHECK_LIB(avcodec,avcodec_open2,have_ffmpeg=yes,have_ffmpeg=no,)
+AC_CHECK_HEADER(libavcodec/avcodec.h,have_avcodec_h=yes,have_avcodec_h=no,)
+if test x$enable_avcodec = xyes; then
+    if test x$have_ffmpeg = xyes; then
+        if test x$have_avcodec_h = xyes; then
+            AC_MSG_RESULT(yes)
+            AC_DEFINE(C_AVCODEC,1)
+        fi
+    fi
+fi
+
+AH_TEMPLATE(C_OPENGL,[Define to 1 to use opengl display output support])
+AC_CHECK_LIB(GL, main, have_gl_lib=yes, have_gl_lib=no , )
+AC_CHECK_LIB(opengl32, main, have_opengl32_lib=yes,have_opengl32_lib=no , )
+AC_CHECK_HEADER(GL/gl.h, have_gl_h=yes , have_gl_h=no , )
+AC_ARG_ENABLE(opengl,AC_HELP_STRING([--disable-opengl],[Disable opengl support]),,enable_opengl=yes)
+AC_MSG_CHECKING(whether opengl display output will be enabled)
+if test x$enable_opengl = xyes; then
+case "$host" in
+    *-*-darwin*)
+       AC_MSG_RESULT(yes)
+       LIBS="$LIBS -framework OpenGL"
+       AC_DEFINE(C_OPENGL,1)
+       ;;
+    *)
+       if test x$have_gl_h = xyes -a x$have_gl_lib = xyes ; then
+         AC_MSG_RESULT(yes)
+         LIBS="$LIBS -lGL"
+         AC_DEFINE(C_OPENGL,1)
+       elif test x$have_gl_h = xyes -a x$have_opengl32_lib = xyes ; then
+         AC_MSG_RESULT(yes)
+         LIBS="$LIBS -lopengl32"
+         AC_DEFINE(C_OPENGL,1)
+       else
+         AC_MSG_RESULT(no)
+       fi
+       ;;
+esac
 fi
 
 dnl Check for mprotect. Needed for 64 bits linux 

--- a/src/hardware/voodoo_emu.cpp
+++ b/src/hardware/voodoo_emu.cpp
@@ -70,7 +70,7 @@ iterated W    = 18.32 [48 bits]
 
 **************************************************************************/
 
-
+#include <string.h>
 #include <stdlib.h>
 #include <math.h>
 


### PR DESCRIPTION
Some minor tweaks I needed to do to compile successfully on Fedora 25 x86_64, with gcc 6.3.1

The first patch adds a missing header,
while the second moves the ffmpeg and opengl checks down to after the other libs.
On my system the ffmpeg check errored like
```
/usr/lib/gcc/x86_64-redhat-linux/6.3.1/../../../../lib64/libavutil.so: undefined reference to `clReleaseMemObject@OPENCL_1.0'
```
due to misconfigured LD_LIBRARY_PATH, but it also affected the checks for the other libs, since the LIBS variable is concatenated.

This, in turn, caused some compilation errors since in src/hardware.cpp, not all usage of the video part of the capture struct is guarded behind C_SSHOT (didnt patch this as issue was resovled after configure had succeeded)