### PR TITLE
macos: fix compilation with current xcode

### DIFF
--- a/src/hardware/ne2000.cpp
+++ b/src/hardware/ne2000.cpp
@@ -50,8 +50,6 @@
 
 #include "ne2000.h"
 
-#define HAVE_REMOTE
-
 #include "pcap.h"
 // Handle to WinPCap device
 pcap_t *adhandle = 0;


### PR DESCRIPTION
Without this change, the master branch currently fails to compile due to a missing remote-ext.h that gets included inside libpcap

```
g++ -DHAVE_CONFIG_H -I. -I../..  -I../../include -I/usr/local/include/SDL -D_GNU_SOURCE=1 -D_THREAD_SAFE -I/usr/local/include -I/usr/local/Cellar/ffmpeg/3.3.2/include  -g -O2 -Wall -D_FILE_OFFSET_BITS=64 -mmmx -msse -msse2 -Wno-strict-aliasing  -std=gnu++11   -MT ne2000.o -MD -MP -MF .deps/ne2000.Tpo -c -o ne2000.o ne2000.cpp
In file included from ne2000.cpp:55:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/usr/include/pcap.h:43:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/usr/include/pcap/pcap.h:538:12: fatal error: 'remote-ext.h' file not found
  #include <remote-ext.h>
           ^
1 error generated.
```

I have no idea if this breaks networking on linux or something, I have not tried the ne2000 features of dosbox-x yet.