### PR TITLE
Do not compare pointer with integer

### DIFF
--- a/src/hardware/serialport/nullmodem.cpp
+++ b/src/hardware/serialport/nullmodem.cpp
@@ -155,7 +155,7 @@ CNullModem::CNullModem(Bitu id, CommandLine* cmd):CSerial (id, cmd) {
 	setCTS(dtrrespect||transparent);
 	setDSR(dtrrespect||transparent);
 	setRI(false);
-	setCD(clientsocket > 0); // CD on if connection established
+	setCD(clientsocket != 0); // CD on if connection established
 }
 
 CNullModem::~CNullModem() {


### PR DESCRIPTION
dosbox-x does not compile with the latest clang version (Xcode 9 on macOS 10.12 or 10.13). The error is:

```
nullmodem.cpp:150:21: error: ordered comparison between pointer and zero ('TCPClientSocket *' and 'int')
        setCD(clientsocket > 0); // CD on if connection established
              ~~~~~~~~~~~~ ^ ~
```

This pull request fixes the issue, by changing the invalid ordered comparison.