### PR TITLE
Fix -Wmisleading-indentation GCC warnings

### DIFF
--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -1232,7 +1232,10 @@ static void DrawCode(void) {
 		// Spacepad it up to 28 characters
         if (no_bytes) dline[0] = 0;
 		size_t dline_len = strlen(dline);
-		if(dline_len < 28) for (c = (Bitu)dline_len; c < 28;c++) dline[c] = ' '; dline[28] = 0;
+        if (dline_len < 28) {
+            for (c = (Bitu)dline_len; c < 28; c++) dline[c] = ' ';
+            dline[28] = 0;
+        }
 		waddstr(dbg.win_code,dline);
 		// Spacepad it up to 20 characters
 		size_t res_len = strlen(res);
@@ -1284,86 +1287,79 @@ void SkipSpace(char*& hex) {
 
 Bit32u GetHexValue(char* const str, char* &hex,bool *parsed)
 {
-	Bit32u	value = 0;
-	Bit32u regval = 0;
-	hex = str;
-	while (*hex == ' ') hex++;
+    Bit32u	value = 0;
+    Bit32u regval = 0;
+    hex = str;
+    while (*hex == ' ') hex++;
 
-	if (strncmp(hex,"EFLAGS",6) == 0) { hex+=6; regval = (Bit32u)reg_flags; } else
-	if (strncmp(hex,"FLAGS",5) == 0) { hex+=5; regval = (Bit32u)reg_flags; } else
+    if (strncmp(hex, "EFLAGS", 6) == 0) { hex += 6; regval = (Bit32u)reg_flags; }
+    else if (strncmp(hex, "FLAGS", 5) == 0) { hex += 5; regval = (Bit32u)reg_flags; }
+    else if (strncmp(hex, "IOPL", 4) == 0) { hex += 4; regval = (reg_flags & FLAG_IOPL) >> 12u; }
+    else if (strncmp(hex, "CR0", 3) == 0) { hex += 3; regval = (Bit32u)cpu.cr0; }
+    else if (strncmp(hex, "CR2", 3) == 0) { hex += 3; regval = (Bit32u)paging.cr2; }
+    else if (strncmp(hex, "CR3", 3) == 0) { hex += 3; regval = (Bit32u)paging.cr3; }
+    else if (strncmp(hex, "EAX", 3) == 0) { hex += 3; regval = reg_eax; }
+    else if (strncmp(hex, "EBX", 3) == 0) { hex += 3; regval = reg_ebx; }
+    else if (strncmp(hex, "ECX", 3) == 0) { hex += 3; regval = reg_ecx; }
+    else if (strncmp(hex, "EDX", 3) == 0) { hex += 3; regval = reg_edx; }
+    else if (strncmp(hex, "ESI", 3) == 0) { hex += 3; regval = reg_esi; }
+    else if (strncmp(hex, "EDI", 3) == 0) { hex += 3; regval = reg_edi; }
+    else if (strncmp(hex, "EBP", 3) == 0) { hex += 3; regval = reg_ebp; }
+    else if (strncmp(hex, "ESP", 3) == 0) { hex += 3; regval = reg_esp; }
+    else if (strncmp(hex, "EIP", 3) == 0) { hex += 3; regval = reg_eip; }
+    else if (strncmp(hex, "AX", 2) == 0) { hex += 2; regval = reg_ax; }
+    else if (strncmp(hex, "BX", 2) == 0) { hex += 2; regval = reg_bx; }
+    else if (strncmp(hex, "CX", 2) == 0) { hex += 2; regval = reg_cx; }
+    else if (strncmp(hex, "DX", 2) == 0) { hex += 2; regval = reg_dx; }
+    else if (strncmp(hex, "SI", 2) == 0) { hex += 2; regval = reg_si; }
+    else if (strncmp(hex, "DI", 2) == 0) { hex += 2; regval = reg_di; }
+    else if (strncmp(hex, "BP", 2) == 0) { hex += 2; regval = reg_bp; }
+    else if (strncmp(hex, "SP", 2) == 0) { hex += 2; regval = reg_sp; }
+    else if (strncmp(hex, "IP", 2) == 0) { hex += 2; regval = reg_ip; }
+    else if (strncmp(hex, "AL", 2) == 0) { hex += 2; regval = reg_al; }
+    else if (strncmp(hex, "BL", 2) == 0) { hex += 2; regval = reg_bl; }
+    else if (strncmp(hex, "CL", 2) == 0) { hex += 2; regval = reg_cl; }
+    else if (strncmp(hex, "DL", 2) == 0) { hex += 2; regval = reg_dl; }
+    else if (strncmp(hex, "AH", 2) == 0) { hex += 2; regval = reg_ah; }
+    else if (strncmp(hex, "BH", 2) == 0) { hex += 2; regval = reg_bh; }
+    else if (strncmp(hex, "CH", 2) == 0) { hex += 2; regval = reg_ch; }
+    else if (strncmp(hex, "DH", 2) == 0) { hex += 2; regval = reg_dh; }
+    else if (strncmp(hex, "CS", 2) == 0) { hex += 2; regval = SegValue(cs); }
+    else if (strncmp(hex, "DS", 2) == 0) { hex += 2; regval = SegValue(ds); }
+    else if (strncmp(hex, "ES", 2) == 0) { hex += 2; regval = SegValue(es); }
+    else if (strncmp(hex, "FS", 2) == 0) { hex += 2; regval = SegValue(fs); }
+    else if (strncmp(hex, "GS", 2) == 0) { hex += 2; regval = SegValue(gs); }
+    else if (strncmp(hex, "SS", 2) == 0) { hex += 2; regval = SegValue(ss); }
+    else if (strncmp(hex, "AC", 2) == 0) { hex += 2; regval = GETFLAG(AC); }
+    else if (strncmp(hex, "AF", 2) == 0) { hex += 2; regval = GETFLAG(AF); }
+    else if (strncmp(hex, "CF", 2) == 0) { hex += 2; regval = GETFLAG(CF); }
+    else if (strncmp(hex, "DF", 2) == 0) { hex += 2; regval = GETFLAG(DF); }
+    else if (strncmp(hex, "ID", 2) == 0) { hex += 2; regval = GETFLAG(ID); }
+    else if (strncmp(hex, "IF", 2) == 0) { hex += 2; regval = GETFLAG(IF); }
+    else if (strncmp(hex, "NT", 2) == 0) { hex += 2; regval = GETFLAG(NT); }
+    else if (strncmp(hex, "OF", 2) == 0) { hex += 2; regval = GETFLAG(OF); }
+    else if (strncmp(hex, "PF", 2) == 0) { hex += 2; regval = GETFLAG(PF); }
+    else if (strncmp(hex, "SF", 2) == 0) { hex += 2; regval = GETFLAG(SF); }
+    else if (strncmp(hex, "TF", 2) == 0) { hex += 2; regval = GETFLAG(TF); }
+    else if (strncmp(hex, "VM", 2) == 0) { hex += 2; regval = GETFLAG(VM); }
+    else if (strncmp(hex, "ZF", 2) == 0) { hex += 2; regval = GETFLAG(ZF); }
 
-	if (strncmp(hex,"IOPL",4) == 0) { hex+=4; regval = (reg_flags & FLAG_IOPL) >> 12u; } else
-
-	if (strncmp(hex,"CR0",3) == 0) { hex+=3; regval = (Bit32u)cpu.cr0; } else
-	if (strncmp(hex,"CR2",3) == 0) { hex+=3; regval = (Bit32u)paging.cr2; } else
-	if (strncmp(hex,"CR3",3) == 0) { hex+=3; regval = (Bit32u)paging.cr3; } else
-
-	if (strncmp(hex,"EAX",3) == 0) { hex+=3; regval = reg_eax; } else
-	if (strncmp(hex,"EBX",3) == 0) { hex+=3; regval = reg_ebx; } else
-	if (strncmp(hex,"ECX",3) == 0) { hex+=3; regval = reg_ecx; } else
-	if (strncmp(hex,"EDX",3) == 0) { hex+=3; regval = reg_edx; } else
-	if (strncmp(hex,"ESI",3) == 0) { hex+=3; regval = reg_esi; } else
-	if (strncmp(hex,"EDI",3) == 0) { hex+=3; regval = reg_edi; } else
-	if (strncmp(hex,"EBP",3) == 0) { hex+=3; regval = reg_ebp; } else
-	if (strncmp(hex,"ESP",3) == 0) { hex+=3; regval = reg_esp; } else
-	if (strncmp(hex,"EIP",3) == 0) { hex+=3; regval = reg_eip; } else
-
-	if (strncmp(hex,"AX",2) == 0)  { hex+=2; regval = reg_ax; } else
-	if (strncmp(hex,"BX",2) == 0)  { hex+=2; regval = reg_bx; } else
-	if (strncmp(hex,"CX",2) == 0)  { hex+=2; regval = reg_cx; } else
-	if (strncmp(hex,"DX",2) == 0)  { hex+=2; regval = reg_dx; } else
-	if (strncmp(hex,"SI",2) == 0)  { hex+=2; regval = reg_si; } else
-	if (strncmp(hex,"DI",2) == 0)  { hex+=2; regval = reg_di; } else
-	if (strncmp(hex,"BP",2) == 0)  { hex+=2; regval = reg_bp; } else
-	if (strncmp(hex,"SP",2) == 0)  { hex+=2; regval = reg_sp; } else
-	if (strncmp(hex,"IP",2) == 0)  { hex+=2; regval = reg_ip; } else
-
-	if (strncmp(hex,"AL",2) == 0) { hex+=2; regval = reg_al; } else
-	if (strncmp(hex,"BL",2) == 0) { hex+=2; regval = reg_bl; } else
-	if (strncmp(hex,"CL",2) == 0) { hex+=2; regval = reg_cl; } else
-	if (strncmp(hex,"DL",2) == 0) { hex+=2; regval = reg_dl; } else
-
-	if (strncmp(hex,"AH",2) == 0) { hex+=2; regval = reg_ah; } else
-	if (strncmp(hex,"BH",2) == 0) { hex+=2; regval = reg_bh; } else
-	if (strncmp(hex,"CH",2) == 0) { hex+=2; regval = reg_ch; } else
-	if (strncmp(hex,"DH",2) == 0) { hex+=2; regval = reg_dh; } else
-
-	if (strncmp(hex,"CS",2) == 0)  { hex+=2; regval = SegValue(cs); } else
-	if (strncmp(hex,"DS",2) == 0)  { hex+=2; regval = SegValue(ds); } else
-	if (strncmp(hex,"ES",2) == 0)  { hex+=2; regval = SegValue(es); } else
-	if (strncmp(hex,"FS",2) == 0)  { hex+=2; regval = SegValue(fs); } else
-	if (strncmp(hex,"GS",2) == 0)  { hex+=2; regval = SegValue(gs); } else
-	if (strncmp(hex,"SS",2) == 0)  { hex+=2; regval = SegValue(ss); } else
-
-	if (strncmp(hex,"AC",2) == 0) { hex+=2; regval = GETFLAG(AC); } else
-    if (strncmp(hex,"AF",2) == 0) { hex+=2; regval = GETFLAG(AF); } else
-	if (strncmp(hex,"CF",2) == 0) { hex+=2; regval = GETFLAG(CF); } else
-	if (strncmp(hex,"DF",2) == 0) { hex+=2; regval = GETFLAG(DF); } else
-	if (strncmp(hex,"ID",2) == 0) { hex+=2; regval = GETFLAG(ID); } else
-	if (strncmp(hex,"IF",2) == 0) { hex+=2; regval = GETFLAG(IF); } else
-	if (strncmp(hex,"NT",2) == 0) { hex+=2; regval = GETFLAG(NT); } else
-	if (strncmp(hex,"OF",2) == 0) { hex+=2; regval = GETFLAG(OF); } else
-	if (strncmp(hex,"PF",2) == 0) { hex+=2; regval = GETFLAG(PF); } else
-	if (strncmp(hex,"SF",2) == 0) { hex+=2; regval = GETFLAG(SF); } else
-	if (strncmp(hex,"TF",2) == 0) { hex+=2; regval = GETFLAG(TF); } else
-	if (strncmp(hex,"VM",2) == 0) { hex+=2; regval = GETFLAG(VM); } else
-	if (strncmp(hex,"ZF",2) == 0) { hex+=2; regval = GETFLAG(ZF); }
-
-	while (*hex) {
-		if 		((*hex >= '0') && (*hex <= '9')) value = (value<<4u) + ((Bit32u)(*hex)) - '0';
-		else if ((*hex >= 'A') && (*hex <= 'F')) value = (value<<4u) + ((Bit32u)(*hex)) - 'A' + 10u;
-		else { 
-			if (*hex == '+') {hex++;return regval + value + GetHexValue(hex,hex,parsed); } else
-			if (*hex == '-') {hex++;return regval + value - GetHexValue(hex,hex,parsed); }
-			else break; // No valid char
-		}
-		hex++;
-	}
+    while (*hex) {
+        if ((*hex >= '0') && (*hex <= '9')) value = (value << 4u) + ((Bit32u)(*hex)) - '0';
+        else if ((*hex >= 'A') && (*hex <= 'F')) value = (value << 4u) + ((Bit32u)(*hex)) - 'A' + 10u;
+        else {
+            if (*hex == '+') { hex++; return regval + value + GetHexValue(hex, hex, parsed); }
+            else
+                if (*hex == '-') { hex++; return regval + value - GetHexValue(hex, hex, parsed); }
+                else break; // No valid char
+        }
+        hex++;
+    }
 
     if (parsed != NULL)
         *parsed = (hex != str);
 
-	return regval + value;
+    return regval + value;
 }
 
 bool ChangeRegister(char* const str)
@@ -3797,10 +3793,16 @@ static void LogInstruction(Bit16u segValue, Bit32u eipValue,  ofstream& out) {
 		res = AnalyzeInstruction(dline,false);
 		if (!res || !(*res)) res = empty;
 		Bitu reslen = strlen(res);
-		if (reslen<22) for (Bitu i=0; i<22-reslen; i++) res[reslen+i] = ' '; res[22] = 0;
+        if (reslen < 22) {
+            for (Bitu i = 0; i < 22 - reslen; i++) res[reslen + i] = ' ';
+            res[22] = 0;
+        }
 	}
 	Bitu len = strlen(dline);
-	if (len<30) for (Bitu i=0; i<30-len; i++) dline[len + i] = ' '; dline[30] = 0;
+    if (len < 30) {
+        for (Bitu i = 0; i < 30 - len; i++) dline[len + i] = ' ';
+        dline[30] = 0;
+    }
 
 	// Get register values
 
@@ -3817,7 +3819,10 @@ static void LogInstruction(Bit16u segValue, Bit32u eipValue,  ofstream& out) {
 			strcat(ibytes,tmpc);
 		}
 		len = strlen(ibytes);
-		if (len<21) { for (Bitu i=0; i<21-len; i++) ibytes[len + i] =' '; ibytes[21]=0;} //NOTE THE BRACKETS
+        if (len < 21) {
+            for (Bitu i = 0; i < 21 - len; i++) ibytes[len + i] = ' ';
+            ibytes[21] = 0;
+        }
 		out << setw(4) << SegValue(cs) << ":" << setw(8) << reg_eip << "  " << dline << "  " << res << "  " << ibytes;
 	}
    
@@ -4281,7 +4286,10 @@ void DEBUG_HeavyLogInstruction(void) {
 		res = AnalyzeInstruction(dline,false);
 		if (!res || !(*res)) res = empty;
 		Bitu reslen = strlen(res);
-		if (reslen<22) for (Bitu i=0; i<22-reslen; i++) res[reslen+i] = ' '; res[22] = 0;
+        if (reslen < 22) {
+            for (Bitu i = 0; i < 22 - reslen; i++) res[reslen + i] = ' ';
+            res[22] = 0;
+        }
 	}
 
 	Bitu len = strlen(dline);

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -4747,5 +4747,5 @@ void DOS_SetupPrograms(void) {
     if (IS_PC98_ARCH)
         PROGRAMS_MakeFile("PC98UTIL.COM",PC98UTIL_ProgramStart);
 
-	PROGRAMS_MakeFile("CAPMOUSE.COM", CAPMOUSE_ProgramStart);
+    PROGRAMS_MakeFile("CAPMOUSE.COM", CAPMOUSE_ProgramStart);
 }

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -535,7 +535,7 @@ static void GUSReset(void) {
     if (GUS_reset_reg ^ p_GUS_reset_reg)
         LOG(LOG_MISC,LOG_DEBUG)("GUS reset with 0x%04X",myGUS.gRegData);
 
-	if ((myGUS.gRegData & 0x100) == 0x000) {
+    if ((myGUS.gRegData & 0x100) == 0x000) {
 		// Stop all channels
 		int i;
 		for(i=0;i<32;i++) {

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -280,7 +280,7 @@ void PCSPEAKER_SetPITControl(Bitu mode) {
     if (spkr.chan == NULL)
         return;
 
-	pic_tickindex_t newindex = PIC_TickIndex();
+    pic_tickindex_t newindex = PIC_TickIndex();
 	ForwardPIT(newindex);
 #ifdef SPKR_DEBUGGING
 	fprintf(PCSpeakerLog, "%f pit command: %u\n", PIC_FullIndex(), mode);
@@ -319,7 +319,7 @@ void PCSPEAKER_SetCounter_NoNewMode(Bitu cntr) {
     if (spkr.chan == NULL)
         return;
 
-	if (!spkr.last_ticks) {
+    if (!spkr.last_ticks) {
 		if(spkr.chan) spkr.chan->Enable(true);
 		spkr.last_index=0;
 	}

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -487,7 +487,7 @@ static void write_cga_color_select(Bitu val) {
     if (vga.other.mcga_mode_control & 1) /* ignore COMPLETELY in 256-color MCGA mode */
         return;
 
-	switch(vga.mode) {
+    switch (vga.mode) {
 	case  M_TANDY4: {
 		Bit8u base = (val & 0x10) ? 0x08 : 0;
 		Bit8u bg = val & 0xf;

--- a/src/hardware/vga_pc98_crtc.cpp
+++ b/src/hardware/vga_pc98_crtc.cpp
@@ -303,7 +303,7 @@ Bitu pc98_read_9a0(Bitu /*port*/,Bitu /*iolen*/) {
     if (gdc_5mhz_mode)
         retval |= 0x02;
 
-	return retval;
+    return retval;
 }
 
 void pc98_write_9a0(Bitu port,Bitu val,Bitu iolen) {
@@ -325,7 +325,7 @@ Bitu pc98_read_9a8(Bitu /*port*/,Bitu /*iolen*/) {
     if (pc98_31khz_mode)
         retval |= 0x01;/*31khz*/
 
-	return retval;
+    return retval;
 }
 
 void pc98_write_9a8(Bitu /*port*/,Bitu val,Bitu /*iolen*/) {

--- a/src/ints/int10_memory.cpp
+++ b/src/ints/int10_memory.cpp
@@ -59,9 +59,9 @@ void INT10_LoadFont(PhysPt font,bool reload,Bit16u count,Bitu offset,Bitu map,Bi
 	if (IS_VGA_ARCH || (IS_EGA_ARCH && vga.mem.memsize >= 0x20000))
         m64k=0x02;
     else
-        m64k=0x00;
+        m64k = 0x00;
 
-	PhysPt ftwhere=PhysMake(0xa000,map_offset[map & 0x7]+(Bit16u)(offset*32));
+    PhysPt ftwhere = PhysMake(0xa000, map_offset[map & 0x7] + (Bit16u)(offset * 32));
 	Bit16u base=real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS);
 	bool mono=(base==VGAREG_MDA_CRTC_ADDRESS);
 	

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -843,18 +843,18 @@ bool INT10_SetVideoMode_OTHER(Bit16u mode,bool clearmem) {
 		if (machine==MCH_HERC || machine==MCH_MDA) scanline=14;
 		else scanline=8;
 		break;
-	case M_CGA2: // graphics mode: even/odd banks interleaved
+    case M_CGA2: // graphics mode: even/odd banks interleaved
         if (machine == MCH_MCGA && CurMode->mode >= 0x11)
-    		scanline=1; // as seen on real hardware, modes 0x11 and 0x13 have max scanline register == 0x00
+            scanline = 1; // as seen on real hardware, modes 0x11 and 0x13 have max scanline register == 0x00
         else
-    		scanline=2;
-		break;
-	case M_VGA: // MCGA
+            scanline = 2;
+        break;
+    case M_VGA: // MCGA
         if (machine == MCH_MCGA)
-    		scanline=1; // as seen on real hardware, modes 0x11 and 0x13 have max scanline register == 0x00
+            scanline = 1; // as seen on real hardware, modes 0x11 and 0x13 have max scanline register == 0x00
         else
-    		scanline=2;
-		break;
+            scanline = 2;
+        break;
 	case M_CGA4:
 		if (CurMode->mode!=0xa) scanline=2;
 		else scanline=4;
@@ -1488,7 +1488,7 @@ bool INT10_SetVideoMode(Bit16u mode) {
     if (IS_EGA_ARCH && vga.mem.memsize < 0x20000)
         mode_control &= ~0x20; // address wrap bit 13
 
-	IO_Write(crtc_base,0x17);IO_Write(crtc_base+1u,mode_control);
+    IO_Write(crtc_base, 0x17); IO_Write(crtc_base + 1u, mode_control);
 	/* Renable write protection */
 	IO_Write(crtc_base,0x11);
 	IO_Write(crtc_base+1u,IO_Read(crtc_base+1u)|0x80);
@@ -1545,12 +1545,12 @@ bool INT10_SetVideoMode(Bit16u mode) {
 	case M_LIN24:
 	case M_LIN32:
     case M_PACKED4:
-		gfx_data[0x5]|=0x40;		//256 color mode
+        gfx_data[0x5] |= 0x40;		//256 color mode
         if (int10_vesa_map_as_128kb)
-    		gfx_data[0x6]|=0x01;	//graphics mode at 0xa000-bffff
+            gfx_data[0x6] |= 0x01;	//graphics mode at 0xa000-bffff
         else
-    		gfx_data[0x6]|=0x05;	//graphics mode at 0xa000-affff
-		break;
+            gfx_data[0x6] |= 0x05;	//graphics mode at 0xa000-affff
+        break;
 	case M_VGA:
 		gfx_data[0x5]|=0x40;		//256 color mode
 		gfx_data[0x6]|=0x05;		//graphics mode at 0xa000-affff

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1086,8 +1086,8 @@ void SHELL_Init() {
     else
         VFILE_RegisterBuiltinFileBlob(bfb_DSXMENU_EXE_PC);
 
-	/* don't register 28.com unless EGA/VGA */
-	if (IS_EGAVGA_ARCH) VFILE_RegisterBuiltinFileBlob(bfb_28_COM);
+    /* don't register 28.com unless EGA/VGA */
+    if (IS_EGAVGA_ARCH) VFILE_RegisterBuiltinFileBlob(bfb_28_COM);
 
 	/* don't register 50 unless VGA */
 	if (IS_VGA_ARCH) VFILE_RegisterBuiltinFileBlob(bfb_50_COM);


### PR DESCRIPTION
Trying to build with GCC, there are several warnings that appear. Many of them (19) are `-Wmisleading-indentation` warnings, and they are all fixed by this PR.

There were two cases causing this warning:
1. There were some cases in `debug.cpp` where there is a line like:
`if(dline_len < 28) for (c = (Bitu)dline_len; c < 28;c++) dline[c] = ' '; dline[28] = 0;`

where `dline[28] = 0;` would trigger the warning. I think this line is supposed to be within the if block (in other similar code in the same file it is within the if block), so in addition to silencing the warning I put it within the if block.

2. Most cases were just caused by a mixture of using tabs and spaces.

```    if (IS_PC98_ARCH)	    if (IS_PC98_ARCH)
        PROGRAMS_MakeFile("PC98UTIL.COM",PC98UTIL_ProgramStart);

	PROGRAMS_MakeFile("CAPMOUSE.COM", CAPMOUSE_ProgramStart);
```

This would cause it because of the tab before `PROGRAMS_MakeFile("CAPMOUSE.COM", CAPMOUSE_ProgramStart);`

I know you are only accepting last-minute bug fixes, and I don't know if you consider silencing warnings as bug fixes, but here it is. If you want to wait until after the release that is fine with me. I did check the debugger with this PR just in case (the only part with slightly modified behavior) and didn't see any difference.