### PR TITLE
VS2017 typecast fixes (cpu core files)

### DIFF
--- a/src/cpu/core_normal/prefix_0f.h
+++ b/src/cpu/core_normal/prefix_0f.h
@@ -28,8 +28,8 @@
 					Bitu saveval;
 					if (!which) saveval=CPU_SLDT();
 					else saveval=CPU_STR();
-					if (rm >= 0xc0) {GetEArw;*earw=saveval;}
-					else {GetEAa;SaveMw(eaa,saveval);}
+					if (rm >= 0xc0) {GetEArw;*earw=(Bit16u)saveval;}
+					else {GetEAa;SaveMw(eaa,(Bit16u)saveval);}
 				}
 				break;
 			case 0x02:case 0x03:case 0x04:case 0x05:
@@ -72,13 +72,13 @@
 					 *      Some programs, including Microsoft Windows 3.0, execute SGDT and then compare the most
 					 *      significant byte against 0xFF. It does NOT use the standard Intel detection process. */
 				case 0x00:										/* SGDT */
-					SaveMw(eaa,CPU_SGDT_limit());
-					SaveMd(eaa+2,CPU_SGDT_base()|(CPU_ArchitectureType<CPU_ARCHTYPE_386?0xFF000000UL:0));
+					SaveMw(eaa,(Bit16u)CPU_SGDT_limit());
+					SaveMd(eaa+2,(Bit32u)(CPU_SGDT_base()|(CPU_ArchitectureType<CPU_ARCHTYPE_386?0xFF000000UL:0)));
 					break;
 					/* NTS: Same comments for SIDT as SGDT */
 				case 0x01:										/* SIDT */
-					SaveMw(eaa,CPU_SIDT_limit());
-					SaveMd(eaa+2,CPU_SIDT_base()|(CPU_ArchitectureType<CPU_ARCHTYPE_386?0xFF000000UL:0));
+					SaveMw(eaa,(Bit16u)CPU_SIDT_limit());
+					SaveMd(eaa+2,(Bit32u)(CPU_SIDT_base()|(CPU_ArchitectureType<CPU_ARCHTYPE_386?0xFF000000UL:0)));
 					break;
 				case 0x02:										/* LGDT */
 					if (cpu.pmode && cpu.cpl) EXCEPTION(EXCEPTION_GP);
@@ -89,7 +89,7 @@
 					CPU_LIDT(LoadMw(eaa),LoadMd(eaa+2) & 0xFFFFFF);
 					break;
 				case 0x04:										/* SMSW */
-					SaveMw(eaa,CPU_SMSW());
+					SaveMw(eaa,(Bit16u)CPU_SMSW());
 					break;
 				case 0x06:										/* LMSW */
 					limit=LoadMw(eaa);
@@ -111,7 +111,7 @@
 					if (cpu.pmode && cpu.cpl) EXCEPTION(EXCEPTION_GP);
 					goto illegal_opcode;
 				case 0x04:										/* SMSW */
-					*earw=CPU_SMSW();
+					*earw=(Bit16u)CPU_SMSW();
 					break;
 				case 0x06:										/* LMSW */
 					if (CPU_LMSW(*earw)) RUNEXCEPTION();

--- a/src/cpu/core_normal/prefix_66.h
+++ b/src/cpu/core_normal/prefix_66.h
@@ -148,9 +148,9 @@
 		reg_edi=Pop_32();break;
 	CASE_D(0x60)												/* PUSHAD */
 		{
-			Bitu old_esp = reg_esp;
+			Bit32u old_esp = reg_esp;
 			try {
-				Bitu tmpesp = reg_esp;
+				Bit32u tmpesp = reg_esp;
 				Push_32(reg_eax);Push_32(reg_ecx);Push_32(reg_edx);Push_32(reg_ebx);
 				Push_32(tmpesp);Push_32(reg_ebp);Push_32(reg_esi);Push_32(reg_edi);
 			}
@@ -163,7 +163,7 @@
 		} break;
 	CASE_D(0x61)												/* POPAD */
 		{
-			Bitu old_esp = reg_esp;
+			Bit32u old_esp = reg_esp;
 			try {
 				reg_edi=Pop_32();reg_esi=Pop_32();reg_ebp=Pop_32();Pop_32();//Don't save ESP
 				reg_ebx=Pop_32();reg_edx=Pop_32();reg_ecx=Pop_32();reg_eax=Pop_32();

--- a/src/cpu/core_normal/prefix_66_0f.h
+++ b/src/cpu/core_normal/prefix_66_0f.h
@@ -28,7 +28,7 @@
 					if (!which) saveval=CPU_SLDT();
 					else saveval=CPU_STR();
 					if (rm >= 0xc0) {GetEArw;*earw=(Bit16u)saveval;}
-					else {GetEAa;SaveMw(eaa,saveval);}
+					else {GetEAa;SaveMw(eaa,(Bit16u)saveval);}
 				}
 				break;
 			case 0x02:case 0x03:case 0x04:case 0x05:

--- a/src/cpu/core_normal/prefix_none.h
+++ b/src/cpu/core_normal/prefix_none.h
@@ -230,7 +230,7 @@
 	CASE_W(0x60)												/* PUSHA */
 		if (CPU_ArchitectureType<CPU_ARCHTYPE_80186) goto illegal_opcode;
 		{
-			Bitu old_esp = reg_esp;
+			Bit32u old_esp = reg_esp;
 			try {
 				Bit16u old_sp = (CPU_ArchitectureType >= CPU_ARCHTYPE_286 ? reg_sp : (reg_sp-10));
 				Push_16(reg_ax);Push_16(reg_cx);Push_16(reg_dx);Push_16(reg_bx);
@@ -246,7 +246,7 @@
 	CASE_W(0x61)												/* POPA */
 		if (CPU_ArchitectureType<CPU_ARCHTYPE_80186) goto illegal_opcode;
 		{
-			Bitu old_esp = reg_esp;
+			Bit32u old_esp = reg_esp;
 			try {
 				reg_di=Pop_16();reg_si=Pop_16();reg_bp=Pop_16();Pop_16();//Don't save SP
 				reg_bx=Pop_16();reg_dx=Pop_16();reg_cx=Pop_16();reg_ax=Pop_16();

--- a/src/cpu/core_normal_8086.cpp
+++ b/src/cpu/core_normal_8086.cpp
@@ -78,9 +78,9 @@ static void SaveMw(Bitu off,Bitu val) {
 
 static inline Bit16u LoadMw(Bitu off) {
 	if (last_ea86_offset == 0xffff)
-		return (mem_readb_inline(off) | (mem_readb_inline(off-0xffff) << 8));
+		return (mem_readb_inline((PhysPt)off) | (mem_readb_inline((PhysPt)(off-0xffff)) << 8));
 
-	return mem_readw_inline(off);	
+	return mem_readw_inline((PhysPt)off);
 }
 
 #define LoadMd(off) mem_readd_inline(off)
@@ -89,11 +89,11 @@ static inline Bit16u LoadMw(Bitu off) {
 
 static void SaveMw(Bitu off,Bitu val) {
 	if (last_ea86_offset == 0xffff) {
-		mem_writeb_inline(off,val);
-		mem_writeb_inline(off-0xffff,val>>8);
+		mem_writeb_inline((PhysPt)off,(Bit8u)val);
+		mem_writeb_inline((PhysPt)(off-0xffff),(Bit8u)(val>>8));
 	}
 	else {
-		mem_writew_inline(off,val);
+		mem_writew_inline((PhysPt)off,(Bit16u)val);
 	}
 }
 

--- a/src/cpu/core_prefetch_8086.cpp
+++ b/src/cpu/core_prefetch_8086.cpp
@@ -84,9 +84,9 @@ static void SaveMw(Bitu off,Bitu val) {
 
 static inline Bit16u LoadMw(Bitu off) {
 	if (last_ea86_offset == 0xffff)
-		return (mem_readb_inline(off) | (mem_readb_inline(off-0xffff) << 8));
+		return (mem_readb_inline((PhysPt)off) | (mem_readb_inline((PhysPt)(off-0xffff)) << 8));
 
-	return mem_readw_inline(off);	
+	return mem_readw_inline((PhysPt)off);
 }
 
 #define LoadMd(off) mem_readd_inline(off)
@@ -95,11 +95,11 @@ static inline Bit16u LoadMw(Bitu off) {
 
 static void SaveMw(Bitu off,Bitu val) {
 	if (last_ea86_offset == 0xffff) {
-		mem_writeb_inline(off,val);
-		mem_writeb_inline(off-0xffff,val>>8);
+		mem_writeb_inline((PhysPt)off,(Bit8u)val);
+		mem_writeb_inline((PhysPt)(off-0xffff),(Bit8u)(val>>8));
 	}
 	else {
-		mem_writew_inline(off,val);
+		mem_writew_inline((PhysPt)off,(Bit16u)val);
 	}
 }
 


### PR DESCRIPTION
More warning fixes. Together with the other PRs, this finishes out the last of the Visual Studio 2017 compiler type conversion warnings.