### PR TITLE
Miscellaneous cleanup to imageDisk classes

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -51,12 +51,14 @@ extern const Bit8u freedos_mbr[];
 
 class imageDisk {
 public:
-	enum {
+	enum IMAGE_TYPE {
 		ID_BASE=0,
 		ID_EL_TORITO_FLOPPY,
-        ID_VFD
+        ID_VFD,
+		ID_MEMORY,
+		ID_VHD
 	};
-public:
+
 	virtual Bit8u Read_Sector(Bit32u head,Bit32u cylinder,Bit32u sector,void * data);
 	virtual Bit8u Write_Sector(Bit32u head,Bit32u cylinder,Bit32u sector,void * data);
 	virtual Bit8u Read_AbsoluteSector(Bit32u sectnum, void * data);
@@ -68,28 +70,31 @@ public:
 	virtual void Get_Geometry(Bit32u * getHeads, Bit32u *getCyl, Bit32u *getSect, Bit32u *getSectSize);
 	virtual Bit8u GetBiosType(void);
 	virtual Bit32u getSectSize(void);
-    imageDisk();
 	imageDisk(FILE *imgFile, Bit8u *imgName, Bit32u imgSizeK, bool isHardDisk);
+	imageDisk(FILE* diskimg, const char* diskName, Bit32u cylinders, Bit32u heads, Bit32u sectors, Bit32u sector_size, bool hardDrive);
 	virtual ~imageDisk() { if(diskimg != NULL) { fclose(diskimg); diskimg=NULL; } };
 
-	int class_id;
-
-	bool hardDrive;
-	bool active;
-	FILE *diskimg;
+	IMAGE_TYPE class_id;
 	std::string diskname;
+	bool active;
+	Bit32u sector_size;
+	Bit32u heads, cylinders, sectors;
+	bool hardDrive;
+	Bit64u diskSizeK;
+
+protected:
+	imageDisk(IMAGE_TYPE class_id);
+	FILE *diskimg;
 	Bit8u floppytype;
 
-	Bit32u sector_size;
-	Bit32u heads,cylinders,sectors;
 	Bit32u reserved_cylinders;
-	Bit64u current_fpos;
     Bit64u image_base;
-    Bit32u diskSizeK;
+	Bit64u image_length;
 
+private:
 	volatile int refcount;
-	bool auto_delete_on_refcount_zero;
 
+public:
 	int Addref() {
 		return ++refcount;
 	}
@@ -99,7 +104,7 @@ public:
 			fprintf(stderr,"WARNING: imageDisk Release() changed refcount to %d\n",ret);
 			abort();
 		}
-		if (ret == 0 && auto_delete_on_refcount_zero) delete this;
+		if (ret == 0) delete this;
 		return ret;
 	}
 };
@@ -154,7 +159,7 @@ public:
 	// Create a hard drive image of a specified size; automatically select c/h/s
 	imageDiskMemory(Bit32u imgSizeK);
 	// Create a hard drive image of a specified geometry
-	imageDiskMemory(Bit32u cylinders, Bit32u heads, Bit32u sectors, Bit32u sectorSize);
+	imageDiskMemory(Bit16u cylinders, Bit16u heads, Bit16u sectors, Bit16u sectorSize);
 	// Create a floppy image of a specified geometry
 	imageDiskMemory(diskGeo floppyGeometry);
 	// Create a copy-on-write memory image of an existing image
@@ -261,7 +266,7 @@ private:
 		bool IsValid();
 	};
 
-	imageDiskVHD() : parentDisk(NULL), copiedFooter(false), currentBlock(0xFFFFFFFF), currentBlockAllocated(false), currentBlockDirtyMap(NULL) { }
+	imageDiskVHD() : imageDisk(ID_VHD), parentDisk(NULL), copiedFooter(false), currentBlock(0xFFFFFFFF), currentBlockAllocated(false), currentBlockDirtyMap(NULL) { }
 	static ErrorCodes TryOpenParent(const char* childFileName, const ParentLocatorEntry &entry, Bit8u* data, const Bit32u dataLength, imageDisk** disk, const Bit8u* uniqueId);
 	static ErrorCodes Open(const char* fileName, const bool readOnly, imageDisk** imageDisk, const Bit8u* matchUniqueId);
 	virtual bool loadBlock(const Bit32u blockNumber);

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2338,7 +2338,7 @@ public:
 			LOG_MSG("BUG! unsupported floppy_emu_type in El Torito floppy object\n");
 		}
 
-        diskSizeK = (((heads * cylinders * sectors * sector_size) + 1023) / 1024);
+        diskSizeK = ((Bit64u)heads * cylinders * sectors * sector_size) / 1024;
 		active = true;
 	}
 	virtual ~imageDiskElToritoFloppy() {

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -788,7 +788,7 @@ Bit32u fatDrive::getSectSize(void) {
     return sector_size;
 }
 
-void fatDrive::fatDriveInit(const char *sysFilename, Bit32u bytesector, Bit32u cylsector, Bit32u headscyl, Bit32u cylinders, Bit32u filesize) {
+void fatDrive::fatDriveInit(const char *sysFilename, Bit32u bytesector, Bit32u cylsector, Bit32u headscyl, Bit32u cylinders, Bit64u filesize) {
 	Bit32u startSector;
 	bool pc98_512_to_1024_allow = false;
 	struct partTable mbrData;

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -206,7 +206,7 @@ class fatDrive : public DOS_Drive {
 public:
 	fatDrive(const char * sysFilename, Bit32u bytesector, Bit32u cylsector, Bit32u headscyl, Bit32u cylinders);
 	fatDrive(imageDisk *sourceLoadedDisk);
-    void fatDriveInit(const char *sysFilename, Bit32u bytesector, Bit32u cylsector, Bit32u headscyl, Bit32u cylinders, Bit32u filesize);
+    void fatDriveInit(const char *sysFilename, Bit32u bytesector, Bit32u cylsector, Bit32u headscyl, Bit32u cylinders, Bit64u filesize);
     virtual ~fatDrive();
 	virtual bool FileOpen(DOS_File * * file,const char * name,Bit32u flags);
 	virtual bool FileCreate(DOS_File * * file,const char * name,Bit16u attributes);

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -232,7 +232,11 @@ Bit8u imageDisk::Read_AbsoluteSector(Bit32u sectnum, void * data) {
 	int got;
 
 	bytenum = (Bit64u)sectnum * (Bit64u)sector_size;
-    bytenum += image_base;
+	if ((bytenum + sector_size) > this->image_length) {
+		LOG_MSG("Attempt to read invalid sector in Read_AbsoluteSector for sector %lu.\n", (unsigned long)sectnum);
+		return 0x05;
+	}
+	bytenum += image_base;
 
 	//LOG_MSG("Reading sectors %ld at bytenum %I64d", sectnum, bytenum);
 
@@ -267,13 +271,17 @@ Bit8u imageDisk::Write_AbsoluteSector(Bit32u sectnum, void *data) {
 	Bit64u bytenum;
 
 	bytenum = (Bit64u)sectnum * sector_size;
-    bytenum += image_base;
+	if ((bytenum + sector_size) > this->image_length) {
+		LOG_MSG("Attempt to read invalid sector in Write_AbsoluteSector for sector %lu.\n", (unsigned long)sectnum);
+		return 0x05;
+	}
+	bytenum += image_base;
 
 	//LOG_MSG("Writing sectors to %ld at bytenum %d", sectnum, bytenum);
 
 	fseeko64(diskimg,bytenum,SEEK_SET);
 	if ((Bit64u)ftello64(diskimg) != bytenum)
-		LOG_MSG("WARNING: fseek() failed in Read_AbsoluteSector for sector %lu\n",(unsigned long)sectnum);
+		LOG_MSG("WARNING: fseek() failed in Write_AbsoluteSector for sector %lu\n",(unsigned long)sectnum);
 
 	size_t ret=fwrite(data, sector_size, 1, diskimg);
 

--- a/src/ints/bios_vhd.cpp
+++ b/src/ints/bios_vhd.cpp
@@ -95,16 +95,7 @@ imageDiskVHD::ErrorCodes imageDiskVHD::Open(const char* fileName, const bool rea
 			fclose(file);
 			return INVALID_DATA;
 		}
-		imageDisk* d = new imageDisk();
-		d->cylinders = footer.geometry.cylinders;
-		d->heads = footer.geometry.heads;
-		d->sectors = footer.geometry.sectors;
-		d->sector_size = 512;
-		d->diskSizeK = (Bit32u)(calcDiskSize / (Bit64u)1024); //impossible to overflow
-		d->diskimg = file;
-		d->hardDrive = true;
-		d->active = true;
-		*disk = d;
+		*disk = new imageDisk(file, fileName, footer.geometry.cylinders, footer.geometry.heads, footer.geometry.sectors, 512, true);
 		return OPEN_SUCCESS;
 	}
 
@@ -118,7 +109,7 @@ imageDiskVHD::ErrorCodes imageDiskVHD::Open(const char* fileName, const bool rea
 	vhd->heads = footer.geometry.heads;
 	vhd->sectors = footer.geometry.sectors;
 	vhd->sector_size = 512;
-	vhd->diskSizeK = (Bit32u)(calcDiskSize / (Bit64u)1024); //impossible to overflow
+	vhd->diskSizeK = calcDiskSize / 1024;
 	vhd->diskimg = file;
 	vhd->hardDrive = true;
 	vhd->active = true;


### PR DESCRIPTION
- reduce scope of variables not accessed outside of imageDisk
- delete unused variables
- protect virtualized software from overwriting past end of a mounted image (for example, a VHD file has a footer, which could be easily overwritten if the chs values were ignored or changed)
- enforce classes that inherit from imageDisk to define and use a unique class_id (what's the point of this variable anyway? let's delete it!)
- similar misc stuff