### PR TITLE
add BSD license for Neko II

### DIFF
--- a/README
+++ b/README
@@ -606,7 +606,7 @@ PC-98 video rendering and I/O handling code (written by myself; GPLv2+)
 3dfx Voodoo Graphics SST-1/2 emulation (Aaron Giles; BSD 3-clause)
   src/hardware/voodoo_emu.cpp
 
-PC-98 FM board emulation (Neko Project II; no license)
+PC-98 FM board emulation (Neko Project II; BSD 3-clause)
   src/hardware/snd_pc98/*
 
 QCOW image support (Michael Greger; GPLv2+)


### PR DESCRIPTION
# Description

I received information from xnp2 upstream (nonakap, https://www.nonakap.org/np2/) that original Neko Project II by yui is BSD 3-clause licensed


**Does this PR address some issue(s) ?**

#883 (not fully fixed yet, FreeDOS component license still in progress)


**Does this PR introduce new feature(s) ?**

No.


**Are there any breaking changes ?**

No.


**Additional information**

Email replay from nonaka here:

```
> What is the license for the PC-98 FM board emulation in Neko Project II? Would                    
> like to add this information to the Dosbox-X repo.                                                
                                                                                                    
The emulation code of the FM board is written by yui the author of the                              
original Neko Project II.                                                                           
Neko Project II use the modified BSD license                                                        
(https://opensource.org/licenses/BSD-3-Clause).                                                     
                                                                                                    
-----                                                                                               
Copyright yui (np2@yui.ne.jp)                                                                       
All rights reserved.                                                                                
                                                                                                    
Redistribution and use in source and binary forms, with or without                                  
modification, are permitted provided that the following conditions                                  
are met:                                                                                            
  1. Redistributions of source code must retain the above copyright notice,                         
     this list of conditions and the following disclaimer.                                          
  2. Redistributions in binary form must reproduce the above copyright                              
     notice, this list of conditions and the following disclaimer in the                            
     documentation and/or other materials provided with the distribution.                           
  3. Neither the name of the copyright holder nor the names of its                                  
     contributors may be used to endorse or promote products derived from                           
     this software without specific prior written permission.                                       
                                                                                                    
THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"                         
AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,                               
THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR                              
PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR                                   
CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,                               
EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,                                 
PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;                         
OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,                            
WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR                             
OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF                              
ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                                                          
-----                                                                                               
                                                                                                    
Regards,                                                                                            
--                                                                                                  
Kimihiro Nonaka
```
