### PR TITLE
Some SVN commits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,9 @@
     status bit after seek/calibrate, not just when the
     head hits track 0 (programming mistake).
   - PC-98 40-column text mode is now supported.
+  - Integrated commits from mainline (Allofich)
+    - In the mapper, display disabled items or events
+    with no binding in grey. 
 0.82.20
   - Dynamic core IMUL instruction mistake fixed,
     signed multiply works properly again.

--- a/patch-integration/Skipped SVN commits.txt
+++ b/patch-integration/Skipped SVN commits.txt
@@ -1,16 +1,5 @@
 Commit#:	Reason for skipping:
 
-3847		Conflicts with https://github.com/joncampbell123/dosbox-x/commit/ac70b5599fb2fb824be7ed627ec4e70aa8b6bc79
-3857		Conflict
-3859		Conflict. Masking/wrapping is implemented in DOSBox-X by masking the array access per pixel.
-3863		Conflict
-3865		Conflict
-3867		Conflict
-3869		Not sure if this is needed for DOSBox-X
-3870		Conflict
-3871		Conflict
-3873		Conflict
-3891		Conflict
 3922		Conflict. "Use safe_strncpy for resolution lines" part is already in DOSBox-X.
 3930		Conflict
 3931		May not have effect or be wanted

--- a/src/gui/midi_win32.h
+++ b/src/gui/midi_win32.h
@@ -127,13 +127,13 @@ public:
 
 #if WIN32_MIDI_PORT_PROTECT
 				if( midi_dll == false || strcmp( mididev.szPname, "Roland VSC" ) != 0 )
-					res = midiOutOpen(&m_out, nummer, PtrToUlong(m_event), 0, CALLBACK_EVENT);
+					res = midiOutOpen(&m_out, nummer, (DWORD_PTR)m_event, 0, CALLBACK_EVENT);
 				else {
 					// Roland VSC - crash protection
 					res = MidiHelper_Start(nummer);
 				}
 #else
-				res = midiOutOpen(&m_out, nummer, PtrToUlong(m_event), 0, CALLBACK_EVENT);
+				res = midiOutOpen(&m_out, nummer, (DWORD_PTR)m_event, 0, CALLBACK_EVENT);
 #endif
 
 
@@ -142,12 +142,12 @@ public:
 
 					if( nummer != 0 ) {
 						LOG_MSG("MIDI:win32 selected %s","default");
-						res = midiOutOpen(&m_out, MIDI_MAPPER, PtrToUlong(m_event), 0, CALLBACK_EVENT);
+						res = midiOutOpen(&m_out, MIDI_MAPPER, (DWORD_PTR)m_event, 0, CALLBACK_EVENT);
 					}
 				}
 			}
 		} else {
-			res = midiOutOpen(&m_out, MIDI_MAPPER, PtrToUlong(m_event), 0, CALLBACK_EVENT);
+			res = midiOutOpen(&m_out, MIDI_MAPPER, (DWORD_PTR)m_event, 0, CALLBACK_EVENT);
 		}
 		if (res != MMSYSERR_NOERROR) return false;
 

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -90,10 +90,11 @@ class CModEvent;
 
 enum {
     CLR_BLACK = 0,
-    CLR_WHITE = 1,
-    CLR_RED   = 2,
-    CLR_BLUE  = 3,
-    CLR_GREEN = 4
+    CLR_GREY = 1,
+    CLR_WHITE = 2,
+    CLR_RED = 3,
+    CLR_BLUE = 4,
+    CLR_GREEN = 5
 };
 
 enum BB_Types {
@@ -213,13 +214,14 @@ static CKeyEvent*                               num_lock_event = NULL;
 
 static std::map<std::string, size_t>            name_to_events;
 
-static SDL_Color                                map_pal[5] =
+static SDL_Color                                map_pal[6] =
 {
     {0x00,0x00,0x00,0x00},          //0=black
-    {0xff,0xff,0xff,0x00},          //1=white
-    {0xff,0x00,0x00,0x00},          //2=red
-    {0x10,0x30,0xff,0x00},          //3=blue
-    {0x00,0xff,0x20,0x00}           //4=green
+    {0x7f,0x7f,0x7f,0x00},          //1=grey
+    {0xff,0xff,0xff,0x00},          //2=white
+    {0xff,0x00,0x00,0x00},          //3=red
+    {0x10,0x30,0xff,0x00},          //4=blue
+    {0x00,0xff,0x20,0x00}           //5=green
 };
 
 static KeyBlock combo_f[12] =
@@ -250,38 +252,38 @@ static KeyBlock combo_1_pc98[14] =
 
 static KeyBlock combo_2[12] =
 {
-    {"q","q",KBD_q},            {"w","w",KBD_w},    {"e","e",KBD_e},
-    {"r","r",KBD_r},            {"t","t",KBD_t},    {"y","y",KBD_y},
-    {"u","u",KBD_u},            {"i","i",KBD_i},    {"o","o",KBD_o},
-    {"p","p",KBD_p},            {"[","lbracket",KBD_leftbracket},
-    {"]","rbracket",KBD_rightbracket},
+    {"Q","q",KBD_q},            {"W","w",KBD_w},    {"E","e",KBD_e},
+    {"R","r",KBD_r},            {"T","t",KBD_t},    {"Y","y",KBD_y},
+    {"U","u",KBD_u},            {"I","i",KBD_i},    {"O","o",KBD_o},
+    {"P","p",KBD_p},            {"[{","lbracket",KBD_leftbracket},
+    {"]}","rbracket",KBD_rightbracket},
 };
 
 static KeyBlock combo_3[12] =
 {
-    {"a","a",KBD_a},            {"s","s",KBD_s},    {"d","d",KBD_d},
-    {"f","f",KBD_f},            {"g","g",KBD_g},    {"h","h",KBD_h},
-    {"j","j",KBD_j},            {"k","k",KBD_k},    {"l","l",KBD_l},
-    {";","semicolon",KBD_semicolon},                {"'","quote",KBD_quote},
-    {"\\","backslash",KBD_backslash},
+    {"A","a",KBD_a},            {"S","s",KBD_s},    {"D","d",KBD_d},
+    {"F","f",KBD_f},            {"G","g",KBD_g},    {"H","h",KBD_h},
+    {"J","j",KBD_j},            {"K","k",KBD_k},    {"L","l",KBD_l},
+    {";:","semicolon",KBD_semicolon},               {"'\"","quote",KBD_quote},
+    {"\\|","backslash",KBD_backslash},
 };
 
 static KeyBlock combo_3_pc98[12] =
 {
-    {"a","a",KBD_a},            {"s","s",KBD_s},    {"d","d",KBD_d},
-    {"f","f",KBD_f},            {"g","g",KBD_g},    {"h","h",KBD_h},
-    {"j","j",KBD_j},            {"k","k",KBD_k},    {"l","l",KBD_l},
-    {";+","semicolon",KBD_semicolon},               {"'","quote",KBD_quote},
-    {"\\","backslash",KBD_backslash},
+    {"A","a",KBD_a},            {"S","s",KBD_s},    {"D","d",KBD_d},
+    {"F","f",KBD_f},            {"G","g",KBD_g},    {"H","h",KBD_h},
+    {"J","j",KBD_j},            {"K","k",KBD_k},    {"L","l",KBD_l},
+    {";:+","semicolon",KBD_semicolon},              {"'\"","quote",KBD_quote},
+    {"\\|","backslash",KBD_backslash},
 };
 
 static KeyBlock combo_4[11] =
 {
-    {"<","lessthan",KBD_extra_lt_gt},
-    {"z","z",KBD_z},            {"x","x",KBD_x},    {"c","c",KBD_c},
-    {"v","v",KBD_v},            {"b","b",KBD_b},    {"n","n",KBD_n},
-    {"m","m",KBD_m},            {",","comma",KBD_comma},
-    {".","period",KBD_period},                      {"/","slash",KBD_slash},
+    {"<>","lessthan",KBD_extra_lt_gt},
+    {"Z","z",KBD_z},            {"X","x",KBD_x},    {"C","c",KBD_c},
+    {"V","v",KBD_v},            {"B","b",KBD_b},    {"N","n",KBD_n},
+    {"M","m",KBD_m},            {",<","comma",KBD_comma},
+    {".>","period",KBD_period},                     {"/?","slash",KBD_slash},
 };
 
 static void                                     SetActiveEvent(CEvent * event);
@@ -1887,7 +1889,6 @@ void CBindGroup::ActivateBindList(CBindList * list,Bits value,bool ev_trigger) {
         }
     }
     for (it=list->begin();it!=list->end();it++) {
-    /*BUG:CRASH if keymapper key is removed*/
         if (validmod==(*it)->mods) (*it)->ActivateBind(value,ev_trigger);
     }
 }
@@ -2028,8 +2029,11 @@ public:
         event=_event;   
     }
     virtual ~CEventButton() {}
+    void BindColor(void) {
+        this->SetColor(event->bindlist.begin() == event->bindlist.end() ? CLR_GREY : CLR_WHITE);
+    }
     void Click(void) {
-        if (last_clicked) last_clicked->SetColor(CLR_WHITE);
+        if (last_clicked) last_clicked->BindColor();
         this->SetColor(CLR_GREEN);
         SetActiveEvent(event);
         last_clicked=this;
@@ -3060,14 +3064,17 @@ static void CreateLayout(void) {
     AddJHatButton(PX(XO+8+2),PY(YO+1),BW,BH,"RGT",0,0,1);
 
     /* Labels for the joystick */
+    CTextButton* btn;
     if (joytype ==JOY_2AXIS) {
         new CTextButton(PX(XO+0),PY(YO-1),3*BW,20,"Joystick 1");
         new CTextButton(PX(XO+4),PY(YO-1),3*BW,20,"Joystick 2");
-        new CTextButton(PX(XO+8),PY(YO-1),3*BW,20,"Disabled");
+        btn = new CTextButton(PX(XO + 8), PY(YO - 1), 3 * BW, 20, "Disabled");
+        btn->SetColor(CLR_GREY);
     } else if(joytype ==JOY_4AXIS || joytype == JOY_4AXIS_2) {
         new CTextButton(PX(XO+0),PY(YO-1),3*BW,20,"Axis 1/2");
         new CTextButton(PX(XO+4),PY(YO-1),3*BW,20,"Axis 3/4");
-        new CTextButton(PX(XO+8),PY(YO-1),3*BW,20,"Disabled");
+        btn = new CTextButton(PX(XO + 8), PY(YO - 1), 3 * BW, 20, "Disabled");
+        btn->SetColor(CLR_GREY);
     } else if(joytype == JOY_CH) {
         new CTextButton(PX(XO+0),PY(YO-1),3*BW,20,"Axis 1/2");
         new CTextButton(PX(XO+4),PY(YO-1),3*BW,20,"Axis 3/4");
@@ -3077,9 +3084,12 @@ static void CreateLayout(void) {
         new CTextButton(PX(XO+4),PY(YO-1),3*BW,20,"Axis 3");
         new CTextButton(PX(XO+8),PY(YO-1),3*BW,20,"Hat/D-pad");
     } else if(joytype == JOY_NONE) {
-        new CTextButton(PX(XO+0),PY(YO-1),3*BW,20,"Disabled");
-        new CTextButton(PX(XO+4),PY(YO-1),3*BW,20,"Disabled");
-        new CTextButton(PX(XO+8),PY(YO-1),3*BW,20,"Disabled");
+        btn = new CTextButton(PX(XO + 0), PY(YO - 1), 3 * BW, 20, "Disabled");
+        btn->SetColor(CLR_GREY);
+        btn = new CTextButton(PX(XO + 4), PY(YO - 1), 3 * BW, 20, "Disabled");
+        btn->SetColor(CLR_GREY);
+        btn = new CTextButton(PX(XO + 8), PY(YO - 1), 3 * BW, 20, "Disabled");
+        btn->SetColor(CLR_GREY);
     }
    
    
@@ -3907,9 +3917,9 @@ void MAPPER_RunInternal() {
     if (mapper.surface == NULL) E_Exit("Could not initialize video mode for mapper: %s",SDL_GetError());
 
     /* Set some palette entries */
-    SDL_SetPalette(mapper.surface, SDL_LOGPAL|SDL_PHYSPAL, map_pal, 0, 5);
+    SDL_SetPalette(mapper.surface, SDL_LOGPAL|SDL_PHYSPAL, map_pal, 0, 6);
     if (last_clicked) {
-        last_clicked->SetColor(CLR_WHITE);
+        last_clicked->BindColor();
         last_clicked=NULL;
     }
 #endif
@@ -4055,6 +4065,9 @@ void MAPPER_Init(void) {
     CreateLayout();
     CreateBindGroups();
     if (!MAPPER_LoadBinds()) CreateDefaultBinds();
+    for (CButton_it but_it = buttons.begin(); but_it != buttons.end(); but_it++) {
+        (*but_it)->BindColor();
+    }
     if (SDL_GetModState()&KMOD_CAPS) {
         for (CBindList_it bit=caps_lock_event->bindlist.begin();bit!=caps_lock_event->bindlist.end();bit++) {
 #if SDL_VERSION_ATLEAST(1, 2, 14)
@@ -4090,7 +4103,6 @@ void MAPPER_StartUp() {
     Section_prop * section=static_cast<Section_prop *>(control->GetSection("sdl"));
     mapper.sticks.num=0;
     mapper.sticks.num_groups=0;
-    Bitu i;
 
 #ifdef DOSBOXMENU_EXTERNALLY_MANAGED
     {
@@ -4134,18 +4146,7 @@ void MAPPER_StartUp() {
 
     LOG(LOG_MISC,LOG_DEBUG)("MAPPER starting up");
 
-    for (i=0; i<MAX_VJOY_BUTTONS; i++) {
-        virtual_joysticks[0].button_pressed[i]=false;
-        virtual_joysticks[1].button_pressed[i]=false;
-    }
-    for (i=0; i<MAX_VJOY_HATS; i++) {
-        virtual_joysticks[0].hat_pressed[i]=false;
-        virtual_joysticks[1].hat_pressed[i]=false;
-    }
-    for (i=0; i<MAX_VJOY_AXES; i++) {
-        virtual_joysticks[0].axis_pos[i]=0;
-        virtual_joysticks[1].axis_pos[i]=0;
-    }
+    memset(&virtual_joysticks,0,sizeof(virtual_joysticks));
 
 #if !defined(C_SDL2)
     usescancodes = false;


### PR DESCRIPTION
I'm going back over the commits from SVN I skipped for one reason or another, and implementing them where I can.

Up through 3981, I found 2 commits that could be applied. The others either were irrelevant to DOSBox-X or already applied in DOSBox-X, etc.

The first commit is
https://sourceforge.net/p/dosbox/code-0/3847/

The conversion of DWORD for 64-bit was already done in DOSBox-X in https://github.com/joncampbell123/dosbox-x/commit/ac70b5599fb2fb824be7ed627ec4e70aa8b6bc79 but it seems like casting to DWORD_PTR is preferable. SVN did it that way, the Microsoft article linked in the above commit says "The general rule is that if the original type is DWORD and it needs to be pointer width, convert it to a DWORD_PTR value. " and the function being passed a value takes a DWORD_PTR for that parameter. https://github.com/joncampbell123/dosbox-x/commit/ac70b5599fb2fb824be7ed627ec4e70aa8b6bc79 suggests that the function needs the value to be 32-bit, but I don't see anything to indicate that in the function's documentation:
https://docs.microsoft.com/en-us/windows/win32/api/mmeapi/nf-mmeapi-midioutopen

If you're sure it needs 32-bit, though, maybe the SVN solution isn't good.

The other commit https://sourceforge.net/p/dosbox/code-0/3891/ was partially already implemented in DOSBox-X (the part about preventing the crash). This PR implements the rest: removed the comment about the bug, joystick initialization is simplified, and unassigned keys and events in the mapper show in grey, which seems like a nice feature. Seems to work OK from some light testing.