### PR TITLE
Make D3D support truly conditional (using HAVE_D3D9_H define)

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1579,7 +1579,7 @@ void sticky_keys(bool restore){
 
 #ifdef __WIN32__
 static void d3d_init(void) {
-#if 0
+#if !(HAVE_D3D9_H)
 	E_Exit("D3D not supported");
 #else
 	void change_output(int output);


### PR DESCRIPTION
Just a small followup: with this change 
#define HAVE_D3D9_H 1
really regulates D3D support, if undef or set to 0, it compiles well without DX SDK