### PR TITLE
Start of integration of DOSBox SVN where DOSBox-X left off

### DIFF
--- a/NOTES/Skipped SVN commits.txt
+++ b/NOTES/Skipped SVN commits.txt
@@ -1,0 +1,4 @@
+Commit#:	Reason for skipping:
+
+3835		Preparatory commit for 3836, which was skipped.
+3836		Assumes the Windows API. midiOutGetNumDevs() and midiOutGetDevCaps() are specific to Windows and do not exist anywhere else.

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -513,7 +513,7 @@ void CBreakpoint::Activate(bool _active)
 // Statics
 std::list<CBreakpoint*> CBreakpoint::BPoints;
 CBreakpoint*			CBreakpoint::ignoreOnce = 0;
-Bitu					ignoreAddressOnce = 0;
+PhysPt					ignoreAddressOnce = 0;
 
 CBreakpoint* CBreakpoint::AddBreakpoint(Bit16u seg, Bit32u off, bool once)
 {
@@ -769,7 +769,7 @@ void CBreakpoint::ShowList(void)
 
 bool DEBUG_Breakpoint(void)
 {
-	/* First get the phyiscal address and check for a set Breakpoint */
+	/* First get the physical address and check for a set Breakpoint */
 	if (!CBreakpoint::CheckBreakpoint(SegValue(cs),reg_eip)) return false;
 	// Found. Breakpoint is valid
 	PhysPt where=(Bitu)GetAddress(SegValue(cs),reg_eip);
@@ -779,7 +779,7 @@ bool DEBUG_Breakpoint(void)
 
 bool DEBUG_IntBreakpoint(Bit8u intNum)
 {
-	/* First get the phyiscal address and check for a set Breakpoint */
+	/* First get the physical address and check for a set Breakpoint */
 	PhysPt where=(Bitu)GetAddress(SegValue(cs),reg_eip);
 	if (!CBreakpoint::CheckIntBreakpoint(where,intNum,reg_ah)) return false;
 	// Found. Breakpoint is valid
@@ -1472,7 +1472,7 @@ bool ParseCommand(char* str) {
 		return true;
 	};
 
-	if (command == "MEMDUMPBIN") { // Dump memory to file bineary
+	if (command == "MEMDUMPBIN") { // Dump memory to file binary
 		Bit16u seg = (Bit16u)GetHexValue(found,found); found++;
 		Bit32u ofs = GetHexValue(found,found); found++;
 		Bit32u num = GetHexValue(found,found); found++;
@@ -2426,7 +2426,7 @@ char* AnalyzeInstruction(char* inst, bool saveSelector) {
 		// Variable found ?
 		CDebugVar* var = CDebugVar::FindVar(address);
 		if (var) {
-			// Replace occurence
+			// Replace occurrence
 			char* pos1 = strchr(inst,'[');
 			char* pos2 = strchr(inst,']');
 			if (pos1 && pos2) {
@@ -3090,7 +3090,8 @@ static void LogMCBChain(Bit16u mcb_segment) {
 	DOS_MCB mcb(mcb_segment);
 	char filename[9]; // 8 characters plus a terminating NUL
 	const char *psp_seg_note;
-	PhysPt dataAddr = PhysMake(dataSeg,dataOfs);// location being viewed in the "Data Overview"
+	Bit16u DOS_dataOfs = static_cast<Bit16u>(dataOfs); //Realmode addressing only
+	PhysPt dataAddr = PhysMake(dataSeg,DOS_dataOfs);// location being viewed in the "Data Overview"
 
 	// loop forever, breaking out of the loop once we've processed the last MCB
 	while (true) {
@@ -3120,7 +3121,7 @@ static void LogMCBChain(Bit16u mcb_segment) {
 		PhysPt mcbStartAddr = PhysMake(mcb_segment+1,0);
 		PhysPt mcbEndAddr = PhysMake(mcb_segment+1+mcb.GetSize(),0);
 		if (dataAddr >= mcbStartAddr && dataAddr < mcbEndAddr) {
-			LOG(LOG_MISC,LOG_ERROR)("   (data addr %04hX:%04X is %u bytes past this MCB)",dataSeg,dataOfs,dataAddr - mcbStartAddr);
+			LOG(LOG_MISC,LOG_ERROR)("   (data addr %04hX:%04X is %u bytes past this MCB)",dataSeg,DOS_dataOfs,dataAddr - mcbStartAddr);
 		}
 
 		// if we've just processed the last MCB in the chain, break out of the loop


### PR DESCRIPTION
# Description

_Summary of changes brought by this PR._

Integrates the next 3 DOSBox SVN commits starting from where they seem to be missing from DOSBox-X.

**Does this PR address some issue(s) ?**

May be slightly helpful for https://github.com/joncampbell123/dosbox-x/issues/975, as a more common base would probably make any feature integration go more smoothly.

**Additional information**

I was looking at the DOSBox-X code, and it looks like it started on GitHub based on an older SVN base:
https://github.com/joncampbell123/dosbox-x/commit/f3318240311646e6aa14663a9e3e2c41d0da2a68

Then you integrated the daum branch, which included newer commits from mainline:
https://github.com/joncampbell123/dosbox-x/commit/21614b8c3f2e945fb46b0f1bbd3d9f12f7847355

I think this gave you as far as commit r3873 from mainline.
https://sourceforge.net/p/dosbox/code-0/3873/

You have later commits that selectively add in other mainline commits, like this one:
https://github.com/joncampbell123/dosbox-x/commit/85de2c9372bd9201964446e10d93266bc54672c9

I would like to try to help fill in the gaps so that the improvements from mainline DOSBox are also in DOSBox-X.

This PR includes the next 3 commits after r3873, authored by qbix79.

https://sourceforge.net/p/dosbox/code-0/3834/
https://sourceforge.net/p/dosbox/code-0/3835/
https://sourceforge.net/p/dosbox/code-0/3836/

There was no conflict with DOSBox-X work, and DOSBox-X successfully compiled and ran. I'm doing the compilation through AppVeyor compiling with Visual Studio 2017 and running the result on Windows 10, so I'm only able to check those environments.

If you're okay with this, I'm thinking of maybe doing these in sets of 3 commits like this, skipping over those that are already in DOSBox-X, and prioritizing DOSBox-X if there are conflicts.