### PR TITLE
Check for Direct3D 9 headers in configure.ac, but don't enable Direct3D 9 support in MinGW for now.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -430,6 +430,10 @@ AC_CHECK_LIB(GL, main, have_gl_lib=yes, have_gl_lib=no , )
 AC_CHECK_LIB(opengl32, main, have_opengl32_lib=yes,have_opengl32_lib=no , )
 AC_CHECK_HEADER(GL/gl.h, have_gl_h=yes , have_gl_h=no , )
 
+dnl LIBRARY TEST: Direct3D 9 header support
+AC_CHECK_HEADER(d3d9.h, have_d3d9_h=yes , have_d3d9_h=no , )
+AC_CHECK_HEADER(d3dx9math.h, have_d3dx9math_h=yes , have_d3dx9math_h=no , )
+
 dnl ================== SDL net special test for OS/2
 if test x$host = xi386-pc-os2-emx ; then
   LIBS_BACKUP=$LIBS;
@@ -679,6 +683,34 @@ case "$host" in
        fi
        ;;
 esac
+fi
+
+dnl FEATURE: Whether to use Direct3D 9 output
+AH_TEMPLATE(HAVE_D3D9_H,[Define to 1 to use Direct3D 9 display output support])
+AC_ARG_ENABLE(d3d9,AC_HELP_STRING([--disable-d3d9],[Disable Direct3D 9 support]),,enable_d3d9=yes)
+AC_MSG_CHECKING(whether Direct3D 9 display output will be enabled)
+
+# HACK: Don't enable Direct 3D 9 on SDL2
+if test -n "$SDL2_LIBS"; then
+    enable_d3d9=no
+fi
+
+if test x$enable_d3d9 = xyes; then
+case "$host" in
+    *-*-cygwin* | *-*-mingw32*)
+      if test x$have_d3d9_h = xyes -a x$have_d3dx9math_h = xyes ; then
+        AC_MSG_RESULT(yes)
+        AC_DEFINE(HAVE_D3D9_H,1)
+	  else
+        AC_MSG_RESULT(no)
+      fi
+    ;;
+    *)
+     AC_MSG_RESULT(no)
+    ;;
+esac
+else
+  AC_MSG_RESULT(no)
 fi
 
 AC_CONFIG_FILES([ 

--- a/configure.ac
+++ b/configure.ac
@@ -687,7 +687,7 @@ fi
 
 dnl FEATURE: Whether to use Direct3D 9 output
 AH_TEMPLATE(HAVE_D3D9_H,[Define to 1 to use Direct3D 9 display output support])
-AC_ARG_ENABLE(d3d9,AC_HELP_STRING([--disable-d3d9],[Disable Direct3D 9 support]),,enable_d3d9=yes)
+AC_ARG_ENABLE(d3d9,AC_HELP_STRING([--enable-d3d9],[Enable Direct3D 9 support]),,enable_d3d9=no)
 AC_MSG_CHECKING(whether Direct3D 9 display output will be enabled)
 
 # HACK: Don't enable Direct 3D 9 on SDL2

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1919,8 +1919,8 @@ dosurface:
 			}
 		}
 		else {
-			int final_height = max(sdl.clip.h, userResizeWindowHeight);
-			int final_width = max(sdl.clip.w, userResizeWindowWidth);
+			int final_height = max((Bitu)sdl.clip.h, userResizeWindowHeight);
+			int final_width = max((Bitu)sdl.clip.w, userResizeWindowWidth);
 
 			window_width = final_width;
 			window_height = final_height;
@@ -5240,7 +5240,7 @@ void SDL_SetupConfigSection() {
 #ifdef __WIN32__
 # if defined(HX_DOS)
 		Pstring = sdl_sec->Add_string("output", Property::Changeable::Always, "surface"); /* HX DOS should stick to surface */
-# elif defined(__MINGW32__)
+# elif defined(__MINGW32__) && !(HAVE_D3D9_H)
 		Pstring = sdl_sec->Add_string("output", Property::Changeable::Always, "opengl"); /* MinGW builds do not yet have Direct3D */
 # else
 		Pstring = sdl_sec->Add_string("output", Property::Changeable::Always, "direct3d");


### PR DESCRIPTION
I found that if HAVE_D3D9_H is enabled and the headers from mingw-w64 are present, Dosbox-X builds but will crash at enabling Direct3D output.