### PR TITLE
configure.ac: Check fluid_synth_sysex instead of new_fluid_synth

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -414,7 +414,7 @@ AC_CHECK_HEADER(X11/XKBlib.h, have_x11_h=yes, have_x11_h=no, )
 
 dnl LIBRARY TEST: Fluidsynth support
 AC_CHECK_HEADER(fluidsynth.h,have_fluidsynth_h=yes,)
-AC_CHECK_LIB(fluidsynth, new_fluid_synth, have_fluidsynth_lib=yes,,)
+AC_CHECK_LIB(fluidsynth, fluid_synth_sysex, have_fluidsynth_lib=yes,,)
 
 dnl LIBRARY TEST: FFMPEG support
 AC_CHECK_LIB(avcodec,avcodec_open2,have_ffmpeg=yes,have_ffmpeg=no,)


### PR DESCRIPTION
Disabling FluidSynth support is the simplest solution to unbreaking the
build with FluidSynth 1.0.9.

Of the FluidSynth functions used this is the one added latest, before
the release of 1.1.0.

1.0.9 is also missing fluid_synth_system_reset, which seems rather
important to have.