### PR TITLE
Fluidsynth 2.0 logging compatibility

### DIFF
--- a/src/gui/midi_synth.h
+++ b/src/gui/midi_synth.h
@@ -28,7 +28,12 @@ static MixerChannel *synthchan = NULL;
 static fluid_synth_t *synth_soft = NULL;
 static int synthsamplerate = 0;
 
-static void synth_log(int level, char *message, void *data) {
+static void synth_log(int level,
+#if FLUIDSYNTH_VERSION_MAJOR >= 2
+                      const
+#endif
+                      char *message,
+                      void *data) {
     (void)data;//UNUSED
 
 	switch (level) {


### PR DESCRIPTION
Fix for fluidsynth 2.0 compatibility.
Taken from [MPD](https://github.com/MusicPlayerDaemon/MPD/blob/b0994bad31619e1a3371c4441555bbf784055559/src/decoder/plugins/FluidsynthDecoderPlugin.cxx#L68-L70)
