### PR TITLE
Revert SVN r4206

### DIFF
--- a/include/paging.h
+++ b/include/paging.h
@@ -77,11 +77,9 @@ static inline Bitu MEMMASK_Combine(const Bitu a,const Bitu b) {
 #define PFLAG_READABLE		0x1
 #define PFLAG_WRITEABLE		0x2
 #define PFLAG_HASROM		0x4
-#define PFLAG_HASCODE32		0x8				//Page contains 32-bit dynamic code
+#define PFLAG_HASCODE		0x8				//Page contains dynamic code
 #define PFLAG_NOCODE		0x10			//No dynamic code can be generated here
 #define PFLAG_INIT			0x20			//No dynamic code can be generated here
-#define PFLAG_HASCODE16		0x40			//Page contains 16-bit dynamic code
-#define PFLAG_HASCODE		(PFLAG_HASCODE32|PFLAG_HASCODE16)
 
 #define LINK_START	((1024+64)/4)			//Start right after the HMA
 

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -174,14 +174,16 @@ CacheBlockDynRec * LinkBlocks(BlockReturn ret) {
 	// the last instruction was a control flow modifying instruction
 	Bitu temp_ip=SegPhys(cs)+reg_eip;
 	CodePageHandlerDynRec * temp_handler=(CodePageHandlerDynRec *)get_tlb_readhandler(temp_ip);
-	if (temp_handler->flags & (cpu.code.big ? PFLAG_HASCODE32:PFLAG_HASCODE16)) {
+	if (temp_handler->flags & PFLAG_HASCODE) {
 		// see if the target is an already translated block
 		block=temp_handler->FindCacheBlock(temp_ip & 4095);
-		if (block) { // found it, link the current block to
-			cache.block.running->LinkTo(ret==BR_Link2,block);
-		}
+		if (!block) return NULL;
+
+		// found it, link the current block to
+		cache.block.running->LinkTo(ret==BR_Link2,block);
+		return block;
 	}
-	return block;
+	return NULL;
 }
 
 /*

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -96,7 +96,7 @@ public:
 		old_pagehandler=_old_pagehandler;
 
 		// adjust flags
-		flags=old_pagehandler->flags|(cpu.code.big ? PFLAG_HASCODE32:PFLAG_HASCODE16);
+		flags=old_pagehandler->flags|PFLAG_HASCODE;
 		flags&=~PFLAG_WRITEABLE;
 
 		active_blocks=0;

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -130,30 +130,21 @@ static struct DynDecode {
 
 static bool MakeCodePage(Bitu lin_addr,CodePageHandlerDynRec * &cph) {
 	Bit8u rdval;
-	const Bitu cflag = cpu.code.big ? PFLAG_HASCODE32:PFLAG_HASCODE16;
 	//Ensure page contains memory:
 	if (GCC_UNLIKELY(mem_readb_checked((PhysPt)lin_addr,&rdval))) return true;
 
 	PageHandler * handler=get_tlb_readhandler((PhysPt)lin_addr);
 	if (handler->flags & PFLAG_HASCODE) {
-		// this is a codepage handler, make sure it matches current code size
+		// this is a codepage handler, and the one that we're looking for
 		cph=(CodePageHandlerDynRec *)handler;
-		if (handler->flags & cflag) return false;
-		// wrong code size/stale dynamic code, drop it
-		cph->ClearRelease();
-		cph=0;
-		// handler was changed, refresh
-		handler=get_tlb_readhandler(lin_addr);
+		return false;
 	}
 	if (handler->flags & PFLAG_NOCODE) {
 		if (false) { // PAGING_ForcePageInit(lin_addr)) {
 			handler=get_tlb_readhandler((PhysPt)lin_addr);
 			if (handler->flags & PFLAG_HASCODE) {
 				cph=(CodePageHandlerDynRec *)handler;
-				if (handler->flags & cflag) return false;
-				cph->ClearRelease();
-				cph=0;
-				handler=get_tlb_readhandler(lin_addr);
+				return false;
 			}
 		}
 		if (handler->flags & PFLAG_NOCODE) {


### PR DESCRIPTION
SVN r4206
https://github.com/joncampbell123/dosbox-x/commit/15338b598d676d953af53d21e96a77c9528164a2
causes _The Elder Scrolls: Daggerfall_ to crash DOSBox-X when started, with


`DYNREC:Can't run code in this page`

appearing twice in a row in the log.

This doesn't happen in mainline DOSBox, despite having the same commit in it (except that in the case of mainline commit, changes were also applied to `core_dyn_x86`, which was removed from DOSBox-X).

Reverting the commit stops the problem. Any idea what the cause is? Can we salvage the commit, and do you think it's useful? (It _sounds_ useful, as the original SVN commit message states it "fixes some hard to reproduce problems")

I'm putting off updating the skipped SVN commits file and removing the CHANGELOG entry for now.

