### PR TITLE
PC-98: Make MSW4 Sound BIOS bit configurable for some older games that need it.

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1184,6 +1184,10 @@ void DOSBOX_SetupConfigSections(void) {
     Phex = secprop->Add_hex("pc-98 fm board io port", Property::Changeable::WhenIdle,0);
     Phex->Set_help("If set, helps to determine the base I/O port of the FM board. A setting of zero means to auto-determine the port number.");
 
+    Pbool = secprop->Add_bool("pc-98 sound bios",Property::Changeable::WhenIdle,false);
+    Pbool->Set_help("Set Sound BIOS enabled bit in MEMSW 4 for some games that require it.\n"
+                    "TODO: Real emulation of PC-9801-26K/86 Sound BIOS");
+
     Pbool = secprop->Add_bool("pc-98 buffer page flip",Property::Changeable::WhenIdle,false);
     Pbool->Set_help("If set, the game's request to page flip will be delayed to vertical retrace, which can eliminate tearline artifacts.\n"
                     "Note that this is NOT the behavior of actual hardware. This option is provided for the user's preference.");


### PR DESCRIPTION
Some older booter games (for example Falcom's Ys II and Sorcerian) requires that bit in Memory Switch set to on for detecting FM board. They don't actually use Sound BIOS but without this bit on they wouldn't try to detect FM board at all.
In fact, Sound BIOS on PC-9801-26K or 86 boards are almost only used for N88-BASIC extended BASIC PLAY command and almost not used by any games at all. But we could make Dosbox-X to load SOUND.ROM for Neko Project II or simulate Sound BIOS calls ourselves later when we emulate N88-BASIC.
