### PR TITLE
Add scaler for grayscale effect

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -942,7 +942,7 @@ void DOSBOX_SetupConfigSections(void) {
         "advmame2x", "advmame3x", "advinterp2x", "advinterp3x", "hq2x", "hq3x", "2xsai", "super2xsai", "supereagle",
 #endif
 #if RENDER_USE_ADVANCED_SCALERS>0
-        "tv2x", "tv3x", "rgb2x", "rgb3x", "scan2x", "scan3x",
+        "tv2x", "tv3x", "rgb2x", "rgb3x", "scan2x", "scan3x", "gray2x",
 #endif
         "hardware_none", "hardware2x", "hardware3x", "hardware4x", "hardware5x",
 #if C_XBRZ

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -501,15 +501,28 @@ void RENDER_Reset( void ) {
             else if (render.scale.size == 3)
                 simpleBlock = &ScaleScan3x;
             break;
+        case scalerOpGray:
+            if (render.scale.size == 2){
+			        simpleBlock = &ScaleGrayNormal;
+            }else if (render.scale.size == 2){
+			        simpleBlock = &ScaleGray2x;
+            }
+        break;
         default:
             break;
         }
 #endif
     } else if (dblw && !render.scale.hardware) {
+      if(scalerOpGray == render.scale.op){
+        simpleBlock = &ScaleGrayDw;
+      }else{
         simpleBlock = &ScaleNormalDw;
+      }
     } else if (dblh && !render.scale.hardware) {
 		//Check whether tv2x and scan2x is selected
-		if(scalerOpTV == render.scale.op){
+		if(scalerOpGray == render.scale.op){
+			simpleBlock = &ScaleGrayDh;
+    }else if(scalerOpTV == render.scale.op){
 			simpleBlock = &ScaleTVDh;
         }else if(scalerOpScan == render.scale.op){
 			simpleBlock = &ScaleScanDh;
@@ -519,7 +532,11 @@ void RENDER_Reset( void ) {
     } else  {
 forcenormal:
         complexBlock = 0;
-        simpleBlock = &ScaleNormal1x;
+        if(scalerOpGray==render.scale.op){
+          simpleBlock = &ScaleGrayNormal;
+        }else{
+          simpleBlock = &ScaleNormal1x;
+        }
     }
     if (complexBlock) {
 #if RENDER_USE_ADVANCED_SCALERS>1
@@ -934,6 +951,7 @@ void RENDER_UpdateFromScalerSetting(void) {
     else if (scaler == "rgb3x"){ render.scale.op = scalerOpRGB; render.scale.size = 3; render.scale.hardware=false; }
     else if (scaler == "scan2x"){ render.scale.op = scalerOpScan; render.scale.size = 2; render.scale.hardware=false; }
     else if (scaler == "scan3x"){ render.scale.op = scalerOpScan; render.scale.size = 3; render.scale.hardware=false; }
+    else if (scaler == "gray2x"){ render.scale.op = scalerOpGray; render.scale.size = 2; render.scale.hardware=false; }
 #endif
     else if (scaler == "hardware_none") { render.scale.op = scalerOpNormal; render.scale.size = 1; render.scale.hardware=true; }
     else if (scaler == "hardware2x") { render.scale.op = scalerOpNormal; render.scale.size = 4; render.scale.hardware=true; }

--- a/src/gui/render_scalers.cpp
+++ b/src/gui/render_scalers.cpp
@@ -443,6 +443,74 @@ ScalerSimpleBlock_t ScaleRGB3x = {
 {	0,		RGB3x_32_15_R,	RGB3x_32_16_R,	RGB3x_32_32_R},
 {	0,		RGB3x_9_15_R ,	RGB3x_9_16_R ,	RGB3x_9_32_R }
 }};
+
+ScalerSimpleBlock_t ScaleGrayNormal = {
+	"Gray2x",
+	GFX_CAN_15|GFX_CAN_16|GFX_CAN_32|GFX_RGBONLY,
+	1,1,{
+{	0,		GrayNormal_8_15_L ,	GrayNormal_8_16_L ,	GrayNormal_8_32_L },
+{	0,		GrayNormal_15_15_L,	GrayNormal_15_16_L,	GrayNormal_15_32_L},
+{	0,		GrayNormal_16_15_L,	GrayNormal_16_16_L,	GrayNormal_16_32_L},
+{	0,		GrayNormal_32_15_L,	GrayNormal_32_16_L,	GrayNormal_32_32_L},
+{	0,		GrayNormal_9_15_L ,	GrayNormal_9_16_L ,	GrayNormal_9_32_L }
+},{
+{	0,		GrayNormal_8_15_R ,	GrayNormal_8_16_R ,	GrayNormal_8_32_R },
+{	0,		GrayNormal_15_15_R,	GrayNormal_15_16_R,	GrayNormal_15_32_R},
+{	0,		GrayNormal_16_15_R,	GrayNormal_16_16_R,	GrayNormal_16_32_R},
+{	0,		GrayNormal_32_15_R,	GrayNormal_32_16_R,	GrayNormal_32_32_R},
+{	0,		GrayNormal_9_15_R ,	GrayNormal_9_16_R ,	GrayNormal_9_32_R }
+}};
+
+ScalerSimpleBlock_t ScaleGrayDw = {
+	"Gray2x",
+	GFX_CAN_15|GFX_CAN_16|GFX_CAN_32|GFX_RGBONLY,
+	2,1,{
+{	0,		GrayDw_8_15_L ,	GrayDw_8_16_L ,	GrayDw_8_32_L },
+{	0,		GrayDw_15_15_L,	GrayDw_15_16_L,	GrayDw_15_32_L},
+{	0,		GrayDw_16_15_L,	GrayDw_16_16_L,	GrayDw_16_32_L},
+{	0,		GrayDw_32_15_L,	GrayDw_32_16_L,	GrayDw_32_32_L},
+{	0,		GrayDw_9_15_L ,	GrayDw_9_16_L ,	GrayDw_9_32_L }
+},{
+{	0,		GrayDw_8_15_R ,	GrayDw_8_16_R ,	GrayDw_8_32_R },
+{	0,		GrayDw_15_15_R,	GrayDw_15_16_R,	GrayDw_15_32_R},
+{	0,		GrayDw_16_15_R,	GrayDw_16_16_R,	GrayDw_16_32_R},
+{	0,		GrayDw_32_15_R,	GrayDw_32_16_R,	GrayDw_32_32_R},
+{	0,		GrayDw_9_15_R ,	GrayDw_9_16_R ,	GrayDw_9_32_R }
+}};
+
+ScalerSimpleBlock_t ScaleGrayDh = {
+	"Gray2x",
+	GFX_CAN_15|GFX_CAN_16|GFX_CAN_32|GFX_RGBONLY,
+	1,2,{
+{	0,		GrayDh_8_15_L ,	GrayDh_8_16_L ,	GrayDh_8_32_L },
+{	0,		GrayDh_15_15_L,	GrayDh_15_16_L,	GrayDh_15_32_L},
+{	0,		GrayDh_16_15_L,	GrayDh_16_16_L,	GrayDh_16_32_L},
+{	0,		GrayDh_32_15_L,	GrayDh_32_16_L,	GrayDh_32_32_L},
+{	0,		GrayDh_9_15_L ,	GrayDh_9_16_L ,	GrayDh_9_32_L }
+},{
+{	0,		GrayDh_8_15_R ,	GrayDh_8_16_R ,	GrayDh_8_32_R },
+{	0,		GrayDh_15_15_R,	GrayDh_15_16_R,	GrayDh_15_32_R},
+{	0,		GrayDh_16_15_R,	GrayDh_16_16_R,	GrayDh_16_32_R},
+{	0,		GrayDh_32_15_R,	GrayDh_32_16_R,	GrayDh_32_32_R},
+{	0,		GrayDh_9_15_R ,	GrayDh_9_16_R ,	GrayDh_9_32_R }
+}};
+
+ScalerSimpleBlock_t ScaleGray2x = {
+	"Gray2x",
+	GFX_CAN_15|GFX_CAN_16|GFX_CAN_32|GFX_RGBONLY,
+	2,2,{
+{	0,		Gray2x_8_15_L ,	Gray2x_8_16_L ,	Gray2x_8_32_L },
+{	0,		Gray2x_15_15_L,	Gray2x_15_16_L,	Gray2x_15_32_L},
+{	0,		Gray2x_16_15_L,	Gray2x_16_16_L,	Gray2x_16_32_L},
+{	0,		Gray2x_32_15_L,	Gray2x_32_16_L,	Gray2x_32_32_L},
+{	0,		Gray2x_9_15_L ,	Gray2x_9_16_L ,	Gray2x_9_32_L }
+},{
+{	0,		Gray2x_8_15_R ,	Gray2x_8_16_R ,	Gray2x_8_32_R },
+{	0,		Gray2x_15_15_R,	Gray2x_15_16_R,	Gray2x_15_32_R},
+{	0,		Gray2x_16_15_R,	Gray2x_16_16_R,	Gray2x_16_32_R},
+{	0,		Gray2x_32_15_R,	Gray2x_32_16_R,	Gray2x_32_32_R},
+{	0,		Gray2x_9_15_R ,	Gray2x_9_16_R ,	Gray2x_9_32_R }
+}};
 #endif
 
 

--- a/src/gui/render_scalers.h
+++ b/src/gui/render_scalers.h
@@ -55,6 +55,7 @@ typedef enum scalerOperation {
 	scalerOpTV,
 	scalerOpRGB,
 	scalerOpScan,
+	scalerOpGray,
 #endif
 	scalerLast
 } scalerOperation_t;
@@ -124,6 +125,10 @@ extern ScalerSimpleBlock_t ScaleRGB3x;
 extern ScalerSimpleBlock_t ScaleScan2x;
 extern ScalerSimpleBlock_t ScaleScanDh;
 extern ScalerSimpleBlock_t ScaleScan3x;
+extern ScalerSimpleBlock_t ScaleGrayNormal;
+extern ScalerSimpleBlock_t ScaleGrayDw;
+extern ScalerSimpleBlock_t ScaleGrayDh;
+extern ScalerSimpleBlock_t ScaleGray2x;
 #endif
 /* Complex scalers */
 #if RENDER_USE_ADVANCED_SCALERS>2

--- a/src/gui/render_templates.h
+++ b/src/gui/render_templates.h
@@ -543,6 +543,63 @@ static inline void conc3d(Cache,SBPP,DBPP) (const void * s) {
 #undef SCALERHEIGHT
 #undef SCALERFUNC
 
+/* Grayscale scalers */
+#define SCALERNAME		GrayNormal
+#define SCALERWIDTH		1
+#define SCALERHEIGHT	1
+#define SCALERFUNC								\
+	Bitu _red=(P&redMask)>>redShift,_green=(P&greenMask)>>greenShift,_blue=(P&blueMask)>>blueShift;	\
+  double _gray=0.2125*(double)_red+0.7154*(double)_green+0.0721*(double)_blue; \
+  Bitu _value = _gray>255?0xff:(uint8_t)(_gray);  \
+	line0[0] = ((_value<<redShift)|(_value<<greenShift)|(_value)<<blueShift);
+#include "render_simple.h"
+#undef SCALERNAME
+#undef SCALERWIDTH
+#undef SCALERHEIGHT
+#undef SCALERFUNC
+
+#define SCALERNAME		GrayDw
+#define SCALERWIDTH		2
+#define SCALERHEIGHT	1
+#define SCALERFUNC								\
+	Bitu _red=(P&redMask)>>redShift,_green=(P&greenMask)>>greenShift,_blue=(P&blueMask)>>blueShift;	\
+  double _gray=0.2125*(double)_red+0.7154*(double)_green+0.0721*(double)_blue; \
+  Bitu _value = _gray>255?0xff:(uint8_t)(_gray);  \
+	line0[0]=line0[1] = ((_value<<redShift)|(_value<<greenShift)|(_value)<<blueShift);
+#include "render_simple.h"
+#undef SCALERNAME
+#undef SCALERWIDTH
+#undef SCALERHEIGHT
+#undef SCALERFUNC
+
+#define SCALERNAME		GrayDh
+#define SCALERWIDTH		1
+#define SCALERHEIGHT	2
+#define SCALERFUNC								\
+	Bitu _red=(P&redMask)>>redShift,_green=(P&greenMask)>>greenShift,_blue=(P&blueMask)>>blueShift;	\
+  double _gray=0.2125*(double)_red+0.7154*(double)_green+0.0721*(double)_blue; \
+  Bitu _value = _gray>255?0xff:(uint8_t)(_gray);  \
+	line0[0]=line1[0] = ((_value<<redShift)|(_value<<greenShift)|(_value)<<blueShift);
+#include "render_simple.h"
+#undef SCALERNAME
+#undef SCALERWIDTH
+#undef SCALERHEIGHT
+#undef SCALERFUNC
+
+#define SCALERNAME		Gray2x
+#define SCALERWIDTH		2
+#define SCALERHEIGHT	2
+#define SCALERFUNC								\
+	Bitu _red=(P&redMask)>>redShift,_green=(P&greenMask)>>greenShift,_blue=(P&blueMask)>>blueShift;	\
+  double _gray=0.2125*(double)_red+0.7154*(double)_green+0.0721*(double)_blue; \
+  Bitu _value = _gray>255?0xff:(uint8_t)(_gray);  \
+	line0[0]=line1[0]=line0[1]=line1[1] = ((_value<<redShift)|(_value<<greenShift)|(_value)<<blueShift);
+#include "render_simple.h"
+#undef SCALERNAME
+#undef SCALERWIDTH
+#undef SCALERHEIGHT
+#undef SCALERFUNC
+
 #endif		//#if RENDER_USE_ADVANCED_SCALERS>0
 
 #endif		//#if (DBPP > 8)


### PR DESCRIPTION
Add new scaler called `gray2x` to create a grayscale effect.

This scaler simply does the weighted RGB->Grayscale conversion, with the VGA hardware level unaltered, may be useful to emulate the look of a monochrome VGA monitor.

Files modified:
`src/dosbox.cpp`
`src/gui/render.cpp`
`src/gui/render_scalers.cpp`
`src/gui/render_scalers.h`
`src/gui/render_templates.h`