### PR TITLE
Show menu bar toggle

### DIFF
--- a/include/resource.h
+++ b/include/resource.h
@@ -719,4 +719,5 @@
 
 #if defined(WIN32)
 # define ID_WIN_SYSMENU_RESTOREMENU 0x0F00
+# define ID_WIN_SYSMENU_TOGGLEMENU 0x0F01
 #endif

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -763,8 +763,8 @@ void DOSBox_SetSysMenu(void) {
 		memset(&mii, 0, sizeof(mii));
 		mii.cbSize = sizeof(mii);
 		mii.fMask = MIIM_ID | MIIM_STRING | MIIM_STATE;
-		mii.fState = GFX_GetPreventFullscreen() ? MFS_DISABLED : MFS_ENABLED;
-		mii.wID = ID_WIN_SYSMENU_RESTOREMENU;
+		mii.fState = (menu.toggle ? MFS_CHECKED : 0) | (GFX_GetPreventFullscreen() ? MFS_DISABLED : MFS_ENABLED);
+		mii.wID = ID_WIN_SYSMENU_TOGGLEMENU;
 		mii.dwTypeData = (LPTSTR)(msg);
 		mii.cch = strlen(msg)+1;
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3962,6 +3962,13 @@ void GFX_Events() {
                             if (!GFX_GetPreventFullscreen())
                                 DOSBox_SetMenu();
 							break;
+						case ID_WIN_SYSMENU_TOGGLEMENU:
+							/* prevent removing the menu in 3Dfx mode */
+							if (!GFX_GetPreventFullscreen())
+							{
+								if (menu.toggle) DOSBox_NoMenu(); else DOSBox_SetMenu();
+							}
+							break;
 					}
 				default:
 					break;


### PR DESCRIPTION
Currently there does not seem to be a way to hide the menu from the gui.  This feature change makes it so that the 'show menu bar' selection in the system menu is a toggle, allowing the menu bar to be turned on or off at runtime.