### PR TITLE
Note and ignore Logitech CyberMan INT 33 call

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.82.22 (next)
+  - (Allofich) Note and ignore INT 33, AX=53C1 call
+    for the Logitech CyberMan.
   - Fixed odd code addition that disabled (through
     the configuration) XMS, EMS, and UMB when
     booting a guest OS. This fixes a problem where

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -1340,6 +1340,9 @@ static Bitu INT33_Handler(void) {
         reg_cx = (Bit16u)mouse.max_x;
         reg_dx = (Bit16u)mouse.max_y;
         break;
+    case 0x53C1: /* Logitech CyberMan */
+        LOG(LOG_MOUSE, LOG_NORMAL)("Mouse function 53C1 for Logitech CyberMan called. Ignored by regular mouse driver.");
+        break;
     default:
         LOG(LOG_MOUSE, LOG_ERROR)("Mouse Function %04X not implemented!", reg_ax);
         break;


### PR DESCRIPTION
I noticed that both The Elder Scrolls: Arena and Descent would log a message about unimplemented mouse function 0x53C1.

Descent's source code is online, so I took a look and found the call, and that it is to detect support for "SWIFT functions" used by the Logitech CyberMan mouse, provided by that mouse's drivers.

Descent code:
https://github.com/videogamepreservation/descent/blob/05216a7e6953aa82902d9107109fa7ffbadd9710/BIOS/MOUSE.C#L346

Logitech CyberMan:
http://www.computinghistory.org.uk/det/12416/Logitech-Cyberman/

Also a DOOM message referencing using the 0x53C1 function to check for CyberMan "SWIFT" support is mentioned here: https://www.doomworld.com/forum/topic/37039-doom-on-lan/