### PR TITLE
Remove empty statements

### DIFF
--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -180,7 +180,7 @@ static void LogEMUMachine(void) {
             case MCH_MCGA:      m="MCGA";       break;
             case MCH_MDA:       m="MDA";        break;
             default:            break;
-        };
+        }
 
         switch (svgaCard) {
             case SVGA_None:             svga="";                break;
@@ -188,7 +188,7 @@ static void LogEMUMachine(void) {
             case SVGA_TsengET4K:        svga="Tseng ET4000";    break;
             case SVGA_TsengET3K:        svga="Tseng ET3000";    break;
             case SVGA_ParadisePVGA1A:   svga="Paradise PVGA1A"; break;
-        };
+        }
 
         DEBUG_ShowMsg("Machine: %s %s",m,svga);
     }
@@ -605,7 +605,7 @@ void CBreakpoint::ActivateBreakpointsExceptAt(PhysPt adr)
 		if (bp->GetType() == BKPNT_PHYSICAL && bp->GetLocation() == adr)
 			continue;
 		bp->Activate(true);
-	};
+	}
 }
 
 bool CBreakpoint::CheckBreakpoint(Bit16u seg, Bit32u off)
@@ -806,7 +806,7 @@ void CBreakpoint::ShowList(void)
 			DEBUG_ShowMsg("%02X. BPPM %04X:%08X (%02X)\n",nr,bp->GetSegment(),bp->GetOffset(),bp->GetValue());
 		} else if (bp->GetType()==BKPNT_MEMORY_LINEAR ) {
 			DEBUG_ShowMsg("%02X. BPLM %08X (%02X)\n",nr,bp->GetOffset(),bp->GetValue());
-		};
+		}
 		nr++;
 	}
 }
@@ -1195,7 +1195,7 @@ static void DrawCode(void) {
         }
 		mvwprintw(dbg.win_code,i,0,"%04X:%08X ",codeViewData.useCS,disEIP);
 
-		if (drawsize>10) { toolarge = true; drawsize = 9; };
+		if (drawsize>10) { toolarge = true; drawsize = 9; }
  
         if (start != mem_no_address) {
             for (c=0;c<drawsize;c++) {
@@ -1217,7 +1217,7 @@ static void DrawCode(void) {
         }
 
         wattrset (dbg.win_code,0);
-        if (toolarge) { waddstr(dbg.win_code,".."); drawsize++; };
+        if (toolarge) { waddstr(dbg.win_code,".."); drawsize++; }
 		// Spacepad up to 20 characters
 		if(drawsize && (drawsize < 11)) {
 			line20[20 - drawsize*2] = 0;
@@ -1428,7 +1428,7 @@ bool ChangeRegister(char* const str)
     	if (strncmp(hex,"TF",2) == 0) { hex+=2; SETFLAGBIT(TF,GetHexValue(hex,hex)); } else
         //             "VM"
 	    if (strncmp(hex,"ZF",2) == 0) { hex+=2; SETFLAGBIT(ZF,GetHexValue(hex,hex)); } else
-    	{ return false; };
+    	{ return false; }
     }
 
 	return true;
@@ -1522,7 +1522,7 @@ bool ParseCommand(char* str) {
 		Bit32u num = GetHexValue(found,found); found++;
 		SaveMemory(seg,ofs,num);
 		return true;
-	};
+	}
 
 	if (command == "MEMDUMPBIN") { // Dump memory to file binary
 		Bit16u seg = (Bit16u)GetHexValue(found,found); found++;
@@ -1530,7 +1530,7 @@ bool ParseCommand(char* str) {
 		Bit32u num = GetHexValue(found,found); found++;
 		SaveMemoryBin(seg,ofs,num);
 		return true;
-	};
+	}
 
 	if (command == "IV") { // Insert variable
 		Bit16u seg = (Bit16u)GetHexValue(found,found); found++;
@@ -1538,39 +1538,39 @@ bool ParseCommand(char* str) {
 		char name[16];
 		for (int i=0; i<16; i++) {
 			if (found[i] && (found[i]!=' ')) name[i] = found[i]; 
-			else { name[i] = 0; break; };
-		};
+			else { name[i] = 0; break; }
+		}
 		name[15] = 0;
 
 		if(!name[0]) return false;
 		DEBUG_ShowMsg("DEBUG: Created debug var %s at %04X:%04X\n",name,seg,ofs);
 		CDebugVar::InsertVariable(name,(PhysPt)GetAddress(seg,ofs));
 		return true;
-	};
+	}
 
 	if (command == "SV") { // Save variables
 		char name[13];
 		for (int i=0; i<12; i++) {
 			if (found[i] && (found[i]!=' ')) name[i] = found[i]; 
-			else { name[i] = 0; break; };
-		};
+			else { name[i] = 0; break; }
+		}
 		name[12] = 0;
 		if(!name[0]) return false;
 		DEBUG_ShowMsg("DEBUG: Variable list save (%s) : %s.\n",name,(CDebugVar::SaveVars(name)?"ok":"failure"));
 		return true;
-	};
+	}
 
 	if (command == "LV") { // load variables
 		char name[13];
 		for (int i=0; i<12; i++) {
 			if (found[i] && (found[i]!=' ')) name[i] = found[i]; 
-			else { name[i] = 0; break; };
-		};
+			else { name[i] = 0; break; }
+		}
 		name[12] = 0;
 		if(!name[0]) return false;
 		DEBUG_ShowMsg("DEBUG: Variable list load (%s) : %s.\n",name,(CDebugVar::LoadVars(name)?"ok":"failure"));
 		return true;
-	};
+	}
 
     if (command == "EV") { // echo value (for viewing contents through GetHexValue
         std::string cpptmp;
@@ -1598,12 +1598,12 @@ bool ParseCommand(char* str) {
 	if (command == "ADDLOG") {
 		if(found && *found)	DEBUG_ShowMsg("NOTICE: %s\n",found);
 		return true;
-	};
+	}
 
 	if (command == "SR") { // Set register value
 		DEBUG_ShowMsg("DEBUG: Set Register %s.\n",(ChangeRegister(found)?"success":"failure"));
 		return true;
-	};
+	}
 
 	if (command == "SM") { // Set memory with following values
 		Bit16u seg = (Bit16u)GetHexValue(found,found); SkipSpace(found);
@@ -1642,13 +1642,13 @@ bool ParseCommand(char* str) {
                 mem_writeb_checked((PhysPt)GetAddress(seg,ofs+count),value);
                 count++;
             }
-        };
+        }
 
         if (count > 0)
             DEBUG_ShowMsg("DEBUG: Memory changed (%u bytes)\n",(unsigned int)count);
 
 		return true;
-	};
+	}
 
 	if (command == "BP") { // Add new breakpoint
 		Bit16u seg = (Bit16u)GetHexValue(found,found);found++; // skip ":"
@@ -1656,7 +1656,7 @@ bool ParseCommand(char* str) {
 		CBreakpoint::AddBreakpoint(seg,ofs,false);
 		DEBUG_ShowMsg("DEBUG: Set breakpoint at %04X:%04X\n",seg,ofs);
 		return true;
-	};
+	}
 
 #if C_HEAVY_DEBUG
 
@@ -1666,7 +1666,7 @@ bool ParseCommand(char* str) {
 		CBreakpoint::AddMemBreakpoint(seg,ofs);
 		DEBUG_ShowMsg("DEBUG: Set memory breakpoint at %04X:%04X\n",seg,ofs);
 		return true;
-	};
+	}
 
 	if (command == "BPPM") { // Add new breakpoint
 		Bit16u seg = (Bit16u)GetHexValue(found,found);found++; // skip ":"
@@ -1677,7 +1677,7 @@ bool ParseCommand(char* str) {
 			DEBUG_ShowMsg("DEBUG: Set prot-mode memory breakpoint at %04X:%08X\n",seg,ofs);
 		}
 		return true;
-	};
+	}
 
 	if (command == "BPLM") { // Add new breakpoint
 		Bit32u ofs = GetHexValue(found,found);
@@ -1685,7 +1685,7 @@ bool ParseCommand(char* str) {
 		if (bp) bp->SetType(BKPNT_MEMORY_LINEAR);
 		DEBUG_ShowMsg("DEBUG: Set linear memory breakpoint at %08X\n",ofs);
 		return true;
-	};
+	}
 
 #endif
 
@@ -1708,7 +1708,7 @@ bool ParseCommand(char* str) {
 			}
 		}
 		return true;
-	};
+	}
 
 	if (command == "BPLIST") {
         DEBUG_BeginPagedContent();
@@ -1717,7 +1717,7 @@ bool ParseCommand(char* str) {
 		CBreakpoint::ShowList();
         DEBUG_EndPagedContent();
 		return true;
-	};
+	}
 
 	if (command == "BPDEL") { // Delete Breakpoints
 		Bit8u bpNr	= (Bit8u)GetHexValue(found,found); 
@@ -1729,7 +1729,7 @@ bool ParseCommand(char* str) {
 			DEBUG_ShowMsg("DEBUG: Breakpoint deletion %s.\n",(CBreakpoint::DeleteByIndex(bpNr)?"success":"failure"));
 		}
 		return true;
-	};
+	}
 
     if (command == "RUN") {
         DrawRegistersUpdateOld();
@@ -1834,7 +1834,7 @@ bool ParseCommand(char* str) {
 		codeViewData.useEIP = codeOfs;
 		codeViewData.cursorPos = 0;
 		return true;
-	};
+	}
 
 	if (command == "D") { // Set data overview
 		dataSeg = (Bit16u)GetHexValue(found,found); SkipSpace(found);
@@ -1846,7 +1846,7 @@ bool ParseCommand(char* str) {
         dbg.set_data_view(DBGBlock::DATV_SEGMENTED);
 		DEBUG_ShowMsg("DEBUG: Set data overview to %04X:%04X\n",dataSeg,dataOfs);
 		return true;
-	};
+	}
 
 	if (command == "DV") { // Set data overview
         dataSeg = 0;
@@ -1854,7 +1854,7 @@ bool ParseCommand(char* str) {
         dbg.set_data_view(DBGBlock::DATV_VIRTUAL);
 		DEBUG_ShowMsg("DEBUG: Set data overview to %04X:%04X\n",dataSeg,dataOfs);
 		return true;
-	};
+	}
 
 	if (command == "DP") { // Set data overview
         dataSeg = 0;
@@ -1862,7 +1862,7 @@ bool ParseCommand(char* str) {
         dbg.set_data_view(DBGBlock::DATV_PHYSICAL);
 		DEBUG_ShowMsg("DEBUG: Set data overview to %04X:%04X\n",dataSeg,dataOfs);
 		return true;
-	};
+	}
 
 #if C_HEAVY_DEBUG
 
@@ -1897,7 +1897,7 @@ bool ParseCommand(char* str) {
 		CBreakpoint::ActivateBreakpointsExceptAt(SegPhys(cs)+reg_eip);
 		DOSBOX_SetNormalLoop();	
 		return true;
-	};
+	}
 
 #endif
 
@@ -1907,7 +1907,7 @@ bool ParseCommand(char* str) {
 		CPU_HW_Interrupt(intNr);
 		SetCodeWinStart();
 		return true;
-	};
+	}
 
 	if (command == "INT") { // start int.
 		Bit8u intNr = (Bit8u)GetHexValue(found,found);
@@ -1920,7 +1920,7 @@ bool ParseCommand(char* str) {
 		DOSBOX_SetNormalLoop();
 		CPU_HW_Interrupt(intNr);
 		return true;
-	};	
+	}
 
 	if (command == "SELINFO") {
 		while (found[0] == ' ') found++;
@@ -1928,7 +1928,7 @@ bool ParseCommand(char* str) {
 		GetDescriptorInfo(found,out1,out2);
 		DEBUG_ShowMsg("SelectorInfo %s:\n%s\n%s\n",found,out1,out2);
 		return true;
-	};
+	}
 
 	if (command == "DOS") {
 		stream >> command;
@@ -2449,7 +2449,7 @@ bool ParseCommand(char* str) {
 			OutputVecTable(found);
 			return true;
 		}
-	};
+	}
 
 	if (command == "INTHAND") {
 		if (found[0] != 0) {
@@ -2472,18 +2472,18 @@ bool ParseCommand(char* str) {
 			codeViewData.cursorPos = 0;
 			return true;
 		}
-	};
+	}
 
 	if(command == "EXTEND") { //Toggle additional data.	
 		showExtend = !showExtend;
 		return true;
-	};
+	}
 
 	if(command == "TIMERIRQ") { //Start a timer irq
 		DEBUG_RaiseTimerIrq(); 
 		DEBUG_ShowMsg("Debug: Timer Int started.\n");
 		return true;
-	};
+	}
 
 
 #if C_HEAVY_DEBUG
@@ -2491,13 +2491,13 @@ bool ParseCommand(char* str) {
 		logHeavy = !logHeavy;
 		DEBUG_ShowMsg("DEBUG: Heavy cpu logging %s.\n",logHeavy?"on":"off");
 		return true;
-	};
+	}
 
 	if (command == "ZEROPROTECT") { //toggle zero protection
 		zeroProtect = !zeroProtect;
 		DEBUG_ShowMsg("DEBUG: Zero code execution protection %s.\n",zeroProtect?"on":"off");
 		return true;
-	};
+	}
 
 #endif
 	if (command == "HELP" || command == "?") {
@@ -2600,8 +2600,8 @@ char* AnalyzeInstruction(char* inst, bool saveSelector) {
 			} else {
 				seg = SegValue(ds);
 				strcpy(prefix,"ds");
-			};
-		};
+			}
+		}
 
 		pos++;
 		Bit32u adr = GetHexValue(pos,pos);
@@ -2614,7 +2614,7 @@ char* AnalyzeInstruction(char* inst, bool saveSelector) {
 				adr -= GetHexValue(pos,pos); 
 			} else 
 				pos++;
-		};
+		}
 		Bit32u address = (Bit32u)GetAddress(seg,adr);
 		if (!(get_tlb_readhandler(address)->flags & PFLAG_INIT)) {
 			static char outmask[] = "%s:[%04X]=%02X";
@@ -2649,13 +2649,13 @@ char* AnalyzeInstruction(char* inst, bool saveSelector) {
 				pos1++; *pos1 = 0;				// cut after '['
 				strcat(inst,var->GetName());	// add var name
 				strcat(inst,temp);				// add end
-			};
-		};
+			}
+		}
 		// show descriptor info, if available
 		if ((cpu.pmode) && saveSelector) {
 			strcpy(curSelectorName,prefix);
-		};
-	};
+		}
+	}
 	// If it is a callback add additional info
 	pos = strstr(inst,"callback");
 	if (pos) {
@@ -2665,7 +2665,7 @@ char* AnalyzeInstruction(char* inst, bool saveSelector) {
 		if (descr) {
 			strcat(inst,"  ("); strcat(inst,descr); strcat(inst,")");
 		}
-	};
+	}
 	// Must be a jump
 	if (instu[0] == 'J')
 	{
@@ -3721,7 +3721,7 @@ const char *FPU_tag(unsigned int i) {
         case TAG_Zero:  return "Zero";
         case TAG_Weird: return "Weird";
         case TAG_Empty: return "Empty";
-    };
+    }
 
     return "?";
 }
@@ -3798,7 +3798,7 @@ static void LogInstruction(Bit16u segValue, Bit32u eipValue,  ofstream& out) {
 		if (!res || !(*res)) res = empty;
 		Bitu reslen = strlen(res);
 		if (reslen<22) for (Bitu i=0; i<22-reslen; i++) res[reslen+i] = ' '; res[22] = 0;
-	};
+	}
 	Bitu len = strlen(dline);
 	if (len<30) for (Bitu i=0; i<30-len; i++) dline[len + i] = ' '; dline[30] = 0;
 
@@ -4089,7 +4089,7 @@ bool CDebugVar::SaveVars(char* name) {
 		// adr
 		PhysPt adr = bp->GetAdr();
 		fwrite(&adr,1,sizeof(adr),f);
-	};
+	}
 	fclose(f);
 	return true;
 }
@@ -4112,7 +4112,7 @@ bool CDebugVar::LoadVars(char* name)
 		if (fread(&adr,sizeof(adr),1,f) != 1) break;
 		// insert
 		InsertVariable(name,adr);
-	};
+	}
 	fclose(f);
 	return true;
 }
@@ -4212,7 +4212,7 @@ static void DrawVariables(void) {
 			varchanges = true;
 		} else {
 			if ( dv->HasValue() && dv->GetValue() == value) {
-				; //It already had a value and it didn't change (most likely case)
+				//It already had a value and it didn't change (most likely case)
 			} else {
 				dv->SetValue(true,value);
 				snprintf(buffer,DEBUG_VAR_BUF_LEN, "0x%04x", value);
@@ -4282,7 +4282,7 @@ void DEBUG_HeavyLogInstruction(void) {
 		if (!res || !(*res)) res = empty;
 		Bitu reslen = strlen(res);
 		if (reslen<22) for (Bitu i=0; i<22-reslen; i++) res[reslen+i] = ' '; res[22] = 0;
-	};
+	}
 
 	Bitu len = strlen(dline);
 	if (len < 30) for (Bitu i=0; i < 30-len; i++) dline[len+i] = ' ';

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -720,7 +720,7 @@ void LOG::operator() (char const* format, ...){
 		case LOG_ERROR: s_severity = " ERROR"; break;
 		case LOG_FATAL: s_severity = " FATAL"; break;
 		default: break;
-	};
+	}
 
 	va_start(msg,format);
 	vsnprintf(buf,sizeof(buf)-1,format,msg);

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -103,7 +103,7 @@ bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 	while (fullname[t]!=0) {
 		if ((fullname[t]=='\\') && (fullname[t+1]!=0)) lastdir=t;
 		t++;
-	};
+	}
 	r=0;w=0;
 	tempdir[0]=0;
 	bool stop=false;
@@ -364,11 +364,11 @@ bool DOS_ReadFile(Bit16u entry,Bit8u * data,Bit16u * amount,bool fcb) {
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 	if (!Files[handle] || !Files[handle]->IsOpen()) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 /*
 	if ((Files[handle]->flags & 0x0f) == OPEN_WRITE)) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
@@ -390,11 +390,11 @@ bool DOS_WriteFile(Bit16u entry,Bit8u * data,Bit16u * amount,bool fcb) {
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 	if (!Files[handle] || !Files[handle]->IsOpen()) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 /*
 	if ((Files[handle]->flags & 0x0f) == OPEN_READ)) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
@@ -412,11 +412,11 @@ bool DOS_SeekFile(Bit16u entry,Bit32u * pos,Bit32u type,bool fcb) {
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 	if (!Files[handle] || !Files[handle]->IsOpen()) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 	return Files[handle]->Seek(pos,type);
 }
 
@@ -426,11 +426,11 @@ bool DOS_LockFile(Bit16u entry,Bit8u mode,Bit32u pos,Bit32u size) {
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 	if (!Files[handle] || !Files[handle]->IsOpen()) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 #ifdef WIN32
 	return Files[handle]->LockFile(mode,pos,size);
 #else
@@ -450,11 +450,11 @@ bool DOS_CloseFile(Bit16u entry, bool fcb) {
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 	if (!Files[handle]) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 	if (Files[handle]->IsOpen()) {
 		Files[handle]->Close();
 	}
@@ -474,11 +474,11 @@ bool DOS_FlushFile(Bit16u entry) {
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 	if (!Files[handle] || !Files[handle]->IsOpen()) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 	LOG(LOG_DOSMISC,LOG_NORMAL)("FFlush used.");
 	return true;
 }
@@ -738,11 +738,11 @@ bool DOS_DuplicateEntry(Bit16u entry,Bit16u * newentry) {
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 	if (!Files[handle] || !Files[handle]->IsOpen()) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 	DOS_PSP psp(dos.psp());
 	*newentry = psp.FindFreeFileEntry();
 	if (*newentry==0xff) {
@@ -763,11 +763,11 @@ bool DOS_ForceDuplicateEntry(Bit16u entry,Bit16u newentry) {
 	if (orig >= DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 	if (!Files[orig] || !Files[orig]->IsOpen()) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 	Bit8u newone = RealHandle(newentry);
 	if (newone < DOS_FILES && Files[newone]) {
 		DOS_CloseFile(newentry);
@@ -1365,11 +1365,11 @@ bool DOS_GetFileDate(Bit16u entry, Bit16u* otime, Bit16u* odate) {
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 	if (!Files[handle] || !Files[handle]->IsOpen()) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 	if (!Files[handle]->UpdateDateTimeFromHost()) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false; 
@@ -1385,11 +1385,11 @@ bool DOS_SetFileDate(Bit16u entry, Bit16u ntime, Bit16u ndate)
 	if (handle>=DOS_FILES) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 	if (!Files[handle]) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
-	};
+	}
 	Files[handle]->time = ntime;
 	Files[handle]->date = ndate;
 	Files[handle]->newtime = true;

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2828,9 +2828,7 @@ public:
         cmd->FindString("-ide",ideattach,true);
 
         if (ideattach == "auto") {
-            if (type == "floppy") {
-            }
-            else {
+            if (type != "floppy") {
                 IDE_Auto(ide_index,ide_slave);
             }
                 

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -938,8 +938,6 @@ bool localDrive::FileStat(const char* name, FileStat_Block * const stat_block) {
 	if((time=localtime(&temp_stat.st_mtime))!=0) {
 		stat_block->time=DOS_PackTime((Bit16u)time->tm_hour,(Bit16u)time->tm_min,(Bit16u)time->tm_sec);
 		stat_block->date=DOS_PackDate((Bit16u)(time->tm_year+1900),(Bit16u)(time->tm_mon+1),(Bit16u)time->tm_mday);
-	} else {
-
 	}
 	stat_block->size=(Bit32u)temp_stat.st_size;
 	return true;

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -411,7 +411,7 @@ static void UI_Shutdown(GUI::ScreenSDL *screen) {
             SDL_BlitSurface(background, NULL, sdlscreen, NULL);
             SDL_BlitSurface(screenshot, NULL, sdlscreen, NULL);
             SDL_UpdateRect(sdlscreen, 0, 0, 0, 0);
-            while (SDL_PollEvent(&event)) {};
+            while (SDL_PollEvent(&event)) {}
             SDL_Delay(40); 
         }
     }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -216,7 +216,7 @@ const char *DKM_to_string(const unsigned int dkm) {
         case DKM_JPN_PC98:  return "jpn_pc98";
         case DKM_JPN:       return "jpn";
         default:            break;
-    };
+    }
 
     return "";
 }
@@ -228,7 +228,7 @@ const char *DKM_to_descriptive_string(const unsigned int dkm) {
         case DKM_JPN_PC98:  return "Japanese (PC-98)";
         case DKM_JPN:       return "Japanese";
         default:            break;
-    };
+    }
 
     return "";
 }
@@ -313,7 +313,7 @@ void KeyboardLayoutDetect(void) {
         case 0x0409:    nlayout = DKM_US; break;
         case 0x0411:    nlayout = DKM_JPN; break;
         default:        break;
-    };
+    }
 #endif
 
     host_keyboard_layout = nlayout;
@@ -426,7 +426,7 @@ void PrintScreenSizeInfo(void) {
         case ScreenSizeInfo::METHOD_WIN98BASE:  method = "Win98base";   break;
         case ScreenSizeInfo::METHOD_COREGRAPHICS:method = "CoreGraphics";break;
         default:                                                        break;
-    };
+    }
 
     LOG_MSG("Screen report: Method '%s' (%.3f x %.3f pixels) at (%.3f x %.3f) (%.3f x %.3f mm) (%.3f x %.3f in) (%.3f x %.3f DPI)",
             method,

--- a/src/hardware/voodoo_opengl.cpp
+++ b/src/hardware/voodoo_opengl.cpp
@@ -1756,9 +1756,7 @@ void voodoo_ogl_reset_videomode(void) {
 
 	GLint depth_csize;
 	glGetIntegerv(GL_DEPTH_BITS, &depth_csize);
-	if (depth_csize == 24) {
-	} else if (depth_csize == 16) {
-	} else if (depth_csize < 16) {
+	if (depth_csize < 16) {
 		LOG_MSG("VOODOO: OpenGL: invalid depth size %d",depth_csize);
 	}
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -386,8 +386,8 @@ void DOS_Shell::Run(void) {
 						ShowPrompt();
 						WriteOut_NoParsing(input_line);
 						WriteOut_NoParsing("\n");
-					};
-				};
+					}
+				}
 			} else input_line[0]='\0';
 		} else {
 			if (echo) ShowPrompt();

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -616,15 +616,15 @@ static void FormatNumber(Bit32u num,char * buf) {
 	if (numg) {
 		sprintf(buf,"%d,%03d,%03d,%03d",numg,numm,numk,numb);
 		return;
-	};
+	}
 	if (numm) {
 		sprintf(buf,"%d,%03d,%03d",numm,numk,numb);
 		return;
-	};
+	}
 	if (numk) {
 		sprintf(buf,"%d,%03d",numk,numb);
 		return;
-	};
+	}
 	sprintf(buf,"%d",numb);
 }
 
@@ -959,7 +959,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 		WriteOut(MSG_Get("SHELL_MISSING_PARAMETER"));
 		dos.dta(save_dta);
 		return;
-	};
+	}
 
 	copysource target;
 	// If more then one object exists and last target is not part of a 
@@ -1141,11 +1141,11 @@ void DOS_Shell::CMD_COPY(char * args) {
 						WriteOut(MSG_Get("SHELL_CMD_COPY_FAILURE"),const_cast<char*>(target.filename.c_str()));
 					}
 				} else WriteOut(MSG_Get("SHELL_CMD_COPY_FAILURE"),const_cast<char*>(source.filename.c_str()));
-			};
+			}
 			//On to the next file if the previous one wasn't a device
 			if ((attr&DOS_ATTR_DEVICE) == 0) ret = DOS_FindNext();
 			else ret = false;
-		};
+		}
 	}
 
 	WriteOut(MSG_Get("SHELL_CMD_COPY_SUCCESS"),count);

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -600,7 +600,7 @@ void DOS_Shell::InputCommand(char * line) {
                     }
                     line[++str_len]=0;//new end (as the internal buffer moved one place to the right
                     size--;
-                };
+                }
 
                 line[str_index]=(char)(cr&0xFF);
                 str_index ++;
@@ -786,7 +786,7 @@ bool DOS_Shell::Execute(char * name,char * args) {
 		}
 	}else{
 		line[0]=0;
-	};
+	}
 
 	/* check for a drive change */
 	if (((strcmp(name + 1, ":") == 0) || (strcmp(name + 1, ":\\") == 0)) && isalpha(*name))

--- a/vs2015/sdl/src/audio/SDL_audiocvt.c
+++ b/vs2015/sdl/src/audio/SDL_audiocvt.c
@@ -1429,7 +1429,7 @@ int SDL_BuildAudioCVT(SDL_AudioCVT *cvt,
 			cvt->len_ratio /= 2;
 		}
 		if ( src_channels != dst_channels ) {
-			/* Uh oh.. */;
+			/* Uh oh.. */
 		}
 	}
 

--- a/vs2015/sdl/src/audio/SDL_wave.c
+++ b/vs2015/sdl/src/audio/SDL_wave.c
@@ -363,7 +363,7 @@ static int IMA_ADPCM_decode(Uint8 **audio_buf, Uint32 *audio_len)
 			state[c].index = *encoded++;
 			/* Reserved byte in buffer header, should be 0 */
 			if ( *encoded++ != 0 ) {
-				/* Uh oh, corrupt data?  Buggy code? */;
+				/* Uh oh, corrupt data?  Buggy code? */
 			}
 
 			/* Store the initial sample we start with */

--- a/vs2015/sdl/src/cdrom/SDL_cdrom.c
+++ b/vs2015/sdl/src/cdrom/SDL_cdrom.c
@@ -157,7 +157,7 @@ CDstatus SDL_CDStatus(SDL_CD *cdrom)
 		/* If the drive is playing, get current play position */
 		if ( (status == CD_PLAYING) || (status == CD_PAUSED) ) {
 			for ( i=1; cdrom->track[i].offset <= position; ++i ) {
-				/* Keep looking */;
+				/* Keep looking */
 			}
 #ifdef DEBUG_CDROM
   fprintf(stderr, "Current position: %d, track = %d (offset is %d)\n",

--- a/vs2015/sdl/src/video/SDL_cursor.c
+++ b/vs2015/sdl/src/video/SDL_cursor.c
@@ -285,7 +285,7 @@ int SDL_ShowCursor (int toggle)
 			}
 		}
 	} else {
-		/* Query current state */ ;
+		/* Query current state */ 
 	}
 	return(showing ? 1 : 0);
 }

--- a/vs2015/sdl/src/video/SDL_video.c
+++ b/vs2015/sdl/src/video/SDL_video.c
@@ -1245,7 +1245,6 @@ static int SetPalette_physical(SDL_Surface *screen,
 			   the video driver is responsible for copying back the
 			   correct colors into the video surface palette.
 			*/
-			;
 		}
 		SDL_CursorPaletteChanged();
 	}

--- a/vs2015/sdl/src/video/windib/SDL_dibevents.c
+++ b/vs2015/sdl/src/video/windib/SDL_dibevents.c
@@ -676,7 +676,7 @@ void DIB_InitOSKeymapPriv(void) {
 			VK_keymap[VK_OEM_6] = SDLK_RIGHTBRACKET;
 			VK_keymap[VK_OEM_5] = SDLK_JP_YEN;
 			break;
-	};
+	}
 
 	Arrows_keymap[3] = 0x25;
 	Arrows_keymap[2] = 0x26;


### PR DESCRIPTION
Remove more empty statements, mostly unnecessary semicolons. I think this takes care of all of the unnecessary semicolons in the DOSBox-X and SDL1 source files. Also rewrote a few if statements to get rid of empty code in brackets.