### PR TITLE
Warning fixes

### DIFF
--- a/include/fpu.h
+++ b/include/fpu.h
@@ -207,7 +207,7 @@ static INLINE void FPU_SetCW(Bitu word){
 }
 
 
-static INLINE Bitu FPU_GET_TOP(void) {
+static INLINE Bit8u FPU_GET_TOP(void) {
 	return (fpu.sw & 0x3800U) >> 11U;
 }
 

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -124,7 +124,7 @@ static void MOUSE_ProgramStart(Program * * make) {
 }
 
 void MSCDEX_SetCDInterface(int intNr, int forceCD);
-Bitu ZDRIVE_NUM = 25;
+Bit8u ZDRIVE_NUM = 25;
 
 class MOUNT : public Program {
 public:
@@ -221,9 +221,9 @@ public:
         /* Only allowing moving it once. It is merely a convenience added for the wine team */
         if (ZDRIVE_NUM == 25 && cmd->FindString("-z", newz,false)) {
             newz[0] = toupper(newz[0]);
-            int i_newz = newz[0] - 'A';
+            Bit8u i_newz = newz[0] - 'A';
             if (i_newz >= 0 && i_newz < DOS_DRIVES-1 && !Drives[i_newz]) {
-                ZDRIVE_NUM = (unsigned int)i_newz;
+                ZDRIVE_NUM = i_newz;
                 /* remap drives */
                 Drives[i_newz] = Drives[25];
                 Drives[25] = 0;
@@ -1923,7 +1923,7 @@ restart_int:
         }
 
         Bit8u mediadesc = 0xF8; // media descriptor byte; also used to differ fd and hd
-        Bitu root_ent = 512; // FAT root directory entries: 512 is for harddisks
+        Bit16u root_ent = 512; // FAT root directory entries: 512 is for harddisks
         if(disktype=="fd_160") {
             c = 40; h = 1; s = 8; mediadesc = 0xFE; root_ent = 56; // root_ent?
         } else if(disktype=="fd_180") {

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1808,8 +1808,8 @@ restart_int:
 
                         if(retries) goto restart_int;
                         const Bit8u badfood[]="IMGMAKE BAD FLOPPY SECTOR \xBA\xAD\xF0\x0D";
-                        for(Bitu z = 0; z < 512/32; z++)
-                            memcpy(&data[512*k+z*32],badfood,32);
+                        for(Bit8u z = 0; z < 512/32; z++)
+                            memcpy(&data[512*k+z*32],badfood,31);
                         WriteOut("\b\b");
                         break;
                     }

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -751,7 +751,7 @@ void DOS_Drive_Cache::CopyEntry(CFileInfo* dir, CFileInfo* from) {
 
 bool DOS_Drive_Cache::ReadDir(Bit16u id, char* &result) {
     // shouldnt happen...
-    if (id>MAX_OPENDIRS) return false;
+    if (id>=MAX_OPENDIRS) return false;
 
     if (!IsCachedIn(dirSearch[id])) {
         // Try to open directory

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -208,9 +208,9 @@ static void FPU_FLD_I64(PhysPt addr,Bitu store_to) {
 
 static void FPU_FBLD(PhysPt addr,Bitu store_to) {
 	Bit64u val = 0;
-	Bitu in = 0;
+	Bit8u in = 0;
 	Bit64u base = 1;
-	for(Bitu i = 0;i < 9;i++){
+	for(Bit8u i = 0;i < 9;i++){
 		in = mem_readb(addr + i);
 		val += ( (in&0xf) * base); //in&0xf shouldn't be higher then 9
 		base *= 10;
@@ -296,7 +296,7 @@ static void FPU_FBST(PhysPt addr) {
 	//numbers from back to front
 	Real64 temp=val.d;
 	Bitu p;
-	for(Bitu i=0;i<9;i++){
+	for(Bit8u i=0;i<9;i++){
 		val.d=temp;
 		temp = static_cast<Real64>(static_cast<Bit64s>(floor(val.d/10.0)));
 		p = static_cast<Bitu>(val.d - 10.0*temp);  
@@ -304,14 +304,14 @@ static void FPU_FBST(PhysPt addr) {
 		temp = static_cast<Real64>(static_cast<Bit64s>(floor(val.d/10.0)));
 		p |= (static_cast<Bitu>(val.d - 10.0*temp)<<4);
 
-		mem_writeb(addr+i,p);
+		mem_writeb(addr+i,(Bit8u)p);
 	}
 	val.d=temp;
 	temp = static_cast<Real64>(static_cast<Bit64s>(floor(val.d/10.0)));
 	p = static_cast<Bitu>(val.d - 10.0*temp);
 	if(sign)
 		p|=0x80;
-	mem_writeb(addr+9,p);
+	mem_writeb(addr+9,(Bit8u)p);
 }
 
 #if defined(WIN32) && defined(_MSC_VER) && (_MSC_VER < 1910)
@@ -631,8 +631,8 @@ static void FPU_FLDENV(PhysPt addr){
 
 static void FPU_FSAVE(PhysPt addr){
 	FPU_FSTENV(addr);
-	Bitu start = (cpu.code.big?28:14);
-	for(Bitu i = 0;i < 8;i++){
+	Bit8u start = (cpu.code.big?28:14);
+	for(Bit8u i = 0;i < 8;i++){
 		FPU_ST80(addr+start,STV(i),/*&*/fpu.regs_80[STV(i)],fpu.use80[STV(i)]);
 		start += 10;
 	}
@@ -641,8 +641,8 @@ static void FPU_FSAVE(PhysPt addr){
 
 static void FPU_FRSTOR(PhysPt addr){
 	FPU_FLDENV(addr);
-	Bitu start = (cpu.code.big?28:14);
-	for(Bitu i = 0;i < 8;i++){
+	Bit8u start = (cpu.code.big?28:14);
+	for(Bit8u i = 0;i < 8;i++){
 		fpu.regs[STV(i)].d = FPU_FLD80(addr+start,/*&*/fpu.regs_80[STV(i)]);
 		fpu.use80[STV(i)] = true;
 		start += 10;


### PR DESCRIPTION
Some size-conversion fixes. Size-conversion warnings in Visual Studio 2017 build fall from 1843 to 1818.

Also 2 fixes to possible reads beyond the range of data arrays. These are warnings in the Visual Studio editor but not included in the above warning numbers.