### PR TITLE
Build error "hardware.cpp" on Ubuntu 18.10.

### DIFF
--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -420,7 +420,7 @@ void ffmpeg_reopen_video(double fps,const int bpp) {
 	ffmpeg_vid_ctx->max_b_frames = 0;
 	ffmpeg_vid_ctx->pix_fmt = ffmpeg_choose_pixfmt(ffmpeg_yuv_format_choice);
 	ffmpeg_vid_ctx->thread_count = 0;		// auto-choose
-	ffmpeg_vid_ctx->flags2 = CODEC_FLAG2_FAST;
+	ffmpeg_vid_ctx->flags2 = AV_CODEC_FLAG2_FAST;
 	ffmpeg_vid_ctx->qmin = 1;
 	ffmpeg_vid_ctx->qmax = 63;
 	ffmpeg_vid_ctx->rc_max_rate = ffmpeg_vid_ctx->bit_rate;
@@ -1080,7 +1080,7 @@ skip_shot:
 			ffmpeg_vid_ctx->max_b_frames = 0;
 			ffmpeg_vid_ctx->pix_fmt = ffmpeg_choose_pixfmt(ffmpeg_yuv_format_choice); // TODO: auto-choose according to what codec says is supported, and let user choose as well
 			ffmpeg_vid_ctx->thread_count = 0;		// auto-choose
-			ffmpeg_vid_ctx->flags2 = CODEC_FLAG2_FAST;
+			ffmpeg_vid_ctx->flags2 = AV_CODEC_FLAG2_FAST;
 			ffmpeg_vid_ctx->qmin = 1;
 			ffmpeg_vid_ctx->qmax = 63;
 			ffmpeg_vid_ctx->rc_max_rate = ffmpeg_vid_ctx->bit_rate;


### PR DESCRIPTION
# Description

I checked build error  DOSBox-x sourcecode in Ubuntu 18.10.
This issue is "Replace CODEC_FLAG2_FAST with AV_CODEC_FLAG2_FAST" in Hardware.cpp.  
In this point of view from "https://xpra.org/trac/ticket/1768", Please see it.

**Does this PR address some issue(s) ?**

Fixed build error on Hardware.cpp from  CODEC_FLAG2_FAST to AV_CODEC_FLAG2_FAST.

**Does this PR introduce new feature(s) ?**

No

**Are there any breaking changes ?**

No

**Additional information**

Build error messages on Ubuntu 18.10, I want to fix it.


hardware.cpp:423:27: error: ‘CODEC_FLAG2_FAST’ was not declared in this scope
  ffmpeg_vid_ctx->flags2 = CODEC_FLAG2_FAST;
                           ^~~~~~~~~~~~~~~~

hardware.cpp:1083:29: error: ‘CODEC_FLAG2_FAST’ was not declared in this scope
    ffmpeg_vid_ctx->flags2 = CODEC_FLAG2_FAST;
                             ^~~~~~~~~~~~~~~~

Thank you!