### PR TITLE
Detect and link with tinfo if ncurses requires it

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -363,6 +363,11 @@ AC_CHECK_HEADER(curses.h,have_curses_h=yes,)
 AC_CHECK_LIB(curses, initscr, have_curses_lib=yes, , )
 AC_CHECK_LIB(ncurses, initscr, have_ncurses_lib=yes, , )
 AC_CHECK_LIB(pdcurses, initscr, have_pdcurses_lib=yes, , )
+# Check if this system's ncurses uses a separate tinfo library
+AC_CHECK_LIB(tinfo, nodelay,
+	     if test x$have_ncurses_lib = xyes ; then
+	       LIBS="$LIBS -ltinfo";
+	     fi)
 
 dnl LIBRARY TEST: libpng
 AC_CHECK_HEADER(png.h,have_png_h=yes,)


### PR DESCRIPTION
Some distributions use a libncurses where the low-level terminal info
is split out into a separate library, libtinfo. Handle this by
checking if the libtinfo library exists and it has a symbol (nodelay)
which is known to cause link failures where a split libncurses is
used.