### PR TITLE
Revisit some skipped SVN commits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -181,6 +181,11 @@
     - Raise lower limit of cycles in autodetermine mode to
     improve stability.
     - Fix for 256 color encoding in zmbv.dll codec
+    - Rework ListMidi so it can be more easily added to more
+    backends.
+    - Implement mixer /listmidi for coremidi.
+    - Increase size of SysEx buffer to support Sierra's Yamaha
+    FB-01 driver.
   - Integrated a commit from mainline:
      #3860 "Use PCJr specific method to clear the video RAM.
             Also don't scroll at unspecified video page.

--- a/NOTES/Skipped SVN commits.txt
+++ b/NOTES/Skipped SVN commits.txt
@@ -1,10 +1,5 @@
 Commit#:	Reason for skipping:
 
-3835		Preparatory commit for 3836, which was skipped.
-3836		Assumes the Windows API. midiOutGetNumDevs() and midiOutGetDevCaps() are specific to Windows and do not exist anywhere else.
-3837		References midi.h, from skipped 3835.
-3838		Related to skipped commit 3836.
-3846		Large commit
 3847		Conflicts with https://github.com/joncampbell123/dosbox-x/commit/ac70b5599fb2fb824be7ed627ec4e70aa8b6bc79
 3857		Conflicts with DOSBox-X
 3859		Conflicts with DOSBox-X. Masking/wrapping is implemented in DOSBox-X by masking the array access per pixel.
@@ -21,11 +16,10 @@ Commit#:	Reason for skipping:
 3931		May not have effect or be wanted
 3939		A commented-out log message.
 3960		Thought to be unneeded.
-3963		Relies on midi.h from former skipped commit
 3967		Conflicts with DOSBox-X and may be unnecessary.
 3968		Conflicts with DOSBox-X and may be unnecessary.
 3969		Related to 3968.
 3980		Conflicts with DOSBox-X
 3981		Conflicts with DOSBox-X
 3986		Conflicts with DOSBox-X
-3989		Seems unnecessary, and DOSBox-X's GUI menu uses "Pause"
+3989		Seems unnecessary, and DOSBox-X's GUI uses "Pause"

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -21,6 +21,7 @@ keyboard.h \
 logging.h \
 mapper.h \
 mem.h \
+midi.h \
 mixer.h \
 modules.h \
 mouse.h \

--- a/include/midi.h
+++ b/include/midi.h
@@ -38,7 +38,7 @@ public:
 };
 
 
-#define SYSEX_SIZE 1024
+#define SYSEX_SIZE 8192
 struct DB_Midi {
 	Bitu status;
 	Bitu cmd_len;

--- a/include/midi.h
+++ b/include/midi.h
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (C) 2002-2013  The DOSBox Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+
+#ifndef DOSBOX_MIDI_H
+#define DOSBOX_MIDI_H
+
+#ifndef DOSBOX_PROGRAMS_H
+#include "programs.h"
+#endif
+
+class MidiHandler {
+public:
+	MidiHandler();
+	virtual bool Open(const char * /*conf*/) { return true; };
+	virtual void Close(void) {};
+	virtual void PlayMsg(Bit8u * /*msg*/) {};
+	virtual void PlaySysex(Bit8u * /*sysex*/,Bitu /*len*/) {};
+	virtual const char * GetName(void) { return "none"; };
+	virtual void ListAll(Program * base) {};
+	virtual ~MidiHandler() { };
+	MidiHandler * next;
+};
+
+
+#define SYSEX_SIZE 1024
+struct DB_Midi {
+	Bitu status;
+	Bitu cmd_len;
+	Bitu cmd_pos;
+	Bit8u cmd_buf[8];
+	Bit8u rt_buf[8];
+	struct midi_state_sysex_t {
+		Bit8u buf[SYSEX_SIZE];
+		Bitu used;
+		Bitu delay;
+		Bit32u start;
+
+		midi_state_sysex_t() : used(0), delay(0), start(0) { }
+	} sysex;
+	bool available;
+	MidiHandler * handler;
+
+	DB_Midi() : status(0x00), cmd_len(0), cmd_pos(0), available(false), handler(NULL) { }
+};
+
+extern DB_Midi midi;
+
+#endif

--- a/src/gui/midi.cpp
+++ b/src/gui/midi.cpp
@@ -25,6 +25,7 @@
 #include "SDL.h"
 
 #include "dosbox.h"
+#include "midi.h"
 #include "control.h"
 #include "cross.h"
 #include "support.h"
@@ -34,7 +35,6 @@
 #include "hardware.h"
 #include "timer.h"
 
-#define SYSEX_SIZE 1024
 #define RAWBUF	1024
 
 Bit8u MIDI_evt_len[256] = {
@@ -60,49 +60,15 @@ Bit8u MIDI_evt_len[256] = {
   0,2,3,2, 0,0,1,0, 1,0,1,1, 1,0,1,0   // 0xf0
 };
 
-class MidiHandler;
+MidiHandler * handler_list = 0;
 
-MidiHandler * handler_list=0;
-
-class MidiHandler {
-public:
-	MidiHandler() {
-		next=handler_list;
-		handler_list=this;
-	};
-	virtual bool Open(const char * /*conf*/) { return true; };
-	virtual void Close(void) {};
-	virtual void PlayMsg(Bit8u * /*msg*/) {};
-	virtual void PlaySysex(Bit8u * /*sysex*/,Bitu /*len*/) {};
-	virtual const char * GetName(void) { return "none"; };
-	virtual void Reset() {};
-	virtual ~MidiHandler() { };
-	MidiHandler * next;
+MidiHandler::MidiHandler(){
+	next = handler_list;
+	handler_list = this;
 };
 
 MidiHandler Midi_none;
-
-
-static struct midi_state_t {
-	Bitu status;
-	Bitu cmd_len;
-	Bitu cmd_pos;
-	Bit8u cmd_buf[8];
-	Bit8u rt_buf[8];
-	struct midi_state_sysex_t {
-		Bit8u buf[SYSEX_SIZE];
-		Bitu used;
-		Bitu delay;
-		Bit32u start;
-
-		midi_state_sysex_t() : used(0), delay(0), start(0) { }
-	} sysex;
-	bool available;
-	MidiHandler * handler;
-
-	midi_state_t() : status(0x00), cmd_len(0), cmd_pos(0), available(false), handler(NULL) { }
-} midi;
-
+DB_Midi midi;
 
 static struct {
 	bool init;

--- a/src/gui/midi_coremidi.h
+++ b/src/gui/midi_coremidi.h
@@ -25,14 +25,14 @@ private:
 public:
 	MidiHandler_coremidi()  {m_pCurPacket = 0;}
 	const char * GetName(void) { return "coremidi"; }
-	bool Open(const char * conf) {
-	
+	bool Open(const char * conf) {	
 		// Get the MIDIEndPoint
 		m_endpoint = 0;
 //		OSStatus result;
 		Bitu numDests = MIDIGetNumberOfDestinations();
-	        Bitu destId = 0;
-	        if(conf && conf[0]) destId = atoi(conf);
+		Bitu destId = 0;
+		if(conf && conf[0]) destId = atoi(conf);
+
 		if (destId < numDests)
 		{
 			m_endpoint = MIDIGetDestination(destId);
@@ -67,7 +67,8 @@ public:
 		MIDIClientDispose(m_client);
 
 		// Dispose the endpoint
-		MIDIEndpointDispose(m_endpoint);
+		// Not, as it is for Endpoints created by us
+//		MIDIEndpointDispose(m_endpoint);
 	}
 	
 	void PlayMsg(Bit8u * msg) {
@@ -98,6 +99,22 @@ public:
 		
 		// Send the MIDIPacketList
 		MIDISend(m_port,m_endpoint,packetList);
+	}
+	
+	void ListAll(Program* base) {
+		Bitu numDests = MIDIGetNumberOfDestinations();
+		for(Bitu i = 0; i < numDests; i++){
+			MIDIEndpointRef dest = MIDIGetDestination(i);
+			if(!dest) continue;
+			CFStringRef midiname = 0;
+			if(MIDIObjectGetStringProperty(dest, kMIDIPropertyDisplayName, &midiname) == noErr) {
+				const char * s = CFStringGetCStringPtr(midiname, kCFStringEncodingMacRoman);
+				if(s) base->WriteOut("%02d\t%s\n",i,s);
+			}
+			//This is for EndPoints created by us.
+			//MIDIEndpointDispose(dest);
+		}
+
 	}
 };
 

--- a/src/gui/midi_win32.h
+++ b/src/gui/midi_win32.h
@@ -197,6 +197,17 @@ public:
 		}
 #endif
 	}
+	
+	void ListAll(Program* base) {
+#if defined (WIN32)
+		unsigned int total = midiOutGetNumDevs();	
+		for(unsigned int i = 0;i < total;i++) {
+			MIDIOUTCAPS mididev;
+			midiOutGetDevCaps(i, &mididev, sizeof(MIDIOUTCAPS));
+			base->WriteOut("%2d\t \"%s\"\n",i,mididev.szPname);
+		}
+#endif
+	}
 
 	void Reset()
 	{

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -57,6 +57,7 @@
 #include "mapper.h"
 #include "hardware.h"
 #include "programs.h"
+#include "midi.h"
 
 #define MIXER_SSIZE 4
 #define MIXER_VOLSHIFT 13
@@ -871,17 +872,8 @@ private:
     }
 
     void ListMidi(){
-#if defined (WIN32)
-        unsigned int total = midiOutGetNumDevs();   
-        for(unsigned int i=0;i<total;i++) {
-            MIDIOUTCAPS mididev;
-            midiOutGetDevCaps(i, &mididev, sizeof(MIDIOUTCAPS));
-            WriteOut("%2d\t \"%s\"\n",i,mididev.szPname);
-        }
-#endif
-    return;
+        if(midi.handler) midi.handler->ListAll(this);
     };
-
 };
 
 static void MIXER_ProgramStart(Program * * make) {

--- a/vs2015/dosbox-x.vcxproj
+++ b/vs2015/dosbox-x.vcxproj
@@ -1588,6 +1588,7 @@ copy "$(SolutionDir)\..\CHANGELOG" "$(OutputPath)\changelog.txt"</Command>
     <ClInclude Include="..\include\bios_disk.h" />
     <ClInclude Include="..\include\bitmapinfoheader.h" />
     <ClInclude Include="..\include\bitop.h" />
+    <ClInclude Include="..\include\midi.h" />
     <ClInclude Include="..\include\ptrop.h" />
     <ClInclude Include="..\include\builtin.h" />
     <ClInclude Include="..\include\callback.h" />

--- a/vs2015/dosbox-x.vcxproj.filters
+++ b/vs2015/dosbox-x.vcxproj.filters
@@ -1559,6 +1559,9 @@
     <ClInclude Include="..\src\output\direct3d\ScalingEffect.h">
       <Filter>Sources\output\direct3d</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\midi.h">
+      <Filter>Includes</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\src\winres.rc">


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/3835/ - In this PR
https://sourceforge.net/p/dosbox/code-0/3836/ - In this PR
https://sourceforge.net/p/dosbox/code-0/3837/ - Effectively the same thing done for VS 2017 solution
https://sourceforge.net/p/dosbox/code-0/3838/ - In this PR
https://sourceforge.net/p/dosbox/code-0/3846/ - Skipped. Already in DOSBox-X
https://sourceforge.net/p/dosbox/code-0/3963/ - In this PR

I originally did 3835 and 3836 in https://github.com/joncampbell123/dosbox-x/pull/1054, but 3836 was rejected because it uses it assumed the Windows API. I took a closer look now and the code in question was just a move of some existing code, but for some reason SVN didn't move  the #ifdef WIN32 with it. This time around I did, so that code is the same as in master branch.

3835 and 3836 are the same commit message and subject matter, so I merged them to one commit here.

3837 is to add `midi.h` to the Visual Studio solution. I did that for the VS 2017 solution. (I have not been updating the VS 2013 solution as I don't have that installed.)

3846 was one I had originally skipped because it was large and I didn't want to attempt one that large yet, but it turns out it was already in DOSBox-X.

3963 was a change to `midi.h` (although not dependent on it like I assumed at first. The modified line existed elsewhere before being moved to `midi.h`) and is implemented now.

Confirmed to compile and run (Visual Studio 2017, Windows 10).
