### PR TITLE
Mouse Integration DOS ? (too easy to be true)

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -545,6 +545,7 @@ struct SDL_Block {
     struct {
         bool autolock;
         bool autoenable;
+        bool synced;
         bool requestlock;
         bool locked;
         Bitu sensitivity;
@@ -3682,6 +3683,7 @@ static void GUI_StartUp() {
         sdl.desktop.full.height=width;
     }
     sdl.mouse.autoenable=section->Get_bool("autolock");
+    sdl.mouse.synced=section->Get_bool("synced");
     if (!sdl.mouse.autoenable) SDL_ShowCursor(SDL_DISABLE);
     sdl.mouse.autolock=false;
     sdl.mouse.sensitivity=(unsigned int)section->Get_int("sensitivity");
@@ -4007,6 +4009,7 @@ static void HandleVideoResize(void * event) {
 extern unsigned int mouse_notify_mode;
 
 bool user_cursor_locked = false;
+bool user_cursor_synced = false;
 int user_cursor_x = 0,user_cursor_y = 0;
 int user_cursor_sw = 640,user_cursor_sh = 480;
 
@@ -4166,6 +4169,7 @@ static void HandleMouseMotion(SDL_MouseMotionEvent * motion) {
     user_cursor_x = motion->x - sdl.clip.x;
     user_cursor_y = motion->y - sdl.clip.y;
     user_cursor_locked = sdl.mouse.locked;
+    user_cursor_synced = sdl.mouse.synced;
     user_cursor_sw = sdl.clip.w;
     user_cursor_sh = sdl.clip.h;
 
@@ -6043,6 +6047,9 @@ void SDL_SetupConfigSection() {
 
     Pbool = sdl_sec->Add_bool("autolock",Property::Changeable::Always,true);
     Pbool->Set_help("Mouse will automatically lock, if you click on the screen. (Press CTRL-F10 to unlock)");
+
+    Pbool = sdl_sec->Add_bool("synced",Property::Changeable::Always,true);
+    Pbool->Set_help("Mouse position reported will be exactly where user hand has moved to.");
 
     Pint = sdl_sec->Add_int("sensitivity",Property::Changeable::Always,100);
     Pint->SetMinMax(1,1000);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4192,6 +4192,7 @@ static void HandleMouseMotion(SDL_MouseMotionEvent * motion) {
     else {
         SDL_ShowCursor(SDL_ENABLE);
     }
+    SDL_ShowCursor(SDL_ENABLE); // TODO remove
 }
 
 #if DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW /* SDL drawn menus */

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -611,6 +611,16 @@ void Mouse_CursorMoved(float xrel,float yrel,float x,float y,bool emulate) {
     if (mouse.x < mouse.min_x) mouse.x = mouse.min_x;
     if (mouse.y > mouse.max_y) mouse.y = mouse.max_y;
     if (mouse.y < mouse.min_y) mouse.y = mouse.min_y;
+    extern int  user_cursor_x,  user_cursor_y;
+    extern int  user_cursor_sw, user_cursor_sh;
+    extern bool user_cursor_synced;
+    if (user_cursor_synced)
+    {
+        const auto x1 = 1.0 / static_cast<double>(user_cursor_sw) * user_cursor_x;
+        const auto y1 = 1.0 / static_cast<double>(user_cursor_sh) * user_cursor_y;
+        mouse.x       = x1 * mouse.max_x;
+        mouse.y       = y1 * mouse.max_y;
+    }
 
     mouse.ps2x += xrel;
     mouse.ps2y += yrel;


### PR DESCRIPTION
After fiddling failed with ```INT33_Handler``` since DOSZIP only triggers mouse release (0x06), I decided to try another approach and to much of my surprise it works !

What I've done is that I've added ```synced``` in conf to ensure good results, in fact ```bool emulate``` parameter upstream in the call stack could have been changed but I didn't bother since it could break something else.

With the following I get VM-like integration:

```
[sdl]
autolock=false
synced=true
```

I didn't really test beside DOSZIP but it works well,

PS this still suffer of poor handling where when you move away the mouse too fast, cursor is not exactly at the edge you exited.

What do you think ?

PPS basically logic was already in but it was ```bool emulate``` that was resulting in poor UX (try with ```synced=false``` to see what I'm talking about)