### PR TITLE
SID Frequency Correction

### DIFF
--- a/src/hardware/innova.cpp
+++ b/src/hardware/innova.cpp
@@ -26,8 +26,7 @@
 
 #include "reSID/sid.h"
 
-#define SID_FREQ 1022727
-//#define SID_FREQ 985248
+#define SID_FREQ 894886
 
 static struct {
 	SID2* sid;


### PR DESCRIPTION
I modified SID frequency to 894886Hz.
This frequency is correct for IBM-PC.
985248(PAL) and 1022727(NTSC) was used for Commodore 64.

http://www.vgmpf.com/Wiki/index.php/SSI_2001