### PR TITLE
Fix arithmetic overflow and shift warnings

### DIFF
--- a/include/dma.h
+++ b/include/dma.h
@@ -121,7 +121,7 @@ public:
 	}
 	void SetPage(Bit8u val) {
 		pagenum=val;
-		pagebase=(Bitu)((Bitu)(pagenum >> DMA16_PAGESHIFT) << (Bitu)(16u + DMA16_PAGESHIFT));
+		pagebase=(pagenum >> DMA16_PAGESHIFT) << ((Bitu)16u + DMA16_PAGESHIFT);
 	}
 	void Raise_Request(void) {
 		request=true;

--- a/src/aviwriter/riff_wav_writer.cpp
+++ b/src/aviwriter/riff_wav_writer.cpp
@@ -95,7 +95,7 @@ int riff_wav_writer_set_format_ex(riff_wav_writer *w,windows_WAVEFORMATEX *f,siz
 		return 0;
 
 	w->fmt_len = sizeof(windows_WAVEFORMAT);
-	if (__le_u16(&f->cbSize) != 0u) w->fmt_len += 2u + __le_u16(&f->cbSize);
+	if (__le_u16(&f->cbSize) != 0u) w->fmt_len += (size_t)2u + __le_u16(&f->cbSize);
 	if (w->fmt_len > len)
 		return 0;
 	if ((w->fmt = malloc(w->fmt_len)) == NULL)

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -177,7 +177,7 @@ public:
 #else
 		(*(Bit16u*)&invalidation_map[addr])+=0x101;
 #endif
-		InvalidateRange(addr,addr+1);
+		InvalidateRange(addr,addr+(Bitu)1);
 	}
 	void writed(PhysPt addr,Bit32u val){
 		addr&=4095;
@@ -199,7 +199,7 @@ public:
 #else
 		(*(Bit32u*)&invalidation_map[addr])+=0x1010101;
 #endif
-		InvalidateRange(addr,addr+3);
+		InvalidateRange(addr,addr+(Bitu)3);
 	}
 	bool writeb_checked(PhysPt addr,Bit8u val) {
 		addr&=4095;
@@ -246,7 +246,7 @@ public:
 #else
 			(*(Bit16u*)&invalidation_map[addr])+=0x101;
 #endif
-			if (InvalidateRange(addr,addr+1)) {
+			if (InvalidateRange(addr,addr+(Bitu)1)) {
 				cpu.exception.which=SMC_CURRENT_BLOCK;
 				return true;
 			}
@@ -275,7 +275,7 @@ public:
 #else
 			(*(Bit32u*)&invalidation_map[addr])+=0x1010101;
 #endif
-			if (InvalidateRange(addr,addr+3)) {
+			if (InvalidateRange(addr,addr+(Bitu)3)) {
 				cpu.exception.which=SMC_CURRENT_BLOCK;
 				return true;
 			}
@@ -286,7 +286,7 @@ public:
 
     // add a cache block to this page and note it in the hash map
 	void AddCacheBlock(CacheBlockDynRec * block) {
-		Bitu index=1+(block->page.start>>DYN_HASH_SHIFT);
+		Bitu index=(Bitu)1+(block->page.start>>DYN_HASH_SHIFT);
 		block->hash.next=hash_map[index];	// link to old block at index from the new block
 		block->hash.index=index;
 		hash_map[index]=block;				// put new block at hash position

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -265,7 +265,7 @@ static void INLINE decode_increase_wmapmask(Bitu size) {
 		mapidx=decode.page.index-activecb->cache.maskstart;
 		if (GCC_UNLIKELY(mapidx+size>=activecb->cache.masklen)) {
 			// mask buffer too small, increase
-			Bitu newmasklen=activecb->cache.masklen*4;
+			Bitu newmasklen=activecb->cache.masklen*(Bitu)4;
 			if (newmasklen<mapidx+size) newmasklen=((mapidx+size)&~3)*2;
 			Bit8u* tempmem=(Bit8u*)malloc(newmasklen);
 			memset(tempmem,0,newmasklen);

--- a/src/cpu/core_dynrec/operators.h
+++ b/src/cpu/core_dynrec/operators.h
@@ -1434,7 +1434,7 @@ static void DRC_CALL_CONV dynrec_mul_word(Bit16u op) {
 static void DRC_CALL_CONV dynrec_imul_word(Bit16u op) DRC_FC;
 static void DRC_CALL_CONV dynrec_imul_word(Bit16u op) {
 	FillFlagsNoCFOF();
-	Bits temps=((Bit16s)reg_ax)*((Bit16s)op);
+	Bits temps=((Bit16s)reg_ax)*((Bits)op);
 	reg_ax=(Bit16s)(temps);
 	reg_dx=(Bit16s)(temps >> 16);
 	if (((temps & 0xffff8000)==0xffff8000 || (temps & 0xffff8000)==0x0000)) {
@@ -1567,7 +1567,7 @@ static bool DRC_CALL_CONV dynrec_idiv_dword(Bit32u op) {
 static Bit16u DRC_CALL_CONV dynrec_dimul_word(Bit16u op1,Bit16u op2) DRC_FC;
 static Bit16u DRC_CALL_CONV dynrec_dimul_word(Bit16u op1,Bit16u op2) {
 	FillFlagsNoCFOF();
-	Bits res=((Bit16s)op1) * ((Bit16s)op2);
+	Bits res=((Bit16s)op1) * ((Bits)op2);
 	if ((res>-32768)  && (res<32767)) {
 		SETFLAGBIT(CF,false);
 		SETFLAGBIT(OF,false);

--- a/src/cpu/core_prefetch.cpp
+++ b/src/cpu/core_prefetch.cpp
@@ -207,7 +207,7 @@ Bits CPU_Core_Prefetch_Run(void) {
 			invalidate_pq=false;
 		}
 		LOADIP;
-		core.opcode_index=cpu.code.big*0x200u;
+		core.opcode_index=cpu.code.big*(Bitu)0x200u;
 		core.prefixes=cpu.code.big;
 		core.ea_table=&EATable[cpu.code.big*256u];
 		BaseDS=SegBase(ds);

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -145,7 +145,7 @@ bool CDROM_Interface_Image::GetAudioTrackInfo(int track, TMSF& start, unsigned c
 {
 	if (track < 1 || track > (int)tracks.size()) return false;
 	FRAMES_TO_MSF((unsigned int)tracks[(unsigned int)track - 1u].start + 150u, &start.min, &start.sec, &start.fr);
-	attr = tracks[(unsigned int)track - 1u].attr;
+	attr = tracks[(Bitu)track - 1u].attr;
 	return true;
 }
 
@@ -238,7 +238,7 @@ bool CDROM_Interface_Image::ReadSectorsHost(void *buffer, bool raw, unsigned lon
 	unsigned int sectorSize = raw ? RAW_SECTOR_SIZE : COOKED_SECTOR_SIZE;
 	bool success = true; //Gobliiins reads 0 sectors
 	for(unsigned long i = 0; i < num; i++) {
-		success = ReadSector((Bit8u*)buffer + (i * sectorSize), raw, sector + i);
+		success = ReadSector((Bit8u*)buffer + (i * (Bitu)sectorSize), raw, sector + i);
 		if (!success) break;
 	}
 

--- a/src/dos/dos_tables.cpp
+++ b/src/dos/dos_tables.cpp
@@ -71,7 +71,7 @@ void DOS_GetMemory_reinit() {
 void DOS_GetMemory_unmap() {
 	if (DOS_PRIVATE_SEGMENT != 0) {
 		LOG(LOG_MISC,LOG_DEBUG)("Unmapping DOS private segment 0x%04x-0x%04x",DOS_PRIVATE_SEGMENT,DOS_PRIVATE_SEGMENT_END-1u);
-		if (DOS_PRIVATE_SEGMENT >= 0xA000u) MEM_unmap_physmem((unsigned int)DOS_PRIVATE_SEGMENT<<4u,((unsigned int)DOS_PRIVATE_SEGMENT_END<<4u)-1u);
+		if (DOS_PRIVATE_SEGMENT >= 0xA000u) MEM_unmap_physmem((Bitu)DOS_PRIVATE_SEGMENT<<4u,((Bitu)DOS_PRIVATE_SEGMENT_END<<4u)-1u);
 		DOS_GetMemory_unmapped = true;
 		DOS_PRIVATE_SEGMENT_END = 0;
 		DOS_PRIVATE_SEGMENT = 0;
@@ -118,8 +118,8 @@ void DOS_GetMemory_Choose() {
         }
 
 		if (DOS_PRIVATE_SEGMENT >= 0xA000) {
-			memset(GetMemBase()+((unsigned int)DOS_PRIVATE_SEGMENT<<4u),0x00,(unsigned int)(DOS_PRIVATE_SEGMENT_END-DOS_PRIVATE_SEGMENT)<<4u);
-			MEM_map_RAM_physmem((unsigned int)DOS_PRIVATE_SEGMENT<<4u,((unsigned int)DOS_PRIVATE_SEGMENT_END<<4u)-1u);
+			memset(GetMemBase()+((Bitu)DOS_PRIVATE_SEGMENT<<4u),0x00,(Bitu)(DOS_PRIVATE_SEGMENT_END-DOS_PRIVATE_SEGMENT)<<4u);
+			MEM_map_RAM_physmem((Bitu)DOS_PRIVATE_SEGMENT<<4u,((Bitu)DOS_PRIVATE_SEGMENT_END<<4u)-1u);
 		}
 
 		LOG(LOG_MISC,LOG_DEBUG)("DOS private segment set to 0x%04x-0x%04x",DOS_PRIVATE_SEGMENT,DOS_PRIVATE_SEGMENT_END-1);

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -368,7 +368,7 @@ Bit32u fatDrive::getClusterValue(Bit32u clustNum) {
 	fatsectnum = bootbuffer.reservedsectors + (fatoffset / bootbuffer.bytespersector) + partSectOff;
 	fatentoff = fatoffset % bootbuffer.bytespersector;
 
-    assert((bootbuffer.bytespersector * 2) <= sizeof(fatSectBuffer));
+    assert((bootbuffer.bytespersector * (Bitu)2) <= sizeof(fatSectBuffer));
 
 	if(curFatSect != fatsectnum) {
 		/* Load two sectors at once for FAT12 */
@@ -417,7 +417,7 @@ void fatDrive::setClusterValue(Bit32u clustNum, Bit32u clustValue) {
 	fatsectnum = bootbuffer.reservedsectors + (fatoffset / bootbuffer.bytespersector) + partSectOff;
 	fatentoff = fatoffset % bootbuffer.bytespersector;
 
-    assert((bootbuffer.bytespersector * 2) <= sizeof(fatSectBuffer));
+    assert((bootbuffer.bytespersector * (Bitu)2) <= sizeof(fatSectBuffer));
 
 	if(curFatSect != fatsectnum) {
 		/* Load two sectors at once for FAT12 */
@@ -976,7 +976,7 @@ void fatDrive::fatDriveInit(const char *sysFilename, Bit32u bytesector, Bit32u c
         if (!memcmp(mbrData.booter+4,"IPL1",4)) {
             unsigned char ipltable[SECTOR_SIZE_MAX];
             unsigned int max_entries = (std::min)(16UL,(unsigned long)(loadedDisk->getSectSize() / sizeof(_PC98RawPartition)));
-            unsigned int i;
+            Bitu i;
 
             LOG_MSG("PC-98 IPL1 signature detected");
 

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -142,7 +142,7 @@ template <class MT> bool String_DBCS_TO_HOST_SHIFTJIS(host_cnv_char_t *d/*CROSS_
         if (rawofs == 0xFFFF)
             return false;
 
-        assert((size_t)(rawofs+0x40) <= rawtbl_max);
+        assert((size_t)(rawofs+ (Bitu)0x40) <= rawtbl_max);
         wc = rawtbl[rawofs + (ic & 0x3F)];
         if (wc == 0x0000)
             return false;
@@ -177,7 +177,7 @@ template <class MT> int DBCS_SHIFTJIS_From_Host_Find(int c,const MT *hitbl,const
         MT ofs = hitbl[h];
 
         if (ofs == 0xFFFF) continue;
-        assert((size_t)(ofs+0x40) <= rawtbl_max);
+        assert((size_t)(ofs+ (Bitu)0x40) <= rawtbl_max);
 
         for (size_t l=0;l < 0x40;l++) {
             if ((MT)c == rawtbl[ofs+l])

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -104,7 +104,7 @@ static Real64 FPU_FLD80(PhysPt addr,FPU_Reg_80 &raw) {
 	test.eind.l.upper = (Bit32s)mem_readd(addr+4);
 	test.begin = (Bit16s)mem_readw(addr+8);
    
-	Bit64s exp64 = (((test.begin&0x7fff) - BIAS80));
+	Bit64s exp64 = (((test.begin&0x7fff) - (Bit64s)BIAS80));
 	Bit64s blah = ((exp64 >0)?exp64:-exp64)&0x3ff;
 	Bit64s exp64final = ((exp64 >0)?blah:-blah) +BIAS64;
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -754,8 +754,8 @@ static void MIXER_MixData(Bitu fracs/*render up to*/) {
     unsigned int whole,frac;
     bool endframe = false;
 
-    if (fracs >= (Bitu)(mixer.samples_this_ms.w * mixer.samples_this_ms.fd)) {
-        fracs = (Bitu)(mixer.samples_this_ms.w * mixer.samples_this_ms.fd);
+    if (fracs >= ((Bitu)mixer.samples_this_ms.w * mixer.samples_this_ms.fd)) {
+        fracs = ((Bitu)mixer.samples_this_ms.w * mixer.samples_this_ms.fd);
         endframe = true;
     }
 
@@ -823,7 +823,7 @@ static void MIXER_FillUp(void) {
     SDL_LockAudio();
     float index = PIC_TickIndex();
     if (index < 0) index = 0;
-    MIXER_MixData((Bitu)(index * ((Bitu)mixer.samples_this_ms.w * (Bitu)mixer.samples_this_ms.fd)));
+    MIXER_MixData((Bitu)(((double)index * ((Bitu)mixer.samples_this_ms.w * mixer.samples_this_ms.fd))));
     SDL_UnlockAudio();
 }
 
@@ -1001,7 +1001,7 @@ public:
 private:
     void ShowVolume(const char * name,float vol0,float vol1) {
         WriteOut("%-8s %3.0f:%-3.0f  %+3.2f:%-+3.2f \n",name,
-            vol0*100,vol1*100,
+            (double)vol0*100,(double)vol1*100,
             20*log(vol0)/log(10.0f),20*log(vol1)/log(10.0f)
         );
     }
@@ -1053,7 +1053,7 @@ bool MENU_get_swapstereo(void) {
 void MAPPER_VolumeUp(bool pressed) {
     if (!pressed) return;
 
-    double newvol = ((mixer.mastervol[0] + mixer.mastervol[1]) / 0.7) * 0.5;
+    double newvol = (((double)mixer.mastervol[0] + mixer.mastervol[1]) / 0.7) * 0.5;
 
     if (newvol > 1) newvol = 1;
 
@@ -1065,7 +1065,7 @@ void MAPPER_VolumeUp(bool pressed) {
 void MAPPER_VolumeDown(bool pressed) {
     if (!pressed) return;
 
-    double newvol = (mixer.mastervol[0] + mixer.mastervol[1]) * 0.7 * 0.5;
+    double newvol = ((double)mixer.mastervol[0] + mixer.mastervol[1]) * 0.7 * 0.5;
 
     if (fabs(newvol - 1.0) < 0.25)
         newvol = 1;
@@ -1078,7 +1078,7 @@ void MAPPER_VolumeDown(bool pressed) {
 void MAPPER_RecVolumeUp(bool pressed) {
     if (!pressed) return;
 
-    double newvol = ((mixer.recordvol[0] + mixer.recordvol[1]) / 0.7) * 0.5;
+    double newvol = (((double)mixer.recordvol[0] + mixer.recordvol[1]) / 0.7) * 0.5;
 
     if (newvol > 1) newvol = 1;
 
@@ -1090,7 +1090,7 @@ void MAPPER_RecVolumeUp(bool pressed) {
 void MAPPER_RecVolumeDown(bool pressed) {
     if (!pressed) return;
 
-    double newvol = (mixer.recordvol[0] + mixer.recordvol[1]) * 0.7 * 0.5;
+    double newvol = ((double)mixer.recordvol[0] + mixer.recordvol[1]) * 0.7 * 0.5;
 
     if (fabs(newvol - 1.0) < 0.25)
         newvol = 1;


### PR DESCRIPTION
Fixes warnings that appear in the Visual Studio 2019 IDE about potential arithmetic overflows and shifting problems.

Most are for the case where you have an arithmetic operation between two variables, with the result being casted to a larger type. At least one of the variables needs to be casted to the larger type before the operation is done to make sure no overflow happens that wouldn't have happened with the larger type.

There are also a few fixes for shifts, where data could be lost when shifting using the smaller type. Casting to the larger type before the shift fixes the warning.