### PR TITLE
Fix ALSA MIDI mistake preventing creation of subscription ports

### DIFF
--- a/src/gui/midi_alsa.h
+++ b/src/gui/midi_alsa.h
@@ -155,7 +155,7 @@ public:
 	
 		caps = SND_SEQ_PORT_CAP_READ;
 		if (seq_client == SND_SEQ_ADDRESS_SUBSCRIBERS)
-			caps = ~((unsigned int)SND_SEQ_PORT_CAP_SUBS_READ);
+			caps |= SND_SEQ_PORT_CAP_SUBS_READ;
 		my_port =
 		          snd_seq_create_simple_port(seq_handle, "DOSBOX", caps,
 		          SND_SEQ_PORT_TYPE_MIDI_GENERIC | SND_SEQ_PORT_TYPE_APPLICATION);


### PR DESCRIPTION
# Description

Permits creation of virtual MIDI ports in ALSA, which was blocked by a probable programming mistake.

**Does this PR introduce new feature(s) ?**

ALSA virtual ports (subscribe ability).
It's an ability which, as I understand from code, is intended to be provided originally by Dosbox. It permits flexibility of MIDI connections on Linux OS.
But this feature seems broken in a trivial way, and I make this single line patch to fix that.


**Additional information**

Virtual port is supposed to be provided under configuration `mididevice=alsa` `midiconfig=s`.
Where 's' as I understand stands for subscriber and replaces what is usually a fixed port identifier of ALSA sequencer.

@Wohlstand