### PR TITLE
Take removed option out of reference .conf

### DIFF
--- a/dosbox.reference.conf
+++ b/dosbox.reference.conf
@@ -1319,11 +1319,6 @@ dongle=false
 #                                                      direct    Non-standard behavior, encode the CALL FAR directly to the entry point rather than indirectly
 #                                                   Possible values: auto, off, msdos2, msdos5, direct.
 #                                            share: Report SHARE.EXE as resident. Does not actually emulate SHARE functions.
-#           write plain iretf for debug interrupts: If true (default), the DOS kernel will create an alternate interrupt handler for debug interrupts INT 1 and INT 3
-#                                                   that contain ONLY an IRETF instruction. If false, INT 1 and INT 3 will use the same default interrupt handler in
-#                                                   the DOS kernel, which contains a callback instruction followed by IRETF. Some DOS games/demos assume they are being
-#                                                   debugged if the debug interrupts point to anything other than an IRETF instruction. Set this option to false if
-#                                                   you need notification that INT 1/INT 3 was not handled.
 #              minimum dos initial private segment: In non-mainline mapping mode, where DOS structures are allocated from base memory, this sets the
 #                                                   minimum segment value. Recommended value is 0x70. You may reduce the value down to 0x50 if freeing
 #                                                   up more memory is important. Set to 0 for default.
@@ -1448,7 +1443,6 @@ dos sda size=0
 hma free space=34816
 cpm compatibility mode=auto
 share=true
-write plain iretf for debug interrupts=true
 minimum dos initial private segment=0
 minimum mcb segment=0
 minimum mcb free=0


### PR DESCRIPTION
In https://github.com/joncampbell123/dosbox-x/pull/1111, with regards to dosbox.reference.conf, I accidentally only removed the description of the removed option but left the default value in.

In https://github.com/joncampbell123/dosbox-x/commit/3e7ef9de73e9e6db294a7673d30d9d3387d1d61b,  you restored the description (was this intentional?)

The commit message for https://github.com/joncampbell123/dosbox-x/commit/a5822f0318eced02ad95a0bec21cee694035035c sounds like you are removing the option from the .conf file, but is actually removing something in dosbox.cpp.

Seems like things got a little confused (or I'm missing something?) This PR removes the option's description and default value setting from the reference .conf file.