### PR TITLE
SHELL: added word navigation with Ctrl+Left/Right.

### DIFF
--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -203,6 +203,51 @@ void DOS_Shell::InputCommand(char * line) {
                 }
                 break;
 
+			case 0x7400: /*CTRL + RIGHT : cmd.exe-like next word*/
+				{
+					auto pos = line + str_index;
+					auto spc = *pos == ' ';
+					const auto end = line + str_len;
+
+					while (pos < end) {
+						if (spc && *pos != ' ')
+							break;
+						if (*pos == ' ')
+							spc = true;
+						pos++;
+					}
+					
+					const auto lgt = min(pos, end) - (line + str_index);
+					
+					for (auto i = 0; i < lgt; i++)
+						outc(static_cast<Bit8u>(line[str_index++]));
+				}	
+        		break;
+			case 0x7300: /*CTRL + LEFT : cmd.exe-like previous word*/
+				{
+					auto pos = line + str_index - 1;
+					const auto beg = line;
+					const auto spc = *pos == ' ';
+
+					if (spc) {
+						while(*pos == ' ') pos--;
+						while(*pos != ' ') pos--;
+						pos++;
+					}
+					else {
+						while(*pos != ' ') pos--;
+						while(*pos == ' ') pos--;
+						pos++;
+					}
+					
+					const auto lgt = abs(max(pos, beg) - (line + str_index));
+					
+					for (auto i = 0; i < lgt; i++) {
+						outc(8);
+						str_index--;
+					}
+				}	
+        		break;
             case 0x4D00:	/* RIGHT */
                 if (str_index < str_len) {
                     outc((Bit8u)line[str_index++]);


### PR DESCRIPTION
This was bugging me for a while, I've struggled to the point thinking I needed to bring in int10 cursorpos and prompt length but in fact my code was only missing the last ```str_index--;``` X)

It does just like cmd does, jump to beginning of words, or to edges when close.

Note that original cmd does not interpret quotes so if you have ```abcd "efgh ijkl"```, the separation is reached between ```efgh``` and ```ijkl```, sounds good IMO.

I have tested it for a while but please do it too.

