### PR TITLE
Memory coalescing from SVN r3895 plus next 3 commits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,8 +8,11 @@
     3866 - Correction to Hercules video height parameter
     3867 - The mapper now uses the wrapper as well
     3889 - Fix the possible/suggested values for integer properties.
-    3895 - Minor cleanup
-    3896 - Do less to update the frequency of an active SB DMA transfer
+    3895 - Minor cleanup. Re-ordering of memory coalescing to match commit from mainline.
+    3896 - Do less to update the frequency of an active SB DMA transfer. Fixes sound in Tempest 2000.
+    3898 - Add missing --disable-fpu-x64 option
+    3899 - Use clock_gettime when available instead of the obsolete ftime.
+    3904 - Allow CRTC read/write access on all mirror ports for non-VGA machine types. Fixes Tandy and EGA display in International Hockey booter.	
   - Integrated a commit from mainline:
      #3860 "Use PCJr specific method to clear the video RAM.
             Also don't scroll at unspecified video page.

--- a/INSTALL
+++ b/INSTALL
@@ -67,7 +67,8 @@ In step 1 you could add the following switches:
         finished and isn't entirely accurate it's advised to leave it on. 
 
 --disable-fpu-x86
-        disables the assembly fpu core. Although relatively new the x86 fpu 
+--disable-fpu-x64
+        disables the assembly fpu core. Although relatively new, the x86/x64 fpu  
         core has more accuracy then the regular fpu core. 
 
 --disable-dynamic-x86

--- a/configure.ac
+++ b/configure.ac
@@ -230,6 +230,13 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <math.h>]],[[
 ]])], [AC_MSG_RESULT(yes)], [AC_DEFINE([DB_HAVE_NO_POWF],[1],[libm doesn't include powf])])
 LIBS=$LIBS_BACKUP
 
+dnl Look for clock_gettime, a DB_HAVE_CLOCK_GETTIME is set when present
+AH_TEMPLATE([DB_HAVE_CLOCK_GETTIME],[Determines if the function clock_gettime is available.])
+AC_SEARCH_LIBS([clock_gettime], [rt] , [found_clock_gettime=yes], [found_clock_gettime=no])
+if test x$found_clock_gettime = xyes; then
+  AC_DEFINE(DB_HAVE_CLOCK_GETTIME)
+fi
+
 dnl TEST: Check if the compiler support attributes
 AH_TEMPLATE([C_HAS_ATTRIBUTE],[Determines if the compilers supports attributes for structures.])
 AC_MSG_CHECKING(if compiler allows __attribute__)

--- a/src/dos/dos_memory.cpp
+++ b/src/dos/dos_memory.cpp
@@ -327,11 +327,12 @@ bool DOS_ResizeMemory(Bit16u segment,Bit16u * blocks) {
 
 	if (*blocks > total)
 		DOS_CompressMemory(segment-1);
+	else
+		DOS_CompressMemory();
 
 	if (*blocks<=total) {
 		if (GCC_UNLIKELY(*blocks==total)) {
 			/* Nothing to do */
-			DOS_CompressMemory();
 			return true;
 		}
 		/* Shrinking MCB */
@@ -367,7 +368,6 @@ bool DOS_ResizeMemory(Bit16u segment,Bit16u * blocks) {
 		mcb_next.SetPSPSeg(MCB_FREE);
 		mcb.SetType(0x4d);
 		mcb.SetPSPSeg(dos.psp());
-		DOS_CompressMemory();
 		return true;
 	}
 
@@ -380,7 +380,6 @@ bool DOS_ResizeMemory(Bit16u segment,Bit16u * blocks) {
 	}
 	mcb.SetSize(total);
 	mcb.SetPSPSeg(dos.psp());
-	DOS_CompressMemory();
 	if (*blocks==total) return true;	/* block fit exactly */
 
 	*blocks=total;	/* return maximum */

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1091,9 +1091,6 @@ void VGA_SetupOther(void) {
 		write_pcjr( 0x3df, 0x7 | (0x7 << 3), 0 );
 		IO_RegisterWriteHandler(0x3da,write_pcjr,IO_MB);
 		IO_RegisterWriteHandler(0x3df,write_pcjr,IO_MB);
-		// additional CRTC access documented
-		IO_RegisterWriteHandler(0x3d0,write_crtc_index_other,IO_MB);
-		IO_RegisterWriteHandler(0x3d1,write_crtc_data_other,IO_MB);
 	}
 	if (machine==MCH_HERC || machine==MCH_MDA) {
 		Bitu base=0x3b0;
@@ -1132,22 +1129,6 @@ void VGA_SetupOther(void) {
 			IO_RegisterReadHandler(base+port_ct*2+1,read_crtc_data_other,IO_MB);
 		}
 	}
-	if (machine==MCH_MCGA) {
-		Bitu base=0x3d0;
-		for (Bitu port_ct=0; port_ct<4; port_ct++) {
-			IO_RegisterWriteHandler(base+port_ct*2,write_crtc_index_other,IO_MB);
-			IO_RegisterWriteHandler(base+port_ct*2+1,write_crtc_data_mcga,IO_MB);
-			IO_RegisterReadHandler(base+port_ct*2,read_crtc_index_other,IO_MB);
-			IO_RegisterReadHandler(base+port_ct*2+1,read_crtc_data_mcga,IO_MB);
-		}
-	}
-	if (IS_TANDY_ARCH) {
-		Bitu base=0x3d4;
-		IO_RegisterWriteHandler(base,write_crtc_index_other,IO_MB);
-		IO_RegisterWriteHandler(base+1,write_crtc_data_other,IO_MB);
-		IO_RegisterReadHandler(base,read_crtc_index_other,IO_MB);
-		IO_RegisterReadHandler(base+1,read_crtc_data_other,IO_MB);
-	}
 	if (machine==MCH_AMSTRAD) {
 		Bitu base=(machine==MCH_HERC || machine==MCH_MDA) ? 0x3b4 : 0x3d4;
 		IO_RegisterWriteHandler(base,write_crtc_index_other,IO_MB);
@@ -1163,7 +1144,14 @@ void VGA_SetupOther(void) {
 			IO_RegisterReadHandler(base,read_crtc_index_other,IO_MB);
 			IO_RegisterReadHandler(base+1,read_crtc_data_other,IO_MB);
 		}
+	} else if (!IS_EGAVGA_ARCH) {
+		Bitu base=0x3d0;
+		for (Bitu port_ct=0; port_ct<4; port_ct++) {
+			IO_RegisterWriteHandler(base+port_ct*2,write_crtc_index_other,IO_MB);
+			IO_RegisterWriteHandler(base+port_ct*2+1,write_crtc_data_mcga,IO_MB);
+			IO_RegisterReadHandler(base+port_ct*2,read_crtc_index_other,IO_MB);
+			IO_RegisterReadHandler(base+port_ct*2+1,read_crtc_data_mcga,IO_MB);
+		}
 	}
-	// AMSTRAD
 }
 

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -44,7 +44,12 @@
 extern bool PS1AudioCard;
 #include "parport.h"
 #include <time.h>
+
+#if defined(DB_HAVE_CLOCK_GETTIME) && ! defined(WIN32)
+//time.h is already included
+#else
 #include <sys/timeb.h>
+#endif
 
 #if C_EMSCRIPTEN
 # include <emscripten.h>
@@ -4761,13 +4766,23 @@ static Bitu INT11_Handler(void) {
 #endif
 
 static void BIOS_HostTimeSync() {
+    Bit32u milli = 0;
+#if defined(DB_HAVE_CLOCK_GETTIME) && ! defined(WIN32)
+    struct timespec tp;
+    clock_gettime(CLOCK_REALTIME,&tp);
+	
+    struct tm *loctime;
+    loctime = localtime(&tp.tv_sec);
+    milli = (Bit32u) (tp.tv_nsec / 1000000);
+#else
     /* Setup time and date */
     struct timeb timebuffer;
     ftime(&timebuffer);
     
     struct tm *loctime;
     loctime = localtime (&timebuffer.time);
-
+    milli = (Bit32u) timebuffer.millitm;
+#endif
     /*
     loctime->tm_hour = 23;
     loctime->tm_min = 59;
@@ -4785,7 +4800,7 @@ static void BIOS_HostTimeSync() {
         loctime->tm_hour*3600*1000+
         loctime->tm_min*60*1000+
         loctime->tm_sec*1000+
-        timebuffer.millitm))*(((double)PIT_TICK_RATE/65536.0)/1000.0));
+        milli))*(((double)PIT_TICK_RATE/65536.0)/1000.0));
     mem_writed(BIOS_TIMER,ticks);
 }
 


### PR DESCRIPTION
Revisited https://sourceforge.net/p/dosbox/code-0/3895/ and integrated it with DOSBox-X's code.

r3896 was in the last PR. Continuing on from r3897:

https://sourceforge.net/p/dosbox/code-0/3897/ - Skipped. Superceded by 3902.
https://sourceforge.net/p/dosbox/code-0/3898/ - In this PR
https://sourceforge.net/p/dosbox/code-0/3899/ - In this PR
https://sourceforge.net/p/dosbox/code-0/3900/ - Skipped. Already in DOSBox-X.
https://sourceforge.net/p/dosbox/code-0/3901/ - Skipped. Already in DOSBox-X.
https://sourceforge.net/p/dosbox/code-0/3902/ - Skipped. Already in DOSBox-X.
https://sourceforge.net/p/dosbox/code-0/3903/ - Skipped. Already in DOSBox-X.
https://sourceforge.net/p/dosbox/code-0/3904/ - In this PR

The commit for 3904 is an integration into DOSBox-X's slightly different code. Please take a look that it's OK.