### PR TITLE
imgmount -u support, and el-torito booting bug fix

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -179,8 +179,9 @@ void updateDPT(void);
 void incrementFDD(void);
 
 #define MAX_HDD_IMAGES 2
+#define MAX_DISK_IMAGES 4 //MAX_HDD_IMAGES + 2
 
-extern imageDisk *imageDiskList[2 + MAX_HDD_IMAGES];
+extern imageDisk *imageDiskList[MAX_DISK_IMAGES];
 extern imageDisk *diskSwap[20];
 extern Bits swapPosition;
 extern Bit16u imgDTASeg; /* Real memory location of temporary DTA pointer for fat image disk access */

--- a/include/ide.h
+++ b/include/ide.h
@@ -12,7 +12,9 @@ extern void (*ide_inits[MAX_IDE_CONTROLLERS])(Section *);
 
 void IDE_Auto(signed char &index,bool &slave);
 void IDE_CDROM_Attach(signed char index,bool slave,unsigned char drive_index);
+void IDE_CDROM_Detach(unsigned char drive_index);
 void IDE_Hard_Disk_Attach(signed char index,bool slave,unsigned char bios_drive_index);
+void IDE_Hard_Disk_Detach(unsigned char bios_drive_index);
 void IDE_ResetDiskByBIOS(unsigned char disk);
 
 #endif

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2564,12 +2564,15 @@ private:
 				if (i_drive <= 1)
 					FDC_UnassignINT13Disk(i_drive);
 
+				//get reference to image and cdrom before they are possibly destroyed
+				fatDrive * drive = dynamic_cast<fatDrive*>(Drives[i_drive]);
+				imageDisk* image = drive ? drive->loadedDisk : NULL;
+				isoDrive * cdrom = dynamic_cast<isoDrive*>(Drives[i_drive]);
+
 				switch (DriveManager::UnmountDrive(i_drive)) {
 				case 0: //success
 				{
 					//detatch hard drive or floppy drive from bios and ide controller
-					fatDrive * drive = dynamic_cast<fatDrive*>(Drives[i_drive]);
-					imageDisk* image = drive ? drive->loadedDisk : NULL;
 					if (image) {
 						for (int index = 0; index < 4; index++) {
 							if (imageDiskList[index] == image) {
@@ -2581,7 +2584,6 @@ private:
 					}
 
 					/* If the drive letter is also a CD-ROM drive attached to IDE, then let the IDE code know */
-					isoDrive * cdrom = dynamic_cast<isoDrive*>(Drives[i_drive]);
 					if (cdrom) IDE_CDROM_Detach(i_drive);
 
 					Drives[i_drive] = NULL;
@@ -2889,7 +2891,7 @@ private:
 			WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_2"), drive, tmp.c_str());
 		}
 
-		if (type != "ram" && paths.size() == 1) {
+		if (imgDisks.size() == 1) {
 			imageDisk* image = ((fatDrive*)imgDisks[0])->loadedDisk;
 			if (image->hardDrive) {
 				if (imageDiskList[2] == NULL) {
@@ -2930,7 +2932,7 @@ private:
 		}
 	}
 
-	void AddToDriveManager(const char drive, const std::vector<DOS_Drive*> imgDisks, const Bit8u mediaid) {
+	void AddToDriveManager(const char drive, const std::vector<DOS_Drive*> &imgDisks, const Bit8u mediaid) {
 		std::vector<DOS_Drive*>::size_type ct;
 
 		// Update DriveManager

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2601,7 +2601,7 @@ private:
 			int index = letter - '0';
 
 			//detatch hard drive or floppy drive from bios and ide controller
-			if (imageDiskList[index]) {
+			if (index < MAX_DISK_IMAGES && imageDiskList[index]) {
 				if (index > 1) IDE_Hard_Disk_Detach(index);
 				imageDiskList[index]->Release();
 				imageDiskList[index] = NULL;

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2573,15 +2573,7 @@ private:
 				case 0: //success
 				{
 					//detatch hard drive or floppy drive from bios and ide controller
-					if (image) {
-						for (int index = 0; index < 4; index++) {
-							if (imageDiskList[index] == image) {
-								if (index > 1) IDE_Hard_Disk_Detach(index);
-								imageDiskList[index]->Release();
-								imageDiskList[index] = NULL;
-							}
-						}
-					}
+					if (image) DetachFromBios(image);
 
 					/* If the drive letter is also a CD-ROM drive attached to IDE, then let the IDE code know */
 					if (cdrom) IDE_CDROM_Detach(i_drive);
@@ -2815,7 +2807,7 @@ private:
 		return true;
 	}
 
-	bool MountFat(bool &imgsizedetect, Bitu sizes[], const char drive, const Bitu mediaid, const std::string str_size, const std::string type, const std::vector<std::string> paths, const signed char ide_index, const bool ide_slave) {
+	bool MountFat(bool &imgsizedetect, Bitu sizes[], const char drive, const Bitu mediaid, const std::string &str_size, const std::string &type, const std::vector<std::string> &paths, const signed char ide_index, const bool ide_slave) {
 		DOS_Drive * newdrive;
 
 		if (imgsizedetect) {
@@ -2903,7 +2895,7 @@ private:
 	}
 
 	void AttachToBios(imageDisk* image, const unsigned char bios_drive_index) {
-		if (bios_drive_index > 3) return;
+		if (bios_drive_index >= MAX_DISK_IMAGES) return;
 		if (imageDiskList[bios_drive_index] != NULL) {
 			/* Notify IDE ATA emulation if a drive is already there */
 			if (bios_drive_index >= 2) IDE_Hard_Disk_Detach(bios_drive_index);
@@ -2922,6 +2914,19 @@ private:
 		if (bios_drive_index == 2 || bios_drive_index == 3) {
 			if (ide_index >= 0) IDE_Hard_Disk_Attach(ide_index, ide_slave, bios_drive_index);
 			updateDPT();
+		}
+	}
+
+	void DetachFromBios(imageDisk* image) {
+		if (image) {
+			for (int index = 0; index < MAX_DISK_IMAGES; index++) {
+				if (imageDiskList[index] == image) {
+					if (index > 1) IDE_Hard_Disk_Detach(index);
+					//todo: check this code
+					imageDiskList[index]->Release();
+					imageDiskList[index] = NULL;
+				}
+			}
 		}
 	}
 
@@ -3073,7 +3078,7 @@ private:
 		}
 	}
 
-	bool MountIso(const char drive, const Bit8u mediaid, const std::vector<std::string> paths, const signed char ide_index, const bool ide_slave) {
+	bool MountIso(const char drive, const Bit8u mediaid, const std::vector<std::string> &paths, const signed char ide_index, const bool ide_slave) {
 		//mount cdrom
 
 		if (Drives[drive - 'A']) {

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -2185,6 +2185,7 @@ void IDE_CDROM_Attach(signed char index,bool slave,unsigned char drive_index) {
 void IDE_CDROM_Detach(unsigned char drive_index) {
 	for (int index = 0; index < MAX_IDE_CONTROLLERS; index++) {
 		IDEController *c = idecontroller[index];
+		if (c)
 		for (int slave = 0; slave < 2; slave++) {
 			IDEATAPICDROMDevice *dev;
 			dev = dynamic_cast<IDEATAPICDROMDevice*>(c->device[slave]);
@@ -2226,6 +2227,7 @@ void IDE_Hard_Disk_Attach(signed char index,bool slave,unsigned char bios_disk_i
 void IDE_Hard_Disk_Detach(unsigned char bios_disk_index) {
 	for (int index = 0; index < MAX_IDE_CONTROLLERS; index++) {
 		IDEController *c = idecontroller[index];
+		if (c)
 		for (int slave = 0; slave < 2; slave++) {
 			IDEATADevice *dev;
 			dev = dynamic_cast<IDEATADevice*>(c->device[slave]);

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -2181,6 +2181,22 @@ void IDE_CDROM_Attach(signed char index,bool slave,unsigned char drive_index) {
 	c->device[slave?1:0] = (IDEDevice*)dev;
 }
 
+/* drive_index = drive letter 0...A to 25...Z */
+void IDE_CDROM_Detach(unsigned char drive_index) {
+	for (int index = 0; index < MAX_IDE_CONTROLLERS; index++) {
+		IDEController *c = idecontroller[index];
+		for (int slave = 0; slave < 2; slave++) {
+			IDEATAPICDROMDevice *dev;
+			dev = dynamic_cast<IDEATAPICDROMDevice*>(c->device[slave]);
+			if (dev && dev->drive_index == drive_index) {
+				//todo: check this code
+				delete dev;
+				c->device[slave] = NULL;
+			}
+		}
+	}
+}
+
 /* bios_disk_index = index into BIOS INT 13h disk array: imageDisk *imageDiskList[MAX_DISK_IMAGES]; */
 void IDE_Hard_Disk_Attach(signed char index,bool slave,unsigned char bios_disk_index/*not INT13h, the index into DOSBox's BIOS drive emulation*/) {
 	IDEController *c;
@@ -2206,6 +2222,21 @@ void IDE_Hard_Disk_Attach(signed char index,bool slave,unsigned char bios_disk_i
 	c->device[slave?1:0] = (IDEDevice*)dev;
 }
 
+/* bios_disk_index = index into BIOS INT 13h disk array: imageDisk *imageDiskList[MAX_DISK_IMAGES]; */
+void IDE_Hard_Disk_Detach(unsigned char bios_disk_index) {
+	for (int index = 0; index < MAX_IDE_CONTROLLERS; index++) {
+		IDEController *c = idecontroller[index];
+		for (int slave = 0; slave < 2; slave++) {
+			IDEATADevice *dev;
+			dev = dynamic_cast<IDEATADevice*>(c->device[slave]);
+			if (dev && dev->bios_disk_index == bios_disk_index) {
+				//todo: check this code
+				delete dev;
+				c->device[slave] = NULL;
+			}
+		}
+	}
+}
 static IDEController* GetIDEController(Bitu idx) {
 	if (idx >= MAX_IDE_CONTROLLERS) return NULL;
 	return idecontroller[idx];

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -26,8 +26,6 @@
 #include "../dos/drives.h"
 #include "mapper.h"
 
-#define MAX_DISK_IMAGES 4
-
 extern bool int13_extensions_enable;
 
 diskGeo DiskGeometryList[] = {

--- a/src/ints/bios_memdisk.cpp
+++ b/src/ints/bios_memdisk.cpp
@@ -387,10 +387,10 @@ Bit8u imageDiskMemory::Format() {
 	Bit32u partitionStart = writeMBR ? this->sectors : 0; //must be aligned with the start of a head (multiple of this->sectors)
 	Bit32u partitionLength = reported_total_sectors - partitionStart; //must be aligned with the start of a head (multiple of this->sectors)
 	//figure out the media id
-	Bit8u mediaID = this->hardDrive ? 0xF0 : this->floppyInfo.mediaid;
+	Bit8u mediaID = this->hardDrive ? 0xF8 : this->floppyInfo.mediaid;
 	//figure out the number of root entries and minimum number of sectors per cluster
 	Bit32u root_ent = this->hardDrive ? 512 : this->floppyInfo.rootentries;
-	Bit32u sectors_per_cluster = this->hardDrive ? 1 : this->floppyInfo.sectcluster;
+	Bit32u sectors_per_cluster = this->hardDrive ? 4 : this->floppyInfo.sectcluster; //fat requires 2k clusters minimum on hard drives
 
 	//calculate the number of:
 	//  root sectors


### PR DESCRIPTION
These code changes allow imgmount -u unmount drives from the bios and ide controller.  I've tested it best i can, but it should be given another look over to make sure it's done correctly.  Some other changes:
- Enable ramdrives to mount in BIOS and attach to IDE controller
- Formatting fix so MS-DOS 5.0 will install on a ramdisk (mediaid = 0xf8 not 0xf0, and 4 sectors/cluster minimum for hard drives)
- Bug fix so el-torito floppies are bootable again (can't find what broke it, but it was probably me)
- A little refactoring and elimination of duplicate code

Looking at the commits individually you can see what was changed better.

Functions to double check:
- IMGMOUNT::DetachFromBios - dos_programs.cpp:2920
- IDE_CDROM_Detach - ide.cpp:2185
- IDE_Hard_Disk_Detach - ide.cpp:2227
