### PR TITLE
Fixing the readme to go to the proper URL : dosbox-x.com

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-DOSBox-X Manual (always use the latest version from www.dosbox-x.com)
+DOSBox-X Manual (always use the latest version from dosbox-x.com)
 
 DOSBox-X is a fork of the original DOSBox project (www.dosbox.com)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-DOSBox-X Manual (always use the latest version from dosbox-x.com)
+DOSBox-X Manual (always use the latest version from [dosbox-x.com](dosbox-x.com))
 
 DOSBox-X is a fork of the original DOSBox project (www.dosbox.com)
 


### PR DESCRIPTION
# Description
Greetings. Found this project via a google search and clicked the URL at the top of the readme and learned that there is no `www.` subdomain for `dosbos-x.com`. So, I updated the Readme accordingly.   

Feel free to merge or reject at your leisure. 