### PR TITLE
Enable /LTCG option where it was not enabled

### DIFF
--- a/vs2015/libpdcurses/libpdcurses.vcxproj
+++ b/vs2015/libpdcurses/libpdcurses.vcxproj
@@ -540,6 +540,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Lib>
       <OutputFile>$(IntDir)$(TargetName)$(TargetExt)</OutputFile>
+      <LinkTimeCodeGeneration>true</LinkTimeCodeGeneration>
     </Lib>
     <ClCompile>
       <PreprocessorDefinitions>_MBCS;_CRT_SECURE_NO_WARNINGS=1;%(PreprocessorDefinitions);PDC_FORCE_UTF8=1</PreprocessorDefinitions>

--- a/vs2015/sdl/VisualC/SDL/SDL.vcxproj
+++ b/vs2015/sdl/VisualC/SDL/SDL.vcxproj
@@ -898,6 +898,7 @@
     </Link>
     <Lib>
       <OutputFile>$(IntDir)$(TargetName)$(TargetExt)</OutputFile>
+      <LinkTimeCodeGeneration>true</LinkTimeCodeGeneration>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">

--- a/vs2015/sdl/VisualC/SDLmain/SDLmain.vcxproj
+++ b/vs2015/sdl/VisualC/SDLmain/SDLmain.vcxproj
@@ -398,6 +398,7 @@
     </ClCompile>
     <Lib>
       <OutputFile>$(IntDir)$(TargetName)$(TargetExt)</OutputFile>
+      <LinkTimeCodeGeneration>true</LinkTimeCodeGeneration>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">

--- a/vs2015/sdl2/VisualC/SDL/SDL.vcxproj
+++ b/vs2015/sdl2/VisualC/SDL/SDL.vcxproj
@@ -425,6 +425,7 @@
     </Link>
     <Lib>
       <OutputFile>$(IntDir)$(TargetName)$(TargetExt)</OutputFile>
+      <LinkTimeCodeGeneration>true</LinkTimeCodeGeneration>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release SDL2|ARM64'">

--- a/vs2015/sdl2/VisualC/SDLmain/SDLmain.vcxproj
+++ b/vs2015/sdl2/VisualC/SDLmain/SDLmain.vcxproj
@@ -215,6 +215,7 @@
     </ClCompile>
     <Lib>
       <OutputFile>$(IntDir)$(TargetName)$(TargetExt)</OutputFile>
+      <LinkTimeCodeGeneration>true</LinkTimeCodeGeneration>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release SDL2|ARM64'">

--- a/vs2015/sdlnet/VisualC/SDL_net_VS2008.vcxproj
+++ b/vs2015/sdlnet/VisualC/SDL_net_VS2008.vcxproj
@@ -909,6 +909,7 @@
     </Bscmake>
     <Lib>
       <OutputFile>$(IntDir)$(TargetName)$(TargetExt)</OutputFile>
+      <LinkTimeCodeGeneration>true</LinkTimeCodeGeneration>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">

--- a/vs2015/zlib/zlib/zlib.vcxproj
+++ b/vs2015/zlib/zlib/zlib.vcxproj
@@ -706,6 +706,7 @@
     </Link>
     <Lib>
       <OutputFile>$(IntDir)$(TargetName)$(TargetExt)</OutputFile>
+      <LinkTimeCodeGeneration>true</LinkTimeCodeGeneration>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">


### PR DESCRIPTION
The Visual Studio build would output this message 5 times during compilation (with SDL1):

```
LINK : MSIL .netmodule or module compiled with /GL found; restarting link with /LTCG; add /LTCG to the link command line to improve linker performance
```

/LTCG ("Link-time code generation") would be used regardless once the /GL option was found, but with this PR it is set from the start and so these messages will no longer appear in the build log.

The /GL option is enabled for all the projects (freetype, libpdcurses, libpng, zlib, SDL, SDL_net, SDLmain, SDL2, SDL2main, dosbox-x), so it is appropriate for /LTCG to be enabled for all of them as well.

Compiles and runs.