### PR TITLE
More SVN commits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -128,6 +128,24 @@
     and file info in XTree Gold.
     - Prevent a multiplication overflow and more accuracy
     by using floats for attack rate loop
+    - Set record size to 128 if it is 0 in the FCB when
+    calling any FCB read/write function
+    - Fixes for acad 10:
+      - Add missing reference counting when the file is
+      already open when calling FCB_Open, so that acad, which
+      uses FCBs and normal handles on the same file, works
+      better.
+      - Remove FCBs being added to the PSP filetable and
+      rewrite most functions to support this change. This way
+      acad won't run out of temporary (fcb) files when low on
+      memory.
+    - More flexible setting of version with "VER" command.
+    - Fix screen clearing when setting mode 0xA on PCjr
+    machine type.
+    - Fill DTA for FCB search results more like real DOS,
+    fixing hang in SETUP.EXE and MSDOSD.EXE from Windows V1.01.
+    - Add support for mode 8 row copy/fill. Fixes Tandy
+    GW-BASIC interpreter SCREEN 3 scrolling/clearing.
   - Integrated a commit from mainline:
      #3860 "Use PCJr specific method to clear the video RAM.
             Also don't scroll at unspecified video page.

--- a/NOTES/Skipped SVN commits.txt
+++ b/NOTES/Skipped SVN commits.txt
@@ -20,3 +20,8 @@ Commit#:	Reason for skipping:
 3930		Conflicts with DOSBox-X
 3931		May not have effect or be wanted
 3939		A commented-out log message.
+3960		Thought to be unneeded.
+3963		Relies on midi.h from former skipped commit
+3967		Conflicts with DOSBox-X and may be unnecessary.
+3968		Conflicts with DOSBox-X and may be unnecessary.
+3969		Related to 3968.

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -163,12 +163,12 @@ enum { HAND_NONE=0,HAND_FILE,HAND_DEVICE};
 
 /* Routines for File Class */
 void DOS_SetupFiles (void);
-bool DOS_ReadFile(Bit16u handle,Bit8u * data,Bit16u * amount);
-bool DOS_WriteFile(Bit16u handle,Bit8u * data,Bit16u * amount);
-bool DOS_SeekFile(Bit16u handle,Bit32u * pos,Bit32u type);
+bool DOS_ReadFile(Bit16u handle,Bit8u * data,Bit16u * amount, bool fcb = false);
+bool DOS_WriteFile(Bit16u handle,Bit8u * data,Bit16u * amount,bool fcb = false);
+bool DOS_SeekFile(Bit16u handle,Bit32u * pos,Bit32u type,bool fcb = false);
 /* ert, 20100711: Locking extensions */
 bool DOS_LockFile(Bit16u entry,Bit8u mode,Bit32u pos,Bit32u size);
-bool DOS_CloseFile(Bit16u handle);
+bool DOS_CloseFile(Bit16u handle,bool fcb = false);
 bool DOS_FlushFile(Bit16u handle);
 bool DOS_DuplicateEntry(Bit16u entry,Bit16u * newentry);
 bool DOS_ForceDuplicateEntry(Bit16u entry,Bit16u newentry);
@@ -176,9 +176,9 @@ bool DOS_GetFileDate(Bit16u entry, Bit16u* otime, Bit16u* odate);
 bool DOS_SetFileDate(Bit16u entry, Bit16u ntime, Bit16u ndate);
 
 /* Routines for Drive Class */
-bool DOS_OpenFile(char const * name,Bit8u flags,Bit16u * entry);
+bool DOS_OpenFile(char const * name,Bit8u flags,Bit16u * entry,bool fcb = false);
 bool DOS_OpenFileExtended(char const * name, Bit16u flags, Bit16u createAttr, Bit16u action, Bit16u *entry, Bit16u* status);
-bool DOS_CreateFile(char const * name,Bit16u attribute,Bit16u * entry);
+bool DOS_CreateFile(char const * name,Bit16u attribute,Bit16u * entry, bool fcb = false);
 bool DOS_UnlinkFile(char const * const name);
 bool DOS_FindFirst(char *search,Bit16u attr,bool fcb_findfirst=false);
 bool DOS_FindNext(void);
@@ -580,6 +580,7 @@ public:
 	void GetRecord(Bit16u & _cur_block,Bit8u & _cur_rec);
 	void SetRecord(Bit16u _cur_block,Bit8u _cur_rec);
 	void GetSeqData(Bit8u & _fhandle,Bit16u & _rec_size);
+	void SetSeqData(Bit8u _fhandle,Bit16u _rec_size);
 	void GetRandom(Bit32u & _random);
 	void SetRandom(Bit32u  _random);
 	Bit8u GetDrive(void);
@@ -608,6 +609,8 @@ private:
 		Bit8u sft_entries;
 		Bit8u share_attributes;
 		Bit8u extra_info;
+		/* Maybe swap file_handle and sft_entries now that fcbs 
+		 * aren't stored in the psp filetable anymore */
 		Bit8u file_handle;
 		Bit8u reserved[4];
 		/* end */

--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -1006,10 +1006,10 @@ bool device_CON::Write(const Bit8u * data,Bit16u * size) {
                         ansi.warned = true;
                         LOG(LOG_IOCTL,LOG_WARN)("ANSI SEQUENCES USED");
                     }
-					if (!IS_PC98_ARCH) {
-						ansi.ncols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-						ansi.nrows = real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS) + 1;
-					}
+                    if (!IS_PC98_ARCH) {
+                        ansi.ncols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
+                        ansi.nrows = real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS) + 1;
+                    }
                     /* Turn them into positions that are on the screen */
                     if(ansi.data[0] == 0) ansi.data[0] = 1;
                     if(ansi.data[1] == 0) ansi.data[1] = 1;
@@ -1057,9 +1057,9 @@ bool device_CON::Write(const Bit8u * data,Bit16u * size) {
                 case 'K': /* erase till end of line (don't touch cursor) */
                     col = CURSOR_POS_COL(page);
                     row = CURSOR_POS_ROW(page);
-					if (!IS_PC98_ARCH) {
-						ansi.ncols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-					}
+                    if (!IS_PC98_ARCH) {
+                        ansi.ncols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
+                    }
 					INT10_WriteChar(' ',ansi.attr,page,ansi.ncols-col,true); //Real_WriteChar(ansi.ncols-col,row,page,' ',ansi.attr,true);
 
                     //for(i = col;i<(Bitu) ansi.ncols; i++) INT10_TeletypeOutputAttr(' ',ansi.attr,true);
@@ -1068,10 +1068,10 @@ bool device_CON::Write(const Bit8u * data,Bit16u * size) {
                     break;
                 case 'M': /* delete line (NANSI) */
                     row = CURSOR_POS_ROW(page);
-					if (!IS_PC98_ARCH) {
-						ansi.ncols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-						ansi.nrows = real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS) + 1;
-					}
+                    if (!IS_PC98_ARCH) {
+                        ansi.ncols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
+                        ansi.nrows = real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS) + 1;
+                    }
 					INT10_ScrollWindow(row,0,ansi.nrows-1,ansi.ncols-1,ansi.data[0]? -ansi.data[0] : -1,ansi.attr,0xFF);
                     ClearAnsi();
                     break;

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -428,8 +428,8 @@ bool DOS_FCB::Extended(void) {
 
 void DOS_FCB::Create(bool _extended) {
 	Bitu fill;
-	if (_extended) fill=36+7;
-	else fill=36;
+	if (_extended) fill=33+7;
+	else fill=33;
 	Bitu i;
 	for (i=0;i<fill;i++) mem_writeb(real_pt+i,0);
 	pt=real_pt;

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -474,6 +474,10 @@ void DOS_FCB::GetSeqData(Bit8u & _fhandle,Bit16u & _rec_size) {
 	_rec_size=(Bit16u)sGet(sFCB,rec_size);
 }
 
+void DOS_FCB::SetSeqData(Bit8u _fhandle,Bit16u _rec_size) {
+	sSave(sFCB,file_handle,_fhandle);
+	sSave(sFCB,rec_size,_rec_size);
+}
 
 void DOS_FCB::GetRandom(Bit32u & _random) {
 	_random=sGet(sFCB,rndm);
@@ -494,14 +498,13 @@ void DOS_FCB::FileOpen(Bit8u _fhandle) {
 	sSave(sFCB,cur_block,0u);
 	sSave(sFCB,rec_size,128u);
 //	sSave(sFCB,rndm,0); // breaks Jewels of darkness. 
-	Bit8u temp = RealHandle(_fhandle);
 	Bit32u size = 0;
-	Files[temp]->Seek(&size,DOS_SEEK_END);
+	Files[_fhandle]->Seek(&size,DOS_SEEK_END);
 	sSave(sFCB,filesize,size);
 	size = 0;
-	Files[temp]->Seek(&size,DOS_SEEK_SET);
-	sSave(sFCB,time,Files[temp]->time);
-	sSave(sFCB,date,Files[temp]->date);
+	Files[_fhandle]->Seek(&size,DOS_SEEK_SET);
+	sSave(sFCB,time,Files[_fhandle]->time);
+	sSave(sFCB,date,Files[_fhandle]->date);
 }
 
 bool DOS_FCB::Valid() {

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -355,12 +355,12 @@ bool DOS_FindNext(void) {
 }
 
 
-bool DOS_ReadFile(Bit16u entry,Bit8u * data,Bit16u * amount) {
+bool DOS_ReadFile(Bit16u entry,Bit8u * data,Bit16u * amount,bool fcb) {
 #if defined(WIN32) && !defined(__MINGW32__)
 	if(Network_IsActiveResource(entry))
 		return Network_ReadFile(entry,data,amount);
 #endif
-	Bit32u handle=RealHandle(entry);
+	Bit32u handle = fcb?entry:RealHandle(entry);
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
@@ -381,12 +381,12 @@ bool DOS_ReadFile(Bit16u entry,Bit8u * data,Bit16u * amount) {
 	return ret;
 }
 
-bool DOS_WriteFile(Bit16u entry,Bit8u * data,Bit16u * amount) {
+bool DOS_WriteFile(Bit16u entry,Bit8u * data,Bit16u * amount,bool fcb) {
 #if defined(WIN32) && !defined(__MINGW32__)
 	if(Network_IsActiveResource(entry))
 		return Network_WriteFile(entry,data,amount);
 #endif
-	Bit32u handle=RealHandle(entry);
+	Bit32u handle = fcb?entry:RealHandle(entry);
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
@@ -407,8 +407,8 @@ bool DOS_WriteFile(Bit16u entry,Bit8u * data,Bit16u * amount) {
 	return ret;
 }
 
-bool DOS_SeekFile(Bit16u entry,Bit32u * pos,Bit32u type) {
-	Bit32u handle=RealHandle(entry);
+bool DOS_SeekFile(Bit16u entry,Bit32u * pos,Bit32u type,bool fcb) {
+	Bit32u handle = fcb?entry:RealHandle(entry);
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
@@ -441,12 +441,12 @@ bool DOS_LockFile(Bit16u entry,Bit8u mode,Bit32u pos,Bit32u size) {
 #endif
 }
 
-bool DOS_CloseFile(Bit16u entry) {
+bool DOS_CloseFile(Bit16u entry, bool fcb) {
 #if defined(WIN32) && !defined(__MINGW32__)
 	if(Network_IsActiveResource(entry))
 		return Network_CloseFile(entry);
 #endif
-	Bit32u handle=RealHandle(entry);
+	Bit32u handle = fcb?entry:RealHandle(entry);
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
@@ -458,8 +458,10 @@ bool DOS_CloseFile(Bit16u entry) {
 	if (Files[handle]->IsOpen()) {
 		Files[handle]->Close();
 	}
+
 	DOS_PSP psp(dos.psp());
-	psp.SetFileHandle(entry,0xff);
+	if (!fcb) psp.SetFileHandle(entry,0xff);
+
 	if (Files[handle]->RemoveRef()<=0) {
 		delete Files[handle];
 		Files[handle]=0;
@@ -496,11 +498,11 @@ static bool PathExists(char const * const name) {
 }
 
 
-bool DOS_CreateFile(char const * name,Bit16u attributes,Bit16u * entry) {
+bool DOS_CreateFile(char const * name,Bit16u attributes,Bit16u * entry,bool fcb) {
 	// Creation of a device is the same as opening it
 	// Tc201 installer
 	if (DOS_FindDevice(name) != DOS_DEVICES)
-		return DOS_OpenFile(name, OPEN_READ, entry);
+		return DOS_OpenFile(name, OPEN_READ, entry, fcb);
 
 	LOG(LOG_FILES,LOG_NORMAL)("file create attributes %X file %s",attributes,name);
 	char fullname[DOS_PATHLENGTH];Bit8u drive;
@@ -519,7 +521,7 @@ bool DOS_CreateFile(char const * name,Bit16u attributes,Bit16u * entry) {
 		return false;
 	}
 	/* We have a position in the main table now find one in the psp table */
-	*entry = psp.FindFreeFileEntry();
+	*entry = fcb?handle:psp.FindFreeFileEntry();
 	if (*entry==0xff) {
 		DOS_SetError(DOSERR_TOO_MANY_OPEN_FILES);
 		return false;
@@ -534,7 +536,7 @@ bool DOS_CreateFile(char const * name,Bit16u attributes,Bit16u * entry) {
 		Files[handle]->SetDrive(drive);
 		Files[handle]->AddRef();
 		Files[handle]->drive = drive;
-		psp.SetFileHandle(*entry,handle);
+		if (!fcb) psp.SetFileHandle(*entry,handle);
 		return true;
 	} else {
 		if(!PathExists(name)) DOS_SetError(DOSERR_PATH_NOT_FOUND); 
@@ -543,7 +545,7 @@ bool DOS_CreateFile(char const * name,Bit16u attributes,Bit16u * entry) {
 	}
 }
 
-bool DOS_OpenFile(char const * name,Bit8u flags,Bit16u * entry) {
+bool DOS_OpenFile(char const * name,Bit8u flags,Bit16u * entry,bool fcb) {
 #if defined(WIN32) && !defined(__MINGW32__)
 	if(Network_IsNetworkResource(const_cast<char *>(name)))
 		return Network_OpenFile(const_cast<char *>(name),flags,entry);
@@ -580,7 +582,7 @@ bool DOS_OpenFile(char const * name,Bit8u flags,Bit16u * entry) {
 		return false;
 	}
 	/* We have a position in the main table now find one in the psp table */
-	*entry = psp.FindFreeFileEntry();
+	*entry = fcb?handle:psp.FindFreeFileEntry();
 
 	if (*entry==0xff) {
 		DOS_SetError(DOSERR_TOO_MANY_OPEN_FILES);
@@ -1018,7 +1020,7 @@ bool DOS_FCBCreate(Bit16u seg,Bit16u offset) {
 	Bit8u attr = DOS_ATTR_ARCHIVE;
 	fcb.GetAttr(attr);
 	if (!attr) attr = DOS_ATTR_ARCHIVE; //Better safe than sorry 
-	if (!DOS_CreateFile(shortname,attr,&handle)) return false;
+	if (!DOS_CreateFile(shortname,attr,&handle,true)) return false;
 	fcb.FileOpen((Bit8u)handle);
 	return true;
 }
@@ -1034,21 +1036,15 @@ bool DOS_FCBOpen(Bit16u seg,Bit16u offset) {
 	if (!DOS_MakeName(shortname,fullname,&drive)) return false;
 	
 	/* Check, if file is already opened */
-	for (Bit8u i=0;i<DOS_FILES;i++) {
-		DOS_PSP psp(dos.psp());
+	for (Bit8u i = 0;i < DOS_FILES;i++) {
 		if (Files[i] && Files[i]->IsOpen() && Files[i]->IsName(fullname)) {
-			handle = psp.FindEntryByHandle(i);
-			if (handle==0xFF) {
-				// This shouldnt happen
-				LOG(LOG_FILES,LOG_ERROR)("DOS: File %s is opened but has no psp entry.",shortname);
-				return false;
-			}
-			fcb.FileOpen((Bit8u)handle);
+			Files[i]->AddRef();
+			fcb.FileOpen(i);
 			return true;
 		}
 	}
 	
-	if (!DOS_OpenFile(shortname,OPEN_READWRITE,&handle)) return false;
+	if (!DOS_OpenFile(shortname,OPEN_READWRITE,&handle,true)) return false;
 	fcb.FileOpen((Bit8u)handle);
 	return true;
 }
@@ -1058,7 +1054,7 @@ bool DOS_FCBClose(Bit16u seg,Bit16u offset) {
 	if(!fcb.Valid()) return false;
 	Bit8u fhandle;
 	fcb.FileClose(fhandle);
-	DOS_CloseFile(fhandle);
+	DOS_CloseFile(fhandle,true);
 	return true;
 }
 
@@ -1092,11 +1088,15 @@ Bit8u DOS_FCBRead(Bit16u seg,Bit16u offset,Bit16u recno) {
 		LOG(LOG_FCB,LOG_WARN)("Reopened closed FCB");
 		fcb.GetSeqData(fhandle,rec_size);
 	}
+	if (rec_size == 0) {
+		rec_size = 128;
+		fcb.SetSeqData(fhandle,rec_size);
+	}
 	fcb.GetRecord(cur_block,cur_rec);
 	Bit32u pos=((cur_block*128u)+cur_rec)*rec_size;
-	if (!DOS_SeekFile(fhandle,&pos,DOS_SEEK_SET)) return FCB_READ_NODATA; 
+	if (!DOS_SeekFile(fhandle,&pos,DOS_SEEK_SET,true)) return FCB_READ_NODATA; 
 	Bit16u toread=rec_size;
-	if (!DOS_ReadFile(fhandle,dos_copybuf,&toread)) return FCB_READ_NODATA;
+	if (!DOS_ReadFile(fhandle,dos_copybuf,&toread,true)) return FCB_READ_NODATA;
 	if (toread==0) return FCB_READ_NODATA;
 	if (toread < rec_size) { //Zero pad copybuffer to rec_size
 		Bitu i = toread;
@@ -1119,12 +1119,16 @@ Bit8u DOS_FCBWrite(Bit16u seg,Bit16u offset,Bit16u recno) {
 		LOG(LOG_FCB,LOG_WARN)("Reopened closed FCB");
 		fcb.GetSeqData(fhandle,rec_size);
 	}
+	if (rec_size == 0) {
+		rec_size = 128;
+		fcb.SetSeqData(fhandle,rec_size);
+	}
 	fcb.GetRecord(cur_block,cur_rec);
 	Bit32u pos=((cur_block*128u)+cur_rec)*rec_size;
-	if (!DOS_SeekFile(fhandle,&pos,DOS_SEEK_SET)) return FCB_ERR_WRITE; 
+	if (!DOS_SeekFile(fhandle,&pos,DOS_SEEK_SET,true)) return FCB_ERR_WRITE; 
 	MEM_BlockRead(Real2Phys(dos.dta())+(PhysPt)(recno*rec_size),dos_copybuf,rec_size);
 	Bit16u towrite=rec_size;
-	if (!DOS_WriteFile(fhandle,dos_copybuf,&towrite)) return FCB_ERR_WRITE;
+	if (!DOS_WriteFile(fhandle,dos_copybuf,&towrite,true)) return FCB_ERR_WRITE;
 	Bit32u size;Bit16u date,time;
 	fcb.GetSizeDateTime(size,date,time);
 	if (pos+towrite>size) size=pos+towrite;
@@ -1136,9 +1140,8 @@ Bit8u DOS_FCBWrite(Bit16u seg,Bit16u offset,Bit16u recno) {
 	Bit16u min = (Bit16u)((seconds % 3600u)/60u);
 	Bit16u sec = (Bit16u)(seconds % 60u);
 	time = DOS_PackTime(hour,min,sec);
-	Bit8u temp=RealHandle(fhandle);
-	Files[temp]->time=time;
-	Files[temp]->date=date;
+	Files[fhandle]->time = time;
+	Files[fhandle]->date = date;
 	fcb.SetSizeDateTime(size,date,time);
 	if (++cur_rec>127u) { cur_block++;cur_rec=0; }	
 	fcb.SetRecord(cur_block,cur_rec);
@@ -1151,9 +1154,9 @@ Bit8u DOS_FCBIncreaseSize(Bit16u seg,Bit16u offset) {
 	fcb.GetSeqData(fhandle,rec_size);
 	fcb.GetRecord(cur_block,cur_rec);
 	Bit32u pos=((cur_block*128u)+cur_rec)*rec_size;
-	if (!DOS_SeekFile(fhandle,&pos,DOS_SEEK_SET)) return FCB_ERR_WRITE; 
+	if (!DOS_SeekFile(fhandle,&pos,DOS_SEEK_SET,true)) return FCB_ERR_WRITE; 
 	Bit16u towrite=0;
-	if (!DOS_WriteFile(fhandle,dos_copybuf,&towrite)) return FCB_ERR_WRITE;
+	if (!DOS_WriteFile(fhandle,dos_copybuf,&towrite,true)) return FCB_ERR_WRITE;
 	Bit32u size;Bit16u date,time;
 	fcb.GetSizeDateTime(size,date,time);
 	if (pos+towrite>size) size=pos+towrite;
@@ -1165,9 +1168,8 @@ Bit8u DOS_FCBIncreaseSize(Bit16u seg,Bit16u offset) {
 	Bit16u min = (Bit16u)((seconds % 3600u)/60u);
 	Bit16u sec = (Bit16u)(seconds % 60u);
 	time = DOS_PackTime(hour,min,sec);
-	Bit8u temp=RealHandle(fhandle);
-	Files[temp]->time=time;
-	Files[temp]->date=date;
+	Files[fhandle]->time = time;
+	Files[fhandle]->date = date;
 	fcb.SetSizeDateTime(size,date,time);
 	fcb.SetRecord(cur_block,cur_rec);
 	return FCB_SUCCESS;
@@ -1237,15 +1239,18 @@ Bit8u DOS_FCBRandomWrite(Bit16u seg,Bit16u offset,Bit16u * numRec,bool restore) 
 }
 
 bool DOS_FCBGetFileSize(Bit16u seg,Bit16u offset) {
-	char shortname[DOS_PATHLENGTH];Bit16u entry;Bit8u handle;Bit16u rec_size;
+	char shortname[DOS_PATHLENGTH];Bit16u entry;
 	DOS_FCB fcb(seg,offset);
 	fcb.GetName(shortname);
-	if (!DOS_OpenFile(shortname,OPEN_READ,&entry)) return false;
-	handle = RealHandle(entry);
+	if (!DOS_OpenFile(shortname,OPEN_READ,&entry,true)) return false;
 	Bit32u size = 0;
-	Files[handle]->Seek(&size,DOS_SEEK_END);
-	DOS_CloseFile(entry);fcb.GetSeqData(handle,rec_size);
+	Files[entry]->Seek(&size,DOS_SEEK_END);
+	DOS_CloseFile(entry,true);
+
+	Bit8u handle; Bit16u rec_size;
+	fcb.GetSeqData(handle,rec_size);
 	if (rec_size == 0) rec_size = 128; //Use default if missing.
+
 	Bit32u random=(size/rec_size);
 	if (size % rec_size) random++;
 	fcb.SetRandom(random);
@@ -1272,7 +1277,7 @@ bool DOS_FCBDeleteFile(Bit16u seg,Bit16u offset){
 		nextfile = DOS_FCBFindNext(seg,offset);
 	}
 	dos.dta(old_dta);  /*Restore dta */
-	return  return_value;
+	return return_value;
 }
 
 bool DOS_FCBRenameFile(Bit16u seg, Bit16u offset){
@@ -1291,12 +1296,12 @@ bool DOS_FCBRenameFile(Bit16u seg, Bit16u offset){
 	for (Bit8u i=0;i<DOS_FILES;i++) {
 		if (Files[i] && Files[i]->IsOpen() && Files[i]->IsName(fullname)) {
 			Bit16u handle = psp.FindEntryByHandle(i);
+			//(more than once maybe)
 			if (handle == 0xFFu) {
-				// This shouldnt happen
-				LOG(LOG_FILES,LOG_ERROR)("DOS: File %s is opened but has no psp entry.",oldname);
-				return false;
+				DOS_CloseFile(i,true);
+			} else {
+				DOS_CloseFile(handle);
 			}
-			DOS_CloseFile(handle);
 		}
 	}
 

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -55,6 +55,12 @@ bool Mouse_Vertical = false;
 #include "os2.h"
 #endif
 
+#if defined(WIN32)
+#ifndef S_ISDIR
+#define S_ISDIR(m) (((m)&S_IFMT)==S_IFDIR)
+#endif
+#endif
+
 #if defined(RISCOS)
 #include <unixlib/local.h>
 #include <limits.h>
@@ -415,7 +421,7 @@ public:
                 return;
             }
             /* Not a switch so a normal directory/file */
-            if (!is_physfs && !(test.st_mode & S_IFDIR)) {
+            if (!is_physfs && !S_ISDIR(test.st_mode)) {
 #ifdef OS2
                 HFILE cdrom_fd = 0;
                 ULONG ulAction = 0;
@@ -3068,7 +3074,7 @@ private:
                     }
                 }
             }
-            if ((test.st_mode & S_IFDIR)) {
+            if (S_ISDIR(test.st_mode)) {
                 WriteOut(MSG_Get("PROGRAM_IMGMOUNT_MOUNT"));
                 return;
             }

--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -72,14 +72,12 @@ static void CGA4_CopyRow(Bit8u cleft,Bit8u cright,Bit8u rold,Bit8u rnew,PhysPt b
 
 static void TANDY16_CopyRow(Bit8u cleft,Bit8u cright,Bit8u rold,Bit8u rnew,PhysPt base) {
     Bit8u cheight = real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
-    PhysPt dest=base+((CurMode->twidth*rnew)*(cheight/4)+cleft)*4;
-    PhysPt src=base+((CurMode->twidth*rold)*(cheight/4)+cleft)*4;   
+	Bit8u banks=CurMode->twidth/10;
+    PhysPt dest=base+((CurMode->twidth*rnew)*(cheight/banks)+cleft)*4;
+    PhysPt src=base+((CurMode->twidth*rold)*(cheight/banks)+cleft)*4;
     Bitu copy=(Bitu)(cright-cleft)*4u;Bitu nextline=(Bitu)CurMode->twidth*4u;
-    for (Bitu i=0;i<cheight/4U;i++) {
-        MEM_BlockCopy(dest,src,copy);
-        MEM_BlockCopy(dest+8*1024,src+8*1024,copy);
-        MEM_BlockCopy(dest+16*1024,src+16*1024,copy);
-        MEM_BlockCopy(dest+24*1024,src+24*1024,copy);
+    for (Bitu i=0;i<cheight/banks;i++) {
+		for (Bitu b=0;b<banks;b++) MEM_BlockCopy(dest+b*8*1024,src+b*8*1024,copy);
         dest+=nextline;src+=nextline;
     }
 }
@@ -182,15 +180,13 @@ static void CGA4_FillRow(Bit8u cleft,Bit8u cright,Bit8u row,PhysPt base,Bit8u at
 
 static void TANDY16_FillRow(Bit8u cleft,Bit8u cright,Bit8u row,PhysPt base,Bit8u attr) {
     Bit8u cheight = real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
-    PhysPt dest=base+((CurMode->twidth*row)*(cheight/4)+cleft)*4;
+	Bit8u banks=CurMode->twidth/10;
+    PhysPt dest=base+((CurMode->twidth*row)*(cheight/banks)+cleft)*4;
     Bitu copy=(Bitu)(cright-cleft)*4u;Bitu nextline=CurMode->twidth*4;
     attr=(attr & 0xf) | (attr & 0xf) << 4;
-    for (Bitu i=0;i<cheight/4U;i++) {
+    for (Bitu i=0;i<cheight/banks;i++) {
         for (Bitu x=0;x<copy;x++) {
-            mem_writeb(dest+x,attr);
-            mem_writeb(dest+8*1024+x,attr);
-            mem_writeb(dest+16*1024+x,attr);
-            mem_writeb(dest+24*1024+x,attr);
+            for (Bitu b=0;b<banks;b++) mem_writeb(dest+b*8*1024+x,attr);
         }
         dest+=nextline;
     }

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -661,6 +661,7 @@ static void FinishSetMode(bool clearmem) {
 	if (clearmem) {
         switch (CurMode->type) {
         case M_TANDY16:
+        case M_CGA4:
             if ((machine==MCH_PCJR) && (CurMode->mode >= 9)) {
                 // PCJR cannot access the full 32k at 0xb800
                 for (Bit16u ct=0;ct<16*1024;ct++) {
@@ -670,7 +671,6 @@ static void FinishSetMode(bool clearmem) {
                 break;
             }
             // fall-through
-        case M_CGA4:
 		case M_CGA2:
             if (machine == MCH_MCGA && CurMode->mode == 0x11) {
                 for (Bit16u ct=0;ct<32*1024;ct++) {

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1737,8 +1737,17 @@ void DOS_Shell::CMD_VER(char *args) {
 		char* word = StripWord(args);
 		if(strcasecmp(word,"set")) return;
 		word = StripWord(args);
-		dos.version.major = (Bit8u)(atoi(word));
-		dos.version.minor = (Bit8u)(atoi(args));
+		if (!*args && !*word) { //Reset
+			dos.version.major = 5;
+			dos.version.minor = 0;
+		} else if (*args == 0 && *word && (strchr(word,'.') != 0)) { //Allow: ver set 5.1
+			const char * p = strchr(word,'.');
+			dos.version.major = (Bit8u)(atoi(word));
+			dos.version.minor = (Bit8u)(atoi(p+1));
+		} else { //Official syntax: ver set 5 2
+			dos.version.major = (Bit8u)(atoi(word));
+			dos.version.minor = (Bit8u)(atoi(args));
+		}
 	} else WriteOut(MSG_Get("SHELL_CMD_VER_VER"),VERSION,SDL_STRING,dos.version.major,dos.version.minor);
 }
 


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/3960/ - Skipped. Thought to be unneeded. See comments in: https://github.com/joncampbell123/dosbox-x/pull/1096
https://sourceforge.net/p/dosbox/code-0/3961/ - Skipped. Issue created to look at it later.
https://sourceforge.net/p/dosbox/code-0/3962/ - In this PR
https://sourceforge.net/p/dosbox/code-0/3963/ - Skipped, relies on midi.h from former skipped commit
https://sourceforge.net/p/dosbox/code-0/3964/ - In this PR
https://sourceforge.net/p/dosbox/code-0/3965/ - In this PR
https://sourceforge.net/p/dosbox/code-0/3966/ - In this PR 
https://sourceforge.net/p/dosbox/code-0/3967/ - Skipped. Conflicts with DOSBox-X and may be unnecessary.
https://sourceforge.net/p/dosbox/code-0/3968/ - Skipped. Conflicts with DOSBox-X and may be unnecessary.
https://sourceforge.net/p/dosbox/code-0/3969/ - Skipped. Related to 3968.
https://sourceforge.net/p/dosbox/code-0/3970/ - In this PR
https://sourceforge.net/p/dosbox/code-0/3971/ - In this PR (a fix to 3962)
https://sourceforge.net/p/dosbox/code-0/3972/ - In this PR

Confirmed to compile and run.

I skipped https://sourceforge.net/p/dosbox/code-0/3967/ because the contents of that conditional are different in DOSBox-X, and I didn't seem to have a problem with pcspeaker=false causing a crash, although I don't know if the problem only happened with specific programs (the bug report isn't specific). Any idea if adding `cntr == 0` to the condition would be useful for DOSBox-X?

I also skipped https://sourceforge.net/p/dosbox/code-0/3968/  because DOSBox-X already has code for case 7. It's different from this SVN commit's code, though. You might want to take a look.

Note that https://sourceforge.net/p/dosbox/code-0/3969/ adds some defines for 3968.