### PR TITLE
PC-98: A quick and dirty hack to force an IBM US-English like keyboard layout in BIOS

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1213,6 +1213,9 @@ void DOSBOX_SetupConfigSections(void) {
                    "    0: Disable\n"
                    "    1: Enable");
 
+	Pbool = secprop->Add_bool("pc-98 force ibm keyboard layout",Property::Changeable::WhenIdle,false);
+	Pbool->Set_help("Force to use a default keyboard layout like IBM US-English for PC-98 emulation.\n");
+
 	Pint = secprop->Add_int("vga bios size override", Property::Changeable::WhenIdle,0);
 	Pint->SetMinMax(512,65536);
 	Pint->Set_help("VGA BIOS size override. Override the size of the VGA BIOS (normally 32KB in compatible or 12KB in non-compatible).");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1214,7 +1214,8 @@ void DOSBOX_SetupConfigSections(void) {
                    "    1: Enable");
 
 	Pbool = secprop->Add_bool("pc-98 force ibm keyboard layout",Property::Changeable::WhenIdle,false);
-	Pbool->Set_help("Force to use a default keyboard layout like IBM US-English for PC-98 emulation.\n");
+	Pbool->Set_help("Force to use a default keyboard layout like IBM US-English for PC-98 emulation.\n"
+					"Will only work with apps and games using BIOS for keyboard.");
 
 	Pint = secprop->Add_int("vga bios size override", Property::Changeable::WhenIdle,0);
 	Pint->SetMinMax(512,65536);

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -561,6 +561,7 @@ irq1_end:
 }
 
 unsigned char AT_read_60(void);
+extern bool pc98_force_ibm_layout;
 
 /* BIOS INT 18h output vs keys:
  *
@@ -694,7 +695,10 @@ static Bitu IRQ1_Handler_PC98(void) {
             case 0x02:  //  2           2       "       ???     フ
                 if (pressed) {
                     if (flags1 & 3) /* shift */
-                        add_key(scan_add + '\"');
+						if(!pc98_force_ibm_layout)
+							add_key(scan_add + '\"');
+						else
+							add_key(scan_add + '@');
                     else
                         add_key(scan_add + '2');
                 }
@@ -726,7 +730,10 @@ static Bitu IRQ1_Handler_PC98(void) {
             case 0x06:  //  6           6       &       ???     オ
                 if (pressed) {
                     if (flags1 & 3) /* shift */
-                        add_key(scan_add + '&');
+						if(!pc98_force_ibm_layout)
+							add_key(scan_add + '&');
+						else
+							add_key(scan_add + '^');
                     else
                         add_key(scan_add + '6');
                 }
@@ -734,7 +741,10 @@ static Bitu IRQ1_Handler_PC98(void) {
             case 0x07:  //  7           7       '       ???     ヤ
                 if (pressed) {
                     if (flags1 & 3) /* shift */
-                        add_key(scan_add + '\'');
+						if(!pc98_force_ibm_layout)
+							add_key(scan_add + '\'');
+						else
+							add_key(scan_add + '&');
                     else
                         add_key(scan_add + '7');
                 }
@@ -742,7 +752,10 @@ static Bitu IRQ1_Handler_PC98(void) {
             case 0x08:  //  8           8       (       ???     ユ
                 if (pressed) {
                     if (flags1 & 3) /* shift */
-                        add_key(scan_add + '(');
+						if(!pc98_force_ibm_layout)
+							add_key(scan_add + '(');
+						else
+							add_key(scan_add + '*');
                     else
                         add_key(scan_add + '8');
                 }
@@ -750,7 +763,10 @@ static Bitu IRQ1_Handler_PC98(void) {
             case 0x09:  //  9           9       )       ???     ヨ
                 if (pressed) {
                     if (flags1 & 3) /* shift */
-                        add_key(scan_add + ')');
+						if(!pc98_force_ibm_layout)
+							add_key(scan_add + ')');
+						else
+							add_key(scan_add + '(');
                     else
                         add_key(scan_add + '9');
                 }
@@ -758,7 +774,10 @@ static Bitu IRQ1_Handler_PC98(void) {
             case 0x0A:  //  0           0       ---     ???     ワ
                 if (pressed) {
                     if (flags1 & 3) /* shift */
-                        { /* nothing */ }
+						if(!pc98_force_ibm_layout)
+							{ /* nothing */ }
+						else
+							add_key(scan_add + ')');
                     else
                         add_key(scan_add + '0');
                 }
@@ -766,17 +785,27 @@ static Bitu IRQ1_Handler_PC98(void) {
             case 0x0B:  //  -           -       =       ???     ホ
                 if (pressed) {
                     if (flags1 & 3) /* shift */
-                        add_key(scan_add + '=');
+						if(!pc98_force_ibm_layout)
+							add_key(scan_add + '=');
+						else
+							add_key(scan_add + '_');
                     else
                         add_key(scan_add + '-');
                 }
                 break;
             case 0x0C:  //  ^           ^       `       ???     ヘ
                 if (pressed) {
-                    if (flags1 & 3) /* shift */
-                        add_key(scan_add + '`');
-                    else
-                        add_key(scan_add + '^');
+					if(!pc98_force_ibm_layout) {
+						if (flags1 & 3) /* shift */
+							add_key(scan_add + '`');
+						else
+							add_key(scan_add + '^');
+					} else {
+						if (flags1 & 3) /* shift */
+							add_key(scan_add + '+');
+						else
+							add_key(scan_add + '=');					
+					}
                 }
                 break;
             case 0x0D:  //  ¥           ¥       |       ???     ???
@@ -882,7 +911,10 @@ static Bitu IRQ1_Handler_PC98(void) {
                     if (flags1 & 3) /* shift */
                         add_key(scan_add + '~');
                     else
-                        add_key(scan_add + '@');
+						if(!pc98_force_ibm_layout)
+							add_key(scan_add + '@');
+						else
+							add_key(scan_add + '`');
                 }
                 break;
             case 0x1B: // [             [       {       --      ﾟ       ｢
@@ -973,17 +1005,27 @@ static Bitu IRQ1_Handler_PC98(void) {
             case 0x26: //   ;           ;       +       ---     レ
                 if (pressed) {
                     if (flags1 & 3) /* shift */
-                        add_key(scan_add + '+');
+						if(!pc98_force_ibm_layout)
+							add_key(scan_add + '+');
+						else
+							add_key(scan_add + ':');
                     else
                         add_key(scan_add + ';');
                 }
                 break;
             case 0x27: //   :           :       *       ---     ケ
                 if (pressed) {
-                    if (flags1 & 3) /* shift */
-                        add_key(scan_add + '*');
-                    else
-                        add_key(scan_add + ':');
+					if(!pc98_force_ibm_layout) {
+						if (flags1 & 3) /* shift */
+							add_key(scan_add + '*');
+						else
+							add_key(scan_add + ':');
+					} else {
+						if (flags1 & 3) /* shift */
+							add_key(scan_add + '\"');
+						else
+							add_key(scan_add + '\'');
+					}
                 }
                 break;
             case 0x28: //   ]           ]       }       ---     ム      ｣


### PR DESCRIPTION
Changed some key mappings that different between IBM and PC-98 layouts only.
Note: I think this code will only work for those games/apps that use BIOS for keyboard.

It's a dirty hack and you may ignore this if you think it's unacceptable.
 