### PR TITLE
Latest SVN commits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -99,6 +99,25 @@
     on each get_modrm call.
     - Strip leading = from value. Can happen if you execute
     "irq =5".
+    - Don't remove bytes from autoexec.bat when changing
+    settings from autoexec.bat, but replace them instead. This
+    way the location stays valid.
+    - Let dynamic core recompile interrupt instructions in
+    non-debug builds. Can help software with many INTs, such as
+    compiled BASIC, run faster.
+    - Add logic in mouse driver to ignore button events that
+    are out of sequence. Fixes International Rugby Challenge
+    when clicking to lock the mouse.
+    - Use a more compatible offset for DOS redirected interrupt
+    vector. Works around a null pointer bug in the notes dropdown
+    list of Jack the Ripper.
+    - Reqrite pop_ev so it can trigger pagefaults again. Fixes
+    Win 3.11.
+    - Fix uninitialized access to some isoDrive fields. Pause audio
+    before switching. Use right subunit with multiple CDs on one
+    drive letter.
+    - Move all stack alignment operations into one place and
+    some optimalisations to RISC x64 dynamic core.
 0.82.19
   - Prefetch core fixed up, made more aggressive, and string
     instructions (REP MOVSW) cause more prefetch. "Stereotype"

--- a/configure.ac
+++ b/configure.ac
@@ -277,6 +277,9 @@ AC_CHECK_HEADER([sys/mman.h], [
 AC_CHECK_FUNC([mprotect],[AC_DEFINE(C_HAVE_MPROTECT,1)])
 ])
 
+dnl Check for realpath. Used on Linux
+AC_CHECK_FUNCS([realpath])
+
 dnl Setpriority
 AH_TEMPLATE(C_SET_PRIORITY,[Define to 1 if you have setpriority support])
 AC_MSG_CHECKING(for setpriority support)

--- a/include/shell.h
+++ b/include/shell.h
@@ -42,11 +42,12 @@
 #define CMD_MAXCMDS 20
 #define CMD_OLDSIZE 4096
 extern Bitu call_shellstop;
+class DOS_Shell;
+
 /* first_shell is used to add and delete stuff from the shell env 
  * by "external" programs. (config) */
-extern Program * first_shell;
+extern DOS_Shell * first_shell;
 
-class DOS_Shell;
 
 class BatchFile {
 public:

--- a/patch-integration/Skipped SVN commits.txt
+++ b/patch-integration/Skipped SVN commits.txt
@@ -68,3 +68,8 @@ Commit#:	Reason for skipping:
 4196		New overlay drive, skipping for now
 4199		Conflict
 4200		Conflict
+4215		Conflict
+4216		Overlay
+4217		Overlay
+4225		Overlay
+4228		Not sure if needed

--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -446,7 +446,9 @@ restart_prefix:
 		case 0xcb:dyn_ret_far(0);goto finish_block;
 
 		// int/iret
+#if !(C_DEBUG)
 		case 0xcd:dyn_interrupt(decode_fetchb());goto finish_block;
+#endif
 		case 0xcf:dyn_iret();goto finish_block;
 
 //		case 0xd4: AAM missing

--- a/src/cpu/core_dynrec/risc_x64.h
+++ b/src/cpu/core_dynrec/risc_x64.h
@@ -83,17 +83,12 @@ typedef Bit8u HostReg;
 
 // move a full register from reg_src to reg_dst
 static void gen_mov_regs(HostReg reg_dst,HostReg reg_src) {
+	if (reg_dst==reg_src) return;
 	cache_addb(0x8b);					// mov reg_dst,reg_src
 	cache_addb(0xc0+(reg_dst<<3)+reg_src);
 }
 
-// move a 64bit constant value into a full register
-static void gen_mov_reg_qword(HostReg dest_reg,Bit64u imm) {
-	cache_addb(0x48);
-	cache_addb(0xb8+dest_reg);			// mov dest_reg,imm
-	cache_addq(imm);
-}
-
+static void gen_mov_reg_qword(HostReg dest_reg,Bit64u imm);
 
 // This function generates an instruction with register addressing and a memory location
 static INLINE void gen_reg_memaddr(HostReg reg,void* data,Bit8u op,Bit8u prefix=0) {
@@ -195,6 +190,17 @@ static void gen_mov_dword_to_reg_imm(HostReg dest_reg,Bit32u imm) {
 	cache_addd(imm);
 }
 
+// move a 64bit constant value into a full register
+static void gen_mov_reg_qword(HostReg dest_reg,Bit64u imm) {
+	if (imm==(Bit32u)imm) {
+		gen_mov_dword_to_reg_imm(dest_reg, (Bit32u)imm);
+		return;
+	}
+	cache_addb(0x48);
+	cache_addb(0xb8+dest_reg);			// mov dest_reg,imm
+	cache_addq(imm);
+}
+
 // move 32bit (dword==true) or 16bit (dword==false) of a register into memory
 static void gen_mov_word_from_reg(HostReg src_reg,void* dest,bool dword,Bit8u prefix=0) {
 	gen_reg_memaddr(src_reg,dest,0x89,(dword?prefix:0x66));		// mov [data],reg
@@ -264,6 +270,7 @@ static void gen_add(HostReg reg,void* op) {
 
 // add a 32bit constant value to a full register
 static void gen_add_imm(HostReg reg,Bit32u imm) {
+	if (!imm) return;
 	cache_addw(0xc081+(reg<<8));		// add reg,imm
 	cache_addd(imm);
 }
@@ -291,11 +298,13 @@ static void INLINE gen_mov_direct_ptr(void* dest,DRC_PTR_SIZE_IM imm) {
 
 // add an 8bit constant value to a memory value
 static void gen_add_direct_byte(void* dest,Bit8s imm) {
+	if (!imm) return;
 	gen_memaddr(0x4,dest,1,imm,0x83);	// add [data],imm
 }
 
 // add a 32bit (dword==true) or 16bit (dword==false) constant value to a memory value
 static void gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
+	if (!imm) return;
 	if ((imm<128) && dword) {
 		gen_add_direct_byte(dest,(Bit8s)imm);
 		return;
@@ -305,11 +314,13 @@ static void gen_add_direct_word(void* dest,Bit32u imm,bool dword) {
 
 // subtract an 8bit constant value from a memory value
 static void gen_sub_direct_byte(void* dest,Bit8s imm) {
+	if (!imm) return;
 	gen_memaddr(0x2c,dest,1,imm,0x83);
 }
 
 // subtract a 32bit (dword==true) or 16bit (dword==false) constant value from a memory value
 static void gen_sub_direct_word(void* dest,Bit32u imm,bool dword) {
+	if (!imm) return;
 	if ((imm<128) && dword) {
 		gen_sub_direct_byte(dest,(Bit8s)imm);
 		return;
@@ -364,31 +375,9 @@ static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 
 // generate a call to a parameterless function
 static void INLINE gen_call_function_raw(void * func) {
-//	cache_addb(0x48); 
-//	cache_addw(0xec83); 
-#if defined (_WIN64)
-//	cache_addb(0x28);	// allocate windows shadow space
-	cache_addd(0x28ec8348);
-#else
-//	cache_addb(0x08);	// sub rsp,0x08 (align stack to 16 byte boundary)
-	cache_addd(0x08ec8348);
-#endif 
-
-//	cache_addb(0x48);
-//	cache_addb(0xb8);	// mov reg,imm64
 	cache_addw(0xb848);
 	cache_addq((Bit64u)func);
 	cache_addw(0xd0ff);
-
-//	cache_addb(0x48); 
-//	cache_addw(0xc483); 
-#if defined (_WIN64)
-//	cache_addb(0x28);	// deallocate windows shadow space
-	cache_addd(0x28c48348);
-#else
-//	cache_addb(0x08);	// add rsp,0x08 (reset alignment)
-	cache_addd(0x08c48348);
-#endif 
 }
 
 // generate a call to a function with paramcount parameters
@@ -398,58 +387,8 @@ static Bit64u INLINE gen_call_function_setup(void * func,Bitu paramcount,bool fa
 	(void)paramcount;
 	(void)fastcall;
 
-	// align the stack
-	cache_addb(0x48);
-	cache_addw(0xc48b);		// mov rax,rsp
-
-//	cache_addb(0x48);
-//	cache_addw(0xec83);		// sub rsp,0x08
-//	cache_addb(0x08);		// 0x08==return address pushed onto stack by call
-	cache_addd(0x08ec8348);
-
-//	cache_addb(0x48);
-//	cache_addw(0xe483);		// and esp,0xfffffffffffffff0
-//	cache_addb(0xf0);
-	cache_addd(0xf0e48348);
-
-//	cache_addb(0x48);
-//	cache_addw(0xc483);		// add rsp,0x08
-//	cache_addb(0x08);
-	cache_addd(0x08c48348);
-
-	// stack is 16 byte aligned now
-
-
-	cache_addb(0x50);		// push rax (==old rsp)
-
-#if defined (_WIN64)
-//	cache_addb(0x48);
-//	cache_addw(0xec83);		// sub rsp,0x20
-//	cache_addb(0x20);	// allocate windows shadow space
-	cache_addd(0x20ec8348);
-#endif 
-
-	// returned address relates to where the address is stored in gen_call_function_raw
-	Bit64u proc_addr=(Bit64u)cache.pos-4;
-
-	// Do the actual call to the procedure
-//	cache_addb(0x48);
-//	cache_addb(0xb8);		// mov reg,imm64
-	cache_addw(0xb848);
-	cache_addq((Bit64u)func);
-
-	cache_addw(0xd0ff);
-
-#if defined (_WIN64)
-//	cache_addb(0x48);
-//	cache_addw(0xc483);		// add rsp,0x20
-//	cache_addb(0x20);	// deallocate windows shadow space
-	cache_addd(0x20c48348);
-#endif 
-
-	// restore stack
-	cache_addb(0x5c);		// pop rsp
-
+	Bit64u proc_addr = (Bit64u)cache.pos;
+	gen_call_function_raw(func);
 	return proc_addr;
 }
 
@@ -465,13 +404,13 @@ static void INLINE gen_load_param_imm(Bitu imm,Bitu param) {
 			gen_mov_dword_to_reg_imm(FC_OP2,(Bit32u)imm);
 			break;
 #if defined (_WIN64)
-		case 2:			// mov r8,imm32
-			cache_addw(0xb849);
-			cache_addq((Bit32u)imm);
+		case 2:			// mov r8d,imm32
+			cache_addw(0xb841);
+			cache_addd((Bit32u)imm);
 			break;
-		case 3:			// mov r9,imm32
-			cache_addw(0xb949);
-			cache_addq((Bit32u)imm);
+		case 3:			// mov r9d,imm32
+			cache_addw(0xb941);
+			cache_addd((Bit32u)imm);
 			break;
 #else
 		case 2:			// mov rdx,imm32
@@ -564,17 +503,17 @@ static void INLINE gen_load_param_mem(Bitu mem,Bitu param) {
 			gen_mov_word_to_reg(FC_OP2,(void*)mem,true);
 			break;
 #if defined (_WIN64)
-		case 2:		// mov r8,[mem]
-			gen_mov_word_to_reg(0,(void*)mem,true,0x4c);	// 0x4c, use x64 rX regs
+		case 2:		// mov r8d,[mem]
+			gen_mov_word_to_reg(0,(void*)mem,true,0x44);	// 0x44, use x64 rXd regs
 			break;
-		case 3:		// mov r9,[mem]
-			gen_mov_word_to_reg(1,(void*)mem,true,0x4c);	// 0x4c, use x64 rX regs
+		case 3:		// mov r9d,[mem]
+			gen_mov_word_to_reg(1,(void*)mem,true,0x44);	// 0x44, use x64 rXd regs
 			break;
 #else
-		case 2:		// mov rdx,[mem]
+		case 2:		// mov edx,[mem]
 			gen_mov_word_to_reg(HOST_EDX,(void*)mem,true);
 			break;
-		case 3:		// mov rcx,[mem]
+		case 3:		// mov ecx,[mem]
 			gen_mov_word_to_reg(HOST_ECX,(void*)mem,true);
 			break;
 #endif
@@ -665,22 +604,19 @@ static void gen_fill_branch_long(Bit64u data) {
 	*(Bit32u*)data=(Bit32u)((Bit64u)cache.pos-data-4);
 }
 
-
 static void gen_run_code(void) {
-	cache_addb(0x53);					// push rbx
-#if defined (_WIN64)
-	cache_addw(0x5657);			// push rdi; push rsi
-#endif
-	cache_addw(0xd0ff+(FC_OP1<<8));		// call rdi
-#if defined (_WIN64)
-	cache_addw(0x5f5e);			// pop rsi; pop rdi
-#endif
-	cache_addb(0x5b);					// pop  rbx
+	cache_addw(0x5355);     // push rbp,rbx
+	cache_addb(0x56);       // push rsi
+	cache_addd(0x20EC8348); // sub rsp, 32
+	cache_addb(0x48);cache_addw(0x2D8D);cache_addd(2); // lea rbp, [rip+2]
+	cache_addw(0xE0FF+(FC_OP1<<8)); // jmp FC_OP1
+	cache_addd(0x20C48348); // add rsp, 32
+	cache_addd(0xC35D5B5E); // pop rsi,rbx,rbp;ret
 }
 
 // return from a function
 static void gen_return_function(void) {
-	cache_addb(0xc3);		// ret
+	cache_addw(0xE5FF); // jmp rbp
 }
 
 #ifdef DRC_FLAGS_INVALIDATION
@@ -695,126 +631,77 @@ static void gen_fill_function_ptr(Bit8u * pos,void* fct_ptr,Bitu flags_type) {
 		case t_ADDb:
 		case t_ADDw:
 		case t_ADDd:
-#if defined (_WIN64)
-			*(Bit32u*)(pos+0)=0xd001c889; // mov eax, ecx; add eax, edx
-#else
-			*(Bit32u*)(pos+0)=0xf001f889;	// mov eax,edi; add eax,esi
-#endif
-			*(Bit32u*)(pos+4)=0x90900eeb;	// skip
+			// mov eax,FC_OP1; add eax,FC_OP2
+			*(Bit32u*)(pos+0)=0xc001c089+(FC_OP1<<11)+(FC_OP2<<27);
+			*(Bit32u*)(pos+4)=0x909006eb;	// skip
 			*(Bit32u*)(pos+8)=0x90909090;
-			*(Bit32u*)(pos+12)=0x90909090;
-			*(Bit32u*)(pos+16)=0x90909090;
-			break;
+			return;
 		case t_ORb:
 		case t_ORw:
 		case t_ORd:
-#if defined (_WIN64)
-			*(Bit32u*)(pos+0)=0xd009c889; // mov eax, ecx; or eax, edx
-#else
-			*(Bit32u*)(pos+0)=0xf009f889;	// mov eax,edi; or eax,esi
-#endif
-			*(Bit32u*)(pos+4)=0x90900eeb;	// skip
+			// mov eax,FC_OP1; or eax,FC_OP2
+			*(Bit32u*)(pos+0)=0xc009c089+(FC_OP1<<11)+(FC_OP2<<27);
+			*(Bit32u*)(pos+4)=0x909006eb;	// skip
 			*(Bit32u*)(pos+8)=0x90909090;
-			*(Bit32u*)(pos+12)=0x90909090;
-			*(Bit32u*)(pos+16)=0x90909090;
-			break;
+			return;
 		case t_ANDb:
 		case t_ANDw:
 		case t_ANDd:
-#if defined (_WIN64)
-			*(Bit32u*)(pos+0)=0xd021c889; // mov eax, ecx; and eax, edx
-#else
-			*(Bit32u*)(pos+0)=0xf021f889;	// mov eax,edi; and eax,esi
-#endif
-			*(Bit32u*)(pos+4)=0x90900eeb;	// skip
+			// mov eax,FC_OP1; and eax,FC_OP2
+			*(Bit32u*)(pos+0)=0xc021c089+(FC_OP1<<11)+(FC_OP2<<27);
+			*(Bit32u*)(pos+4)=0x909006eb;	// skip
 			*(Bit32u*)(pos+8)=0x90909090;
-			*(Bit32u*)(pos+12)=0x90909090;
-			*(Bit32u*)(pos+16)=0x90909090;
-			break;
+			return;
 		case t_SUBb:
 		case t_SUBw:
 		case t_SUBd:
-#if defined (_WIN64)
-			*(Bit32u*)(pos+0)=0xd029c889; // mov eax, ecx; sub eax, edx
-#else
-			*(Bit32u*)(pos+0)=0xf029f889;	// mov eax,edi; sub eax,esi
-#endif
-			*(Bit32u*)(pos+4)=0x90900eeb;	// skip
+			// mov eax,FC_OP1; sub eax,FC_OP2
+			*(Bit32u*)(pos+0)=0xc029c089+(FC_OP1<<11)+(FC_OP2<<27);
+			*(Bit32u*)(pos+4)=0x909006eb;	// skip
 			*(Bit32u*)(pos+8)=0x90909090;
-			*(Bit32u*)(pos+12)=0x90909090;
-			*(Bit32u*)(pos+16)=0x90909090;
-			break;
+			return;
 		case t_XORb:
 		case t_XORw:
 		case t_XORd:
-#if defined (_WIN64)
-			*(Bit32u*)(pos+0)=0xd031c889; // mov eax, ecx; xor eax, edx
-#else
-			*(Bit32u*)(pos+0)=0xf031f889;	// mov eax,edi; xor eax,esi
-#endif
-			*(Bit32u*)(pos+4)=0x90900eeb;	// skip
+			// mov eax,FC_OP1; xor eax,FC_OP2
+			*(Bit32u*)(pos+0)=0xc031c089+(FC_OP1<<11)+(FC_OP2<<27);
+			*(Bit32u*)(pos+4)=0x909006eb;	// skip
 			*(Bit32u*)(pos+8)=0x90909090;
-			*(Bit32u*)(pos+12)=0x90909090;
-			*(Bit32u*)(pos+16)=0x90909090;
-			break;
+			return;
 		case t_CMPb:
 		case t_CMPw:
 		case t_CMPd:
 		case t_TESTb:
 		case t_TESTw:
 		case t_TESTd:
-			*(Bit32u*)(pos+0)=0x909012eb;	// skip
+			*(Bit32u*)(pos+0)=0x90900aeb;	// skip
 			*(Bit32u*)(pos+4)=0x90909090;
 			*(Bit32u*)(pos+8)=0x90909090;
-			*(Bit32u*)(pos+12)=0x90909090;
-			*(Bit32u*)(pos+16)=0x90909090;
-			break;
+			return;
 		case t_INCb:
 		case t_INCw:
 		case t_INCd:
-#if defined (_WIN64)
-			*(Bit32u*)(pos+0)=0xc0ffc889; // mov eax, ecx; inc eax
-#else
-			*(Bit32u*)(pos+0)=0xc0fff889;	// mov eax,edi; inc eax
-#endif
-			*(Bit32u*)(pos+4)=0x90900eeb;	// skip
+			*(Bit32u*)(pos+0)=0xc0ffc089+(FC_OP1<<11); // mov eax,ecx; inc eax
+			*(Bit32u*)(pos+4)=0x909006eb;	// skip
 			*(Bit32u*)(pos+8)=0x90909090;
-			*(Bit32u*)(pos+12)=0x90909090;
-			*(Bit32u*)(pos+16)=0x90909090;
-			break;
+				return;
 		case t_DECb:
 		case t_DECw:
 		case t_DECd:
-#if defined (_WIN64)
-			*(Bit32u*)(pos+0)=0xc8ffc889; // mov eax, ecx; dec eax
-#else
-			*(Bit32u*)(pos+0)=0xc8fff889;	// mov eax,edi; dec eax
-#endif
-			*(Bit32u*)(pos+4)=0x90900eeb;	// skip
+			*(Bit32u*)(pos+0)=0xc8ffc089+(FC_OP1<<11); // mov eax, FC_OP1; dec eax
+			*(Bit32u*)(pos+4)=0x909006eb;	// skip
 			*(Bit32u*)(pos+8)=0x90909090;
-			*(Bit32u*)(pos+12)=0x90909090;
-			*(Bit32u*)(pos+16)=0x90909090;
-			break;
+			return;
 		case t_NEGb:
 		case t_NEGw:
 		case t_NEGd:
-#if defined (_WIN64)
-			*(Bit32u*)(pos+0)=0xd8f7c889; // mov eax, ecx; neg eax
-#else
-			*(Bit32u*)(pos+0)=0xd8f7f889;	// mov eax,edi; neg eax
-#endif
-			*(Bit32u*)(pos+4)=0x90900eeb;	// skip
+			*(Bit32u*)(pos+0)=0xd8f7c089+(FC_OP1<<11); // mov eax, FC_OP1; neg eax
+			*(Bit32u*)(pos+4)=0x909006eb;	// skip
 			*(Bit32u*)(pos+8)=0x90909090;
-			*(Bit32u*)(pos+12)=0x90909090;
-			*(Bit32u*)(pos+16)=0x90909090;
-			break;
-		default:
-			*(Bit64u*)(pos+6)=(Bit64u)fct_ptr;		// fill function pointer
-			break;
+			return;
 	}
-#else
-	*(Bit64u*)(pos+6)=(Bit64u)fct_ptr;		// fill function pointer
 #endif
+	*(Bit64u*)(pos+2)=(Bit64u)fct_ptr;		// fill function pointer
 }
 #endif
 

--- a/src/debug/debug_disasm.cpp
+++ b/src/debug/debug_disasm.cpp
@@ -496,6 +496,7 @@ static void uprintf(char const *s, ...)
 	va_list	arg_ptr;
 	va_start (arg_ptr, s);
 	vsprintf(ubufp, s, arg_ptr);
+	va_end(arg_ptr);
 	while (*ubufp)
 		ubufp++;
 }

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -51,6 +51,7 @@ CDROM_Interface_Image::BinaryFile::BinaryFile(const char *filename, bool &error)
 CDROM_Interface_Image::BinaryFile::~BinaryFile()
 {
 	delete file;
+	file = NULL;
 }
 
 bool CDROM_Interface_Image::BinaryFile::read(Bit8u *buffer, int seek, int count)
@@ -76,6 +77,7 @@ CDROM_Interface_Image::imagePlayer CDROM_Interface_Image::player = {
 
 	
 CDROM_Interface_Image::CDROM_Interface_Image(Bit8u subUnit)
+                      :subUnit(subUnit)
 {
 	images[subUnit] = this;
 	if (refCount == 0) {
@@ -357,6 +359,7 @@ bool CDROM_Interface_Image::LoadIsoFile(char* filename)
 	track.file = new BinaryFile(filename, error);
 	if (error) {
 		delete track.file;
+		track.file = NULL;
 		return false;
 	}
 	track.number = 1;
@@ -511,6 +514,7 @@ bool CDROM_Interface_Image::LoadCueSheet(char *cuefile)
 			}
 			if (error) {
 				delete track.file;
+				track.file = NULL;
 				success = false;
 			}
 		}

--- a/src/dos/dos_memory.cpp
+++ b/src/dos/dos_memory.cpp
@@ -527,7 +527,7 @@ void DOS_SetupMemory(void) {
 
 	assert(DOS_IHSEG != 0);
 	ihseg = DOS_IHSEG;
-	ihofs = 0x08;
+	ihofs = 0xF4;
 
 	real_writeb(ihseg,ihofs,(Bit8u)0xCF);		//An IRET Instruction
 	RealSetVec(0x01,RealMake(ihseg,ihofs));		//BioMenace (offset!=4)

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -408,9 +408,11 @@ bool CMscdex::HasDrive(Bit16u drive) {
 }
 
 void CMscdex::ReplaceDrive(CDROM_Interface* newCdrom, Bit8u subUnit) {
-	delete cdrom[subUnit];
+	if (cdrom[subUnit] != NULL) {
+		StopAudio(subUnit);
+		delete cdrom[subUnit];
+	}
 	cdrom[subUnit] = newCdrom;
-	StopAudio(subUnit);
 }
 
 PhysPt CMscdex::GetDefaultBuffer(void) {
@@ -1316,6 +1318,11 @@ bool MSCDEX_HasDrive(char driveLetter)
 void MSCDEX_ReplaceDrive(CDROM_Interface* cdrom, Bit8u subUnit)
 {
 	mscdex->ReplaceDrive(cdrom, subUnit);
+}
+
+Bit8u MSCDEX_GetSubUnit(char driveLetter)
+{
+	return mscdex->GetSubUnit(driveLetter-'A');
 }
 
 bool MSCDEX_GetVolumeName(Bit8u subUnit, char* name)

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -237,12 +237,12 @@ public:
                 /* remap drives */
                 Drives[i_newz] = Drives[25];
                 Drives[25] = 0;
-                DOS_Shell *fs = static_cast<DOS_Shell *>(first_shell); //dynamic ?              
+                if (!first_shell) return; //Should not be possible
                 /* Update environment */
                 std::string line = "";
                 char ppp[2] = {newz[0],0};
                 std::string tempenv = ppp; tempenv += ":\\";
-                if (fs->GetEnvStr("PATH",line)){
+                if (first_shell->GetEnvStr("PATH",line)){
                     std::string::size_type idx = line.find('=');
                     std::string value = line.substr(idx +1 , std::string::npos);
                     while ( (idx = value.find("Z:\\")) != std::string::npos ||
@@ -251,13 +251,13 @@ public:
                     line = value;
                 }
                 if (!line.size()) line = tempenv;
-                fs->SetEnv("PATH",line.c_str());
+                first_shell->SetEnv("PATH",line.c_str());
                 tempenv += "COMMAND.COM";
-                fs->SetEnv("COMSPEC",tempenv.c_str());
+                first_shell->SetEnv("COMSPEC",tempenv.c_str());
 
                 /* Update batch file if running from Z: (very likely: autoexec) */
-                if(fs->bf) {
-                    std::string &name = fs->bf->filename;
+                if(first_shell->bf) {
+                    std::string &name = first_shell->bf->filename;
                     if(name.length() >2 &&  name[0] == 'Z' && name[1] == ':') name[0] = newz[0];
                 }
                 /* Change the active drive */

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -152,10 +152,8 @@ isoDrive::isoDrive(char driveLetter, const char *fileName, Bit8u mediaid, int &e
          :iso(false),
           dataCD(false),
           mediaid(0),
-          fileName{'\0'},
           subUnit(0),
-          driveLetter('\0'),
-          discLabel{'\0'}
+          driveLetter('\0')
  {
 	size_t i;
 
@@ -165,6 +163,8 @@ isoDrive::isoDrive(char driveLetter, const char *fileName, Bit8u mediaid, int &e
             CDROM_Interface_Image::images[i] = NULL;
     }
 
+	this->fileName[0]  = '\0';
+	this->discLabel[0] = '\0';
 	subUnit = 0;
 	nextFreeDirIterator = 0;
 	memset(dirIterators, 0, sizeof(dirIterators));

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -139,15 +139,24 @@ Bit32u isoFile::GetSeekPos() {
 }
 
 
-int  MSCDEX_RemoveDrive(char driveLetter);
-int  MSCDEX_AddDrive(char driveLetter, const char* physicalPath, Bit8u& subUnit);
-void MSCDEX_ReplaceDrive(CDROM_Interface* cdrom, Bit8u subUnit);
-bool MSCDEX_HasDrive(char driveLetter);
-bool MSCDEX_GetVolumeName(Bit8u subUnit, char* name);
+int   MSCDEX_RemoveDrive(char driveLetter);
+int   MSCDEX_AddDrive(char driveLetter, const char* physicalPath, Bit8u& subUnit);
+void  MSCDEX_ReplaceDrive(CDROM_Interface* cdrom, Bit8u subUnit);
+bool  MSCDEX_HasDrive(char driveLetter);
+bool  MSCDEX_GetVolumeName(Bit8u subUnit, char* name);
+Bit8u MSCDEX_GetSubUnit(char driveLetter);
 
 bool CDROM_Interface_Image::images_init = false;
 
-isoDrive::isoDrive(char driveLetter, const char *fileName, Bit8u mediaid, int &error) {
+isoDrive::isoDrive(char driveLetter, const char *fileName, Bit8u mediaid, int &error)
+         :iso(false),
+          dataCD(false),
+          mediaid(0),
+          fileName{'\0'},
+          subUnit(0),
+          driveLetter('\0'),
+          discLabel{'\0'}
+ {
 	size_t i;
 
     if (!CDROM_Interface_Image::images_init) {
@@ -191,6 +200,7 @@ isoDrive::~isoDrive() { }
 
 int isoDrive::UpdateMscdex(char driveLetter, const char* path, Bit8u& subUnit) {
 	if (MSCDEX_HasDrive(driveLetter)) {
+		subUnit = MSCDEX_GetSubUnit(driveLetter);
 		CDROM_Interface_Image* oldCdrom = CDROM_Interface_Image::images[subUnit];
 		CDROM_Interface* cdrom = new CDROM_Interface_Image(subUnit);
 		char pathCopy[CROSS_LEN];

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -1262,7 +1262,10 @@ bool MSCDEX_GetVolumeName(Bit8u subUnit, char* name);
 
 
 cdromDrive::cdromDrive(const char driveLetter, const char * startdir,Bit16u _bytes_sector,Bit8u _sectors_cluster,Bit16u _total_clusters,Bit16u _free_clusters,Bit8u _mediaid, int& error)
-		   :localDrive(startdir,_bytes_sector,_sectors_cluster,_total_clusters,_free_clusters,_mediaid) {
+		   :localDrive(startdir,_bytes_sector,_sectors_cluster,_total_clusters,_free_clusters,_mediaid),
+		    subUnit(0),
+		    driveLetter('\0')
+{
 	// Init mscdex
 	error = MSCDEX_AddDrive(driveLetter,startdir,subUnit);
 	strcpy(info, "CDRom ");

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -57,7 +57,6 @@ protected:
 };
 
 extern Bit8u                int10_font_14[256 * 14];
-extern Program*             first_shell;
 
 extern uint32_t             GFX_Rmask;
 extern unsigned char        GFX_Rshift;
@@ -867,10 +866,9 @@ public:
         if (arg == "OK") section->data = *(std::string*)content->getText();
         if (arg == "OK" || arg == "Cancel" || arg == "Close") { close(); if(shortcut) running=false; }
         else if (arg == "Append History") {
-            DOS_Shell *s = static_cast<DOS_Shell *>(first_shell);
-            std::list<std::string>::reverse_iterator i = s->l_history.rbegin();
+            std::list<std::string>::reverse_iterator i = first_shell->l_history.rbegin();
             std::string lines = *(std::string*)content->getText();
-            while (i != s->l_history.rend()) {
+            while (i != first_shell->l_history.rend()) {
                 lines += "\n";
                 lines += *i;
                 ++i;

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -737,18 +737,21 @@ void Mouse_ButtonPressed(Bit8u button) {
     switch (button) {
 #if (MOUSE_BUTTONS >= 1)
     case 0:
+        if (mouse.buttons&1) return;
         mouse.buttons|=1;
         Mouse_AddEvent(MOUSE_LEFT_PRESSED);
         break;
 #endif
 #if (MOUSE_BUTTONS >= 2)
     case 1:
+        if (mouse.buttons&2) return;
         mouse.buttons|=2;
         Mouse_AddEvent(MOUSE_RIGHT_PRESSED);
         break;
 #endif
 #if (MOUSE_BUTTONS >= 3)
     case 2:
+        if (mouse.buttons&4) return;
         mouse.buttons|=4;
         Mouse_AddEvent(MOUSE_MIDDLE_PRESSED);
         break;
@@ -797,18 +800,21 @@ void Mouse_ButtonReleased(Bit8u button) {
     switch (button) {
 #if (MOUSE_BUTTONS >= 1)
     case 0:
+        if (!(mouse.buttons&1)) return;
         mouse.buttons&=~1;
         Mouse_AddEvent(MOUSE_LEFT_RELEASED);
         break;
 #endif
 #if (MOUSE_BUTTONS >= 2)
     case 1:
+        if (!(mouse.buttons&2)) return;
         mouse.buttons&=~2;
         Mouse_AddEvent(MOUSE_RIGHT_RELEASED);
         break;
 #endif
 #if (MOUSE_BUTTONS >= 3)
     case 2:
+        if (!(mouse.buttons&4)) return;
         mouse.buttons&=~4;
         Mouse_AddEvent(MOUSE_MIDDLE_RELEASED);
         break;
@@ -991,6 +997,8 @@ static void Mouse_Reset(void) {
 
     mouse.mickey_x = 0;
     mouse.mickey_y = 0;
+
+    mouse.buttons = 0;
 
     for (Bit16u but=0; but<MOUSE_BUTTONS; but++) {
         mouse.times_pressed[but] = 0;

--- a/src/libs/zmbv/zmbv_vfw.cpp
+++ b/src/libs/zmbv/zmbv_vfw.cpp
@@ -50,6 +50,7 @@ void Msg(const char fmt[], ...) {
   
   va_start(val, fmt);
   wvsprintf(buf, fmt, val);
+  va_end(val);
 
   const COORD _80x50 = {80,50};
   static BOOL startup = (AllocConsole(), SetConsoleScreenBufferSize(GetStdHandle(STD_OUTPUT_HANDLE), _80x50));

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -41,13 +41,18 @@ void CALLBACK_DeAllocate(Bitu in);
 Bitu call_shellstop = 0;
 /* Larger scope so shell_del autoexec can use it to
  * remove things from the environment */
-Program * first_shell = 0; 
+DOS_Shell * first_shell = 0; 
 
 static Bitu shellstop_handler(void) {
 	return CBRET_STOP;
 }
 
 static void SHELL_ProgramStart(Program * * make) {
+	*make = new DOS_Shell;
+}
+//Repeat it with the correct type, could do it in the function below, but this way it should be 
+//clear that if the above function is changed, this function might need a change as well.
+static void SHELL_ProgramStart_First_shell(DOS_Shell * * make) {
 	*make = new DOS_Shell;
 }
 
@@ -1130,7 +1135,7 @@ void SHELL_Run() {
 	LOG(LOG_MISC,LOG_DEBUG)("Running DOS shell now");
 
 	if (first_shell != NULL) E_Exit("Attempt to start shell when shell already running");
-	SHELL_ProgramStart(&first_shell);
+	SHELL_ProgramStart_First_shell(&first_shell);
 
 	try {
 		first_shell->Run();


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/4211/ - In this PR
https://sourceforge.net/p/dosbox/code-0/4212/ - In this PR
https://sourceforge.net/p/dosbox/code-0/4213/ - In this PR
https://sourceforge.net/p/dosbox/code-0/4214/ - In this PR
https://sourceforge.net/p/dosbox/code-0/4215/ - Skipped. Conflict.
https://sourceforge.net/p/dosbox/code-0/4216/ - Skipped. Overlay
https://sourceforge.net/p/dosbox/code-0/4217/ - Skipped. Overlay
https://sourceforge.net/p/dosbox/code-0/4218/ - In this PR
https://sourceforge.net/p/dosbox/code-0/4219/ - In this PR
https://sourceforge.net/p/dosbox/code-0/4220/ - Skipped. Irrelevant
https://sourceforge.net/p/dosbox/code-0/4221/ - Skipped. Irrelevant
https://sourceforge.net/p/dosbox/code-0/4222/ - Skipped. Irrelevant
https://sourceforge.net/p/dosbox/code-0/4223/ - In this PR
https://sourceforge.net/p/dosbox/code-0/4224/ - In this PR
https://sourceforge.net/p/dosbox/code-0/4225/ - Skipped. Overlay
https://sourceforge.net/p/dosbox/code-0/4226/ - In this PR
https://sourceforge.net/p/dosbox/code-0/4227/ - In this PR
https://sourceforge.net/p/dosbox/code-0/4228/ - Skipped. Not sure if needed
https://sourceforge.net/p/dosbox/code-0/4229/ - Skipped. Already in DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4230/ - In this PR

Compiles and runs.

As of now, r4230 is the latest SVN commit, so this brings us up-to-date! Although, I still need to go back and add the MAME sound and overlay drive commits, and I might be able to do something with some of the commits I skipped because they seemed to conflict with DOSBox-X's existing code.

Regarding https://sourceforge.net/p/dosbox/code-0/4228/, I skipped this as I wasn't sure if it is needed, because of all the changes to the SDL code. Do you know if the "red border with pixel_buffer and NVIDIA cards on Mac OS X and Linux" also affects DOSBox-X? The commit could be easily applied to DOSBox-X if it will help.

Also, regarding https://sourceforge.net/p/dosbox/code-0/4229/, I think this is unnecessary because it is already handled by DOSBox-X, but can you confirm? The clearing code in DOSBox-X is in src/output/output_opengl.cpp, and looks to be here:

```
void OUTPUT_OPENGL_EndUpdate(const Bit16u *changedLines)
{
    if (!(sdl.must_redraw_all && changedLines == NULL)) 
    {
        if (sdl_opengl.clear_countdown > 0)
        {
            sdl_opengl.clear_countdown--;
            glClearColor(0.0, 0.0, 0.0, 1.0);
            glClear(GL_COLOR_BUFFER_BIT);
        }
```