### PR TITLE
Type-conversion warning fixes

### DIFF
--- a/include/dma.h
+++ b/include/dma.h
@@ -166,6 +166,6 @@ DmaChannel * GetDMAChannel(Bit8u chan);
 void CloseSecondDMAController(void);
 bool SecondDMAControllerAvailable(void);
 
-void DMA_SetWrapping(Bitu wrap);
+void DMA_SetWrapping(Bit32u wrap);
 
 #endif

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -155,12 +155,12 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
         {
         case 0x00:      /* Seconds */
             if (val > 59) return;       // invalid seconds value
-            loctime->tm_sec = val;
+            loctime->tm_sec = (int)val;
             break;
 
         case 0x02:      /* Minutes */
             if (val > 59) return;       // invalid minutes value
-            loctime->tm_min = val;
+            loctime->tm_min = (int)val;
             break;
 
         case 0x04:      /* Hours */
@@ -174,7 +174,7 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
                 if (val > 23) return;                               // invalid hour value
             }
 
-            loctime->tm_hour = val;         
+            loctime->tm_hour = (int)val;         
             break;
 
         case 0x06:      /* Day of week */
@@ -183,16 +183,16 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
 
         case 0x07:      /* Date of month */
             if (val > 31) return;               // invalid date value (mktime() should catch the rest)
-            loctime->tm_mday = val;
+            loctime->tm_mday = (int)val;
             break;
 
         case 0x08:      /* Month */
             if (val > 12) return;               // invalid month value
-            loctime->tm_mon = val;
+            loctime->tm_mon = (int)val;
             break;
 
         case 0x09:      /* Year */
-            loctime->tm_year = val;
+            loctime->tm_year = (int)val;
             break;
 
         case 0x32:      /* Century */
@@ -204,7 +204,7 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
         case 0x03:      /* Minutes Alarm */
         case 0x05:      /* Hours Alarm */
             LOG(LOG_BIOS,LOG_NORMAL)("CMOS:Trying to set alarm");
-            cmos.regs[cmos.reg] = val;
+            cmos.regs[cmos.reg] = (Bit8u)val;
             return;     // done
         }
 
@@ -242,7 +242,7 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
     case 0x05:      /* Hours Alarm */
         if(!date_host_forced) {
             LOG(LOG_BIOS,LOG_NORMAL)("CMOS:Trying to set alarm");
-            cmos.regs[cmos.reg]=val;
+            cmos.regs[cmos.reg]=(Bit8u)val;
             break;
         }
     case 0x0a:      /* Status reg A */
@@ -276,7 +276,7 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
                 cmos.time_diff = cmos.locktime.tv_sec - time(NULL);
             }
 
-            cmos.regs[cmos.reg] = val;
+            cmos.regs[cmos.reg] = (Bit8u)val;
             cmos_checktimer();
         } else {
             cmos.bcd=!(val & 0x4);

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -196,7 +196,7 @@ static void disney_write(Bitu port,Bitu val,Bitu iolen) {
 	switch (port-DISNEY_BASE) {
 	case 0:		/* Data Port */
 	{
-		disney.data=val;
+		disney.data=(Bit8u)val;
 		// if data is written here too often without using the stereo
 		// mechanism we use the simple DAC machanism. 
         if(disney.state != DS_RUNNING) {
@@ -263,7 +263,7 @@ static void disney_write(Bitu port,Bitu val,Bitu iolen) {
 
 //		LOG_WARN("DISNEY:Control write %x",val);
 		if (val&0x10) LOG(LOG_MISC,LOG_ERROR)("DISNEY:Parallel IRQ Enabled");
-		disney.control=val;
+		disney.control=(Bit8u)val;
 		break;
 	}
 }

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -41,19 +41,19 @@ static saa1099_device* device[2];
 
 static void write_cms(Bitu port, Bitu val, Bitu /* iolen */) {
 	if(cms_chan && (!cms_chan->enabled)) cms_chan->Enable(true);
-	lastWriteTicks = PIC_Ticks;
+	lastWriteTicks = (Bit32u)PIC_Ticks;
 	switch ( port - cmsBase ) {
 	case 1:
-		device[0]->control_w(0, 0, val);
+		device[0]->control_w(0, 0, (u8)val);
 		break;
 	case 0:
-		device[0]->data_w(0, 0, val);
+		device[0]->data_w(0, 0, (u8)val);
 		break;
 	case 3:
-		device[1]->control_w(0, 0, val);
+		device[1]->control_w(0, 0, (u8)val);
 		break;
 	case 2:
-		device[1]->data_w(0, 0, val);
+		device[1]->data_w(0, 0, (u8)val);
 		break;
 	}
 }
@@ -77,12 +77,12 @@ static void CMS_CallBack(Bitu len) {
 		Bit16s work[2][BUFFER_SIZE];
 		Bit16s* buffers[2] = { work[0], work[1] };
 		device_sound_interface::sound_stream stream;
-		device[0]->sound_stream_update(stream, 0, buffers, len);
+		device[0]->sound_stream_update(stream, 0, buffers, (int)len);
 		for (Bitu i = 0; i < len; i++) {
 			result[i][0] = work[0][i];
 			result[i][1] = work[1][i];
 		}
-		device[1]->sound_stream_update(stream, 0, buffers, len);
+		device[1]->sound_stream_update(stream, 0, buffers, (int)len);
 		for (Bitu i = 0; i < len; i++) {
 			result[i][0] += work[0][i];
 			result[i][1] += work[1][i];
@@ -98,7 +98,7 @@ static void write_cms_detect(Bitu port, Bitu val, Bitu /* iolen */) {
 	switch ( port - cmsBase ) {
 	case 0x6:
 	case 0x7:
-		cms_detect_register = val;
+		cms_detect_register = (Bit8u)val;
 		break;
 	}
 }
@@ -143,7 +143,7 @@ public:
 		/* Register the Mixer CallBack */
 		cms_chan = MixerChan.Install(CMS_CallBack,sampleRate,"CMS");
 	
-		lastWriteTicks = PIC_Ticks;
+		lastWriteTicks = (Bit32u)PIC_Ticks;
 
 #if 0 // unused?
 		Bit32u freq = 7159000;		//14318180 isa clock / 2

--- a/src/hardware/innova.cpp
+++ b/src/hardware/innova.cpp
@@ -44,25 +44,25 @@ static void innova_write(Bitu port,Bitu val,Bitu iolen) {
 	innova.last_used=PIC_Ticks;
 
 	Bitu sidPort = port-innova.basePort;
-	innova.sid->write(sidPort, val);
+	innova.sid->write((reg8)sidPort, (reg8)val);
 }
 
 static Bitu innova_read(Bitu port,Bitu iolen) {
     (void)iolen;//UNUSED
 	Bitu sidPort = port-innova.basePort;
-	return innova.sid->read(sidPort);
+	return innova.sid->read((reg8)sidPort);
 }
 
 
 static void INNOVA_CallBack(Bitu len) {
 	if (!len) return;
 
-	cycle_count delta_t = SID_FREQ*len/innova.rate;
+	cycle_count delta_t = (cycle_count)(SID_FREQ*len/innova.rate);
 	short* buffer = (short*)MixTemp;
 	Bitu bufindex = 0;
 
 	while(delta_t && bufindex != len) {
-		bufindex += (Bitu)innova.sid->clock(delta_t, buffer+bufindex, len-bufindex);
+		bufindex += (Bitu)innova.sid->clock(delta_t, buffer+bufindex, (int)(len-bufindex));
 	}
 	innova.chan->AddSamples_m16(len, buffer);
 
@@ -102,7 +102,7 @@ public:
 		innova.sid->set_chip_model(MOS6581);
 		innova.sid->enable_filter(true);
 		innova.sid->enable_external_filter(true);
-		innova.sid->set_sampling_parameters(SID_FREQ, method, innova.rate, -1, 0.97);
+		innova.sid->set_sampling_parameters(SID_FREQ, method, (double)innova.rate, -1, 0.97);
 
 		innova.last_used=0;
 

--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -138,11 +138,11 @@ bool ECBClass::writeData() {
 	Bit8u* buffer = databuffer;
 	fragmentDescriptor tmpFrag;
 	setInUseFlag(USEFLAG_AVAILABLE);
-	Bitu fragCount = getFragCount(); 
+	Bit16u fragCount = getFragCount(); 
 	Bitu bufoffset = 0;
-	for(Bitu i = 0;i < fragCount;i++) {
+	for(Bit16u i = 0;i < fragCount;i++) {
 		getFragDesc(i,&tmpFrag);
-		for(Bitu t = 0;t < tmpFrag.size;t++) {
+		for(Bit16u t = 0;t < tmpFrag.size;t++) {
 			real_writeb(tmpFrag.segment, tmpFrag.offset + t, buffer[bufoffset]);
 			bufoffset++;
 			if(bufoffset >= length) {
@@ -231,12 +231,12 @@ void ECBClass::NotifyESR(void) {
 }
 
 void ECBClass::setImmAddress(Bit8u *immAddr) {
-	for(Bitu i=0;i<6;i++)
+	for(Bit8u i=0;i<6;i++)
 		real_writeb(RealSeg(ECBAddr), RealOff(ECBAddr)+28+i, immAddr[i]);
 }
 
 void ECBClass::getImmAddress(Bit8u* immAddr) {
-	for(Bitu i=0;i<6;i++)
+	for(Bit8u i=0;i<6;i++)
 		immAddr[i] = real_readb(RealSeg(ECBAddr), RealOff(ECBAddr)+28+i);
 }
 
@@ -381,7 +381,7 @@ static void handleIpxRequest(void) {
 						// es:si
 						// Currently no support for multiple networks
 
-			for(Bitu i = 0; i < 6; i++) 
+			for(Bit8u i = 0; i < 6; i++) 
 				real_writeb(SegValue(es),reg_di+i,real_readb(SegValue(es),reg_si+i+4));
 
 			reg_cx=1;		// time ticks expected
@@ -1184,7 +1184,7 @@ public:
 		IO_WriteB(0xa1,IO_ReadB(0xa1)|8);	// disable IRQ11
    
 		PhysPt phyDospage = PhysMake(dospage,0);
-		for(Bitu i = 0;i < 32;i++)
+		for(Bit8u i = 0;i < 32;i++)
 			phys_writeb(phyDospage+i,(Bit8u)0x00);
 
 		VFILE_Remove("IPXNET.COM");

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -122,7 +122,7 @@ static void write_p201(Bitu port,Bitu val,Bitu iolen) {
     (void)iolen;//UNUSED
 	/* Store writetime index */
 	write_active = true;
-	last_write = PIC_Ticks;
+	last_write = (Bit32u)PIC_Ticks;
 	if (stick[0].enabled) {
 		stick[0].xcount=(Bitu)((stick[0].xpos*RANGE)+RANGE);
 		stick[0].ycount=(Bitu)((stick[0].ypos*RANGE)+RANGE);

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -1402,7 +1402,7 @@ bool allow_port_92_reset = true;
 static void write_p92(Bitu port,Bitu val,Bitu iolen) {
     (void)iolen;//UNUSED
     (void)port;//UNUSED
-    memory.a20.controlport = val & ~2u;
+    memory.a20.controlport = (Bit8u)(val & ~2u);
     MEM_A20_Enable((val & 2u)>0);
 
     // Bit 0 = system reset (switch back to real mode)


### PR DESCRIPTION
Number of compile warnings in Visual Studio build (x64, SDL1) down from 909 to 760. Compiles and runs.