### PR TITLE
Next SVN commits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -193,6 +193,14 @@
     last
     - Clip to boundaries when there are no suggeted values for
     Prop_int
+    - Implement an obscure behavior of the VGA DAC. Fixes wrong
+    colors in Planet Soccer/Football.
+    - Use default attribute behavior of ANSI.SYS in the console
+    device. Fixes scrolling issues. Anything that wants non-ANSI
+    behavior may not display as intended with the internal DOS,
+    same as real DOS when ANSI.SYS is loaded.
+    - Lower default adlib volume with 2.5dB, based on
+    measurements
   - Integrated a commit from mainline:
      #3860 "Use PCJr specific method to clear the video RAM.
             Also don't scroll at unspecified video page.

--- a/NOTES/Skipped SVN commits.txt
+++ b/NOTES/Skipped SVN commits.txt
@@ -24,3 +24,11 @@ Commit#:	Reason for skipping:
 3986		Conflicts with DOSBox-X
 3989		Seems unnecessary, and DOSBox-X's GUI uses "Pause"
 3999		Formatting cleanup.
+4001		Conflicts with DOSBox-X
+4002		Conflicts with DOSBox-X
+4003		Conflicts with DOSBox-X
+4004		Conflicts with DOSBox-X
+4007		Conflicts with DOSBox-X
+4008		Conflicts with DOSBox-X
+4009		Conflicts with DOSBox-X
+4013		Conflicts with DOSBox-X

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -805,7 +805,9 @@ Module::Module( Section* configuration ) : Module_base(configuration) {
 	adlib_force_timer_overflow_on_polling = section->Get_bool("adlib force timer overflow on detect");
 
 	mixerChan = mixerObject.Install(OPL_CallBack,rate,"FM");
-	mixerChan->SetScale( 2.0 );
+	//Used to be 2.0, which was measured to be too high. Exact value depends on card/clone.
+	mixerChan->SetScale( 1.5f );  
+
 	if (oplemu == "fast") {
 		handler = new DBOPL::Handler();
 	}

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -9,7 +9,7 @@
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Library General Public License for more details.
+ *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program; if not, write to the Free Software

--- a/src/hardware/vga_dac.cpp
+++ b/src/hardware/vga_dac.cpp
@@ -224,6 +224,7 @@ void write_p3c8(Bitu port,Bitu val,Bitu iolen) {
     vga.dac.pel_index=0;
     vga.dac.state=DAC_WRITE;
     vga.dac.write_index=val;        /* NTS: Paradise SVGA behavior, this affects write index, but not read index */
+    vga.dac.read_index= val - 1;
 }
 
 Bitu read_p3c8(Bitu port, Bitu iolen){

--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -508,7 +508,7 @@ void INT10_SetCursorPos(Bit8u row,Bit8u col,Bit8u page) {
 void ReadCharAttr(Bit16u col,Bit16u row,Bit8u page,Bit16u * result) {
     /* Externally used by the mouse routine */
     PhysPt fontdata;
-    Bitu x,y,pos = row*real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS)+col;
+    Bit16u cols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
     Bit8u cheight = real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
     bool split_chr = false;
     switch (CurMode->type) {
@@ -516,7 +516,7 @@ void ReadCharAttr(Bit16u col,Bit16u row,Bit8u page,Bit16u * result) {
         {   
             // Compute the address  
             Bit16u address=page*real_readw(BIOSMEM_SEG,BIOSMEM_PAGE_SIZE);
-            address+=pos*2;
+            address+=(row*cols+col)*2;
             // read the char 
             PhysPt where = CurMode->pstart+address;
             *result=mem_readw(where);
@@ -544,8 +544,7 @@ void ReadCharAttr(Bit16u col,Bit16u row,Bit8u page,Bit16u * result) {
         break;
     }
 
-    x=(pos%CurMode->twidth)*8;
-    y=(pos/CurMode->twidth)*cheight;
+    Bitu x=col*8,y=row*cheight*(cols/CurMode->twidth);
 
     for (Bit16u chr=0;chr<256;chr++) {
 
@@ -597,7 +596,7 @@ void INT10_PC98_CurMode_Relocate(void) {
 void WriteChar(Bit16u col,Bit16u row,Bit8u page,Bit16u chr,Bit8u attr,bool useattr) {
     /* Externally used by the mouse routine */
     PhysPt fontdata;
-    Bitu x,y,pos = row*real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS)+col;
+    Bit16u cols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
     Bit8u back, cheight = IS_PC98_ARCH ? 16 : real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
 
     if (CurMode->type != M_PC98)
@@ -608,7 +607,7 @@ void WriteChar(Bit16u col,Bit16u row,Bit8u page,Bit16u chr,Bit8u attr,bool useat
         {   
             // Compute the address  
             Bit16u address=page*real_readw(BIOSMEM_SEG,BIOSMEM_PAGE_SIZE);
-            address+=pos*2;
+            address+=(row*cols+col)*2;
             // Write the char 
             PhysPt where = CurMode->pstart+address;
             mem_writeb(where,chr);
@@ -709,8 +708,7 @@ void WriteChar(Bit16u col,Bit16u row,Bit8u page,Bit16u chr,Bit8u attr,bool useat
         break;
     }
 
-    x=(pos%CurMode->twidth)*8u;
-    y=(pos/CurMode->twidth)*(unsigned int)cheight;
+    Bitu x=col*8,y=row*cheight*(cols/CurMode->twidth);
 
     Bit16u ty=(Bit16u)y;
     for (Bit8u h=0;h<cheight;h++) {


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/4000/ - In this PR
https://sourceforge.net/p/dosbox/code-0/4001/ - Skipped. Conflicts with DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4002/ - Skipped. Conflicts with DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4003/ - Skipped. Conflicts with DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4004/ - Skipped. Conflicts with DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4005/ - In this PR
https://sourceforge.net/p/dosbox/code-0/4006/ - In this PR
https://sourceforge.net/p/dosbox/code-0/4007/ - Skipped. Conflicts with DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4008/ - Skipped. Conflicts with DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4009/ - Skipped. Conflicts with DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4010/ - Skipped. Already in DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4011/ - In this PR
https://sourceforge.net/p/dosbox/code-0/4012/ - In this PR
https://sourceforge.net/p/dosbox/code-0/4013/ - Skipped. Conflicts with DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4014/ - Skipped. Irrelevant
https://sourceforge.net/p/dosbox/code-0/4015/ - Skipped. Already in DOSBox-X

Confirmed to compile and run.

Regarding https://sourceforge.net/p/dosbox/code-0/4001/ and its follow up
https://sourceforge.net/p/dosbox/code-0/4004/:

These could partially be ported over, but there is some conflict with DOSBox-X so I decided to skip over them. 4001 removes the `AutoAmp` that you changed to an (off by default) option in DOSBox-X, and conflicts with DOSBox-X in the `WaveUpdate` and `pantable` parts. You might want to take a look and see what you think of the changes in these commits and if you want anything from them.