### PR TITLE
Create appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ build:
   
 after_build:
   - ps : >-
-        $shortHash = $env:APPVEYOR_REPO_COMMIT.Substring(0, 10);
+        $shortHash = $env:APPVEYOR_REPO_COMMIT.Substring(0, 7);
         7z a dosbox-x-windows-$shortHash.zip C:\projects\dosbox-x\vs2015\..\bin\x64\Release\changelog.txt;
         7z a dosbox-x-windows-$shortHash.zip C:\projects\dosbox-x\vs2015\..\bin\x64\Release\dosbox.reference.conf;
         7z a dosbox-x-windows-$shortHash.zip C:\projects\dosbox-x\vs2015\..\bin\x64\Release\dosbox-x.exe;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,49 @@
+#---------------------------------#
+#      general configuration      #
+#---------------------------------#
+
+branches:
+  only:
+    - master
+
+only_commits:
+  files:
+    - src\
+    - vs2015\
+
+#---------------------------------#
+#    environment configuration    #
+#---------------------------------#
+
+image: Visual Studio 2017
+
+init:
+  - git config --global core.autocrlf true
+
+#---------------------------------#
+#       build configuration       #
+#---------------------------------#
+
+platform:
+  - x64
+  
+configuration: Release
+
+build:
+  project: vs2015\dosbox-x.sln
+  
+after_build:
+  - ps : >-
+        $shortHash = $env:APPVEYOR_REPO_COMMIT.Substring(0, 10);
+        7z a dosbox-x-windows-$shortHash.zip C:\projects\dosbox-x\vs2015\..\bin\x64\Release\changelog.txt;
+        7z a dosbox-x-windows-$shortHash.zip C:\projects\dosbox-x\vs2015\..\bin\x64\Release\dosbox.reference.conf;
+        7z a dosbox-x-windows-$shortHash.zip C:\projects\dosbox-x\vs2015\..\bin\x64\Release\dosbox-x.exe;
+        7z a dosbox-x-windows-$shortHash.zip C:\projects\dosbox-x\vs2015\..\bin\x64\Release\FREECG98.BMP;
+  
+#---------------------------------#
+#      artifacts configuration    #
+#---------------------------------#
+
+artifacts:
+  - path: dosbox-x-windows-*.zip
+    name: DOSBox-X Windows Build


### PR DESCRIPTION
# Description

A working appveyor.yml file to automatically create a 64-bit Windows build on every commit that changes the source code or the Visual Studio solution.

**Does this PR address some issue(s) ?**

#618

**Additional information**

To use this, create an AppVeyor account and add this repository to your profile. I think it's straightforward to do so.

This `appveyor.yml` only creates an x64 build. The x86 build failed when I tried to use the .sln file in the `vs2015` folder.

Only the `master` branch will be built, and only when a commit modifies the `src` folder or the `vs2015` folder.

The build will be packaged as "dosbox-x-windows-(commitID).zip" and is set to include the four files:
`dosbox-x.exe`, `changelog.txt`, `dosbox.reference.conf` and `FREECG98.BMP`.

Note: This uses AppVeyor's Visual Studio 2017 virtual image to build, as that seems to be what the `vs2015` folder provides a solution for. Maybe that folder should be renamed? If so this `appveyor.yml` will need to be updated.