### PR TITLE
opengl: fix pixel format, updates #254

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1087,7 +1087,7 @@ dosurface:
 			glBufferDataARB(GL_PIXEL_UNPACK_BUFFER_EXT, width*height*4, NULL, GL_STREAM_DRAW_ARB);
 			glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, 0);
 		} else {
-			sdl.opengl.framebuf=malloc(width*height*4);		//32 bit color
+			sdl.opengl.framebuf=calloc(width*height, 4);		//32 bit color
 		}
 		sdl.opengl.pitch=width*4;
 
@@ -1143,6 +1143,7 @@ dosurface:
 		glTexCoord2f(0,0); glVertex2f(-1.0f, 1.0f);
 		glEnd();
 		glEndList();
+
 		sdl.desktop.type=SCREEN_OPENGL;
 		retFlags = GFX_CAN_32 | GFX_SCALING;
 		if (sdl.opengl.pixel_buffer_object)
@@ -2102,7 +2103,14 @@ void GFX_EndUpdate( const Bit16u *changedLines ) {
 					Bitu height = changedLines[index];
 					glTexSubImage2D(GL_TEXTURE_2D, 0, 0, y,
 						sdl.draw.width, height, GL_BGRA_EXT,
-						GL_UNSIGNED_INT_8_8_8_8_REV, pixels );
+						#if defined (MACOSX)
+							// needed for proper looking graphics on macOS 10.12, 10.13
+							GL_UNSIGNED_INT_8_8_8_8,
+						#else
+							// works on Linux
+							GL_UNSIGNED_INT_8_8_8_8_REV,
+						#endif
+						pixels );
 					y += height;
 				}
 				index++;


### PR DESCRIPTION
A follow-up to this PR.

As can be seen in the screenshots in comment https://github.com/joncampbell123/dosbox-x/pull/254#issue-220354988,
there is a color issue in the "after" image.

I originally thought this was due to f.lux on my pc was affecting the screenshot,
so I didn't look closer.

Instead, it appears there is some issue on macOS causing the gfx issue.
By changing parameters for glTexSubImage2D() we get correct looking graphics on macOS, resulting in this new screenshot:

![screen shot 2017-10-24 at 08 54 50](https://user-images.githubusercontent.com/181531/31929130-07f6070e-b89b-11e7-806d-e7cb8c1f1d8c.png)

As compared to the wrongly colored one:

![wrong1](https://cloud.githubusercontent.com/assets/181531/24823322/6f33ccf2-1bfd-11e7-8ec5-b3966319f59e.png)

For comparison, this is how it all looked before #254:

![org](https://cloud.githubusercontent.com/assets/181531/24823323/6f6cde84-1bfd-11e7-921d-4493d938393f.png)

Additionaly graphic corruption could be seen on macOS too, which was fixed by using calloc() to init the frame buffer. I did not see this issue on Linux.
