### PR TITLE
Fix warnings

### DIFF
--- a/include/cpu.h
+++ b/include/cpu.h
@@ -176,10 +176,10 @@ void CPU_NMI_Interrupt();
 static INLINE void CPU_HW_Interrupt(Bitu num) {
 	CPU_Interrupt(num,0,reg_eip);
 }
-static INLINE void CPU_SW_Interrupt(Bitu num,Bitu oldeip) {
+static INLINE void CPU_SW_Interrupt(Bitu num,Bit32u oldeip) {
 	CPU_Interrupt(num,CPU_INT_SOFTWARE,oldeip);
 }
-static INLINE void CPU_SW_Interrupt_NoIOPLCheck(Bitu num,Bitu oldeip) {
+static INLINE void CPU_SW_Interrupt_NoIOPLCheck(Bitu num,Bit32u oldeip) {
 	CPU_Interrupt(num,CPU_INT_SOFTWARE|CPU_INT_NOIOPLCHECK,oldeip);
 }
 

--- a/src/cpu/core_full.cpp
+++ b/src/cpu/core_full.cpp
@@ -97,7 +97,7 @@ Bits CPU_Core_Full_Run(void) {
 #endif
 
 		LoadIP();
-		inst.entry=cpu.code.big*0x200u;
+		inst.entry=cpu.code.big*(Bitu)0x200u;
 		inst.prefix=cpu.code.big;
 restartopcode:
 		inst.entry=(inst.entry & 0xffffff00u) | Fetchb();

--- a/src/cpu/core_normal.cpp
+++ b/src/cpu/core_normal.cpp
@@ -160,7 +160,7 @@ Bits CPU_Core_Normal_Run(void) {
 
 	while (CPU_Cycles-->0) {
 		LOADIP;
-		core.opcode_index=cpu.code.big*0x200u;
+		core.opcode_index=cpu.code.big*(Bitu)0x200u;
 		core.prefixes=cpu.code.big;
 		core.ea_table=&EATable[cpu.code.big*256u];
 		BaseDS=SegBase(ds);

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -653,6 +653,10 @@ class TaskStateSegment {
 public:
 	TaskStateSegment() {
 		valid=false;
+        base = 0;
+        is386 = 0;
+        limit = 0;
+        selector = 0;
 	}
 	bool IsValid(void) {
 		return valid;

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -710,9 +710,6 @@ public:
 		return true;
 	}
 
-	void SaveState( std::ostream& stream );
-	void LoadState( std::istream& stream );
-
 	TSS_Descriptor desc;
 	Bitu selector;
 	PhysPt base;

--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -922,8 +922,8 @@ static void PAGING_LinkPageNew(Bitu lin_page, Bitu phys_page, Bitu linkmode, boo
 void PAGING_LinkPage(Bitu lin_page,Bitu phys_page) {
 	PageHandler * handler=MEM_GetPageHandler(phys_page);
 	Bitu lin_base=lin_page << 12;
-	if (lin_page>=TLB_SIZE || phys_page>=TLB_SIZE) 
-		E_Exit("Illegal page");
+	if (lin_page>=TLB_SIZE || phys_page>=TLB_SIZE)
+		return E_Exit("Illegal page");
 
 	if (paging.links.used>=PAGING_LINKS) {
 		LOG(LOG_PAGING,LOG_NORMAL)("Not enough paging links, resetting cache");

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -471,7 +471,6 @@ public:
 	static void				DeactivateBreakpoints();
 	static void				ActivateBreakpoints	();
 	static void				ActivateBreakpointsExceptAt(PhysPt adr);
-	static bool				CheckBreakpoint		(PhysPt adr);
 	static bool				CheckBreakpoint		(Bitu seg, Bitu off);
 	static bool				CheckIntBreakpoint	(PhysPt adr, Bit8u intNr, Bit16u ahValue, Bit16u alValue);
 	static CBreakpoint*		FindPhysBreakpoint	(Bit16u seg, Bit32u off, bool once);

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -3445,7 +3445,7 @@ static void LogEMS(void) {
         }
     }
 
-    bool EMS_GetMapping(Bitu &handle,Bitu &log_page,Bitu ems_page);
+    bool EMS_GetMapping(Bitu &handle,Bit16u &log_page,Bitu ems_page);
     Bitu GetEMSPageFrameSegment(void);
     Bitu GetEMSPageFrameSize(void);
 
@@ -3455,7 +3455,8 @@ static void LogEMS(void) {
     LOG(LOG_MISC,LOG_ERROR)("Handle Page(p/l) Address");
 
     for (Bitu p=0;p < (GetEMSPageFrameSize() >> 14UL);p++) {
-        Bitu log_page,handle;
+        Bit16u log_page;
+        Bitu handle;
 
         if (EMS_GetMapping(handle,log_page,p)) {
             char tmp[192] = {0};
@@ -3467,8 +3468,8 @@ static void LogEMS(void) {
 
             if (xh_addr != 0)
                 sprintf(tmp," virt -> %08lx-%08lx phys",
-                    (unsigned long)xh_addr + (log_page << 14UL),
-                    (unsigned long)xh_addr + (log_page << 14UL) + (1 << 14UL) - 1);
+                    xh_addr + (log_page << 14),
+                    xh_addr + (log_page << 14) + (1 << 14) - 1);
 
             LOG(LOG_MISC,LOG_ERROR)("%6lu %4lu/%4lu %08lx-%08lx%s",(unsigned long)handle,
                 (unsigned long)p,(unsigned long)log_page,

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -211,7 +211,7 @@ void DOS_AddDevice(DOS_Device * adddev) {
 void DOS_DelDevice(DOS_Device * dev) {
 // We will destroy the device if we find it in our list.
 // TODO:The file table is not checked to see the device is opened somewhere!
-	if (dev == NULL) E_Exit("DOS_DelDevice with null ptr");
+	if (dev == NULL) return E_Exit("DOS_DelDevice with null ptr");
 	for (Bitu i = 0; i <DOS_DEVICES;i++) {
 		if (Devices[i] == dev) { /* NTS: The mainline code deleted by matching names??? Why? */
 //			LOG_MSG("DOS_DelDevice %s (%p)\n",dev->name,(void*)dev);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -191,7 +191,6 @@ extern double           rtdelta;
 static LoopHandler*     loop;
 
 /* The whole load of startups for all the subfunctions */
-void                LOG_StartUp(void);
 void                MEM_Init(Section *);
 void                ISAPNP_Cfg_Init(Section *);
 void                ROMBIOS_Init(Section *);
@@ -240,7 +239,6 @@ void                DONGLE_Init(Section*);
 #if C_IPX
 void                IPX_Init(Section*);
 #endif
-void                SID_Init(Section* sec);
 void                PIC_Init(Section*);
 void                TIMER_Init(Section*);
 void                BIOS_Init(Section*);
@@ -254,9 +252,6 @@ void                XMS_Init(Section*);
 void                DOS_KeyboardLayout_Init(Section*);
 void                AUTOEXEC_Init(Section*);
 void                INT10_Init(Section*);
-#if C_NE2000
-void                NE2K_Init(Section* sec);
-#endif
 #if C_PRINTER
 void                PRINTER_Init(Section*);
 #endif
@@ -717,8 +712,6 @@ void parse_busclk_setting_str(ClockDomain *cd,const char *s) {
 }
 
 unsigned int dosbox_shell_env_size = 0;
-
-void clocktree_build_conversion_list();
 
 void Null_Init(Section *sec) {
 	(void)sec;

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -3551,6 +3551,7 @@ IDEController::IDEController(Section* configuration,unsigned char index):Module_
     select = 0;
     alt_io = 0;
     IRQ = -1;
+    drivehead = 0;
 
     i = section->Get_int("irq");
     if (i > 0 && i <= 15) IRQ = i;

--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -140,7 +140,7 @@ static EMM_Handle emm_handles[EMM_MAX_HANDLES];
 static EMM_Mapping emm_mappings[EMM_MAX_PHYS];
 static EMM_Mapping emm_segmentmappings[0x40];
 
-bool EMS_GetMapping(Bitu &handle,Bitu &log_page,Bitu ems_page) {
+bool EMS_GetMapping(Bitu &handle,Bit16u &log_page,Bitu ems_page) {
     if (ems_page < EMM_MAX_PHYS) {
         auto &x = emm_mappings[ems_page];
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -179,6 +179,7 @@ DOS_Shell::DOS_Shell():Program(){
 	bf=0;
 	call=false;
     input_eof=false;
+    completion_index = 0;
 }
 
 Bitu DOS_Shell::GetRedirection(char *s, char **ifn, char **ofn,bool * append) {

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1027,7 +1027,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 			return;
 		}
 
-		Bit16u sourceHandle,targetHandle;
+		Bit16u sourceHandle,targetHandle = 0;
 		char nameTarget[DOS_PATHLENGTH];
 		char nameSource[DOS_PATHLENGTH];
 		


### PR DESCRIPTION
Fixes to warnings in the Visual Studio build output and IDE.
Build output warnings down from 1807 in master to 1711.

Compiles and runs.