### PR TITLE
Add an experimental implementation for PC-9821 31KHz video mode.

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1185,6 +1185,10 @@ void DOSBOX_SetupConfigSections(void) {
                     "in 200-line graphics modes upconverted to 400-line raster display. When enabled, odd\n"
                     "numbered scanlines are blanked instead of doubled");
 
+	Pbool = secprop->Add_bool("pc-98 31-khz video mode",Property::Changeable::WhenIdle,false);
+	Pbool->Set_help("Emulate PC-9821 31-KHz VGA compatible video mode when enabled. \n"
+					"Experimental and may not be accurate at all.");
+
 	Pint = secprop->Add_int("pc-98 timer master frequency", Property::Changeable::WhenIdle,0);
 	Pint->SetMinMax(0,2457600);
 	Pint->Set_help("8254 timer clock frequency (NEC PC-98). Depending on the CPU frequency the clock frequency is one of two common values.\n"

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -58,6 +58,8 @@ extern float hretrace_fx_avg_weight;
 extern bool ignore_vblank_wraparound;
 extern bool vga_double_buffered_line_compare;
 
+extern bool pc98_31khz_mode;
+
 void memxor(void *_d,unsigned int byte,size_t count) {
 	unsigned char *d = (unsigned char*)_d;
 	while (count-- > 0) *d++ ^= byte;
@@ -2053,7 +2055,7 @@ void VGA_SetupDrawing(Bitu /*val*/) {
         if (false/*future 15KHz hsync*/) {
             oscclock = 14318180;
         }
-        else if (true/*24KHz hsync*/) {
+        else if (!pc98_31khz_mode/*24KHz hsync*/) {
             oscclock = 21052600;
         }
         else {/*31KHz VGA-like hsync*/
@@ -2142,7 +2144,7 @@ void VGA_SetupDrawing(Bitu /*val*/) {
             if (false/*future 15KHz hsync*/) {
                 oscclock = 14318180;
             }
-            else if (true/*24KHz hsync*/) {
+            else if (!pc98_31khz_mode/*24KHz hsync*/) {
                 oscclock = 21052600;
             }
             else {/*31KHz VGA-like hsync*/


### PR DESCRIPTION
I used some display parameters based on http://island.geocities.jp/cklouch/column/pc98bas/pc98dispout2_en.htm, http://tinyvga.com/vga-timing/640x400@70Hz and speculation. 
Experimental and might not be correct at all.