### PR TITLE
MIDI/FluidSynth cleanup and fixes

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1639,10 +1639,14 @@ void DOSBOX_SetupConfigSections(void) {
 
 	Pstring = secprop->Add_string("midiconfig",Property::Changeable::WhenIdle,"");
 	Pstring->Set_help("Special configuration options for the device driver. This is usually the id of the device you want to use.\n"
-	                  "  or in the case of coreaudio, you can specify a soundfont here.\n"
+	                  "  or in the case of coreaudio or synth, you can specify a soundfont here.\n"
 	                  "  When using a Roland MT-32 rev. 0 as midi output device, some games may require a delay in order to prevent 'buffer overflow' issues.\n"
 	                  "  In that case, add 'delaysysex', for example: midiconfig=2 delaysysex\n"
 	                  "  See the README/Manual for more details.");
+
+	Pint = secprop->Add_int("samplerate",Property::Changeable::WhenIdle,44100);
+	Pint->Set_values(rates);
+	Pint->Set_help("Sample rate for MIDI synthesizer, if applicable.");
 	
 	Pint = secprop->Add_int("mpuirq",Property::Changeable::WhenIdle,-1);
 	Pint->SetMinMax(-1,15);

--- a/src/gui/midi_synth.h
+++ b/src/gui/midi_synth.h
@@ -189,10 +189,6 @@ public:
 
 		fluid_settings_setstr(settings, "audio.sample-format", "16bits");
 
-		if (synthsamplerate == 0) {
-			synthsamplerate = 44100;
-		}
-
 		fluid_settings_setnum(settings,
 			"synth.sample-rate", (double)synthsamplerate);
 

--- a/src/gui/midi_synth.h
+++ b/src/gui/midi_synth.h
@@ -19,105 +19,6 @@
 #include <fluidsynth.h>
 #include <math.h>
 
-#define FLUID_FREE(_p)               free(_p)
-#define FLUID_OK   (0) 
-#define FLUID_NEW(_t)                (_t*)malloc(sizeof(_t))
-
-/* Missing fluidsynth API follow: */
-extern "C" {
-  typedef struct _fluid_midi_parser_t fluid_midi_parser_t;
-  typedef struct _fluid_midi_event_t fluid_midi_event_t;
-
-  fluid_midi_parser_t * new_fluid_midi_parser(void);
-  fluid_midi_event_t * fluid_midi_parser_parse(fluid_midi_parser_t *parser, unsigned char c);
-
-  void fluid_log_config(void);
-}
-
-//static fluid_log_function_t fluid_log_function[LAST_LOG_LEVEL];
-//static int fluid_log_initialized = 0;
-
-struct _fluid_midi_event_t {
-  fluid_midi_event_t* next; /* Link to next event */
-  void *paramptr;           /* Pointer parameter (for SYSEX data), size is stored to param1, param2 indicates if pointer should be freed (dynamic if TRUE) */
-  unsigned int dtime;       /* Delay (ticks) between this and previous event. midi tracks. */
-  unsigned int param1;      /* First parameter */
-  unsigned int param2;      /* Second parameter */
-  unsigned char type;       /* MIDI event type */
-  unsigned char channel;    /* MIDI channel */
-};
-
-struct _fluid_midi_parser_t {
-  unsigned char status;           /* Identifies the type of event, that is currently received ('Noteon', 'Pitch Bend' etc). */
-  unsigned char channel;          /* The channel of the event that is received (in case of a channel event) */
-  unsigned int nr_bytes;          /* How many bytes have been read for the current event? */
-  unsigned int nr_bytes_total;    /* How many bytes does the current event type include? */
-  unsigned char data[1024]; /* The parameters or SYSEX data */
-  fluid_midi_event_t event;        /* The event, that is returned to the MIDI driver. */
-};
-
-enum fluid_midi_event_type {
-  /* channel messages */
-  NOTE_OFF = 0x80,
-  NOTE_ON = 0x90,
-  KEY_PRESSURE = 0xa0,
-  CONTROL_CHANGE = 0xb0,
-  PROGRAM_CHANGE = 0xc0,
-  CHANNEL_PRESSURE = 0xd0,
-  PITCH_BEND = 0xe0,
-  /* system exclusive */
-  MIDI_SYSEX = 0xf0,
-  /* system common - never in midi files */
-  MIDI_TIME_CODE = 0xf1,
-  MIDI_SONG_POSITION = 0xf2,
-  MIDI_SONG_SELECT = 0xf3,
-  MIDI_TUNE_REQUEST = 0xf6,
-  MIDI_EOX = 0xf7,
-  /* system real-time - never in midi files */
-  MIDI_SYNC = 0xf8,
-  MIDI_TICK = 0xf9,
-  MIDI_START = 0xfa,
-  MIDI_CONTINUE = 0xfb,
-  MIDI_STOP = 0xfc,
-  MIDI_ACTIVE_SENSING = 0xfe,
-  MIDI_SYSTEM_RESET = 0xff,
-  /* meta event - for midi files only */
-  MIDI_META_EVENT = 0xff
-};
-
-#if 0 /* UNUSED CODE */
-static int fluid_midi_event_length(unsigned char event) {
-      switch (event & 0xF0) {
-            case NOTE_OFF: 
-            case NOTE_ON:
-            case KEY_PRESSURE:
-            case CONTROL_CHANGE:
-            case PITCH_BEND: 
-                  return 3;
-            case PROGRAM_CHANGE:
-            case CHANNEL_PRESSURE: 
-                  return 2;
-      }
-      switch (event) {
-            case MIDI_TIME_CODE:
-            case MIDI_SONG_SELECT:
-            case 0xF4:
-            case 0xF5:
-                  return 2;
-            case MIDI_TUNE_REQUEST:
-                  return 1;
-            case MIDI_SONG_POSITION:
-                  return 3;
-      }
-      return 1;
-}
-#endif
-
-int delete_fluid_midi_parser(fluid_midi_parser_t* parser) {
-      FLUID_FREE(parser);
-      return FLUID_OK;
-}
-
 /* Protect against multiple inclusions */
 #ifndef MIXER_BUFSIZE
 #include "mixer.h"
@@ -125,7 +26,6 @@ int delete_fluid_midi_parser(fluid_midi_parser_t* parser) {
 
 static MixerChannel *synthchan = NULL;
 static fluid_synth_t *synth_soft = NULL;
-static fluid_midi_parser_t *synth_parser = NULL;
 static int synthsamplerate = 0;
 
 static void synth_log(int level, char *message, void *data) {
@@ -161,9 +61,60 @@ static void synth_CallBack(Bitu len) {
 class MidiHandler_synth: public MidiHandler {
 private:
 	fluid_settings_t *settings;
-	fluid_midi_router_t *router;
 	int sfont_id;
 	bool isOpen;
+
+	void PlayEvent(Bit8u *msg, Bitu len) {
+		Bit8u event = msg[0], channel, p1, p2;
+
+		switch (event) {
+		case 0xf0:
+		case 0xf7:
+			LOG(LOG_MISC,LOG_DEBUG)("SYNTH: sysex 0x%02x len %lu", (int)event, (long unsigned)len);
+			fluid_synth_sysex(synth_soft, (char *)(msg + 1), len - 1, NULL, NULL, NULL, 0);
+			return;
+		case 0xf9:
+			LOG(LOG_MISC,LOG_DEBUG)("SYNTH: midi tick");
+			return;
+		case 0xff:
+			LOG(LOG_MISC,LOG_DEBUG)("SYNTH: system reset");
+			fluid_synth_system_reset(synth_soft);
+			return;
+		case 0xf1: case 0xf2: case 0xf3: case 0xf4:
+		case 0xf5: case 0xf6: case 0xf8: case 0xfa:
+		case 0xfb: case 0xfc: case 0xfd: case 0xfe:
+			LOG(LOG_MISC,LOG_WARN)("SYNTH: unhandled event 0x%02x", (int)event);
+			return;
+		}
+
+		channel = event & 0xf;
+		p1 = len > 1 ? msg[1] : 0;
+		p2 = len > 2 ? msg[2] : 0;
+
+		LOG(LOG_MISC,LOG_DEBUG)("SYNTH: event 0x%02x channel %d, 0x%02x 0x%02x",
+			(int)event, (int)channel, (int)p1, (int)p2);
+
+		switch (event & 0xf0) {
+		case 0x80:
+			fluid_synth_noteoff(synth_soft, channel, p1);
+			break;
+		case 0x90:
+			fluid_synth_noteon(synth_soft, channel, p1, p2);
+			break;
+		case 0xb0:
+			fluid_synth_cc(synth_soft, channel, p1, p2);
+			break;
+		case 0xc0:
+			fluid_synth_program_change(synth_soft, channel, p1);
+			break;
+		case 0xd0:
+			fluid_synth_channel_pressure(synth_soft, channel, p1);
+			break;
+		case 0xe0:
+			fluid_synth_pitch_bend(synth_soft, channel, (p2 << 7) | p1);
+			break;
+		}
+	};
 
 public:
 	MidiHandler_synth() : MidiHandler(),isOpen(false) {};
@@ -181,7 +132,6 @@ public:
 			return false;
 		}
 
-		fluid_log_config();
 		fluid_set_log_function(FLUID_PANIC, synth_log, NULL);
 		fluid_set_log_function(FLUID_ERR, synth_log, NULL);
 		fluid_set_log_function(FLUID_WARN, synth_log, NULL);
@@ -223,26 +173,6 @@ public:
 			return false;
 		}
 
-		/* Allocate one event to store the input data */
-		synth_parser = new_fluid_midi_parser();
-		if (synth_parser == NULL) {
-			LOG(LOG_MISC,LOG_WARN)("SYNTH: Failed to allocate MIDI parser");
-			delete_fluid_synth(synth_soft);
-			delete_fluid_settings(settings);
-			return false;
-		}
-
-		router = new_fluid_midi_router(settings,
-					       fluid_synth_handle_midi_event,
-					       (void*)synth_soft);
-		if (router == NULL) {
-			LOG(LOG_MISC,LOG_WARN)("SYNTH: Failed to initialise MIDI router");
-			delete_fluid_midi_parser(synth_parser);
-			delete_fluid_synth(synth_soft);
-			delete_fluid_settings(settings);
-			return false;
-		}
-
 		synthchan = MIXER_AddChannel(synth_CallBack, synthsamplerate, "SYNTH");
 		synthchan->Enable(false);
 		isOpen = true;
@@ -254,49 +184,22 @@ public:
 
 		synthchan->Enable(false);
 		MIXER_DelChannel(synthchan);
-		delete_fluid_midi_router(router);
-		delete_fluid_midi_parser(synth_parser);
 		delete_fluid_synth(synth_soft);
 		delete_fluid_settings(settings);
 
 		synthchan = NULL;
-		router = NULL;
-		synth_parser = NULL;
 		synth_soft = NULL;
 		settings = NULL;
 		isOpen = false;
 	};
 
 	void PlayMsg(Bit8u *msg) {
-		fluid_midi_event_t *evt;
-		Bitu len;
-		Bitu i;
-
-		len=MIDI_evt_len[*msg];
 		synthchan->Enable(true);
-
-		/* let the parser convert the data into events */
-		for (i = 0; i < len; i++) {
-			evt = fluid_midi_parser_parse(synth_parser, msg[i]);
-			if (evt != NULL) {
-			  /* send the event to the next link in the chain */
-			  fluid_midi_router_handle_midi_event(router, evt);
-			}
-		}
+		PlayEvent(msg, MIDI_evt_len[*msg]);
 	};
 
 	void PlaySysex(Bit8u *sysex, Bitu len) {
-		fluid_midi_event_t *evt;
-		Bitu i;
-
-		/* let the parser convert the data into events */
-		for (i = 0; i < len; i++) {
-			evt = fluid_midi_parser_parse(synth_parser, sysex[i]);
-			if (evt != NULL) {
-			  /* send the event to the next link in the chain */
-			  fluid_midi_router_handle_midi_event(router, evt);
-			}
-		}
+		PlayEvent(sysex, len);
 	};
 };
 

--- a/src/gui/midi_synth.h
+++ b/src/gui/midi_synth.h
@@ -155,6 +155,12 @@ static void synth_CallBack(Bitu len) {
     }
 }
 
+#if defined (WIN32) || defined (OS2)
+#	define PATH_SEP "\\";
+#else
+#	define PATH_SEP "/";
+#endif
+
 class MidiHandler_synth: public MidiHandler {
 private:
 	fluid_settings_t *settings;
@@ -204,25 +210,19 @@ public:
 		}
 
 		/* Load a SoundFont */
-		extern std::string capturedir;
-		char str[260];
-		strcpy(str,capturedir.c_str());
-		#if defined (WIN32) || defined (OS2)
-		strcat(str,"\\");
-		#else
-		strcat(str,"/");
-		#endif
-		strcat(str,conf);
 		sfont_id = fluid_synth_sfload(synth_soft, conf, 0);
 		if (sfont_id == -1) {
-			sfont_id = fluid_synth_sfload(synth_soft, str, 0);
-			if (sfont_id == -1) {
-				LOG(LOG_MISC,LOG_WARN)("SYNTH: Failed to load MIDI sound font file \"%s\"",
-				   conf);
-				delete_fluid_synth(synth_soft);
-				delete_fluid_settings(settings);
-				return false;
-			}
+			extern std::string capturedir;
+			std::string str = capturedir + PATH_SEP + conf;
+			sfont_id = fluid_synth_sfload(synth_soft, str.c_str(), 0);
+		}
+
+		if (sfont_id == -1) {
+			LOG(LOG_MISC,LOG_WARN)("SYNTH: Failed to load MIDI sound font file \"%s\"",
+			   conf);
+			delete_fluid_synth(synth_soft);
+			delete_fluid_settings(settings);
+			return false;
 		}
 
 		/* Allocate one event to store the input data */


### PR DESCRIPTION
- Update fluidsynth configurables
- Clean up selection of MidiHandler
- Use std::string concat to make soundfont loading safer
- Minor cleanups to midi_synth.h
- Don't use private FluidSynth API
   Add an event parser function based on GStreamer's fluidsynthmidi plugin.

Fixes #497.