### PR TITLE
Fullscreen scale fix

### DIFF
--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -79,7 +79,7 @@ static Bitu INT2F_Handler(void) {
 	for(Multiplex_it it = Multiplex.begin();it != Multiplex.end();it++)
 		if( (*it)() ) return CBRET_NONE;
    
-	LOG(LOG_DOSMISC,LOG_ERROR)("DOS:Multiplex Unhandled call %4X",reg_ax);
+	LOG(LOG_DOSMISC,LOG_ERROR)("DOS:INT 2F Unhandled call AX=%4X",reg_ax);
 	return CBRET_NONE;
 }
 
@@ -88,6 +88,7 @@ static Bitu INT2A_Handler(void) {
 	return CBRET_NONE;
 }
 
+// INT 2F
 static bool DOS_MultiplexFunctions(void) {
 	switch (reg_ax) {
 	/* ert, 20100711: Locking extensions */

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -1193,7 +1193,7 @@ static bool MSCDEX_Handler(void) {
 	if (mscdex->rootDriverHeaderSeg==0) return false;	// not handled if MSCDEX not installed
 
 	PhysPt data = PhysMake(SegValue(es),reg_bx);
-	MSCDEX_LOG("MSCDEX: INT 2F %04X BX= %04X CX=%04X",reg_ax,reg_bx,reg_cx);
+	MSCDEX_LOG("MSCDEX: INT 2F AX=%04X BX=%04X CX=%04X",reg_ax,reg_bx,reg_cx);
 	switch (reg_ax) {
 	
 		case 0x1500:	/* Install check */

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2758,7 +2758,7 @@ void OpenFileDialog( char * path_arg ) {
 	OpenFileName.lStructSize = sizeof( OPENFILENAME );
 	OpenFileName.hwndOwner = NULL;
 	if(DOSBox_Kor())
-		OpenFileName.lpstrFilter = "角青 颇老(*.com, *.exe, *.bat)\0*.com;*.exe;*.bat\0葛电 颇老(*.*)\0*.*\0";
+		OpenFileName.lpstrFilter = "鞁ろ枆 韺岇澕(*.com, *.exe, *.bat)\0*.com;*.exe;*.bat\0氇摖 韺岇澕(*.*)\0*.*\0";
 	else
 		OpenFileName.lpstrFilter = "Executable files(*.com, *.exe, *.bat)\0*.com;*.exe;*.bat\0All files(*.*)\0*.*\0";
 	OpenFileName.lpstrCustomFilter = NULL;
@@ -2875,7 +2875,7 @@ void Go_Boot(const char boot_drive[_MAX_DRIVE]) {
 	OpenFileName.hwndOwner = NULL;
 
 	if(DOSBox_Kor())
-		OpenFileName.lpstrFilter = "捞固瘤 颇老(*.img, *.ima, *.pcjr, *.jrc)\0*.pcjr;*.img;*.ima;*.jrc\0葛电 颇老(*.*)\0*.*\0";
+		OpenFileName.lpstrFilter = "鞚措歆� 韺岇澕(*.img, *.ima, *.pcjr, *.jrc)\0*.pcjr;*.img;*.ima;*.jrc\0氇摖 韺岇澕(*.*)\0*.*\0";
 	else
 		OpenFileName.lpstrFilter = "Image files(*.img, *.ima, *.pcjr, *.jrc)\0*.pcjr;*.img;*.ima;*.jrc\0All files(*.*)\0*.*\0";
 
@@ -3046,7 +3046,7 @@ void OpenFileDialog_Img( char drive ) {
 	OpenFileName.hwndOwner = NULL;
 
 	if(DOSBox_Kor())
-		OpenFileName.lpstrFilter = "捞固瘤/ZIP 颇老(*.ima, *.img, *.iso, *.cue, *.bin, *.mdf, *.zip, *.7z)\0*.ima;*.img;*.iso;*.mdf;*.zip;*.cue;*.bin;*.7z\0葛电 颇老(*.*)\0*.*\0";
+		OpenFileName.lpstrFilter = "鞚措歆�/ZIP 韺岇澕(*.ima, *.img, *.iso, *.cue, *.bin, *.mdf, *.zip, *.7z)\0*.ima;*.img;*.iso;*.mdf;*.zip;*.cue;*.bin;*.7z\0氇摖 韺岇澕(*.*)\0*.*\0";
 	else
 		OpenFileName.lpstrFilter = "Image/Zip files(*.ima, *.img, *.iso, *.cue, *.bin, *.mdf, *.zip, *.7z)\0*.ima;*.img;*.iso;*.mdf;*.zip;*.cue;*.bin;*.7z\0All files(*.*)\0*.*\0";
 
@@ -3109,7 +3109,7 @@ void D3D_PS(void) {
 	OpenFileName.lStructSize = sizeof( OPENFILENAME );
 	OpenFileName.hwndOwner = NULL;
 	if(DOSBox_Kor())
-		OpenFileName.lpstrFilter = "瓤苞 颇老(*.fx)\0*.fx\0葛电 颇老(*.*)\0*.*\0";
+		OpenFileName.lpstrFilter = "須臣 韺岇澕(*.fx)\0*.fx\0氇摖 韺岇澕(*.*)\0*.*\0";
 	else
 		OpenFileName.lpstrFilter = "Effect files(*.fx)\0*.fx\0All files(*.*)\0*.*\0";
 	OpenFileName.lpstrCustomFilter = NULL;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1043,7 +1043,7 @@ dosurface:
 		// SDLScreen_Reset();
 		int texsize=2 << int_log2(width > height ? width : height);
 		if (texsize>sdl.opengl.max_texsize) {
-			LOG_MSG("SDL:OPENGL:No support for texturesize of %d, falling back to surface",texsize);
+			LOG_MSG("SDL:OPENGL:No support for texturesize of %d (max size is %d), falling back to surface",texsize,sdl.opengl.max_texsize);
 			goto dosurface;
 		}
 		SDL_GL_SetAttribute( SDL_GL_DOUBLEBUFFER, 1 );

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -3356,7 +3356,7 @@ static Bitu INT15_Handler(void) {
 				}
 				break;
 			default:
-				LOG(LOG_BIOS,LOG_ERROR)("INT15:Unknown call %4X",reg_ax);
+				LOG(LOG_BIOS,LOG_ERROR)("INT15:Unknown E8 call ax=%4X",reg_ax);
 				reg_ah=0x86;
 				CALLBACK_SCF(true);
 				if ((IS_EGAVGA_ARCH) || (machine==MCH_CGA) || (machine==MCH_AMSTRAD)) {
@@ -3366,7 +3366,7 @@ static Bitu INT15_Handler(void) {
 		}
 		break;
 	default:
-		LOG(LOG_BIOS,LOG_ERROR)("INT15:Unknown call %4X",reg_ax);
+		LOG(LOG_BIOS,LOG_ERROR)("INT15:Unknown call ax=%4X",reg_ax);
 		reg_ah=0x86;
 		CALLBACK_SCF(true);
 		if ((IS_EGAVGA_ARCH) || (machine==MCH_CGA) || (machine==MCH_AMSTRAD)) {

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -3356,7 +3356,7 @@ static Bitu INT15_Handler(void) {
 				}
 				break;
 			default:
-				LOG(LOG_BIOS,LOG_ERROR)("INT15:Unknown E8 call ax=%4X",reg_ax);
+				LOG(LOG_BIOS,LOG_ERROR)("INT15:Unknown call ah=E8, al=%2X",reg_al);
 				reg_ah=0x86;
 				CALLBACK_SCF(true);
 				if ((IS_EGAVGA_ARCH) || (machine==MCH_CGA) || (machine==MCH_AMSTRAD)) {


### PR DESCRIPTION
This PR fixes sdl setup to enable OpenGL, which other parts of the code assumed to be around. Because sdl didn't get the SDL_OPENGL flag, later probe of max texture size always returned 0, which made scaling not working.

Using dosbox.conf settings like the following now uses the full screen with correct aspect ratio.
Without this patch, there is a lot of black border around the video in full screen mode.

```
[sdl]
fullscreen=true
fullresolution=1280x800  # your native resolution
output=opengl

[render]
aspect=true
```

Tested on macOS and Fedora 25. In order to compile on macOS, one also need #253 

Regarding sdlmain.cpp. It is a mess. I considered doing more major cleanup of it but there is just too much of it. Especially, there is not a central place to control screen resolution changes, but calls to SDL_SetVideoMode is thrown all over the place, with mixed amount of flags set. While debugging I noticed that video mode was changed maybe 7 times just while BIOS booted. It could be cleaned up to offer a better experience.

Also a unrelated commit sneaked in, which fixes file encoding to UTF8 for some Korean text

Before:
![before_ultima](https://cloud.githubusercontent.com/assets/181531/24823323/6f6cde84-1bfd-11e7-921d-4493d938393f.png)

With this PR:
![after_ultima](https://cloud.githubusercontent.com/assets/181531/24823322/6f33ccf2-1bfd-11e7-8ec5-b3966319f59e.png)

