### PR TITLE
Fix a build error for SDL1 on X11

### DIFF
--- a/vs2015/sdl/src/video/x11/SDL_x11sym.h
+++ b/vs2015/sdl/src/video/x11/SDL_x11sym.h
@@ -165,7 +165,7 @@ SDL_X11_SYM(Bool,XShmQueryExtension,(Display* a),(a),return)
  */
 #ifdef LONG64
 SDL_X11_MODULE(IO_32BIT)
-SDL_X11_SYM(int,_XData32,(Display *dpy,register long *data,unsigned len),(dpy,data,len),return)
+SDL_X11_SYM(int,_XData32,(Display *dpy,register _Xconst long *data,unsigned len),(dpy,data,len),return)
 SDL_X11_SYM(void,_XRead32,(Display *dpy,register long *data,long len),(dpy,data,len),)
 #endif
 


### PR DESCRIPTION
# Description

Fixes a build problem on Linux X11 in the bundled SDL1.
It's a mismatch of types because of a missing const qualifier.
