### PR TITLE
Fix compilation with GCC 4.7

### DIFF
--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -431,7 +431,8 @@ public:
 
 	void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
         (void)b;//UNUSED
-        (void)arg;//UNUSED
+        // HACK: Attempting to cast a String to void causes "forming reference to void" errors when building with GCC 4.7
+        (void)arg.size();//UNUSED
 		std::string line;
 		if (prepare(line)) {
 			prop->SetValue(GUI::String(line));
@@ -738,7 +739,8 @@ public:
 
 	void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
         (void)b;//UNUSED
-        (void)arg;//UNUSED
+        // HACK: Attempting to cast a String to void causes "forming reference to void" errors when building with GCC 4.7
+        (void)arg.size();//UNUSED
 		if (arg == "OK") control->PrintConfig(name->getText());
 		close();
 		if(shortcut) running=false;

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -2372,7 +2372,8 @@ protected:
 
 	/// Execute handlers.
 	virtual void actionExecuted(ActionEventSource *src, const String &arg) {
-        (void)arg;//UNUSED
+        // HACK: Attempting to cast a String to void causes "forming reference to void" errors when building with GCC 4.7
+        (void)arg.size();//UNUSED
 		for (std::list<Window *>::iterator i = children.begin(); i != children.end(); ++i) {
 			Radiobox *r = dynamic_cast<Radiobox*>(*i);
 			if (r != NULL && src != dynamic_cast<ActionEventSource*>(r)) r->setChecked(false);


### PR DESCRIPTION
Attempting to cast a String to void causes "forming reference to void" errors when building with GCC 4.7