### PR TITLE
Type-cast warning fixes, and update changelog and skipped commits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -110,10 +110,6 @@
     - Check lengths before adding C-style strings together.
     - Fix unmounting of complex drives where parts were left and
     file pointers were kept open.
-    - Store whether generated code is 16- or 32-bit, so this
-    information can be used when checking for self-modifying
-    code. Some code is identical except for being 32- or 16-bit.
-    Fixes some hard to reproduce problems with small codeblocks.
     - Stop storing raw modrm value. Should save an instruction
     on each get_modrm call.
     - Strip leading = from value. Can happen if you execute

--- a/patch-integration/Skipped SVN commits.txt
+++ b/patch-integration/Skipped SVN commits.txt
@@ -60,6 +60,7 @@ Commit#:	Reason for skipping:
 4196		New overlay drive, skipping for now
 4199		Conflict
 4200		Conflict
+4206		Caused unexpected "DYNREC:Can't run code in this page" error
 4215		Conflict
 4216		Overlay
 4217		Overlay

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -172,7 +172,7 @@ static struct {
 CacheBlockDynRec * LinkBlocks(BlockReturn ret) {
 	CacheBlockDynRec * block=NULL;
 	// the last instruction was a control flow modifying instruction
-	Bitu temp_ip=SegPhys(cs)+reg_eip;
+	Bit32u temp_ip=SegPhys(cs)+reg_eip;
 	CodePageHandlerDynRec * temp_handler=(CodePageHandlerDynRec *)get_tlb_readhandler(temp_ip);
 	if (temp_handler->flags & PFLAG_HASCODE) {
 		// see if the target is an already translated block

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -122,7 +122,7 @@ static struct DynDecode {
 	struct {
 //		Bitu val;
 		Bitu mod;
-		Bitu rm;
+		Bit8u rm;
 		Bitu reg;
 	} modrm;
 } decode;

--- a/src/cpu/core_dynrec/decoder_opcodes.h
+++ b/src/cpu/core_dynrec/decoder_opcodes.h
@@ -313,14 +313,14 @@ static void dyn_sop_word(SingleOps op,Bit8u reg) {
 }
 
 
-static void dyn_mov_byte_al_direct(Bitu imm) {
+static void dyn_mov_byte_al_direct(Bit32u imm) {
 	MOV_SEG_PHYS_TO_HOST_REG(FC_ADDR,(decode.seg_prefix_used ? decode.seg_prefix : DRC_SEG_DS));
 	gen_add_imm(FC_ADDR,imm);
 	dyn_read_byte(FC_ADDR,FC_TMP_BA1);
 	MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_TMP_BA1,DRC_REG_EAX,0);
 }
 
-static void dyn_mov_byte_ax_direct(Bitu imm) {
+static void dyn_mov_byte_ax_direct(Bit32u imm) {
 	MOV_SEG_PHYS_TO_HOST_REG(FC_ADDR,(decode.seg_prefix_used ? decode.seg_prefix : DRC_SEG_DS));
 	gen_add_imm(FC_ADDR,imm);
 	dyn_read_word(FC_ADDR,FC_OP1,decode.big_op);
@@ -343,7 +343,7 @@ static void dyn_mov_byte_direct_al() {
 	dyn_write_byte(FC_ADDR,FC_TMP_BA1);
 }
 
-static void dyn_mov_byte_direct_ax(Bitu imm) {
+static void dyn_mov_byte_direct_ax(Bit32u imm) {
 	MOV_SEG_PHYS_TO_HOST_REG(FC_ADDR,(decode.seg_prefix_used ? decode.seg_prefix : DRC_SEG_DS));
 	gen_add_imm(FC_ADDR,imm);
 	MOV_REG_WORD_TO_HOST_REG(FC_OP1,DRC_REG_EAX,decode.big_op);
@@ -433,7 +433,7 @@ static void dyn_push_byte_imm(Bit8s imm) {
 	else gen_call_function_raw((void*)&dynrec_push_word);
 }
 
-static void dyn_push_word_imm(Bitu imm) {
+static void dyn_push_word_imm(Bit32u imm) {
 	if (decode.big_op) {
 		gen_mov_dword_to_reg_imm(FC_OP1,imm);
 		gen_call_function_raw((void*)&dynrec_push_dword);
@@ -1096,7 +1096,7 @@ static void dyn_sahf(void) {
 }
 
 
-static void dyn_exit_link(Bits eip_change) {
+static void dyn_exit_link(Bit32s eip_change) {
 	gen_add_direct_word(&reg_eip,(decode.code-decode.code_start)+eip_change,decode.big_op);
 	dyn_reduce_cycles();
 	gen_jmp_ptr(&decode.block->link[0].to,offsetof(CacheBlockDynRec,cache.start));
@@ -1105,7 +1105,7 @@ static void dyn_exit_link(Bits eip_change) {
 
 
 static void dyn_branched_exit(BranchTypes btype,Bit32s eip_add) {
-	Bitu eip_base=decode.code-decode.code_start;
+	Bit32u eip_base=decode.code-decode.code_start;
 	dyn_reduce_cycles();
 
 	dyn_branchflag_to_reg(btype);
@@ -1138,8 +1138,8 @@ static void dyn_set_byte_on_condition(BranchTypes btype) {
 
 static void dyn_loop(LoopTypes type) {
 	dyn_reduce_cycles();
-	Bits eip_add=(Bit8s)decode_fetchb();
-	Bitu eip_base=decode.code-decode.code_start;
+	Bit8s eip_add=(Bit8s)decode_fetchb();
+	Bit32u eip_base=decode.code-decode.code_start;
 	DRC_PTR_SIZE_IM branch1=0;
 	DRC_PTR_SIZE_IM branch2=0;
 	switch (type) {
@@ -1186,7 +1186,7 @@ static void dyn_loop(LoopTypes type) {
 }
 
 
-static void dyn_ret_near(Bitu bytes) {
+static void dyn_ret_near(Bit16u bytes) {
 	dyn_reduce_cycles();
 
 	if (decode.big_op) gen_call_function_raw((void*)&dynrec_pop_dword);
@@ -1202,7 +1202,7 @@ static void dyn_ret_near(Bitu bytes) {
 }
 
 static void dyn_call_near_imm(void) {
-	Bits imm;
+	Bit32s imm;
 	if (decode.big_op) imm=(Bit32s)decode_fetchd();
 	else imm=(Bit16s)decode_fetchw();
 	dyn_set_eip_end(FC_OP1);
@@ -1426,7 +1426,7 @@ static void dynrec_pusha_word(void) {
 }
 
 static void dynrec_pusha_dword(void) {
-	Bitu tmpesp = reg_esp;
+	Bit32u tmpesp = reg_esp;
 	CPU_Push32(reg_eax);CPU_Push32(reg_ecx);CPU_Push32(reg_edx);CPU_Push32(reg_ebx);
 	CPU_Push32(tmpesp);CPU_Push32(reg_ebp);CPU_Push32(reg_esi);CPU_Push32(reg_edi);
 }

--- a/src/cpu/core_dynrec/operators.h
+++ b/src/cpu/core_dynrec/operators.h
@@ -1676,8 +1676,8 @@ static Bit32u DRC_CALL_CONV dynrec_movsb_dword(Bit32u count,Bit32s add_index,Phy
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
-		count_left=count-CPU_Cycles;
-		count=CPU_Cycles;
+		count_left= (Bit32u)(count-CPU_Cycles);
+		count= (Bit32u)CPU_Cycles;
 		CPU_Cycles=0;
 	}
 	for (;count>0;count--) {
@@ -1713,8 +1713,8 @@ static Bit32u DRC_CALL_CONV dynrec_movsw_dword(Bit32u count,Bit32s add_index,Phy
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
-		count_left=count-CPU_Cycles;
-		count=CPU_Cycles;
+		count_left= (Bit32u)(count-CPU_Cycles);
+		count= (Bit32u)CPU_Cycles;
 		CPU_Cycles=0;
 	}
 	add_index<<=1;
@@ -1751,8 +1751,8 @@ static Bit32u DRC_CALL_CONV dynrec_movsd_dword(Bit32u count,Bit32s add_index,Phy
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
-		count_left=count-CPU_Cycles;
-		count=CPU_Cycles;
+		count_left= (Bit32u)(count - CPU_Cycles);
+		count= (Bit32u)CPU_Cycles;
 		CPU_Cycles=0;
 	}
 	add_index<<=2;
@@ -1788,8 +1788,8 @@ static Bit32u DRC_CALL_CONV dynrec_lodsb_dword(Bit32u count,Bit32s add_index,Phy
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
-		count_left=count-CPU_Cycles;
-		count=CPU_Cycles;
+		count_left= (Bit32u)(count - CPU_Cycles);
+		count= (Bit32u)CPU_Cycles;
 		CPU_Cycles=0;
 	}
 	for (;count>0;count--) {
@@ -1823,8 +1823,8 @@ static Bit32u DRC_CALL_CONV dynrec_lodsw_dword(Bit32u count,Bit32s add_index,Phy
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
-		count_left=count-CPU_Cycles;
-		count=CPU_Cycles;
+		count_left= (Bit32u)(count - CPU_Cycles);
+		count= (Bit32u)CPU_Cycles;
 		CPU_Cycles=0;
 	}
 	add_index<<=1;
@@ -1859,8 +1859,8 @@ static Bit32u DRC_CALL_CONV dynrec_lodsd_dword(Bit32u count,Bit32s add_index,Phy
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
-		count_left=count-CPU_Cycles;
-		count=CPU_Cycles;
+		count_left= (Bit32u)(count - CPU_Cycles);
+		count= (Bit32u)CPU_Cycles;
 		CPU_Cycles=0;
 	}
 	add_index<<=2;
@@ -1895,8 +1895,8 @@ static Bit32u DRC_CALL_CONV dynrec_stosb_dword(Bit32u count,Bit32s add_index,Phy
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
-		count_left=count-CPU_Cycles;
-		count=CPU_Cycles;
+		count_left= (Bit32u)(count - CPU_Cycles);
+		count= (Bit32u)CPU_Cycles;
 		CPU_Cycles=0;
 	}
 	for (;count>0;count--) {
@@ -1930,8 +1930,8 @@ static Bit32u DRC_CALL_CONV dynrec_stosw_dword(Bit32u count,Bit32s add_index,Phy
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
-		count_left=count-CPU_Cycles;
-		count=CPU_Cycles;
+		count_left= (Bit32u)(count - CPU_Cycles);
+		count=(Bit32u) CPU_Cycles;
 		CPU_Cycles=0;
 	}
 	add_index<<=1;
@@ -1966,8 +1966,8 @@ static Bit32u DRC_CALL_CONV dynrec_stosd_dword(Bit32u count,Bit32s add_index,Phy
 	if (count<(Bitu)CPU_Cycles) {
 		count_left=0;
 	} else {
-		count_left=count-CPU_Cycles;
-		count=CPU_Cycles;
+		count_left= (Bit32u)(count - CPU_Cycles);
+		count=(Bit32u) CPU_Cycles;
 		CPU_Cycles=0;
 	}
 	add_index<<=2;

--- a/src/cpu/core_dynrec/risc_x64.h
+++ b/src/cpu/core_dynrec/risc_x64.h
@@ -352,8 +352,8 @@ static INLINE void gen_lea(HostReg dest_reg,HostReg scale_reg,Bitu scale,Bits im
 
 	switch (imm_size) {
 	case 0:	break;
-	case 1:cache_addb(imm);break;
-	case 4:cache_addd(imm);break;
+	case 1:cache_addb((Bit8u)imm);break;
+	case 4:cache_addd((Bit32u)imm);break;
 	}
 }
 
@@ -366,9 +366,9 @@ static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 	cache_addb(0x48);
 	cache_addb(0x8d);			//LEA
 	cache_addb(0x04+(dest_reg<<3));
-	cache_addb(0x05+(dest_reg<<3)+(scale<<6));
+	cache_addb((Bit8u)(0x05+(dest_reg<<3)+(scale<<6)));
 
-	cache_addd(imm);		// always add dword immediate
+	cache_addd((Bit32u)imm);		// always add dword immediate
 }
 
 
@@ -535,10 +535,10 @@ static void gen_jmp_ptr(void * ptr,Bits imm=0) {
 		cache_addb(0x20);
     } else if ((imm>=-128 && imm<=127)) {
 		cache_addb(0x60);
-		cache_addb(imm);
+		cache_addb((Bit8u)imm);
 	} else {
 		cache_addb(0xa0);
-		cache_addd(imm);
+		cache_addd((Bit32u)imm);
 	}
 }
 

--- a/src/cpu/core_full/string.h
+++ b/src/cpu/core_full/string.h
@@ -19,8 +19,8 @@
 {
 	extern int cpu_rep_max;
 	static PhysPt  si_base,di_base;
-	static Bitu	si_index,di_index;
-	static Bitu	add_mask;
+	static Bit32u	si_index,di_index;
+	static Bit32u	add_mask;
 	static Bitu	count,count_left;
 	static Bits	add_index;
 

--- a/src/cpu/core_normal/string.h
+++ b/src/cpu/core_normal/string.h
@@ -34,8 +34,8 @@ extern int cpu_rep_max;
 
 void DoString(STRING_OP type) {
 	static PhysPt  si_base,di_base;
-	static Bitu	si_index,di_index;
-	static Bitu	add_mask;
+	static Bit32u	si_index,di_index;
+	static Bit32u	add_mask;
 	static Bitu	count,count_left;
 	static Bits	add_index;
 

--- a/src/cpu/lazyflags.h
+++ b/src/cpu/lazyflags.h
@@ -39,7 +39,7 @@ struct LazyFlags {
     GenReg32 var1,var2,res;
 	Bitu type;
 	Bitu prev_type;
-	Bitu oldcf;
+	Bit8u oldcf;
 };
 
 extern LazyFlags lfags;


### PR DESCRIPTION
Fixes for type-cast warnings in the Visual Studio compiler output.

Number of warnings down from 1711 to 1365.

Compiles and runs.

Also updated changelog and skipped commits regarding the reverting of SVN r4206.