### PR TITLE
Fix type-conversion warnings

### DIFF
--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -1138,7 +1138,7 @@ Bit16u device_CON::GetInformation(void) {
 		 * will trigger the INT 16h AH=0x11 hook it relies on. */
 		if (readcache || dev_con_pos < dev_con_max) return 0x8093; /* key available */
 
-		Bitu saved_ax = reg_ax;
+		Bit16u saved_ax = reg_ax;
 
 		reg_ah = (IS_EGAVGA_ARCH)?0x11:0x1; // check for keystroke
 

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -784,7 +784,7 @@ static Bitu DOS_21Handler(void) {
                         SegSet16(es,SegValue(ss));
                         CALLBACK_RunRealInt(0x1c);
 
-                        Bitu memaddr = ((Bitu)SegValue(es) << 4u) + reg_bx;
+                        Bit32u memaddr = ((Bit32u)SegValue(es) << 4u) + reg_bx;
 
                         reg_sp += 6;
                         SegSet16(es,CPU_Pop16());
@@ -893,7 +893,7 @@ static Bitu DOS_21Handler(void) {
                     SegSet16(es,SegValue(ss));
                     CALLBACK_RunRealInt(0x1c);
 
-                    Bitu memaddr = ((PhysPt)SegValue(es) << 4u) + reg_bx;
+                    Bit32u memaddr = ((PhysPt)SegValue(es) << 4u) + reg_bx;
 
                     reg_sp += 6;
                     SegSet16(es,CPU_Pop16());
@@ -2122,7 +2122,7 @@ public:
             if (MEM_TotalPages() > 0x9C)
                 DOS_PRIVATE_SEGMENT_END = 0x9C00;
             else
-                DOS_PRIVATE_SEGMENT_END = (MEM_TotalPages() << (12 - 4)) - 1; /* NTS: Remember DOSBox's implementation reuses the last paragraph for UMB linkage */
+                DOS_PRIVATE_SEGMENT_END = (Bit16u)((MEM_TotalPages() << (12 - 4)) - 1); /* NTS: Remember DOSBox's implementation reuses the last paragraph for UMB linkage */
         }
 
         LOG(LOG_MISC,LOG_DEBUG)("DOS kernel structures will be allocated from pool 0x%04x-0x%04x",

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -367,7 +367,7 @@ void DOS_DTA::SetupSearch(Bit8u _sdrive,Bit8u _sattr,char * pattern) {
 	sSave(sDTA,sdrive,_sdrive);
 	sSave(sDTA,sattr,_sattr);
 	/* Fill with spaces */
-	Bitu i;
+	Bit8u i;
 	for (i=0;i<11;i++) mem_writeb(pt+offsetof(sDTA,sname)+i,' ');
 	char * find_ext;
 	find_ext=strchr(pattern,'.');
@@ -431,10 +431,10 @@ bool DOS_FCB::Extended(void) {
 }
 
 void DOS_FCB::Create(bool _extended) {
-	Bitu fill;
+	Bit8u fill;
 	if (_extended) fill=33+7;
 	else fill=33;
-	Bitu i;
+	Bit8u i;
 	for (i=0;i<fill;i++) mem_writeb(real_pt+i,0);
 	pt=real_pt;
 	if (_extended) {
@@ -554,6 +554,6 @@ void DOS_FCB::SetResult(Bit32u size,Bit16u date,Bit16u time,Bit8u attr) {
 
 void DOS_SDA::Init() {
 	/* Clear */
-	for(Bitu i=0;i<sizeof(sSDA);i++) mem_writeb(pt+i,0x00);
+	for(Bit8u i=0;i<sizeof(sSDA);i++) mem_writeb(pt+i,0x00);
 	sSave(sSDA,drive_crit_error,0xff);   
 }

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -109,9 +109,9 @@ static bool DOS_MultiplexFunctions(void) {
 		if (reg_bx<16) {
 			RealPt sftrealpt=mem_readd(Real2Phys(dos_infoblock.GetPointer())+4);
 			PhysPt sftptr=Real2Phys(sftrealpt);
-			Bitu sftofs=0x06u+reg_bx*0x3bu;
+			Bit32u sftofs=0x06u+reg_bx*0x3bu;
 
-			if (Files[reg_bx]) mem_writeb(sftptr+sftofs,Files[reg_bx]->refCtr);
+			if (Files[reg_bx]) mem_writeb(sftptr+sftofs, (Bit8u)(Files[reg_bx]->refCtr));
 			else mem_writeb(sftptr+sftofs,0);
 
 			if (!Files[reg_bx]) return true;


### PR DESCRIPTION
Fixes some more type-conversion warnings.

Number of warnings down from 1822 (something raised it a bit since last warnings PR) to 1790.

Compiles and runs.