### PR TITLE
SVN r4028

### DIFF
--- a/patch-integration/Skipped SVN commits.txt
+++ b/patch-integration/Skipped SVN commits.txt
@@ -1,6 +1,5 @@
 Commit#:	Reason for skipping:
 
-4028		Conflict
 4038		Conflict
 4049		Conflict
 4055		Conflict


### PR DESCRIPTION
Original commit message:
"make increaseticks a separate function and rewrite it for easier reading. The behaviour is identical. No fixes!"
https://sourceforge.net/p/dosbox/code-0/4028/

The code being modified by this SVN commit is a little different between DOSBox-X and SVN, which is why I skipped over this commit the first time, but this PR should recreate the SVN commit changes, which are basically just a rearrangement of code, as adapted to DOSBox-X.

Also includes minor cleanup (formatting, comments, removing unnecessary casts).

Compiles and runs.
