### PR TITLE
Fix uninitialized member variable warnings (VS2019 IDE)

### DIFF
--- a/include/8255.h
+++ b/include/8255.h
@@ -115,28 +115,28 @@ public:
     }
 public:
     //! Port A write mask. Controls which bits are writeable
-    uint8_t             portAWriteMask;
+    uint8_t             portAWriteMask = 0;
     //! Port B write mask. Controls which bits are writeable
-    uint8_t             portBWriteMask;
+    uint8_t             portBWriteMask = 0;
     //! Port C write mask. Controls which bits are writeable
-    uint8_t             portCWriteMask;
+    uint8_t             portCWriteMask = 0;
 public:
     //! PPI chip name (for debug/UI purposes)
-    const char*         ppiName;                        
+    const char*         ppiName;
 public:
     //! Pin names (for debug/UI purposes)
-    const char*         pinNames[3/*port*/][8/*bit*/];  
+    const char*         pinNames[3/*port*/][8/*bit*/] = {};
     //! Port names (for debug/UI purposes)
-    const char*         portNames[3/*port*/];           
+    const char*         portNames[3/*port*/] = {};
 public:
     //! Port A output latch
-    uint8_t             latchOutPortA;
+    uint8_t             latchOutPortA = 0;
     //! Port B output latch
-    uint8_t             latchOutPortB;
+    uint8_t             latchOutPortB = 0;
     //! Port C output latch
-    uint8_t             latchOutPortC;  
+    uint8_t             latchOutPortC = 0;
     //! PPI mode byte
-    uint8_t             mode;                                       
+    uint8_t             mode = 0;
     /* bit[7:7] = 1             mode set flag
      * bit[6:5] = mode select   00=mode 0  01=mode 1  1x=mode 2
      * bit[4:4] = Port A        1=input  0=output
@@ -146,31 +146,31 @@ public:
      * bit[0:0] = Port C lower  1=input  0=output */
 public:
     //! Input Buffer Full, port A contains information (port A, Mode 1)
-    bool                IBF_A;
+    bool                IBF_A = false;
     //! Input Buffer Full, port B contains information (port B, Mode 1)
-    bool                IBF_B;
+    bool                IBF_B = false;
     //! Output Buffer Full, port A contains information for the external device (port A, Mode 1)
-    bool                OBF_A;
+    bool                OBF_A = false;
     //! Output Buffer Full, port B contains information for the external device (port B, Mode 1)
-    bool                OBF_B;
+    bool                OBF_B = false;
 public:
     //! Interrupt Request A (to the microprocessor)
-    bool                INTR_A;
+    bool                INTR_A = false;
     //! Interrupt Request B (to the microprocessor)
-    bool                INTR_B;
+    bool                INTR_B = false;
     //! Previous Interrupt Request A state (for change detection)
-    bool                pINTR_A;
+    bool                pINTR_A = false;
     //! Previous Interrupt Request B state (for change detection)
-    bool                pINTR_B;
+    bool                pINTR_B = false;
 public:
     //! Interrupt 1 enable (mode 2)
-    bool                INTE_1;
+    bool                INTE_1 = false;
     //! Interrupt 2 enable (mode 2)
-    bool                INTE_2; /* mode 2 */
+    bool                INTE_2 = false; /* mode 2 */
     //! Interrupt A enable
-    bool                INTE_A;
+    bool                INTE_A = false;
     //! Interrupt B enable
-    bool                INTE_B;
+    bool                INTE_B = false;
 protected:
     //! Return string "str", or "" (empty string) if str == NULL
     static inline const char *nil_if_null(const char *str) {

--- a/include/dma.h
+++ b/include/dma.h
@@ -137,7 +137,7 @@ class DmaController {
 private:
 	Bit8u ctrlnum;
 	bool flipflop;
-	DmaChannel *DmaChannels[4];
+    DmaChannel* DmaChannels[4] = {};
 public:
 	IO_ReadHandleObject DMA_ReadHandler[0x15];
 	IO_WriteHandleObject DMA_WriteHandler[0x15];

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -84,9 +84,8 @@ static CacheBlockDynRec link_blocks[2];		// default linking (specially marked)
 // cache blocks and intercepts writes to the code for special treatment
 class CodePageHandlerDynRec : public PageHandler {
 public:
-	CodePageHandlerDynRec() {
-		invalidation_map=NULL;
-	}
+    CodePageHandlerDynRec() {
+    }
 
 	void SetupAt(Bitu _phys_page,PageHandler * _old_pagehandler) {
 		// initialize this codepage handler
@@ -381,19 +380,20 @@ public:
 	}
 public:
 	// the write map, there are write_map[i] cache blocks that cover the byte at address i
-	Bit8u write_map[4096];
-	Bit8u * invalidation_map;
-	CodePageHandlerDynRec * next, * prev;	// page linking
+    Bit8u write_map[4096] = {};
+    Bit8u* invalidation_map = NULL;
+    CodePageHandlerDynRec* next = NULL; // page linking
+    CodePageHandlerDynRec* prev = NULL; // page linking
 private:
-	PageHandler * old_pagehandler;
+    PageHandler* old_pagehandler = NULL;
 
 	// hash map to quickly find the cache blocks in this page
-	CacheBlockDynRec * hash_map[1+DYN_PAGE_HASH];
+    CacheBlockDynRec* hash_map[1 + DYN_PAGE_HASH] = {};
 
-	Bitu active_blocks;		// the number of cache blocks in this page
-	Bitu active_count;		// delaying parameter to not immediately release a page
-	HostPt hostmem;	
-	Bitu phys_page;
+    Bitu active_blocks = 0;     // the number of cache blocks in this page
+    Bitu active_count = 0;      // delaying parameter to not immediately release a page
+    HostPt hostmem = NULL;
+    Bitu phys_page = 0;
 };
 
 

--- a/src/debug/debug_inc.h
+++ b/src/debug/debug_inc.h
@@ -57,10 +57,10 @@ public:
 
         WINI_MAX_INDEX
     };
-    bool win_vis[WINI_MAX_INDEX];
+    bool win_vis[WINI_MAX_INDEX] = {};
     std::string win_title[WINI_MAX_INDEX];
-    unsigned char win_order[WINI_MAX_INDEX];
-    unsigned int win_height[WINI_MAX_INDEX];
+    unsigned char win_order[WINI_MAX_INDEX] = {};
+    unsigned int win_height[WINI_MAX_INDEX] = {};
 public:
 	DBGBlock() : win_main(NULL), win_reg(NULL), win_data(NULL), win_code(NULL),
 		win_var(NULL), win_out(NULL), win_inp(NULL), active_win(WINI_CODE), input_y(0), global_mask(0), data_view(0xFF) {

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -721,7 +721,7 @@ public:
 public:
     /*! \brief      Array of disk images to add to floppy swaplist
      */
-    imageDisk *newDiskSwap[MAX_SWAPPABLE_DISKS];
+    imageDisk* newDiskSwap[MAX_SWAPPABLE_DISKS] = {};
 
 private:
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -611,7 +611,7 @@ static void DOSBOX_UnlockSpeed( bool pressed ) {
 
 void DOSBOX_UnlockSpeed2( bool pressed ) {
     if (pressed) {
-        ticksLocked =! ticksLocked;
+        ticksLocked = !ticksLocked;
         DOSBOX_UnlockSpeed(ticksLocked?true:false);
 
         /* make sure the menu item keeps up with our state */

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -102,7 +102,7 @@ namespace OPL3 {
 
 namespace NukedOPL {
 	struct Handler : public Adlib::Handler {
-		opl3_chip chip;
+        opl3_chip chip = {};
 		virtual void WriteReg( Bit32u reg, Bit8u val ) {
 			OPL3_WriteReg(&chip, reg, val);
 		}
@@ -134,7 +134,7 @@ namespace NukedOPL {
 namespace MAMEOPL2 {
 
 struct Handler : public Adlib::Handler {
-	void* chip;
+	void* chip = NULL;
 
 	virtual void WriteReg(Bit32u reg, Bit8u val) {
 		ym3812_write(chip, 0, (int)reg);
@@ -166,7 +166,7 @@ struct Handler : public Adlib::Handler {
 namespace MAMEOPL3 {
 
 struct Handler : public Adlib::Handler {
-	void* chip;
+	void* chip = NULL;
 
 	virtual void WriteReg(Bit32u reg, Bit8u val) {
 		ymf262_write(chip, 0, (int)reg);
@@ -854,6 +854,10 @@ namespace Adlib {
 Module::Module( Section* configuration ) : Module_base(configuration) {
     Bitu sb_addr=0,sb_irq=0,sb_dma=0;
 	DOSBoxMenu::item *item;
+    lastUsed = 0;
+    mode = MODE_OPL2;
+    capture = NULL;
+    handler = NULL;
 
     SB_Get_Address(sb_addr,sb_irq,sb_dma);
 

--- a/src/hardware/adlib.h
+++ b/src/hardware/adlib.h
@@ -41,6 +41,7 @@ struct Timer {
 		enabled = false;
 		counter = 0;
 		delay = 0;
+        start = 0;
 	}
 	//Call update before making any further changes
 	void Update( double time ) {
@@ -140,7 +141,7 @@ class Module: public Module_base {
 		Bit8u lvol;
 		Bit8u rvol;
 		bool mixer;
-	} ctrl;
+    } ctrl = {};
 	void CacheWrite( Bit32u reg, Bit8u val );
 	void DualWrite( Bit8u index, Bit8u reg, Bit8u val );
 	void CtrlWrite( Bit8u val );
@@ -151,7 +152,7 @@ public:
 	Bit32u lastUsed;				//Ticks when adlib was last used to turn of mixing after a few second
 
 	Handler* handler;				//Handler that will generate the sound
-	RegisterCache cache;
+    RegisterCache cache = {};
 	Capture* capture;
 	Chip	chip[2];
 

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -44,26 +44,26 @@ struct PIT_Block {
         Bit16u          cycle = 0;          // cycle (Mode 3: 0 or 1)
     };
 
-	Bitu cntr;      /* counter value written to 40h-42h as the interval. may take effect immediately (after port 43h) or after count expires */
-    Bitu cntr_cur;  /* current counter value in effect */
-	double delay;   /* interval (in ms) between one full count cycle */
-	double start;   /* time base (in ms) that cycle started at */
-    double now;     /* current time (in ms) */
+    Bitu cntr = 0;          /* counter value written to 40h-42h as the interval. may take effect immediately (after port 43h) or after count expires */
+    Bitu cntr_cur = 0;      /* current counter value in effect */
+    double delay = 0;       /* interval (in ms) between one full count cycle */
+    double start = 0;       /* time base (in ms) that cycle started at */
+    double now = 0;         /* current time (in ms) */
 
-	Bit16u read_latch;      /* counter value, latched for read back */
-	Bit16u write_latch;     /* counter value, written by host */
+    Bit16u read_latch = 0;  /* counter value, latched for read back */
+    Bit16u write_latch = 0; /* counter value, written by host */
 
-	Bit8u mode;             /* 8254 mode (mode 0 through 5 inclusive) */
-	Bit8u read_state;       /* 0=read MSB, switch to LSB, 1=LSB only, 2=MSB only, 3=read LSB, switch to MSB, latch next value */
-	Bit8u write_state;      /* 0=write MSB, switch to LSB, 1=LSB only, 2=MSB only, 3=write MSB, switch to LSB, accept value */
+    Bit8u mode = 0;         /* 8254 mode (mode 0 through 5 inclusive) */
+    Bit8u read_state = 0;   /* 0=read MSB, switch to LSB, 1=LSB only, 2=MSB only, 3=read LSB, switch to MSB, latch next value */
+    Bit8u write_state = 0;  /* 0=write MSB, switch to LSB, 1=LSB only, 2=MSB only, 3=write MSB, switch to LSB, accept value */
     Bit8u cycle_base = 0;
 
-	bool bcd;               /* BCD mode */
-	bool go_read_latch;     /* reading should latch another value */
-	bool new_mode;          /* a new mode has been written to port 43h for this timer */
-	bool counterstatus_set; /* set by status_latch(), when using 8254 command to latch multiple counters */
-	bool counting;          /* is counting (?) */
-	bool update_count;      /* update count on completion */
+    bool bcd = false;               /* BCD mode */
+    bool go_read_latch = false;     /* reading should latch another value */
+    bool new_mode = false;          /* a new mode has been written to port 43h for this timer */
+    bool counterstatus_set = false; /* set by status_latch(), when using 8254 command to latch multiple counters */
+    bool counting = false;          /* is counting (?) */
+    bool update_count = false;      /* update count on completion */
 
     bool gate = true;       /* gate signal (IN) */
     bool output = true;     /* output signal (OUT) */

--- a/src/mt32/AReverbModel.cpp
+++ b/src/mt32/AReverbModel.cpp
@@ -131,7 +131,7 @@ float AllpassFilter::process(const float in) {
 	return bufferOut + 0.5f * buffer[index];
 }
 
-CombFilter::CombFilter(const Bit32u useSize) : RingBuffer(useSize) {}
+CombFilter::CombFilter(const Bit32u useSize) : RingBuffer(useSize), feedbackFactor(0.0F), filterFactor(0.0F) {}
 
 void CombFilter::process(const float in) {
 	// This model corresponds to the comb filter implementation of the real CM-32L device
@@ -159,7 +159,7 @@ void CombFilter::setFilterFactor(const float useFilterFactor) {
 	filterFactor = useFilterFactor;
 }
 
-AReverbModel::AReverbModel(const ReverbMode mode) : allpasses(NULL), combs(NULL), currentSettings(*REVERB_SETTINGS[mode]) {}
+AReverbModel::AReverbModel(const ReverbMode mode) : allpasses(NULL), combs(NULL), currentSettings(*REVERB_SETTINGS[mode]), lpfAmp(0.0F), wetLevel(0.0F) {}
 
 AReverbModel::~AReverbModel() {
 	close();

--- a/src/mt32/freeverb/allpass.cpp
+++ b/src/mt32/freeverb/allpass.cpp
@@ -8,7 +8,10 @@
 
 allpass::allpass()
 {
-	bufidx = 0;
+    bufidx = 0;
+    buffer = NULL;
+    bufsize = 0;
+    feedback = 0.0F;
 }
 
 void allpass::setbuffer(float *buf, int size)


### PR DESCRIPTION
Fixes several uninitialized member variable warnings in the Visual Studio 2019 IDE (code analysis warnings, not compiler warnings). Just initializing everything to 0 or false. In one case it was an enum so the 0 enum is used.

Also fixes an assignment of a boolean to it's opposite that looked like x =! x, to make it look as expected, like x = !x.