### PR TITLE
SVN r3961 (modified)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -98,6 +98,9 @@
     - Fix flag behavior of several shift/rotate
     instructions, cause exceptions and fix
     potential 'pop ss' problems
+    - Add support for Print Screen key and
+    interrupt. In-game screenshot feature
+    of Descent and Descent 2 now works.
 0.82.21
   - Reduced title bar size of the Configuration GUI.
   - Fixed sizing and positions of some Help menu dialog

--- a/include/bios.h
+++ b/include/bios.h
@@ -158,6 +158,7 @@ extern Bitu BIOS_DEFAULT_IRQ0_LOCATION;		// (RealMake(0xf000,0xfea5))
 extern Bitu BIOS_DEFAULT_IRQ1_LOCATION;		// (RealMake(0xf000,0xe987))
 extern Bitu BIOS_DEFAULT_IRQ2_LOCATION;		// (RealMake(0xf000,0xff55))
 extern Bitu BIOS_DEFAULT_HANDLER_LOCATION;	// (RealMake(0xf000,0xff53))
+extern Bitu BIOS_DEFAULT_INT5_LOCATION;		// (RealMake(0xf000,0xff54))
 extern Bitu BIOS_VIDEO_TABLE_LOCATION;		// (RealMake(0xf000,0xf0a4))
 extern Bitu BIOS_DEFAULT_RESET_LOCATION;	// RealMake(0xf000,0xe05b)
 extern Bitu BIOS_VIDEO_TABLE_SIZE;

--- a/src/cpu/callback.cpp
+++ b/src/cpu/callback.cpp
@@ -438,7 +438,15 @@ Bitu CALLBACK_SetupExtra(Bitu callback, Bitu type, PhysPt physAddress, bool use_
 		phys_writew(physAddress+0x0b,(Bit16u)(IS_PC98_ARCH ? 0x00e6 : 0x20e6));		// out 0x20, al
 		phys_writeb(physAddress+0x0d,(Bit8u)0x58);			// pop ax
 		phys_writeb(physAddress+0x0e,(Bit8u)0xcf);			//An IRET Instruction
-		return (use_cb?0x15:0x0f);
+        phys_writeb(physAddress+0x0f,(Bit8u)0xfa);			// cli
+        phys_writew(physAddress+0x10,(Bit16u)0x20b0);		// mov al, 0x20
+        phys_writew(physAddress+0x12,(Bit16u)0x20e6);		// out 0x20, al
+        phys_writeb(physAddress+0x14,(Bit8u)0x55);			// push bp
+        phys_writew(physAddress+0x15,(Bit16u)0x05cd);		// int 5
+        phys_writeb(physAddress+0x17,(Bit8u)0x5d);			// pop bp
+        phys_writeb(physAddress+0x18,(Bit8u)0x58);			// pop ax
+        phys_writeb(physAddress+0x19,(Bit8u)0xcf);			//An IRET Instruction
+        return (use_cb ?0x20:0x1a);
 	case CB_IRQ1_BREAK:	// return from int9, when Ctrl-Break is detected; invokes int 1b
 		phys_writew(physAddress+0x00,(Bit16u)0x1bcd);		// int 1b
 		phys_writeb(physAddress+0x02,(Bit8u)0xfa);		// cli

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -1565,9 +1565,13 @@ void KEYBOARD_AddKey1(KBD_KEYS keytype,bool pressed) {
         keyb.repeat.wait=0;
         return;
     case KBD_printscreen:
-        extend=true;
-        if (pressed) { ret=0x2a; ret2=0x37; }
-        else         { ret=0xb7; ret2=0xaa; }
+        KEYBOARD_AddBuffer(0xe0);
+        KEYBOARD_AddBuffer(42 | (pressed ? 0 : 0x80));
+        KEYBOARD_AddBuffer(0xe0);
+        KEYBOARD_AddBuffer(55 | (pressed ? 0 : 0x80));
+        /* pressing this key also disables any previous key repeat */
+        keyb.repeat.key = KBD_NONE;
+        keyb.repeat.wait = 0;
         return;
     case KBD_lwindows:extend=true;ret=0x5B;break;
     case KBD_rwindows:extend=true;ret=0x5C;break;

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -112,6 +112,7 @@ Bitu BIOS_DEFAULT_IRQ07_DEF_LOCATION = ~0u;  // (RealMake(0xf000,0xff55))
 Bitu BIOS_DEFAULT_IRQ815_DEF_LOCATION = ~0u; // (RealMake(0xf000,0xe880))
 
 Bitu BIOS_DEFAULT_HANDLER_LOCATION = ~0u;    // (RealMake(0xf000,0xff53))
+Bitu BIOS_DEFAULT_INT5_LOCATION = ~0u;       // (RealMake(0xf000,0xff54))
 
 Bitu BIOS_VIDEO_TABLE_LOCATION = ~0u;        // RealMake(0xf000,0xf0a4)
 Bitu BIOS_VIDEO_TABLE_SIZE = 0u;
@@ -7647,6 +7648,12 @@ private:
 
         if (!IS_PC98_ARCH) {
             mem_writed(BIOS_TIMER,0);           //Calculate the correct time
+
+            // INT 05h: Print Screen
+            // IRQ1 handler calls it when PrtSc key is pressed; does nothing unless hooked
+            phys_writeb(Real2Phys(BIOS_DEFAULT_INT5_LOCATION), 0xcf);
+            RealSetVec(0x05, BIOS_DEFAULT_INT5_LOCATION);
+
             phys_writew(Real2Phys(RealGetVec(0x12))+0x12,0x20); //Hack for Jurresic
         }
 
@@ -8633,8 +8640,9 @@ public:
         /* pick locations */
         BIOS_DEFAULT_RESET_LOCATION = PhysToReal416(ROMBIOS_GetMemory(64/*several callbacks*/,"BIOS default reset location",/*align*/4));
         BIOS_DEFAULT_HANDLER_LOCATION = PhysToReal416(ROMBIOS_GetMemory(1/*IRET*/,"BIOS default handler location",/*align*/4));
+        BIOS_DEFAULT_INT5_LOCATION = PhysToReal416(ROMBIOS_GetMemory(1/*IRET*/, "BIOS default INT5 location",/*align*/4));
         BIOS_DEFAULT_IRQ0_LOCATION = PhysToReal416(ROMBIOS_GetMemory(0x13/*see callback.cpp for IRQ0*/,"BIOS default IRQ0 location",/*align*/4));
-        BIOS_DEFAULT_IRQ1_LOCATION = PhysToReal416(ROMBIOS_GetMemory(0x15/*see callback.cpp for IRQ1*/,"BIOS default IRQ1 location",/*align*/4));
+        BIOS_DEFAULT_IRQ1_LOCATION = PhysToReal416(ROMBIOS_GetMemory(0x20/*see callback.cpp for IRQ1*/,"BIOS default IRQ1 location",/*align*/4));
         BIOS_DEFAULT_IRQ07_DEF_LOCATION = PhysToReal416(ROMBIOS_GetMemory(7/*see callback.cpp for EOI_PIC1*/,"BIOS default IRQ2-7 location",/*align*/4));
         BIOS_DEFAULT_IRQ815_DEF_LOCATION = PhysToReal416(ROMBIOS_GetMemory(9/*see callback.cpp for EOI_PIC1*/,"BIOS default IRQ8-15 location",/*align*/4));
 


### PR DESCRIPTION
# Description

https://sourceforge.net/p/dosbox/code-0/3961/

Adapted for DOSBox-X. Please take a close look, because I had to do things differently than the SVN commit for the INT 5 part. I tried to mimic existing code in DOSBox-X but I could have made a mistake.


**Does this PR address some issue(s) ?**

https://github.com/joncampbell123/dosbox-x/issues/1099

**Does this PR introduce new feature(s) ?**

Print Screen key and INT 5 support.

**Are there any breaking changes ?**

Not that I know of.

**Additional information**

This implements:
1. Print Screen key, which did nothing before. This allows the screenshot feature of Descent to work.

![descentr_000](https://user-images.githubusercontent.com/19624336/65771560-7318bb00-e173-11e9-937a-b50901160062.png)

2. Pressing Print Screen stopping the repetition of another key that is being held down when Print Screen is pressed. The Pause key already does this in DOSBox-X, and I saw the Print Screen key will likewise stop another key's repetition in real MS-DOS in 86Box and in the command prompt in Windows 10, so I assume that is correct behavior. In mainline DOSBox Print Screen does not interrupt key repetitions.

3. INT 5 support, as provided by the SVN commit. Unfortunately, I haven't been able to test that it works. The original SVN commit claims that "Horror Hotel (TSR text adventure)" and "The Forgotten Land" benefit from this, but I can't find them to test with.

In `callback.cpp` I noticed that DOSBox-X had some separate behavior in place for PC-98 and Tandy, in `CB_IRQ1`, so this PR's addition there might not be appropriate for them.