### PR TITLE
Update changelog and skipped SVN commits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 0.82.19 (next)
-  - INT 2Fh AX=1600h no longer logs an error as unimplemented. (Allofich)
+  - INT 2Fh AX=1600h no longer logs an error as unimplemented.
+    (Allofich)
   - COPY.EXE removed, so that the built-in COPY command can work.
   - PC98UTIL fixed to re-enable the text layer after the BIOS call
     for /24khz and /31khz options.
@@ -32,24 +33,54 @@
     the BIOS (or dosbox.conf) setting.
   - PC-98 port 68h now supports command 0Eh/0Fh to enable display.
   - Integrated commits from mainline (Allofich)
-    3854 - "top" is now used as 32 bit in dynrec core
-    3860 - Don't scroll at unspecified video page
-    3862 - Lower the influence of the aspect table correction trick when using high scale factors (320x200 => 2000x1200)
-    3864 - Code reordering to fix build
-    3866 - Correction to Hercules video height parameter
-    3867 - The mapper now uses the wrapper as well
-    3889 - Fix the possible/suggested values for integer properties.
-    3895 - Minor cleanup. Re-ordering of memory coalescing to match commit from mainline.
-    3896 - Do less to update the frequency of an active SB DMA transfer. Fixes sound in Tempest 2000.
-    3898 - Add missing --disable-fpu-x64 option
-    3899 - Use clock_gettime when available instead of the obsolete ftime.
-    3904 - Allow CRTC read/write access on all mirror ports for non-VGA machine types. Fixes Tandy and EGA display in International Hockey booter.	
+    - Lower the influence of the aspect table correction
+    trick when using high scale factors (320x200 => 2000x1200).
+    - Correction done to Hercules video height parameter.
+    - The mapper now uses the wrapper as well
+    - Fix the possible/suggested values for integer
+    properties.
+    - Do less to update the frequency of an active SB
+    DMA transfer. Fixes sound in Tempest 2000.
+    - Add missing --disable-fpu-x64 option
+    - Use clock_gettime when available instead of the
+    obsolete ftime.
+    - Allow CRTC read/write access on all mirror ports for
+    non-VGA machine types. Fixes Tandy and EGA display in
+    International Hockey booter.
+    - Handle "copy H*.txt file.txt" correctly
+    - Fix detection of always_inline attribute with ming 4.9.2
+    - Introduce mount -pr to mount paths relative to last
+    loaded configuration file.
+    - Use normal teletype function for non-ANSI output so the
+    default attribute 7 applies only to graphics modes and
+    existing attributes are not changed in text modes.
+    - Improve compatibility of internal mouse driver with
+    respect to video mode changes and hiding the pointer, and
+    handle font reloading as a kind of mode change. Also fix
+    unlocked mouse pointer to recognize the full range of
+    tweaked/fontloaded text modes.
+    - Bring OS2 port up to date.
+    - Ignore/remove single % in batchfiles.
+    (Fixes B13Demo batchfiles on PC Gamer cover disc 1995-08)
+    - Clear incomplete Sound Blaster DSP command at reset,
+    fixes Romancing Prince.
+    - Add some more cases to the Alt-Tab detection.
+    - Add alternate font tables and associated loading logic
+    in video BIOS, allowing correct gaps between "wide"
+    characters (e.g. m,w,M,W,T,Z,0) in all VGA machine types.
+    - Update all related BIOS memory values and CRTC registers
+    when loading fonts.
+    - Improve support for MDA emulation in the vgaonly machine
+    type, as it is the only way the video BIOS can make use
+    of the 14-line alternate symbols.
+    - Be compatible by setting the INT 43h vector to the first
+    half of the 8-line font table for standard text modes.
+    - Move VESA mode table and OEM string before font tables
+    in the video ROM, which is a more compatible ordering.	
   - Integrated a commit from mainline:
      #3860 "Use PCJr specific method to clear the video RAM.
             Also don't scroll at unspecified video page.
             Fixes issues with KQ1 and KQ2."
-  - Integrated commits from mainline: 3854, 3860, 3861, 3862,
-    3864, 3866 (Allofich)
   - PEGC emulation will now print a warning if the guest
     application or OS attempts to use 256-color planar mode.
   - PC-98 PEGC 256-color linear framebuffer is not mapped by
@@ -73,14 +104,20 @@
   - Added debugger commands "VGA DRAW" and "VGA AC" to view
     drawing and attribute controller state in the VGA emulation.
   - Integrated commits from mainline (Allofich)
-    3834 - Fix typos
-    3839 - CD audio status now returns zero start and end times when no track is playing. Fixes "The Manhole".
-    3840 - Add "ADDLOG" debug command to manually add a message to the log.
-    3843 - "Strip off leading zeroes from the IP", a fix for the serial modem.
-    3845 - Add a small delay when raising the Sound Blaster 8-bit IRQ to emulate the slowness of the DSP, fixes Llamatron 2012 and Lemmings 3D.
-    3849 - Add ability to set debugger breakpoint on AL values.
-    3850 - The SB DMA callback now ignores previously selected, but not currently selected, DMA channels. Fixes Visual Player 2 with SB16.
-    3853 - Minor cleanup to joystick code.
+    - CD audio status now returns zero start and end times
+    when no track is playing. Fixes "The Manhole".
+    - Add "ADDLOG" debug command to manually add a message
+    to the log.
+    - "Strip off leading zeroes from the IP", a fix for
+    the serial modem.
+    - Add a small delay when raising the Sound Blaster
+    8-bit IRQ to emulate the slowness of the DSP, fixes
+    Llamatron 2012 and Lemmings 3D.
+    - Add ability to set debugger breakpoint on AL values.
+    - The SB DMA callback now ignores previously selected,
+    but not currently selected, DMA channels. Fixes Visual
+    Player 2 with SB16.
+    - Minor cleanup to joystick code.
   - PSG noise channel emulation (PC-98 FM board) apparently
     broke on Mac OS X due to type promotion by Clang/LLVM.
     Modified the code to behave as originally intended, to

--- a/NOTES/Skipped SVN commits.txt
+++ b/NOTES/Skipped SVN commits.txt
@@ -16,3 +16,6 @@ Commit#:	Reason for skipping:
 3871		Conflicts with DOSBox-X
 3873		Conflicts with DOSBox-X
 3891		Conflicts with DOSBox-X
+3922		Conflicts with DOSBox-X. "Use safe_strncpy for resolution lines" part is already in DOSBox-X.
+3930		Conflicts with DOSBox-X
+3931		Skipped. May not have effect or be wanted


### PR DESCRIPTION
Update changelog and skipped SVN commits.

Notes about changelog update:
- I noticed that you keep your messages in the changelog from being too long on a single line. I added new lines to keep my entries at the same length.
- I decided to not bother including the numbers of each integrated SVN commit. What matters for the changelog is the features or fixes they bring. Minor cleanup commits are omitted from mention.