### PR TITLE
Type-conversion warning fixes

### DIFF
--- a/src/gui/render_scalers.cpp
+++ b/src/gui/render_scalers.cpp
@@ -63,9 +63,9 @@ static INLINE void BituMove( void *_dst, const void * _src, Bitu size) {
 
 static INLINE void ScalerAddLines( Bitu changed, Bitu count ) {
 	if ((Scaler_ChangedLineIndex & 1) == changed ) {
-		Scaler_ChangedLines[Scaler_ChangedLineIndex] += count;
+		Scaler_ChangedLines[Scaler_ChangedLineIndex] += (Bit16u)count;
 	} else {
-		Scaler_ChangedLines[++Scaler_ChangedLineIndex] = count;
+		Scaler_ChangedLines[++Scaler_ChangedLineIndex] = (Bit16u)count;
 	}
 	render.scale.outWrite += render.scale.outPitch * count;
 }

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -352,7 +352,7 @@ static GUI::ScreenSDL *UI_Startup(GUI::ScreenSDL *screen) {
     if (screen) screen->setSurface(sdlscreen);
     else screen = new GUI::ScreenSDL(sdlscreen);
 
-    saved_bpp = render.src.bpp;
+    saved_bpp = (int)render.src.bpp;
     render.src.bpp = 0;
     running = true;
 

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1091,7 +1091,7 @@ public:
         const auto joystick = this->GetJoystick();
         const auto axis = this->GetAxis();
         const auto positive = this->GetPositive();
-        const auto deadzone = GetJoystickDeadzone(joystick, axis, positive);
+        const auto deadzone = GetJoystickDeadzone((int)joystick, (int)axis, positive);
         
         if (_value > deadzone && event->IsTrigger()) 
             _value = 25000 + 1;
@@ -1192,7 +1192,7 @@ public:
         emulated_hats=0;
         JOYSTICK_Enable(emustick,true);
 
-        sdl_joystick=SDL_JoystickOpen(_stick);
+        sdl_joystick=SDL_JoystickOpen((int)_stick);
         if (sdl_joystick==NULL) {
             button_wrap=emulated_buttons;
             return;
@@ -1220,7 +1220,7 @@ public:
 #if defined(C_SDL2)
         LOG_MSG("Using joystick %s with %d axes, %d buttons and %d hat(s)",SDL_JoystickNameForIndex(stick),(int)axes,(int)buttons,(int)hats);
 #else
-        LOG_MSG("Using joystick %s with %d axes, %d buttons and %d hat(s)",SDL_JoystickName(stick),(int)axes,(int)buttons,(int)hats);
+        LOG_MSG("Using joystick %s with %d axes, %d buttons and %d hat(s)",SDL_JoystickName((int)stick),(int)axes,(int)buttons,(int)hats);
 #endif
 
         // fetching these at every call simply freezes DOSBox at times so we do it once
@@ -1331,7 +1331,7 @@ public:
                 JOYSTICK_Button(emustick,i,button_pressed[i]);
         }
 
-        auto v = GetJoystickVector(emustick, 0, 0, 1);
+        auto v = GetJoystickVector((int)emustick, 0, 0, 1);
         JOYSTICK_Move_X(emustick, v.X);
         JOYSTICK_Move_Y(emustick, v.Y);
     }
@@ -1345,7 +1345,7 @@ public:
         for (i=0; i<MAXBUTTON; i++) button_pressed[i]=false;
         /* read button states */
         for (i=0; i<button_cap; i++) {
-            if (SDL_JoystickGetButton(sdl_joystick,i))
+            if (SDL_JoystickGetButton(sdl_joystick,(int)i))
                 button_pressed[i % button_wrap]=true;
         }
         for (i=0; i<button_wrap; i++) {
@@ -1359,7 +1359,7 @@ public:
         
         int* axis_map = stick == 0 ? &joy1axes[0] : &joy2axes[0];
         for (i=0; i<axes; i++) {
-            Bitu i1 = axis_map[i];
+            int i1 = axis_map[i];
             Sint16 caxis_pos=SDL_JoystickGetAxis(sdl_joystick,i1);
             /* activate bindings for joystick position */
             if (caxis_pos>1) {
@@ -1392,7 +1392,7 @@ public:
         }
 
         for (i=0; i<hats; i++) {
-            Uint8 chat_state=SDL_JoystickGetHat(sdl_joystick,i);
+            Uint8 chat_state=SDL_JoystickGetHat(sdl_joystick,(int)i);
 
             /* activate binding if hat state has changed */
             if ((chat_state & SDL_HAT_UP) != (old_hat_state[i] & SDL_HAT_UP)) {
@@ -1445,7 +1445,7 @@ private:
 #if defined(C_SDL2)
         if (sdl_joystick!=NULL) return SDL_JoystickNameForIndex(stick);
 #else
-        if (sdl_joystick!=NULL) return SDL_JoystickName(stick);
+        if (sdl_joystick!=NULL) return SDL_JoystickName((int)stick);
 #endif
         else return "[missing joystick]";
     }
@@ -2353,8 +2353,8 @@ public:
         if (notify_button != NULL)
             notify_button->SetInvert(yesno);
 
-        if (yesno) mapper.mods|=(1u << (wmod-1u));
-        else mapper.mods&=~(1u << (wmod-1u));
+        if (yesno) mapper.mods|=((Bitu)1u << (wmod-1u));
+        else mapper.mods&=~((Bitu)1u << (wmod-1u));
     };
 
     //! \brief Associate this object with a text button in the mapper UI
@@ -2373,7 +2373,7 @@ std::string CBind::GetModifierText(void) {
     std::string r,t;
 
     for (size_t m=4u/*Host key first*/;m >= 1u;m--) {
-        if ((mods & (1u << (m - 1u))) && mod_event[m] != NULL) {
+        if ((mods & ((Bitu)1u << (m - 1u))) && mod_event[m] != NULL) {
             t = mod_event[m]->GetBindMenuText();
             if (!r.empty()) r += "+";
             r += t;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -810,7 +810,7 @@ void GFX_SDL_Overscan(void) {
                 }
             } else {
                 for (Bitu i=0; i<4; i++)
-                    SDL_FillRect(sdl.surface, &sdl.updateRects[i], border_color);
+                    SDL_FillRect(sdl.surface, &sdl.updateRects[i], (Uint32)border_color);
 
 #if defined(C_SDL2)
                 SDL_UpdateWindowSurfaceRects(sdl.window, sdl.updateRects, 4);
@@ -1812,8 +1812,8 @@ Bitu GFX_SetSize(Bitu width, Bitu height, Bitu flags, double scalex, double scal
 
     sdl.must_redraw_all = true;
 
-    sdl.draw.width = width;
-    sdl.draw.height = height;
+    sdl.draw.width = (Bit32u)width;
+    sdl.draw.height = (Bit32u)height;
     sdl.draw.flags = flags;
     sdl.draw.callback = callback;
     sdl.draw.scalex = scalex;
@@ -2477,7 +2477,7 @@ void change_output(int output) {
     if (sdl.draw.callback)
         (sdl.draw.callback)( GFX_CallBackReset );
 
-    GFX_SetTitle(CPU_CycleMax,-1,-1,false);
+    GFX_SetTitle((Bit32s)CPU_CycleMax,-1,-1,false);
     GFX_LogSDLState();
 
     UpdateWindowDimensions();
@@ -2845,11 +2845,11 @@ void GFX_SetPalette(Bitu start,Bitu count,GFX_PalEntry * entries) {
 #if !defined(C_SDL2)
     /* I should probably not change the GFX_PalEntry :) */
     if (sdl.surface->flags & SDL_HWPALETTE) {
-        if (!SDL_SetPalette(sdl.surface,SDL_PHYSPAL,(SDL_Color *)entries,start,count)) {
+        if (!SDL_SetPalette(sdl.surface,SDL_PHYSPAL,(SDL_Color *)entries,(int)start,(int)count)) {
             E_Exit("SDL:Can't set palette");
         }
     } else {
-        if (!SDL_SetPalette(sdl.surface,SDL_LOGPAL,(SDL_Color *)entries,start,count)) {
+        if (!SDL_SetPalette(sdl.surface,SDL_LOGPAL,(SDL_Color *)entries,(int)start,(int)count)) {
             E_Exit("SDL:Can't set palette");
         }
     }
@@ -6969,7 +6969,7 @@ bool showdetails_menu_callback(DOSBoxMenu * const xmenu, DOSBoxMenu::item * cons
     (void)xmenu;//UNUSED
     (void)menuitem;//UNUSED
     menu.showrt = !(menu.hidecycles = !menu.hidecycles);
-    GFX_SetTitle(CPU_CycleMax, -1, -1, false);
+    GFX_SetTitle((Bit32s)CPU_CycleMax, -1, -1, false);
     mainMenu.get_item("showdetails").check(!menu.hidecycles).refresh_item(mainMenu);
     return true;
 }
@@ -8221,8 +8221,8 @@ fresh_boot:
 
             /* revector some dos-allocated interrupts */
             if (!reboot_machine) {
-                real_writed(0,0x01*4,BIOS_DEFAULT_HANDLER_LOCATION);
-                real_writed(0,0x03*4,BIOS_DEFAULT_HANDLER_LOCATION);
+                real_writed(0,0x01*4,(Bit32u)BIOS_DEFAULT_HANDLER_LOCATION);
+                real_writed(0,0x03*4,(Bit32u)BIOS_DEFAULT_HANDLER_LOCATION);
             }
 
             /* shutdown DOSBox's virtual drive Z */

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -61,7 +61,7 @@ namespace OPL2 {
 		}
 
 		virtual void Init( Bitu rate ) {
-			adlib_init(rate);
+			adlib_init((Bit32u)rate);
 		}
 
 		~Handler() {
@@ -92,7 +92,7 @@ namespace OPL3 {
 		}
 
 		virtual void Init( Bitu rate ) {
-			adlib_init(rate);
+			adlib_init((Bit32u)rate);
 		}
 
 		~Handler() {
@@ -119,12 +119,12 @@ namespace NukedOPL {
 			while( samples > 0 ) {
 				Bitu todo = samples > 1024 ? 1024 : samples;
 				samples -= todo;
-				OPL3_GenerateStream(&chip, buf, todo);
+				OPL3_GenerateStream(&chip, buf, (Bit32u)todo);
 				chan->AddSamples_s16( todo, buf );
 			}
 		}
 		virtual void Init( Bitu rate ) {
-			OPL3_Reset(&chip, rate);
+			OPL3_Reset(&chip, (Bit32u)rate);
 		}
 		~Handler() {
 		}
@@ -148,7 +148,7 @@ struct Handler : public Adlib::Handler {
 		while (samples > 0) {
 			Bitu todo = samples > 1024 ? 1024 : samples;
 			samples -= todo;
-			ym3812_update_one(chip, buf, todo);
+			ym3812_update_one(chip, buf, (int)todo);
 			chan->AddSamples_m16(todo, buf);
 		}
 	}

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -478,7 +478,8 @@ void disable_operator(op_type* op_pt, Bit32u act_type) {
 }
 
 void adlib_init(Bit32u samplerate) {
-	Bits i, j, oct;
+    Bit16s i;
+	Bits j, oct;
 
 	int_samplerate = samplerate;
 

--- a/vs2015/freetype/src/psaux/psintrp.c
+++ b/vs2015/freetype/src/psaux/psintrp.c
@@ -999,7 +999,7 @@
 
 
             if ( val )
-              subrNum = *val;
+              subrNum = (FT_Fast)*val;
             else
               subrNum = -1;
           }

--- a/vs2015/freetype/src/sfnt/sfdriver.c
+++ b/vs2015/freetype/src/sfnt/sfdriver.c
@@ -835,7 +835,7 @@
                                    sfnt_is_alphanumeric,
                                    0 );
 
-      len = ft_strlen( result );
+      len = (FT_UInt)ft_strlen( result );
 
       /* sanitize if necessary; we reserve space for 36 bytes (a 128bit  */
       /* checksum as a hex number, preceded by `-' and followed by three */
@@ -986,7 +986,7 @@
       FT_UInt32*  h;
 
 
-      murmur_hash_3_128( result, p - result, seed, hash );
+      murmur_hash_3_128( result, (unsigned int)(p - result), seed, hash );
 
       p = result + face->var_postscript_prefix_len;
       *p++ = '-';

--- a/vs2015/freetype/src/smooth/ftgrays.c
+++ b/vs2015/freetype/src/smooth/ftgrays.c
@@ -1770,7 +1770,7 @@ typedef ptrdiff_t  FT_PtrDist;
     for ( y = yMin; y < yMax; )
     {
       ras.min_ey = y;
-      y         += height;
+      y         += (TCoord)height;
       ras.max_ey = FT_MIN( y, yMax );
 
       band    = bands;

--- a/vs2015/freetype/src/truetype/ttgload.c
+++ b/vs2015/freetype/src/truetype/ttgload.c
@@ -1794,7 +1794,7 @@
       /* clear the nodes filled by sibling chains */
       node = ft_list_get_node_at( &loader->composites, recurse_count );
       for ( node2 = node; node2; node2 = node2->next )
-        node2->data = (void*)FT_ULONG_MAX;
+        node2->data = (void*)(uintptr_t)FT_ULONG_MAX;
 
       /* check whether we already have a composite glyph with this index */
       if ( FT_List_Find( &loader->composites,

--- a/vs2015/freetype/src/type1/t1driver.c
+++ b/vs2015/freetype/src/type1/t1driver.c
@@ -270,7 +270,7 @@
       break;
 
     case PS_DICT_FONT_NAME:
-      retval = ft_strlen( type1->font_name ) + 1;
+      retval = (FT_ULong)(ft_strlen( type1->font_name ) + 1);
       if ( value && value_len >= retval )
         ft_memcpy( value, (void *)( type1->font_name ), retval );
       break;
@@ -290,7 +290,7 @@
     case PS_DICT_CHAR_STRING_KEY:
       if ( idx < (FT_UInt)type1->num_glyphs )
       {
-        retval = ft_strlen( type1->glyph_names[idx] ) + 1;
+        retval = (FT_ULong)(ft_strlen( type1->glyph_names[idx] ) + 1);
         if ( value && value_len >= retval )
         {
           ft_memcpy( value, (void *)( type1->glyph_names[idx] ), retval );
@@ -322,7 +322,7 @@
       if ( type1->encoding_type == T1_ENCODING_TYPE_ARRAY &&
            idx < (FT_UInt)type1->encoding.num_chars       )
       {
-        retval = ft_strlen( type1->encoding.char_name[idx] ) + 1;
+        retval = (FT_ULong)(ft_strlen( type1->encoding.char_name[idx] ) + 1);
         if ( value && value_len >= retval )
         {
           ft_memcpy( value, (void *)( type1->encoding.char_name[idx] ),
@@ -352,7 +352,7 @@
 
           if ( val )
           {
-            idx = *val;
+            idx = (FT_UInt)(*val);
             ok  = 1;
           }
         }
@@ -559,31 +559,31 @@
       break;
 
     case PS_DICT_VERSION:
-      retval = ft_strlen( type1->font_info.version ) + 1;
+      retval = (FT_ULong)(ft_strlen( type1->font_info.version ) + 1);
       if ( value && value_len >= retval )
         ft_memcpy( value, (void *)( type1->font_info.version ), retval );
       break;
 
     case PS_DICT_NOTICE:
-      retval = ft_strlen( type1->font_info.notice ) + 1;
+      retval = (FT_ULong)(ft_strlen( type1->font_info.notice ) + 1);
       if ( value && value_len >= retval )
         ft_memcpy( value, (void *)( type1->font_info.notice ), retval );
       break;
 
     case PS_DICT_FULL_NAME:
-      retval = ft_strlen( type1->font_info.full_name ) + 1;
+      retval = (FT_ULong)(ft_strlen( type1->font_info.full_name ) + 1);
       if ( value && value_len >= retval )
         ft_memcpy( value, (void *)( type1->font_info.full_name ), retval );
       break;
 
     case PS_DICT_FAMILY_NAME:
-      retval = ft_strlen( type1->font_info.family_name ) + 1;
+      retval = (FT_ULong)(ft_strlen( type1->font_info.family_name ) + 1);
       if ( value && value_len >= retval )
         ft_memcpy( value, (void *)( type1->font_info.family_name ), retval );
       break;
 
     case PS_DICT_WEIGHT:
-      retval = ft_strlen( type1->font_info.weight ) + 1;
+      retval = (FT_ULong)(ft_strlen( type1->font_info.weight ) + 1);
       if ( value && value_len >= retval )
         ft_memcpy( value, (void *)( type1->font_info.weight ), retval );
       break;

--- a/vs2015/freetype/src/type1/t1load.c
+++ b/vs2015/freetype/src/type1/t1load.c
@@ -1578,7 +1578,7 @@
                   " (from %d to %d)\n",
                   num_subrs,
                   ( parser->root.limit - parser->root.cursor ) >> 3 ));
-      num_subrs = ( parser->root.limit - parser->root.cursor ) >> 3;
+      num_subrs = (FT_Int)(( parser->root.limit - parser->root.cursor ) >> 3);
 
       if ( !loader->subrs_hash )
       {
@@ -1739,7 +1739,7 @@
       FT_TRACE0(( "parse_charstrings: adjusting number of glyphs"
                   " (from %d to %d)\n",
                   num_glyphs, ( limit - cur ) >> 3 ));
-      num_glyphs = ( limit - cur ) >> 3;
+      num_glyphs = (FT_Int)(( limit - cur ) >> 3);
     }
 
     /* some fonts like Optima-Oblique not only define the /CharStrings */

--- a/vs2015/freetype/src/type42/t42parse.c
+++ b/vs2015/freetype/src/type42/t42parse.c
@@ -818,7 +818,7 @@
                     " (from %d to %d)\n",
                     loader->num_glyphs,
                     ( limit - parser->root.cursor ) >> 2 ));
-        loader->num_glyphs = ( limit - parser->root.cursor ) >> 2;
+        loader->num_glyphs = (FT_Int)(( limit - parser->root.cursor ) >> 2);
       }
 
     }

--- a/vs2015/sdl/src/cdrom/win32/SDL_syscdrom.c
+++ b/vs2015/sdl/src/cdrom/win32/SDL_syscdrom.c
@@ -171,7 +171,7 @@ static int SDL_SYS_CDGetTOC(SDL_CD *cdrom)
 	mci_status.dwItem = MCI_STATUS_NUMBER_OF_TRACKS;
 	flags = MCI_STATUS_ITEM | MCI_WAIT;
 	if ( SDL_SYS_CDioctl(cdrom->id, MCI_STATUS, flags, &mci_status) == 0 ) {
-		cdrom->numtracks = mci_status.dwReturn;
+		cdrom->numtracks = (int)mci_status.dwReturn;
 		if ( cdrom->numtracks > SDL_MAX_TRACKS ) {
 			cdrom->numtracks = SDL_MAX_TRACKS;
 		}
@@ -339,7 +339,7 @@ static int SDL_SYS_CDResume(SDL_CD *cdrom)
 
 		flags = MCI_FROM | MCI_TO | MCI_NOTIFY;
 		mci_play.dwCallback = 0;
-		mci_play.dwFrom = mci_status.dwReturn;
+		mci_play.dwFrom = (DWORD)mci_status.dwReturn;
 		mci_play.dwTo = SDL_CD_end_position;
 		if (SDL_SYS_CDioctl(cdrom->id,MCI_PLAY,flags,&mci_play) == 0) {
 			okay = 1;

--- a/vs2015/sdl/src/file/SDL_rwops.c
+++ b/vs2015/sdl/src/file/SDL_rwops.c
@@ -127,7 +127,7 @@ static int SDLCALL win32_file_open(SDL_RWops *context, const char *filename, con
 
 	if (unicode_support) {  /* everything but Win95/98/ME. */
 		wchar_t *filenameW = SDL_stack_alloc(wchar_t, size);
-		if ( MultiByteToWideChar(CP_UTF8, 0, filename, -1, filenameW, size) == 0 ) {
+		if ( MultiByteToWideChar(CP_UTF8, 0, filename, -1, filenameW, (int)size) == 0 ) {
 			SDL_stack_free(filenameW);
 			SDL_free(context->hidden.win32io.buffer.data);
 			context->hidden.win32io.buffer.data = NULL;
@@ -152,7 +152,7 @@ static int SDLCALL win32_file_open(SDL_RWops *context, const char *filename, con
 
 		/* Dither down to a codepage and hope for the best. */
 		if (!utf16 ||
-			!WideCharToMultiByte(CP_ACP, 0, (LPCWSTR)utf16, -1, filenameA, size*6, 0, &bDefCharUsed) ||
+			!WideCharToMultiByte(CP_ACP, 0, (LPCWSTR)utf16, -1, filenameA, (int)(size*6), 0, &bDefCharUsed) ||
 			bDefCharUsed) {
 			SDL_stack_free(filenameA);
 			SDL_free(utf16);
@@ -341,7 +341,7 @@ static int SDLCALL stdio_read(SDL_RWops *context, void *ptr, int size, int maxnu
 	if ( nread == 0 && ferror(context->hidden.stdio.fp) ) {
 		SDL_Error(SDL_EFREAD);
 	}
-	return(nread);
+	return (int)nread;
 }
 static int SDLCALL stdio_write(SDL_RWops *context, const void *ptr, int size, int num)
 {
@@ -351,7 +351,7 @@ static int SDLCALL stdio_write(SDL_RWops *context, const void *ptr, int size, in
 	if ( nwrote == 0 && ferror(context->hidden.stdio.fp) ) {
 		SDL_Error(SDL_EFWRITE);
 	}
-	return(nwrote);
+	return (int)nwrote;
 }
 static int SDLCALL stdio_close(SDL_RWops *context)
 {
@@ -393,7 +393,7 @@ static int SDLCALL mem_seek(SDL_RWops *context, int offset, int whence)
 		newpos = context->hidden.mem.stop;
 	}
 	context->hidden.mem.here = newpos;
-	return(context->hidden.mem.here-context->hidden.mem.base);
+	return (int)(context->hidden.mem.here-context->hidden.mem.base);
 }
 static int SDLCALL mem_read(SDL_RWops *context, void *ptr, int size, int maxnum)
 {
@@ -413,12 +413,12 @@ static int SDLCALL mem_read(SDL_RWops *context, void *ptr, int size, int maxnum)
 	SDL_memcpy(ptr, context->hidden.mem.here, total_bytes);
 	context->hidden.mem.here += total_bytes;
 
-	return (total_bytes / size);
+	return (int)(total_bytes / size);
 }
 static int SDLCALL mem_write(SDL_RWops *context, const void *ptr, int size, int num)
 {
 	if ( (context->hidden.mem.here + (num*size)) > context->hidden.mem.stop ) {
-		num = (context->hidden.mem.stop-context->hidden.mem.here)/size;
+		num = (int)((context->hidden.mem.stop-context->hidden.mem.here)/size);
 	}
 	SDL_memcpy(context->hidden.mem.here, ptr, num*size);
 	context->hidden.mem.here += num*size;

--- a/vs2015/sdl/src/stdlib/SDL_string.c
+++ b/vs2015/sdl/src/stdlib/SDL_string.c
@@ -1243,6 +1243,6 @@ int SDL_vsnprintf(char *text, size_t maxlen, const char *fmt, va_list ap)
     }
     *text = '\0';
 
-    return (text - textstart);
+    return (int)(text - textstart);
 }
 #endif

--- a/vs2015/sdl/src/video/wincommon/SDL_syswm.c
+++ b/vs2015/sdl/src/video/wincommon/SDL_syswm.c
@@ -227,7 +227,7 @@ void WIN_SetWMCaption(_THIS, const char *title, const char *icon)
 	Uint16 *lpsz = SDL_iconv_utf8_ucs2(title);
 	size_t len = WideCharToMultiByte(CP_ACP, 0, lpsz, -1, NULL, 0, NULL, NULL);
 	char *cvt = SDL_stack_alloc(char, len + 1);
-	WideCharToMultiByte(CP_ACP, 0, lpsz, -1, cvt, len, NULL, NULL);
+	WideCharToMultiByte(CP_ACP, 0, lpsz, -1, cvt, (int)len, NULL, NULL);
 	SetWindowText(ParentWindowHWND, cvt);
 	SDL_stack_free(cvt);
 	SDL_free(lpsz);

--- a/vs2015/sdl/src/video/windib/SDL_dibevents.c
+++ b/vs2015/sdl/src/video/windib/SDL_dibevents.c
@@ -751,7 +751,7 @@ static int SDL_MapVirtualKey(int scancode, int vkey)
 static SDL_keysym *TranslateKey(WPARAM vkey, UINT scancode, SDL_keysym *keysym, int pressed)
 {
 	/* Set the keysym information */
-	keysym->win32_vk = vkey;
+	keysym->win32_vk = (Uint32)vkey;
 	keysym->scancode = (unsigned char) scancode;
 	keysym->mod = KMOD_NONE;
 	keysym->unicode = 0;
@@ -761,7 +761,7 @@ static SDL_keysym *TranslateKey(WPARAM vkey, UINT scancode, SDL_keysym *keysym, 
 		keysym->sym = SDLK_KP_ENTER;
 	}
 	else {
-		keysym->sym = VK_keymap[SDL_MapVirtualKey(scancode, vkey)];
+		keysym->sym = VK_keymap[SDL_MapVirtualKey(scancode, (int)vkey)];
 	}
 
 	if ( pressed && SDL_TranslateUNICODE ) {
@@ -778,7 +778,7 @@ static SDL_keysym *TranslateKey(WPARAM vkey, UINT scancode, SDL_keysym *keysym, 
 		 * so we handle it as a special case here */
 		if ((keystate[VK_NUMLOCK] & 1) && vkey >= VK_NUMPAD0 && vkey <= VK_NUMPAD9)
 		{
-			keysym->unicode = vkey - VK_NUMPAD0 + '0';
+			keysym->unicode = (Uint16)(vkey - VK_NUMPAD0 + '0');
 		}
 		else if (SDL_ToUnicode((UINT)vkey, scancode, keystate, wchars, sizeof(wchars)/sizeof(wchars[0]), 0) > 0)
 		{

--- a/vs2015/sdlnet/SDLnetUDP.c
+++ b/vs2015/sdlnet/SDLnetUDP.c
@@ -424,7 +424,7 @@ static int SocketReady(SOCKET sock)
 		tv.tv_usec = 0;
 
 		/* Look! */
-		retval = select(sock+1, &mask, NULL, NULL, &tv);
+		retval = select((int)(sock+1), &mask, NULL, NULL, &tv);
 	} while ( SDLNet_GetLastError() == EINTR );
 
 	return(retval == 1);

--- a/vs2015/sdlnet/SDLnetselect.c
+++ b/vs2015/sdlnet/SDLnetselect.c
@@ -138,7 +138,7 @@ int SDLNet_CheckSockets(SDLNet_SocketSet set, Uint32 timeout)
 		tv.tv_usec = (timeout%1000)*1000;
 
 		/* Look! */
-		retval = select(maxfd+1, &mask, NULL, NULL, &tv);
+		retval = select((int)(maxfd+1), &mask, NULL, NULL, &tv);
 	} while ( SDLNet_GetLastError() == EINTR );
 
 	/* Mark all file descriptors ready that have data available */

--- a/vs2015/zlib/gzread.c
+++ b/vs2015/zlib/gzread.c
@@ -316,7 +316,7 @@ local z_size_t gz_read(state, buf, len)
         /* set n to the maximum amount of len that fits in an unsigned int */
         n = -1;
         if (n > len)
-            n = len;
+            n = (unsigned int)len;
 
         /* first just try copying data from the output buffer */
         if (state->x.have) {
@@ -397,7 +397,7 @@ int ZEXPORT gzread(file, buf, len)
     }
 
     /* read len or fewer bytes to buf */
-    len = gz_read(state, buf, len);
+    len = (unsigned int)gz_read(state, buf, len);
 
     /* check for an error */
     if (len == 0 && state->err != Z_OK && state->err != Z_BUF_ERROR)
@@ -469,7 +469,7 @@ int ZEXPORT gzgetc(file)
     }
 
     /* nothing there -- try gz_read() */
-    ret = gz_read(state, buf, 1);
+    ret = (int)gz_read(state, buf, 1);
     return ret < 1 ? -1 : buf[0];
 }
 

--- a/vs2015/zlib/gzwrite.c
+++ b/vs2015/zlib/gzwrite.c
@@ -209,7 +209,7 @@ local z_size_t gz_write(state, buf, len)
                               state->in);
             copy = state->size - have;
             if (copy > len)
-                copy = len;
+                copy = (unsigned int)len;
             memcpy(state->in + have, buf, copy);
             state->strm.avail_in += copy;
             state->x.pos += copy;
@@ -229,7 +229,7 @@ local z_size_t gz_write(state, buf, len)
         do {
             unsigned n = (unsigned)-1;
             if (n > len)
-                n = len;
+                n = (unsigned int)len;
             state->strm.avail_in = n;
             state->x.pos += n;
             if (gz_comp(state, Z_NO_FLUSH) == -1)
@@ -368,7 +368,7 @@ int ZEXPORT gzputs(file, str)
 
     /* write string */
     len = strlen(str);
-    ret = gz_write(state, str, len);
+    ret = (int)gz_write(state, str, len);
     return ret == 0 && len != 0 ? -1 : ret;
 }
 


### PR DESCRIPTION
More type-conversion warning fixes.

Visual Studio compile warnings down from 985 to 909.

Compiles and runs.