### PR TITLE
xBRZ branch updates

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1478,6 +1478,14 @@ void DOSBOX_SetupConfigSections(void) {
     Pint->SetMinMax(1,1024);
     Pint->Set_help("Number of screen lines to process in single xBRZ scaler taskset task, affects xBRZ performance, 16 is the default");
 
+    Pint = secprop->Add_int("xbrz fixed scale factor",Property::Changeable::OnlyAtStart, 0);
+    Pint->SetMinMax(0,6);
+    Pint->Set_help("To use fixed xBRZ scale factor (i.e. to attune performance), set it to 2-6, 0 - use automatic calculation (default)");
+
+    Pint = secprop->Add_int("xbrz max scale factor",Property::Changeable::OnlyAtStart, 0);
+    Pint->SetMinMax(0,6);
+    Pint->Set_help("To cap maximum xBRZ scale factor used (i.e. to attune performance), set it to 2-6, 0 - use scaler allowed maximum (default)");
+
     Pbool = secprop->Add_bool("autofit",Property::Changeable::Always,true);
     Pbool->Set_help(
         "Best fits image to window\n"

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -567,9 +567,17 @@ struct SDL_Block {
     bool deferred_resize;
     bool init_ignore;
     unsigned int gfx_force_redraw_count = 0;
-    bool xBRZ;
-    bool xBRZ_Bilinear;
-    int xBRZ_task_granularity = 16;
+    struct {
+        bool enable;
+        bool postscale_bilinear;
+        int task_granularity = 16;
+        int fixed_scale_factor = 0;
+        int max_scale_factor = xbrz::SCALE_FACTOR_MAX;
+        std::vector<uint32_t> renderbuf;
+        std::vector<uint32_t> pixbuf;
+        bool tex_scale_on;
+        int tex_scale_factor;
+    } xBRZ;
 };
 
 static SDL_Block sdl;
@@ -1789,7 +1797,7 @@ dosurface:
         sdl.clip.w=width;
         sdl.clip.h=height;
         if (GFX_IsFullscreen()) {
-            if (sdl.desktop.full.fixed || sdl.xBRZ) {
+            if (sdl.desktop.full.fixed) {
                 sdl.clip.x=(Sint16)((sdl.desktop.full.width-width)/2);
                 sdl.clip.y=(Sint16)((sdl.desktop.full.height-height)/2);
                 sdl.window = GFX_SetSDLWindowMode(sdl.desktop.full.width,
@@ -1877,7 +1885,7 @@ dosurface:
             Uint32 wflags = SDL_FULLSCREEN | SDL_HWPALETTE |
                 ((flags & GFX_CAN_RANDOM) ? SDL_SWSURFACE : SDL_HWSURFACE) |
                 (sdl.desktop.doublebuf ? SDL_DOUBLEBUF|SDL_ASYNCBLIT : 0);
-            if (sdl.desktop.full.fixed || sdl.xBRZ) 
+            if (sdl.desktop.full.fixed) 
             {
                 sdl.clip.x=(Sint16)((sdl.desktop.full.width-width)/2);
                 sdl.clip.y=(Sint16)((sdl.desktop.full.height-height)/2);
@@ -2076,7 +2084,31 @@ dosurface:
         glGetIntegerv(GL_MAX_TEXTURE_SIZE, &sdl.opengl.max_texsize);
 
         //if (!(flags&GFX_CAN_32) || (flags & GFX_RGBONLY)) goto dosurface;
-        int texsize=2 << int_log2(width > height ? width : height);
+
+        // we do the same as with Direct3D: precreate pixel buffer adjusted for xBRZ
+        Bitu adjTexWidth = width;
+        Bitu adjTexHeight = height;
+        if (sdl.xBRZ.enable) 
+        {
+            sdl.xBRZ.tex_scale_factor = (sdl.xBRZ.fixed_scale_factor == 0) ?
+                static_cast<int>(std::sqrt(1.0 * sdl.clip.w * sdl.clip.h / (width * height)) + 0.5) :
+                sdl.xBRZ.fixed_scale_factor;
+
+            if (sdl.xBRZ.tex_scale_factor >= 2)
+            {
+                sdl.xBRZ.tex_scale_factor = min(sdl.xBRZ.tex_scale_factor, sdl.xBRZ.max_scale_factor);
+                adjTexWidth = width * sdl.xBRZ.tex_scale_factor;
+                adjTexHeight = height * sdl.xBRZ.tex_scale_factor;
+                sdl.xBRZ.tex_scale_on = true;
+            }
+            else
+            {
+                // we cannot scale, so do not even attempt to
+                sdl.xBRZ.tex_scale_on = false;
+            }
+        }
+
+        int texsize=2 << int_log2(adjTexWidth > adjTexHeight ? adjTexWidth : adjTexHeight);
         if (texsize>sdl.opengl.max_texsize) {
             LOG_MSG("SDL:OPENGL:No support for texturesize of %d (max size is %d), falling back to surface",texsize,sdl.opengl.max_texsize);
             goto dosurface;
@@ -2085,12 +2117,11 @@ dosurface:
         if (sdl.opengl.pixel_buffer_object) {
             glGenBuffersARB(1, &sdl.opengl.buffer);
             glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, sdl.opengl.buffer);
-            glBufferDataARB(GL_PIXEL_UNPACK_BUFFER_EXT, width*height*4, NULL, GL_STREAM_DRAW_ARB);
+            glBufferDataARB(GL_PIXEL_UNPACK_BUFFER_EXT, adjTexWidth*adjTexHeight*4, NULL, GL_STREAM_DRAW_ARB);
             glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, 0);
-        } else {
-            sdl.opengl.framebuf=calloc(width*height, 4);        //32 bit color
-        }
-        sdl.opengl.pitch=width*4;
+        } else
+            sdl.opengl.framebuf=calloc(adjTexWidth*adjTexHeight, 4); //32 bit color
+        sdl.opengl.pitch=adjTexWidth*4;
 
         glBindTexture(GL_TEXTURE_2D,0);
 
@@ -2157,13 +2188,13 @@ dosurface:
         glBindTexture(GL_TEXTURE_2D, sdl.opengl.texture);
         glBegin(GL_QUADS);
         // lower left
-        glTexCoord2i(0,    0     ); glVertex2i(sdl.clip.x,           sdl.clip.y           );
+        glTexCoord2i(0,          0     );       glVertex2i(sdl.clip.x,           sdl.clip.y           );
         // lower right
-        glTexCoord2i(width,0     ); glVertex2i(sdl.clip.x+sdl.clip.w,sdl.clip.y           );
+        glTexCoord2i(adjTexWidth,0     );       glVertex2i(sdl.clip.x+sdl.clip.w,sdl.clip.y           );
         // upper right
-        glTexCoord2i(width,height); glVertex2i(sdl.clip.x+sdl.clip.w,sdl.clip.y+sdl.clip.h);
+        glTexCoord2i(adjTexWidth,adjTexHeight); glVertex2i(sdl.clip.x+sdl.clip.w,sdl.clip.y+sdl.clip.h);
         // upper left
-        glTexCoord2i(0,    height); glVertex2i(sdl.clip.x,           sdl.clip.y+sdl.clip.h);
+        glTexCoord2i(0,          adjTexHeight); glVertex2i(sdl.clip.x,           sdl.clip.y+sdl.clip.h);
         glEnd();
         glEndList();
 
@@ -2249,18 +2280,8 @@ dosurface:
             Bit16u fixedHeight;
             Bit16u windowWidth;
             Bit16u windowHeight;
-
-            // Calculate texture size
-            if((!d3d->square) && (!d3d->pow2)) {
-                d3d->dwTexWidth=width;
-                d3d->dwTexHeight=height;
-            } else if(d3d->square) {
-                int texsize=2 << int_log2(width > height ? width : height);
-                d3d->dwTexWidth=d3d->dwTexHeight=texsize;
-            } else {
-                d3d->dwTexWidth=2 << int_log2(width);
-                d3d->dwTexHeight=2 << int_log2(height);
-            }
+            Bitu adjTexWidth = width;
+            Bitu adjTexHeight = height;
 
             if (sdl.desktop.fullscreen) {
                 fixedWidth = sdl.desktop.full.fixed ? sdl.desktop.full.width : 0;
@@ -2328,6 +2349,40 @@ dosurface:
                 sdl.clip.h=windowHeight=(Bit16u)(sdl.draw.height*sdl.draw.scaley);
             }
 
+            // when xBRZ scaler is used, we can adjust render target size to exactly what xBRZ scaler will output, leaving final scaling to default D3D scaler / shaders
+            if (sdl.xBRZ.enable) {
+                sdl.xBRZ.tex_scale_factor = (sdl.xBRZ.fixed_scale_factor == 0) ?
+                    static_cast<int>(std::sqrt(1.0 * sdl.clip.w * sdl.clip.h / (width * height)) + 0.5) :
+                    sdl.xBRZ.fixed_scale_factor;
+
+                if (sdl.xBRZ.tex_scale_factor >= 2)
+                {
+                    sdl.xBRZ.tex_scale_factor = min(sdl.xBRZ.tex_scale_factor, sdl.xBRZ.max_scale_factor);
+                    adjTexWidth = width * sdl.xBRZ.tex_scale_factor;
+                    adjTexHeight = height * sdl.xBRZ.tex_scale_factor;
+                    sdl.xBRZ.tex_scale_on = true;
+                }
+                else 
+                {
+                    // we cannot scale, so do not even attempt to
+                    sdl.xBRZ.tex_scale_on = false;
+                }
+            }
+
+            // Calculate texture size
+            if ((!d3d->square) && (!d3d->pow2)) {
+                d3d->dwTexWidth = adjTexWidth;
+                d3d->dwTexHeight = adjTexHeight;
+            }
+            else if (d3d->square) {
+                int texsize = 2 << int_log2(adjTexWidth > adjTexHeight ? adjTexWidth : adjTexHeight);
+                d3d->dwTexWidth = d3d->dwTexHeight = texsize;
+            }
+            else {
+                d3d->dwTexWidth = 2 << int_log2(adjTexWidth);
+                d3d->dwTexHeight = 2 << int_log2(adjTexHeight);
+            }
+
             LOG(LOG_MISC,LOG_DEBUG)("GFX_SetSize Direct3D texture=%ux%u window=%ux%u clip=x,y,w,h=%d,%d,%d,%d",
                     (unsigned int)d3d->dwTexWidth,
                     (unsigned int)d3d->dwTexHeight,
@@ -2383,8 +2438,8 @@ dosurface:
 
         SDL1_hax_inhibit_WM_PAINT = 1;
 
-        if(GCC_UNLIKELY(d3d->Resize3DEnvironment(windowWidth,windowHeight,sdl.clip.x,sdl.clip.y,sdl.clip.w,sdl.clip.h,width,
-                            height,sdl.desktop.fullscreen) != S_OK)) {
+        if(GCC_UNLIKELY(d3d->Resize3DEnvironment(windowWidth,windowHeight,sdl.clip.x,sdl.clip.y,sdl.clip.w,sdl.clip.h,adjTexWidth,
+                            adjTexHeight,sdl.desktop.fullscreen) != S_OK)) {
             retFlags = 0;
         }
 #if LOG_D3D
@@ -3143,24 +3198,14 @@ void GFX_ReleaseSurfacePtr(void) {
 }
 #endif
 
-std::vector<uint32_t> renderBuffer;
-
-bool supportsXBRZ(const SDL_PixelFormat& fmt)
-{
-    return fmt.BytesPerPixel == sizeof(uint32_t) &&
-        fmt.Rmask == 0xff0000 && //
-        fmt.Gmask == 0x00ff00 && //xBRZ scaler needs BGRA byte order
-        fmt.Bmask == 0x0000ff;   //
-}
-
 bool GFX_StartUpdate(Bit8u * & pixels,Bitu & pitch) {
     if (!sdl.active || sdl.updating)
         return false;
     switch (sdl.desktop.type) {
     case SCREEN_SURFACE:
-        if (sdl.xBRZ && supportsXBRZ(*sdl.surface->format)) {
-            renderBuffer.resize(sdl.draw.width * sdl.draw.height);
-            pixels = renderBuffer.empty() ? nullptr : reinterpret_cast<Bit8u*>(&renderBuffer[0]);
+        if (sdl.xBRZ.enable) {
+            sdl.xBRZ.renderbuf.resize(sdl.draw.width * sdl.draw.height);
+            pixels = sdl.xBRZ.renderbuf.empty() ? nullptr : reinterpret_cast<Bit8u*>(&sdl.xBRZ.renderbuf[0]);
             pitch = sdl.draw.width * sizeof(uint32_t);
         }
         else
@@ -3185,18 +3230,35 @@ bool GFX_StartUpdate(Bit8u * & pixels,Bitu & pitch) {
         return true;
 #if C_OPENGL
     case SCREEN_OPENGL:
-        if(sdl.opengl.pixel_buffer_object) {
-            glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, sdl.opengl.buffer);
-            pixels=(Bit8u *)glMapBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, GL_WRITE_ONLY);
-        } else
-            pixels=(Bit8u *)sdl.opengl.framebuf;
-        pitch=sdl.opengl.pitch;
+        if (sdl.xBRZ.enable && sdl.xBRZ.tex_scale_on) {
+            sdl.xBRZ.renderbuf.resize(sdl.draw.width * sdl.draw.height);
+            pixels = sdl.xBRZ.renderbuf.empty() ? nullptr : reinterpret_cast<Bit8u*>(&sdl.xBRZ.renderbuf[0]);
+            pitch = sdl.draw.width * sizeof(uint32_t);
+        }
+        else 
+        {
+            if (sdl.opengl.pixel_buffer_object) {
+                glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, sdl.opengl.buffer);
+                pixels = (Bit8u *)glMapBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, GL_WRITE_ONLY);
+            }
+            else
+                pixels = (Bit8u *)sdl.opengl.framebuf;
+            pitch = sdl.opengl.pitch;
+        }
+
         sdl.updating=true;
         return true;
 #endif
 #if (HAVE_D3D9_H) && defined(WIN32)
     case SCREEN_DIRECT3D:
-        sdl.updating=d3d->LockTexture(pixels, pitch);
+        if (sdl.xBRZ.enable && sdl.xBRZ.tex_scale_on) {
+            sdl.xBRZ.renderbuf.resize(sdl.draw.width * sdl.draw.height);
+            pixels = sdl.xBRZ.renderbuf.empty() ? nullptr : reinterpret_cast<Bit8u*>(&sdl.xBRZ.renderbuf[0]);
+            pitch = sdl.draw.width * sizeof(uint32_t);
+            sdl.updating = true;
+        }
+        else
+            sdl.updating = d3d->LockTexture(pixels, pitch);
         return sdl.updating;
 #endif
     default:
@@ -3227,6 +3289,49 @@ void GFX_OpenGLRedrawScreen(void) {
 #endif
 }
 
+void xBRZ_Render(const uint32_t* renderBuf, uint32_t* xbrzBuf, const Bit16u *changedLines, const int srcWidth, const int srcHeight, int scalingFactor)
+{
+    if (changedLines) // perf: in worst case similar to full input scaling
+    {
+        concurrency::task_group tg; // perf: task_group is slightly faster than pure prallel_for
+        int yLast = 0;
+        Bitu y = 0, index = 0;
+        while (y < sdl.draw.height)
+        {
+            if (!(index & 1))
+                y += changedLines[index];
+            else
+            {
+                const int sliceFirst = y;
+                const int sliceLast = y + changedLines[index];
+                y += changedLines[index];
+
+                int yFirst = max(yLast, sliceFirst - 2); // we need to update two adjacent lines as well since they are analyzed by xBRZ!
+                yLast = min(srcHeight, sliceLast + 2);   // (and make sure to not overlap with last slice!)
+
+                for (int i = yFirst; i < yLast; i += sdl.xBRZ.task_granularity)
+                {
+                    const int iLast = min(i + sdl.xBRZ.task_granularity, yLast);
+                    tg.run([=] { xbrz::scale(scalingFactor, renderBuf, xbrzBuf, srcWidth, srcHeight, xbrz::ColorFormat::RGB, xbrz::ScalerCfg(), i, iLast); });
+                }
+            }
+            index++;
+        }
+        tg.wait();
+    }
+    else // process complete input image
+    {
+        concurrency::task_group tg;
+        for (int i = 0; i < srcHeight; i += sdl.xBRZ.task_granularity)
+            tg.run([=]
+        {
+            const int iLast = min(i + sdl.xBRZ.task_granularity, srcHeight);
+            xbrz::scale(scalingFactor, renderBuf, xbrzBuf, srcWidth, srcHeight, xbrz::ColorFormat::RGB, xbrz::ScalerCfg(), i, iLast);
+        });
+        tg.wait();
+    }
+}
+
 void GFX_EndUpdate( const Bit16u *changedLines ) {
     /* don't present our output if 3Dfx is in OpenGL mode */
     if (sdl.desktop.prevent_fullscreen)
@@ -3245,13 +3350,12 @@ void GFX_EndUpdate( const Bit16u *changedLines ) {
 #if DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW
             GFX_DrawSDLMenu(mainMenu,mainMenu.display_list);
 #endif
-            if (sdl.xBRZ && supportsXBRZ(*sdl.surface->format)) {
+            if (sdl.xBRZ.enable) {
                 const int srcWidth = sdl.draw.width;
                 const int srcHeight = sdl.draw.height;
-                if (renderBuffer.size() == srcWidth * srcHeight &&
-                    srcWidth > 0 && srcHeight > 0)
+                if (sdl.xBRZ.renderbuf.size() == srcWidth * srcHeight && srcWidth > 0 && srcHeight > 0)
                 {
-                    // we assume renderBuffer is *not* scaled!
+                    // we assume render buffer is *not* scaled!
                     const int outputHeight = sdl.surface->h; // in full screen mode surface == screen
                     const int outputWidth = sdl.surface->w; 
                                                             // scale to full screen (preserving input aspect)
@@ -3274,71 +3378,32 @@ void GFX_EndUpdate( const Bit16u *changedLines ) {
                         clipY = (outputHeight - clipHeight) / 2;
                     }
 
-                    // 1. xBRZ-scale renderBuffer into xbrzBuffer
-                    int scalingFactor = static_cast<int>(std::sqrt(1.0 * clipWidth * clipHeight / (srcWidth * srcHeight)) + 0.5);
+                    // 1. xBRZ-scale render buffer into xbrz pixel buffer
+                    int scalingFactor = (sdl.xBRZ.fixed_scale_factor == 0) ?
+                        static_cast<int>(std::sqrt(1.0 * clipWidth * clipHeight / (srcWidth * srcHeight)) + 0.5) : 
+                        sdl.xBRZ.fixed_scale_factor;
                     // the ideal scaling factor scales source image to have roughly similar pixel count like target
 
                     int xbrzWidth = 0;
                     int xbrzHeight = 0;
-                    static std::vector<uint32_t> xbrzBuffer;
+                    uint32_t* xbrzBuf;
                     if (scalingFactor >= 2)
                     {
-                        scalingFactor = min(scalingFactor, xbrz::SCALE_FACTOR_MAX);
+                        scalingFactor = min(scalingFactor, sdl.xBRZ.max_scale_factor);
 
                         xbrzWidth = srcWidth * scalingFactor;
                         xbrzHeight = srcHeight * scalingFactor;
-                        xbrzBuffer.resize(xbrzWidth * xbrzHeight);
+                        sdl.xBRZ.pixbuf.resize(xbrzWidth * xbrzHeight);
 
-                        const uint32_t* renderBuf = &renderBuffer[0]; // help VS compiler a little + support capture by value
-                        uint32_t*       xbrzBuf = &xbrzBuffer[0];
-
-                        if (changedLines) // perf: in worst case similar to full input scaling
-                        {
-                            concurrency::task_group tg; // perf: task_group is slightly faster than pure prallel_for
-                            const int xBRZ_task_granularity = sdl.xBRZ_task_granularity;
-                            int yLast = 0;
-                            Bitu y = 0, index = 0;
-                            while (y < sdl.draw.height)
-                            {
-                                if (!(index & 1))
-                                    y += changedLines[index];
-                                else
-                                {
-                                    const int sliceFirst = y;
-                                    const int sliceLast = y + changedLines[index];
-                                    y += changedLines[index];
-
-                                    int yFirst = max(yLast, sliceFirst - 2); // we need to update two adjacent lines as well since they are analyzed by xBRZ!
-                                    yLast = min(srcHeight, sliceLast + 2);   // (and make sure to not overlap with last slice!)
-
-                                    for (int i = yFirst; i < yLast; i += xBRZ_task_granularity)
-                                    {
-                                        const int iLast = min(i + xBRZ_task_granularity, yLast);
-                                        tg.run([=] { xbrz::scale(scalingFactor, renderBuf, xbrzBuf, srcWidth, srcHeight, xbrz::ColorFormat::RGB, xbrz::ScalerCfg(), i, iLast); });
-                                    }
-                                }
-                                index++;
-                            }
-                            tg.wait();
-                        }
-                        else // process complete input image
-                        {
-                            concurrency::task_group tg;
-                            const int xBRZ_task_granularity = sdl.xBRZ_task_granularity;
-                            for (int i = 0; i < srcHeight; i += xBRZ_task_granularity)
-                                tg.run([=]
-                            {
-                                const int iLast = min(i + xBRZ_task_granularity, srcHeight);
-                                xbrz::scale(scalingFactor, renderBuf, xbrzBuf, srcWidth, srcHeight, xbrz::ColorFormat::RGB, xbrz::ScalerCfg(), i, iLast);
-                            });
-                            tg.wait();
-                        }
+                        const uint32_t* renderBuf = &sdl.xBRZ.renderbuf[0]; // help VS compiler a little + support capture by value
+                        xbrzBuf = &sdl.xBRZ.pixbuf[0];
+                        xBRZ_Render(renderBuf, xbrzBuf, changedLines, srcWidth, srcHeight, scalingFactor);
                     }
                     else // no scaling
                     {
                         xbrzWidth = srcWidth;
                         xbrzHeight = srcHeight;
-                        xbrzBuffer = renderBuffer;
+                        xbrzBuf = &sdl.xBRZ.renderbuf[0];
 
                         // don't change aspect when showing unscaled image:
                         clipWidth = min(srcWidth, outputWidth);
@@ -3347,22 +3412,21 @@ void GFX_EndUpdate( const Bit16u *changedLines ) {
                         clipY = (outputHeight - clipHeight) / 2;
                     }
 
-                    // 2. nearest neighbor/bilinear scale xbrzBuffer into output surface clipping area
+                    // 2. nearest neighbor/bilinear scale xbrz buffer into output surface clipping area
                     const bool mustLock = SDL_MUSTLOCK(sdl.surface);
                     if (mustLock) SDL_LockSurface(sdl.surface);
-                    if (sdl.surface->pixels) // if locking fails, this can be nullptr
+                    if (sdl.surface->pixels) // if locking fails, this can be nullptr, also check if we really need to draw
                     {
                         uint32_t* clipTrg = reinterpret_cast<uint32_t*>(static_cast<char*>(sdl.surface->pixels) + clipY * sdl.surface->pitch + clipX * sizeof(uint32_t));
 
-                        if (sdl.xBRZ_Bilinear) {
+                        if (sdl.xBRZ.postscale_bilinear) {
                             concurrency::task_group tg;
-                            const int xBRZ_task_granularity = sdl.xBRZ_task_granularity;
-                            for (int i = 0; i < clipHeight; i += xBRZ_task_granularity)
+                            for (int i = 0; i < clipHeight; i += sdl.xBRZ.task_granularity)
                                 tg.run([=]
                             {
-                                const int iLast = min(i + xBRZ_task_granularity, clipHeight);
+                                const int iLast = min(i + sdl.xBRZ.task_granularity, clipHeight);
 
-                                xbrz::bilinearScale(&xbrzBuffer[0], // const uint32_t* src,
+                                xbrz::bilinearScale(&xbrzBuf[0], // const uint32_t* src,
                                     xbrzWidth, xbrzHeight, xbrzWidth * sizeof(uint32_t), // int srcWidth, int srcHeight, int srcPitch,
                                     clipTrg,        //PixTrg* trg,
                                     clipWidth, clipHeight, sdl.surface->pitch, // int trgWidth, int trgHeight, int trgPitch,
@@ -3370,17 +3434,16 @@ void GFX_EndUpdate( const Bit16u *changedLines ) {
                                     [](uint32_t pix) { return pix; });  // PixConverter pixCvrt
                             });
                             tg.wait();
-                        } 
+                        }
                         else
                         {
                             concurrency::task_group tg;
-                            const int xBRZ_task_granularity = sdl.xBRZ_task_granularity;
-                            for (int i = 0; i < clipHeight; i += xBRZ_task_granularity)
+                            for (int i = 0; i < clipHeight; i += sdl.xBRZ.task_granularity)
                                 tg.run([=]
                             {
-                                const int iLast = min(i + xBRZ_task_granularity, clipHeight);
+                                const int iLast = min(i + sdl.xBRZ.task_granularity, clipHeight);
 
-                                xbrz::nearestNeighborScale(&xbrzBuffer[0], xbrzWidth, xbrzHeight, xbrzWidth * sizeof(uint32_t),
+                                xbrz::nearestNeighborScale(&xbrzBuf[0], xbrzWidth, xbrzHeight, xbrzWidth * sizeof(uint32_t),
                                     clipTrg, clipWidth, clipHeight, sdl.surface->pitch,
                                     i, iLast, [](uint32_t pix) { return pix; }); // perf: going over target is by factor 4 faster than going over source for similar image sizes
                             });
@@ -3388,6 +3451,7 @@ void GFX_EndUpdate( const Bit16u *changedLines ) {
                         }
                     }
                     if (mustLock) SDL_UnlockSurface(sdl.surface);
+                    if (!menu.hidecycles && !sdl.desktop.fullscreen) frames++;
 #if defined(C_SDL2)
                     SDL_UpdateWindowSurfaceRects(sdl.window, sdl.updateRects, 1);
 #else
@@ -3467,7 +3531,54 @@ void GFX_EndUpdate( const Bit16u *changedLines ) {
 #endif
                 }
 
-                if (sdl.opengl.pixel_buffer_object) {
+                if (sdl.xBRZ.enable && sdl.xBRZ.tex_scale_on) {
+                    // OpenGL pixel buffer is precreated for direct xBRZ output, while xBRZ render buffer is used for rendering
+                    const int srcWidth = sdl.draw.width;
+                    const int srcHeight = sdl.draw.height;
+
+                    if (sdl.xBRZ.renderbuf.size() == srcWidth * srcHeight && srcWidth > 0 && srcHeight > 0)
+                    {
+                        // we assume render buffer is *not* scaled!
+                        const uint32_t* renderBuf = &sdl.xBRZ.renderbuf[0]; // help VS compiler a little + support capture by value
+                        uint32_t* trgTex;
+                        if (sdl.opengl.pixel_buffer_object) {
+                            glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, sdl.opengl.buffer);
+                            trgTex = (uint32_t *)glMapBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, GL_WRITE_ONLY);
+                        }
+                        else 
+                            trgTex = reinterpret_cast<uint32_t*>(static_cast<void*>(sdl.opengl.framebuf));
+
+                        if (trgTex)
+                            xBRZ_Render(renderBuf, trgTex, changedLines, srcWidth, srcHeight, sdl.xBRZ.tex_scale_factor);
+                    }
+
+                    // and here we go repeating some stuff with xBRZ related modifications
+                    if (sdl.opengl.pixel_buffer_object) 
+                    {
+                        glUnmapBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT);
+                        glBindTexture(GL_TEXTURE_2D, sdl.opengl.texture);
+                        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0,
+                            sdl.draw.width * sdl.xBRZ.tex_scale_factor, sdl.draw.height * sdl.xBRZ.tex_scale_factor, GL_BGRA_EXT,
+                            GL_UNSIGNED_INT_8_8_8_8_REV, 0);
+                        glBindBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT, 0);
+                    }
+                    else
+                    {
+                        glBindTexture(GL_TEXTURE_2D, sdl.opengl.texture);
+                        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0,
+                            sdl.draw.width * sdl.xBRZ.tex_scale_factor, sdl.draw.height * sdl.xBRZ.tex_scale_factor, GL_BGRA_EXT,
+#if defined (MACOSX)
+                            // needed for proper looking graphics on macOS 10.12, 10.13
+                            GL_UNSIGNED_INT_8_8_8_8,
+#else
+                            // works on Linux
+                            GL_UNSIGNED_INT_8_8_8_8_REV,
+#endif
+                            (Bit8u *)sdl.opengl.framebuf);
+                    }
+                    glCallList(sdl.opengl.displaylist);
+                    SDL_GL_SwapBuffers();
+                } else if (sdl.opengl.pixel_buffer_object) {
                     if(changedLines && (changedLines[0] == sdl.draw.height)) 
                         return; 
                     glUnmapBufferARB(GL_PIXEL_UNPACK_BUFFER_EXT);
@@ -3553,6 +3664,43 @@ void GFX_EndUpdate( const Bit16u *changedLines ) {
 #endif
 #if (HAVE_D3D9_H) && defined(WIN32)
     case SCREEN_DIRECT3D:
+        if (sdl.xBRZ.enable && sdl.xBRZ.tex_scale_on) {
+            // we have xBRZ pseudo render buffer to be output to the pre-sized texture, do the xBRZ part
+            const int srcWidth = sdl.draw.width;
+            const int srcHeight = sdl.draw.height;
+            if (sdl.xBRZ.renderbuf.size() == srcWidth * srcHeight && srcWidth > 0 && srcHeight > 0)
+            {
+                // we assume render buffer is *not* scaled!
+                const int outputHeight = sdl.surface->h; // in full screen mode surface == screen
+                const int outputWidth = sdl.surface->w;
+
+                int xbrzWidth = srcWidth * sdl.xBRZ.tex_scale_factor;
+                int xbrzHeight = srcHeight * sdl.xBRZ.tex_scale_factor;
+                sdl.xBRZ.pixbuf.resize(xbrzWidth * xbrzHeight);
+
+                const uint32_t* renderBuf = &sdl.xBRZ.renderbuf[0]; // help VS compiler a little + support capture by value
+                uint32_t*       xbrzBuf = &sdl.xBRZ.pixbuf[0];
+                xBRZ_Render(renderBuf, xbrzBuf, changedLines, srcWidth, srcHeight, sdl.xBRZ.tex_scale_factor);
+
+                // now copy xBRZ buffer to the texture, adjusting for texture pitch
+                Bit8u *tgtPix;
+                Bitu tgtPitch;
+                if (d3d->LockTexture(tgtPix, tgtPitch) && tgtPix) // if locking fails, target texture can be nullptr
+                {
+                    uint32_t* tgtTex = reinterpret_cast<uint32_t*>(static_cast<Bit8u*>(tgtPix));
+                    concurrency::task_group tg;
+                    for (int i = 0; i < xbrzHeight; i += sdl.xBRZ.task_granularity)
+                        tg.run([=]
+                    {
+                        const int iLast = min(i + sdl.xBRZ.task_granularity, xbrzHeight);
+                        xbrz::pitchChange(&xbrzBuf[0], &tgtTex[0], xbrzWidth, xbrzHeight, xbrzWidth * sizeof(uint32_t), tgtPitch, i, iLast,
+                            [](uint32_t pix) { return pix; });
+                    });
+                    tg.wait();
+                }
+            }
+        }
+
         if(!menu.hidecycles) frames++; //implemented
         if(GCC_UNLIKELY(!d3d->UnlockTexture(changedLines))) {
             E_Exit("Failed to draw screen!");
@@ -3873,14 +4021,21 @@ static void GUI_StartUp() {
         Section_prop * r_section = static_cast<Section_prop *>(control->GetSection("render"));
         Prop_multival* r_prop = r_section->Get_multival("scaler");
         std::string r_scaler = r_prop->GetSection()->Get_string("type");
-        sdl.xBRZ = ((r_scaler == "xbrz") || (r_scaler == "xbrz_bilinear"));
-        sdl.xBRZ_Bilinear = (r_scaler == "xbrz_bilinear");
-        sdl.xBRZ_task_granularity = r_section->Get_int("xbrz slice");
+        sdl.xBRZ.enable = ((r_scaler == "xbrz") || (r_scaler == "xbrz_bilinear"));
+        sdl.xBRZ.postscale_bilinear = (r_scaler == "xbrz_bilinear");
+        sdl.xBRZ.task_granularity = r_section->Get_int("xbrz slice");
+        sdl.xBRZ.fixed_scale_factor = r_section->Get_int("xbrz fixed scale factor");
+        sdl.xBRZ.max_scale_factor = r_section->Get_int("xbrz max scale factor");
+        if ((sdl.xBRZ.max_scale_factor < 2) || (sdl.xBRZ.max_scale_factor > xbrz::SCALE_FACTOR_MAX))
+            sdl.xBRZ.max_scale_factor = xbrz::SCALE_FACTOR_MAX;
+        if ((sdl.xBRZ.fixed_scale_factor < 2) || (sdl.xBRZ.fixed_scale_factor > xbrz::SCALE_FACTOR_MAX))
+            sdl.xBRZ.fixed_scale_factor = 0;
     }
 
-    if (sdl.xBRZ) {
+    if (sdl.xBRZ.enable) {
         // xBRZ requirements
-        output = "surface";
+        if ((output != "surface") && (output != "direct3d") && (output != "opengl") && (output != "openglhq") && (output != "openglnb"))
+            output = "surface";
     }
 
     if (output == "surface") {


### PR DESCRIPTION
[+] xBRZ: add Direct3D and OpenGL output support (improves performance offloading final 'fit to screen' scaling step to GPU, also, Direct3D shaders can be combined with xBRZ now allowing to have more fun)
[+] xBRZ: add scaling factor options (max / fixed)
[+] xBRZ: add pitch change routine (used to fit xBRZ result into D3D texture)
[*] xBRZ: move all of the sdlmain configuration and global volatiles for xBRZ into sdl.xBRZ structure, cleaning up the mess
[*] xBRZ: split xBRZ scale render routine into separate procedure
[*] xBRZ: fix render structure (missing element)
[*] xBRZ: disable doublescanning if xBRZ enabled (breaks scaling)
[-] xBRZ: remove surface format checking, no point in it,  format conversion will have to be added if necessary somewhere
[-] xBRZ: remove enforcing fullscreen, it works in windowed mode so why not