### PR TITLE
Minor fixes

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3199,7 +3199,7 @@ int utf8_encode(char **ptr,char *fence,uint32_t code) {
             *p++ = (char)(0x80 | ((code >> 6) & 0x3F));
             *p++ = (char)(0x80 | (code & 0x3F));
             break;
-    };
+    }
 
     *ptr = p;
     return 0;
@@ -3268,7 +3268,7 @@ int utf8_decode(const char **ptr,const char *fence) {
             c = (unsigned char)(*p++); if ((c&0xC0) != 0x80) return UTF8ERR_INVALID;
             ret |= c&0x3F;
             break;
-    };
+    }
 
     *ptr = p;
     return ret;

--- a/src/gui/zipfile.cpp
+++ b/src/gui/zipfile.cpp
@@ -63,7 +63,7 @@ int ZIPFileEntry::read(void *buffer,size_t count) {
     if (file == NULL || file_offset == (off_t)0) return -1;
     if (position >= file_length) return 0;
 
-    size_t mread = size_t(file_length - position);
+    size_t mread = (size_t)file_length - position;
     if (mread > count) mread = count;
 
     if (mread > 0) {

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -3903,9 +3903,7 @@ void PC98_BIOS_SCSI_CALL(void) {
 
                     for (i=0;i < ssize;i++) PC98_BIOS_FLOPPY_BUFFER[i] = mem_readb(memaddr+i);
 
-                    if (floppy->Write_AbsoluteSector(sector,PC98_BIOS_FLOPPY_BUFFER) == 0) {
-                    }
-                    else {
+                    if (floppy->Write_AbsoluteSector(sector,PC98_BIOS_FLOPPY_BUFFER) != 0) {
                         reg_ah = 0xD0;
                         CALLBACK_SCF(true);
                         break;

--- a/src/ints/int10_put_pixel.cpp
+++ b/src/ints/int10_put_pixel.cpp
@@ -209,7 +209,7 @@ void INT10_GetPixel(Bit16u x,Bit16u y,Bit8u page,Bit8u * color) {
 			Bit16u off=(y>>1)*80+(x>>3);
 			if (y&1) off+=8*1024;
 			Bit8u val=real_readb(0xb800,off);
-			*color=(val>>((7-(x&7)))) & 1 ;
+			*color=(val>>(7-(x&7))) & 1 ;
 		}
 		break;
 	case M_TANDY16:

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -224,7 +224,7 @@ Drawable::Drawable(Drawable &src, RGB clear) :
 		this->clear(clear);
 	} else {
 		for (unsigned int h = 0; (int)h < src.ch; h++) {
-			memcpy(buffer+(unsigned int)src.cw*h,src.buffer+(unsigned int)src.width*(h+(unsigned int)src.ty)+src.tx,4u*(unsigned int)src.cw);
+			memcpy(buffer+(size_t)src.cw*h,src.buffer+src.width*(h+(size_t)src.ty)+src.tx,4u*(size_t)src.cw);
 		}
 	}
 }
@@ -430,8 +430,8 @@ void Drawable::drawDrawable(Drawable &d, unsigned char alpha)
 	RGB *src, *dest;
 
 	for (h = imax(d.cy,-ty-y); h < sch && y+h < ch; h++) {
-		src = d.buffer+d.width*(h+d.ty)+d.tx;
-		dest = buffer+width*(y+ty+h)+tx+x;
+		src = d.buffer+d.width*((size_t)h+d.ty)+d.tx;
+		dest = buffer+width*((size_t)y+ty+h)+tx+x;
 		for (w = imax(d.cx,-tx-x); w < scw && x+w < cw; w++) {
 			RGB srcb = src[w], destb = dest[w];
 			unsigned int sop = Color::A(srcb)*((unsigned int)alpha)/255;

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -1290,7 +1290,7 @@ public:
 	/** Can be used to provide kerning. */
 	virtual int getWidth(const String &s, Size start = 0, Size len = (Size)-1) const {
 		int width = 0;
-		if (start+len > s.size()) len = (Size)(s.size()-start);
+		if ((size_t)start+len > s.size()) len = (Size)(s.size()-start);
 		while (len--) width += getWidth(s[start++]);
 		return width;
 	}

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -366,12 +366,7 @@ void close_directory(dir_information* dirp) {
 #endif
 
 FILE *fopen_wrap(const char *path, const char *mode) {
-#if defined(WIN32) || defined(OS2)
-	;
-#elif defined (MACOSX)
-	;
-#else  
-#if defined (HAVE_REALPATH)
+#if !defined(WIN32) && !defined(OS2) && !defined(MACOSX) && defined(HAVE_REALPATH)
 	char work[CROSS_LEN] = {0};
 	strncpy(work,path,CROSS_LEN-1);
 	char* last = strrchr(work,'/');
@@ -413,8 +408,6 @@ FILE *fopen_wrap(const char *path, const char *mode) {
 	}
 */
 #endif //0 
-
-#endif //HAVE_REALPATH
 #endif
 
 	return fopen(path,mode);

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -359,7 +359,7 @@ bool Prop_double::CheckValue(Value const& in, bool warn)
 	return false;
 }
 
-bool Prop_int::SetValue(std::string const& input) {;
+bool Prop_int::SetValue(std::string const& input) {
     Value val;
     if (!val.SetValue(input,Value::V_INT)) return false;
     return SetVal(val,false,/*warn*/true);
@@ -451,7 +451,7 @@ bool Prop_multival_remain::SetValue(std::string const& input,bool init) {
     Value::Etype prevtype = Value::V_NONE;
     string prevargument = "";
     
-    while( (section->Get_prop(number_of_properties)) )
+    while(section->Get_prop(number_of_properties))
         number_of_properties++;
 
     string::size_type loc = string::npos;
@@ -1150,7 +1150,7 @@ bool CommandLine::FindStringRemainBegin(char const * const name,std::string & va
         size_t len = strlen(name);
             for (it=cmds.begin();it!=cmds.end();it++) {
                 if (strncasecmp(name,(*it).c_str(),len)==0) {
-                    std::string temp = ((*it).c_str() + len);
+                    std::string temp = (*it).c_str() + len;
                     //Restore quotes for correct parsing in later stages
                     if (temp.find(" ") != std::string::npos)
                         value = std::string("\"") + temp + std::string("\"");
@@ -1164,7 +1164,7 @@ bool CommandLine::FindStringRemainBegin(char const * const name,std::string & va
     it++;
     for (;it!=cmds.end();it++) {
         value += " ";
-        std::string temp = (*it);
+        std::string temp = *it;
         if (temp.find(" ") != std::string::npos)
             value += std::string("\"") + temp + std::string("\"");
         else
@@ -1436,7 +1436,7 @@ CommandLine::CommandLine(char const * const name,char const * const cmdline,enum
 
 void CommandLine::Shift(unsigned int amount) {
     while(amount--) {
-        file_name = cmds.size()?(*(cmds.begin())):"";
+        file_name = cmds.size()?*(cmds.begin()):"";
         if (cmds.size()) cmds.erase(cmds.begin());
     }
 }

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -77,7 +77,7 @@ char *ltrim(char *str) {
 char *rtrim(char *str) {
 	char *p;
 	p = strchr(str, '\0');
-	while (--p >= str && isspace(*reinterpret_cast<unsigned char*>(p))) {};
+	while (--p >= str && isspace(*reinterpret_cast<unsigned char*>(p))) {}
 	p[1] = '\0';
 	return str;
 }
@@ -115,7 +115,7 @@ bool ScanCMDBool(char * cmd,char const * const check) {
 
 /* This scans the command line for a remaining switch and reports it else returns 0*/
 char * ScanCMDRemain(char * cmd) {
-	char * scan,*found;;
+	char * scan,*found;
 	if ((scan=found=strchr(cmd,'/'))) {
 		while ( *scan && !isspace(*reinterpret_cast<unsigned char*>(scan)) ) scan++;
 		*scan=0;

--- a/src/mt32/Tables.cpp
+++ b/src/mt32/Tables.cpp
@@ -63,12 +63,12 @@ Tables::Tables() {
 	// CONFIRMED: Based on a table found by Mok in the MT-32 control ROM
 	masterVolToAmpSubtraction[0] = 255;
 	for (int masterVol = 1; masterVol <= 100; masterVol++) {
-		masterVolToAmpSubtraction[masterVol] = (int)(106.31 - 16.0f * LOG2F((float)masterVol));
+        masterVolToAmpSubtraction[masterVol] = (Bit8u)(106.31 - 16.0 * LOG2F((float)masterVol));
 	}
 #endif
 
 	for (int i = 0; i <= 100; i++) {
-		pulseWidth100To255[i] = (int)(i * 255 / 100.0f + 0.5f);
+		pulseWidth100To255[i] = (Bit8u)(i * 255 / 100.0f + 0.5f);
 		//synth->printDebug("%d: %d", i, pulseWidth100To255[i]);
 	}
 

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1463,7 +1463,7 @@ void DOS_Shell::CMD_DATE(char * args) {
 	const char* datestring = MSG_Get("SHELL_CMD_DATE_DAYS");
 	Bit32u length;
 	char day[6] = {0};
-	if(sscanf(datestring,"%u",&length) && (length<5) && (strlen(datestring)==(length*7+1))) {
+	if(sscanf(datestring,"%u",&length) && (length<5) && (strlen(datestring)==((size_t)length*7+1))) {
 		// date string appears valid
 		for(Bit32u i = 0; i < length; i++) day[i] = datestring[reg_al*length+1+i];
 	}
@@ -1804,7 +1804,8 @@ void DOS_Shell::CMD_ADDKEY(char * args){
 		return;
 	}
 	char * word;
-	int delay = 0, duration = 0, core=0;
+    pic_tickindex_t delay = 0;
+    int duration = 0, core = 0;
 
 	while (*args) {
 		word=StripWord(args);

--- a/src/xBRZ/xbrz.cpp
+++ b/src/xBRZ/xbrz.cpp
@@ -482,7 +482,7 @@ void scaleImage(const uint32_t* src, uint32_t* trg, int srcWidth, int srcHeight,
     //"use" space at the end of the image as temporary buffer for "on the fly preprocessing": we even could use larger area of
     //"sizeof(uint32_t) * srcWidth * (yLast - yFirst)" bytes without risk of accidental overwriting before accessing
     const int bufferSize = srcWidth;
-    unsigned char* preProcBuffer = reinterpret_cast<unsigned char*>(trg + yLast * Scaler::scale * trgWidth) - bufferSize;
+    unsigned char* preProcBuffer = reinterpret_cast<unsigned char*>(trg + (size_t)yLast * Scaler::scale * trgWidth) - bufferSize;
     std::fill(preProcBuffer, preProcBuffer + bufferSize, '\0');
     static_assert(BLEND_NONE == 0, "");
 
@@ -492,10 +492,10 @@ void scaleImage(const uint32_t* src, uint32_t* trg, int srcWidth, int srcHeight,
     {
         const int y = yFirst - 1;
 
-        const uint32_t* s_m1 = src + srcWidth * std::max(y - 1, 0);
-        const uint32_t* s_0  = src + srcWidth * y; //center line
-        const uint32_t* s_p1 = src + srcWidth * std::min(y + 1, srcHeight - 1);
-        const uint32_t* s_p2 = src + srcWidth * std::min(y + 2, srcHeight - 1);
+        const uint32_t* s_m1 = src + (size_t)srcWidth * std::max(y - 1, 0);
+        const uint32_t* s_0  = src + (size_t)srcWidth * y; //center line
+        const uint32_t* s_p1 = src + (size_t)srcWidth * std::min(y + 1, srcHeight - 1);
+        const uint32_t* s_p2 = src + (size_t)srcWidth * std::min(y + 2, srcHeight - 1);
 
         for (int x = 0; x < srcWidth; ++x)
         {
@@ -543,12 +543,12 @@ void scaleImage(const uint32_t* src, uint32_t* trg, int srcWidth, int srcHeight,
 
     for (int y = yFirst; y < yLast; ++y)
     {
-        uint32_t* out = trg + Scaler::scale * y * trgWidth; //consider MT "striped" access
+        uint32_t* out = trg + (size_t)Scaler::scale * y * trgWidth; //consider MT "striped" access
 
-        const uint32_t* s_m1 = src + srcWidth * std::max(y - 1, 0);
-        const uint32_t* s_0  = src + srcWidth * y; //center line
-        const uint32_t* s_p1 = src + srcWidth * std::min(y + 1, srcHeight - 1);
-        const uint32_t* s_p2 = src + srcWidth * std::min(y + 2, srcHeight - 1);
+        const uint32_t* s_m1 = src + (size_t)srcWidth * std::max(y - 1, 0);
+        const uint32_t* s_0  = src + (size_t)srcWidth * y; //center line
+        const uint32_t* s_p1 = src + (size_t)srcWidth * std::min(y + 1, srcHeight - 1);
+        const uint32_t* s_p2 = src + (size_t)srcWidth * std::min(y + 2, srcHeight - 1);
 
         unsigned char blend_xy1 = 0; //corner blending for current (x, y + 1) position
 


### PR DESCRIPTION
Fixes some more arithmetic overflow warnings.
Remove some unnecessary semicolons, parentheses, incorrect casts (casting to int for a Bit8u assignment).

Compiles and runs.