### PR TITLE
Added single quote support

### DIFF
--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1335,7 +1335,7 @@ CommandLine::CommandLine(char const * const name,char const * const cmdline,enum
     opt_style = opt;
     while ((c=*c_cmdline)!=0) {
         if (inquote) {
-            if (c!='"') str+=c;
+            if (c!='"'&&c!='\'') str+=c;
             else {
                 inquote=false;
                 cmds.push_back(str);
@@ -1349,7 +1349,7 @@ CommandLine::CommandLine(char const * const name,char const * const cmdline,enum
                 str.erase();
             }
         } 
-        else if (c=='"') { inquote=true;}
+        else if (c=='"'||c=='\'') { inquote=true;}
         else if (c!=' ') { str+=c;inword=true;}
         c_cmdline++;
     }


### PR DESCRIPTION
**MOUNT command doesn't accept single quotes around path (original DosBox does) #770**

While this easy to fix, I am against that change because ```'``` (single quote) is a **valid** character for a file name:

[8.3 filename](https://en.wikipedia.org/wiki/8.3_filename)

[Naming Files, Paths, and Namespaces](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247%28v=vs.85%29.aspx#naming_conventions)

