### PR TITLE
Pass configure arguments to build scripts

### DIFF
--- a/build
+++ b/build
@@ -15,6 +15,6 @@ echo Compiling our internal SDL 1.x
 # now compile ourself
 echo Compiling DOSBox-X
 chmod +x configure
-./configure --enable-core-inline --disable-debug --enable-avcodec --prefix=/usr || exit 1
+./configure --enable-core-inline --disable-debug --enable-avcodec --prefix=/usr "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-debug
+++ b/build-debug
@@ -25,6 +25,6 @@ echo Compiling our internal SDL 1.x
 # now compile ourself
 echo Compiling DOSBox-X
 chmod +x configure
-./configure --enable-core-inline --enable-debug=heavy --enable-avcodec --prefix=/usr || exit 1
+./configure --enable-core-inline --enable-debug=heavy --enable-avcodec --prefix=/usr "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-debug-g3
+++ b/build-debug-g3
@@ -20,6 +20,6 @@ echo Compiling our internal SDL 1.x
 # now compile ourself
 echo Compiling DOSBox-X
 # NTS: --disable-dynamic-core is needed. the dynamic core doesn't work properly with the CFLAGS given above
-./configure --enable-core-inline --enable-debug=heavy --prefix=/usr --disable-dynamic-core || exit 1
+./configure --enable-core-inline --enable-debug=heavy --prefix=/usr --disable-dynamic-core "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-debug-g3-sdl2
+++ b/build-debug-g3-sdl2
@@ -14,6 +14,6 @@ export CFLAGS="$CFLAGS -g3 -O0 -fno-inline -fno-omit-frame-pointer"
 export CXXFLAGS="$CXXFLAGS -g3 -O0 -fno-inline -fno-omit-frame-pointer"
 
 # NTS: --disable-dynamic-core is needed. the dynamic core doesn't work properly with the CFLAGS given above
-./configure --enable-core-inline --enable-debug=heavy --prefix=/usr --disable-dynamic-core --enable-sdl2 || exit 1
+./configure --enable-core-inline --enable-debug=heavy --prefix=/usr --disable-dynamic-core --enable-sdl2 "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-debug-no-avcodec
+++ b/build-debug-no-avcodec
@@ -15,6 +15,6 @@ echo Compiling our internal SDL 1.x
 # now compile ourself
 echo Compiling DOSBox-X
 chmod +x configure
-./configure --enable-core-inline --enable-debug=heavy --prefix=/usr || exit 1
+./configure --enable-core-inline --enable-debug=heavy --prefix=/usr "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-debug-no-mt32
+++ b/build-debug-no-mt32
@@ -15,6 +15,6 @@ echo Compiling our internal SDL 1.x
 # now compile ourself
 echo Compiling DOSBox-X
 chmod +x configure
-./configure --enable-core-inline --enable-debug=heavy --enable-avcodec --prefix=/usr --disable-mt32 || exit 1
+./configure --enable-core-inline --enable-debug=heavy --enable-avcodec --prefix=/usr --disable-mt32 "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-debug-sdl2
+++ b/build-debug-sdl2
@@ -16,6 +16,6 @@ if test -z "$x" ; then
 fi
 
 chmod +x configure
-./configure --enable-core-inline --enable-debug=heavy --enable-avcodec --prefix=/usr --enable-sdl2 || exit 1
+./configure --enable-core-inline --enable-debug=heavy --enable-avcodec --prefix=/usr --enable-sdl2 "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-emscripten-sdl2
+++ b/build-emscripten-sdl2
@@ -14,7 +14,7 @@ chmod +x configure
 export PATH=/opt/emsdk/emscripten/incoming/system/bin:$PATH
 
 # build command borrowed from Yksoft1 vanilla DOSBox-X port with modifications
-CC="emcc" CXX="em++" LD="emcc" LD_CXX="em++" CFLAGS="-DEMTERPRETER_SYNC" CXXFLAGS="-DEMSCRIPTEN=1 -DEMTERPRETER_SYNC" ./configure --host=x86_64-linux --disable-dynamic-x86 --enable-sdl2 --with-sdl-prefix=/opt/emsdk/emscripten/incoming/system --disable-opengl --disable-mt32 --enable-emscripten --enable-force-menu-sdldraw
+CC="emcc" CXX="em++" LD="emcc" LD_CXX="em++" CFLAGS="-DEMTERPRETER_SYNC" CXXFLAGS="-DEMSCRIPTEN=1 -DEMTERPRETER_SYNC" ./configure --host=x86_64-linux --disable-dynamic-x86 --enable-sdl2 --with-sdl-prefix=/opt/emsdk/emscripten/incoming/system --disable-opengl --disable-mt32 --enable-emscripten --enable-force-menu-sdldraw "$@"
 make -j3 || exit 1
 #emcc -O1 -s USE_SDL=2 -s TOTAL_MEMORY=104857600 -s EMTERPRETIFY=1 -s EMTERPRETIFY_ASYNC=1 -s EMTERPRETIFY_WHITELIST=@d3.txt dosbox-x.bc --memory-init-file 0 -o th5e.html --preload-file d:/tmpp/th5x@/
 

--- a/build-macosx
+++ b/build-macosx
@@ -39,6 +39,6 @@ export CXXFLAGS="$new$CXXFLAGS"
 # now compile ourself
 echo Compiling DOSBox-X
 chmod +x configure
-./configure --enable-core-inline --enable-debug=heavy --enable-avcodec --prefix=/usr || exit 1
+./configure --enable-core-inline --enable-debug=heavy --enable-avcodec --prefix=/usr "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-macosx-sdl2
+++ b/build-macosx-sdl2
@@ -42,6 +42,6 @@ export CXXFLAGS="$new$CXXFLAGS"
 # now compile ourself
 echo Compiling DOSBox-X
 chmod +x configure
-./configure --enable-core-inline --enable-debug=heavy --enable-avcodec --prefix=/usr --enable-sdl2 || exit 1
+./configure --enable-core-inline --enable-debug=heavy --enable-avcodec --prefix=/usr --enable-sdl2 "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-mingw
+++ b/build-mingw
@@ -43,6 +43,6 @@ export CXXFLAGS="$new$CXXFLAGS"
 echo Compiling DOSBox-X
 chmod +x configure
 # FIXME: I would like MinGW builds to enable the debugger, eventually
-./configure --enable-core-inline --enable-d3d9 --enable-d3d-shaders --prefix=/usr || exit 1
+./configure --enable-core-inline --enable-d3d9 --enable-d3d-shaders --prefix=/usr "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-mingw-hx-dos
+++ b/build-mingw-hx-dos
@@ -43,6 +43,6 @@ export CXXFLAGS="$new$CXXFLAGS"
 echo Compiling DOSBox-X
 chmod +x configure
 # FIXME: I would like MinGW builds to enable the debugger, eventually
-./configure --enable-core-inline --disable-mt32 --disable-opengl --enable-hx-dos --prefix=/usr || exit 1
+./configure --enable-core-inline --disable-mt32 --disable-opengl --enable-hx-dos --prefix=/usr "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-mingw-lowend
+++ b/build-mingw-lowend
@@ -43,6 +43,6 @@ export CXXFLAGS="$new$CXXFLAGS"
 echo Compiling DOSBox-X
 chmod +x configure
 # FIXME: I would like MinGW builds to enable the debugger, eventually
-./configure --enable-core-inline --disable-mt32 --prefix=/usr || exit 1
+./configure --enable-core-inline --disable-mt32 --prefix=/usr "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-mingw-sdl2
+++ b/build-mingw-sdl2
@@ -46,6 +46,6 @@ export CXXFLAGS="$new$CXXFLAGS"
 echo Compiling DOSBox-X
 chmod +x configure
 # FIXME: I would like MinGW builds to enable the debugger, eventually
-./configure --enable-core-inline --prefix=/usr --enable-sdl2 || exit 1
+./configure --enable-core-inline --prefix=/usr --enable-sdl2 "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-mingw-sdldraw
+++ b/build-mingw-sdldraw
@@ -43,6 +43,6 @@ export CXXFLAGS="$new$CXXFLAGS"
 echo Compiling DOSBox-X
 chmod +x configure
 # FIXME: I would like MinGW builds to enable the debugger, eventually
-./configure --enable-core-inline --enable-force-menu-sdldraw --enable-d3d9 --enable-d3d-shaders --prefix=/usr || exit 1
+./configure --enable-core-inline --enable-force-menu-sdldraw --enable-d3d9 --enable-d3d-shaders --prefix=/usr "$@" || exit 1
 make -j3 || exit 1
 


### PR DESCRIPTION
Added `"$@"` to the end of the `./configure` call in each build script to pass any arguments forward.
This is to smooth installation with macos `brew`.
I've only tested this on macos and I'm not sure of the implications elsewhere, I updated them all for consistency.