### PR TITLE
SVN r4009

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -57,6 +57,10 @@
   - LABEL reimplemented to imitate MS-DOS behavior
     with regard to how it handles the command line.
   - File I/O checking and cleanup (Allofich)
+  - Integrated commits from mainline (Allofich)
+    - Handle errant IRQs as a real BIOS does. Also
+    remove r3263 workaround, as it's no longer
+    needed.	
 0.82.21
   - Reduced title bar size of the Configuration GUI.
   - Fixed sizing and positions of some Help menu dialog

--- a/include/bios.h
+++ b/include/bios.h
@@ -85,6 +85,7 @@
 #define BIOS_VDU_CONTROL                0x465
 #define BIOS_VDU_COLOR_REGISTER         0x466
 /* 0x467-0x468 is reserved */
+#define BIOS_LAST_UNEXPECTED_IRQ        0x46b
 #define BIOS_TIMER                      0x46c
 #define BIOS_24_HOURS_FLAG              0x470
 #define BIOS_CTRL_BREAK_FLAG            0x471

--- a/patch-integration/Skipped SVN commits.txt
+++ b/patch-integration/Skipped SVN commits.txt
@@ -1,13 +1,5 @@
 Commit#:	Reason for skipping:
 
-4002		Conflict
-4003		Conflict
-4007		Conflict
-4008		Conflict
-4009		Conflict
-4013		Conflict
-4019		Conflict
-4023		Conflict
 4028		Conflict
 4038		Conflict
 4049		Conflict

--- a/src/cpu/callback.cpp
+++ b/src/cpu/callback.cpp
@@ -45,7 +45,7 @@ unsigned int last_callback = 0;
 CallBack_Handler CallBack_Handlers[CB_MAX] = {NULL};
 char* CallBack_Description[CB_MAX] = {NULL};
 
-Bitu call_stop,call_default,call_default2;
+Bitu call_stop,call_default;
 Bit8u call_idle;
 Bitu call_priv_io;
 
@@ -887,8 +887,6 @@ void CALLBACK_Init() {
 	/* Default handlers for unhandled interrupts that have to be non-null */
 	call_default=CALLBACK_Allocate();
 	CALLBACK_Setup(call_default,&default_handler,CB_IRET,"default");
-	call_default2=CALLBACK_Allocate();
-	CALLBACK_Setup(call_default2,&default_handler,CB_IRET,"default");
 
 	/* Setup block of 0xCD 0xxx instructions */
 	PhysPt rint_base=CALLBACK_GetBase()+CB_MAX*CB_SIZE;


### PR DESCRIPTION
Implemented https://sourceforge.net/p/dosbox/code-0/4009/, which I skipped over last time because I wasn't sure it was compatible with DOSBox-X, but it seems to be, and removed other SVN commits from the list of skipped commits after checking them and seeing they are irrelevant to DOSBox-X.

4009's SVN commit message is
"Handle errant IRQs as a real BIOS does. Fixes Tandy DAC in Chuck Yeager's Air Combat. Also remove r3263 workaround, as it's no longer needed."

I'm not sure if the sound is in fact better in "Chuck Yeager's Air Combat". It might be a little better, but I couldn't discern a clear difference. The r3263 workaround is for "Design Your Own Railroad", which appears to still work fine when the workaround is removed.