### PR TITLE
Two new aspect ratio correction modes for output=surface

### DIFF
--- a/include/render.h
+++ b/include/render.h
@@ -37,6 +37,15 @@ enum SCREEN_TYPES {
 	SCREEN_DIRECT3D
 };
 
+enum ASPECT_MODES {
+    ASPECT_FALSE = 0
+    ,ASPECT_TRUE
+#if C_SURFACE_POSTRENDER_ASPECT
+    ,ASPECT_NEAREST
+    ,ASPECT_BILINEAR
+#endif
+};
+
 typedef struct {
 	struct { 
 		Bit8u red;
@@ -92,7 +101,7 @@ typedef struct {
 	RenderPal_t pal;
 	bool updating;
 	bool active;
-	bool aspect;
+	int aspect;
     bool aspectOffload;
 	bool fullFrame;
 	bool forceUpdate;

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -323,7 +323,6 @@ static Bitu MakeAspectTable(Bitu skip,Bitu height,double scaley,Bitu miny) {
     return linesadded;
 }
 
-
 void RENDER_Reset( void ) {
     Bitu width=render.src.width;
     Bitu height=render.src.height;
@@ -341,7 +340,7 @@ void RENDER_Reset( void ) {
     ScalerComplexBlock_t    *complexBlock = 0;
     gfx_scalew = 1;
     gfx_scaleh = 1;
-    if (render.aspect && !render.aspectOffload) {
+    if (render.aspect == ASPECT_TRUE && !render.aspectOffload) {
         if (render.src.ratio>1.0) {
             gfx_scalew = 1;
             gfx_scaleh = render.src.ratio;
@@ -722,7 +721,7 @@ bool RENDER_GetAutofit(void) {
     return render.autofit;
 }
 
-bool RENDER_GetAspect(void) {
+int RENDER_GetAspect(void) {
     return render.aspect;
 }
 
@@ -748,9 +747,16 @@ void RENDER_OnSectionPropChange(Section *x) {
 
     bool p_doublescan = vga.draw.doublescan_set;
     bool p_char9 = vga.draw.char9_set;
-    bool p_aspect = render.aspect;
+    int p_aspect = render.aspect;
 
-    render.aspect = section->Get_bool("aspect");
+    std::string s_aspect = section->Get_string("aspect");
+    render.aspect = ASPECT_FALSE;
+    if (s_aspect == "true" || s_aspect == "1" || s_aspect == "yes") render.aspect = ASPECT_TRUE;
+#if C_SURFACE_POSTRENDER_ASPECT
+    if (s_aspect == "nearest") render.aspect = ASPECT_NEAREST;
+    if (s_aspect == "bilinear") render.aspect = ASPECT_BILINEAR;
+#endif
+
     render.frameskip.max = (Bitu)section->Get_int("frameskip");
 
     vga.draw.doublescan_set=section->Get_bool("doublescan");
@@ -847,7 +853,7 @@ void RENDER_Init() {
 
     //For restarting the renderer.
     static bool running = false;
-    bool aspect = render.aspect;
+    int aspect = render.aspect;
     Bitu scalersize = render.scale.size;
     bool scalerforced = render.scale.forced;
     scalerOperation_t scaleOp = render.scale.op;
@@ -857,7 +863,15 @@ void RENDER_Init() {
 
     render.pal.first=0;
     render.pal.last=255;
-    render.aspect=section->Get_bool("aspect");
+
+    std::string s_aspect = section->Get_string("aspect");
+    render.aspect = ASPECT_FALSE;
+    if (s_aspect == "true" || s_aspect == "1") render.aspect = ASPECT_TRUE;
+#if C_SURFACE_POSTRENDER_ASPECT
+    if (s_aspect == "nearest") render.aspect = ASPECT_NEAREST;
+    if (s_aspect == "bilinear") render.aspect = ASPECT_BILINEAR;
+#endif
+
     render.frameskip.max=(Bitu)section->Get_int("frameskip");
 
     RENDER_UpdateFrameskipMenu();

--- a/vs2015/config.h
+++ b/vs2015/config.h
@@ -117,6 +117,11 @@
 /* Set to 1 to enable XBRZ support */
 #define C_XBRZ 1
 
+/* Set to 1 to enable scaler friendly but CPU intensive aspect ratio correction options (post-scalers) for 'surface' output */
+/* Please note that this option includes small part of xBRZ code and uses task group parallelism like xBRZ (batch size is hardcoded here) */
+#define C_SURFACE_POSTRENDER_ASPECT 1
+#define C_SURFACE_POSTRENDER_ASPECT_BATCH_SIZE 16
+
 /* Define to 1 if you have setpriority support */
 #undef C_SET_PRIORITY
 


### PR DESCRIPTION
This one is for consideration (and testing, but it's not complex and fully optional). It complements previous (xBRZ) patchset which also adjusted aspect ratio correction code. For me it's finishing touch on all the aspect ratio stuff I think, I don't currently see anything more to adjust on that part.

Basically, what I came to is that DOSBox original scanline (renderer) based aspect ratio correction is not i.e. hq2x/hq3x friendly because it adds lines and breaks these multiline scaler algorithms (that's why xBRZ reimplements aspect ratio correction for surface mode). I reused a part of xBRZ code to do post-render aspect ratio correction with aspect=nearest and aspect=bilinear options (for 'surface' output only). This way it's done only after i.e hq scalers did their work on the original source image.

Also adds extensive comments about all the modes into config when saving.

Made fully optional (C_SURFACE_POSTRENDER_ASPECT) to build, automatically includes xbrz_tools.h and ppl.h when enabled.