### PR TITLE
Add option for compiler optimization in configure.ac.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -148,13 +148,25 @@ fi
 CFLAGS="$CFLAGS -std=gnu11";
 CXXFLAGS="$CXXFLAGS -std=gnu++0x";
 
-dnl Yksoft1 wants a MinGW build for Windows that doesn't use the Windows menu system.
+dnl yksoft1 wants a MinGW build for Windows that doesn't use the Windows menu system.
 AH_TEMPLATE(C_FORCE_MENU_SDLDRAW,[Define to 1 to force SDL-drawn menus])
 AC_ARG_ENABLE(force-menu-sdldraw,AC_HELP_STRING([--enable-force-menu-sdldraw],[Force SDL drawn menus]),enable_force_menu_sdldraw=yes)
 
 dnl This is how the build script can specify a HX DOS extender target
 AH_TEMPLATE(C_HX_DOS,[Define to 1 to target HX DOS])
 AC_ARG_ENABLE(hx-dos,AC_HELP_STRING([--enable-hx-dos],[Enable HX target]),enable_hx=yes)
+
+dnl Optimize for speed by default
+AC_ARG_ENABLE(optimize,AC_HELP_STRING([--disable-optimize],[Don't enable compiler optimizations]))
+
+dnl FIXME: Remove default "-O2" set by some autotools versions. TODO: check availability of sed.
+CFLAGS=["`echo $CFLAGS' ' | sed -e 's/-O[^ ]* //g'`"]
+CXXFLAGS=["`echo $CXXFLAGS' ' | sed -e 's/-O[^ ]* //g'`"]
+
+if test x$enable_optimize != xno; then
+	CFLAGS="$CFLAGS -O2"
+	CXXFLAGS="$CXXFLAGS -O2"
+fi
 
 dnl Some stuff for the icon.
 case "$host" in


### PR DESCRIPTION
# Description

I found that neither in configure.ac nor in any build scripts (using autotools) are there anything about compiler optimization mentioned. 
Thus a non-optimized dosbox-x.exe would be built using any of build-mingw* scripts.
I think most people will expect an optimized executable when they just use "./configure" and "make", so I decided to make configure.ac to add "-O2" option by default. However, we should make that configurable as an unoptimized executable is easier to debug.

**Does this PR address some issue(s) ?**

This should fix #846 by building optimized executable files in MinGW by default.

**Does this PR introduce new feature(s) ?**

An option to enable/disable compiler optimization option "-O2" in configure.ac.

**Are there any breaking changes ?**

Nothing I think.


**Additional information**

_Add any additional information that may be useful._