### PR TITLE
configure.ac: Reduce automake's pedantry

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_CANONICAL_HOST
 AC_CANONICAL_BUILD
 
 dnl Setup for automake
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_HEADER(config.h)
 
 dnl Checks for programs.


### PR DESCRIPTION
In its default configuration, automake makes some sanity checks to
ensure the project meets standards meant for GNU projects. See
https://www.gnu.org/software/automake/manual/html_node/Gnits.html
for details.

Mark this project as foreign to remove the checks.