### PR TITLE
More SVN commits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,9 @@
   - Integrated commits from mainline (Allofich)
     - In the mapper, display disabled items or events
     with no binding in grey. 
+    - Implemented BIOS beep sound for ASCII character 7
+    - Return failure for INT 13 format calls if the
+    drive is inactive.
 0.82.20
   - Dynamic core IMUL instruction mistake fixed,
     signed multiply works properly again.

--- a/patch-integration/Skipped SVN commits.txt
+++ b/patch-integration/Skipped SVN commits.txt
@@ -1,18 +1,5 @@
 Commit#:	Reason for skipping:
 
-3922		Conflict. "Use safe_strncpy for resolution lines" part is already in DOSBox-X.
-3930		Conflict
-3931		May not have effect or be wanted
-3939		A commented-out log message.
-3960		Thought to be unneeded.
-3967		Conflict and may be unnecessary.
-3968		Conflict and may be unnecessary.
-3969		Related to 3968.
-3980		Conflict
-3981		Conflict
-3986		Conflict
-3989		Seems unnecessary, and DOSBox-X's GUI uses "Pause"
-3999		Formatting cleanup.
 4001		Conflict
 4002		Conflict
 4003		Conflict

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -949,18 +949,33 @@ static Bitu INT13_DiskHandler(void) {
     case 0x05: /* Format track */
         /* ignore it. I just fucking want FORMAT.COM to write the FAT structure for God's sake */
         LOG_MSG("WARNING: Format track ignored\n");
+        if (driveInactive(drivenum)) {
+            reg_ah = 0xff;
+            CALLBACK_SCF(true);
+            return CBRET_NONE;
+        }
         CALLBACK_SCF(false);
         reg_ah = 0x00;
         break;
     case 0x06: /* Format track set bad sector flags */
         /* ignore it. I just fucking want FORMAT.COM to write the FAT structure for God's sake */
         LOG_MSG("WARNING: Format track set bad sector flags ignored (6)\n");
+        if (driveInactive(drivenum)) {
+            reg_ah = 0xff;
+            CALLBACK_SCF(true);
+            return CBRET_NONE;
+        }
         CALLBACK_SCF(false);
         reg_ah = 0x00;
         break;
     case 0x07: /* Format track set bad sector flags */
         /* ignore it. I just fucking want FORMAT.COM to write the FAT structure for God's sake */
         LOG_MSG("WARNING: Format track set bad sector flags ignored (7)\n");
+        if (driveInactive(drivenum)) {
+            reg_ah = 0xff;
+            CALLBACK_SCF(true);
+            return CBRET_NONE;
+        }
         CALLBACK_SCF(false);
         reg_ah = 0x00;
         break;

--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -776,14 +776,21 @@ static void INT10_TeletypeOutputAttr(Bit8u chr,Bit8u attr,bool useattr,Bit8u pag
     Bit8u cur_row=CURSOR_POS_ROW(page);
     Bit8u cur_col=CURSOR_POS_COL(page);
     switch (chr) {
-    case 7: {
-        // enable speaker
-        IO_Write(0x61,IO_Read(0x61)|0x3);
-        for(Bitu i=0; i < 333; i++) CALLBACK_Idle();
-        IO_Write(0x61,IO_Read(0x61)&~0x3);
-    break;
-    }
-
+    case 7: /* Beep */
+        // Prepare PIT counter 2 for ~900 Hz square wave
+        IO_Write(0x43, 0xb6);
+        IO_Write(0x42, 0x28);
+        IO_Write(0x42, 0x05);
+        // Speaker on
+        IO_Write(0x61, IO_Read(0x61) | 0x3);
+        // Idle for 1/3rd of a second
+        double start;
+        start = PIC_FullIndex();
+        while ((PIC_FullIndex() - start) < 333.0) CALLBACK_Idle();
+        // Speaker off
+        IO_Write(0x61, IO_Read(0x61) & ~0x3);
+        // No change in position
+        return;
     case 8:
         if(cur_col>0) cur_col--;
         break;


### PR DESCRIPTION
Continuing to go over skipped SVN commits.

https://sourceforge.net/p/dosbox/code-0/3968/
Causes a beep to play. You can hear it by pressing CTRL+G to type "^G" at the command prompt. (Note: There seems to be a difference in command prompt handling with MS-DOS. When testing with MS-DOS in the 86Box emulator, just pressing CTRL+G won't cause a beep, but running "echo ^G" will)

https://sourceforge.net/p/dosbox/code-0/3980/
The main purpose of this one is already in DOSBox-X, but it included returning a failure when the disk isn't active, which isn't in DOSBox-X. This PR adds it in.