### PR TITLE
Xbrz

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,11 @@
 TODO add version
-  - Improved shell:
+  - INT 10h AH=10h now ignores AL=3 in PCjr mode.
+  - Fixed keyboard handler bug in PCjr mode that caused some CPU
+    register corruption and general crashiness in games.
+  - Improved shell: (Aybe, Joncampbell123)
     - Ctrl+Left and Ctrl+Right permits word-navigation.
     - Added emulation of 'Ins' key behavior.
-  - Num Lock stays on at startup and is synchronized with host
+  - Num Lock stays on at startup and is synchronized with host (Aybe)
     when DOSBox-X window gains focus (Windows). (Aybe)
   - Added visual feedback to Hat/D-pad buttons in mapper. (Aybe)
   - Added documentation for 'dir' command sorting switches. (Aybe)
@@ -12,6 +15,15 @@ TODO add version
     - Axes can be remapped for devices with questionable layout.
     - User-settable deadzones for joystick bindings in mapper,
       mappings like WSAD keys to axes is less frustrating.
+  - Improve mouse support:
+    - Added pointer integration behavior for DOS applications.
+    - Auto-lock is now disabled by default, this results in
+      pointer integration becoming the default behavior.
+    - Added feedback for auto-lock state, can be visual or auditive.
+    - When the mouse is not locked, its position is exactly where
+      the mouse is reported by the system. This results in a more
+      consistent experience between DOSBox-X and host OS,
+      e.g. High DPI mouse don't become suddenly slow in DOSBox-X.
     
 0.82.7
   - Mac OS X builds now honor showmenu=false by leaving the

--- a/README.xbrz
+++ b/README.xbrz
@@ -1,0 +1,60 @@
+xBRZ (https://sourceforge.net/projects/xbrz/) scaler is integrated into DOSBox-X.
+
+To enable, use
+    scaler=xbrz
+or
+    scaler=xbrz_bilinear
+option in [render] section.
+
+The difference between two options is in the post-scaling resize method. 
+xBRZ scaler uses fixed scale factors, 2X to 6X, which are usually not exactly
+matching the display window. So nearest size xBRZ scaler output is then 
+resized (upscaled/dowscaled) using either nearest neighbor ('xbrz') or 
+bilinear ('xbrz_bilinear') algorithm to match the window size.
+
+It is highly recommended to use 'direct3d' or any of the 'opengl' output modes
+with xBRZ because bilinear post-scaler performance is terrible and nearest
+neighbor post-scaler does not provide good results.
+
+In 'direct3d' / 'opengl' output modes, there is no difference between
+'xbrz' and 'xbrz_bilinear' variants, because software post-scaler is not used
+and output is post-scaled by the output interface/hardware.
+
+Differences from reference implementation on xBRZ site / in Daum build:
+
+- DOSBox-X implementation supports 'surface', 'direct3d' and 'opengl' outputs
+  (including opengl variants 'openglnb' and 'openglhq')
+- Windowed mode is fully working with xBRZ scaler enabled
+- You can combine xBRZ with 'direct3d' mode post-scalers to get i.e. TV effect
+- Enabling xBRZ scaler does not disable 'aspect' option, it is honored
+
+Things to notice:
+
+- The scaler is very CPU intensive so it will run with decent speed for
+  games and demos only on high-end CPUs. Keep this in mind. You can try
+  to correct performance for high output resolutions by using either
+  'xbrz fixed scale factor' or 'xbrz max scale factor' options to limit
+  xBRZ scale factor (lower factors improve performance), of course this
+  reduces image quality for higher output resolutions proportionally.
+
+- Using 'direct3d' or 'opengl' mode actually improves performance a lot
+  because it gets rid of the software post-scaler pass.
+
+- xBRZ scaler code uses parallel processing internally. There is also
+  'xbrz slice' option that affects parallelism, its default (16) gives
+  good results on 4-8 core CPUs.
+
+- When xBRZ scaler is enabled, internal DOSBox scaler options are disabled
+  because any pre-scaling will break xBRZ algorithm. For the same very reason,
+  'doublescan' option is always turned off internally when xBRZ is enabled.
+
+- When using xBRZ in 'surface' output mode and window/screen sizes less than
+  2x of the original DOS resolution, 'xbrz' scaler can degrade quality instead
+  of improving it, use 'direct3d'/'opengl' outputs or 'xbrz_bilinear' scaler
+  variant to avoid this.
+
+Caveats / issues / things to do / incomplete:
+
+- In case video adapter interface uses non-standard color scheme / byte order,
+  colors with xBRZ scaler enabled would most probably be garbled.
+  [YET TO REPRODUCE ANYWHERE]

--- a/dosbox.reference.conf
+++ b/dosbox.reference.conf
@@ -90,6 +90,7 @@ sst=false
 #           output: What video system to use for output.
 #                   Possible values: surface, overlay, opengl, openglnb, openglhq, ddraw.
 #         autolock: Mouse will automatically lock, if you click on the screen. (Press CTRL-F10 to unlock)
+#           synced: Mouse position reported will be exactly where user hand has moved to.
 #      sensitivity: Mouse sensitivity.
 #      waitonerror: Wait before closing the console if dosbox has an error.
 #         priority: Priority levels for dosbox. Second entry behind the comma is for when dosbox is not focused/minimized.
@@ -106,6 +107,7 @@ fullresolution=desktop
 windowresolution=original
 output=surface
 autolock=true
+synced=false
 sensitivity=100
 waitonerror=true
 priority=higher,normal
@@ -386,6 +388,8 @@ showmenu=true
 #                                                    try setting this option. Else, leave it turned off. Changes to other VGA CRTC registers will trigger
 #                                                    a DOSBox mode change as normal regardless of this setting.
 #                                    enable pci bus: Enable PCI bus emulation
+#                   vga palette update on full load: If set, all three bytes of the palette entry must be loaded before taking the color,
+#                                                    which is fairly typical SVGA behavior. If not set, partial changes are allowed.
 #             ignore odd-even mode in non-cga modes: Some demoscene productions use VGA Mode X but accidentally enable odd/even mode.
 #                                                    Setting this option can correct for that and render the demo properly.
 #                                                    This option forces VGA emulation to ignore odd/even mode except in text and CGA modes.
@@ -489,6 +493,7 @@ ignore vblank wraparound=false
 enable vga resize delay=false
 resize only on vga active display width increase=false
 enable pci bus=true
+vga palette update on full load=true
 ignore odd-even mode in non-cga modes=false
 
 [render]

--- a/include/build_timestamp.h
+++ b/include/build_timestamp.h
@@ -1,3 +1,3 @@
 /*auto-generated*/
-#define UPDATED_STR "Jun 23, 2018 8:13:20am"
+#define UPDATED_STR "Jun 27, 2018 11:42:01am"
 #define COPYRIGHT_END_YEAR "2018"

--- a/include/render.h
+++ b/include/render.h
@@ -93,6 +93,7 @@ typedef struct {
 	bool updating;
 	bool active;
 	bool aspect;
+    bool aspectOffload;
 	bool fullFrame;
 	bool forceUpdate;
 	bool autofit;

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -339,7 +339,9 @@ void RENDER_Reset( void ) {
     Bitu gfx_flags, xscale, yscale;
     ScalerSimpleBlock_t     *simpleBlock = &ScaleNormal1x;
     ScalerComplexBlock_t    *complexBlock = 0;
-    if (render.aspect) {
+    gfx_scalew = 1;
+    gfx_scaleh = 1;
+    if (render.aspect && !render.aspectOffload) {
         if (render.src.ratio>1.0) {
             gfx_scalew = 1;
             gfx_scaleh = render.src.ratio;
@@ -347,9 +349,6 @@ void RENDER_Reset( void ) {
             gfx_scalew = (1.0/render.src.ratio);
             gfx_scaleh = 1;
         }
-    } else {
-        gfx_scalew = 1;
-        gfx_scaleh = 1;
     }
     if ((dblh && dblw) || (render.scale.forced && !dblh && !dblw)) {
         /* Initialize always working defaults */
@@ -883,13 +882,11 @@ void RENDER_Init() {
 #if C_XBRZ
     if (render.scale.xBRZ) {
         // xBRZ requirements
-        render.aspect = false;
 		vga.draw.doublescan_set = false;
     }
 #endif
 
     render.autofit=section->Get_bool("autofit");
-
 
     //If something changed that needs a ReInit
     // Only ReInit when there is a src.bpp (fixes crashes on startup and directly changing the scaler without a screen specified yet)

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1941,24 +1941,28 @@ dosurface:
         }
 #endif
 
-        // there is a small problem we need to solve here: aspect corrected windows can be smaller than needed due to source with non-4:3 pixel ratio
-        // if we detect non-4:3 pixel ratio here with aspect correction on, we correct it so original fits into resized window properly
-        if (render.aspect) {
-            if (width*sdl.srcAspect.y != height * sdl.srcAspect.x)
-            {
-                // abnormal aspect ratio detected, apply correction
-                if (width*sdl.srcAspect.y > height*sdl.srcAspect.x)
+#if C_XBRZ
+        if (sdl.xBRZ.enable) {
+            // there is a small problem we need to solve here: aspect corrected windows can be smaller than needed due to source with non-4:3 pixel ratio
+            // if we detect non-4:3 pixel ratio here with aspect correction on, we correct it so original fits into resized window properly
+            if (render.aspect) {
+                if (width*sdl.srcAspect.y != height * sdl.srcAspect.x)
                 {
-                    // wide pixel ratio, height should be extended to fit
-                    height = (Bitu)floor((double)width * sdl.srcAspect.y / sdl.srcAspect.x + 0.5);
-                }
-                else
-                {
-                    // long pixel ratio, width should be extended
-                    width = (Bitu)floor((double)height * sdl.srcAspect.x / sdl.srcAspect.y + 0.5);
+                    // abnormal aspect ratio detected, apply correction
+                    if (width*sdl.srcAspect.y > height*sdl.srcAspect.x)
+                    {
+                        // wide pixel ratio, height should be extended to fit
+                        height = (Bitu)floor((double)width * sdl.srcAspect.y / sdl.srcAspect.x + 0.5);
+                    }
+                    else
+                    {
+                        // long pixel ratio, width should be extended
+                        width = (Bitu)floor((double)height * sdl.srcAspect.x / sdl.srcAspect.y + 0.5);
+                    }
                 }
             }
         }
+#endif
 
         sdl.desktop.type=SCREEN_SURFACE;
         sdl.clip.w=width;

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -131,6 +131,7 @@ Bitu INT10_Handler(void) {
 	case 0x10:								/* Palette functions */
 		if (!IS_EGAVGA_ARCH && (reg_al>0x02)) break;
 		else if (!IS_VGA_ARCH && (reg_al>0x03)) break;
+        else if (machine==MCH_PCJR && (reg_al>0x02)) break; /* "Looking at the PCjr tech ref page A-61, ... the BIOS listing stops at subfunction 2." */
 		switch (reg_al) {
 		case 0x00:							/* SET SINGLE PALETTE REGISTER */
 			INT10_SetSinglePaletteRegister(reg_bl,reg_bh);

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -1389,3 +1389,7 @@ void MOUSE_Init() {
     AddVMEventFunction(VM_EVENT_RESET,AddVMEventFunctionFuncPair(MOUSE_OnReset));
 }
 
+bool MOUSE_IsHidden()
+{
+    return static_cast<bool>(mouse.hidden);
+}

--- a/vs2015/dosbox-x.vcxproj
+++ b/vs2015/dosbox-x.vcxproj
@@ -120,57 +120,57 @@
     <OutDir>$(SolutionDir)..\bin\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>$(IncludePath);%DXSDK_DIR%\Include;</IncludePath>
-    <LibraryPath>$(LibraryPath);%DXSDK_DIR%\Lib;</LibraryPath>
+    <IncludePath>$(IncludePath);$(DXSDK_DIR)Include;</IncludePath>
+    <LibraryPath>$(LibraryPath);$(DXSDK_DIR)Lib;</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug SDL2|Win32'">
     <OutDir>$(SolutionDir)..\bin\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>$(IncludePath);%DXSDK_DIR%\Include;</IncludePath>
-    <LibraryPath>$(LibraryPath);%DXSDK_DIR%\Lib;$(SolutionDir)..\bin\$(Platform)\$(Configuration)\</LibraryPath>
+    <IncludePath>$(IncludePath);$(DXSDK_DIR)Include;</IncludePath>
+    <LibraryPath>$(LibraryPath);$(DXSDK_DIR)Lib;$(SolutionDir)..\bin\$(Platform)\$(Configuration)\</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutDir>$(SolutionDir)..\bin\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>$(IncludePath);%DXSDK_DIR%\Include;</IncludePath>
-    <LibraryPath>$(LibraryPath);%DXSDK_DIR%\Lib;</LibraryPath>
+    <IncludePath>$(IncludePath);$(DXSDK_DIR)Include;</IncludePath>
+    <LibraryPath>$(LibraryPath);$(DXSDK_DIR)Lib;</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug SDL2|x64'">
     <OutDir>$(SolutionDir)..\bin\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>$(IncludePath);%DXSDK_DIR%\Include;</IncludePath>
-    <LibraryPath>$(LibraryPath);%DXSDK_DIR%\Lib;$(SolutionDir)..\bin\$(Platform)\$(Configuration)\</LibraryPath>
+    <IncludePath>$(IncludePath);$(DXSDK_DIR)Include;</IncludePath>
+    <LibraryPath>$(LibraryPath);$(DXSDK_DIR)Lib;$(SolutionDir)..\bin\$(Platform)\$(Configuration)\</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)..\bin\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>$(IncludePath);%DXSDK_DIR%\Include;</IncludePath>
-    <LibraryPath>$(LibraryPath);%DXSDK_DIR%\Lib;</LibraryPath>
+    <IncludePath>$(IncludePath);$(DXSDK_DIR)Include;</IncludePath>
+    <LibraryPath>$(LibraryPath);$(DXSDK_DIR)Lib;</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release SDL2|Win32'">
     <OutDir>$(SolutionDir)..\bin\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>$(IncludePath);%DXSDK_DIR%\Include;</IncludePath>
-    <LibraryPath>$(LibraryPath);%DXSDK_DIR%\Lib;$(SolutionDir)..\bin\$(Platform)\$(Configuration)\</LibraryPath>
+    <IncludePath>$(IncludePath);$(DXSDK_DIR)Include;</IncludePath>
+    <LibraryPath>$(LibraryPath);$(DXSDK_DIR)Lib;$(SolutionDir)..\bin\$(Platform)\$(Configuration)\</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(SolutionDir)..\bin\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>$(IncludePath);%DXSDK_DIR%\Include;</IncludePath>
-    <LibraryPath>$(LibraryPath);%DXSDK_DIR%\Lib;</LibraryPath>
+    <IncludePath>$(IncludePath);$(DXSDK_DIR)Include;</IncludePath>
+    <LibraryPath>$(LibraryPath);$(DXSDK_DIR)Lib;</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release SDL2|x64'">
     <OutDir>$(SolutionDir)..\bin\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>$(IncludePath);%DXSDK_DIR%\Include;</IncludePath>
-    <LibraryPath>$(LibraryPath);%DXSDK_DIR%\Lib;$(SolutionDir)..\bin\$(Platform)\$(Configuration)\</LibraryPath>
+    <IncludePath>$(IncludePath);$(DXSDK_DIR)Include;</IncludePath>
+    <LibraryPath>$(LibraryPath);$(DXSDK_DIR)Lib;$(SolutionDir)..\bin\$(Platform)\$(Configuration)\</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>


### PR DESCRIPTION
- Quite extensive aspect ratio correction fix. It assumes 'real' pixels in both source/output are square (should be the case). Not really xBRZ related, but well, it was due to xBRZ + aspect behavior.
- xBRZ now honors aspect ratio correction as well. 
- For modes allowing for native aspect ratio correction (D3D/OGL/xBRZ), render-based one is not used anymore.

Please test. I've checked all the possible combinations of output + aspect parameters, plus xBRZ scaler in each of combination, + some other scalers (normal2x/3x/advmame2x/hq2x forced) in non-xBRZ modes to make sure I did not break anything. Checks pattern included different resolutions: text modes 80x25 and 80x50, 320x200, non-standard (Lost Vikings), resizing back and forth, going to fullscreen and back from default and non-default sizes.

Related options:
[sdl] output=surface/direct3d/opengl(nb/hq)
[render] aspect=true/false
[render] scaler=xbrz/xbrz_bilinear