### PR TITLE
add licenses info to README; add GPLv2+ license to Jon's files referenced in Origins section

### DIFF
--- a/README
+++ b/README
@@ -553,18 +553,18 @@ This is my attempt to properly credit the code and it's
 sources below. Feel free to revise and correct this list
 if there are errors.
 
-NE2000 network card emulation (Bochs)
+NE2000 network card emulation (Bochs; LGPLv2+)
   src/hardware/ne2000.cpp
 
-MT32 synthesizer (MUNT)
+MT32 synthesizer (MUNT; LGPLv2.1+)
   src/mt32/*.cpp
   src/mt32/*.h
 
-AVI writer with OpenDML support (written by myself)
+AVI writer with OpenDML support (written by myself; GPLv2+)
   src/aviwriter/*.cpp
   src/aviwriter/*.h
 
-Framework-agnostic GUI toolkit (Jorg Walter)
+Framework-agnostic GUI toolkit (Jorg Walter; GPLv3+)
   src/libs/gui_tk/*.cpp
   src/libs/gui_tk/*.h
 
@@ -572,36 +572,36 @@ Porttalk library, to read/write I/O ports directly (Unknown source)
   src/libs/porttalk/*.cpp
   src/libs/porttalk/*.h
 
-FreeDOS utilities as binary blobs (FreeDOS)
+FreeDOS utilities as binary blobs (FreeDOS; no license)
   src/builtin/*.cpp
 
-NukedOPL OPL3 emulation (Alexey Khokholov)
+NukedOPL OPL3 emulation (Alexey Khokholov; GPLv2+)
   src/hardware/nukedopl.cpp
 
-OPL emulation based on Ken Silverman OPL2 emulation
+OPL emulation based on Ken Silverman OPL2 emulation (LGPLv2.1+)
   src/hardware/opl.cpp
 
-MOS6581 SID emulation
+MOS6581 SID emulation (GPLv2+)
   src/hardware/reSID/*.cpp
   src/hardware/reSID/*.h
 
-SN76496 emulation (MAME project)
+SN76496 emulation (MAME project; GPLv2+)
   src/hardware/sn76496.h
   src/hardware/tandy_sound.cpp
 
-PC-98 video rendering and I/O handling code (written by myself)
+PC-98 video rendering and I/O handling code (written by myself; GPLv2+)
   src/hardware/vga_pc98*.cpp
 
-3dfx Voodoo Graphics SST-1/2 emulation (Aaron Giles)
+3dfx Voodoo Graphics SST-1/2 emulation (Aaron Giles; BSD 3-clause)
   src/hardware/voodoo_emu.cpp
 
-PC-98 FM board emulation (Neko Project II)
+PC-98 FM board emulation (Neko Project II; no license)
   src/hardware/snd_pc98/*
 
-QCOW image support (Michael Greger)
+QCOW image support (Michael Greger; GPLv2+)
   src/ints/qcow2_disk.cpp
 
-HQ2X and HQ3X render scaler (ScummVM, Maxim Stepin)
+HQ2X and HQ3X render scaler (ScummVM, Maxim Stepin; GPLv2+)
   src/gui/render_templates_hq2x.h
 
 

--- a/src/aviwriter/avi.h
+++ b/src/aviwriter/avi.h
@@ -1,3 +1,21 @@
+/*
+ *  Copyright (C) 2018  Jon Campbell
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
 #ifndef __VIDEOMGR_UTIL_AVI_H
 #define __VIDEOMGR_UTIL_AVI_H
 

--- a/src/aviwriter/avi_rw_iobuf.cpp
+++ b/src/aviwriter/avi_rw_iobuf.cpp
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (C) 2018  Jon Campbell
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/aviwriter/avi_rw_iobuf.h
+++ b/src/aviwriter/avi_rw_iobuf.h
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (C) 2018  Jon Campbell
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
 
 extern unsigned char*		avi_io_buf;
 extern unsigned char*		avi_io_read;

--- a/src/aviwriter/avi_writer.cpp
+++ b/src/aviwriter/avi_writer.cpp
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (C) 2018  Jon Campbell
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
 
 /* Shut up! */
 #define _CRT_NONSTDC_NO_DEPRECATE

--- a/src/aviwriter/avi_writer.h
+++ b/src/aviwriter/avi_writer.h
@@ -1,3 +1,21 @@
+/*
+ *  Copyright (C) 2018  Jon Campbell
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
 #ifndef __ISP_UTILS_AVI_WRITER_H
 #define __ISP_UTILS_AVI_WRITER_H
 

--- a/src/aviwriter/guid.cpp
+++ b/src/aviwriter/guid.cpp
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (C) 2018  Jon Campbell
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/aviwriter/guid.h
+++ b/src/aviwriter/guid.h
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (C) 2018  Jon Campbell
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
 
 #ifndef __ISP_UTILS_V4_GUID_H
 #define __ISP_UTILS_V4_GUID_H

--- a/src/aviwriter/ksdataformat.cpp
+++ b/src/aviwriter/ksdataformat.cpp
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (C) 2018  Jon Campbell
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
 
 #include "ksdataformat.h"
 

--- a/src/aviwriter/ksdataformat.h
+++ b/src/aviwriter/ksdataformat.h
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (C) 2018  Jon Campbell
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
 
 #ifndef _ISP_UTILS_V4_WIN_KSDATAFORMAT_H_H
 #define _ISP_UTILS_V4_WIN_KSDATAFORMAT_H_H

--- a/src/aviwriter/riff.cpp
+++ b/src/aviwriter/riff.cpp
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (C) 2018  Jon Campbell
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
 
 /* Shut up! */
 #define _CRT_NONSTDC_NO_DEPRECATE

--- a/src/aviwriter/riff.h
+++ b/src/aviwriter/riff.h
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (C) 2018  Jon Campbell
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
 
 #ifndef __VIDEOMGRUTIL_RIFF_H
 #define __VIDEOMGRUTIL_RIFF_H

--- a/src/aviwriter/riff_wav_writer.cpp
+++ b/src/aviwriter/riff_wav_writer.cpp
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (C) 2018  Jon Campbell
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
 
 /* Shut up! */
 #define _CRT_NONSTDC_NO_DEPRECATE

--- a/src/aviwriter/riff_wav_writer.h
+++ b/src/aviwriter/riff_wav_writer.h
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (C) 2018  Jon Campbell
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
 
 #ifndef __ISP_UTILS_V4_AVI_RIFF_WAV_WRITER_H
 #define __ISP_UTILS_V4_AVI_RIFF_WAV_WRITER_H

--- a/src/hardware/vga_pc98_cg.cpp
+++ b/src/hardware/vga_pc98_cg.cpp
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (C) 2018  Jon Campbell
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
 
 #include "dosbox.h"
 #include "setup.h"

--- a/src/hardware/vga_pc98_crtc.cpp
+++ b/src/hardware/vga_pc98_crtc.cpp
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (C) 2018  Jon Campbell
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
 
 #include "dosbox.h"
 #include "setup.h"

--- a/src/hardware/vga_pc98_dac.cpp
+++ b/src/hardware/vga_pc98_dac.cpp
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (C) 2018  Jon Campbell
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
 
 #include "dosbox.h"
 #include "setup.h"

--- a/src/hardware/vga_pc98_egc.cpp
+++ b/src/hardware/vga_pc98_egc.cpp
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (C) 2018  Jon Campbell
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
 
 #include "dosbox.h"
 #include "setup.h"

--- a/src/hardware/vga_pc98_gdc.cpp
+++ b/src/hardware/vga_pc98_gdc.cpp
@@ -1,3 +1,20 @@
+/*
+ *  Copyright (C) 2018  Jon Campbell
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
 
 #include "dosbox.h"
 #include "setup.h"


### PR DESCRIPTION
# Description

Complement README section *Origins, and crediting of source code* with license information where available for transparency.

Includes suggestion to add GPLv2+ license to files referenced in this section that were written by Jon.

**Does this PR address some issue(s) ?**

Would address issue #883 (albeit incompletely - don't close it yet because it would be best to clarify missing licenses first)

**Does this PR introduce new feature(s) ?** No.

**Are there any breaking changes ?** No.

**Additional information**

* Porttalk not addressed.
* Was unable to find code origin in FreeDOS project
* PC-98 FM board emulation also without license info - if source is known, I'd be happy to try to find out.
