### PR TITLE
Fix more GCC warnings

### DIFF
--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -287,7 +287,7 @@ bool DOS_Execute(char * name,PhysPt block_pt,Bit8u flags) {
 	Bit16u pspseg,envseg,loadseg,memsize=0xffff,readsize;
 	Bit16u minsize,maxsize,maxfree=0xffff;
 	PhysPt loadaddress;RealPt relocpt;
-    Bit32u headersize, imagesize = 0;
+    Bit32u headersize = 0, imagesize = 0;
 	DOS_ParamBlock block(block_pt);
 
 	block.LoadData();

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -176,12 +176,20 @@ static Bit32u read_kcl_file(const char* kcl_file_name, const char* layout_id, bo
 		fseek(tempfile, -2, SEEK_CUR);
 		// get all language codes for this layout
 		for (Bitu i=0; i<data_len;) {
-			fread(rbuf, sizeof(Bit8u), 2, tempfile);
+            size_t readResult = fread(rbuf, sizeof(Bit8u), 2, tempfile);
+            if (readResult != 2) {
+                LOG(LOG_IO, LOG_ERROR) ("Reading error in read_kcl_file\n");
+                return 0;
+            }
 			Bit16u lcnum=host_readw(&rbuf[0]);
 			i+=2;
 			Bitu lcpos=0;
 			for (;i<data_len;) {
-				fread(rbuf, sizeof(Bit8u), 1, tempfile);
+                readResult = fread(rbuf, sizeof(Bit8u), 1, tempfile);
+                if (readResult != 1) {
+                    LOG(LOG_IO, LOG_ERROR) ("Reading error in read_kcl_file\n");
+                    return 0;
+                }
 				i++;
 				if (((char)rbuf[0])==',') break;
 				lng_codes[lcpos++]=(char)rbuf[0];
@@ -801,16 +809,35 @@ Bitu keyboard_layout::read_codepage_file(const char* codepage_file_name, Bit32s 
 			// check if compressed cpi file
 			Bit8u next_byte=0;
 			for (Bitu i=0; i<100; i++) {
-				fread(&next_byte, sizeof(Bit8u), 1, tempfile);	found_at_pos++;
-				while (next_byte==0x55) {
-					fread(&next_byte, sizeof(Bit8u), 1, tempfile);	found_at_pos++;
-					if (next_byte==0x50) {
-						fread(&next_byte, sizeof(Bit8u), 1, tempfile);	found_at_pos++;
-						if (next_byte==0x58) {
-							fread(&next_byte, sizeof(Bit8u), 1, tempfile);	found_at_pos++;
-							if (next_byte==0x21) {
-								// read version ID
-								fread(&next_byte, sizeof(Bit8u), 1, tempfile);
+                size_t readResult = fread(&next_byte, sizeof(Bit8u), 1, tempfile);
+                if (readResult != 1) {
+                    LOG(LOG_IO, LOG_ERROR) ("Reading error in read_codepage_file\n");
+                }
+                found_at_pos++;
+                while (next_byte == 0x55) {
+                    readResult = fread(&next_byte, sizeof(Bit8u), 1, tempfile);
+                    if (readResult != 1) {
+                        LOG(LOG_IO, LOG_ERROR) ("Reading error in read_codepage_file\n");
+                    }
+                    found_at_pos++;
+                    if (next_byte == 0x50) {
+                        readResult = fread(&next_byte, sizeof(Bit8u), 1, tempfile);
+                        if (readResult != 1) {
+                            LOG(LOG_IO, LOG_ERROR) ("Reading error in read_codepage_file\n");
+                        }
+                        found_at_pos++;
+                        if (next_byte == 0x58) {
+                            readResult = fread(&next_byte, sizeof(Bit8u), 1, tempfile);
+                            if (readResult != 1) {
+                                LOG(LOG_IO, LOG_ERROR) ("Reading error in read_codepage_file\n");
+                            }
+                            found_at_pos++;
+                            if (next_byte == 0x21) {
+                                // read version ID
+                                readResult = fread(&next_byte, sizeof(Bit8u), 1, tempfile);
+                                if (readResult != 1) {
+                                    LOG(LOG_IO, LOG_ERROR) ("Reading error in read_codepage_file\n");
+                                }
 								found_at_pos++;
 								upxfound=true;
 								break;

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -905,8 +905,12 @@ public:
             Bitu segbase = 0x100000 - loadsz;
             LOG_MSG("Loading BIOS image %s to 0x%lx, 0x%lx bytes",bios.c_str(),(unsigned long)segbase,(unsigned long)loadsz);
             fseek(romfp, 0, SEEK_SET);
-            fread(GetMemBase()+segbase,loadsz,1,romfp);
+            size_t readResult = fread(GetMemBase()+segbase,loadsz,1,romfp);
             fclose(romfp);
+            if (readResult != 1) {
+                LOG(LOG_IO, LOG_ERROR) ("Reading error in Run\n");
+                return;
+            }
 
             // The PC-98 BIOS has a bank switching system where at least the last 32KB
             // can be switched to an Initial Firmware Test BIOS, which initializes the
@@ -928,10 +932,13 @@ public:
                 LOG_MSG("Found ITF (initial firmware test) BIOS image (0x%lx bytes)",(unsigned long)isz2);
 
                 memset(PC98_ITF_ROM,0xFF,sizeof(PC98_ITF_ROM));
-                fread(PC98_ITF_ROM,isz2,1,itffp);
-                PC98_ITF_ROM_init = true;
-
+                readResult = fread(PC98_ITF_ROM,isz2,1,itffp);
                 fclose(itffp);
+                if (readResult != 1) {
+                    LOG(LOG_IO, LOG_ERROR) ("Reading error in Run\n");
+                    return;
+                }
+                PC98_ITF_ROM_init = true;
             }
 
             IO_RegisterWriteHandler(0x43D,pc98_43d_write,IO_MB);
@@ -1027,7 +1034,11 @@ public:
                     }
 
                     fseeko64(usefile, 0L, SEEK_SET);
-                    fread(tmp,256,1,usefile); // look for magic signatures
+                    size_t readResult = fread(tmp,256,1,usefile); // look for magic signatures
+                    if (readResult != 1) {
+                        LOG(LOG_IO, LOG_ERROR) ("Reading error in Run\n");
+                        return;
+                    }
 
                     const char *ext = strrchr(temp_line.c_str(),'.');
 
@@ -1214,7 +1225,11 @@ public:
                 if (cart_cmd!="") {
                     /* read cartridge data into buffer */
                     fseek(usefile_1, (long)pcjr_hdr_length, SEEK_SET);
-                    fread(rombuf, 1, rombytesize_1-pcjr_hdr_length, usefile_1);
+                    size_t readResult = fread(rombuf, 1, rombytesize_1-pcjr_hdr_length, usefile_1);
+                    if (readResult != rombytesize_1 - pcjr_hdr_length) {
+                        LOG(LOG_IO, LOG_ERROR) ("Reading error in Run\n");
+                        return;
+                    }
 
                     char cmdlist[1024];
                     cmdlist[0]=0;
@@ -1302,16 +1317,29 @@ public:
                     unsigned int romseg_pt=0;
 
                     fseek(usefile_2, 0x0L, SEEK_SET);
-                    fread(rombuf, 1, pcjr_hdr_length, usefile_2);
+                    size_t readResult = fread(rombuf, 1, pcjr_hdr_length, usefile_2);
+                    if (readResult != pcjr_hdr_length) {
+                        LOG(LOG_IO, LOG_ERROR) ("Reading error in Run\n");
+                        return;
+                    }
+
                     if (pcjr_hdr_type == 1) {
                         romseg_pt=host_readw(&rombuf[0x1ce]);
                     } else {
                         fseek(usefile_2, 0x61L, SEEK_SET);
-                        fscanf(usefile_2, "%4x", &romseg_pt);
+                        int scanResult = fscanf(usefile_2, "%4x", &romseg_pt);
+                        if (scanResult == 0) {
+                            LOG(LOG_IO, LOG_ERROR) ("Scanning error in Run\n");
+                            return;
+                        }
                     }
                     /* read cartridge data into buffer */
                     fseek(usefile_2, (long)pcjr_hdr_length, SEEK_SET);
-                    fread(rombuf, 1, rombytesize_2-pcjr_hdr_length, usefile_2);
+                    readResult = fread(rombuf, 1, rombytesize_2-pcjr_hdr_length, usefile_2);
+                    if (readResult != rombytesize_2 - pcjr_hdr_length) {
+                        LOG(LOG_IO, LOG_ERROR) ("Reading error in Run\n");
+                        return;
+                    }
                     //fclose(usefile_2); //usefile_2 is in diskSwap structure which should be deleted to close the file
 
                     /* write cartridge data into ROM */
@@ -1321,16 +1349,30 @@ public:
                 unsigned int romseg=0;
 
                 fseek(usefile_1, 0x0L, SEEK_SET);
-                fread(rombuf, 1, pcjr_hdr_length, usefile_1);
+                size_t readResult = fread(rombuf, 1, pcjr_hdr_length, usefile_1);
+                if (readResult != pcjr_hdr_length) {
+                    LOG(LOG_IO, LOG_ERROR) ("Reading error in Run\n");
+                    return;
+                }
+
                 if (pcjr_hdr_type == 1) {
                     romseg=host_readw(&rombuf[0x1ce]);
                 } else {
                     fseek(usefile_1, 0x61L, SEEK_SET);
-                    fscanf(usefile_1, "%4x", &romseg);
+                    int scanResult = fscanf(usefile_1, "%4x", &romseg);
+                    if (scanResult == 0) {
+                        LOG(LOG_IO, LOG_ERROR) ("Scanning error in Run\n");
+                        return;
+                    }
                 }
                 /* read cartridge data into buffer */
                 fseek(usefile_1,(long)pcjr_hdr_length, SEEK_SET);
-                fread(rombuf, 1, rombytesize_1-pcjr_hdr_length, usefile_1);
+                readResult = fread(rombuf, 1, rombytesize_1-pcjr_hdr_length, usefile_1);
+                if (readResult != rombytesize_1 - pcjr_hdr_length) {
+                    LOG(LOG_IO, LOG_ERROR) ("Reading error in Run\n");
+                    return;
+                }
+
                 //fclose(usefile_1); //usefile_1 is in diskSwap structure which should be deleted to close the file
                 /* write cartridge data into ROM */
                 for(i=0;i<rombytesize_1-pcjr_hdr_length;i++) phys_writeb((PhysPt)((romseg<<4)+i),rombuf[i]);
@@ -3980,7 +4022,11 @@ private:
             char tmp[256];
 
             fseeko64(newDisk, 0L, SEEK_SET);
-            fread(tmp, 256, 1, newDisk); // look for magic signatures
+            size_t readResult = fread(tmp, 256, 1, newDisk); // look for magic signatures
+            if (readResult != 1) {
+                LOG(LOG_IO, LOG_ERROR) ("Reading error in MountImageNone\n");
+                return NULL;
+            }
 
             const char *ext = strrchr(fileName,'.');
 

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -807,7 +807,11 @@ fatDrive::fatDrive(const char *sysFilename, Bit32u bytesector, Bit32u cylsector,
 	else{
 		fseeko64(diskfile, 0L, SEEK_SET);
         assert(sizeof(bootbuffer.bootcode) >= 256);
-        fread(bootbuffer.bootcode,256,1,diskfile); // look for magic signatures
+        size_t readResult = fread(bootbuffer.bootcode,256,1,diskfile); // look for magic signatures
+        if (readResult != 1) {
+            LOG(LOG_IO, LOG_ERROR) ("Reading error in fatDrive constructor\n");
+            return;
+        }
 
         const char *ext = strrchr(sysFilename,'.');
 

--- a/src/gui/midi_oss.h
+++ b/src/gui/midi_oss.h
@@ -55,7 +55,10 @@ public:
 			buf[pos++] = 0;
 			msg++;
 		}
-		write(device,buf,pos);
+        ssize_t writeResult = write(device, buf, pos);
+        if (writeResult == -1) {
+            LOG(LOG_IO, LOG_ERROR) ("Writing error in PlayMsg\n");
+        }
 	};
 	void PlaySysex(Bit8u * sysex,Bitu len) {
 		Bit8u buf[SYSEX_SIZE*4];Bitu pos=0;
@@ -65,7 +68,10 @@ public:
 			buf[pos++] = device_num;
 			buf[pos++] = 0;
 		}
-		write(device,buf,pos);	
+        ssize_t writeResult = write(device, buf, pos);
+        if (writeResult == -1) {
+            LOG(LOG_IO, LOG_ERROR) ("Writing error in PlaySysex\n");
+        }
 	}
 };
 

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -9157,8 +9157,12 @@ void ROMBIOS_Init() {
                      *      depends on it. */
                     assert(GetMemBase() != NULL);
                     assert((base+(Bitu)st.st_size) <= 0x100000ul);
-                    fread(GetMemBase()+base,(size_t)st.st_size,1u,fp);
+                    size_t readResult = fread(GetMemBase()+base,(size_t)st.st_size,1u,fp);
                     fclose(fp);
+                    if (readResult != 1) {
+                        LOG(LOG_IO, LOG_ERROR) ("Reading error in ROMBIOS_Init\n");
+                        return;
+                    }
 
                     LOG_MSG("User reset vector binary '%s' loaded at 0x%lx",path.c_str(),(unsigned long)base);
                     bios_user_reset_vector_blob = base;
@@ -9192,8 +9196,12 @@ void ROMBIOS_Init() {
                      *      depends on it. */
                     assert(GetMemBase() != NULL);
                     assert((base+(Bitu)st.st_size) <= 0x100000ul);
-                    fread(GetMemBase()+base,(size_t)st.st_size,1u,fp);
+                    size_t readResult = fread(GetMemBase()+base,(size_t)st.st_size,1u,fp);
                     fclose(fp);
+                    if (readResult != 1) {
+                        LOG(LOG_IO, LOG_ERROR) ("Reading error in ROMBIOS_Init\n");
+                        return;
+                    }
 
                     LOG_MSG("User boot hook binary '%s' loaded at 0x%lx",path.c_str(),(unsigned long)base);
                     bios_user_boot_hook = base;

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -1471,7 +1471,11 @@ imageDiskVFD::imageDiskVFD(FILE *imgFile, Bit8u *imgName, Bit32u imgSizeK, bool 
     //  +0x8: absolute data offset (32-bit integer) or 0xFFFFFFFF if the entire sector is that fill byte
     fseek(diskimg,0,SEEK_SET);
     memset(tmp,0,8);
-    fread(tmp,1,8,diskimg);
+    size_t readResult = fread(tmp,1,8,diskimg);
+    if (readResult != 8) {
+            LOG(LOG_IO, LOG_ERROR) ("Reading error in imageDiskVFD constructor\n");
+            return;
+    }
 
     if (!memcmp(tmp,"VFD1.",5)) {
         Bit8u i=0;
@@ -1488,7 +1492,11 @@ imageDiskVFD::imageDiskVFD(FILE *imgFile, Bit8u *imgName, Bit32u imgSizeK, bool 
         fseek(diskimg,0xDC,SEEK_SET);
         while ((entof=((unsigned long)ftell(diskimg)+12ul)) <= stop_at) {
             memset(tmp,0xFF,12);
-            fread(tmp,12,1,diskimg);
+            readResult = fread(tmp,12,1,diskimg);
+            if (readResult != 1) {
+                LOG(LOG_IO, LOG_ERROR) ("Reading error in imageDiskVFD constructor\n");
+                return;
+            }
 
             if (!memcmp(tmp,"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF",12))
                 continue;

--- a/src/ints/qcow2_disk.cpp
+++ b/src/ints/qcow2_disk.cpp
@@ -70,7 +70,11 @@ using namespace std;
 			char* backing_file_name = new char[header.backing_file_size + 1];
 			backing_file_name[header.backing_file_size] = 0;
 			fseeko64(file, (off_t)header.backing_file_offset, SEEK_SET);
-			fread(backing_file_name, header.backing_file_size, 1, file);
+            size_t readResult = fread(backing_file_name, header.backing_file_size, 1, file);
+            if (readResult != 1) {
+                LOG(LOG_IO, LOG_ERROR) ("Reading error in QCow2Image constructor\n");
+                return;
+            }
 			if (backing_file_name[0] != 0x2F){
 				for (int image_name_index = (int)strlen(imageName); image_name_index > -1; image_name_index--){
 					if (imageName[image_name_index] == 0x2F){


### PR DESCRIPTION
Fixes for more GCC warnings.

Fixed the one warning about a possibly uninitialized variable being used.
Fixed 26 warnings about unused return values, mostly for `fread`.