### PR TITLE
SVN r3929

### DIFF
--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -165,6 +165,8 @@ struct SDL_Block {
     Bitu num_joysticks;
 #if defined (WIN32)
     bool using_windib;
+    // Time when sdl regains focus (alt-tab) in windowed mode
+    Bit32u focus_ticks;
 #endif
     // state of alt-keys for certain special handlings
     Bit16u laltstate;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4964,6 +4964,9 @@ void GFX_Events() {
         case SDL_ACTIVEEVENT:
                 if (event.active.state & (SDL_APPINPUTFOCUS | SDL_APPACTIVE)) {
                 if (event.active.gain) {
+#ifdef WIN32
+                    if (!sdl.desktop.fullscreen) sdl.focus_ticks = GetTicks();
+#endif
                     if (sdl.desktop.fullscreen && !sdl.mouse.locked)
                         GFX_CaptureMouse();
                     SetPriority(sdl.priority.focus);
@@ -5066,6 +5069,10 @@ void GFX_Events() {
             if (event.key.keysym.sym==SDLK_RALT) sdl.raltstate = event.key.type;
             if (((event.key.keysym.sym==SDLK_TAB)) &&
                 ((sdl.laltstate==SDL_KEYDOWN) || (sdl.raltstate==SDL_KEYDOWN))) { MAPPER_LosingFocus(); break; }
+            // This can happen as well.
+            if (((event.key.keysym.sym == SDLK_TAB )) && (event.key.keysym.mod & KMOD_ALT)) break;
+            // ignore tab events that arrive just after regaining focus. (likely the result of alt-tab)
+            if ((event.key.keysym.sym == SDLK_TAB) && (GetTicks() - sdl.focus_ticks < 2)) break;
 #endif
 #if defined (MACOSX)            
         case SDL_KEYDOWN:


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/3929

Compiles and runs.

https://sourceforge.net/p/dosbox/code-0/3930/ - Skipped. Conflicts with DOSBox-X, which looks like it implements the same thing a different way.

https://sourceforge.net/p/dosbox/code-0/3931/ - Skipped. Commit message is just "Only compile when in debug mode." but I assume it means the debugger? However, when I tried applying it the debugger was still available in the resulting "Release"-build executable.

Mainline DOSBox only has the debugger available if you specifically compile for it, right? But DOSBox-X has "Debugger" in the drop-down menu so I'm not sure that this commit would be wanted even if it does what it says.