### PR TITLE
Fix AVI/WAV writer with NDEBUG defined. Fix nMakefile for Direct3D output.

### DIFF
--- a/ref-nmake/nMakefile
+++ b/ref-nmake/nMakefile
@@ -320,6 +320,10 @@ OBJS_MT32 =	$(DBX_PATH)\src\mt32\AReverbModel.obj \
 			$(DBX_PATH)\src\mt32\freeverb\revmodel.obj \
 			$(DBX_PATH)\src\mt32\sha1\sha1.obj 
 
+OBJS_D3D =	$(DBX_PATH)\src\output\direct3d\direct3d.obj \
+			$(DBX_PATH)\src\output\direct3d\hq2x_d3d.obj \
+			$(DBX_PATH)\src\output\direct3d\ScalingEffect.obj
+
 OBJS4 = $(OBJS4) $(OBJS_MT32)
 CXXFLAGS = $(CXXFLAGS) -I$(DBX_PATH)/src/mt32
 
@@ -333,6 +337,7 @@ LFLAGS = $(LFLAGS) -LTCG
 
 !IFDEF D3D9
 CXXFLAGS = -DHAVE_D3D9_H=1 $(CXXFLAGS)
+OBJS4 = $(OBJS4) $(OBJS_D3D)
 !ENDIF
 
 .SUFFIXES: .c.o

--- a/src/aviwriter/avi_writer.cpp
+++ b/src/aviwriter/avi_writer.cpp
@@ -36,7 +36,7 @@
 #endif
 
 /* FIXME: I made the mistake of putting critical calls in assert() calls, which under MSVC++ may evaluate to nothing in Release builds */
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined (__MINGW32__)
 # ifdef NDEBUG
 #  undef assert
 #  define assert(x) x

--- a/src/aviwriter/riff_wav_writer.cpp
+++ b/src/aviwriter/riff_wav_writer.cpp
@@ -36,6 +36,14 @@
 # define O_BINARY 0
 #endif
 
+/* FIXME: I made the mistake of putting critical calls in assert() calls, which under MSVC++ may evaluate to nothing in Release builds */
+#if defined(_MSC_VER) || defined (__MINGW32__)
+# ifdef NDEBUG
+#  undef assert
+#  define assert(x) x
+# endif
+#endif
+
 #include "riff_wav_writer.h"
 #include "rawint.h"
 


### PR DESCRIPTION
Besides Visual C++, The CRT of MinGW/mingw-w64 also defines assert() to nothing if NDEBUG was defined. 
By the way,  riff_wav_writer.cpp also has some critical routines wrapped in assert().

