### PR TITLE
Updated build instructions for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,9 @@ I am rewriting this README, and new information will be added over time --J.C.
 How to compile DOSBox-X in Ubuntu (kapper1224)
 ----------------------------------------------
 
-sudo apt install libavformat-* libswscale-* libavcodec-*
-./autogen.sh
-./configure
-make
-sudo make install
+    sudo apt install automake libncurses-dev nasm libsdl-net1.2-dev libpcap-dev libfluidsynth-devffmpeg libavdevice58 libavformat-* libswscale-* libavcodec-*
+    ./build
+    sudo make install
 
 
 


### PR DESCRIPTION
I fixed the formatting, changed it to recommend `build` instead of `autogen.sh` etc to properly compile the internal SDL, and added a few packages that I noticed `configure.sh` wanted. I also think the original line using wildcards is too general and will probably install unnecessary packages, but I'm a noob and I feel like that's outside my wheelhouse.