### PR TITLE
SVN r4256

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -60,7 +60,10 @@
   - Integrated commits from mainline (Allofich)
     - Handle errant IRQs as a real BIOS does. Also
     remove r3263 workaround, as it's no longer
-    needed.	
+    needed.
+    - Fix flag behavior of several shift/rotate
+    instructions, cause exceptions and fix
+    potential 'pop ss' problems
 0.82.21
   - Reduced title bar size of the Configuration GUI.
   - Fixed sizing and positions of some Help menu dialog

--- a/src/cpu/core_full/load.h
+++ b/src/cpu/core_full/load.h
@@ -186,15 +186,19 @@ l_M_Ed:
 		case M_GRP:
 			inst.code=Groups[inst.code.op][inst.rm_index];
 			goto l_MODRMswitch;
-		case M_GRP_Ib:
-			inst_op2_d=Fetchb();
+		case M_SHIFT_Ib:
+			inst_op2_d = Fetchb() & 0x1f;
+			if (!inst_op2_d)
+				break;
 			inst.code=Groups[inst.code.op][inst.rm_index];
 			goto l_MODRMswitch;
-		case M_GRP_CL:
-			inst_op2_d=reg_cl;
+		case M_SHIFT_CL:
+			inst_op2_d = reg_cl & 0x1f;
+			if (!inst_op2_d)
+				break;
 			inst.code=Groups[inst.code.op][inst.rm_index];
 			goto l_MODRMswitch;
-		case M_GRP_1:
+		case M_SHIFT_1:
 			inst_op2_d=1;
 			inst.code=Groups[inst.code.op][inst.rm_index];
 			goto l_MODRMswitch;

--- a/src/cpu/core_full/optable.h
+++ b/src/cpu/core_full/optable.h
@@ -155,7 +155,7 @@ static OpCode OpCodeTable[1024]={
 {L_Iw		,0			,S_REGw	,REGI_SI},{L_Iw	,0			,S_REGw	,REGI_DI},
 
 /* 0xc0 - 0xc7 */
-{L_MODRM	,5			,0	,M_GRP_Ib	},{L_MODRM	,6			,0	,M_GRP_Ib	},
+{L_MODRM	,5			,0	,M_SHIFT_Ib	},{L_MODRM	,6			,0	,M_SHIFT_Ib	},
 {L_POPw		,0			,S_IPIw	,0		},{L_POPw	,0			,S_IP	,0		},
 {L_MODRM	,O_SEGES	,S_SEGGw,M_Efw	},{L_MODRM	,O_SEGDS	,S_SEGGw,M_Efw	},
 {L_MODRM	,0			,S_Eb	,M_Ib	},{L_MODRM	,0			,S_Ew	,M_Iw	},
@@ -166,8 +166,8 @@ static OpCode OpCodeTable[1024]={
 {L_INTO		,O_INT		,0		,0		},{D_IRETw	,0			,0		,0		},
 
 /* 0xd0 - 0xd7 */
-{L_MODRM	,5			,0	,M_GRP_1	},{L_MODRM	,6			,0	,M_GRP_1	},
-{L_MODRM	,5			,0	,M_GRP_CL	},{L_MODRM	,6			,0	,M_GRP_CL	},
+{L_MODRM	,5			,0	,M_SHIFT_1	},{L_MODRM	,6			,0	,M_SHIFT_1	},
+{L_MODRM	,5			,0	,M_SHIFT_CL	},{L_MODRM	,6			,0	,M_SHIFT_CL	},
 {L_Ib		,O_AAM		,0		,0		},{L_Ib		,O_AAD		,0		,0		},
 {D_SETALC	,0			,0		,0		},{D_XLAT	,0			,0		,0		},
 //TODO FPU
@@ -511,7 +511,7 @@ static OpCode OpCodeTable[1024]={
 {L_Id		,0			,S_REGd	,REGI_SI},{L_Id	,0			,S_REGd	,REGI_DI},
 
 /* 0x2c0 - 0x2c7 */
-{L_MODRM	,5			,0	,M_GRP_Ib	},{L_MODRM	,7			,0	,M_GRP_Ib	},
+{L_MODRM	,5			,0	,M_SHIFT_Ib	},{L_MODRM	,7			,0	,M_SHIFT_Ib	},
 {L_POPd		,0			,S_IPIw	,0		},{L_POPd	,0			,S_IP	,0		},
 {L_MODRM	,O_SEGES	,S_SEGGd,M_Efd	},{L_MODRM	,O_SEGDS	,S_SEGGd,M_Efd	},
 {L_MODRM	,0			,S_Eb	,M_Ib	},{L_MODRM	,0			,S_Ed	,M_Id	},
@@ -522,8 +522,8 @@ static OpCode OpCodeTable[1024]={
 {L_INTO		,O_INT		,0		,0		},{D_IRETd	,0			,0		,0		},
 
 /* 0x2d0 - 0x2d7 */
-{L_MODRM	,5			,0	,M_GRP_1	},{L_MODRM	,7			,0	,M_GRP_1	},
-{L_MODRM	,5			,0	,M_GRP_CL	},{L_MODRM	,7			,0	,M_GRP_CL	},
+{L_MODRM	,5			,0	,M_SHIFT_1	},{L_MODRM	,7			,0	,M_SHIFT_1	},
+{L_MODRM	,5			,0	,M_SHIFT_CL	},{L_MODRM	,7			,0	,M_SHIFT_CL	},
 {L_Ib		,O_AAM		,0		,0		},{L_Ib		,O_AAD		,0		,0		},
 {D_SETALC	,0			,0		,0		},{D_XLAT	,0			,0		,0		},
 /* 0x2d8 - 0x2df */

--- a/src/cpu/core_full/support.h
+++ b/src/cpu/core_full/support.h
@@ -167,7 +167,8 @@ enum {
 
 	M_SEG,M_EA,
 	M_GRP,
-	M_GRP_Ib,M_GRP_CL,M_GRP_1,
+	//Special shift groups
+	M_SHIFT_1, M_SHIFT_Ib, M_SHIFT_CL,
 
 	M_POPw,M_POPd
 };

--- a/src/cpu/instructions.h
+++ b/src/cpu/instructions.h
@@ -230,14 +230,6 @@ extern bool enable_fpu;
 
 
 #define ROLB(op1,op2,load,save)						\
-	if (!(op2&0x7)) {								\
-		if (op2&0x18) {								\
-			FillFlagsNoCFOF();						\
-			SETFLAGBIT(CF,op1 & 1);					\
-			SETFLAGBIT(OF,(op1 & 1) ^ (op1 >> 7));	\
-		}											\
-		break;										\
-	}												\
 	FillFlagsNoCFOF();								\
 	lf_var1b=load(op1);								\
 	lf_var2b=op2&0x07;								\
@@ -248,14 +240,6 @@ extern bool enable_fpu;
 	SETFLAGBIT(OF,(lf_resb & 1) ^ (lf_resb >> 7));
 
 #define ROLW(op1,op2,load,save)						\
-	if (!(op2&0xf)) {								\
-		if (op2&0x10) {								\
-			FillFlagsNoCFOF();						\
-			SETFLAGBIT(CF,op1 & 1);					\
-			SETFLAGBIT(OF,(op1 & 1) ^ (op1 >> 15));	\
-		}											\
-		break;										\
-	}												\
 	FillFlagsNoCFOF();								\
 	lf_var1w=load(op1);								\
 	lf_var2b=op2&0xf;								\
@@ -266,7 +250,6 @@ extern bool enable_fpu;
 	SETFLAGBIT(OF,(lf_resw & 1) ^ (lf_resw >> 15));
 
 #define ROLD(op1,op2,load,save)						\
-	if (!op2) break;								\
 	FillFlagsNoCFOF();								\
 	lf_var1d=load(op1);								\
 	lf_var2b=op2;									\
@@ -278,14 +261,6 @@ extern bool enable_fpu;
 
 
 #define RORB(op1,op2,load,save)						\
-	if (!(op2&0x7)) {								\
-		if (op2&0x18) {								\
-			FillFlagsNoCFOF();						\
-			SETFLAGBIT(CF,op1>>7);					\
-			SETFLAGBIT(OF,(op1>>7) ^ ((op1>>6) & 1));			\
-		}											\
-		break;										\
-	}												\
 	FillFlagsNoCFOF();								\
 	lf_var1b=load(op1);								\
 	lf_var2b=op2&0x07;								\
@@ -296,14 +271,6 @@ extern bool enable_fpu;
 	SETFLAGBIT(OF,(lf_resb ^ (lf_resb<<1)) & 0x80);
 
 #define RORW(op1,op2,load,save)					\
-	if (!(op2&0xf)) {							\
-		if (op2&0x10) {							\
-			FillFlagsNoCFOF();					\
-			SETFLAGBIT(CF,op1>>15);				\
-			SETFLAGBIT(OF,(op1>>15) ^ ((op1>>14) & 1));			\
-		}										\
-		break;									\
-	}											\
 	FillFlagsNoCFOF();							\
 	lf_var1w=load(op1);							\
 	lf_var2b=op2&0xf;							\
@@ -314,7 +281,6 @@ extern bool enable_fpu;
 	SETFLAGBIT(OF,(lf_resw ^ (lf_resw<<1)) & 0x8000);
 
 #define RORD(op1,op2,load,save)					\
-	if (!op2) break;							\
 	FillFlagsNoCFOF();							\
 	lf_var1d=load(op1);							\
 	lf_var2b=op2;								\
@@ -368,8 +334,6 @@ extern bool enable_fpu;
 	SETFLAGBIT(OF,(reg_flags & 1u) ^ ((unsigned int)lf_resd >> 31u));	\
 }
 
-
-
 #define RCRB(op1,op2,load,save)								\
 	if (op2%9) {											\
 		Bit8u cf=(Bit8u)FillFlags()&0x1;					\
@@ -415,21 +379,18 @@ extern bool enable_fpu;
 
 
 #define SHLB(op1,op2,load,save)								\
-	if (!op2) break;										\
 	lf_var1b=load(op1);lf_var2b=op2;				\
 	lf_resb=(lf_var2b < 8u) ? ((unsigned int)lf_var1b << lf_var2b) : 0;			\
 	save(op1,lf_resb);								\
 	lflags.type=t_SHLb;
 
 #define SHLW(op1,op2,load,save)								\
-	if (!op2) break;										\
 	lf_var1w=load(op1);lf_var2b=op2 ;				\
 	lf_resw=(lf_var2b < 16u) ? ((unsigned int)lf_var1w << lf_var2b) : 0;			\
 	save(op1,lf_resw);								\
 	lflags.type=t_SHLw;
 
 #define SHLD(op1,op2,load,save)								\
-	if (!op2) break;										\
 	lf_var1d=load(op1);lf_var2b=op2;				\
 	lf_resd=(lf_var2b < 32u) ? ((unsigned int)lf_var1d << lf_var2b) : 0;			\
 	save(op1,lf_resd);								\
@@ -437,21 +398,18 @@ extern bool enable_fpu;
 
 
 #define SHRB(op1,op2,load,save)								\
-	if (!op2) break;										\
 	lf_var1b=load(op1);lf_var2b=op2;				\
 	lf_resb=(lf_var2b < 8u) ? ((unsigned int)lf_var1b >> lf_var2b) : 0;			\
 	save(op1,lf_resb);								\
 	lflags.type=t_SHRb;
 
 #define SHRW(op1,op2,load,save)								\
-	if (!op2) break;										\
 	lf_var1w=load(op1);lf_var2b=op2;				\
 	lf_resw=(lf_var2b < 16u) ? ((unsigned int)lf_var1w >> lf_var2b) : 0;			\
 	save(op1,lf_resw);								\
 	lflags.type=t_SHRw;
 
 #define SHRD(op1,op2,load,save)								\
-	if (!op2) break;										\
 	lf_var1d=load(op1);lf_var2b=op2;				\
 	lf_resd=(lf_var2b < 32u) ? ((unsigned int)lf_var1d >> lf_var2b) : 0;			\
 	save(op1,lf_resd);								\
@@ -459,7 +417,6 @@ extern bool enable_fpu;
 
 
 #define SARB(op1,op2,load,save)								\
-	if (!op2) break;										\
 	lf_var1b=load(op1);lf_var2b=op2;				\
 	if (lf_var2b>8) lf_var2b=8;						\
     if (lf_var1b & 0x80) {								\
@@ -472,7 +429,6 @@ extern bool enable_fpu;
 	lflags.type=t_SARb;
 
 #define SARW(op1,op2,load,save)								\
-	if (!op2) break;								\
 	lf_var1w=load(op1);lf_var2b=op2;			\
 	if (lf_var2b>16) lf_var2b=16;					\
 	if (lf_var1w & 0x8000) {							\
@@ -485,7 +441,6 @@ extern bool enable_fpu;
 	lflags.type=t_SARw;
 
 #define SARD(op1,op2,load,save)								\
-	if (!op2) break;								\
 	lf_var2b=op2;lf_var1d=load(op1);			\
 	if (lf_var1d & 0x80000000) {						\
 		lf_resd=(lf_var1d >> lf_var2b)|		\
@@ -897,6 +852,7 @@ extern bool enable_fpu;
 	if (rm >= 0xc0) {										\
 		GetEArb;											\
 		Bit8u val=CPU_SHIFTOP_MASK(blah,7);								\
+		if (!val) break;									\
 		switch (which)	{									\
 		case 0x00:ROLB(*earb,val,LoadRb,SaveRb);break;		\
 		case 0x01:RORB(*earb,val,LoadRb,SaveRb);break;		\
@@ -910,6 +866,7 @@ extern bool enable_fpu;
 	} else {												\
 		GetEAa;												\
 		Bit8u val=CPU_SHIFTOP_MASK(blah,7);								\
+		if (!val) break;									\
 		switch (which) {									\
 		case 0x00:ROLB(eaa,val,LoadMb,SaveMb);break;		\
 		case 0x01:RORB(eaa,val,LoadMb,SaveMb);break;		\
@@ -931,6 +888,7 @@ extern bool enable_fpu;
 	if (rm >= 0xc0) {										\
 		GetEArw;											\
 		Bit8u val=CPU_SHIFTOP_MASK(blah,15);								\
+		if (!val) break;									\
 		switch (which)	{									\
 		case 0x00:ROLW(*earw,val,LoadRw,SaveRw);break;		\
 		case 0x01:RORW(*earw,val,LoadRw,SaveRw);break;		\
@@ -944,6 +902,7 @@ extern bool enable_fpu;
 	} else {												\
 		GetEAa;												\
 		Bit8u val=CPU_SHIFTOP_MASK(blah,15);								\
+		if (!val) break;									\
 		switch (which) {									\
 		case 0x00:ROLW(eaa,val,LoadMw,SaveMw);break;		\
 		case 0x01:RORW(eaa,val,LoadMw,SaveMw);break;		\
@@ -964,6 +923,7 @@ extern bool enable_fpu;
 	if (rm >= 0xc0) {										\
 		GetEArd;											\
 		Bit8u val=CPU_SHIFTOP_MASK(blah,31);								\
+		if (!val) break;									\
 		switch (which)	{									\
 		case 0x00:ROLD(*eard,val,LoadRd,SaveRd);break;		\
 		case 0x01:RORD(*eard,val,LoadRd,SaveRd);break;		\
@@ -977,6 +937,7 @@ extern bool enable_fpu;
 	} else {												\
 		GetEAa;												\
 		Bit8u val=CPU_SHIFTOP_MASK(blah,31);								\
+		if (!val) break;									\
 		switch (which) {									\
 		case 0x00:ROLD(eaa,val,LoadMd,SaveMd);break;		\
 		case 0x01:RORD(eaa,val,LoadMd,SaveMd);break;		\


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/4256/

"Fix flag behaviour of several shift/rotate instructions, cause
exceptions and fix potential 'pop ss' problems"

I skipped ahead in the SVN commits because there was this interesting one that I wanted to try.

Although they haven't marked it as fixed yet, this fixes this bug in the DOSBox mainline bug tracker:
https://sourceforge.net/p/dosbox/bugs/511/

Before this PR, the program outputs "1". With this PR, it outputs "0". I don't know of any other test cases, but it would be interesting if this fixes some programs.
