### PR TITLE
Silence all VS2019 "uninitialized member variable" warnings

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -694,36 +694,36 @@ private:
 extern DOS_InfoBlock dos_infoblock;
 
 struct DOS_Block {
-	DOS_Date date;
-	DOS_Version version;
-	Bit16u firstMCB;
-	Bit16u errorcode;
-	Bit16u psp();//{return DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).GetPSP();};
-	void psp(Bit16u _seg);//{ DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).SetPSP(_seg);};
-	RealPt dta();//{return DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).GetDTA();};
-	void dta(RealPt _dta);//{DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).SetDTA(_dta);};
-	Bit8u return_code,return_mode;
-	
-	Bit8u current_drive;
-	bool verify;
-	bool breakcheck;
-	bool echo;          // if set to true dev_con::read will echo input
-	bool direct_output;
-	bool internal_output;
-	struct  {
-		RealPt mediaid;
-		RealPt tempdta;
-		RealPt tempdta_fcbdelete;
-		RealPt dbcs;
-		RealPt filenamechar;
-		RealPt collatingseq;
-		RealPt upcase;
-		Bit8u* country;//Will be copied to dos memory. resides in real mem
-		Bit16u dpb; //Fake Disk parameter system using only the first entry so the drive letter matches
+    DOS_Date date = {};
+    DOS_Version version = {};
+    Bit16u firstMCB = 0;
+    Bit16u errorcode = 0;
+    Bit16u psp();//{return DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).GetPSP();};
+    void psp(Bit16u _seg);//{ DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).SetPSP(_seg);};
+    RealPt dta();//{return DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).GetDTA();};
+    void dta(RealPt _dta);//{DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).SetDTA(_dta);};
+    Bit8u return_code = 0, return_mode = 0;
+
+    Bit8u current_drive = 0;
+    bool verify = false;
+    bool breakcheck = false;
+    bool echo = false;          // if set to true dev_con::read will echo input
+    bool direct_output = false;
+    bool internal_output = false;
+    struct {
+        RealPt mediaid = 0;
+        RealPt tempdta = 0;
+        RealPt tempdta_fcbdelete = 0;
+        RealPt dbcs = 0;
+        RealPt filenamechar = 0;
+        RealPt collatingseq = 0;
+        RealPt upcase = 0;
+        Bit8u* country = NULL;//Will be copied to dos memory. resides in real mem
+        Bit16u dpb = 0; //Fake Disk parameter system using only the first entry so the drive letter matches
         Bit16u dpb_size = 0x21; // bytes per DPB entry (MS-DOS 4.x-6.x size)
         Bit16u mediaid_offset = 0x17; // media ID offset in DPB (MS-DOS 4.x-6.x case)
-	} tables;
-	Bit16u loaded_codepage;
+    } tables;
+    Bit16u loaded_codepage = 0;
 };
 
 extern DOS_Block dos;
@@ -734,8 +734,8 @@ static INLINE Bit8u RealHandle(Bit16u handle) {
 }
 
 struct DOS_GetMemLog_Entry {
-    Bit16u      segbase;
-    Bit16u      pages;
+    Bit16u      segbase = 0;
+    Bit16u      pages = 0;
     std::string who;
 };
 

--- a/include/programs.h
+++ b/include/programs.h
@@ -82,7 +82,7 @@ private:
 	typedef std::list<std::string>::iterator cmd_it;
 	std::string opt_gnu_getopt_singlechar;		/* non-empty if we hit GNU options like -abcd => -a -b -c -d */
 	cmd_it opt_scan;
-	bool opt_eat_argv;
+	bool opt_eat_argv = false;
 	std::list<std::string> cmds;
 	std::string file_name;
     std::string raw_cmdline;

--- a/include/vga.h
+++ b/include/vga.h
@@ -750,28 +750,28 @@ typedef struct {
 static const size_t VGA_Draw_2_elem = 2;
 
 typedef struct {
-	VGAModes mode;								/* The mode the vga system is in */
-	VGAModes lastmode;
-	Bit8u misc_output;
+    VGAModes mode = {};                              /* The mode the vga system is in */
+    VGAModes lastmode = {};
+    Bit8u misc_output = 0;
     VGA_Draw_2 draw_2[VGA_Draw_2_elem];         /* new parallel video emulation. PC-98 mode will use both, all others only the first. */
-	VGA_Draw draw;
-	VGA_Config config;
-	VGA_Internal internal;
-/* Internal module groups */
-	VGA_Seq seq;
-	VGA_Attr attr;
-	VGA_Crtc crtc;
-	VGA_Gfx gfx;
-	VGA_Dac dac;
-	VGA_Latch latch;
-	VGA_S3 s3;
-	VGA_SVGA svga;
-	VGA_HERC herc;
-	VGA_TANDY tandy;
-	VGA_AMSTRAD amstrad;
-	VGA_OTHER other;
-	VGA_Memory mem;
-	VGA_LFB lfb;
+    VGA_Draw draw = {};
+    VGA_Config config = {};
+    VGA_Internal internal = {};
+    /* Internal module groups */
+    VGA_Seq seq = {};
+    VGA_Attr attr = {};
+    VGA_Crtc crtc = {};
+    VGA_Gfx gfx = {};
+    VGA_Dac dac = {};
+    VGA_Latch latch;
+    VGA_S3 s3 = {};
+    VGA_SVGA svga = {};
+    VGA_HERC herc = {};
+    VGA_TANDY tandy = {};
+    VGA_AMSTRAD amstrad = {};
+    VGA_OTHER other = {};
+    VGA_Memory mem;
+    VGA_LFB lfb = {};
 } VGA_Type;
 
 

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -81,7 +81,7 @@ public:
 		Bit16u  wReserved;
 		Bit8u	driveLetter;
 		Bit8u	numSubUnits;
-	} GCC_ATTRIBUTE(packed) TDeviceHeader;
+    } GCC_ATTRIBUTE(packed) TDeviceHeader = {};
 	#ifdef _MSC_VER
 	#pragma pack()
 	#endif

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -41,7 +41,7 @@ public:
 	Bit32u GetSeekPos(void);
 private:
 	isoDrive *drive;
-	Bit8u buffer[ISO_FRAMESIZE];
+    Bit8u buffer[ISO_FRAMESIZE] = {};
 	int cachedSector;
 	Bit32u fileBegin;
 	Bit32u filePos;

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -46,7 +46,7 @@ public:
 private:
 	static struct DriveInfo {
 		std::vector<DOS_Drive*> disks;
-		Bit32u currentDisk;
+		Bit32u currentDisk = 0;
 	} driveInfos[DOS_DRIVES];
 	
 	static int currentDrive;
@@ -90,7 +90,7 @@ protected:
 	friend void DOS_Shell::CMD_SUBST(char* args); 	
 	struct {
 		char srch_dir[CROSS_LEN];
-	} srchInfo[MAX_OPENDIRS];
+    } srchInfo[MAX_OPENDIRS] = {};
 
 	struct {
 		Bit16u bytes_sector;
@@ -254,7 +254,7 @@ private:
 	friend void DOS_Shell::CMD_SUBST(char* args); 	
 	struct {
 		char srch_dir[CROSS_LEN];
-	} srchInfo[MAX_OPENDIRS];
+    } srchInfo[MAX_OPENDIRS] = {};
 
 	struct {
 		Bit16u bytes_sector;
@@ -262,20 +262,20 @@ private:
 		Bit16u total_clusters;
 		Bit16u free_clusters;
 		Bit8u mediaid;
-	} allocation;
+    } allocation = {};
 	
-	bootstrap bootbuffer;
-	bool absolute;
-	Bit8u fattype;
-	Bit32u CountOfClusters;
-	Bit32u partSectOff;
-	Bit32u firstDataSector;
-	Bit32u firstRootDirSect;
+    bootstrap bootbuffer = {};
+	bool absolute = false;
+	Bit8u fattype = 0;
+	Bit32u CountOfClusters = 0;
+	Bit32u partSectOff = 0;
+	Bit32u firstDataSector = 0;
+	Bit32u firstRootDirSect = 0;
 
-	Bit32u cwdDirCluster;
+	Bit32u cwdDirCluster = 0;
 
-	Bit8u fatSectBuffer[SECTOR_SIZE_MAX * 2];
-	Bit32u curFatSect;
+    Bit8u fatSectBuffer[SECTOR_SIZE_MAX * 2] = {};
+	Bit32u curFatSect = 0;
 
 	DOS_Drive_Cache labelCache;
 public:
@@ -287,7 +287,7 @@ public:
 	virtual Bit8u Read_AbsoluteSector(Bit32u sectnum, void * data);
 	virtual Bit8u Write_AbsoluteSector(Bit32u sectnum, void * data);
 	virtual Bit32u getSectSize(void);
-	Bit32u sector_size;
+	Bit32u sector_size = 0;
 
     // INT 25h/INT 26h
     virtual Bit32u GetSectorCount(void);

--- a/src/gui/midi_mt32.h
+++ b/src/gui/midi_mt32.h
@@ -9,7 +9,7 @@ private:
 	static const unsigned int bufferSize = 1024;
 	volatile unsigned int startpos;
 	volatile unsigned int endpos;
-	Bit64u ringBuffer[bufferSize];
+    Bit64u ringBuffer[bufferSize] = {};
 
 public:
 	RingBuffer() {
@@ -49,11 +49,11 @@ private:
 	SDL_Thread *thread;
 	SDL_mutex *synthMutex;
 	SDL_semaphore *procIdleSem, *mixerReqSem;
-	Bit16s mixerBuffer[2 * MIXER_BUFFER_SIZE];
-	volatile Bitu mixerBufferSize;
-	volatile bool stopProcessing;
-	bool open, noise, reverseStereo, renderInThread;
-	Bit16s numPartials;
+    Bit16s mixerBuffer[2 * MIXER_BUFFER_SIZE] = {};
+	volatile Bitu mixerBufferSize = 0;
+	volatile bool stopProcessing = false;
+	bool open, noise = false, reverseStereo = false, renderInThread = false;
+	Bit16s numPartials = 0;
 
 	class MT32ReportHandler : public MT32Emu::ReportHandler {
 	protected:

--- a/src/gui/midi_win32.h
+++ b/src/gui/midi_win32.h
@@ -29,15 +29,15 @@
 
 class MidiHandler_win32: public MidiHandler {
 private:
-	HMIDIOUT m_out;
-	MIDIHDR m_hdr;
-	HANDLE m_event;
+	HMIDIOUT m_out = NULL;
+    MIDIHDR m_hdr = {};
+	HANDLE m_event = NULL;
 	bool isOpen;
 
 #if WIN32_MIDI_PORT_PROTECT
-	HINSTANCE hMidiHelper;
-	bool midi_dll;
-	bool midi_dll_active;
+	HINSTANCE hMidiHelper = NULL;
+	bool midi_dll = false;
+	bool midi_dll_active = false;
 
 	void MidiHelper_Reset()
 	{

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -719,8 +719,8 @@ public:
 
 class SectionEditor : public GUI::ToplevelWindow {
     Section_prop * section;
-    GUI::Button * closeButton;
-    GUI::WindowInWindow * wiw;
+    GUI::Button * closeButton = NULL;
+    GUI::WindowInWindow * wiw = NULL;
 public:
     std::vector<GUI::Char> cfg_sname;
 public:
@@ -887,9 +887,9 @@ public:
 };
 
 class AutoexecEditor : public GUI::ToplevelWindow {
-    GUI::Button *closeButton;
+    GUI::Button *closeButton = NULL;
     Section_line * section;
-    GUI::Input *content;
+    GUI::Input *content = NULL;
 public:
     std::vector<GUI::Char> cfg_sname;
 public:

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -135,19 +135,19 @@ static struct CMapper {
     SDL_Surface*                                draw_surface_nonpaletted;
     SDL_Surface*                                draw_surface;
 #endif
-    SDL_Surface*                                surface;
-    bool                                        exit;
-    CEvent*                                     aevent;                     //Active Event
-    CBind*                                      abind;                      //Active Bind
+    SDL_Surface*                                surface = NULL;
+    bool                                        exit = false;
+    CEvent*                                     aevent = NULL;                     //Active Event
+    CBind*                                      abind = NULL;                      //Active Bind
     CBindList_it                                abindit;                    //Location of active bind in list
-    bool                                        redraw;
-    bool                                        addbind;
+    bool                                        redraw = false;
+    bool                                        addbind = false;
     bool                                        running = false;
-    Bitu                                        mods;
+    Bitu                                        mods = 0;
     struct {
         Bitu                                    num_groups,num;
         CStickBindGroup*                        stick[MAXSTICKS];
-    } sticks;
+    } sticks = {};
     std::string                                 filename;
 } mapper;
 
@@ -519,6 +519,7 @@ public:
         event=0;
         active=holding=false;
         type = _type;
+        value = 0;
     }
 
     //! \brief Get modifier text
@@ -1418,7 +1419,7 @@ public:
     }
 
 private:
-    float joy1dz1, joy1rs1, joy1dz2, joy1rs2, joy2dz1, joy2rs1;
+    float joy1dz1 = 0, joy1rs1 = 0, joy1dz2 = 0, joy1rs2 = 0, joy2dz1 = 0, joy2rs1 = 0;
     CBind * CreateAxisBind(Bitu axis,bool positive) {
         if (axis<axes) {
             if (positive) return new CJAxisBind(&pos_axis_lists[axis],this,stick,axis,positive);
@@ -1494,11 +1495,11 @@ protected:
     Bitu button_wrap,button_cap,axes_cap,hats_cap;
     SDL_Joystick * sdl_joystick;
     char configname[10];
-    Bitu button_autofire[MAXBUTTON];
-    bool old_button_state[MAXBUTTON];
-    bool old_pos_axis_state[MAXAXIS];
-    bool old_neg_axis_state[MAXAXIS];
-    Uint8 old_hat_state[16];
+    Bitu button_autofire[MAXBUTTON] = {};
+    bool old_button_state[MAXBUTTON] = {};
+    bool old_pos_axis_state[MAXAXIS] = {};
+    bool old_neg_axis_state[MAXAXIS] = {};
+    Uint8 old_hat_state[16] = {};
     bool is_dummy;
 
     DOSBox_Vector2 GetJoystickVector(int joystick, int thumbStick, int xAxis, int yAxis) const

--- a/src/hardware/dbopl.h
+++ b/src/hardware/dbopl.h
@@ -193,20 +193,20 @@ struct Channel {
 
 struct Chip {
 	//This is used as the base counter for vibrato and tremolo
-	Bit32u lfoCounter;
-	Bit32u lfoAdd;
+	Bit32u lfoCounter = 0;
+	Bit32u lfoAdd = 0;
 	
 
-	Bit32u noiseCounter;
-	Bit32u noiseAdd;
-	Bit32u noiseValue;
+	Bit32u noiseCounter = 0;
+	Bit32u noiseAdd = 0;
+	Bit32u noiseValue = 0;
 
 	//Frequency scales for the different multiplications
-	Bit32u freqMul[16];
+    Bit32u freqMul[16] = {};
 	//Rates for decay and release for rate of this chip
-	Bit32u linearRates[76];
+    Bit32u linearRates[76] = {};
 	//Best match attack rates for the rate of this chip
-	Bit32u attackRates[76];
+    Bit32u attackRates[76] = {};
 
 	//18 channels with 2 operators each
 	Channel chan[18];
@@ -215,15 +215,15 @@ struct Chip {
 	Bit8u reg08;
 	Bit8u reg04;
 	Bit8u regBD;
-	Bit8u vibratoIndex;
-	Bit8u tremoloIndex;
-	Bit8s vibratoSign;
-	Bit8u vibratoShift;
-	Bit8u tremoloValue;
-	Bit8u vibratoStrength;
-	Bit8u tremoloStrength;
+	Bit8u vibratoIndex = 0;
+	Bit8u tremoloIndex = 0;
+	Bit8s vibratoSign = 0;
+	Bit8u vibratoShift = 0;
+	Bit8u tremoloValue = 0;
+	Bit8u vibratoStrength = 0;
+	Bit8u tremoloStrength = 0;
 	//Mask for allowed wave forms
-	Bit8u waveFormMask;
+	Bit8u waveFormMask = 0;
 	//0 or -1 when enabled
 	Bit8s opl3Active;
 

--- a/src/hardware/floppy.cpp
+++ b/src/hardware/floppy.cpp
@@ -43,7 +43,7 @@ class FloppyController;
 
 class FloppyDevice {
 public:
-	FloppyController *controller;
+	FloppyController *controller = NULL;
 public:
 	unsigned char current_track;
 	bool select,motor;

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1190,13 +1190,13 @@ public:
 		}
 public:
 		float		AttenDb[2];
-		uint32_t	Fix1616Mult[2];		// linear multiply to apply volume
+        uint32_t	Fix1616Mult[2] = {};		// linear multiply to apply volume
 	};
 public:
 	struct mixcontrol	mixpair[8];		// pairs 1-5 and Master
 	struct volpair		volpair[5];		// pairs 1-5 scaled by master
-	uint8_t			addr_attenuator;	// which attenuator is selected
-	uint8_t			addr_control;		// which control is selected
+	uint8_t			addr_attenuator = 0;	// which attenuator is selected
+	uint8_t			addr_control = 0;		// which control is selected
 } GUS_ICS2101;
 
 static inline uint8_t read_GF1_mapping_control(const unsigned int ch) {
@@ -1331,9 +1331,9 @@ public:
 	bool		mce;
 	bool		init;
 
-	uint8_t		ADCInputControl[2];	/* left (I0) and right (I1) ADC Input control. bits 7-6 select source. bit 5 is mic gain. bits 3-0 controls gain. */
-	uint8_t		Aux1InputControl[2];	/* left (I2) and right (I3) aux. input control. bits 5-0 control gain in 1.5dB steps. bit 7 is mute */
-	uint8_t		DACOutputControl[2];	/* left (I6) and right (I7) output control attenuation. bits 5-0 control in -1.5dB steps, bit 7 is mute */
+    uint8_t		ADCInputControl[2] = {};	/* left (I0) and right (I1) ADC Input control. bits 7-6 select source. bit 5 is mic gain. bits 3-0 controls gain. */
+    uint8_t		Aux1InputControl[2] = {};	/* left (I2) and right (I3) aux. input control. bits 5-0 control gain in 1.5dB steps. bit 7 is mute */
+    uint8_t		DACOutputControl[2] = {};	/* left (I6) and right (I7) output control attenuation. bits 5-0 control in -1.5dB steps, bit 7 is mute */
 } GUS_CS4231;
 
 static Bitu read_gus_cs4231(Bitu port,Bitu iolen) {

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -325,21 +325,21 @@ static struct {
 		Bitu used;
 		Bit32u length;
 		Bit32u freq;
-	} wave;
+    } wave = {};
     struct {
         avi_writer  *writer;
 		Bitu		audiorate;
         std::map<std::string,size_t> name_to_stream_index;
-    } multitrack_wave;
+    } multitrack_wave = {};
 	struct {
 		FILE * handle;
 		Bit8u buffer[MIDI_BUF];
 		Bitu used,done;
 		Bit32u last;
-	} midi;
+    } midi = {};
 	struct {
 		Bitu rowlen;
-	} image;
+    } image = {};
 #if (C_SSHOT) || (C_AVCODEC)
 	struct {
 		avi_writer	*writer;
@@ -354,7 +354,7 @@ static struct {
 		float		fps;
 		int		bufSize;
 		void		*buf;
-	} video;
+    } video = {};
 #endif
 } capture;
 

--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -1092,7 +1092,7 @@ private:
 	CALLBACK_HandlerObject callback_ipx;
 	CALLBACK_HandlerObject callback_esr;
 	CALLBACK_HandlerObject callback_ipxint;
-	RealPt old_73_vector;
+	RealPt old_73_vector = 0;
 	bool ipx_init;
 public:
 	IPX(Section* configuration):Module_base(configuration) {

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -1941,7 +1941,7 @@ static struct pc98_8251_keyboard_uart {
     double                      tx_load_ms;
 
     /* recv data from keyboard */
-    unsigned char               recv_buffer[32];
+    unsigned char               recv_buffer[32] = {};
     unsigned char               recv_in,recv_out;
 
     pc98_8251_keyboard_uart() : data(0xFF), txdata(0xFF), state(MODE_STATE), mode_byte(0), keyboard_reset(false), rx_enable(false), tx_enable(false), valid_state(false), rx_busy(false), rx_ready(false), tx_busy(false), tx_empty(true), recv_in(0), recv_out(0) {

--- a/src/hardware/mame/sn76496.h
+++ b/src/hardware/mame/sn76496.h
@@ -66,7 +66,7 @@ private:
 
 
 
-	bool            m_ready_state;
+	bool            m_ready_state = false;
 
 	//devcb_write_line m_ready_handler;
 
@@ -81,23 +81,23 @@ private:
 	const bool      m_ncr_style_psg;    // flag to ignore writes to regs 1,3,5,6,7 with bit 7 low
 	const bool      m_sega_style_psg;   // flag to make frequency zero acts as if it is one more than max (0x3ff+1) or if it acts like 0; the initial register is pointing to 0x3 instead of 0x0; the volume reg is preloaded with 0xF instead of 0x0
 
-	int32_t           m_vol_table[16];    // volume table (for 4-bit to db conversion)
-	int32_t           m_register[8];      // registers
-	int32_t           m_last_register;    // last register written
-	int32_t           m_volume[4];        // db volume of voice 0-2 and noise
-	uint32_t          m_RNG;              // noise generator LFSR
-	int32_t           m_current_clock;
-	int32_t           m_stereo_mask;      // the stereo output mask
-	int32_t           m_period[4];        // Length of 1/2 of waveform
-	int32_t           m_count[4];         // Position within the waveform
-	int32_t           m_output[4];        // 1-bit output of each channel, pre-volume
-	int32_t           m_cycles_to_ready;  // number of cycles until the READY line goes active
+    int32_t           m_vol_table[16] = {};    // volume table (for 4-bit to db conversion)
+    int32_t           m_register[8] = {};      // registers
+	int32_t           m_last_register = 0;    // last register written
+    int32_t           m_volume[4] = {};        // db volume of voice 0-2 and noise
+	uint32_t          m_RNG = 0;              // noise generator LFSR
+	int32_t           m_current_clock = 0;
+	int32_t           m_stereo_mask = 0;      // the stereo output mask
+    int32_t           m_period[4] = {};        // Length of 1/2 of waveform
+    int32_t           m_count[4] = {};         // Position within the waveform
+    int32_t           m_output[4] = {};        // 1-bit output of each channel, pre-volume
+	int32_t           m_cycles_to_ready = 0;  // number of cycles until the READY line goes active
 	
 	//Modifications for easier sample conversion
-	int32_t			  sample_rate;
+	int32_t			  sample_rate = 0;
 	//Sample rate conversion
-	int32_t			  rate_add;
-	int32_t			  rate_counter;
+	int32_t			  rate_add = 0;
+	int32_t			  rate_counter = 0;
 };
 
 // SN76496: Whitenoise verified, phase verified, periodic verified (by Michael Zapf)

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -82,17 +82,17 @@ static struct MemoryBlock {
         Bitu        end_page;
         Bitu        pages;
         PageHandler *handler;
-    } lfb;
+    } lfb = {};
     struct {
         Bitu        start_page;
         Bitu        end_page;
         Bitu        pages;
         PageHandler *handler;
-    } lfb_mmio;
+    } lfb_mmio = {};
     struct {
         bool enabled;
         Bit8u controlport;
-    } a20;
+    } a20 = {};
     Bit32u mem_alias_pagemask;
     Bit32u mem_alias_pagemask_active;
     Bit32u address_bits;

--- a/src/hardware/parport/directlpt_win32.h
+++ b/src/hardware/parport/directlpt_win32.h
@@ -36,8 +36,8 @@
 class CDirectLPT : public CParallel {
 public:
 	//HANDLE driverHandle;
-	Bit32u realbaseaddress;
-	Bit8u originalECPControlReg;
+	Bit32u realbaseaddress = 0;
+	Bit8u originalECPControlReg = 0;
 	
 	CDirectLPT(
 			Bitu nr,
@@ -48,11 +48,11 @@ public:
 
 	~CDirectLPT();
 	
-	bool interruptflag;
-	bool isECP;
-	bool InstallationSuccessful;	// check after constructing. If
+	bool interruptflag = false;
+	bool isECP = false;
+	bool InstallationSuccessful = false;	// check after constructing. If
 									// something was wrong, delete it right away.
-	bool ack_polarity;
+	bool ack_polarity = false;
 
 	Bitu Read_PR();
 	Bitu Read_COM();

--- a/src/hardware/parport/filelpt.h
+++ b/src/hardware/parport/filelpt.h
@@ -35,24 +35,24 @@ public:
 									// something was wrong, delete it right away.
 	
 	bool fileOpen;
-	DFTYPE filetype;			// which mode to operate in (capture,fileappend,device)
-	FILE* file;
+	DFTYPE filetype = (DFTYPE)0;			// which mode to operate in (capture,fileappend,device)
+	FILE* file = NULL;
 	std::string name;			// name of the thing to open
 	bool addFF;					// add a formfeed character before closing the file/device
 	bool addLF;					// if set, add line feed after carriage return if not used by app
 
-	Bit8u lastChar;				// used to save the previous character to decide wether to add LF
+	Bit8u lastChar = 0;				// used to save the previous character to decide wether to add LF
 	const Bit16u* codepage_ptr; // pointer to the translation codepage if not null
 
 	bool OpenFile();
 	
-	bool ack_polarity;
+	bool ack_polarity = false;
 
 	Bitu Read_PR();
 	Bitu Read_COM();
 	Bitu Read_SR();
 
-	Bit8u datareg;
+	Bit8u datareg = 0;
 	Bit8u controlreg;
 
 	void Write_PR(Bitu);
@@ -60,10 +60,10 @@ public:
 	void Write_IOSEL(Bitu);
 	bool Putchar(Bit8u);
 
-	bool autofeed;
+	bool autofeed = false;
 	bool ack;
-	unsigned int timeout;
-	Bitu lastUsedTick;
+	unsigned int timeout = 0;
+	Bitu lastUsedTick = 0;
 	virtual void handleUpperEvent(Bit16u type);
 };
 

--- a/src/hardware/parport/printer.h
+++ b/src/hardware/parport/printer.h
@@ -164,44 +164,44 @@ private:
 	FT_Library FTlib;					// FreeType2 library used to render the characters
 
 	SDL_Surface* page;					// Surface representing the current page
-	FT_Face curFont;					// The font currently used to render characters
-	Bit8u color;
+	FT_Face curFont = NULL;					// The font currently used to render characters
+	Bit8u color = 0;
 
-	Real64 curX, curY;					// Position of the print head (in inch)
+	Real64 curX = 0, curY = 0;					// Position of the print head (in inch)
 
-	Bit16u dpi;							// dpi of the page
-	Bit16u ESCCmd;						// ESC-command that is currently processed
-	bool ESCSeen;						// True if last read character was an ESC (0x1B)
-	bool FSSeen;						// True if last read character was an FS (0x1C) (IBM commands)
+	Bit16u dpi = 0;							// dpi of the page
+	Bit16u ESCCmd = 0;						// ESC-command that is currently processed
+	bool ESCSeen = false;						// True if last read character was an ESC (0x1B)
+	bool FSSeen = false;						// True if last read character was an FS (0x1C) (IBM commands)
 
-	Bit8u numParam, neededParam;		// Numbers of parameters already read/needed to process command
+	Bit8u numParam = 0, neededParam = 0;		// Numbers of parameters already read/needed to process command
 
-	Bit8u params[20];					// Buffer for the read params
-	Bit16u style;						// Style of font (see STYLE_* constants)
-	Real64 cpi, actcpi;					// CPI value set by program and the actual one (taking in account font types)
-	Bit8u score;						// Score for lines (see SCORE_* constants)
+    Bit8u params[20] = {};					// Buffer for the read params
+	Bit16u style = 0;						// Style of font (see STYLE_* constants)
+	Real64 cpi = 0, actcpi = 0;					// CPI value set by program and the actual one (taking in account font types)
+	Bit8u score = 0;						// Score for lines (see SCORE_* constants)
 
-	Real64 topMargin, bottomMargin, rightMargin, leftMargin;	// Margins of the page (in inch)
-	Real64 pageWidth, pageHeight;								// Size of page (in inch)
-	Real64 defaultPageWidth, defaultPageHeight;					// Default size of page (in inch)
-	Real64 lineSpacing;											// Size of one line (in inch)
+	Real64 topMargin = 0, bottomMargin = 0, rightMargin = 0, leftMargin = 0;	// Margins of the page (in inch)
+	Real64 pageWidth = 0, pageHeight = 0;								// Size of page (in inch)
+	Real64 defaultPageWidth = 0, defaultPageHeight = 0;					// Default size of page (in inch)
+	Real64 lineSpacing = 0;											// Size of one line (in inch)
 
-	Real64 horiztabs[32];				// Stores the set horizontal tabs (in inch)
-	Bit8u numHorizTabs;					// Number of configured tabs
+    Real64 horiztabs[32] = {};				// Stores the set horizontal tabs (in inch)
+	Bit8u numHorizTabs = 0;					// Number of configured tabs
 
-	Real64 verttabs[16];				// Stores the set vertical tabs (in inch)
-	Bit8u numVertTabs;					// Number of configured tabs
+    Real64 verttabs[16] = {};				// Stores the set vertical tabs (in inch)
+	Bit8u numVertTabs = 0;					// Number of configured tabs
 
-	Bit8u curCharTable;					// Currently used char table und charset
-	Bit8u printQuality;					// Print quality (see QUALITY_* constants)
+	Bit8u curCharTable = 0;					// Currently used char table und charset
+	Bit8u printQuality = 0;					// Print quality (see QUALITY_* constants)
 
-	Typeface LQtypeFace;				// Typeface used in LQ printing mode
+	Typeface LQtypeFace = (Typeface)0;				// Typeface used in LQ printing mode
 
-	Real64 extraIntraSpace;				// Extra space between two characters (set by program, in inch)
+	Real64 extraIntraSpace = 0;				// Extra space between two characters (set by program, in inch)
 
-	bool charRead;						// True if a character was read since the printer was last initialized
-	bool autoFeed;						// True if a LF should automatically added after a CR
-	bool printUpperContr;				// True if the upper command characters should be printed
+	bool charRead = false;						// True if a character was read since the printer was last initialized
+	bool autoFeed = false;						// True if a LF should automatically added after a CR
+	bool printUpperContr = false;				// True if the upper command characters should be printed
 
 	struct bitGraphicParams				// Holds information about printing bit images
 	{
@@ -211,36 +211,36 @@ private:
 		Bit16u remBytes;				// Bytes left to read before image is done
 		Bit8u column[6];				// Bytes of the current and last column
 		Bit8u readBytesColumn;			// Bytes read so far for the current column
-	} bitGraph;
+    } bitGraph = {};
 
-	Bit8u densk, densl, densy, densz;	// Image density modes used in ESC K/L/Y/Z commands
+	Bit8u densk = 0, densl = 0, densy = 0, densz = 0;	// Image density modes used in ESC K/L/Y/Z commands
 
-	Bit16u curMap[256];					// Currently used ASCII => Unicode mapping
-	Bit16u charTables[4];				// Charactertables
+    Bit16u curMap[256] = {};					// Currently used ASCII => Unicode mapping
+    Bit16u charTables[4] = {};				// Charactertables
 
-	Real64 definedUnit;					// Unit used by some ESC/P2 commands (negative => use default)
+	Real64 definedUnit = 0;					// Unit used by some ESC/P2 commands (negative => use default)
 
-	bool multipoint;					// If multipoint mode is enabled
-	Real64 multiPointSize;				// Point size of font in multipoint mode
-	Real64 multicpi;					// CPI used in multipoint mode
+	bool multipoint = false;					// If multipoint mode is enabled
+	Real64 multiPointSize = 0;				// Point size of font in multipoint mode
+	Real64 multicpi = 0;					// CPI used in multipoint mode
 
-	Real64 hmi;							// Horizontal motion index (in inch; overrides CPI settings)
+	Real64 hmi = 0;							// Horizontal motion index (in inch; overrides CPI settings)
 
-	Bit8u msb;							// MSB mode
-	Bit16u numPrintAsChar;				// Number of bytes to print as characters (even when normally control codes)
+	Bit8u msb = 0;							// MSB mode
+	Bit16u numPrintAsChar = 0;				// Number of bytes to print as characters (even when normally control codes)
 
 #if defined (WIN32)
-	HDC printerDC;						// Win32 printer device
+	HDC printerDC = NULL;						// Win32 printer device
 #endif
 
-	char* output;						// Output method selected by user
-	void* outputHandle;					// If not null, additional pages will be appended to the given handle
-	bool multipageOutput;				// If true, all pages are combined to one file/print job etc. until the "eject page" button is pressed
-	Bit16u multiPageCounter;			// Current page (when printing multipages)
+	char* output = NULL;						// Output method selected by user
+	void* outputHandle = NULL;					// If not null, additional pages will be appended to the given handle
+	bool multipageOutput = false;				// If true, all pages are combined to one file/print job etc. until the "eject page" button is pressed
+	Bit16u multiPageCounter = 0;			// Current page (when printing multipages)
 
-	Bit8u ASCII85Buffer[4];				// Buffer used in ASCII85 encoding
-	Bit8u ASCII85BufferPos;				// Position in ASCII85 encode buffer
-	Bit8u ASCII85CurCol;				// Columns printed so far in the current lines
+    Bit8u ASCII85Buffer[4] = {};				// Buffer used in ASCII85 encoding
+	Bit8u ASCII85BufferPos = 0;				// Position in ASCII85 encode buffer
+	Bit8u ASCII85CurCol = 0;				// Columns printed so far in the current lines
 };
 
 #endif

--- a/src/hardware/reSID/sid.h
+++ b/src/hardware/reSID/sid.h
@@ -58,20 +58,20 @@ public:
   public:
     State();
 
-    char sid_register[0x20];
+    char sid_register[0x20] = {};
 
     reg8 bus_value;
     cycle_count bus_value_ttl;
 
-    reg24 accumulator[3];
-    reg24 shift_register[3];
-    reg16 rate_counter[3];
-    reg16 rate_counter_period[3];
-    reg16 exponential_counter[3];
-    reg16 exponential_counter_period[3];
-    reg8 envelope_counter[3];
-    EnvelopeGenerator::State envelope_state[3];
-    bool hold_zero[3];
+    reg24 accumulator[3] = {};
+    reg24 shift_register[3] = {};
+    reg16 rate_counter[3] = {};
+    reg16 rate_counter_period[3] = {};
+    reg16 exponential_counter[3] = {};
+    reg16 exponential_counter_period[3] = {};
+    reg8 envelope_counter[3] = {};
+    EnvelopeGenerator::State envelope_state[3] = {};
+    bool hold_zero[3] = {};
 	};
     
   State read_state();

--- a/src/hardware/serialport/directserial.cpp
+++ b/src/hardware/serialport/directserial.cpp
@@ -52,11 +52,6 @@ CDirectSerial::CDirectSerial (Bitu id, CommandLine* cmd)
 		return;
 	}
 
-#if SERIAL_DEBUG
-	dbgmsg_poll_block=false;
-	dbgmsg_rx_block=false;
-#endif
-
 	// rxdelay: How many milliseconds to wait before causing an
 	// overflow when the application is unresponsive.
 	if(getBituSubstring("rxdelay:", &rx_retry_max, cmd)) {

--- a/src/hardware/serialport/directserial.h
+++ b/src/hardware/serialport/directserial.h
@@ -48,7 +48,7 @@ public:
 private:
 	COMPORT comport;
 
-	Bitu rx_state;
+	Bitu rx_state = 0;
 #define D_RX_IDLE		0
 #define D_RX_WAIT		1
 #define D_RX_BLOCKED	2
@@ -60,8 +60,8 @@ private:
 	bool doReceive();
 
 #if SERIAL_DEBUG
-	bool dbgmsg_poll_block;
-	bool dbgmsg_rx_block;
+	bool dbgmsg_poll_block = false;
+	bool dbgmsg_rx_block = false;
 #endif
 
 };

--- a/src/hardware/serialport/misc_util.h
+++ b/src/hardware/serialport/misc_util.h
@@ -97,12 +97,12 @@ class TCPClientSocket {
 	bool SendArrayBuffered(Bit8u* data, Bitu bufsize);
 
 	private:
-	TCPsocket mysock;
-	SDLNet_SocketSet listensocketset;
+	TCPsocket mysock = NULL;
+	SDLNet_SocketSet listensocketset = NULL;
 
 	// Items for send buffering
-	Bitu sendbuffersize;
-	Bitu sendbufferindex;
+	Bitu sendbuffersize = 0;
+	Bitu sendbufferindex = 0;
 	
 	Bit8u* sendbuffer;
 };

--- a/src/hardware/serialport/serialmouse.h
+++ b/src/hardware/serialport/serialmouse.h
@@ -44,7 +44,7 @@ public:
 	void start_packet();
 
 	Bit8u send_ack;
-	Bit8u packet[3];
+    Bit8u packet[3] = {};
 	Bit8u packet_xmit;
 	Bit8u mouse_buttons;	/* bit 0 = left   bit 1 = right     becomes bits 5 (L) and 4 (R) in packet[0] */
 	Bit8u xmit_another_packet;

--- a/src/hardware/vga_memory.cpp
+++ b/src/hardware/vga_memory.cpp
@@ -663,15 +663,15 @@ struct pc98_egc_shifter {
     uint16_t            remain;
     uint16_t            srcbit;
     uint16_t            dstbit;
-    uint16_t            o_srcbit;
-    uint16_t            o_dstbit;
+    uint16_t            o_srcbit = 0;
+    uint16_t            o_dstbit = 0;
 
-    uint8_t             buffer[512]; /* 4096/8 = 512 */
-    uint16_t            bufi,bufo;
+    uint8_t             buffer[512] = {}; /* 4096/8 = 512 */
+    uint16_t            bufi = 0, bufo = 0;
 
-    uint8_t             shft8load;
-    uint8_t             shft8bitr;
-    uint8_t             shft8bitl;
+    uint8_t             shft8load = 0;
+    uint8_t             shft8bitr = 0;
+    uint8_t             shft8bitl = 0;
 
     std::string debug_status(void) {
         char tmp[512];

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -618,10 +618,10 @@ protected:
     bool mouse_in_window;
 public:
     /// \c first element of a tabbable list
-    bool first_tabbable;
+    bool first_tabbable = false;
 
     /// \c last element of a tabbable list
-    bool last_tabbable;
+    bool last_tabbable = false;
 protected:
 	/// Child windows.
 	/** Z ordering is done in list order. The first element is the lowermost
@@ -815,7 +815,7 @@ public:
     bool    vscroll_dragging = false;
 
     bool    dragging = false;
-    int     drag_x,drag_y;
+    int     drag_x = 0, drag_y = 0;
 
     int     scroll_pos_x = 0;
     int     scroll_pos_y = 0;
@@ -854,7 +854,7 @@ protected:
 	String clipboard;
 
 	/// Currently pressed mouse button.
-	MouseButton button;
+	MouseButton button = (MouseButton)0;
 
 	/// Store a single RGB triple (8 bit each) as a native pixel value and advance pointer.
 	virtual void rgbToSurface(RGB color, void **pixel) = 0;

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -773,7 +773,7 @@ public:
 	}
 
     unsigned int getChildCount(void) {
-        return children.size();
+        return (unsigned int)children.size();
     }
 
 };

--- a/src/mt32/File.h
+++ b/src/mt32/File.h
@@ -25,7 +25,7 @@ namespace MT32Emu {
 class File {
 private:
 	bool sha1DigestCalculated;
-	char sha1Digest[41];
+    char sha1Digest[41] = {};
 protected:
 	size_t fileSize;
 	unsigned char *data;

--- a/src/mt32/LA32Ramp.h
+++ b/src/mt32/LA32Ramp.h
@@ -25,7 +25,7 @@ private:
 	Bit32u current;
 	unsigned int largeTarget;
 	unsigned int largeIncrement;
-	bool descending;
+	bool descending = false;
 
 	int interruptCountdown;
 	bool interruptRaised;

--- a/src/mt32/Partial.h
+++ b/src/mt32/Partial.h
@@ -42,20 +42,20 @@ private:
 	unsigned long sampleNum;
 
 	int ownerPart; // -1 if unassigned
-	int mixType;
-	int structurePosition; // 0 or 1 of a structure pair
-	StereoVolume stereoVolume;
+	int mixType = 0;
+	int structurePosition = 0; // 0 or 1 of a structure pair
+    StereoVolume stereoVolume = {};
 
-	Bit16s myBuffer[MAX_SAMPLES_PER_RUN];
+    Bit16s myBuffer[MAX_SAMPLES_PER_RUN] = {};
 
 	// Only used for PCM partials
-	int pcmNum;
+	int pcmNum = 0;
 	// FIXME: Give this a better name (e.g. pcmWaveInfo)
 	PCMWaveEntry *pcmWave;
 
 	// Final pulse width value, with velfollow applied, matching what is sent to the LA32.
 	// Range: 0-255
-	int pulseWidthVal;
+	int pulseWidthVal = 0;
 
 	Poly *poly;
 
@@ -63,7 +63,7 @@ private:
 	LA32Ramp cutoffModifierRamp;
 
 	// TODO: This should be owned by PartialPair
-	LA32PartialPair la32Pair;
+    LA32PartialPair la32Pair = {};
 
 	Bit32u getAmpValue();
 	Bit32u getCutoffValue();
@@ -77,7 +77,7 @@ public:
 	PatchCache cachebackup;
 
 	Partial *pair;
-	bool alreadyOutputed;
+	bool alreadyOutputed = false;
 
 	Partial(Synth *synth, int debugPartialNum);
 	~Partial();

--- a/src/mt32/PartialManager.h
+++ b/src/mt32/PartialManager.h
@@ -27,8 +27,8 @@ private:
 	Synth *synth; // Only used for sending debug output
 	Part **parts;
 
-	Partial *partialTable[MT32EMU_MAX_PARTIALS];
-	Bit8u numReservedPartialsForPart[9];
+    Partial* partialTable[MT32EMU_MAX_PARTIALS] = {};
+    Bit8u numReservedPartialsForPart[9] = {};
 
 	bool abortFirstReleasingPolyWhereReserveExceeded(int minPart);
 	bool abortFirstPolyPreferHeldWhereReserveExceeded(int minPart);

--- a/src/mt32/Poly.h
+++ b/src/mt32/Poly.h
@@ -43,7 +43,7 @@ private:
 
 	PolyState state;
 
-	Partial *partials[4];
+    Partial* partials[4] = {};
 
 	Poly *next;
 

--- a/src/mt32/TVA.h
+++ b/src/mt32/TVA.h
@@ -64,13 +64,13 @@ private:
 	const MemParams::PatchTemp *patchTemp;
 	const MemParams::RhythmTemp *rhythmTemp;
 
-	bool playing;
+	bool playing = false;
 
-	int biasAmpSubtraction;
-	int veloAmpSubtraction;
-	int keyTimeSubtraction;
+	int biasAmpSubtraction = 0;
+	int veloAmpSubtraction = 0;
+	int keyTimeSubtraction = 0;
 
-	Bit8u target;
+	Bit8u target = 0;
 	int phase;
 
 	void startRamp(Bit8u newTarget, Bit8u newIncrement, int newPhase);

--- a/src/mt32/TVF.h
+++ b/src/mt32/TVF.h
@@ -26,12 +26,12 @@ private:
 	LA32Ramp *cutoffModifierRamp;
 	const TimbreParam::PartialParam *partialParam;
 
-	Bit8u baseCutoff;
-	int keyTimeSubtraction;
-	unsigned int levelMult;
+	Bit8u baseCutoff = 0;
+	int keyTimeSubtraction = 0;
+	unsigned int levelMult = 0;
 
-	Bit8u target;
-	unsigned int phase;
+	Bit8u target = 0;
+	unsigned int phase = 0;
 
 	void startRamp(Bit8u newTarget, Bit8u newIncrement, int newPhase);
 	void nextPhase();

--- a/src/mt32/TVP.h
+++ b/src/mt32/TVP.h
@@ -31,23 +31,23 @@ private:
 
 	int maxCounter;
 	int processTimerIncrement;
-	int counter;
-	Bit32u timeElapsed;
+	int counter = 0;
+	Bit32u timeElapsed = 0;
 
-	int phase;
-	Bit32u basePitch;
-	Bit32s targetPitchOffsetWithoutLFO;
-	Bit32s currentPitchOffset;
+	int phase = 0;
+	Bit32u basePitch = 0;
+	Bit32s targetPitchOffsetWithoutLFO = 0;
+	Bit32s currentPitchOffset = 0;
 
-	Bit16s lfoPitchOffset;
+	Bit16s lfoPitchOffset = 0;
 	// In range -12 - 36
-	Bit8s timeKeyfollowSubtraction;
+	Bit8s timeKeyfollowSubtraction = 0;
 
-	Bit16s pitchOffsetChangePerBigTick;
-	Bit16u targetPitchOffsetReachedBigTick;
-	unsigned int shifts;
+	Bit16s pitchOffsetChangePerBigTick = 0;
+	Bit16u targetPitchOffsetReachedBigTick = 0;
+	unsigned int shifts = 0;
 
-	Bit16u pitch;
+	Bit16u pitch = 0;
 
 	void updatePitch();
 	void setupPitchChange(int targetPitchOffset, Bit8u changeDuration);

--- a/src/mt32/Tables.h
+++ b/src/mt32/Tables.h
@@ -45,7 +45,7 @@ public:
 	// - PartialParam.tva.level
 	// - expression
 	// It's used to determine how much to subtract from the amp envelope's target value
-	Bit8u levelToAmpSubtraction[101];
+    Bit8u levelToAmpSubtraction[101] = {};
 
 	// CONFIRMED: ...
 	Bit8u envLogarithmicTime[256];
@@ -54,9 +54,9 @@ public:
 	Bit8u masterVolToAmpSubtraction[101];
 
 	// CONFIRMED:
-	Bit8u pulseWidth100To255[101];
+    Bit8u pulseWidth100To255[101] = {};
 
-	Bit16u exp9[512];
+    Bit16u exp9[512] = {};
 	Bit16u logsin9[512];
 
 	const Bit8u *resAmpDecayFactor;

--- a/src/mt32/freeverb/comb.h
+++ b/src/mt32/freeverb/comb.h
@@ -26,12 +26,12 @@ public:
 					void saveState( std::ostream &stream );
 					void loadState( std::istream &stream );
 private:
-	float   feedback;
+	float   feedback = 0;
 	float   filterstore;
-	float   damp1;
-	float   damp2;
-	float   *buffer;
-	int     bufsize;
+	float   damp1 = 0;
+	float   damp2 = 0;
+	float   *buffer = NULL;
+	int     bufsize = 0;
 	int     bufidx;
 };
 

--- a/src/output/direct3d/direct3d.h
+++ b/src/output/direct3d/direct3d.h
@@ -80,21 +80,21 @@ private:
     IDirect3D9*			pD3D9 = NULL;
     IDirect3DDevice9*		pD3DDevice9 = NULL;
 
-    D3DPRESENT_PARAMETERS 	d3dpp;			// Present parameters
-    D3DLOCKED_RECT		d3dlr;			// Texture lock rectangle
+    D3DPRESENT_PARAMETERS 	d3dpp = {};			// Present parameters
+    D3DLOCKED_RECT		d3dlr = {};			// Texture lock rectangle
 
-    HWND hwnd;						// DOSBow window
-    DWORD dwX,dwY;					// X,Y position
+    HWND hwnd = NULL;						// DOSBox window
+    DWORD dwX = 0, dwY = 0;					// X,Y position
     DWORD dwWidth, dwHeight;                            // DOSBox framebuffer size
-    DWORD dwScaledWidth, dwScaledHeight;                // D3D backbuffer size
-    const Bit16u* changedLines;
+    DWORD dwScaledWidth = 0, dwScaledHeight = 0;                // D3D backbuffer size
+    const Bit16u* changedLines = NULL;
 
-	int					backbuffer_clear_countdown;
+	int					backbuffer_clear_countdown = 0;
 
     // display modes
     D3DDISPLAYMODE*		modes;
-    unsigned int		iMode;
-    DWORD			dwNumModes;
+    unsigned int		iMode = 0;
+    DWORD			dwNumModes = 0;
 
     bool			deviceLost;
 
@@ -160,7 +160,7 @@ private:
 
     volatile enum D3D_state { D3D_IDLE = 0, D3D_LOADPS, D3D_LOCK, D3D_UNLOCK } thread_command;
     volatile bool thread_run, wait;
-    volatile HRESULT thread_hr;
+    volatile HRESULT thread_hr = 0;
 #if LOG_D3D
     void EnterLOGCriticalSection(LPCRITICAL_SECTION lpCriticalSection, int);
 #endif
@@ -175,10 +175,10 @@ private:
 public:
 
     // texture stuff
-    DWORD	dwTexHeight, dwTexWidth;
+    DWORD	dwTexHeight = 0, dwTexWidth = 0;
 
-    bool 	square, pow2, dynamic, bpp16;		// Texture limitations
-    Bit8s 	aspect, autofit;
+    bool 	square = false, pow2 = false, dynamic = false, bpp16;		// Texture limitations
+    Bit8s 	aspect, autofit = 0;
 
     // Pixel shader status
     bool 	psActive;


### PR DESCRIPTION
This silences all Visual Studio 2019 code analysis warnings about uninitialized member variables.

All are initialized to:
0 if a numeric value
false if a boolean
NULL if a pointer
0 (by zero-initializing with = {}) if a structure

Also silenced a single type conversion compiler warning that recently appeared.