### PR TITLE
Next SVN commits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -48,7 +48,7 @@
     non-VGA machine types. Fixes Tandy and EGA display in
     International Hockey booter.
     - Handle "copy H*.txt file.txt" correctly
-    - Fix detection of always_inline attribute with ming 4.9.2
+    - Fix detection of always_inline attribute with MinGW 4.9.2
     - Introduce mount -pr to mount paths relative to last
     loaded configuration file.
     - Use normal teletype function for non-ANSI output so the
@@ -76,7 +76,11 @@
     - Be compatible by setting the INT 43h vector to the first
     half of the 8-line font table for standard text modes.
     - Move VESA mode table and OEM string before font tables
-    in the video ROM, which is a more compatible ordering.	
+    in the video ROM, which is a more compatible ordering.
+    - Add opl3gold option to oplmode setting. With this option
+    the Adlib Gold music can be selected in Dune. Only music
+    without effects is supported. FM volume control does work.
+    - Add hardware text mode cursor support.
   - Integrated a commit from mainline:
      #3860 "Use PCJr specific method to clear the video RAM.
             Also don't scroll at unspecified video page.

--- a/dosbox.reference.conf
+++ b/dosbox.reference.conf
@@ -897,7 +897,7 @@ mt32.partials=32
 #                                          oplmode: Type of OPL emulation. On 'auto' the mode is determined by sblaster type.
 #                                                   To emulate Adlib, set sbtype=none and oplmode=opl2. To emulate a Game Blaster, set
 #                                                   sbtype=none and oplmode=cms
-#                                                   Possible values: auto, cms, opl2, dualopl2, opl3, none, hardware, hardwaregb.
+#                                                   Possible values: auto, cms, opl2, dualopl2, opl3, opl3gold, none, hardware, hardwaregb.
 #             adlib force timer overflow on detect: If set, Adlib/OPL emulation will signal 'overflow' on timers after 50 I/O reads.
 #                                                   This is a temporary hack to work around timing bugs noted in DOSBox-X. Certain
 #                                                   games (Wolfenstein 3D) poll the Adlib status port a fixed number of times assuming

--- a/include/hardware.h
+++ b/include/hardware.h
@@ -24,7 +24,7 @@
 
 class Section;
 enum OPL_Mode {
-	OPL_none,OPL_cms,OPL_opl2,OPL_dualopl2,OPL_opl3,OPL_hardware,OPL_hardwareCMS
+	OPL_none,OPL_cms,OPL_opl2,OPL_dualopl2,OPL_opl3,OPL_opl3gold,OPL_hardware,OPL_hardwareCMS
 };
 #define CAPTURE_WAVE	0x01
 #define CAPTURE_OPL		0x02

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -958,7 +958,7 @@ void DOSBOX_SetupConfigSections(void) {
     const char *mt32reverbLevels[] = {"0", "1", "2", "3", "4", "5", "6", "7",0};
     const char* gustypes[] = { "classic", "classic37", "max", "interwave", 0 };
     const char* sbtypes[] = { "sb1", "sb2", "sbpro1", "sbpro2", "sb16", "sb16vibra", "gb", "ess688", "reveal_sc400", "none", 0 };
-    const char* oplmodes[]={ "auto", "cms", "opl2", "dualopl2", "opl3", "none", "hardware", "hardwaregb", 0};
+    const char* oplmodes[]={ "auto", "cms", "opl2", "dualopl2", "opl3", "opl3gold", "none", "hardware", "hardwaregb", 0};
     const char* serials[] = { "dummy", "disabled", "modem", "nullmodem", "serialmouse", "directserial", "log", 0 };
     const char* acpi_rsd_ptr_settings[] = { "auto", "bios", "ebda", 0 };
     const char* cpm_compat_modes[] = { "auto", "off", "msdos2", "msdos5", "direct", 0 };

--- a/src/hardware/adlib.h
+++ b/src/hardware/adlib.h
@@ -97,7 +97,8 @@ struct Chip {
 typedef enum {
 	MODE_OPL2,
 	MODE_DUALOPL2,
-	MODE_OPL3
+	MODE_OPL3,
+	MODE_OPL3GOLD
 } Mode;
 
 class Handler {
@@ -133,8 +134,17 @@ class Module: public Module_base {
 		Bit32u normal;
 		Bit8u dual[2];
 	} reg;
+	struct {
+		bool active;
+		Bit8u index;
+		Bit8u lvol;
+		Bit8u rvol;
+		bool mixer;
+	} ctrl;
 	void CacheWrite( Bit32u reg, Bit8u val );
 	void DualWrite( Bit8u index, Bit8u reg, Bit8u val );
+	void CtrlWrite( Bit8u val );
+	Bitu CtrlRead( void );
 public:
 	static OPL_Mode oplmode;
 	MixerChannel* mixerChan;

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -3165,6 +3165,7 @@ private:
         else if (!strcasecmp(omode,"opl2")) opl_mode=OPL_opl2;
         else if (!strcasecmp(omode,"dualopl2")) opl_mode=OPL_dualopl2;
         else if (!strcasecmp(omode,"opl3")) opl_mode=OPL_opl3;
+        else if (!strcasecmp(omode,"opl3gold")) opl_mode=OPL_opl3gold;
         else if (!strcasecmp(omode,"hardware")) opl_mode=OPL_hardware;
         else if (!strcasecmp(omode,"hardwaregb")) opl_mode=OPL_hardwareCMS;
         /* Else assume auto */
@@ -3363,6 +3364,7 @@ public:
         case OPL_dualopl2:
             assert(!IS_PC98_ARCH);
         case OPL_opl3:
+        case OPL_opl3gold:
             OPL_Init(section,oplmode);
             break;
         case OPL_hardwareCMS:
@@ -3635,6 +3637,7 @@ ASP>
             // fall-through
         case OPL_dualopl2:
         case OPL_opl3:
+        case OPL_opl3gold:
             OPL_ShutDown(m_configuration);
             break;
         default:


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/3933/ - Skipped. Not relevant.
https://sourceforge.net/p/dosbox/code-0/3934/ - In this PR, although disabled.
https://sourceforge.net/p/dosbox/code-0/3935/ - Skipped. Not relevant.
https://sourceforge.net/p/dosbox/code-0/3936/ - In this PR
https://sourceforge.net/p/dosbox/code-0/3937/ - In this PR

3934 has no effect for DOSBox-X, as the affected code was commented out previously (apparently you didn't care for it). Therefore this just updates the disabled code to the newer version, but doesn't un-disable it.

The supposed fix, that it makes "dosbox -fullscreen A.EXE" work, already works in DOSBox-X in my testing.

For 3936, I can confirm that this commit allows Dune to run with Adlib Gold music, which doesn't work in master branch.
Dune II also has an option for Adlib Gold music, but it doesn't work with this commit. The game will freeze when you try to select the house to play as if you try to use Adlib Gold. This also happens if you try to play with Adlib Gold in DOSBox SVN.

I don't know how to test 3937, but it's a straightforward change with no conflicts.

Compiles and runs.