### PR TITLE
Add dosbox.conf option to not disable dynamic core while paging is on.

### DIFF
--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -260,6 +260,8 @@ extern int dynamic_core_cache_block_size;
 
 static bool paging_warning = true;
 
+bool use_dynamic_core_with_paging = false;
+
 Bits CPU_Core_Dyn_X86_Run(void) {
     /* Dynamic core is NOT compatible with the way page faults
      * in the guest are handled in this emulator. Do not use
@@ -270,7 +272,7 @@ Bits CPU_Core_Dyn_X86_Run(void) {
      * with the idea that it works. This code cannot handle
      * the sudden context switch of a page fault and it never
      * will. Don't do it. You have been warned. */
-    if (paging.enabled) {
+    if (paging.enabled && !use_dynamic_core_with_paging) {
         if (paging_warning) {
             LOG_MSG("Dynamic core warning: The guest OS/Application has just switched on 80386 paging, which is not supported by the dynamic core. The normal core will be used until paging is switched off again.");
             paging_warning = false;

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -66,6 +66,8 @@ bool ignore_undefined_msr = true;
 
 extern bool ignore_opcode_63;
 
+extern bool use_dynamic_core_with_paging;
+
 bool cpu_double_fault_enable;
 bool cpu_triple_fault_reset;
 
@@ -2884,6 +2886,7 @@ public:
 		CPU_SkipCycleAutoAdjust=false;
 
 		ignore_opcode_63 = section->Get_bool("ignore opcode 63");
+		use_dynamic_core_with_paging = section->Get_bool("use dynamic core with paging on");
 		cpu_double_fault_enable = section->Get_bool("double fault");
 		cpu_triple_fault_reset = section->Get_bool("reset on triple fault");
 		cpu_allow_big16 = section->Get_bool("realbig16");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1541,6 +1541,10 @@ void DOSBOX_SetupConfigSections(void) {
 	Pint->SetMinMax(1,1000000);
 	Pint->Set_help("Setting it lower than 100 will be a percentage.");
 
+	Pbool = secprop->Add_bool("use dynamic core with paging on",Property::Changeable::Always,false);
+	Pbool->Set_help("Dynamic core is NOT compatible with the way page faults in the guest are handled in DosBox-X.\n"
+			"Windows 9x may crash with paging on if dynamic core is enabled.\n");
+			
 	Pbool = secprop->Add_bool("ignore opcode 63",Property::Changeable::Always,true);
 	Pbool->Set_help("When debugging, do not report illegal opcode 0x63.\n"
 			"Enable this option to ignore spurious errors while debugging from within Windows 3.1/9x/ME");


### PR DESCRIPTION
I've found that Windows 3.1 is running too slow in Dosbox-X on some of my PCs. It's because that Dosbox-X force itself to use normal core when 386 paging is on.
I understand and appreciate joncampbell123's struggle for running Windows 9x better in Dosbox-X, however in my tests I'm sure that Dosbox-X only crashes using dynamic core in Windows 3.1 when running Win32s or DOS programs and most Win16 programs work well with it.
I thought that there should be an option (disabled by default, of course) to force using dynamic core with paging on for some users.
