### PR TITLE
Mouse integration fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,12 +18,12 @@ TODO add version
   - Improve mouse support:
     - Added pointer integration behavior for DOS applications.
     - Auto-lock is now disabled by default, this results in
-	  pointer integration becoming the default behavior.
+      pointer integration becoming the default behavior.
     - Added feedback for auto-lock state, can be visual or auditive.
     - When the mouse is not locked, its position is exactly where
-	  the mouse is reported by the system. This results in a more
-	  consistent experience between DOSBox-X and host OS,
-	  e.g. High DPI mouse don't become suddenly slow in DOSBox-X.
+      the mouse is reported by the system. This results in a more
+      consistent experience between DOSBox-X and host OS,
+      e.g. High DPI mouse don't become suddenly slow in DOSBox-X.
     
 0.82.7
   - Mac OS X builds now honor showmenu=false by leaving the

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,15 @@ TODO add version
     - Axes can be remapped for devices with questionable layout.
     - User-settable deadzones for joystick bindings in mapper,
       mappings like WSAD keys to axes is less frustrating.
+  - Improve mouse support:
+    - Added pointer integration behavior for DOS applications.
+    - Auto-lock is now disabled by default, this results in
+	  pointer integration becoming the default behavior.
+    - Added feedback for auto-lock state, can be visual or auditive.
+    - When the mouse is not locked, its position is exactly where
+	  the mouse is reported by the system. This results in a more
+	  consistent experience between DOSBox-X and host OS,
+	  e.g. High DPI mouse don't become suddenly slow in DOSBox-X.
     
 0.82.7
   - Mac OS X builds now honor showmenu=false by leaving the

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -6207,7 +6207,7 @@ void SDL_SetupConfigSection() {
     Pbool->Set_help("Mouse will automatically lock, if you click on the screen. (Press CTRL-F10 to unlock)");
 
     const char* feeds[] = { "none", "beep", "flash", nullptr};
-    Pstring = sdl_sec->Add_string("autolock_feedback", Property::Changeable::Always, feeds[0]);
+    Pstring = sdl_sec->Add_string("autolock_feedback", Property::Changeable::Always, feeds[1]);
     Pstring->Set_help("Autolock status feedback type, i.e. visual, auditive, none.");
     Pstring->Set_values(feeds);
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -545,7 +545,6 @@ struct SDL_Block {
     struct {
         bool autolock;
         bool autoenable;
-        bool synced;
         bool requestlock;
         bool locked;
         Bitu sensitivity;
@@ -3683,7 +3682,6 @@ static void GUI_StartUp() {
         sdl.desktop.full.height=width;
     }
     sdl.mouse.autoenable=section->Get_bool("autolock");
-    sdl.mouse.synced=section->Get_bool("synced");
     if (!sdl.mouse.autoenable) SDL_ShowCursor(SDL_DISABLE);
     sdl.mouse.autolock=false;
     sdl.mouse.sensitivity=(unsigned int)section->Get_int("sensitivity");
@@ -4169,7 +4167,6 @@ static void HandleMouseMotion(SDL_MouseMotionEvent * motion) {
     user_cursor_x = motion->x - sdl.clip.x;
     user_cursor_y = motion->y - sdl.clip.y;
     user_cursor_locked = sdl.mouse.locked;
-    user_cursor_synced = sdl.mouse.synced;
     user_cursor_sw = sdl.clip.w;
     user_cursor_sh = sdl.clip.h;
 
@@ -6050,9 +6047,6 @@ void SDL_SetupConfigSection() {
 
     Pbool = sdl_sec->Add_bool("autolock",Property::Changeable::Always,true);
     Pbool->Set_help("Mouse will automatically lock, if you click on the screen. (Press CTRL-F10 to unlock)");
-
-    Pbool = sdl_sec->Add_bool("synced",Property::Changeable::Always,false);
-    Pbool->Set_help("Mouse position reported will be exactly where user hand has moved to.");
 
     Pint = sdl_sec->Add_int("sensitivity",Property::Changeable::Always,100);
     Pint->SetMinMax(1,1000);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4798,6 +4798,7 @@ static void HandleMouseButton(SDL_MouseButtonEvent * button) {
     case SDL_PRESSED:
         if (inMenu) return;
         if (sdl.mouse.requestlock && !sdl.mouse.locked && mouse_notify_mode == 0) {
+            CaptureMouseNotify();
             GFX_CaptureMouse();
             // Dont pass klick to mouse handler
             break;
@@ -5755,7 +5756,11 @@ void GFX_Events() {
                     CPU_Disable_SkipAutoAdjust();
 					BIOS_SynchronizeNumLock();
 				} else {
-                    if (sdl.mouse.locked) GFX_CaptureMouse();
+                    if (sdl.mouse.locked)
+                    {
+                        CaptureMouseNotify();
+                        GFX_CaptureMouse();
+                    }
 
 #if defined(WIN32)
                     if (sdl.desktop.fullscreen)

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2799,6 +2799,7 @@ static void CaptureMouse(bool pressed) {
     if (!pressed)
         return;
 
+    CaptureMouseNotify();
     GFX_CaptureMouse();
 }
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2786,15 +2786,18 @@ void CaptureMouseNotifyWin32()
 }
 #endif
 
-static void CaptureMouse(bool pressed) {
-    if (!pressed)
-        return;
-
+void CaptureMouseNotify()
+{
 #if WIN32
     CaptureMouseNotifyWin32();
 #else
     // TODO
 #endif
+}
+
+static void CaptureMouse(bool pressed) {
+    if (!pressed)
+        return;
 
     GFX_CaptureMouse();
 }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -6133,7 +6133,7 @@ void SDL_SetupConfigSection() {
     Pstring->Set_help("What video system to use for output.");
     Pstring->Set_values(outputs);
 
-    Pbool = sdl_sec->Add_bool("autolock",Property::Changeable::Always,true);
+    Pbool = sdl_sec->Add_bool("autolock",Property::Changeable::Always, false);
     Pbool->Set_help("Mouse will automatically lock, if you click on the screen. (Press CTRL-F10 to unlock)");
 
     Pint = sdl_sec->Add_int("sensitivity",Property::Changeable::Always,100);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4190,10 +4190,10 @@ static void HandleMouseMotion(SDL_MouseMotionEvent * motion) {
         /* TODO: If guest has not read mouse cursor position within 250ms show cursor again */
     }
     bool MOUSE_IsHidden();
-    if (!user_cursor_locked && MOUSE_IsHidden())
+    if (!user_cursor_locked)
     {
         /* Show only when DOS app is not using mouse */
-        SDL_ShowCursor(SDL_ENABLE);
+        SDL_ShowCursor(MOUSE_IsHidden() ? SDL_ENABLE : SDL_DISABLE);
     }
     Mouse_CursorMoved(xrel, yrel, x, y, emu);
 }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5450,6 +5450,9 @@ void GFX_EventsMouseWin32()
  */
 void GFX_EventsMouse()
 {
+    if (sdl.desktop.fullscreen || sdl.mouse.locked)
+        return;
+
 #if WIN32
     GFX_EventsMouseWin32();
 #else

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -1389,3 +1389,7 @@ void MOUSE_Init() {
     AddVMEventFunction(VM_EVENT_RESET,AddVMEventFunctionFuncPair(MOUSE_OnReset));
 }
 
+bool MOUSE_IsHidden()
+{
+    return static_cast<bool>(mouse.hidden);
+}


### PR DESCRIPTION
On the last commit,

- I refactored by moving ```Mouse_CursorMoved``` params above, 
- this allowed me to entirely remove ```if(sdl.mouse.locked || !sdl.mouse.autoenable)``` condition
   which prevented syncing to work as we defined
- the whole block is simpler
- added a helper for showing cursor only when hooked by app
- removed ```[sdl] synced```, was very confusing because would work only when ```autolock=false```

i.e. behavior is the same, synced works as expected, simpler code and config

Let me know how that works !