### PR TITLE
Updates to ramdrive and imgmount

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2930,9 +2930,9 @@ private:
 					}
 				}
 			}
-			else {
-				//AttachToBios(image, 0); //always attach as primary floppy drive (???)
-				AttachToBios(image, drive - 'A');  //attach as secondary floppy if mounting at B:
+			else if ((drive - 'A') < 2) {
+				//only mount floppies at A: or B: in the BIOS
+				AttachToBios(image, drive - 'A'); 
 			}
 		}
 		return true;
@@ -2998,7 +2998,8 @@ private:
 				}
 			}
 		}
-		else {
+		else if ((drive - 'A') < 2) {
+			//only mount A: or B: floppies to BIOS
 			AttachToBios(dsk, drive - 'A');
 		}
 		return true;

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -4762,6 +4762,8 @@ void write_FFFF_PC98_signature() {
 
 extern bool                         gdc_5mhz_mode;
 extern bool                         enable_pc98_egc;
+extern bool                         enable_pc98_grcg;
+extern bool                         enable_pc98_16color;
 
 void gdc_egc_enable_update_vars(void) {
     unsigned char b;
@@ -4873,7 +4875,7 @@ private:
 
             /* various BIOS flags */
             mem_writeb(0x53B,0x0F); // CRT_RASTER, 640x400 24.83KHz-hsync 56.42Hz-vsync
-            mem_writeb(0x54C,0x06); // PRXCRT, 16-color G-VRAM, GRCG
+            mem_writeb(0x54C,(enable_pc98_grcg ? 0x02 : 0x00) | (enable_pc98_16color ? 0x04 : 0x00)); // PRXCRT, 16-color G-VRAM, GRCG
             mem_writeb(0x54D,(enable_pc98_egc ? 0x40 : 0x00) | (gdc_5mhz_mode ? 0x20 : 0x00) | (gdc_5mhz_mode ? 0x04 : 0x00)); // EGC
             mem_writeb(0x597,(enable_pc98_egc ? 0x04 : 0x00/*FIXME*/)); // EGC
         }

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -360,8 +360,6 @@ imageDisk::imageDisk(FILE *imgFile, Bit8u *imgName, Bit32u imgSizeK, bool isHard
 		}
 		if(!founddisk) {
 			active = false;
-		} else {
-			incrementFDD();
 		}
 	}
     else { /* hard disk */

--- a/src/ints/bios_memdisk.cpp
+++ b/src/ints/bios_memdisk.cpp
@@ -42,13 +42,8 @@
 
 // Create a hard drive image of a specified size; automatically select c/h/s
 imageDiskMemory::imageDiskMemory(Bit32u imgSizeK) {
-	// The fatDrive class is hard-coded to assume that disks 2880KB or smaller are floppies,
-	//   whether or not they are attached to a floppy controller.  So, let's enforce a minimum
-	//   size of 4096kb for hard drives.  Use the other constructor for floppy drives.
-	if (imgSizeK < 4096) imgSizeK = 4096;
-
 	//notes:
-	//  this code always returns drives with 512 byte sectors
+	//  this code always returns HARD DRIVES with 512 byte sectors
 	//  the code will round up in case it cannot make an exact match
 	//  it enforces a minimum drive size of 32kb, since a hard drive cannot be formatted as FAT12 with a smaller parition
 	//  the code works properly throughout the range of a 32-bit unsigned integer, however:


### PR DESCRIPTION
New:
- More code cleanup in imgmount
- Fixed unchecked bounds while parsing size parameter. and makes sure size parameter values are >0.
- Added -chs parameter, which does the same as -size, but matches imgmake and seems to make more sense than inputting the values in reverse order.  Also, when using -chs, sector size is optional (defaults to 512).
- Added capability to imgmount ramdrives to A: or B:, and fixed some related bugs.

Problems still existing:
- Cannot mount ramdrive to B: and use BOOT to boot to A:, as BIOS does not simulate the fact that two floppy drives are connected.  Tried calling incrementFDD() from BOOT::Run but that made it worse.  Using imgmount to mount the floppy to A: and then boot -l A works as expected, however.

Also:
- Cannot boot to hard drive image (problem existed before this set of commits)