### PR TITLE
Num lock fix and synchronization with host

### DIFF
--- a/include/bios.h
+++ b/include/bios.h
@@ -151,6 +151,9 @@ void INT10_ReloadRomFonts();
 void BIOS_SetComPorts (Bit16u baseaddr[]);
 void BIOS_SetLPTPort (Bitu port, Bit16u baseaddr);
 
+// \brief Synchronizes emulator num lock state with host.
+void BIOS_SynchronizeNumLock();
+
 bool ISAPNP_RegisterSysDev(const unsigned char *raw,Bitu len,bool already=false);
 
 class ISAPnPDevice {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5591,7 +5591,8 @@ void GFX_Events() {
                         GFX_CaptureMouse();
                     SetPriority(sdl.priority.focus);
                     CPU_Disable_SkipAutoAdjust();
-                } else {
+					BIOS_SynchronizeNumLock();
+				} else {
                     if (sdl.mouse.locked) GFX_CaptureMouse();
 
 #if defined(WIN32)

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -6381,7 +6381,10 @@ void CheckNumLockState(void) {
     BYTE keyState[256];
 
     GetKeyboardState((LPBYTE)(&keyState));
-    if (keyState[VK_NUMLOCK] & 1) numlock_stat=true;
+	if (keyState[VK_NUMLOCK] & 1) {
+		numlock_stat = true;
+		startup_state_numlock = true;
+	}
 #endif
 }
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -6382,7 +6382,6 @@ void CheckNumLockState(void) {
 
     GetKeyboardState((LPBYTE)(&keyState));
     if (keyState[VK_NUMLOCK] & 1) numlock_stat=true;
-    if (numlock_stat) SetNumLock();
 #endif
 }
 

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -7405,3 +7405,19 @@ void ROMBIOS_Init() {
     }
 }
 
+void BIOS_SynchronizeNumLock()
+{
+	auto flag = mem_readb(BIOS_KEYBOARD_FLAGS1);
+	auto leds = mem_readb(BIOS_KEYBOARD_LEDS);
+	auto stat = GetKeyState(VK_NUMLOCK);
+	if (stat & 1) {
+		flag |= 0x20;
+		leds |= 0x02;
+	}
+	else {
+		flag &= ~0x20;
+		leds &= ~0x02;
+	}
+	mem_writeb(BIOS_KEYBOARD_FLAGS1, flag);
+	mem_writeb(BIOS_KEYBOARD_LEDS, leds);
+}

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -1387,7 +1387,7 @@ static void InitBiosSegment(void) {
     Bit8u flag1 = 0;
     Bit8u leds = 16; /* Ack received */
 
-#if SDL_VERSION_ATLEAST(1, 2, 14)
+#if 0 /*SDL_VERSION_ATLEAST(1, 2, 14)*/
 //Nothing, mapper handles all.
 #else
     if (startup_state_capslock) { flag1|=0x40; leds|=0x04;}


### PR DESCRIPTION
This is my attempt to address this long plaguing issue,

Not sure if it's the best approach, I tried to keep it as simple and clean as possible and it just works !

- on startup, numlock is not turned off anymore
- ```startup_state_numlock``` is set so ```InitBiosSegment``` sets the flags
- when window gets activated again, ```BIOS_SynchronizeNumLock``` is called

Also, it's probably lacking ```#if Win32``` or whatever [since it seems to be only for it](https://github.com/joncampbell123/dosbox-x/issues/703).