### PR TITLE
Minor fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -319,8 +319,6 @@ if test x$host = xi386-pc-os2-emx ; then
     LDFLAGS="$LDFLAGS -Zomf -Zmt"
 fi
 
-AC_CHECK_CXXFLAGS([ -Wno-unknown-warning ])
-
 dnl I would like to know of any concerns given by the C++ compiler.
 dnl Clang/LLVM already does this to some degree, let's get GCC to do it too.
 AC_CHECK_CXXFLAGS([ -Wall ])
@@ -350,8 +348,6 @@ dnl Clang/LLVM warning: don't care the address of a member may be unaligned, unl
 AC_CHECK_CXXFLAGS([ -Wno-address-of-packed-member ])
 dnl Clang/LLVM warning: don't care about int to void*, since void* is either same size or larger
 AC_CHECK_CXXFLAGS([ -Wno-int-to-void-pointer-cast ])
-dnl Clang/LLVM warning: extended field designator
-AC_CHECK_CXXFLAGS([ -Wno-extended-offsetof ])
 
 dnl Some stuff for the icon.
 case "$host" in

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -1026,7 +1026,7 @@ static void SaveFindResult(DOS_FCB & find_fcb) {
     else
         DTAExtendName(name,file_name,ext);	
 
-	DOS_FCB fcb(RealSeg(dos.dta()),RealOff(dos.dta()));//TODO
+    DOS_FCB fcb(RealSeg(dos.dta()),RealOff(dos.dta()));//TODO
 	fcb.Create(find_fcb.Extended());
 	fcb.SetName(drive,file_name,ext);
 	fcb.SetAttr(find_attr);      /* Only adds attribute if fcb is extended */

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -80,8 +80,7 @@ void MOUSE::Run(void) {
         WriteOut(MSG_Get("PROGRAM_MOUSE_HELP"));
         return;
     }
-    switch ((unsigned char)Mouse_Drv) { /* FIXME: Mouse_Drv is boolean, clang/llvm complains here */
-    case 0:
+	if (!Mouse_Drv) {
         if (cmd->FindExist("/u",false))
             WriteOut(MSG_Get("PROGRAM_MOUSE_NOINSTALLED"));
         else {
@@ -96,8 +95,8 @@ void MOUSE::Run(void) {
             }
             mainMenu.get_item("dos_mouse_y_axis_reverse").check(Mouse_Vertical).refresh_item(mainMenu);
         }
-        break;
-    case 1:
+    }
+	else {
         if (cmd->FindExist("/u",false)) {
             Mouse_Drv = false;
             mainMenu.get_item("dos_mouse_enable_int33").check(Mouse_Drv).refresh_item(mainMenu);
@@ -114,9 +113,7 @@ void MOUSE::Run(void) {
                 mainMenu.get_item("dos_mouse_y_axis_reverse").check(Mouse_Vertical).refresh_item(mainMenu);
             } else
                 WriteOut(MSG_Get("PROGRAM_MOUSE_ERROR"));
-        break;
-    }
-    return;
+	}
 }
 
 static void MOUSE_ProgramStart(Program * * make) {

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1742,10 +1742,10 @@ nextfile:
     if (sectbuf[entryoffset].attrib & DOS_ATTR_VOLUME)
         trimString(find_name);
 
-	/* Compare attributes to search attributes */
+    /* Compare attributes to search attributes */
 
-	//TODO What about attrs = DOS_ATTR_VOLUME|DOS_ATTR_DIRECTORY ?
-	if (attrs == DOS_ATTR_VOLUME) {
+    //TODO What about attrs = DOS_ATTR_VOLUME|DOS_ATTR_DIRECTORY ?
+    if (attrs == DOS_ATTR_VOLUME) {
 		if (!(sectbuf[entryoffset].attrib & DOS_ATTR_VOLUME)) goto nextfile;
 		labelCache.SetLabel(find_name, false, true);
 	} else {

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -551,7 +551,7 @@ void fatDrive::SetLabel(const char *label, bool /*iscdrom*/, bool /*updatable*/)
 
             if (di == 0) {
                 memset(sectbuf,0,sizeof(sectbuf));
-		        readSector(firstRootDirSect+(i/dirent_per_sector),sectbuf);
+		        readSector((Bit32u)(firstRootDirSect+(i/dirent_per_sector)),sectbuf);
             }
 
             if (sectbuf[di].entryname[0] == 0x00 ||
@@ -564,7 +564,7 @@ void fatDrive::SetLabel(const char *label, bool /*iscdrom*/, bool /*updatable*/)
                     while (i < 11 && *s != 0) sectbuf[di].entryname[i++] = toupper(*s++);
                     while (i < 11)            sectbuf[di].entryname[i++] = ' ';
                 }
-                writeSector(firstRootDirSect+(i/dirent_per_sector),sectbuf);
+                writeSector((Bit32u)(firstRootDirSect+(i/dirent_per_sector)),sectbuf);
 		        labelCache.SetLabel(label, false, true);
                 UpdateBootVolumeLabel(label);
                 break;
@@ -578,7 +578,7 @@ void fatDrive::SetLabel(const char *label, bool /*iscdrom*/, bool /*updatable*/)
 
             if (di == 0) {
                 memset(sectbuf,0,sizeof(sectbuf));
-		        readSector(firstRootDirSect+(i/dirent_per_sector),sectbuf);
+		        readSector((Bit32u)(firstRootDirSect+(i/dirent_per_sector)),sectbuf);
             }
 
             if (sectbuf[di].entryname[0] == 0x00 ||
@@ -591,7 +591,7 @@ void fatDrive::SetLabel(const char *label, bool /*iscdrom*/, bool /*updatable*/)
                  *       of just picking the first one */
                 /* found one */
                 sectbuf[di].entryname[0] = 0xe5;
-                writeSector(firstRootDirSect+(i/dirent_per_sector),sectbuf);
+                writeSector((Bit32u)(firstRootDirSect+(i/dirent_per_sector)),sectbuf);
 		        labelCache.SetLabel("", false, true);
                 UpdateBootVolumeLabel("NO NAME");
                 break;

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -146,7 +146,7 @@ void Drawable::drawText(const String& text, bool interpret, Size start, Size len
 						c = font->toSpecial(text[start]);
 					} while (start < len && ((c >= '0' && c <= '9') || c == ';' || c == '['));
 					if (c == 'm' && start < len) {
-						if (font->toSpecial(text[seqstart++]) != '[') break; /* FIXME: Clang/LLVM claims this comparison will never happen */
+						if (text[seqstart++] != '[') break;
 						c = font->toSpecial(text[seqstart++]);
 						while (c != 'm') {
 							unsigned int param = 0;


### PR DESCRIPTION
1. Fix a few Visual Studio value conversion warnings to bring it back to 0 warnings.
2. Fix a couple GCC "misleading indentation" warnings caused by the mix of tabs and spaces. (Probably the whole codebase should be converted from tabs to spaces, as these warnings will continue to pop up, and the mixture looks uneven when viewing the code. That would touch pretty much every file, though. Do you care about it interfering with the "blame" GitHub function?) 
3. Fix the Clang warning about the comparison that is "always true". The reason it said that seems to be that the comparison was comparing the Font:SpecialChar enum against the "[" character, or 91, for which there is no SpecialChar enum. There doesn't seem to be any reason to cast one side of the compare to SpecialChar as was being done there, so I changed it to just compare the char values.
4. Also fix another Clang FIXME in the code, where for some reason a boolean was being cast to a char, then used in a switch statement with only two cases for 1 and 0. Changed it to an if-else. Also removed a pointless return statement at the end of this function.
5. Removed a couple warning flags (`Wno-unknown-warning` and `-Wno-extended-offsetof`) that cause a bunch of warnings in GCC and Clang compiler output about being unrecognized. I don't see either of these in recent documentation for GCC and Clang, but I'm not all that familiar with building with GCC and Clang.
GCC: https://gcc.gnu.org/onlinedocs/gcc-9.2.0/gcc/Warning-Options.html
Clang: https://releases.llvm.org/8.0.0/tools/clang/docs/DiagnosticsReference.html#wint-to-void-pointer-cast

Compiles and runs.