### PR TITLE
Ins key cursor update occurs only during shell

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -424,6 +424,7 @@ static Bitu DOS_21Handler(void) {
         case 0x00:      /* Terminate Program */
             DOS_Terminate(mem_readw(SegPhys(ss)+reg_sp+2),false,0);
             if (DOS_BreakINT23InProgress) throw int(0); /* HACK: Ick */
+            dos_program_running = false;
             break;
         case 0x01:      /* Read character from STDIN, with echo */
             {   
@@ -979,6 +980,7 @@ static Bitu DOS_21Handler(void) {
             DOS_ResizeMemory(dos.psp(),&reg_dx);
             DOS_Terminate(dos.psp(),true,reg_al);
             if (DOS_BreakINT23InProgress) throw int(0); /* HACK: Ick */
+            dos_program_running = false;
             break;
         case 0x1f: /* Get drive parameter block for default drive */
         case 0x32: /* Get drive parameter block for specific drive */

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -401,6 +401,9 @@ void DOS_BreakAction() {
  * --J.C. */
 bool disk_io_unmask_irq0 = true;
 
+//! \brief Is a DOS program running ? (set by INT21 4B/4C)
+bool dos_program_running = false;
+
 #define DOSNAMEBUF 256
 static Bitu DOS_21Handler(void) {
     bool unmask_irq0 = false;
@@ -1343,12 +1346,14 @@ static Bitu DOS_21Handler(void) {
                     reg_ax=dos.errorcode;
                     CALLBACK_SCF(true);
                 }
+                dos_program_running = true;
             }
             break;
             //TODO Check for use of execution state AL=5
         case 0x4c:                  /* EXIT Terminate with return code */
             DOS_Terminate(dos.psp(),false,reg_al);
             if (DOS_BreakINT23InProgress) throw int(0); /* HACK: Ick */
+            dos_program_running = false;
             break;
         case 0x4d:                  /* Get Return code */
             reg_al=dos.return_code;/* Officially read from SDA and clear when read */

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -552,12 +552,16 @@ irq1_end:
     /* update LEDs on keyboard */
     if (leds_orig != leds) KEYBOARD_SetLEDs(leds);
 
-	/* update insert cursor */
-	const auto flg = mem_readb(BIOS_KEYBOARD_FLAGS1);
-	const auto ins = static_cast<bool>(flg & BIOS_KEYBOARD_FLAGS1_INSERT_ACTIVE);
-	const auto ssl = static_cast<Bit8u>(ins ? CURSOR_SCAN_LINE_INSERT : CURSOR_SCAN_LINE_NORMAL);
-	if (CurMode->type == M_TEXT)
-		INT10_SetCursorShape(ssl, CURSOR_SCAN_LINE_END);
+    /* update insert cursor */
+    extern bool dos_program_running;
+    if (!dos_program_running)
+    {
+        const auto flg = mem_readb(BIOS_KEYBOARD_FLAGS1);
+        const auto ins = static_cast<bool>(flg & BIOS_KEYBOARD_FLAGS1_INSERT_ACTIVE);
+        const auto ssl = static_cast<Bit8u>(ins ? CURSOR_SCAN_LINE_INSERT : CURSOR_SCAN_LINE_NORMAL);
+        if (CurMode->type == M_TEXT)
+            INT10_SetCursorShape(ssl, CURSOR_SCAN_LINE_END);
+    }
 					
 /*  IO_Write(0x20,0x20); moved out of handler to be virtualizable */
 #if 0


### PR DESCRIPTION
Is this the right way ?

No more pass-through when a program runs, does not get restored when program exits, though.

I checked with 6.22 on a VM, it doesn't get restored too.

Funnily, it's the opposite in 6.22, small cursor on OVR, big cursor on INS.