### PR TITLE
Fix parsing .BAT filenames, which not in current directory, in command line.

### DIFF
--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -396,19 +396,27 @@ public:
         if (!control->auto_bat_additional.empty()) {
             std::string cmd;
 
-            cmd += "@mount c: . -q\n";
-            cmd += "@c:\n";
-            cmd += "@cd \\\n";
-
             for (unsigned int i=0;i<control->auto_bat_additional.size();i++) {
+				std::string batname;
+				/* NTS: this code might have problems with DBCS filenames - yksoft1 */
+				size_t pos = control->auto_bat_additional[i].find_last_of(CROSS_FILESPLIT);
+				if(pos == std::string::npos) {  //Only a filename, mount current directory
+					batname = control->auto_bat_additional[i];
+					cmd += "@mount c: . -q\n";
+				} else { //Parse the path of .BAT file
+					std::string batpath = control->auto_bat_additional[i].substr(0,pos+1);
+					batname = control->auto_bat_additional[i].substr(pos+1);
+					cmd += "@mount c: " + batpath + " -q\n";
+				}
+				cmd += "@c:\n";
+				cmd += "@cd \\\n";
                 /* NTS: "CALL" does not support quoting the filename.
                  *      This will break if the batch file name has spaces in it. */
                 cmd += "@CALL ";
-                cmd += control->auto_bat_additional[i];
+                cmd += batname;
                 cmd += "\n";
+				cmd += "@mount -u c: -q\n";
             }
-
-            cmd += "@mount -u c: -q\n";
 
             autoexec_auto_bat.Install(cmd);
         }


### PR DESCRIPTION
This is for fixing bug #658. 
