### PR TITLE
SVN r3928

### DIFF
--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -1060,14 +1060,20 @@ bool DEBUG_IsPagingOutput(void);
 
 static void DrawInput(void) {
     if (!debugging) {
+        if (has_colors())
+        {
         wbkgdset(dbg.win_inp,COLOR_PAIR(PAIR_GREEN_BLACK));
         wattrset(dbg.win_inp,COLOR_PAIR(PAIR_GREEN_BLACK));
+        }
 
         mvwprintw(dbg.win_inp,0,0,"%s","(Running)");
         wclrtoeol(dbg.win_inp);
     } else if (DEBUG_IsPagingOutput()) {
+        if (has_colors())
+        {
         wbkgdset(dbg.win_inp,COLOR_PAIR(PAIR_GREEN_BLACK));
         wattrset(dbg.win_inp,COLOR_PAIR(PAIR_GREEN_BLACK));
+        }
 
         mvwprintw(dbg.win_inp,0,0,"%s","^ Paged content: Hit ENTER to continue, Q to exit paging");
         wclrtoeol(dbg.win_inp);
@@ -1081,11 +1087,13 @@ static void DrawInput(void) {
         mvwprintw(dbg.win_inp,0,0,"%c-> %s%c",
                 (codeViewData.ovrMode?'O':'I'),dispPtr,(*curPtr?' ':'_'));
         wclrtoeol(dbg.win_inp); // not correct in pdcurses if full line
+        mvwchgat(dbg.win_inp,10,0,3,0,(PAIR_BLACK_GREY),NULL);
         if (*curPtr) {
             mvwchgat(dbg.win_inp,0,(int)(curPtr-dispPtr+4),1,0,(PAIR_BLACK_GREY),NULL);
         } 
     }
 
+    wattrset(dbg.win_inp,0);
     wrefresh(dbg.win_inp);
 }
 
@@ -1134,7 +1142,7 @@ static void DrawCode(void) {
 				wattrset(dbg.win_code,COLOR_PAIR(PAIR_GREY_RED));			
 			} else {
                 wbkgdset(dbg.win_code,0);
-				wattrset(dbg.win_code,0);			
+                wattrset(dbg.win_code,0);
 			}
 		}
 

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -751,7 +751,7 @@ void LOG::ParseEnableSetting(_LogGroup &group,const char *setting) {
 }
 
 void LOG::Init() {
-	char buf[1024];
+	char buf[64];
 
 	assert(control != NULL);
 
@@ -787,9 +787,8 @@ void LOG::Init() {
 
 	/* read settings for each log category, unless the -debug option was given,
 	 * in which case everything is set to debug level */
-	for (Bitu i=1;i<LOG_MAX;i++) {
-		strcpy(buf,loggrp[i].front);
-		buf[strlen(buf)]=0;
+	for (Bitu i = LOG_ALL + 1;i < LOG_MAX;i++) { //Skip LOG_ALL, it is always enabled
+		safe_strncpy(buf,loggrp[i].front,sizeof(buf));
 		lowcase(buf);
 
 		if (control->opt_debug)
@@ -872,9 +871,9 @@ void LOG::SetupConfigSection(void) {
 	Section_prop * sect=control->AddSection_prop("log",Null_Init);
 	Prop_string* Pstring = sect->Add_string("logfile",Property::Changeable::Always,"");
 	Pstring->Set_help("file where the log messages will be saved to");
-	char buf[1024];
-	for (Bitu i=1;i<LOG_MAX;i++) {
-		strcpy(buf,loggrp[i].front);
+	char buf[64];
+	for (Bitu i = LOG_ALL + 1;i < LOG_MAX;i++) {
+		safe_strncpy(buf,loggrp[i].front, sizeof(buf));
 		lowcase(buf);
 
 		Pstring = sect->Add_string(buf,Property::Changeable::Always,"false");


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/3928/

Most of this commit was already in DOSBox-X as far as I can see, although the debugger code has changed. I just merged in the following minor additions from this commit:

- Removed trailing whitespace
- Added `if (has_colors())` before attempting to set `PAIR_GREEN_BLACK` when it was missing
- The "General improvements to the section parsing" part of the commit
- An additional call of
`mvwchgat(dbg.win_code,10,0,3,0,(PAIR_BLACK_GREY),NULL);`
and
`wattrset(dbg.win_code,0);`
with `dbg.win_code` changed to `dbg.win_inp` to match the surrounding DOSBox-X code. I have no understanding of the details of these, I'm just following mainline's lead.

The result compiles and runs. I don't see any difference in the resulting debugger window.