### PR TITLE
Next 3 mainline commits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 0.82.19 (next)
-  - Integrated commits from mainline: 3854, 3860, 3861, 3862,
-    3864, 3866 (Allofich)
+  - Integrated commits from mainline (Allofich)
+    3854 - "top" is now used as 32 bit in dynrec core
+    3860 - Don't scroll at unspecified video page
+    3862 - Lower the influence of the aspect table correction trick when using high scale factors (320x200 => 2000x1200)
+    3864 - Code reordering to fix build
+    3866 - Correction to Hercules video height parameter
+    3867 - The mapper now uses the wrapper as well
+    3889 - Fix the possible/suggested values for integer properties.
+    3895 - Minor cleanup
+    3896 - Do less to update the frequency of an active SB DMA transfer
   - PEGC emulation will now print a warning if the guest
     application or OS attempts to use 256-color planar mode.
   - PC-98 PEGC 256-color linear framebuffer is not mapped by
@@ -23,8 +31,15 @@
     of VGA emulation.
   - Added debugger commands "VGA DRAW" and "VGA AC" to view
     drawing and attribute controller state in the VGA emulation.
-  - Integrated commits from mainline: 3834, 3839, 3840, 3843,
-    3845, 3849, 3850, 3853 (Allofich)
+  - Integrated commits from mainline (Allofich)
+    3834 - Fix typos
+    3839 - CD audio status now returns zero start and end times when no track is playing. Fixes "The Manhole".
+    3840 - Add "ADDLOG" debug command to manually add a message to the log.
+    3843 - "Strip off leading zeroes from the IP", a fix for the serial modem.
+    3845 - Add a small delay when raising the Sound Blaster 8-bit IRQ to emulate the slowness of the DSP, fixes Llamatron 2012 and Lemmings 3D.
+    3849 - Add ability to set debugger breakpoint on AL values.
+    3850 - The SB DMA callback now ignores previously selected, but not currently selected, DMA channels. Fixes Visual Player 2 with SB16.
+    3853 - Minor cleanup to joystick code.
   - PSG noise channel emulation (PC-98 FM board) apparently
     broke on Mac OS X due to type promotion by Clang/LLVM.
     Modified the code to behave as originally intended, to

--- a/NOTES/Skipped SVN commits.txt
+++ b/NOTES/Skipped SVN commits.txt
@@ -10,3 +10,9 @@ Commit#:	Reason for skipping:
 3859		Conflicts with DOSBox-X. Masking/wrapping is implemented in DOSBox-X by masking the array access per pixel.
 3863		Conflicts with DOSBox-X
 3865		Conflicts with DOSBox-X
+3867		Conflicts with DOSBox-X
+3869		Not sure if this is needed for DOSBox-X
+3870		Conflicts with DOSBox-X
+3871		Conflicts with DOSBox-X
+3873		Conflicts with DOSBox-X
+3891		Conflicts with DOSBox-X

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -69,6 +69,7 @@ bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 	char tempdir[DOS_PATHLENGTH];
 	char upname[DOS_PATHLENGTH];
 	Bitu r,w;
+	Bit8u c;
 	*drive = DOS_GetDefaultDrive();
 	/* First get the drive */
 	if (name_int[1]==':') {
@@ -81,24 +82,15 @@ bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 	}
 	r=0;w=0;
 	while (name_int[r]!=0 && (r<DOS_PATHLENGTH)) {
-		Bit8u c=(Bit8u)name_int[r++];
-		if ((c>='a') && (c<='z')) {upname[w++]=(char)c-32;continue;}
-		if ((c>='A') && (c<='Z')) {upname[w++]=(char)c;continue;}
-		if ((c>='0') && (c<='9')) {upname[w++]=(char)c;continue;}
-		switch (c) {
-		case '/':
-			upname[w++]='\\';
-			break;
-		case ' ': /* should be seperator */
-			break;
-		default:
-			upname[w++]=(char)c;
-            if (IS_PC98_ARCH && shiftjis_lead_byte(c) && r<DOS_PATHLENGTH) {
-                /* The trailing byte is NOT ASCII and SHOULD NOT be converted to uppercase like ASCII */
-                upname[w++]=name_int[r++];
-            }
-			break;
-		}
+		c=(Bit8u)name_int[r++];
+		if ((c>='a') && (c<='z')) c-=32;
+		else if (c==' ') continue; /* should be separator */
+		else if (c=='/') c='\\';
+		upname[w++]=(char)c;
+        if (IS_PC98_ARCH && shiftjis_lead_byte(c) && r<DOS_PATHLENGTH) {
+            /* The trailing byte is NOT ASCII and SHOULD NOT be converted to uppercase like ASCII */
+            upname[w++]=name_int[r++];
+        }
 	}
 	while (r>0 && name_int[r-1]==' ') r--;
 	if (r>=DOS_PATHLENGTH) { DOS_SetError(DOSERR_PATH_NOT_FOUND);return false; }

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -272,7 +272,9 @@ char const* Property::Get_help() {
 
 
 bool Prop_int::CheckValue(Value const& in, bool warn) {
-    if(suggested_values.empty() && Property::CheckValue(in,warn)) return true;
+//  if(!suggested_values.empty() && Property::CheckValue(in,warn)) return true;
+    if(!suggested_values.empty()) return Property::CheckValue(in,warn);
+
     //No >= and <= in Value type and == is ambigious
     int mi = min;
     int ma = max;


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/3867/ - Skipped. Conflicts with DOSBox-X.
https://sourceforge.net/p/dosbox/code-0/3868/ - Skipped. Already in DOSBox-X
https://sourceforge.net/p/dosbox/code-0/3869/ - Skipped. Could be added, but I don't know enough to judge if this is needed for DOSBox-X.
https://sourceforge.net/p/dosbox/code-0/3870/ - Skipped. Conflicts with DOSBox-X.
https://sourceforge.net/p/dosbox/code-0/3871/ - Skipped. Conflicts with DOSBox-X.
https://sourceforge.net/p/dosbox/code-0/3872/ - Skipped. Already in DOSBox-X.
https://sourceforge.net/p/dosbox/code-0/3873/ - Skipped. Conflicts with DOSBox-X.
3874 through 3877 - Skipped. Already in DOSBox-X.
https://sourceforge.net/p/dosbox/code-0/3878/ - Skipped. Out-of-date copyright year change.
3879 through 3888 - Skipped. Already in DOSBox-X.
https://sourceforge.net/p/dosbox/code-0/3889/ - In this PR
https://sourceforge.net/p/dosbox/code-0/3890/ - Skipped. Already in DOSBox-X.
https://sourceforge.net/p/dosbox/code-0/3891/ - Skipped. Conflicts with DOSBox-X.
3892 through 3894 - Skipped. Already in DOSBox-X.
https://sourceforge.net/p/dosbox/code-0/3895/ - In this PR (partial)
https://sourceforge.net/p/dosbox/code-0/3896/ - In this PR (partial)

I ran into an area where a lot of commits were already integrated over to DOSBox-X, so lots were skipped. Also skipped some SDL-related commits that conflict with DOSBox-X because the files are very different now.

About https://sourceforge.net/p/dosbox/code-0/3869/:
This one could be added, but I don't know enough about it to judge. DOSBox-X has a later part in the file not present in the SVN code that also sets `-mno-ms-bitfields` so I skipped this one. Do you know if it would be relevant for DOSBox-X?

About https://sourceforge.net/p/dosbox/code-0/3895/:
I only integrated the code cleanup part. It looks like DOSBox-X does not do the same check for valid characters in the path? Also, I did not do the DOS_CompressMemory() changes because DOSBox-X has an additional

```
	if (*blocks > total)
		DOS_CompressMemory(segment-1);
```

here and I didn't know if the SVN commit would be compatible with that. Do you know?

About https://sourceforge.net/p/dosbox/code-0/3896/:
It's a bit risky because I tried to mix in the SVN commit with the existing DOSBox-X code. It compiles and runs, so there is no obvious problem to me, but this needs your experienced eye. Also, we have a test case game for this one. This change is supposed to fix the sound in Tempest 2000. If you move the cursor at the title screen, a voice will say "Excellent". In master branch DOSBox-X (and, strangely, the DOSBox 0.74-2 copy I have), the voice plays high-pitched. After this change (whether it is this hybrid of code, or exactly the SVN change, I tried both) the voice plays low-pitched. It also plays in the low pitch in the DOSBox ECE copy I have. 

I searched YouTube videos to find what it should sound like. I found one of the MS-DOS version from years ago that was high-pitched, probably played on DOSBox (https://www.youtube.com/watch?v=dEB4SOyOC0k&t=31s). The game is a port of an Atari Jaguar title, and there are videos of the Jaguar version, both on emulator and (what seems to be) the real machine (https://www.youtube.com/watch?v=ijjQpOuognI). They play the "Excellent" voice in a pitch that is lower than master branch, but higher than what this change makes it. To my ear, this change produces a closer sound. The question is, though, what did it sound like in the MS-DOS version on real Sound Blaster 16?

Because I don't know what it is supposed to sound like, I've left off the "fixes Tempest 2000" part of the fix in the changelog and commit message for now.