### PR TITLE
Remove core_dyn_x86.cpp from VS solution

### DIFF
--- a/vs2015/dosbox-x.vcxproj
+++ b/vs2015/dosbox-x.vcxproj
@@ -1341,7 +1341,6 @@ copy "$(SolutionDir)\..\CHANGELOG" "$(OutputPath)\changelog.txt"</Command>
     <ClCompile Include="..\src\builtin\xcopy_exe.cpp" />
     <ClCompile Include="..\src\cpu\callback.cpp" />
     <ClCompile Include="..\src\cpu\core_dynrec.cpp" />
-    <ClCompile Include="..\src\cpu\core_dyn_x86.cpp" />
     <ClCompile Include="..\src\cpu\core_full.cpp" />
     <ClCompile Include="..\src\cpu\core_normal.cpp" />
     <ClCompile Include="..\src\cpu\core_normal_286.cpp" />

--- a/vs2015/dosbox-x.vcxproj.filters
+++ b/vs2015/dosbox-x.vcxproj.filters
@@ -756,9 +756,6 @@
     <ClCompile Include="..\src\dosbox.cpp">
       <Filter>Sources</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\cpu\core_dyn_x86.cpp">
-      <Filter>Sources\cpu</Filter>
-    </ClCompile>
     <ClCompile Include="..\src\hardware\8255.cpp">
       <Filter>Sources\hardware</Filter>
     </ClCompile>


### PR DESCRIPTION
Currently master branch fails to build with the Visual Studio solution because it still tries to access core_dyn_x86.cpp. This fixes it.