### PR TITLE
Imgmount ramdrive progress

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -41,6 +41,9 @@ struct diskGeo {
 	Bit16u cylcount;  /* Cylinders per side */
 	Bit16u biosval;   /* Type to return from BIOS */
     Bit16u bytespersect; /* Bytes per sector */
+	Bit16u rootentries;  /* Root directory entries */
+	Bit8u sectcluster;   /* Sectors per cluster */
+	Bit8u mediaid;       /* Media ID */
 };
 extern diskGeo DiskGeometryList[];
 

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -147,18 +147,21 @@ public:
 	virtual Bit8u Format();
 
 	imageDiskMemory(Bit32u imgSizeK);
-	imageDiskMemory(Bit32u cylinders, Bit32u heads, Bit32u sectors, Bit32u sectorSize);
+	imageDiskMemory(Bit32u cylinders, Bit32u heads, Bit32u sectors, Bit32u sectorSize, bool isHardDrive, Bit8u floppyBiosMediaType);
 	imageDiskMemory(diskGeo floppyGeometry);
+	imageDiskMemory(imageDisk* underylingImage);
 	virtual ~imageDiskMemory();
 
 private:
-	void init(Bit32u cylinders, Bit32u heads, Bit32u sectors, Bit32u sectorSize);
+	void init(Bit32u cylinders, Bit32u heads, Bit32u sectors, Bit32u sectorSize, bool isHardDrive, Bit8u floppyBiosMediaType, imageDisk* underlyingImage);
+	bool CalculateFAT(Bitu partitionStartingSector, Bitu partitionLength, bool isHardDrive, Bitu rootEntries, Bitu* rootSectors, Bitu* sectorsPerCluster, bool* isFat16, Bitu* fatSectors);
 
 	Bit8u * * ChunkMap;
 	Bit32u sectors_per_chunk;
 	Bit32u chunk_size;
 	Bit32u total_chunks;
 	Bit32u total_sectors;
+	imageDisk* underlyingImage;
 
 	Bit8u bios_type;
 };

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -150,13 +150,13 @@ public:
 	virtual Bit8u Format();
 
 	imageDiskMemory(Bit32u imgSizeK);
-	imageDiskMemory(Bit32u cylinders, Bit32u heads, Bit32u sectors, Bit32u sectorSize, bool isHardDrive, Bit8u floppyBiosMediaType);
+	imageDiskMemory(Bit32u cylinders, Bit32u heads, Bit32u sectors, Bit32u sectorSize);
 	imageDiskMemory(diskGeo floppyGeometry);
 	imageDiskMemory(imageDisk* underylingImage);
 	virtual ~imageDiskMemory();
 
 private:
-	void init(Bit32u cylinders, Bit32u heads, Bit32u sectors, Bit32u sectorSize, bool isHardDrive, Bit8u floppyBiosMediaType, imageDisk* underlyingImage);
+	void init(diskGeo diskParams, bool isHardDrive, imageDisk* underlyingImage);
 	bool CalculateFAT(Bitu partitionStartingSector, Bitu partitionLength, bool isHardDrive, Bitu rootEntries, Bitu* rootSectors, Bitu* sectorsPerCluster, bool* isFat16, Bitu* fatSectors, Bitu* reservedSectors);
 
 	Bit8u * * ChunkMap;
@@ -166,7 +166,7 @@ private:
 	Bit32u total_sectors;
 	imageDisk* underlyingImage;
 
-	Bit8u bios_type;
+	diskGeo floppyInfo;
 };
 
 void updateDPT(void);

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -148,7 +148,6 @@ public:
 	virtual Bit8u Write_AbsoluteSector(Bit32u sectnum, void * data);
 	virtual Bit8u GetBiosType(void);
 	virtual void Set_Geometry(Bit32u setHeads, Bit32u setCyl, Bit32u setSect, Bit32u setSectSize);
-	virtual void Set_Reserved_Cylinders(Bitu resCyl);
 	virtual Bit8u Format();
 
 	imageDiskMemory(Bit32u imgSizeK);

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -154,7 +154,7 @@ public:
 
 private:
 	void init(Bit32u cylinders, Bit32u heads, Bit32u sectors, Bit32u sectorSize, bool isHardDrive, Bit8u floppyBiosMediaType, imageDisk* underlyingImage);
-	bool CalculateFAT(Bitu partitionStartingSector, Bitu partitionLength, bool isHardDrive, Bitu rootEntries, Bitu* rootSectors, Bitu* sectorsPerCluster, bool* isFat16, Bitu* fatSectors);
+	bool CalculateFAT(Bitu partitionStartingSector, Bitu partitionLength, bool isHardDrive, Bitu rootEntries, Bitu* rootSectors, Bitu* sectorsPerCluster, bool* isFat16, Bitu* fatSectors, Bitu* reservedSectors);
 
 	Bit8u * * ChunkMap;
 	Bit32u sectors_per_chunk;

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -147,6 +147,8 @@ public:
 	virtual Bit8u Read_AbsoluteSector(Bit32u sectnum, void * data);
 	virtual Bit8u Write_AbsoluteSector(Bit32u sectnum, void * data);
 	virtual Bit8u GetBiosType(void);
+	virtual void Set_Geometry(Bit32u setHeads, Bit32u setCyl, Bit32u setSect, Bit32u setSectSize);
+	virtual void Set_Reserved_Cylinders(Bitu resCyl);
 	virtual Bit8u Format();
 
 	imageDiskMemory(Bit32u imgSizeK);

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -31,21 +31,21 @@
 extern bool int13_extensions_enable;
 
 diskGeo DiskGeometryList[] = {
-    { 160,  8, 1, 40, 0, 512},      // IBM PC double density 5.25" single-sided 160KB
-    { 180,  9, 1, 40, 0, 512},      // IBM PC double density 5.25" single-sided 180KB
-    { 200, 10, 1, 40, 0, 512},      // DEC Rainbow double density 5.25" single-sided 200KB (I think...)
-    { 320,  8, 2, 40, 1, 512},      // IBM PC double density 5.25" double-sided 320KB
-    { 360,  9, 2, 40, 1, 512},      // IBM PC double density 5.25" double-sided 360KB
-    { 400, 10, 2, 40, 1, 512},      // DEC Rainbow double density 5.25" double-sided 400KB (I think...)
-    { 640,  8, 2, 80, 3, 512},      // IBM PC double density 3.5" double-sided 640KB
-    { 720,  9, 2, 80, 3, 512},      // IBM PC double density 3.5" double-sided 720KB
-    {1200, 15, 2, 80, 2, 512},      // IBM PC double density 5.25" double-sided 1.2MB
-    {1440, 18, 2, 80, 4, 512},      // IBM PC high density 3.5" double-sided 1.44MB
-    {2880, 36, 2, 80, 6, 512},      // IBM PC high density 3.5" double-sided 2.88MB
+    { 160,  8, 1, 40, 0, 512,  64, 1, 0xFE},      // IBM PC double density 5.25" single-sided 160KB
+    { 180,  9, 1, 40, 0, 512,  64, 2, 0xFC},      // IBM PC double density 5.25" single-sided 180KB
+    { 200, 10, 1, 40, 0, 512,   0, 0,    0},      // DEC Rainbow double density 5.25" single-sided 200KB (I think...)
+    { 320,  8, 2, 40, 1, 512, 112, 2, 0xFF},      // IBM PC double density 5.25" double-sided 320KB
+    { 360,  9, 2, 40, 1, 512, 112, 2, 0xFD},      // IBM PC double density 5.25" double-sided 360KB
+    { 400, 10, 2, 40, 1, 512,   0, 0,    0},      // DEC Rainbow double density 5.25" double-sided 400KB (I think...)
+    { 640,  8, 2, 80, 3, 512, 112, 2, 0xFB},      // IBM PC double density 3.5" double-sided 640KB
+    { 720,  9, 2, 80, 3, 512, 112, 2, 0xF9},      // IBM PC double density 3.5" double-sided 720KB
+    {1200, 15, 2, 80, 2, 512, 224, 1, 0xF9},      // IBM PC double density 5.25" double-sided 1.2MB
+    {1440, 18, 2, 80, 4, 512, 224, 1, 0xF0},      // IBM PC high density 3.5" double-sided 1.44MB
+    {2880, 36, 2, 80, 6, 512, 240, 2, 0xF0},      // IBM PC high density 3.5" double-sided 2.88MB
 
-    {1232,  8, 2, 77, 7, 1024},     // NEC PC-98 high density 3.5" double-sided 1.2MB "3-mode"
+    {1232,  8, 2, 77, 7, 1024,192, 1, 0xFE},      // NEC PC-98 high density 3.5" double-sided 1.2MB "3-mode"
 
-    {0, 0, 0, 0, 0, 0}
+    {   0,  0, 0,  0, 0,    0,  0, 0,    0}
 };
 
 Bitu call_int13 = 0;

--- a/src/ints/bios_memdisk.cpp
+++ b/src/ints/bios_memdisk.cpp
@@ -42,37 +42,87 @@
 
 // Create a hard drive image of a specified size; automatically select c/h/s
 imageDiskMemory::imageDiskMemory(Bit32u imgSizeK) {
-	// always use sector size of 512, with 255 heads and 63 sectors, which equates to about 8MB increments
-	// round up to the next "8MB" increment and determine the number of cylinders necessary
-	// ideally the number of cylinders should be <= 1024 for full compatibility with DOS (the "8GB limit")
-	Bit32u sector_size = 512; //bytes per sector
-	Bit32u sectors = 63; //sectors per track
-	Bit32u heads = 255; //tracks per cylinder
-	Bit64u imgSizeBytes = (Bit64u)imgSizeK * 1024;
-	Bit64u divBy = sector_size * sectors * heads;
-	Bit32u cylinders = (Bit32u)((imgSizeBytes + divBy - 1) / divBy); //cylinders
-	init(cylinders, heads, sectors, sector_size);
+	// The fatDrive class is hard-coded to assume that disks 2880KB or smaller are floppies,
+	//   whether or not they are attached to a floppy controller.  So, let's enforce a minimum
+	//   size of 4096kb for hard drives.  Use the other constructor for floppy drives.
+	if (imgSizeK < 4096) imgSizeK = 4096;
+
+	//this code always returns drives with 512 byte sectors
+	//first, it primarily prefers 16 sectors, and never more than 255
+	//second, as many cylinders as possible less than 1024
+	//third, as many heads as possible, up to a maximum of 63
+	//
+	//the code will round up in case it cannot make an exact match
+	//it also forces a minimum drive size of 32kb, since a hard drive cannot be formatted as FAT12 with a smaller parition
+	//the code works properly throughout the range of a 32-bit unsigned integer
+
+	//so, these are examples of results: (assuming no 4096k minimum)
+	//
+	// KB requested      C     H     S
+	//-----------------------------------
+	//          0        4     1    16
+	//          1        4     1    16
+	//         32        4     1    16     <<---minimum enforced image size
+	//        100       13     1    16
+	//       1024      128     1    16
+	//       4096      512     1    16     <<---however, with first line of code enforcing 4096kb drives, this is what gets returned
+	//       8184     1023     1    16     <<---at 8mb the head count is increased
+	//       8185      512     2    16
+	//      65472     1023     8    16
+	//      65473      910     9    16
+	//     515592     1023    63    16     <<---at 503mb the sector count is increased
+	//     515593      963    63    17
+	//    8217247     1023    63   255     <<---at 8gb the cylinder count is increased beyond 1023 cylinders
+	//    8217248     1024    63   255
+	// 4294967295   534699    63   255     <<---can create drives up to MAXULONGLONG kb
+
+	//use 32kb as minimum drive size, since it is not possible to format a smaller drive that has 16 sectors
+	if (imgSizeK < 32) imgSizeK = 32;
+	//set the sector size to 512 bytes
+	Bit32u sector_size = 512;
+	//calculate the total number of sectors on the drive (imgSizeK * 2)
+	Bit64u total_sectors = ((Bit64u)imgSizeK * 1024 + sector_size - 1) / sector_size;
+	//assume 1023 cylinders and 16 sectors minimum; calculate the number of heads (round up)
+	Bit32u heads = (total_sectors + (1023 * 16 - 1)) / (1023 * 16);
+	//cap heads at 63
+	if (heads > 63) heads = 63;
+	//now calculate the sectors (again, assuming 1023 cylinders) (round up)
+	Bit32u sectors = (total_sectors + (heads * 1023 - 1)) / (heads * 1023);
+	//set sectors to a minimum of 16 and maximum of 255
+	if (sectors < 16) sectors = 16;
+	if (sectors > 255) sectors = 255;
+	//now calculate the correct number of cylinders (round up)
+	Bit32u cylinders = (total_sectors + (heads * sectors - 1)) / (heads * sectors);
+	//set minimum number of cylinders to be 4 (which equals a 32kb image)
+	if (cylinders < 4) cylinders = 4;
+	//it is possible for the cylinders to be > 1023 at this point - to be trapped within init()
+	//minimum image size possible with this formula is 32kb (16 sectors, 1 head, 4 cylinders), which is enough to format 
+
+	init(cylinders, heads, sectors, sector_size, true, 0, 0);
 }
 
 // Create a floppy image of a specified geometry
 imageDiskMemory::imageDiskMemory(diskGeo floppyGeometry) {
-	init(floppyGeometry.cylcount, floppyGeometry.headscyl, floppyGeometry.secttrack, floppyGeometry.bytespersect);
-	this->hardDrive = false;
-	this->bios_type = floppyGeometry.biosval;
+	init(floppyGeometry.cylcount, floppyGeometry.headscyl, floppyGeometry.secttrack, floppyGeometry.bytespersect, false, floppyGeometry.biosval, 0);
 }
 
-// Return the BIOS type of the floppy image (or 0xF8 for hard drives)
+// Return the BIOS type of the floppy image, or 0 for hard drives
 Bit8u imageDiskMemory::GetBiosType(void) {
-	return bios_type;
+	return this->hardDrive ? 0 : bios_type;
 }
 
 // Create a hard drive image of a specified geometry
-imageDiskMemory::imageDiskMemory(Bit32u cylinders, Bit32u heads, Bit32u sectors, Bit32u sector_size) {
-	init(cylinders, heads, sectors, sector_size);
+imageDiskMemory::imageDiskMemory(Bit32u cylinders, Bit32u heads, Bit32u sectors, Bit32u sector_size, bool isHardDrive, Bit8u floppyBiosMediaType) {
+	init(cylinders, heads, sectors, sector_size, isHardDrive, floppyBiosMediaType, 0);
+}
+
+// Create a copy-on-write memory image of an existing image
+imageDiskMemory::imageDiskMemory(imageDisk* underlyingImage) {
+	init(underlyingImage->cylinders, underlyingImage->heads, underlyingImage->sectors, underlyingImage->sector_size, underlyingImage->hardDrive, underlyingImage->GetBiosType(), underlyingImage);
 }
 
 // Internal initialization code to create a image of a specified geometry
-void imageDiskMemory::init(Bit32u cylinders, Bit32u heads, Bit32u sectors, Bit32u sector_size) {
+void imageDiskMemory::init(Bit32u cylinders, Bit32u heads, Bit32u sectors, Bit32u sector_size, bool isHardDrive, Bit8u floppyBiosMediaType, imageDisk* underlyingImage) {
 	//initialize internal variables in case we fail out
 	this->active = false;
 	this->cylinders = 0;
@@ -80,6 +130,8 @@ void imageDiskMemory::init(Bit32u cylinders, Bit32u heads, Bit32u sectors, Bit32
 	this->sectors = 0;
 	this->sector_size = 0;
 	this->total_sectors = 0;
+	this->underlyingImage = underlyingImage;
+	underlyingImage->Addref();
 
 	//calculate the total number of sectors on the drive, and check for overflows
 	Bit64u absoluteSectors = (Bit64u)cylinders * (Bit64u)heads;
@@ -107,7 +159,12 @@ void imageDiskMemory::init(Bit32u cylinders, Bit32u heads, Bit32u sectors, Bit32
 	}
 
 	//split the sectors into chunks, which are allocated together on an as-needed basis
-	this->sectors_per_chunk = heads;
+	//assuming a maximum of 63 heads and 255 sectors, this formula gives a nice chunk size that scales with the drive size
+	//for any drives under 64mb, the chunks are 8kb each, and the map consumes 1/1000 of the total drive size
+	//then the chunk size grows up to a 8gb drive, while the map consumes 30-60k of memory (on 64bit PCs)
+	//with a 8gb drive, the chunks are about 1mb each, and the map consumes about 60k of memory 
+	//and for larger drives (with over 1023 cylinders), the chunks remain at 1mb each while the map grows
+	this->sectors_per_chunk = (heads + 7) / 8 * sectors; 
 	this->total_chunks = (absoluteSectors + sectors_per_chunk - 1) / sectors_per_chunk;
 	this->chunk_size = sectors_per_chunk * sector_size;
 	//allocate a map of chunks that have been allocated and their memory addresses
@@ -127,8 +184,8 @@ void imageDiskMemory::init(Bit32u cylinders, Bit32u heads, Bit32u sectors, Bit32
 	this->diskSizeK = diskSizeK;
 	this->total_sectors = absoluteSectors;
 	this->reserved_cylinders = 0;
-	this->hardDrive = true;
-	this->bios_type = 0xF8;
+	this->hardDrive = isHardDrive;
+	this->bios_type = isHardDrive ? 0 : floppyBiosMediaType;
 	this->active = true;
 }
 
@@ -136,6 +193,8 @@ void imageDiskMemory::init(Bit32u cylinders, Bit32u heads, Bit32u sectors, Bit32
 imageDiskMemory::~imageDiskMemory() {
 	//quit if the map is already not allocated
 	if (!active) return;
+	//release the underlying image
+	if (this->underlyingImage) this->underlyingImage->Release();
 	//loop through each chunk and release it if it has been allocated
 	Bit8u* chunk;
 	for (int i = 0; i < total_chunks; i++) {
@@ -169,8 +228,11 @@ Bit8u imageDiskMemory::Read_AbsoluteSector(Bit32u sectnum, void * data) {
 	Bit8u* datalocation;
 	datalocation = ChunkMap[chunknum];
 
-	//if the chunk has not yet been allocated, return zeros
+	//if the chunk has not yet been allocated, return underlying image if any, or else zeros
 	if (datalocation == 0) {
+		if (this->underlyingImage) {
+			return this->underlyingImage->Read_AbsoluteSector(sectnum, data);
+		}
 		memset(data, 0, sector_size);
 		return 0x00;
 	}
@@ -204,13 +266,15 @@ Bit8u imageDiskMemory::Write_AbsoluteSector(Bit32u sectnum, void * data) {
 
 	//if the chunk has not yet been allocated, allocate the chunk
 	if (datalocation == NULL) {
-		//first check if we are actually saving anything
-		Bit8u anyData = 0;
-		for (int i = 0; i < sector_size; i++) {
-			anyData |= ((Bit8u*)data)[i];
+		//if no underlying image, first check if we are actually saving anything
+		if (this->underlyingImage == NULL) {
+			Bit8u anyData = 0;
+			for (int i = 0; i < sector_size; i++) {
+				anyData |= ((Bit8u*)data)[i];
+			}
+			//if it's all zeros, return success
+			if (anyData == 0) return 0x00;
 		}
-		//if it's all zeros, return success
-		if (anyData == 0) return 0x00;
 
 		//allocate a new memory chunk
 		datalocation = (Bit8u*)malloc(chunk_size);
@@ -222,6 +286,19 @@ Bit8u imageDiskMemory::Write_AbsoluteSector(Bit32u sectnum, void * data) {
 		ChunkMap[chunknum] = datalocation;
 		//initialize the memory chunk to all zeros (since we are only writing to a single sector within this chunk)
 		memset((void*)datalocation, 0, chunk_size);
+		//if there is an underlying image, read from the underlying image to fill the chunk
+		if (this->underlyingImage) {
+			Bitu chunkFirstSector = chunknum * this->sectors_per_chunk;
+			Bitu sectorsToCopy = this->sectors_per_chunk;
+			//if this is the last chunk, don't read past the end of the original image
+			if ((chunknum + 1) == this->total_chunks) sectorsToCopy = this->total_sectors - chunkFirstSector;
+			//copy the sectors
+			Bit8u* target = datalocation;
+			for (Bitu i = 0; i < sectorsToCopy; i++) {
+				this->underlyingImage->Read_AbsoluteSector(i + chunkFirstSector, target);
+				datalocation += this->sector_size;
+			}
+		}
 	}
 
 	//update the address to the specific sector within the chunk
@@ -235,6 +312,8 @@ Bit8u imageDiskMemory::Write_AbsoluteSector(Bit32u sectnum, void * data) {
 // Parition and format the ramdrive (code is adapted from IMGMAKE code within dos_programs.cpp)
 // - Assumes that the ramdrive is all zeros to begin with (since the root directory is not zeroed)
 Bit8u imageDiskMemory::Format() {
+	//todo: figure out the media id
+	Bit8u mediaID = 0xF0;
 	//verify that the geometry of the drive is valid
 	if (this->sector_size != 512) {
 		LOG_MSG("imageDiskMemory->Format only designed for disks with 512-byte sectors.\n");
@@ -265,11 +344,11 @@ Bit8u imageDiskMemory::Format() {
 		// active partition
 		sbuf[0x1be] = 0x80;
 		// start head - head 0 has the partition table, head 1 first partition
-		sbuf[0x1bf] = 1;
+		sbuf[0x1bf] = this->heads > 1 ? 1 : 0;
 		// start sector with bits 8-9 of start cylinder in bits 6-7
-		sbuf[0x1c0] = 1;
+		sbuf[0x1c0] = this->heads > 1 ? 1 : (this->sectors > 1 ? 2 : 1);
 		// start cylinder bits 0-7
-		sbuf[0x1c1] = 0;
+		sbuf[0x1c1] = this->heads > 1 || this->sectors > 1 ? 0 : 1;
 		// OS indicator: DOS what else ;)
 		sbuf[0x1c2] = 0x06;
 		// end head (0-based)
@@ -287,6 +366,10 @@ Bit8u imageDiskMemory::Format() {
 		this->Write_AbsoluteSector(0, sbuf);
 		bootsect_pos = this->sectors;
 	}
+
+	bool isFat16 = false;
+	Bitu fatSectors = 0;
+
 
 	// set boot sector values
 	memset(sbuf, 0, 512);
@@ -323,6 +406,7 @@ Bit8u imageDiskMemory::Format() {
 	Bitu root_ent = 512;
 	if (!this->hardDrive)
 	{
+		//todo: switch based on media type, not floppy bios type.  see imgmake
 		switch (this->GetBiosType()) {
 		case 0xF0: root_ent = this->sectors == 36 ? 512 : 224; break;
 		case 0xF9: root_ent = this->sectors == 15 ? 224 : 112; break;
@@ -349,6 +433,7 @@ Bit8u imageDiskMemory::Format() {
 	// heads
 	host_writew(&sbuf[0x1a], this->heads);
 	// hidden sectors
+	//todo: check this -- shouldn't it be 1?
 	host_writed(&sbuf[0x1c], bootsect_pos);
 	// sectors (large disk) - this is the same as partition length in MBR
 	if (this->hardDrive) host_writed(&sbuf[0x20], this->total_sectors - this->sectors);
@@ -377,6 +462,9 @@ Bit8u imageDiskMemory::Format() {
 	for (int i = bootsect_pos + 1; i < bootsect_pos + 1 + sect_per_fat + sect_per_fat + root_sectors; i++) {
 		this->Write_AbsoluteSector(i, sbuf);
 	}
+	// set the special markers for cluster 0 and cluster 1
+
+
 	// This code is probably for FAT32 drives...not sure.  The first cluster (identified as cluster id 2) starts immediately after the root directory entries
 	//if (this->hardDrive) host_writed(&sbuf[0], 0xFFFFFFF8);
 	//else host_writed(&sbuf[0], 0xFFFFF0);
@@ -384,6 +472,78 @@ Bit8u imageDiskMemory::Format() {
 	//this->Write_AbsoluteSector(bootsect_pos + 1, sbuf);
 	//this->Write_AbsoluteSector(bootsect_pos + 1 + sect_per_fat, sbuf);
 
+
 	//success
 	return 0x00;
+}
+
+// Calculate the number of sectors per cluster, the number of sectors per fat, and if it is FAT12/FAT16
+// Note that sectorsPerCluster is required to be set to the minimum, which will be 2 for certain types of floppies
+bool imageDiskMemory::CalculateFAT(Bitu partitionStartingSector, Bitu partitionLength, bool isHardDrive, Bitu rootEntries, Bitu* rootSectors, Bitu* sectorsPerCluster, bool* isFat16, Bitu* fatSectors) {
+	//check for null references
+	if (rootSectors == NULL || sectorsPerCluster == NULL || isFat16 == NULL || fatSectors == NULL) return false;
+	//make sure variables all make sense
+	switch (*sectorsPerCluster) {
+		case 1: case 2: case 4: case 8: case 16: case 32: case 64: case 128: break;
+		default: return false;
+	}
+	if (((Bit64u)partitionStartingSector + partitionLength) > MAXULONG32) return false;
+	if (rootEntries > (isHardDrive ? 512 : 240)) return false;
+	if ((rootEntries / 16) * 16 != rootEntries) return false;
+	if (rootEntries == 0) return false;
+	//set the number of root sectors
+	*rootSectors = rootEntries * 32;
+	//make sure there is a minimum number of sectors available
+	//  minimum sectors = root sectors + 1 for boot sector + 1 for fat #1 + 1 for fat #2 + 1 for data sector + add 7 for hard drives due to allow for 4k alignment
+	if (partitionLength < (*rootSectors + 4 + (isHardDrive ? 7 : 0))) return false;
+
+
+	//set the minimum number of reserved sectors
+	//the first sector of a partition is always reserved, of course
+	Bitu reservedSectors = 1;
+	//if this is a hard drive, we will align to a 4kb boundary,
+	//  so set (partitionStartingSector + reservedSectors) to an even number.
+	//Additional alignment can be made by increasing the number of reserved sectors,
+	//  or by increasing the reservedSectors value -- both done after the calculation
+	if (isHardDrive && ((partitionStartingSector + reservedSectors) % 2 == 1)) reservedSectors++;
+
+
+	//compute the number of fat sectors and data sectors
+	Bitu dataSectors;
+	do {
+		//compute the minimum number of fat sectors necessary using the minimum number of sectors per cluster
+		//THIS MATH IS FOR FAT16 DRIVES -- need to do math for FAT12 drives also
+		*fatSectors = (partitionLength - reservedSectors - *rootSectors + (*sectorsPerCluster * 256 + 1)) / (*sectorsPerCluster * 256 + 2);
+
+		//compute the number of data sectors with this arrangement
+		Bitu dataSectors = partitionLength - reservedSectors - *rootSectors - *fatSectors - *fatSectors;
+
+		//check and see if this makes a valid FAT16 or FAT12 drive
+		if (dataSectors < 65525) break;
+
+		//otherwise, double the number of sectors per cluster and try again
+		*sectorsPerCluster <<= 1;
+	} while (true);
+	//determine if the drive is too large for FAT16
+	if (*sectorsPerCluster >= 256) return false;
+
+	//determine whether to use FAT16 or not
+	*isFat16 = (dataSectors >= 4085);
+
+	//add padding to align hard drives to 4kb boundary
+	if (isHardDrive) {
+		//update the reserved sector count
+		reservedSectors = (partitionStartingSector + reservedSectors + *rootSectors + *fatSectors + *fatSectors) % 8;
+		//recompute the number of data sectors
+		dataSectors = partitionLength - reservedSectors - *rootSectors - *fatSectors - *fatSectors;
+
+		//note: by reducing the number of data sectors, the drive might have changed from a FAT16 drive to a FAT12 drive.
+		//  however, the only difference is that there are unused fat sectors allocated.  we cannot allocate them, or else
+		//  the drive alignment will change again, and most likely the drive would change back into a FAT16 drive.
+		//  so, just leave it as-is
+		*isFat16 = (dataSectors >= 4085);
+	}
+
+	//success
+	return true;
 }

--- a/src/ints/bios_memdisk.cpp
+++ b/src/ints/bios_memdisk.cpp
@@ -510,7 +510,7 @@ bool imageDiskMemory::CalculateFAT(Bitu partitionStartingSector, Bitu partitionL
 	if ((rootEntries / 16) * 16 != rootEntries) return false;
 	if (rootEntries == 0) return false;
 	//set the number of root sectors
-	*rootSectors = rootEntries * 32;
+	*rootSectors = rootEntries * 32 / 512;
 	//make sure there is a minimum number of sectors available
 	//  minimum sectors = root sectors + 1 for boot sector + 1 for fat #1 + 1 for fat #2 + 1 for data sector + add 7 for hard drives due to allow for 4k alignment
 	if (partitionLength < (*rootSectors + 4 + (isHardDrive ? 7 : 0))) return false;


### PR DESCRIPTION
Work progress on ramdrive code.
- rewrote the formatting code nearly from scratch, to exactly compute the amount of data sectors that can fit on a given disk
- formatting code can format floppies to match original specifications more closely (2 sectors per cluster for certain disk types)
- ramdrives can mask existing drives, for copy-on-write disk images

Todo:
- fix the bug (memory leak) where imgmounted disks do not get released from bios or ram when unmounted.
- enable mounting ramdisks into the bios
- check/update boot command to allow booting into a mounted ramdisk
- verify formatted floppies works with early versions of PC-DOS and MS-DOS (assuming a compatible type of floppy)
- determine if boot signature should not be written to the disk (because we are not writing a boot sector)
- move Format() to imageDisk, and add format command to dos emulation, so any mounted image can be formatted
- add -cow (?) option to imgmount to mount a copy-on-write image

And maybe:
- add command to save a mouted image (particularly for ramdisks)
- replace imgmake implementation of formatting with new Format() implementation
- enhance imgmount help further (probably pause between pages)
- clean up imgmount / imgmake code
- rename imageDisk variables to match a design pattern, and scope them properly
