### PR TITLE
Fix value conversion warnings

### DIFF
--- a/include/callback.h
+++ b/include/callback.h
@@ -59,7 +59,7 @@ static inline PhysPt CALLBACK_GetBase(void) {
 	return (PhysPt)(((PhysPt)CB_SEG << (PhysPt)4U) + (PhysPt)CB_SOFFSET);
 }
 
-Bitu CALLBACK_Allocate();
+Bit8u CALLBACK_Allocate();
 
 void CALLBACK_Idle(void);
 

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -147,7 +147,7 @@ void CPU_JMP(bool use32,Bitu selector,Bitu offset,Bitu oldeip);
 void CPU_CALL(bool use32,Bitu selector,Bitu offset,Bitu oldeip);
 void CPU_RET(bool use32,Bitu bytes,Bitu oldeip);
 void CPU_IRET(bool use32,Bitu oldeip);
-void CPU_HLT(Bitu oldeip);
+void CPU_HLT(Bit32u oldeip);
 
 bool CPU_POPF(Bitu use32);
 bool CPU_PUSHF(Bitu use32);
@@ -171,7 +171,7 @@ extern bool CPU_NMI_pending;
 
 extern bool do_seg_limits;
 
-void CPU_Interrupt(Bitu num,Bitu type,Bitu oldeip);
+void CPU_Interrupt(Bitu num,Bitu type,Bit32u oldeip);
 void CPU_Check_NMI();
 void CPU_Raise_NMI();
 void CPU_NMI_Interrupt();
@@ -188,14 +188,14 @@ static INLINE void CPU_SW_Interrupt_NoIOPLCheck(Bitu num,Bitu oldeip) {
 bool CPU_PrepareException(Bitu which,Bitu error);
 void CPU_Exception(Bitu which,Bitu error=0);
 
-bool CPU_SetSegGeneral(SegNames seg,Bitu value);
+bool CPU_SetSegGeneral(SegNames seg,Bit16u value);
 bool CPU_PopSeg(SegNames seg,bool use32);
 
 bool CPU_CPUID(void);
-Bitu CPU_Pop16(void);
-Bitu CPU_Pop32(void);
-void CPU_Push16(Bitu value);
-void CPU_Push32(Bitu value);
+Bit16u CPU_Pop16(void);
+Bit32u CPU_Pop32(void);
+void CPU_Push16(Bit16u value);
+void CPU_Push32(Bit32u value);
 
 void CPU_SetFlags(Bitu word,Bitu mask);
 
@@ -526,7 +526,7 @@ struct CPUBlock {
 		Bitu eflags;
 	} masks;
 	struct {
-		Bitu mask,notmask;
+		Bit32u mask,notmask;
 		bool big;
 	} stack;
 	struct {

--- a/include/inout.h
+++ b/include/inout.h
@@ -49,13 +49,13 @@ void IO_FreeWriteHandler(Bitu port,Bitu mask,Bitu range=1);
 
 void IO_InvalidateCachedHandler(Bitu port,Bitu range=1);
 
-void IO_WriteB(Bitu port,Bitu val);
-void IO_WriteW(Bitu port,Bitu val);
-void IO_WriteD(Bitu port,Bitu val);
+void IO_WriteB(Bitu port,Bit8u val);
+void IO_WriteW(Bitu port,Bit16u val);
+void IO_WriteD(Bitu port,Bit32u val);
 
-Bitu IO_ReadB(Bitu port);
-Bitu IO_ReadW(Bitu port);
-Bitu IO_ReadD(Bitu port);
+Bit8u IO_ReadB(Bitu port);
+Bit16u IO_ReadW(Bitu port);
+Bit32u IO_ReadD(Bitu port);
 
 static const Bitu IOMASK_ISA_10BIT = 0x3FFU; /* ISA 10-bit decode */
 static const Bitu IOMASK_ISA_12BIT = 0xFFFU; /* ISA 12-bit decode */
@@ -151,7 +151,7 @@ static INLINE void IO_Write(Bitu port,Bit8u val) {
 	IO_WriteB(port,val);
 }
 static INLINE Bit8u IO_Read(Bitu port){
-	return (Bit8u)IO_ReadB(port);
+	return IO_ReadB(port);
 }
 
 enum IO_Type_t {

--- a/include/paging.h
+++ b/include/paging.h
@@ -90,20 +90,20 @@ class PageHandler {
 public:
 	PageHandler(Bitu flg) : flags(flg) {}
 	virtual ~PageHandler(void) { }
-	virtual Bitu readb(PhysPt addr);
-	virtual Bitu readw(PhysPt addr);
-	virtual Bitu readd(PhysPt addr);
-	virtual void writeb(PhysPt addr,Bitu val);
-	virtual void writew(PhysPt addr,Bitu val);
-	virtual void writed(PhysPt addr,Bitu val);
+	virtual Bit8u readb(PhysPt addr);
+	virtual Bit16u readw(PhysPt addr);
+	virtual Bit32u readd(PhysPt addr);
+	virtual void writeb(PhysPt addr,Bit8u val);
+	virtual void writew(PhysPt addr,Bit16u val);
+	virtual void writed(PhysPt addr,Bit32u val);
 	virtual HostPt GetHostReadPt(Bitu phys_page);
 	virtual HostPt GetHostWritePt(Bitu phys_page);
 	virtual bool readb_checked(PhysPt addr,Bit8u * val);
 	virtual bool readw_checked(PhysPt addr,Bit16u * val);
 	virtual bool readd_checked(PhysPt addr,Bit32u * val);
-	virtual bool writeb_checked(PhysPt addr,Bitu val);
-	virtual bool writew_checked(PhysPt addr,Bitu val);
-	virtual bool writed_checked(PhysPt addr,Bitu val);
+	virtual bool writeb_checked(PhysPt addr,Bit8u val);
+	virtual bool writew_checked(PhysPt addr,Bit16u val);
+	virtual bool writed_checked(PhysPt addr,Bit32u val);
    PageHandler (void) { }
 	Bitu flags; 
 	Bitu getFlags() const {
@@ -405,7 +405,7 @@ static INLINE Bit32u mem_readd_inline(const PhysPt address) {
 	if ((address & 0xfff)<0xffd) {
 		const HostPt tlb_addr=get_tlb_read(address);
 		if (tlb_addr) return host_readd(tlb_addr+address);
-		else return (get_tlb_readhandler(address))->readd(address);
+		else return (Bit32u)(get_tlb_readhandler(address))->readd(address);
 	} else return mem_unalignedreadd(address);
 }
 

--- a/src/cpu/callback.cpp
+++ b/src/cpu/callback.cpp
@@ -45,7 +45,8 @@ unsigned int last_callback = 0;
 CallBack_Handler CallBack_Handlers[CB_MAX] = {NULL};
 char* CallBack_Description[CB_MAX] = {NULL};
 
-Bitu call_stop,call_idle,call_default,call_default2;
+Bitu call_stop,call_default,call_default2;
+Bit8u call_idle;
 Bitu call_priv_io;
 
 static Bitu illegal_handler(void) {
@@ -88,8 +89,8 @@ void CALLBACK_Shutdown(void) {
 	}
 }
 
-Bitu CALLBACK_Allocate(void) {
-	for (Bitu i=1;(i<CB_MAX);i++) {
+Bit8u CALLBACK_Allocate(void) {
+	for (Bit8u i=1;(i<CB_MAX);i++) {
 		if (CallBack_Handlers[i]==&illegal_handler) {
 			if (CallBack_Description[i] != NULL) LOG_MSG("CALLBACK_Allocate() warning: empty slot still has description string!\n");
 			CallBack_Handlers[i]=0;
@@ -147,7 +148,7 @@ void CALLBACK_RunRealFarInt(Bit16u seg,Bit16u off) {
 	reg_sp-=6;
 	mem_writew(SegPhys(ss)+reg_sp,RealOff(CALLBACK_RealPointer(call_stop)));
 	mem_writew(SegPhys(ss)+reg_sp+2,RealSeg(CALLBACK_RealPointer(call_stop)));
-	mem_writew(SegPhys(ss)+reg_sp+4,reg_flags);
+	mem_writew(SegPhys(ss)+reg_sp+4,(Bit16u)reg_flags);
 	Bit32u oldeip=reg_eip;
 	Bit16u oldcs=SegValue(cs);
 	reg_eip=off;
@@ -193,7 +194,7 @@ void CALLBACK_RunRealInt(Bit8u intnum) {
 }
 
 void CALLBACK_SZF(bool val) {
-    Bitu tempf;
+    Bit32u tempf;
 
     if (cpu.stack.big)
         tempf = mem_readd(SegPhys(ss)+reg_esp+8); // first word past FAR 32:32
@@ -206,11 +207,11 @@ void CALLBACK_SZF(bool val) {
     if (cpu.stack.big)
         mem_writed(SegPhys(ss)+reg_esp+8,tempf);
     else
-        mem_writew(SegPhys(ss)+reg_sp+4,tempf);
+        mem_writew(SegPhys(ss)+reg_sp+4,(Bit16u)tempf);
 }
 
 void CALLBACK_SCF(bool val) {
-    Bitu tempf;
+    Bit32u tempf;
 
     if (cpu.stack.big)
         tempf = mem_readd(SegPhys(ss)+reg_esp+8); // first word past FAR 32:32
@@ -223,11 +224,11 @@ void CALLBACK_SCF(bool val) {
     if (cpu.stack.big)
         mem_writed(SegPhys(ss)+reg_esp+8,tempf);
     else
-        mem_writew(SegPhys(ss)+reg_sp+4,tempf);
+        mem_writew(SegPhys(ss)+reg_sp+4,(Bit16u)tempf);
 }
 
 void CALLBACK_SIF(bool val) {
-    Bitu tempf;
+    Bit32u tempf;
 
     if (cpu.stack.big)
         tempf = mem_readd(SegPhys(ss)+reg_esp+8); // first word past FAR 32:32
@@ -240,7 +241,7 @@ void CALLBACK_SIF(bool val) {
     if (cpu.stack.big)
         mem_writed(SegPhys(ss)+reg_esp+8,tempf);
     else
-        mem_writew(SegPhys(ss)+reg_sp+4,tempf);
+        mem_writew(SegPhys(ss)+reg_sp+4,(Bit16u)tempf);
 }
 
 void CALLBACK_SetDescription(Bitu nr, const char* descr) {
@@ -555,7 +556,7 @@ Bitu CALLBACK_SetupExtra(Bitu callback, Bitu type, PhysPt physAddress, bool use_
 			physAddress+=4;
 		}
 		phys_writeb(physAddress+0x01,(Bit8u)0xCF);		//An IRET Instruction
-		for (Bitu i=0;i<=0x0b;i++) phys_writeb(physAddress+0x02+i,0x90);
+		for (Bit8u i=0;i<=0x0b;i++) phys_writeb(physAddress+0x02+i,0x90);
 		phys_writew(physAddress+0x0e,(Bit16u)0xedeb);	//jmp callback
 		return (use_cb?0x10:0x0c);
 	/*case CB_INT28:	// DOS idle
@@ -758,7 +759,7 @@ void CALLBACK_RemoveSetup(Bitu callback) {
 		return;
 	}
 
-	for (Bitu i = 0;i < CB_SIZE;i++) {
+	for (Bit8u i = 0;i < CB_SIZE;i++) {
 		phys_writeb(CALLBACK_PhysPointer(callback)+i ,(Bit8u) 0x00);
 	}
 }
@@ -851,7 +852,7 @@ void CALLBACK_Init() {
 
 	LOG(LOG_CPU,LOG_DEBUG)("Callback area starts at %04x:%04x",CB_SEG,CB_SOFFSET);
 
-	Bitu i;
+	Bit16u i;
 	for (i=0;i<CB_MAX;i++) {
 		CallBack_Handlers[i]=&illegal_handler;
 		CallBack_Description[i]=NULL;

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -117,7 +117,7 @@ public:
 		bool is_current_block=false;	// if the current block is modified, it has to be exited as soon as possible
 
 		Bit32u ip_point=SegPhys(cs)+reg_eip;
-		ip_point=(PAGING_GetPhysicalPage(ip_point)-(phys_page<<12))+(ip_point&0xfff);
+		ip_point=(Bit32u)((PAGING_GetPhysicalPage(ip_point)-(phys_page<<12))+(ip_point&0xfff));
 		while (index>=0) {
 			Bitu map=0;
 			// see if there is still some code in the range
@@ -140,9 +140,9 @@ public:
 	}
 
 	// the following functions will clean all cache blocks that are invalid now due to the write
-	void writeb(PhysPt addr,Bitu val){
+	void writeb(PhysPt addr,Bit8u val){
 		addr&=4095;
-		if (host_readb(hostmem+addr)==(Bit8u)val) return;
+		if (host_readb(hostmem+addr)==val) return;
 		host_writeb(hostmem+addr,val);
 		// see if there's code where we are writing to
 		if (!host_readb(&write_map[addr])) {
@@ -157,9 +157,9 @@ public:
 		invalidation_map[addr]++;
 		InvalidateRange(addr,addr);
 	}
-	void writew(PhysPt addr,Bitu val){
+	void writew(PhysPt addr,Bit16u val){
 		addr&=4095;
-		if (host_readw(hostmem+addr)==(Bit16u)val) return;
+		if (host_readw(hostmem+addr)==val) return;
 		host_writew(hostmem+addr,val);
 		// see if there's code where we are writing to
 		if (!host_readw(&write_map[addr])) {
@@ -179,9 +179,9 @@ public:
 #endif
 		InvalidateRange(addr,addr+1);
 	}
-	void writed(PhysPt addr,Bitu val){
+	void writed(PhysPt addr,Bit32u val){
 		addr&=4095;
-		if (host_readd(hostmem+addr)==(Bit32u)val) return;
+		if (host_readd(hostmem+addr)==val) return;
 		host_writed(hostmem+addr,val);
 		// see if there's code where we are writing to
 		if (!host_readd(&write_map[addr])) {
@@ -201,9 +201,9 @@ public:
 #endif
 		InvalidateRange(addr,addr+3);
 	}
-	bool writeb_checked(PhysPt addr,Bitu val) {
+	bool writeb_checked(PhysPt addr,Bit8u val) {
 		addr&=4095;
-		if (host_readb(hostmem+addr)==(Bit8u)val) return false;
+		if (host_readb(hostmem+addr)==val) return false;
 		// see if there's code where we are writing to
 		if (!host_readb(&write_map[addr])) {
 			if (!active_blocks) {
@@ -225,9 +225,9 @@ public:
 		host_writeb(hostmem+addr,val);
 		return false;
 	}
-	bool writew_checked(PhysPt addr,Bitu val) {
+	bool writew_checked(PhysPt addr,Bit16u val) {
 		addr&=4095;
-		if (host_readw(hostmem+addr)==(Bit16u)val) return false;
+		if (host_readw(hostmem+addr)==val) return false;
 		// see if there's code where we are writing to
 		if (!host_readw(&write_map[addr])) {
 			if (!active_blocks) {
@@ -254,9 +254,9 @@ public:
 		host_writew(hostmem+addr,val);
 		return false;
 	}
-	bool writed_checked(PhysPt addr,Bitu val) {
+	bool writed_checked(PhysPt addr,Bit32u val) {
 		addr&=4095;
-		if (host_readd(hostmem+addr)==(Bit32u)val) return false;
+		if (host_readd(hostmem+addr)==val) return false;
 		// see if there's code where we are writing to
 		if (!host_readd(&write_map[addr])) {
 			if (!active_blocks) {

--- a/src/cpu/core_dynrec/decoder_opcodes.h
+++ b/src/cpu/core_dynrec/decoder_opcodes.h
@@ -1395,7 +1395,7 @@ static void dyn_enter(void) {
 static void dynrec_leave_word(void) {
 	reg_esp&=cpu.stack.notmask;
 	reg_esp|=(reg_ebp&cpu.stack.mask);
-	reg_bp=(Bit16u)CPU_Pop16();
+	reg_bp=CPU_Pop16();
 }
 
 static void dynrec_leave_dword(void) {
@@ -1423,10 +1423,10 @@ static void dynrec_pusha_dword(void) {
 }
 
 static void dynrec_popa_word(void) {
-	reg_di=(Bit16u)CPU_Pop16();reg_si=(Bit16u)CPU_Pop16();
-	reg_bp=(Bit16u)CPU_Pop16();CPU_Pop16();		//Don't save SP
-	reg_bx=(Bit16u)CPU_Pop16();reg_dx=(Bit16u)CPU_Pop16();
-	reg_cx=(Bit16u)CPU_Pop16();reg_ax=(Bit16u)CPU_Pop16();
+	reg_di=CPU_Pop16();reg_si=CPU_Pop16();
+	reg_bp=CPU_Pop16();CPU_Pop16();		//Don't save SP
+	reg_bx=CPU_Pop16();reg_dx=CPU_Pop16();
+	reg_cx=CPU_Pop16();reg_ax=CPU_Pop16();
 }
 
 static void dynrec_popa_dword(void) {

--- a/src/cpu/core_dynrec/risc_x64.h
+++ b/src/cpu/core_dynrec/risc_x64.h
@@ -129,7 +129,7 @@ static INLINE void gen_reg_memaddr(HostReg reg,void* data,Bit8u op,Bit8u prefix=
 }
 
 // Same as above, but with immediate addressing and a memory location
-static INLINE void gen_memaddr(Bitu modreg,void* data,Bitu off,Bitu imm,Bit8u op,Bit8u prefix=0) {
+static INLINE void gen_memaddr(Bit8u modreg,void* data,Bitu off,Bitu imm,Bit8u op,Bit8u prefix=0) {
 	Bit64s diff = (Bit64s)data-((Bit64s)cache.pos+off+(prefix?7:6));
 //	if ((diff<0x80000000LL) && (diff>-0x80000000LL)) {
 	if ( (diff>>63) == (diff>>31) ) {
@@ -337,7 +337,7 @@ static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits im
 	cache_addb(0x48);
 	cache_addb(0x8d);			//LEA
 	cache_addb(0x04+(dest_reg << 3)+rm_base);	//The sib indicator
-	cache_addb(dest_reg+(scale_reg<<3)+(scale<<6));
+	cache_addb((Bit8u)(dest_reg+(scale_reg<<3)+(scale<<6)));
 
 	switch (imm_size) {
 	case 0:	break;

--- a/src/cpu/core_full.cpp
+++ b/src/cpu/core_full.cpp
@@ -103,7 +103,7 @@ restartopcode:
 		inst.entry=(inst.entry & 0xffffff00u) | Fetchb();
 		inst.code=OpCodeTable[inst.entry];
         Bitu old_flags = reg_flags;
-		Bitu old_esp = reg_esp; // always restore stack pointer on page fault
+		Bit32u old_esp = reg_esp; // always restore stack pointer on page fault
 		try {
 			#include "core_full/load.h"
 			#include "core_full/op.h"

--- a/src/cpu/core_full/op.h
+++ b/src/cpu/core_full/op.h
@@ -54,14 +54,14 @@ switch (inst.code.op) {
 		lflags.oldcf=(get_CF()!=0);
 		lf_var1d=inst_op1_d;
 		lf_var2d=inst_op2_d;
-		inst_op1_d=lf_resd=lf_var1d + lf_var2d + lflags.oldcf;
+		inst_op1_d=lf_resd=(Bit32u)(lf_var1d + lf_var2d + lflags.oldcf);
 		lflags.type=inst.code.op;
 		break;
 	case t_SBBb:	case t_SBBw:	case t_SBBd:
 		lflags.oldcf=(get_CF()!=0);
 		lf_var1d=inst_op1_d;
 		lf_var2d=inst_op2_d;
-		inst_op1_d=lf_resd=lf_var1d - lf_var2d - lflags.oldcf;
+		inst_op1_d=lf_resd=(Bit32u)(lf_var1d - lf_var2d - lflags.oldcf);
 		lflags.type=inst.code.op;
 		break;
 	case t_INCb:	case t_INCw:	case t_INCd:
@@ -425,12 +425,12 @@ switch (inst.code.op) {
 	case O_GRP7d:
 		switch (inst.rm_index) {
 		case 0:		/* SGDT */
-			SaveMw(inst.rm_eaa,CPU_SGDT_limit());
-			SaveMd(inst.rm_eaa+2,CPU_SGDT_base());
+			SaveMw(inst.rm_eaa,(Bit16u)CPU_SGDT_limit());
+			SaveMd(inst.rm_eaa+2,(Bit32u)CPU_SGDT_base());
 			goto nextopcode;
 		case 1:		/* SIDT */
-			SaveMw(inst.rm_eaa,CPU_SIDT_limit());
-			SaveMd(inst.rm_eaa+2,CPU_SIDT_base());
+			SaveMw(inst.rm_eaa,(Bit16u)CPU_SIDT_limit());
+			SaveMd(inst.rm_eaa+2,(Bit32u)CPU_SIDT_base());
 			goto nextopcode;
 		case 2:		/* LGDT */
 			if (cpu.pmode && cpu.cpl) EXCEPTION(EXCEPTION_GP);
@@ -441,7 +441,7 @@ switch (inst.code.op) {
 			CPU_LIDT(LoadMw(inst.rm_eaa),LoadMd(inst.rm_eaa+2)&((inst.code.op == O_GRP7w) ? 0xFFFFFF : 0xFFFFFFFF));
 			goto nextopcode;
 		case 4:		/* SMSW */
-			inst_op1_d=CPU_SMSW();
+			inst_op1_d=(Bit32u)CPU_SMSW();
 			break;
 		case 6:		/* LMSW */
 			FillFlags();
@@ -503,7 +503,7 @@ switch (inst.code.op) {
 				SETFLAGBIT(ZF,true);
 				goto nextopcode;
 			} else {
-				Bitu count=0;
+				Bit8u count=0;
 				while (1) {
 					if (inst_op1_w & 0x1) break;
 					count++;inst_op1_w>>=1;
@@ -520,7 +520,7 @@ switch (inst.code.op) {
 				SETFLAGBIT(ZF,true);
 				goto nextopcode;
 			} else {
-				Bitu count=0;
+				Bit8u count=0;
 				while (1) {
 					if (inst_op1_d & 0x1) break;
 					count++;inst_op1_d>>=1;
@@ -537,7 +537,7 @@ switch (inst.code.op) {
 				SETFLAGBIT(ZF,true);
 				goto nextopcode;
 			} else {
-				Bitu count=15;
+				Bit8u count=15;
 				while (1) {
 					if (inst_op1_w & 0x8000) break;
 					count--;inst_op1_w<<=1;
@@ -554,7 +554,7 @@ switch (inst.code.op) {
 				SETFLAGBIT(ZF,true);
 				goto nextopcode;
 			} else {
-				Bitu count=31;
+				Bit8u count=31;
 				while (1) {
 					if (inst_op1_d & 0x80000000) break;
 					count--;inst_op1_d<<=1;

--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -33,32 +33,32 @@
 PagingBlock paging;
 
 // Pagehandler implementation
-Bitu PageHandler::readb(PhysPt addr) {
+Bit8u PageHandler::readb(PhysPt addr) {
 	E_Exit("No byte handler for read from %x",addr);	
 	return 0;
 }
-Bitu PageHandler::readw(PhysPt addr) {
-	Bitu ret = (readb(addr+0) << 0);
+Bit16u PageHandler::readw(PhysPt addr) {
+	Bit16u ret = (readb(addr+0) << 0);
 	ret     |= (readb(addr+1) << 8);
 	return ret;
 }
-Bitu PageHandler::readd(PhysPt addr) {
-	Bitu ret = (readb(addr+0) << 0);
+Bit32u PageHandler::readd(PhysPt addr) {
+	Bit32u ret = (readb(addr+0) << 0);
 	ret     |= (readb(addr+1) << 8);
 	ret     |= (readb(addr+2) << 16);
 	ret     |= (readb(addr+3) << 24);
 	return ret;
 }
 
-void PageHandler::writeb(PhysPt addr,Bitu /*val*/) {
+void PageHandler::writeb(PhysPt addr,Bit8u /*val*/) {
 	E_Exit("No byte handler for write to %x",addr);	
 }
 
-void PageHandler::writew(PhysPt addr,Bitu val) {
+void PageHandler::writew(PhysPt addr,Bit16u val) {
 	writeb(addr+0,(Bit8u) (val >> 0));
 	writeb(addr+1,(Bit8u) (val >> 8));
 }
-void PageHandler::writed(PhysPt addr,Bitu val) {
+void PageHandler::writed(PhysPt addr,Bit32u val) {
 	writeb(addr+0,(Bit8u) (val >> 0));
 	writeb(addr+1,(Bit8u) (val >> 8));
 	writeb(addr+2,(Bit8u) (val >> 16));
@@ -74,21 +74,21 @@ HostPt PageHandler::GetHostWritePt(Bitu /*phys_page*/) {
 }
 
 bool PageHandler::readb_checked(PhysPt addr, Bit8u * val) {
-	*val=(Bit8u)readb(addr);	return false;
+	*val=readb(addr);	return false;
 }
 bool PageHandler::readw_checked(PhysPt addr, Bit16u * val) {
-	*val=(Bit16u)readw(addr);	return false;
+	*val=readw(addr);	return false;
 }
 bool PageHandler::readd_checked(PhysPt addr, Bit32u * val) {
-	*val=(Bit32u)readd(addr);	return false;
+	*val=readd(addr);	return false;
 }
-bool PageHandler::writeb_checked(PhysPt addr,Bitu val) {
+bool PageHandler::writeb_checked(PhysPt addr,Bit8u val) {
 	writeb(addr,val);	return false;
 }
-bool PageHandler::writew_checked(PhysPt addr,Bitu val) {
+bool PageHandler::writew_checked(PhysPt addr,Bit16u val) {
 	writew(addr,val);	return false;
 }
-bool PageHandler::writed_checked(PhysPt addr,Bitu val) {
+bool PageHandler::writed_checked(PhysPt addr,Bit32u val) {
 	writed(addr,val);	return false;
 }
 
@@ -362,22 +362,22 @@ private:
 	}
 public:
 	PageFoilHandler() : PageHandler(PFLAG_INIT|PFLAG_NOCODE) {}
-	Bitu readb(PhysPt addr) {(void)addr;read();return 0;}
-	Bitu readw(PhysPt addr) {(void)addr;read();return 0;}
-	Bitu readd(PhysPt addr) {(void)addr;read();return 0;}
+	Bit8u readb(PhysPt addr) {(void)addr;read();return 0;}
+	Bit16u readw(PhysPt addr) {(void)addr;read();return 0;}
+	Bit32u readd(PhysPt addr) {(void)addr;read();return 0;}
 
-    void writeb(PhysPt addr,Bitu val) {
+    void writeb(PhysPt addr,Bit8u val) {
         work(addr);
         // execute the write:
         // no need to care about mpl because we won't be entered
         // if write isn't allowed
         mem_writeb(addr,val);
     }
-    void writew(PhysPt addr,Bitu val) {
+    void writew(PhysPt addr,Bit16u val) {
         work(addr);
         mem_writew(addr,val);
     }
-    void writed(PhysPt addr,Bitu val) {
+    void writed(PhysPt addr,Bit32u val) {
         work(addr);
         mem_writed(addr,val);
     }
@@ -386,17 +386,17 @@ public:
     bool readw_checked(PhysPt addr, Bit16u * val) {(void)addr;(void)val;read();return true;}
     bool readd_checked(PhysPt addr, Bit32u * val) {(void)addr;(void)val;read();return true;}
 
-    bool writeb_checked(PhysPt addr,Bitu val) {
+    bool writeb_checked(PhysPt addr,Bit8u val) {
         work(addr);
         mem_writeb(addr,val);
         return false;
     }
-    bool writew_checked(PhysPt addr,Bitu val) {
+    bool writew_checked(PhysPt addr,Bit16u val) {
         work(addr);
         mem_writew(addr,val);
         return false;
     }
-    bool writed_checked(PhysPt addr,Bitu val) {
+    bool writed_checked(PhysPt addr,Bit32u val) {
         work(addr);
         mem_writed(addr,val);
         return false;
@@ -453,7 +453,7 @@ private:
 		PAGING_ClearTLB(); // TODO got a better idea?
 	}
 
-	Bitu readb_through(PhysPt addr) {
+	Bit8u readb_through(PhysPt addr) {
 		Bitu lin_page = addr >> 12;
 		Bit32u phys_page = paging.tlb.phys_page[lin_page] & PHYSPAGE_ADDR;
 		PageHandler* handler = MEM_GetPageHandler(phys_page);
@@ -462,7 +462,7 @@ private:
 			}
 		else return handler->readb(addr);
 					}
-	Bitu readw_through(PhysPt addr) {
+	Bit16u readw_through(PhysPt addr) {
 		Bitu lin_page = addr >> 12;
 		Bit32u phys_page = paging.tlb.phys_page[lin_page] & PHYSPAGE_ADDR;
 		PageHandler* handler = MEM_GetPageHandler(phys_page);
@@ -471,7 +471,7 @@ private:
 				}
 		else return handler->readw(addr);
 			}
-	Bitu readd_through(PhysPt addr) {
+	Bit32u readd_through(PhysPt addr) {
 		Bitu lin_page = addr >> 12;
 		Bit32u phys_page = paging.tlb.phys_page[lin_page] & PHYSPAGE_ADDR;
 		PageHandler* handler = MEM_GetPageHandler(phys_page);
@@ -481,27 +481,27 @@ private:
 		else return handler->readd(addr);
 			}
 
-	void writeb_through(PhysPt addr, Bitu val) {
+	void writeb_through(PhysPt addr, Bit8u val) {
 		Bitu lin_page = addr >> 12;
 		Bit32u phys_page = paging.tlb.phys_page[lin_page] & PHYSPAGE_ADDR;
 		PageHandler* handler = MEM_GetPageHandler(phys_page);
 		if (handler->getFlags() & PFLAG_WRITEABLE) {
-			return host_writeb(handler->GetHostWritePt(phys_page) + (addr&0xfff), (Bit8u)val);
+			return host_writeb(handler->GetHostWritePt(phys_page) + (addr&0xfff), val);
 		}
 		else return handler->writeb(addr, val);
 			}
 
-	void writew_through(PhysPt addr, Bitu val) {
+	void writew_through(PhysPt addr, Bit16u val) {
 		Bitu lin_page = addr >> 12;
 		Bit32u phys_page = paging.tlb.phys_page[lin_page] & PHYSPAGE_ADDR;
 		PageHandler* handler = MEM_GetPageHandler(phys_page);
 		if (handler->getFlags() & PFLAG_WRITEABLE) {
-			return host_writew(handler->GetHostWritePt(phys_page) + (addr&0xfff), (Bit16u)val);
+			return host_writew(handler->GetHostWritePt(phys_page) + (addr&0xfff), val);
 		}
 		else return handler->writew(addr, val);
 	}
 
-	void writed_through(PhysPt addr, Bitu val) {
+	void writed_through(PhysPt addr, Bit32u val) {
 		Bitu lin_page = addr >> 12;
 		Bit32u phys_page = paging.tlb.phys_page[lin_page] & PHYSPAGE_ADDR;
 		PageHandler* handler = MEM_GetPageHandler(phys_page);
@@ -513,13 +513,13 @@ private:
 
 public:
 	ExceptionPageHandler() : PageHandler(PFLAG_INIT|PFLAG_NOCODE) {}
-	Bitu readb(PhysPt addr) {
+	Bit8u readb(PhysPt addr) {
 		if (!cpu.mpl) return readb_through(addr);
 			
 		Exception(addr, false, false);
 		return mem_readb(addr); // read the updated page (unlikely to happen?)
 				}
-	Bitu readw(PhysPt addr) {
+	Bit16u readw(PhysPt addr) {
 		// access type is supervisor mode (temporary)
 		// we are always allowed to read in superuser mode
 		// so get the handler and address and read it
@@ -528,13 +528,13 @@ public:
 		Exception(addr, false, false);
 		return mem_readw(addr);
 			}
-	Bitu readd(PhysPt addr) {
+	Bit32u readd(PhysPt addr) {
 		if (!cpu.mpl) return readd_through(addr);
 
 		Exception(addr, false, false);
 		return mem_readd(addr);
 		}
-	void writeb(PhysPt addr,Bitu val) {
+	void writeb(PhysPt addr,Bit8u val) {
 		if (!cpu.mpl) {
 			writeb_through(addr, val);
 			return;
@@ -542,7 +542,7 @@ public:
 		Exception(addr, true, false);
 		mem_writeb(addr, val);
 			}
-	void writew(PhysPt addr,Bitu val) {
+	void writew(PhysPt addr,Bit16u val) {
 		if (!cpu.mpl) {
 			// TODO Exception on a KR-page?
 			writew_through(addr, val);
@@ -558,7 +558,7 @@ public:
 		Exception(addr, true, false);
 		mem_writew(addr, val);
 	}
-	void writed(PhysPt addr,Bitu val) {
+	void writed(PhysPt addr,Bit32u val) {
 		if (!cpu.mpl) {
 			writed_through(addr, val);
 			return;
@@ -582,12 +582,12 @@ public:
 		Exception(addr, false, true);
 		return true;
 		}
-	bool writeb_checked(PhysPt addr,Bitu val) {
+	bool writeb_checked(PhysPt addr,Bit8u val) {
         (void)val;//UNUSED
 		Exception(addr, true, true);
 		return true;
 	}
-	bool writew_checked(PhysPt addr,Bitu val) {
+	bool writew_checked(PhysPt addr,Bit16u val) {
 		if (hack_check(addr)) {
 			LOG_MSG("Page attributes modified without clear");
 			PAGING_ClearTLB();
@@ -597,7 +597,7 @@ public:
 		Exception(addr, true, true);
 		return true;
 	}
-	bool writed_checked(PhysPt addr,Bitu val) {
+	bool writed_checked(PhysPt addr,Bit32u val) {
         (void)val;//UNUSED
 		Exception(addr, true, true);
 		return true;
@@ -609,27 +609,27 @@ static void PAGING_LinkPageNew(Bitu lin_page, Bitu phys_page, Bitu linkmode, boo
 class NewInitPageHandler : public PageHandler {
 public:
 	NewInitPageHandler() : PageHandler(PFLAG_INIT|PFLAG_NOCODE) {}
-	Bitu readb(PhysPt addr) {
+	Bit8u readb(PhysPt addr) {
 		InitPage(addr, false, false);
 		return mem_readb(addr);
 	}
-	Bitu readw(PhysPt addr) {
+	Bit16u readw(PhysPt addr) {
 		InitPage(addr, false, false);
 		return mem_readw(addr);
 	}
-	Bitu readd(PhysPt addr) {
+	Bit32u readd(PhysPt addr) {
 		InitPage(addr, false, false);
 		return mem_readd(addr);
 	}
-	void writeb(PhysPt addr,Bitu val) {
+	void writeb(PhysPt addr,Bit8u val) {
 		InitPage(addr, true, false);
 		mem_writeb(addr,val);
 	}
-	void writew(PhysPt addr,Bitu val) {
+	void writew(PhysPt addr,Bit16u val) {
 		InitPage(addr, true, false);
 		mem_writew(addr,val);
 	}
-	void writed(PhysPt addr,Bitu val) {
+	void writed(PhysPt addr,Bit32u val) {
 		InitPage(addr, true, false);
 		mem_writed(addr,val);
 	}
@@ -649,17 +649,17 @@ public:
 		*val=mem_readd(addr);
 			return false;
 		}
-	bool writeb_checked(PhysPt addr,Bitu val) {
+	bool writeb_checked(PhysPt addr,Bit8u val) {
 		if (InitPage(addr, true, true)) return true;
 		mem_writeb(addr,val);
 		return false;
 	}
-	bool writew_checked(PhysPt addr,Bitu val) {
+	bool writew_checked(PhysPt addr,Bit16u val) {
 		if (InitPage(addr, true, true)) return true;
 		mem_writew(addr,val);
 			return false;
 		}
-	bool writed_checked(PhysPt addr,Bitu val) {
+	bool writed_checked(PhysPt addr,Bit32u val) {
 		if (InitPage(addr, true, true)) return true;
 		mem_writed(addr,val);
 		return false;

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -223,17 +223,17 @@ void SkipSpace(char*& hex);
 #if 0
 class DebugPageHandler : public PageHandler {
 public:
-	Bitu readb(PhysPt /*addr*/) {
+	Bit8u readb(PhysPt /*addr*/) {
 	}
-	Bitu readw(PhysPt /*addr*/) {
+	Bit16u readw(PhysPt /*addr*/) {
 	}
-	Bitu readd(PhysPt /*addr*/) {
+	Bit32u readd(PhysPt /*addr*/) {
 	}
-	void writeb(PhysPt /*addr*/,Bitu /*val*/) {
+	void writeb(PhysPt /*addr*/,Bit8u /*val*/) {
 	}
-	void writew(PhysPt /*addr*/,Bitu /*val*/) {
+	void writew(PhysPt /*addr*/,Bit16u /*val*/) {
 	}
-	void writed(PhysPt /*addr*/,Bitu /*val*/) {
+	void writed(PhysPt /*addr*/,Bit32u /*val*/) {
 	}
 };
 #endif

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -124,7 +124,7 @@ Bit32u DOS_HMA_GET_FREE_SPACE() {
 	return (DOS_HMA_LIMIT() - start);
 }
 
-void DOS_HMA_CLAIMED(Bitu bytes) {
+void DOS_HMA_CLAIMED(Bit16u bytes) {
 	Bit32u limit = DOS_HMA_LIMIT();
 
 	if (limit == 0) E_Exit("HMA allocatiom bug: Claim function called when HMA allocation is not enabled");
@@ -210,7 +210,7 @@ const Bit8u DOS_DATE_months[] = {
 	0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
 };
 
-static void DOS_AddDays(Bitu days) {
+static void DOS_AddDays(Bit8u days) {
 	dos.date.day += days;
 	Bit8u monthlimit = DOS_DATE_months[dos.date.month];
 
@@ -1994,7 +1994,7 @@ public:
         }
     }
 
-    Bitu DOS_Get_CPM_entry_direct(void) {
+    Bit32u DOS_Get_CPM_entry_direct(void) {
         return callback[8].Get_RealPointer();
     }
 
@@ -2387,7 +2387,7 @@ void DOS_Write_HMA_CPM_jmp(void) {
     test->DOS_Write_HMA_CPM_jmp();
 }
 
-Bitu DOS_Get_CPM_entry_direct(void) {
+Bit32u DOS_Get_CPM_entry_direct(void) {
     assert(test != NULL);
     return test->DOS_Get_CPM_entry_direct();
 }

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -55,8 +55,8 @@ void DOS_InfoBlock::SetLocation(Bit16u segment) {
 	seg = segment;
 	pt=PhysMake(seg,0);
 	/* Clear the initial Block */
-	for(Bitu i=0;i<sizeof(sDIB);i++) mem_writeb(pt+i,0xff);
-	for(Bitu i=0;i<14;i++) mem_writeb(pt+i,0);
+	for(Bit8u i=0;i<sizeof(sDIB);i++) mem_writeb(pt+i,0xff);
+	for(Bit8u i=0;i<14;i++) mem_writeb(pt+i,0);
 
 	sSave(sDIB,regCXfrom5e,(Bit16u)0);
 	sSave(sDIB,countLRUcache,(Bit16u)0);
@@ -183,7 +183,7 @@ void DOS_PSP::MakeNew(Bit16u mem_size) {
 	/* get previous */
 //	DOS_PSP prevpsp(dos.psp());
 	/* Clear it first */
-	Bitu i;
+	Bit16u i;
 	for (i=0;i<sizeof(sPSP);i++) mem_writeb(pt+i,0);
 	// Set size
 	sSave(sPSP,next_seg,(unsigned int)seg+mem_size);
@@ -213,7 +213,7 @@ void DOS_PSP::MakeNew(Bit16u mem_size) {
          * which is probably why Microsoft never did this in the DOS kernel. Choosing this method
          * removes the need for the copy of INT 30h in the HMA area, and therefore opens up all 64KB of
          * HMA if you want. */
-        Bitu DOS_Get_CPM_entry_direct(void);
+        Bit32u DOS_Get_CPM_entry_direct(void);
 
 	    /* far call opcode */
         sSave(sPSP,far_call,0x9a);

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -27,7 +27,7 @@
 Bit32u DOS_HMA_LIMIT();
 Bit32u DOS_HMA_FREE_START();
 Bit32u DOS_HMA_GET_FREE_SPACE();
-void DOS_HMA_CLAIMED(Bitu bytes);
+void DOS_HMA_CLAIMED(Bit16u bytes);
 
 extern bool enable_share_exe_fake;
 

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -342,7 +342,7 @@ int CMscdex::AddDrive(Bit16u _drive, char* physicalPath, Bit8u& subUnit)
 
 		// Create Callback Strategy
 		Bit16u off = sizeof(DOS_DeviceHeader::sDeviceHeader);
-		Bit16u call_strategy=(Bit16u)CALLBACK_Allocate();
+		Bit16u call_strategy=CALLBACK_Allocate();
 		CallBack_Handlers[call_strategy]=MSCDEX_Strategy_Handler;
 		real_writeb(seg,off+0,(Bit8u)0xFE);		//GRP 4
 		real_writeb(seg,off+1,(Bit8u)0x38);		//Extra Callback instruction
@@ -352,7 +352,7 @@ int CMscdex::AddDrive(Bit16u _drive, char* physicalPath, Bit8u& subUnit)
 		
 		// Create Callback Interrupt
 		off += 5;
-		Bit16u call_interrupt=(Bit16u)CALLBACK_Allocate();
+		Bit16u call_interrupt=CALLBACK_Allocate();
 		CallBack_Handlers[call_interrupt]=MSCDEX_Interrupt_Handler;
 		real_writeb(seg,off+0,(Bit8u)0xFE);		//GRP 4
 		real_writeb(seg,off+1,(Bit8u)0x38);		//Extra Callback instruction

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -489,7 +489,7 @@ void log_io(Bitu width, bool write, Bitu port, Bitu val) {
 #endif
 
 
-void IO_WriteB(Bitu port,Bitu val) {
+void IO_WriteB(Bitu port,Bit8u val) {
 	log_io(0, true, port, val);
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,1)))) {
 		CPU_ForceV86FakeIO_Out(port,val,1);
@@ -500,7 +500,7 @@ void IO_WriteB(Bitu port,Bitu val) {
 	}
 }
 
-void IO_WriteW(Bitu port,Bitu val) {
+void IO_WriteW(Bitu port,Bit16u val) {
 	log_io(1, true, port, val);
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,2)))) {
 		CPU_ForceV86FakeIO_Out(port,val,2);
@@ -511,7 +511,7 @@ void IO_WriteW(Bitu port,Bitu val) {
 	}
 }
 
-void IO_WriteD(Bitu port,Bitu val) {
+void IO_WriteD(Bitu port,Bit32u val) {
 	log_io(2, true, port, val);
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,4)))) {
 		CPU_ForceV86FakeIO_Out(port,val,4);
@@ -522,8 +522,8 @@ void IO_WriteD(Bitu port,Bitu val) {
 	}
 }
 
-Bitu IO_ReadB(Bitu port) {
-	Bitu retval;
+Bit8u IO_ReadB(Bitu port) {
+	Bit8u retval;
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,1)))) {
 		return CPU_ForceV86FakeIO_In(port,1);
 	}
@@ -535,8 +535,8 @@ Bitu IO_ReadB(Bitu port) {
 	return retval;
 }
 
-Bitu IO_ReadW(Bitu port) {
-	Bitu retval;
+Bit16u IO_ReadW(Bitu port) {
+	Bit16u retval;
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,2)))) {
 		return CPU_ForceV86FakeIO_In(port,2);
 	}
@@ -548,8 +548,8 @@ Bitu IO_ReadW(Bitu port) {
 	return retval;
 }
 
-Bitu IO_ReadD(Bitu port) {
-	Bitu retval;
+Bit32u IO_ReadD(Bitu port) {
+	Bit32u retval;
 	if (GCC_UNLIKELY(GETFLAG(VM) && (CPU_IO_Exception(port,4)))) {
 		return CPU_ForceV86FakeIO_In(port,4);
 	}

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -106,11 +106,11 @@ HostPt MemBase = NULL;
 class UnmappedPageHandler : public PageHandler {
 public:
     UnmappedPageHandler() : PageHandler(PFLAG_INIT|PFLAG_NOCODE) {}
-    Bitu readb(PhysPt addr) {
+    Bit8u readb(PhysPt addr) {
         (void)addr;//UNUSED
         return 0xFF; /* Real hardware returns 0xFF not 0x00 */
     } 
-    void writeb(PhysPt addr,Bitu val) {
+    void writeb(PhysPt addr,Bit8u val) {
         (void)addr;//UNUSED
         (void)val;//UNUSED
     }
@@ -119,7 +119,7 @@ public:
 class IllegalPageHandler : public PageHandler {
 public:
     IllegalPageHandler() : PageHandler(PFLAG_INIT|PFLAG_NOCODE) {}
-    Bitu readb(PhysPt addr) {
+    Bit8u readb(PhysPt addr) {
         (void)addr;
 #if C_DEBUG
         LOG_MSG("Warning: Illegal read from %x, CS:IP %8x:%8x",addr,SegValue(cs),reg_eip);
@@ -132,7 +132,7 @@ public:
 #endif
         return 0xFF; /* Real hardware returns 0xFF not 0x00 */
     } 
-    void writeb(PhysPt addr,Bitu val) {
+    void writeb(PhysPt addr,Bit8u val) {
         (void)addr;//UNUSED
         (void)val;//UNUSED
 #if C_DEBUG
@@ -1189,7 +1189,7 @@ unsigned char CMOS_GetShutdownByte();
 void CPU_Snap_Back_To_Real_Mode();
 void DEBUG_Enable(bool pressed);
 void CPU_Snap_Back_Forget();
-Bitu CPU_Pop16(void);
+Bit16u CPU_Pop16(void);
 
 static bool cmos_reset_type_9_sarcastic_win31_comments=true;
 

--- a/src/hardware/vga_memory.cpp
+++ b/src/hardware/vga_memory.cpp
@@ -371,41 +371,41 @@ public:
         // planer index = addr & 3u             (use low 2 bits as plane index)
         return VGA_Generic_Write_Handler<true/*chained*/>(addr&~3u, addr, val);
 	}
-	Bitu readb(PhysPt addr ) {
+	Bit8u readb(PhysPt addr ) {
 		VGAMEM_USEC_read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 //		addr = CHECKED(addr);
-		return readHandler8( addr );
+		return (Bit8u)readHandler8( addr );
 	}
-	Bitu readw(PhysPt addr ) {
+	Bit16u readw(PhysPt addr ) {
 		VGAMEM_USEC_read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 //		addr = CHECKED(addr);
-		Bitu ret = (readHandler8( addr+0 ) << 0 );
+		Bit16u ret = (readHandler8( addr+0 ) << 0 );
 		ret     |= (readHandler8( addr+1 ) << 8 );
 		return ret;
 	}
-	Bitu readd(PhysPt addr ) {
+	Bit32u readd(PhysPt addr ) {
 		VGAMEM_USEC_read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 //		addr = CHECKED(addr);
-		Bitu ret = (readHandler8( addr+0 ) << 0 );
+		Bit32u ret = (readHandler8( addr+0 ) << 0 );
 		ret     |= (readHandler8( addr+1 ) << 8 );
 		ret     |= (readHandler8( addr+2 ) << 16 );
 		ret     |= (readHandler8( addr+3 ) << 24 );
 		return ret;
 	}
-	void writeb(PhysPt addr, Bitu val ) {
+	void writeb(PhysPt addr, Bit8u val ) {
 		VGAMEM_USEC_write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
 //		addr = CHECKED(addr);
 		writeHandler8( addr, val );
 	}
-	void writew(PhysPt addr,Bitu val) {
+	void writew(PhysPt addr,Bit16u val) {
 		VGAMEM_USEC_write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
@@ -413,7 +413,7 @@ public:
 		writeHandler8( addr+0, val >> 0 );
 		writeHandler8( addr+1, val >> 8 );
 	}
-	void writed(PhysPt addr,Bitu val) {
+	void writed(PhysPt addr,Bit32u val) {
 		VGAMEM_USEC_write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
@@ -438,41 +438,41 @@ public:
         // planer index = addr & 3u             (use low 2 bits as plane index)
         return VGA_Generic_Write_Handler<true/*chained*/>(addr>>2u, addr, val);
 	}
-	Bitu readb(PhysPt addr ) {
+	Bit8u readb(PhysPt addr ) {
 		VGAMEM_USEC_read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 //		addr = CHECKED(addr);
-		return readHandler8( addr );
+		return (Bit8u)readHandler8( addr );
 	}
-	Bitu readw(PhysPt addr ) {
+	Bit16u readw(PhysPt addr ) {
 		VGAMEM_USEC_read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 //		addr = CHECKED(addr);
-		Bitu ret = (readHandler8( addr+0 ) << 0 );
+		Bit16u ret = (Bit16u)(readHandler8( addr+0 ) << 0 );
 		ret     |= (readHandler8( addr+1 ) << 8 );
 		return ret;
 	}
-	Bitu readd(PhysPt addr ) {
+	Bit32u readd(PhysPt addr ) {
 		VGAMEM_USEC_read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 //		addr = CHECKED(addr);
-		Bitu ret = (readHandler8( addr+0 ) << 0 );
+		Bit32u ret = (Bit32u)(readHandler8( addr+0 ) << 0 );
 		ret     |= (readHandler8( addr+1 ) << 8 );
 		ret     |= (readHandler8( addr+2 ) << 16 );
 		ret     |= (readHandler8( addr+3 ) << 24 );
 		return ret;
 	}
-	void writeb(PhysPt addr, Bitu val ) {
+	void writeb(PhysPt addr, Bit8u val ) {
 		VGAMEM_USEC_write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
 //		addr = CHECKED(addr);
 		writeHandler8( addr, val );
 	}
-	void writew(PhysPt addr,Bitu val) {
+	void writew(PhysPt addr,Bit16u val) {
 		VGAMEM_USEC_write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
@@ -480,7 +480,7 @@ public:
 		writeHandler8( addr+0, val >> 0 );
 		writeHandler8( addr+1, val >> 8 );
 	}
-	void writed(PhysPt addr,Bitu val) {
+	void writed(PhysPt addr,Bit32u val) {
 		VGAMEM_USEC_write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
@@ -498,28 +498,28 @@ public:
         return VGA_Generic_Read_Handler(start, start, vga.config.read_map_select);
 	}
 public:
-	Bitu readb(PhysPt addr) {
+	Bit8u readb(PhysPt addr) {
 		VGAMEM_USEC_read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 //		addr = CHECKED2(addr);
-		return readHandler(addr);
+		return (Bit8u)readHandler(addr);
 	}
-	Bitu readw(PhysPt addr) {
+	Bit16u readw(PhysPt addr) {
 		VGAMEM_USEC_read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 //		addr = CHECKED2(addr);
-		Bitu ret = (readHandler(addr+0) << 0);
+		Bit16u ret = (readHandler(addr+0) << 0);
 		ret     |= (readHandler(addr+1) << 8);
 		return  ret;
 	}
-	Bitu readd(PhysPt addr) {
+	Bit32u readd(PhysPt addr) {
 		VGAMEM_USEC_read_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_read_full;
 //		addr = CHECKED2(addr);
-		Bitu ret = (readHandler(addr+0) << 0);
+		Bit32u ret = (readHandler(addr+0) << 0);
 		ret     |= (readHandler(addr+1) << 8);
 		ret     |= (readHandler(addr+2) << 16);
 		ret     |= (readHandler(addr+3) << 24);
@@ -531,14 +531,14 @@ public:
 	}
 public:
 	VGA_UnchainedVGA_Handler() : PageHandler(PFLAG_NOCODE) {}
-	void writeb(PhysPt addr,Bitu val) {
+	void writeb(PhysPt addr,Bit8u val) {
 		VGAMEM_USEC_write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
 //		addr = CHECKED2(addr);
 		writeHandler(addr+0,(Bit8u)(val >> 0));
 	}
-	void writew(PhysPt addr,Bitu val) {
+	void writew(PhysPt addr,Bit16u val) {
 		VGAMEM_USEC_write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
@@ -546,7 +546,7 @@ public:
 		writeHandler(addr+0,(Bit8u)(val >> 0));
 		writeHandler(addr+1,(Bit8u)(val >> 8));
 	}
-	void writed(PhysPt addr,Bitu val) {
+	void writed(PhysPt addr,Bit32u val) {
 		VGAMEM_USEC_write_delay();
 		addr = PAGING_GetPhysicalAddress(addr) & vgapages.mask;
 		addr += vga.svga.bank_write_full;
@@ -565,12 +565,12 @@ public:
 	VGA_CGATEXT_PageHandler() {
 		flags=PFLAG_NOCODE;
 	}
-	Bitu readb(PhysPt addr) {
+	Bit8u readb(PhysPt addr) {
 		addr = PAGING_GetPhysicalAddress(addr) & 0x3FFF;
 		VGAMEM_USEC_read_delay();
 		return vga.tandy.mem_base[addr];
 	}
-	void writeb(PhysPt addr,Bitu val){
+	void writeb(PhysPt addr,Bit8u val){
 		VGAMEM_USEC_write_delay();
 
 		if (enableCGASnow) {
@@ -595,12 +595,12 @@ public:
 	VGA_MCGATEXT_PageHandler() {
 		flags=PFLAG_NOCODE;
 	}
-	Bitu readb(PhysPt addr) {
+	Bit8u readb(PhysPt addr) {
 		addr = PAGING_GetPhysicalAddress(addr) & 0xFFFF;
 		VGAMEM_USEC_read_delay();
 		return vga.tandy.mem_base[addr];
 	}
-	void writeb(PhysPt addr,Bitu val){
+	void writeb(PhysPt addr,Bit8u val){
 		VGAMEM_USEC_write_delay();
 
 		addr = PAGING_GetPhysicalAddress(addr) & 0xFFFF;
@@ -1362,17 +1362,17 @@ void pc98_mem_msw_write(unsigned char which,unsigned char val) {
 class VGA_PC98_TEXT_PageHandler : public PageHandler {
 public:
 	VGA_PC98_TEXT_PageHandler() : PageHandler(PFLAG_NOCODE) {}
-	Bitu readb(PhysPt addr) {
+	Bit8u readb(PhysPt addr) {
         addr &= 0x3FFFu;
 
         if (addr >= 0x3FE0u)
             return pc98_mem_msw((addr >> 2) & 7);
         else if ((addr & 0x2001) == 0x2001)
-            return ~((Bitu)0); /* Odd bytes of attribute RAM do not exist, apparently */
+            return ~((Bit8u)0); /* Odd bytes of attribute RAM do not exist, apparently */
 
         return VRAM98_TEXT[addr];
     }
-	void writeb(PhysPt addr,Bitu val) {
+	void writeb(PhysPt addr,Bit8u val) {
         addr &= 0x3FFFu;
 
         if (addr >= 0x3FE0u)
@@ -1406,11 +1406,11 @@ extern uint16_t a1_font_load_addr;
 class VGA_PC98_CG_PageHandler : public PageHandler {
 public:
 	VGA_PC98_CG_PageHandler() : PageHandler(PFLAG_NOCODE) {}
-	Bitu readb(PhysPt addr) {
+	Bit8u readb(PhysPt addr) {
         return pc98_font_char_read(a1_font_load_addr,(addr >> 1) & 0xF,addr & 1);
     }
-	void writeb(PhysPt addr,Bitu val) {
-        pc98_font_char_write(a1_font_load_addr,(addr >> 1) & 0xF,addr & 1,(uint8_t)val);
+	void writeb(PhysPt addr,Bit8u val) {
+        pc98_font_char_write(a1_font_load_addr,(addr >> 1) & 0xF,addr & 1,val);
     }
 };
 
@@ -1418,11 +1418,11 @@ public:
 class VGA_PC98_256MMIO_PageHandler : public PageHandler {
 public:
 	VGA_PC98_256MMIO_PageHandler() : PageHandler(PFLAG_NOCODE) {}
-	Bitu readb(PhysPt addr) {
+	Bit8u readb(PhysPt addr) {
         return pc98_pegc_mmio_read(addr & 0x7FFFu);
     }
-    void writeb(PhysPt addr,Bitu val) {
-        pc98_pegc_mmio_write(addr & 0x7FFFu,(Bit8u)val);
+    void writeb(PhysPt addr,Bit8u val) {
+        pc98_pegc_mmio_write(addr & 0x7FFFu,val);
     }
 };
 
@@ -1434,25 +1434,25 @@ public:
 class VGA_PC98_256Planar_PageHandler : public PageHandler {
 public:
 	VGA_PC98_256Planar_PageHandler() : PageHandler(PFLAG_NOCODE) {}
-	Bitu readb(PhysPt addr) {
+	Bit8u readb(PhysPt addr) {
         (void)addr;
 
 //        LOG_MSG("PEGC 256-color planar warning: Readb from %lxh",(unsigned long)addr);
-        return ~((Bitu)0);
+        return ~((Bit8u)0);
     }
-	void writeb(PhysPt addr,Bitu val) {
+	void writeb(PhysPt addr,Bit8u val) {
         (void)addr;
         (void)val;
 
 //        LOG_MSG("PEGC 256-color planar warning: Writeb to %lxh val %02xh",(unsigned long)addr,(unsigned int)val);
     }
-	Bitu readw(PhysPt addr) {
+	Bit16u readw(PhysPt addr) {
         (void)addr;
 
 //        LOG_MSG("PEGC 256-color planar warning: Readw from %lxh",(unsigned long)addr);
-        return ~((Bitu)0);
+        return ~((Bit16u)0);
     }
-	void writew(PhysPt addr,Bitu val) {
+	void writew(PhysPt addr,Bit16u val) {
         (void)addr;
         (void)val;
 
@@ -1465,11 +1465,11 @@ public:
 template <const unsigned int bank> class VGA_PC98_256BANK_PageHandler : public PageHandler {
 public:
 	VGA_PC98_256BANK_PageHandler() : PageHandler(PFLAG_NOCODE) {}
-	Bitu readb(PhysPt addr) {
+	Bit8u readb(PhysPt addr) {
         return pc98_vram_256bank_from_window(bank)[addr & 0x7FFFu];
     }
-	void writeb(PhysPt addr,Bitu val) {
-        pc98_vram_256bank_from_window(bank)[addr & 0x7FFFu] = (unsigned char)val;
+	void writeb(PhysPt addr,Bit8u val) {
+        pc98_vram_256bank_from_window(bank)[addr & 0x7FFFu] = val;
     }
 };
 
@@ -1773,16 +1773,16 @@ public:
 	}
 
     /* byte-wise */
-	Bitu readb(PhysPt addr) {
+	Bit8u readb(PhysPt addr) {
         return readc<uint8_t>( PAGING_GetPhysicalAddress(addr) );
     }
-	void writeb(PhysPt addr,Bitu val) {
-        writec<uint8_t>( PAGING_GetPhysicalAddress(addr), (uint8_t)val );
+	void writeb(PhysPt addr,Bit8u val) {
+        writec<uint8_t>( PAGING_GetPhysicalAddress(addr), val );
     }
 
     /* word-wise.
      * in the style of the 8086, non-word-aligned I/O is split into byte I/O */
-	Bitu readw(PhysPt addr) {
+	Bit16u readw(PhysPt addr) {
         addr = PAGING_GetPhysicalAddress(addr);
         if (!(addr & 1)) /* if WORD aligned */
             return readc<uint16_t>(addr);
@@ -1791,10 +1791,10 @@ public:
                     ((unsigned int)readc<uint8_t>(addr+1U) << 8u);
         }
     }
-	void writew(PhysPt addr,Bitu val) {
+	void writew(PhysPt addr,Bit16u val) {
         addr = PAGING_GetPhysicalAddress(addr);
         if (!(addr & 1)) /* if WORD aligned */
-            writec<uint16_t>(addr,(uint16_t)val);
+            writec<uint16_t>(addr,val);
         else {
             writec<uint8_t>(addr+0,(uint8_t)val);
             writec<uint8_t>(addr+1,(uint8_t)(val >> 8U));
@@ -1836,13 +1836,13 @@ public:
 		CPU_IODelayRemoved += delaycyc;
 	}
 
-	Bitu readb(PhysPt addr) {
+	Bit8u readb(PhysPt addr) {
 		delay();
 		return vga.tandy.mem_base[addr - 0xb8000];
 	}
-	void writeb(PhysPt addr,Bitu val){
+	void writeb(PhysPt addr,Bit8u val){
 		delay();
-		vga.tandy.mem_base[addr - 0xb8000] = (Bit8u) val;
+		vga.tandy.mem_base[addr - 0xb8000] = val;
 	}
 	
 };
@@ -1882,20 +1882,20 @@ public:
 		XGA_Write(port, val, 4);
 	}
 
-	Bitu readb(PhysPt addr) {
+	Bit8u readb(PhysPt addr) {
 		VGAMEM_USEC_read_delay();
 		Bitu port = PAGING_GetPhysicalAddress(addr) & 0xffff;
-		return XGA_Read(port, 1);
+		return (Bit8u)XGA_Read(port, 1);
 	}
-	Bitu readw(PhysPt addr) {
+	Bit16u readw(PhysPt addr) {
 		VGAMEM_USEC_read_delay();
 		Bitu port = PAGING_GetPhysicalAddress(addr) & 0xffff;
-		return XGA_Read(port, 2);
+		return (Bit16u)XGA_Read(port, 2);
 	}
-	Bitu readd(PhysPt addr) {
+	Bit32u readd(PhysPt addr) {
 		VGAMEM_USEC_read_delay();
 		Bitu port = PAGING_GetPhysicalAddress(addr) & 0xffff;
-		return XGA_Read(port, 4);
+		return (Bit32u)XGA_Read(port, 4);
 	}
 };
 
@@ -2066,29 +2066,29 @@ public:
 		}
 
 	}
-	Bitu readb(PhysPt addr) {
+	Bit8u readb(PhysPt addr) {
 		VGAMEM_USEC_read_delay();
 		addr = wrAddr( addr ) + ( vga.amstrad.read_plane * 16384u );
 		addr &= (64u*1024u-1u);
 		return readHandler(addr);
 	}
-	Bitu readw(PhysPt addr) {
+	Bit16u readw(PhysPt addr) {
 		VGAMEM_USEC_read_delay();
 		addr = wrAddr( addr ) + ( vga.amstrad.read_plane * 16384u );
 		addr &= (64u*1024u-1u);
 		return 
-			((Bitu)readHandler(addr+0) << 0u) |
-			((Bitu)readHandler(addr+1) << 8u);
+			(readHandler(addr+0) << 0u) |
+			(readHandler(addr+1) << 8u);
 	}
-	Bitu readd(PhysPt addr) {
+	Bit32u readd(PhysPt addr) {
 		VGAMEM_USEC_read_delay();
 		addr = wrAddr( addr ) + ( vga.amstrad.read_plane * 16384u );
 		addr &= (64u*1024u-1u);
 		return 
-			((Bitu)readHandler(addr+0) << 0u)  |
-			((Bitu)readHandler(addr+1) << 8u)  |
-			((Bitu)readHandler(addr+2) << 16u) |
-			((Bitu)readHandler(addr+3) << 24u);
+			(readHandler(addr+0) << 0u)  |
+			(readHandler(addr+1) << 8u)  |
+			(readHandler(addr+2) << 16u) |
+			(readHandler(addr+3) << 24u);
 	}
 
 /*
@@ -2131,11 +2131,11 @@ public:
 class VGA_Empty_Handler : public PageHandler {
 public:
 	VGA_Empty_Handler() : PageHandler(PFLAG_NOCODE) {}
-	Bitu readb(PhysPt /*addr*/) {
+	Bit8u readb(PhysPt /*addr*/) {
 //		LOG(LOG_VGA, LOG_NORMAL ) ( "Read from empty memory space at %x", addr );
 		return 0xff;
 	} 
-	void writeb(PhysPt /*addr*/,Bitu /*val*/) {
+	void writeb(PhysPt /*addr*/,Bit8u /*val*/) {
 //		LOG(LOG_VGA, LOG_NORMAL ) ( "Write %x to empty memory space at %x", val, addr );
 	}
 };

--- a/src/hardware/voodoo_interface.cpp
+++ b/src/hardware/voodoo_interface.cpp
@@ -38,25 +38,25 @@ static voodoo_draw vdraw;
 Voodoo_PageHandler * voodoo_pagehandler;
 
 
-Bitu Voodoo_PageHandler::readb(PhysPt addr) {
+Bit8u Voodoo_PageHandler::readb(PhysPt addr) {
     (void)addr;//UNUSED
 //	LOG_MSG("voodoo readb at %x",addr);
-	return (Bitu)-1;
+	return (Bit8u)-1;
 }
-void Voodoo_PageHandler::writeb(PhysPt addr,Bitu val) {
+void Voodoo_PageHandler::writeb(PhysPt addr,Bit8u val) {
     (void)addr;//UNUSED
     (void)val;//UNUSED
 //	LOG_MSG("voodoo writeb at %x",addr);
 }
 
-Bitu Voodoo_PageHandler::readw(PhysPt addr) {
+Bit16u Voodoo_PageHandler::readw(PhysPt addr) {
 	addr = PAGING_GetPhysicalAddress(addr);
     if (addr&1) {
         LOG_MSG("voodoo readw unaligned");
-        return (Bitu)-1;
+        return (Bit16u)-1;
     }
 
-	Bitu retval=voodoo_r((addr>>2)&0x3FFFFF);
+	Bit16u retval=voodoo_r((addr>>2)&0x3FFFFF);
 	if (addr&3)
 		retval >>= 16;
 	else
@@ -64,7 +64,7 @@ Bitu Voodoo_PageHandler::readw(PhysPt addr) {
 	return retval;
 }
 
-void Voodoo_PageHandler::writew(PhysPt addr,Bitu val) {
+void Voodoo_PageHandler::writew(PhysPt addr,Bit16u val) {
 	addr = PAGING_GetPhysicalAddress(addr);
 	if (addr&1) {
         LOG_MSG("voodoo writew unaligned");
@@ -77,7 +77,7 @@ void Voodoo_PageHandler::writew(PhysPt addr,Bitu val) {
 		voodoo_w((addr>>2)&0x3FFFFF,val,0x0000ffff);
 }
 
-Bitu Voodoo_PageHandler::readd(PhysPt addr) {
+Bit32u Voodoo_PageHandler::readd(PhysPt addr) {
 	addr = PAGING_GetPhysicalAddress(addr);
 	if (!(addr&3)) {
 		return voodoo_r((addr>>2)&0x3FFFFF);
@@ -93,7 +93,7 @@ Bitu Voodoo_PageHandler::readd(PhysPt addr) {
 	return 0xffffffff;
 }
 
-void Voodoo_PageHandler::writed(PhysPt addr,Bitu val) {
+void Voodoo_PageHandler::writed(PhysPt addr,Bit32u val) {
 	addr = PAGING_GetPhysicalAddress(addr);
 	if (!(addr&3)) {
 		voodoo_w((addr>>2)&0x3FFFFF,val,0xffffffff);

--- a/src/hardware/voodoo_interface.h
+++ b/src/hardware/voodoo_interface.h
@@ -45,12 +45,12 @@ public:
 	~Voodoo_PageHandler() {
 	}
 
-	Bitu readb(PhysPt addr);
-	void writeb(PhysPt addr,Bitu val);
-	Bitu readw(PhysPt addr);
-	void writew(PhysPt addr,Bitu val);
-	Bitu readd(PhysPt addr);
-	void writed(PhysPt addr,Bitu val);
+	Bit8u readb(PhysPt addr);
+	void writeb(PhysPt addr,Bit8u val);
+	Bit16u readw(PhysPt addr);
+	void writew(PhysPt addr,Bit16u val);
+	Bit32u readd(PhysPt addr);
+	void writed(PhysPt addr,Bit32u val);
 };
 
 

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -1979,7 +1979,7 @@ static bool Tandy_TransferInProgress(void) {
     else if (tandy_dac.port) tandy_dma = tandy_dac.dma;
 
     IO_Write(0x0c,0x00);
-    Bit16u datalen=(Bit8u)(IO_ReadB(tandy_dma*2u+1u)&0xffu);
+    Bit16u datalen=IO_ReadB(tandy_dma*2u+1u)&0xffu;
     datalen|=(IO_ReadB(tandy_dma*2u+1u)<<8u);
     if (datalen==0xffff) return false;  /* no DMA transfer */
     else if ((datalen<0x10) && (real_readb(0x40,0xd4)==0x0f) && (real_readw(0x40,0xd2)==0x1c)) {
@@ -5320,8 +5320,8 @@ static Bitu INT14_Handler(void) {
         IO_WriteB(port+1u, 0u); // IER
 
         // get result
-        reg_ah=(Bit8u)(IO_ReadB(port+5u)&0xffu);
-        reg_al=(Bit8u)(IO_ReadB(port+6u)&0xffu);
+        reg_ah=IO_ReadB(port+5u)&0xffu;
+        reg_al=IO_ReadB(port+6u)&0xffu;
         CALLBACK_SCF(false);
         break;
     }
@@ -5374,8 +5374,8 @@ static Bitu INT14_Handler(void) {
         CALLBACK_SCF(false);
         break;
     case 0x03: // get status
-        reg_ah=(Bit8u)(IO_ReadB(port+5u)&0xffu);
-        reg_al=(Bit8u)(IO_ReadB(port+6u)&0xffu);
+        reg_ah=IO_ReadB(port+5u)&0xffu;
+        reg_al=IO_ReadB(port+6u)&0xffu;
         CALLBACK_SCF(false);
         break;
 

--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -1306,12 +1306,12 @@ static Bitu V86_Monitor() {
 				break;
 			case 0xe4:		// IN AL,Ib
 				if (!VCPI_trapio_r(mem_readb((unsigned int)(v86_cs<<4u)+(unsigned int)v86_ip+1u),1))
-					reg_al=(Bit8u)(IO_ReadB(mem_readb((unsigned int)(v86_cs<<4)+(unsigned int)v86_ip+1))&0xff);
+					reg_al=IO_ReadB(mem_readb((unsigned int)(v86_cs<<4)+(unsigned int)v86_ip+1))&0xff;
 				mem_writew(SegPhys(ss)+((reg_esp+0) & cpu.stack.mask),v86_ip+2u);
 				break;
 			case 0xe5:		// IN AX,Ib
 				if (!VCPI_trapio_r(mem_readb((unsigned int)(v86_cs<<4u)+(unsigned int)v86_ip+1u),2))
-					reg_ax=(Bit16u)(IO_ReadW(mem_readb((unsigned int)(v86_cs<<4)+(unsigned int)v86_ip+1))&0xffff);
+					reg_ax=IO_ReadW(mem_readb((unsigned int)(v86_cs<<4)+(unsigned int)v86_ip+1))&0xffff;
 				mem_writew(SegPhys(ss)+((reg_esp+0) & cpu.stack.mask),v86_ip+2u);
 				break;
 			case 0xe6:		// OUT Ib,AL
@@ -1326,12 +1326,12 @@ static Bitu V86_Monitor() {
 				break;
 			case 0xec:		// IN AL,DX
 				if (!VCPI_trapio_r(reg_dx,1))
-					reg_al=(Bit8u)(IO_ReadB(reg_dx)&0xff);
+					reg_al=IO_ReadB(reg_dx)&0xff;
 				mem_writew(SegPhys(ss)+((reg_esp+0) & (unsigned int)cpu.stack.mask),(unsigned int)v86_ip+1u);
 				break;
 			case 0xed:		// IN AX,DX
 				if (!VCPI_trapio_r(reg_dx,2))
-					reg_ax=(Bit16u)(IO_ReadW(reg_dx)&0xffff);
+					reg_ax=IO_ReadW(reg_dx)&0xffff;
 				mem_writew(SegPhys(ss)+((reg_esp+0) & (unsigned int)cpu.stack.mask),(unsigned int)v86_ip+1u);
 				break;
 			case 0xee:		// OUT DX,AL

--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -201,7 +201,7 @@ void INT10_PutPixel(Bit16u x,Bit16u y,Bit8u page,Bit8u color);
 void INT10_GetPixel(Bit16u x,Bit16u y,Bit8u page,Bit8u * color);
 
 /* Font Stuff */
-void INT10_LoadFont(PhysPt font,bool reload,Bitu count,Bitu offset,Bitu map,Bitu height);
+void INT10_LoadFont(PhysPt font,bool reload,Bit16u count,Bitu offset,Bitu map,Bit8u height);
 void INT10_ReloadFont(void);
 
 /* Palette Group */

--- a/src/ints/int10_memory.cpp
+++ b/src/ints/int10_memory.cpp
@@ -53,7 +53,7 @@ static Bit16u map_offset[8]={
 	0x2000,0x6000,0xa000,0xe000
 };
 
-void INT10_LoadFont(PhysPt font,bool reload,Bitu count,Bitu offset,Bitu map,Bitu height) {
+void INT10_LoadFont(PhysPt font,bool reload,Bit16u count,Bitu offset,Bitu map,Bit8u height) {
     unsigned char m64k;
 
 	if (IS_VGA_ARCH || (IS_EGA_ARCH && vga.mem.memsize >= 0x20000))
@@ -73,7 +73,7 @@ void INT10_LoadFont(PhysPt font,bool reload,Bitu count,Bitu offset,Bitu map,Bitu
 	IO_Write(0x3ce,0x06);IO_Write(0x3cf,0x04); // CPU memory window A0000-AFFFF
 	
 	//Load character patterns
-	for (Bitu i=0;i<count;i++) {
+	for (Bit16u i=0;i<count;i++) {
 		MEM_BlockCopy(ftwhere+i*32,font,height);
 		font+=height;
 	}

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -34,7 +34,7 @@
 extern bool enable_config_as_shell_commands;
 extern bool dos_shell_running_program;
 
-Bitu shell_psp = 0;
+Bit16u shell_psp = 0;
 
 void CALLBACK_DeAllocate(Bitu in);
 

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -120,7 +120,7 @@ void MoveCaretBackwards()
 void DOS_Shell::InputCommand(char * line) {
 	Bitu size=CMD_MAXLINE-2; //lastcharacter+0
 	Bit8u c;Bit16u n=1;
-	Bitu str_len=0;Bitu str_index=0;
+	Bit16u str_len=0;Bit16u str_index=0;
 	Bit16u len=0;
 	bool current_hist=false; // current command stored in history?
     Bit16u cr;


### PR DESCRIPTION
# Description

Fixes many value conversion warnings.

**Does this PR address some issue(s) ?**

Warnings that appear when building with Visual Studio/AppVeyor.

**Are there any breaking changes ?**

None known.

**Additional information**

Current master branch builds with 2103 warnings when built with the Visual Studio 2017 image in AppVeyor for x64. The vast majority of the warnings are for type conversions, such as a `Bit8u` value being assigned a `Bitu` value. With this PR the number of warnings are reduced to 1855.

There are still many more warnings to address, but I wanted to get your input before going further, in case you don't like my approach.

My approach:
1) Find a warning in the compiler output.
2) Go to the warning line in the code and find out which variable in the line is causing the issue.
3) Check all usage of the warning-causing variable and see if it can be narrowed. (Ex. It is `Bitu` but is never assigned anything larger than a `Bit16u`, or it is a counter variable that never goes higher than a number within the range of `Bit8u`) If so, change type to the narrower variable. This sometimes allows removing no-longer necessary casts.
4) If it's unclear/too hard to check all the usage cases of the variable, just stick a cast in front of the variable being assigned to to silence the warning.

To me step 3 seems like the preferable solution, and methods like `writeB(PhysPtr address, Bitu val)` are better as `writeB(PhysPtr address, Bit8u val)`, since they are supposed to only take a byte anyway. Narrowing the scope of variables allows for silencing type-conversion warnings without sticking casts everywhere (and allows removing some existing ones that were probably placed for that purpose). Maybe there is some reason I don't know of, though, that using `Bitu` is preferable.

Confirmed to compile and run.