### PR TITLE
Fix more GCC warnings

### DIFF
--- a/src/gui/sdlmain_linux.cpp
+++ b/src/gui/sdlmain_linux.cpp
@@ -526,6 +526,10 @@ static bool Linux_TryXRandrGetDPI(ScreenSizeInfo &info,Display *display,Window w
         XRRFreeScreenResources(xr_screen);
         xr_screen = NULL;
     }
+#else
+    (void)info;    //UNUSED
+    (void)display; //UNUSED
+    (void)window;  //UNUSED
 # endif
 
     return result;

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -493,6 +493,9 @@ public:
 	template <typename T> bool operator!=(const T &src) const { return *this != String(src); }
 	/// Compare with other Strings.
 	bool operator!=(const String &src) const { return *(std::vector<Char>*)this != src; }
+
+    /// Explicit declaration of default = operator
+    String& operator=(const String&) = default;
 };
 
 template <typename STR> void NativeString<STR*>::getString(String &dest, const STR* src) {

--- a/vs2015/sdl/src/video/x11/SDL_x11dyn.c
+++ b/vs2015/sdl/src/video/x11/SDL_x11dyn.c
@@ -111,7 +111,7 @@ char *(*pXGetICValues)(XIC, ...) = NULL;
 #undef SDL_X11_MODULE
 #undef SDL_X11_SYM
 
-
+#ifdef SDL_VIDEO_DRIVER_X11_DYNAMIC
 static void *SDL_XGetRequest_workaround(Display* dpy, CARD8 type, size_t len)
 {
 	xReq *req;
@@ -128,6 +128,7 @@ static void *SDL_XGetRequest_workaround(Display* dpy, CARD8 type, size_t len)
 }
 
 static int x11_load_refcount = 0;
+#endif
 
 void SDL_X11_UnloadSymbols(void)
 {

--- a/vs2015/sdl/src/video/x11/SDL_x11events.c
+++ b/vs2015/sdl/src/video/x11/SDL_x11events.c
@@ -24,7 +24,7 @@
 /* Handle the event stream, converting X11 events into SDL events */
 
 #include <setjmp.h>
-#include <X11/Xlib.h>
+#include <X11/XKBlib.h>
 #include <X11/Xutil.h>
 #include <X11/keysym.h>
 #ifdef __SVR4
@@ -1160,7 +1160,7 @@ SDLKey X11_TranslateKeycode(Display *display, KeyCode kc)
 	KeySym xsym;
 	SDLKey key;
 
-	xsym = xlate_last = XKeycodeToKeysym(display, kc, 0);
+	xsym = xlate_last = XkbKeycodeToKeysym(display, kc, 0, 0);
 #ifdef DEBUG_KEYS
 	fprintf(stderr, "Translating key code %d -> 0x%.4x\n", kc, xsym);
 #endif
@@ -1261,7 +1261,7 @@ static void get_modifier_masks(Display *display)
 	for(i = 3; i < 8; i++) {
 		for(j = 0; j < n; j++) {
 			KeyCode kc = xmods->modifiermap[i * n + j];
-			KeySym ks = XKeycodeToKeysym(display, kc, 0);
+			KeySym ks = XkbKeycodeToKeysym(display, kc, 0, 0);
 			unsigned mask = 1 << i;
 			switch(ks) {
 			case XK_Num_Lock:


### PR DESCRIPTION
Fixes:
1 -Wunused-variable warning
2 -Wunused-function warnings
2 -Wdeprecated-declaration warnings (replacing `XKeycodeToKeysym()` with `XkbKeycodeToKeysym()`)

Like with the other PR, I'm fine with waiting until after release, as this is mainly aimed at cleaning up compiler output and doesn't fix any bugs I know of. (supposedly `XKeycodeToKeysym()` has a bug which might be related to why it is deprecated, but I doubt it is something that seriously affects DOSBox-X)