### PR TITLE
Handle INT 2F enhanced-mode Windows check

### DIFF
--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -188,6 +188,9 @@ static bool DOS_MultiplexFunctions(void) {
 
 		}
 		return true;
+	case 0x1600:	/* Windows enhanced mode installation check */
+		// Leave AX as 0x1600, indicating that neither Windows 3.x enhanced mode nor Windows/386 2.x is running, nor is XMS version 1 driver installed
+		return true;
 	case 0x1605:	/* Windows init broadcast */
 		if (enable_a20_on_windows_init) {
 			/* This hack exists because Windows 3.1 doesn't seem to enable A20 first during an


### PR DESCRIPTION
# Description
Handles INF 2F, 0x1600 call to check for enhanced-mode Windows.
Behaviorally it is the same as master, but this call will no longer generate an error in the log.

**Are there any breaking changes ?**

No

**Additional information**

http://www.oldlinux.org/Linux.old/docs/interrupts/int-html/rb-4495.htm

Confirmed in MS-DOS 6.22 that this call when made from MS-DOS, rather than from Windows, it will simply return with AX as 1600, the same as when it entered. This same thing happens in master branch since it just errors out as unimplemented but we don't need to treat it as an error.