### PR TITLE
SVN r4046

### DIFF
--- a/dosbox.reference.conf
+++ b/dosbox.reference.conf
@@ -1319,11 +1319,6 @@ dongle=false
 #                                                      direct    Non-standard behavior, encode the CALL FAR directly to the entry point rather than indirectly
 #                                                   Possible values: auto, off, msdos2, msdos5, direct.
 #                                            share: Report SHARE.EXE as resident. Does not actually emulate SHARE functions.
-#           write plain iretf for debug interrupts: If true (default), the DOS kernel will create an alternate interrupt handler for debug interrupts INT 1 and INT 3
-#                                                   that contain ONLY an IRETF instruction. If false, INT 1 and INT 3 will use the same default interrupt handler in
-#                                                   the DOS kernel, which contains a callback instruction followed by IRETF. Some DOS games/demos assume they are being
-#                                                   debugged if the debug interrupts point to anything other than an IRETF instruction. Set this option to false if
-#                                                   you need notification that INT 1/INT 3 was not handled.
 #              minimum dos initial private segment: In non-mainline mapping mode, where DOS structures are allocated from base memory, this sets the
 #                                                   minimum segment value. Recommended value is 0x70. You may reduce the value down to 0x50 if freeing
 #                                                   up more memory is important. Set to 0 for default.

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1885,7 +1885,6 @@ static Bitu DOS_26Handler(void) {
     return CBRET_NONE;
 }
 
-bool iret_only_for_debug_interrupts = true;
 bool enable_collating_uppercase = true;
 bool keep_private_area_on_boot = false;
 bool private_always_from_umb = false;
@@ -2010,7 +2009,6 @@ public:
 		private_always_from_umb = section->Get_bool("kernel allocation in umb");
 		minimum_dos_initial_private_segment = section->Get_hex("minimum dos initial private segment");
 		dos_con_use_int16_to_detect_input = section->Get_bool("con device use int 16h to detect keyboard input");
-		iret_only_for_debug_interrupts = section->Get_bool("write plain iretf for debug interrupts");
 		dbg_zero_on_dos_allocmem = section->Get_bool("zero memory on int 21h memory allocation");
 		MAXENV = (unsigned int)section->Get_int("maximum environment block size on exec");
 		ENV_KEEPFREE = (unsigned int)section->Get_int("additional environment block size on exec");

--- a/src/dos/dos_memory.cpp
+++ b/src/dos/dos_memory.cpp
@@ -522,7 +522,6 @@ static Bitu DOS_default_handler(void) {
 extern Bit16u DOS_IHSEG;
 
 extern bool enable_dummy_device_mcb;
-extern bool iret_only_for_debug_interrupts;
 
 static	CALLBACK_HandlerObject callbackhandler;
 void DOS_SetupMemory(void) {
@@ -545,23 +544,12 @@ void DOS_SetupMemory(void) {
 	ihseg = DOS_IHSEG;
 	ihofs = 0x08;
 
-	real_writeb(ihseg,ihofs+0x00,(Bit8u)0xFE);	//GRP 4
-	real_writeb(ihseg,ihofs+0x01,(Bit8u)0x38);	//Extra Callback instruction
-	real_writew(ihseg,ihofs+0x02,callbackhandler.Get_callback());  //The immediate word
-	real_writeb(ihseg,ihofs+0x04,(Bit8u)0xCF);	//An IRET Instruction
-
-	if (iret_only_for_debug_interrupts) {
-		//point at IRET, not the callback. Hack for paranoid games & demos that check for debugger presence.
-		RealSetVec(0x01,RealMake(ihseg,ihofs+4));
-		RealSetVec(0x03,RealMake(ihseg,ihofs+4));
-	}
-	else {
-		RealSetVec(0x01,RealMake(ihseg,ihofs));		//BioMenace (offset!=4)
-		RealSetVec(0x03,RealMake(ihseg,ihofs));		//Alien Incident (offset!=0)
-	}
+	real_writeb(ihseg,ihofs,(Bit8u)0xCF);		//An IRET Instruction
+	RealSetVec(0x01,RealMake(ihseg,ihofs));		//BioMenace (offset!=4)
 	if (machine != MCH_PCJR) RealSetVec(0x02,RealMake(ihseg,ihofs)); //BioMenace (segment<0x8000). Else, taken by BIOS NMI interrupt
+	RealSetVec(0x03,RealMake(ihseg,ihofs));		//Alien Incident (offset!=0)
 	RealSetVec(0x04,RealMake(ihseg,ihofs));		//Shadow President (lower byte of segment!=0)
-//	RealSetVec(0x0f,RealMake(ihseg,ihofs));		//Always a tricky one (soundblaster irq)
+	RealSetVec(0x0f,RealMake(ihseg,ihofs));		//Always a tricky one (soundblaster irq)
 
 	Bit16u mcb_sizes=0;
 


### PR DESCRIPTION
I made this a separate PR as it needs a bit more careful consideration than the other commits in https://github.com/joncampbell123/dosbox-x/pull/1110.

This implements the parts of https://sourceforge.net/p/dosbox/code-0/4046/ that are not in DOSBox-X.

Sound in Microleague Football 2 already works in DOSBox-X because of the "write plain iretf for debug interrupts" option being true, which is commented as being a "hack for paranoid games & demos that check for debugger presence." in the source.

The SVN commit claims this behavior is the same as "real DOS" (so not a hack?), and the commit is by ripsaw8080, who I've gotten the impression (by going through the SVN commits like this) makes good changes that are based on replicating real behavior. The SVN commit is also newer (2017-09-10) than the addition of the iretf option https://github.com/joncampbell123/dosboxx/commit/ee467a11514b631f8dca94a14c66110adc573c31 (2015-04-04), so, after considering these things, it seemed worthwhile to me to try putting all of r4046 changes in, and removing the iretf option from DOSBox-X, as otherwise it would need to be extended to INT 2, 4 and F as well to match the SVN commit, and if it is real DOS behavior it seems like it is what we want.

Compiles and runs. Microleague Football 2 still has sound and I didn't notice any obvious problems.