### PR TITLE
macos: remap 'enter debugger' to alt-f12

### DIFF
--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -2223,7 +2223,13 @@ void DEBUG_Init() {
 	LOG(LOG_MISC,LOG_DEBUG)("Initializing debug system");
 
 	/* Add some keyhandlers */
-	MAPPER_AddHandler(DEBUG_Enable,MK_pause,MMOD2,"debugger","Debugger");
+	#if defined(MACOSX)
+		// OSX NOTE: ALT-F12 to launch debugger. pause maps to F16 on macOS,
+		// which is not easy to input on a modern mac laptop
+		MAPPER_AddHandler(DEBUG_Enable,MK_f12,MMOD2,"debugger","Debugger");
+	#else
+		MAPPER_AddHandler(DEBUG_Enable,MK_pause,MMOD2,"debugger","Debugger");
+	#endif
 	/* Reset code overview and input line */
 	memset((void*)&codeViewData,0,sizeof(codeViewData));
 	/* setup debug.com */

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -541,7 +541,7 @@ void PauseDOSBox(bool pressed) {
 			}
 #if defined (MACOSX)
 			if (event.key.keysym.sym == SDLK_q && (event.key.keysym.mod == KMOD_RMETA || event.key.keysym.mod == KMOD_LMETA) ) {
-				/* On macs, all aps exit when pressing cmd-q */
+				/* On macs, all apps exit when pressing cmd-q */
 				KillSwitch(true);
 				break;
 			} 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -609,7 +609,11 @@ void SHELL_Init() {
 	        "\xBA                                                                    \xBA\n"
 	);
 	MSG_Add("SHELL_STARTUP_DEBUG",
+	#if defined(MACOSX)
+	        "\xBA Debugger is available, use \033[31malt-F12\033[37m to enter.                       \xBA\n"
+	#else
 	        "\xBA Debugger is available, use \033[31malt-Pause\033[37m to enter.                     \xBA\n"
+	#endif
 	        "\xBA                                                                    \xBA\n"
 	);
 	MSG_Add("SHELL_STARTUP_END",


### PR DESCRIPTION
background: the default alt-pause is impossible to type on a macbook.

Pause is mapped to F16 on osx in SDL, and the F13-F19 keys only exist on the
larger usb keyboards (with numeric keys).