### PR TITLE
Windows SDL 1.x: Fix keyboard mapping on non-US keyboard layouts

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1713,9 +1713,8 @@ static LRESULT CALLBACK WinExtHookKeyboardHookProc(int nCode,WPARAM wParam,LPARA
 								wParam = WM_USER + 0x101;
 						}
 
-						// catch the keystroke, post it to ourself, do not pass it on
-						PostMessage(myHwnd, wParam, st_hook->vkCode,
-							(st_hook->flags & 0x80/*transition state*/) ? 0x0000 : 0xA000/*bits 13&15 are set*/);
+						// catch the keystroke, post it to ourselves, do not pass it on
+						PostMessage(myHwnd, wParam, st_hook->vkCode, MAKELONG(0, MAKEWORD(st_hook->scanCode,st_hook->flags)));
 						return TRUE;
 					}
 				}


### PR DESCRIPTION
This patch removes the need to load the US English keyboard layout on Windows SDL 1.x by replacing the usage of Virtual Key codes with raw keyboard scan codes.

This change avoids corrupting system-wide keyboard layout configuration on systems which do not have the US English keyboard layout installed (for instance, my system running Windows 10 FCU only has the Spanish keyboard layout installed). When *any* SDL 1.x based application is launched, this corruption happens and the keyboard layout list is filled with garbage (duplicate layouts, etc) - a restart is required to fix this mess.

This issue seems exclusive to SDL 1.x since 2.x doesn't appear to try to load the US keyboard layout.

This change may also help with fixing #434