### PR TITLE
Silence remaining VS2017 + SDL1 compiler warnings 

### DIFF
--- a/vs2015/freetype/src/truetype/ttgxvar.c
+++ b/vs2015/freetype/src/truetype/ttgxvar.c
@@ -1948,7 +1948,7 @@
     FT_Var_Axis*         a;
     FT_Fixed*            c;
     FT_Var_Named_Style*  ns;
-    GX_FVar_Head         fvar_head;
+    GX_FVar_Head         fvar_head = {0};
     FT_Bool              usePsName  = 0;
     FT_UInt              num_instances;
     FT_UInt              num_axes;

--- a/vs2015/sdlnet/SDLnetsys.h
+++ b/vs2015/sdlnet/SDLnetsys.h
@@ -32,6 +32,7 @@
 
 /* Include system network headers */
 #if defined(__WIN32__) || defined(WIN32)
+#define _WINSOCK_DEPRECATED_NO_WARNINGS
 #define __USE_W32_SOCKETS
 #ifdef _WIN64
 #include <winsock2.h>


### PR DESCRIPTION
Together with the other PRs that silence type convesion warnings, this silences the last compiler warnings generated by Visual Studio 2017 when compiling with SDL1 (I don't know about SDL2).

One warning was about a potentially uninitialized variable. Fixed by zero-initializing it on its declaration.

The other warnings were for deprecated WinSock functions in the SDL code. While it would be nice to update these functions, I don't know anything about it or how to test it, and it seems to be more involved than just replacing with the newer functions, as they require different parameters, etc. I took the other suggestion in the warning message, which was to define `_WINSOCK_DEPRECATED_NO_WARNINGS`.

That's all for compiler warnings, but there are still plenty of warnings that appear in the Visual Studio 2019 IDE when opening and looking at files. I've fixed some of these in previous PRs.