### PR TITLE
Fix potential format string vulnerabilities

### DIFF
--- a/src/dos/dos_memory.cpp
+++ b/src/dos/dos_memory.cpp
@@ -68,7 +68,7 @@ static void DOS_Mem_E_Exit(const char *msg) {
     LOG_MSG("DOS fatal memory error: %s",msg);
     throw int(7); // DOS non-fatal error (restart when debugger runs again)
 #else
-	E_Exit(msg);
+	E_Exit("%s",msg);
 #endif
 }
 

--- a/src/gui/midi_mt32.h
+++ b/src/gui/midi_mt32.h
@@ -249,7 +249,7 @@ void MidiHandler_mt32::MT32ReportHandler::printDebug(const char *fmt, va_list li
 		char s[1024];
 		strcpy(s, "MT32: ");
 		vsnprintf(s + 6, 1017, fmt, list);
-		LOG_MSG(s);
+		LOG_MSG("%s", s);
 	}
 }
 

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2870,7 +2870,7 @@ void BIND_MappingEvents(void) {
                 tmp[tmpl] = 0;
 
 				LOG(LOG_GUI,LOG_DEBUG)("Mapper keyboard event: %s",tmp);
-				bind_but.dbg->Change(tmp);
+				bind_but.dbg->Change("%s",tmp);
 				event_count++;
 			}
 			/* fall through to mapper UI processing */

--- a/src/hardware/pc98_fm.cpp
+++ b/src/hardware/pc98_fm.cpp
@@ -56,7 +56,7 @@ extern "C" void _TRACEOUT(const char *fmt,...) {
 
 void getbiospath(OEMCHAR *path, const OEMCHAR *fname, int maxlen) {
     LOG_MSG("PC98FM getbiospath fname='%s'",fname);
-    snprintf(path,maxlen,fname);
+    snprintf(path,maxlen,"%s",fname);
 }
 
 enum {


### PR DESCRIPTION
This allows compiling with `-Werror=format-security', which is required
for packaging in many GNU/Linux distributions.
See https://en.wikipedia.org/wiki/Uncontrolled_format_string for more
information.