### PR TITLE
Fix VS2019 compiler warnings

### DIFF
--- a/include/util_math.h
+++ b/include/util_math.h
@@ -27,7 +27,7 @@ struct DOSBox_Vector2
 	}
 
 	inline float magnitude(void) const {
-		return sqrt(sqrMagnitude());
+		return (float)sqrt(sqrMagnitude());
 	}
 
 	inline float sqrMagnitude(void) const {

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1525,8 +1525,8 @@ protected:
         }
         DOSBox_Vector2 v;
         ProcessInput(x, y, deadzone, v);
-        float x1 = sgn(v.X) * abs(pow(v.X, response));
-        float y1 = sgn(v.Y) * abs(pow(v.Y, response));
+        float x1 = (float)(sgn(v.X) * abs(pow(v.X, response)));
+        float y1 = (float)(sgn(v.Y) * abs(pow(v.Y, response)));
         DOSBox_Vector2 v1(x1, y1);
         return v1;
     }

--- a/src/hardware/parport/printer.cpp
+++ b/src/hardware/parport/printer.cpp
@@ -1571,7 +1571,7 @@ void CPrinter::formFeed()
 
 static void findNextName(char* front, char* ext, char* fname)
 {
-	Bitu i = 1;
+	int i = 1;
 	Bitu slen = (Bitu)strlen(document_path);
 	if(slen > (200 - 15))
     {


### PR DESCRIPTION
A few compiler warnings appear when using Visual Studio 2019 that don't appear with Visual Studio 2017.

```
'return': conversion from 'double' to 'float', possible loss of data include\util_math.h 30 14 dosbox-x
'sprintf' : format string '%d' requires an argument of type 'int', but variadic argument 2 has type 'Bitu' src\hardware\parport\printer.cpp 1591 34 dosbox-x
'initializing': conversion from 'double' to 'float', possible loss of data src\gui\sdl_mapper.cpp 1529 18 dosbox-x
'initializing': conversion from 'double' to 'float', possible loss of data src\gui\sdl_mapper.cpp 1528 18 dosbox-x
```

This PR silences them.