### PR TITLE
fix build on macOS

### DIFF
--- a/configure
+++ b/configure
@@ -629,8 +629,6 @@ LIBOBJS
 HAVE_WINDRES_FALSE
 HAVE_WINDRES_TRUE
 WINDRES
-LINUX_FALSE
-LINUX_TRUE
 CXXCPP
 ALSA_LIBS
 ALSA_CFLAGS
@@ -7867,14 +7865,6 @@ $as_echo "#define C_DIRECTSERIAL 1" >>confdefs.h
 
        ;;
     *-*-linux*)
-        if true; then
-  LINUX_TRUE=
-  LINUX_FALSE='#'
-else
-  LINUX_TRUE='#'
-  LINUX_FALSE=
-fi
-
 
 $as_echo "#define LINUX 1" >>confdefs.h
 
@@ -8154,10 +8144,6 @@ if test -z "${am__fastdepCXX_TRUE}" && test -z "${am__fastdepCXX_FALSE}"; then
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 
-if test -z "${LINUX_TRUE}" && test -z "${LINUX_FALSE}"; then
-  as_fn_error $? "conditional \"LINUX\" was never defined.
-Usually this means the macro was only invoked conditionally." "$LINENO" 5
-fi
 if test -z "${HAVE_WINDRES_TRUE}" && test -z "${HAVE_WINDRES_FALSE}"; then
   as_fn_error $? "conditional \"HAVE_WINDRES\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5

--- a/configure.ac
+++ b/configure.ac
@@ -554,7 +554,6 @@ case "$host" in
        AC_DEFINE(C_DIRECTSERIAL, 1, [ Define to 1 if you want serial passthrough support (Win32, Posix and OS/2).])
        ;;
     *-*-linux*)
-       AM_CONDITIONAL(LINUX, [true])
        AC_DEFINE(LINUX, 1, [Compiling on GNU/Linux])
        AC_DEFINE(C_DIRECTSERIAL, 1, [ Define to 1 if you want serial passthrough support (Win32, Posix and OS/2).])
        AC_DEFINE(C_DIRECTLPT, 1, [ Define to 1 if you want parallel passthrough support (Win32, Linux).])

--- a/include/mem.h
+++ b/include/mem.h
@@ -23,7 +23,7 @@
 #include "dosbox.h"
 #endif
 
-#ifndef _MSC_VER
+#if !defined (_MSC_VER) && !defined(__APPLE__)
 /* NOTE to VS2015 users:
  *   This code primarily uses htoleXX BSD endian functions to convert to/from little endian.
  *   Windows is predominately little endian, so you could get away with #define macros of the
@@ -32,6 +32,26 @@
 #  define _BSD_SOURCE		/* for htole16, etc. endian.h functions */
 # endif
 # include <endian.h>
+#endif
+
+#if defined(__APPLE__)
+/* This is a simple compatibility shim to convert
+ * BSD/Linux endian macros to the Mac OS X equivalents. */
+#include <libkern/OSByteOrder.h>
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
 #endif
 
 typedef Bit8u *HostPt;		/* host (virtual) memory address aka ptr */


### PR DESCRIPTION
The revert fixes ./configure on macOS, which failed like this:

```
...
checking that generated files are newer than configure... done
configure: error: conditional "LINUX" was never defined.
Usually this means the macro was only invoked conditionally.
```

Also, that patch didn't make much sense to me.

Working on another patch to fix compilation on macOS

EDIT: pushed a second commit that fully fixes compilation on macOS.