### PR TITLE
More SVN commits

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -586,7 +586,7 @@ public:
 	bool Extended(void);
 	void GetAttr(Bit8u & attr);
 	void SetAttr(Bit8u attr);
-	void SetResultAttr(Bit8u attr);
+	void SetResult(Bit32u size,Bit16u date,Bit16u time,Bit8u attr);
 	bool Valid(void);
 	void ClearBlockRecsize(void);
 private:

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -538,8 +538,11 @@ void DOS_FCB::SetAttr(Bit8u attr) {
 	if(extended) mem_writeb(pt - 1,attr);
 }
 
-void DOS_FCB::SetResultAttr(Bit8u attr) {
-	mem_writeb(pt + 12,attr);
+void DOS_FCB::SetResult(Bit32u size,Bit16u date,Bit16u time,Bit8u attr) {
+	mem_writed(pt + 0x1d,size);
+	mem_writew(pt + 0x19,date);
+	mem_writew(pt + 0x17,time);
+	mem_writeb(pt + 0x0c,attr);
 }
 
 void DOS_SDA::Init() {

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -1008,8 +1008,7 @@ static void SaveFindResult(DOS_FCB & find_fcb) {
 	fcb.Create(find_fcb.Extended());
 	fcb.SetName(drive,file_name,ext);
 	fcb.SetAttr(find_attr);      /* Only adds attribute if fcb is extended */
-	fcb.SetResultAttr(attr);
-	fcb.SetSizeDateTime(size,date,time);
+	fcb.SetResult(size,date,time,attr);
 }
 
 bool DOS_FCBCreate(Bit16u seg,Bit16u offset) { 

--- a/src/hardware/dbopl.cpp
+++ b/src/hardware/dbopl.cpp
@@ -1181,9 +1181,9 @@ void Chip::GenerateBlock2( Bitu total, Bit32s* output ) {
 	while ( total > 0 ) {
 		Bit32u samples = ForwardLFO( total );
 		memset(output, 0, sizeof(Bit32s) * samples);
-		int count = 0;
+//		int count = 0;
 		for( Channel* ch = chan; ch < chan + 9; ) {
-			count++;
+//			count++;
 			ch = (ch->*(ch->synthHandler))( this, samples, output );
 		}
 		total -= samples;
@@ -1195,9 +1195,9 @@ void Chip::GenerateBlock3( Bitu total, Bit32s* output  ) {
 	while ( total > 0 ) {
 		Bit32u samples = ForwardLFO( total );
 		memset(output, 0, sizeof(Bit32s) * samples *2);
-		int count = 0;
+//		int count = 0;
 		for( Channel* ch = chan; ch < chan + 18; ) {
-			count++;
+//			count++;
 			ch = (ch->*(ch->synthHandler))( this, samples, output );
 		}
 		total -= samples;

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -7361,6 +7361,9 @@ private:
             if (KEYBOARD_Report_BIOS_PS2Mouse())
                 config |= 0x04;
 
+            // DMA *not* supported - Ancient Art of War CGA uses this to identify PCjr
+            if (machine==MCH_PCJR) config |= 0x100;
+
             // Gameport
             config |= 0x1000;
             mem_writew(BIOS_CONFIGURATION,config);


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/3954/ - In this PR
https://sourceforge.net/p/dosbox/code-0/3955/ - In this PR
https://sourceforge.net/p/dosbox/code-0/3956/ - In this PR
https://sourceforge.net/p/dosbox/code-0/3957/ - In this PR
https://sourceforge.net/p/dosbox/code-0/3958/ - In this PR
https://sourceforge.net/p/dosbox/code-0/3959/ - Skipped. Already in DOSBox-X

3957 is an update to 3956, so I merged them into one.
3954 included a change that was undone in 3959, so I omitted it from 3954.

I have questions about the next commits.

https://sourceforge.net/p/dosbox/code-0/3960

Do you know if this commit is relevant for DOSBox-X? One of DOSBox-X's improvements is better timing with the PC speaker, right?

https://sourceforge.net/p/dosbox/code-0/3961

This one seems like a nice emulation improvement but conflicts with DOSBox-X as is and I'm not sure if I can adapt it to the different code in DOSBox-X. I could skip it and make an issue for it if you don't want to look at it now. 
