### PR TITLE
Silence Cppcheck variable scope warnings

### DIFF
--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -413,9 +413,8 @@ static CacheBlockDynRec * cache_getblock(void) {
 }
 
 void CacheBlockDynRec::Clear(void) {
-	Bitu ind;
 	// check if this is not a cross page block
-	if (hash.index) for (ind=0;ind<2;ind++) {
+	if (hash.index) for (Bitu ind=0;ind<2;ind++) {
 		CacheBlockDynRec * fromlink=link[ind].from;
 		link[ind].from=0;
 		while (fromlink) {
@@ -503,11 +502,10 @@ static void cache_closeblock(void) {
 			if (written>block->cache.size+CACHE_MAXSIZE) E_Exit("CacheBlock overrun 1 %lu",(unsigned long)written-block->cache.size);
 		} else E_Exit("CacheBlock overrun 2 written %lu size %lu",(unsigned long)written,(unsigned long)block->cache.size);
 	} else {
-		Bitu new_size;
 		Bitu left=block->cache.size-written;
 		// smaller than cache align then don't bother to resize
 		if (left>CACHE_ALIGN) {
-			new_size=((written-1)|(CACHE_ALIGN-1))+1;
+			Bitu new_size=((written-1)|(CACHE_ALIGN-1))+1;
 			CacheBlockDynRec * newblock=cache_getblock();
 			// align block now to CACHE_ALIGN
 			newblock->cache.start=block->cache.start+new_size;
@@ -565,8 +563,8 @@ static void dyn_run_code(void);
 static bool cache_initialized = false;
 
 static void cache_init(bool enable) {
-	Bits i;
 	if (enable) {
+		Bits i;
 		// see if cache is already initialized
 		if (cache_initialized) return;
 		cache_initialized = true;

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -949,8 +949,6 @@ skip_extend_word:
 	} else {
 		Bits imm=0;
 		Bit8u base_reg=0;
-		Bit8u scaled_reg;
-		Bitu scale=0;
 		switch (decode.modrm.rm) {
 		case 0:base_reg=DRC_REG_EAX;break;
 		case 1:base_reg=DRC_REG_ECX;break;
@@ -966,8 +964,8 @@ skip_extend_word:
 				};
 				// see if scaling should be used and which register is to be scaled in this case
 				if (((sib >> 3) &7)!=4) scaled_reg_used=true;
-				scaled_reg=scaledtable[(sib >> 3) &7];
-				scale=(sib >> 6);
+				Bit8u scaled_reg=scaledtable[(sib >> 3) &7];
+				Bitu scale=(sib >> 6);
 
 				switch (sib & 7) {
 				case 0:base_reg=DRC_REG_EAX;break;

--- a/src/cpu/core_normal/prefix_0f.h
+++ b/src/cpu/core_normal/prefix_0f.h
@@ -635,13 +635,13 @@
 		if (CPU_ArchitectureType<CPU_ARCHTYPE_386) goto illegal_opcode;
 		{
 			GetRMrw;
-			Bit16u result,value;
+			Bit16u value;
 			if (rm >= 0xc0) { GetEArw; value=*earw; } 
 			else			{ GetEAa; value=LoadMw(eaa); }
 			if (value==0) {
 				SETFLAGBIT(ZF,true);
 			} else {
-				result = 0;
+				Bit16u result = 0;
 				while ((value & 0x01)==0) { result++; value>>=1; }
 				SETFLAGBIT(ZF,false);
 				*rmrw = result;
@@ -653,13 +653,13 @@
 		if (CPU_ArchitectureType<CPU_ARCHTYPE_386) goto illegal_opcode;
 		{
 			GetRMrw;
-			Bit16u result,value;
+			Bit16u value;
 			if (rm >= 0xc0) { GetEArw; value=*earw; } 
 			else			{ GetEAa; value=LoadMw(eaa); }
 			if (value==0) {
 				SETFLAGBIT(ZF,true);
 			} else {
-				result = 15;	// Operandsize-1
+				Bit16u result = 15;	// Operandsize-1
 				while ((value & 0x8000)==0) { result--; value<<=1; }
 				SETFLAGBIT(ZF,false);
 				*rmrw = result;

--- a/src/cpu/core_normal/prefix_66_0f.h
+++ b/src/cpu/core_normal/prefix_66_0f.h
@@ -437,13 +437,13 @@
 	CASE_0F_D(0xbc)												/* BSF Gd,Ed */
 		{
 			GetRMrd;
-			Bit32u result,value;
+			Bit32u value;
 			if (rm >= 0xc0) { GetEArd; value=*eard; } 
 			else			{ GetEAa; value=LoadMd(eaa); }
 			if (value==0) {
 				SETFLAGBIT(ZF,true);
 			} else {
-				result = 0;
+				Bit32u result = 0;
 				while ((value & 0x01)==0) { result++; value>>=1; }
 				SETFLAGBIT(ZF,false);
 				*rmrd = result;
@@ -454,13 +454,13 @@
 	CASE_0F_D(0xbd)												/*  BSR Gd,Ed */
 		{
 			GetRMrd;
-			Bit32u result,value;
+			Bit32u value;
 			if (rm >= 0xc0) { GetEArd; value=*eard; } 
 			else			{ GetEAa; value=LoadMd(eaa); }
 			if (value==0) {
 				SETFLAGBIT(ZF,true);
 			} else {
-				result = 31;	// Operandsize-1
+				Bit32u result = 31;	// Operandsize-1
 				while ((value & 0x80000000)==0) { result--; value<<=1; }
 				SETFLAGBIT(ZF,false);
 				*rmrd = result;

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -3543,8 +3543,6 @@ public:
             if (enable_weitek) {
                 LOG_MSG("Weitek coprocessor emulation enabled");
 
-                static Bitu weitek_lfb = 0xC0000000UL;
-                static Bitu weitek_lfb_pages = 0x2000000UL >> 12UL; /* "The coprocessor will respond to memory addresses 0xC0000000-0xC1FFFFFF" */
                 static MEM_Callout_t weitek_lfb_cb = MEM_Callout_t_none;
 
                 if (weitek_lfb_cb == MEM_Callout_t_none) {
@@ -3558,6 +3556,9 @@ public:
                     assert(cb != NULL);
 
                     cb->Uninstall();
+
+                    static Bitu weitek_lfb = 0xC0000000UL;
+                    static Bitu weitek_lfb_pages = 0x2000000UL >> 12UL; /* "The coprocessor will respond to memory addresses 0xC0000000-0xC1FFFFFF" */
 
                     cb->Install(weitek_lfb>>12UL,MEMMASK_Combine(MEMMASK_FULL,MEMMASK_Range(weitek_lfb_pages)),weitek_memio_cb);
 

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -681,9 +681,8 @@ bool CBreakpoint::CheckIntBreakpoint(PhysPt adr, Bit8u intNr, Bit16u ahValue, Bi
 
 	// Search matching breakpoint
 	std::list<CBreakpoint*>::iterator i;
-	CBreakpoint* bp;
 	for(i=BPoints.begin(); i != BPoints.end(); ++i) {
-		bp = (*i);
+		CBreakpoint* bp = (*i);
 		if ((bp->GetType()==BKPNT_INTERRUPT) && bp->IsActive() && (bp->GetIntNr()==intNr)) {
 			if (((bp->GetValue()==BPINT_ALL) || (bp->GetValue()==ahValue)) && ((bp->GetOther()==BPINT_ALL) || (bp->GetOther()==alValue))) {
 				// Ignore it once ?
@@ -704,9 +703,8 @@ bool CBreakpoint::CheckIntBreakpoint(PhysPt adr, Bit8u intNr, Bit16u ahValue, Bi
 void CBreakpoint::DeleteAll() 
 {
 	std::list<CBreakpoint*>::iterator i;
-	CBreakpoint* bp;
 	for(i=BPoints.begin(); i != BPoints.end(); ++i) {
-		bp = (*i);
+		CBreakpoint* bp = (*i);
 		bp->Activate(false);
 		delete bp;
 	}
@@ -1138,7 +1136,6 @@ static void DrawCode(void) {
 	if (dbg.win_main == NULL || dbg.win_code == NULL)
 		return;
 
-	bool saveSel; 
 	Bit32u disEIP = codeViewData.useEIP;
 	char dline[200];Bitu size;Bitu c;
 	static char line20[21] = "                    ";
@@ -1148,7 +1145,7 @@ static void DrawCode(void) {
 	for (int i=0;i<h;i++) {
         Bit64u start = GetAddress(codeViewData.useCS,disEIP);
 
-		saveSel = false;
+		bool saveSel = false;
 		if (has_colors()) {
 			if ((codeViewData.useCS==SegValue(cs)) && (disEIP == reg_eip)) {
 				if (codeViewData.cursorPos==-1) {
@@ -2589,8 +2586,6 @@ char* AnalyzeInstruction(char* inst, bool saveSelector) {
 	static char result[256];
 	
 	char instu[256];
-	char prefix[3];
-	Bit16u seg;
 
 	strcpy(instu,inst);
 	upcase(instu);
@@ -2598,6 +2593,8 @@ char* AnalyzeInstruction(char* inst, bool saveSelector) {
 	result[0] = 0;
 	char* pos = strchr(instu,'[');
 	if (pos) {
+		char prefix[3];
+		Bit16u seg;
 		// Segment prefix ?
 		if (*(pos-1)==':') {
 			char* segpos = pos-3;
@@ -2796,14 +2793,13 @@ void win_code_ui_up(int count) {
             if (codeViewData.cursorPos>0)
                 codeViewData.cursorPos--;
             else {
-                Bitu bytes = 0;
-                char dline[200];
-                Bitu size = 0;
                 Bit32u newEIP = codeViewData.useEIP - 1;
                 if(codeViewData.useEIP) {
+                    Bitu bytes = 0;
+                    char dline[200];
                     for (; bytes < 10; bytes++) {
                         PhysPt start = (PhysPt)GetAddress(codeViewData.useCS,newEIP);
-                        size = DasmI386(dline, start, newEIP, cpu.code.big);
+                        Bitu size = DasmI386(dline, start, newEIP, cpu.code.big);
                         if(codeViewData.useEIP == newEIP+size) break;
                         newEIP--;
                     }
@@ -3703,11 +3699,10 @@ static void LogIDT(void) {
 }
 
 void LogPages(char* selname) {
-	char out1[512];
-
     DEBUG_BeginPagedContent();
 
 	if (paging.enabled) {
+		char out1[512];
 		Bitu sel = GetHexValue(selname,selname);
 		if ((sel==0x00) && ((*selname==0) || (*selname=='*'))) {
 			for (unsigned int i=0; i<0xfffff; i++) {
@@ -4099,9 +4094,8 @@ void CDebugVar::InsertVariable(char* name, PhysPt adr)
 void CDebugVar::DeleteAll(void) 
 {
 	std::vector<CDebugVar*>::iterator i;
-	CDebugVar* bp;
 	for(i=varList.begin(); i != varList.end(); i++) {
-		bp = static_cast<CDebugVar*>(*i);
+		CDebugVar* bp = static_cast<CDebugVar*>(*i);
 		delete bp;
 	}
 	(varList.clear)();
@@ -4112,9 +4106,8 @@ CDebugVar* CDebugVar::FindVar(PhysPt pt)
 	if (varList.empty()) return 0;
 
 	std::vector<CDebugVar*>::size_type s = varList.size();
-	CDebugVar* bp;
 	for(std::vector<CDebugVar*>::size_type i = 0; i != s; i++) {
-		bp = static_cast<CDebugVar*>(varList[i]);
+		CDebugVar* bp = static_cast<CDebugVar*>(varList[i]);
 		if (bp->GetAdr() == pt) return bp;
 	}
 	return 0;
@@ -4240,7 +4233,6 @@ static void OutputVecTable(char* filename) {
 static void DrawVariables(void) {
 	if (CDebugVar::varList.empty()) return;
 
-	CDebugVar *dv;
 	char buffer[DEBUG_VAR_BUF_LEN];
 	std::vector<CDebugVar*>::size_type s = CDebugVar::varList.size();
 	bool windowchanges = false;
@@ -4252,7 +4244,7 @@ static void DrawVariables(void) {
 			break;
 		}
 
-		dv = static_cast<CDebugVar*>(CDebugVar::varList[i]);
+		CDebugVar *dv = static_cast<CDebugVar*>(CDebugVar::varList[i]);
 		Bit16u value;
 		bool varchanges = false;
 		bool has_no_value = mem_readw_checked(dv->GetAdr(),&value);
@@ -4410,7 +4402,6 @@ void DEBUG_HeavyWriteLogInstruction(void) {
 }
 
 bool DEBUG_HeavyIsBreakpoint(void) {
-	static Bitu zero_count = 0;
 	if (cpuLog) {
 		if (cpuLogCounter>0) {
 			LogInstruction(SegValue(cs),reg_eip,cpuLogFile);
@@ -4428,6 +4419,7 @@ bool DEBUG_HeavyIsBreakpoint(void) {
 	// LogInstruction
 	if (logHeavy) DEBUG_HeavyLogInstruction();
 	if (zeroProtect) {
+		static Bitu zero_count = 0;
 		Bit32u value=0;
 		if (!mem_readd_checked(SegPhys(cs)+reg_eip,&value)) {
 			if (value == 0) zero_count++;

--- a/src/debug/debug_disasm.cpp
+++ b/src/debug/debug_disasm.cpp
@@ -533,7 +533,6 @@ static void outhex(char subtype, int extend, int optional, int defsize, int sign
   int n=0, s=0, i;
   INT32 delta = 0;
   unsigned char buff[6];
-  char *name;
   char  signchar;
 
   switch (subtype) {
@@ -618,7 +617,7 @@ static void outhex(char subtype, int extend, int optional, int defsize, int sign
     return;
   }
   if ((n == 4) && !sign) {
-    name = addr_to_hex((UINT32)delta, 0);
+    char *name = addr_to_hex((UINT32)delta, 0);
     uprintf("%s", name);
     return;
   }

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -674,15 +674,13 @@ void DEBUG_ShowMsg(char const* format,...) {
 
     if (IsDebuggerActive() && debugPageStopAt > 0) {
         if (++debugPageCounter >= debugPageStopAt) {
-            int key;
-
             debugPageCounter = 0;
             DEBUG_RefreshPage(0);
             DEBUG_DrawInput();
 
             /* pause, wait for input */
             do {
-                key = getch();
+                int key = getch();
                 if (key > 0) {
                     if (key == ' ' || key == 0x0A) {
                         /* continue */

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -325,9 +325,9 @@ void CDROM_Interface_Image::CDAudioCallBack(Bitu len)
 	}
 	SDL_mutexV(player.mutex);
 	if (player.ctrlUsed) {
-		Bit16s sample0,sample1;
 		Bit16s * samples=(Bit16s *)&player.buffer;
 		for (Bitu pos=0;pos<len/4;pos++) {
+			Bit16s sample0,sample1;
 #if defined(WORDS_BIGENDIAN)
 			sample0=(Bit16s)host_readw((HostPt)&samples[pos*2+player.ctrlData.out[0]]);
 			sample1=(Bit16s)host_readw((HostPt)&samples[pos*2+player.ctrlData.out[1]]);

--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -356,8 +356,6 @@ private:
     }
 
 	static void Real_INT10_TeletypeOutput(Bit8u xChar,Bit8u xAttr) {
-		Bit16u		oldax,oldbx;
-
         if (IS_PC98_ARCH) {
             if (con_sjis.take(xChar)) {
                 BIOS_NCOLS;
@@ -383,6 +381,7 @@ private:
             }
         }
         else {
+            Bit16u oldax,oldbx;
             oldax=reg_ax;
             oldbx=reg_bx;
 

--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -285,7 +285,7 @@ bool DOS_Execute(char * name,PhysPt block_pt,Bit8u flags) {
 	EXE_Header head;Bitu i;
 	Bit16u fhandle;Bit16u len;Bit32u pos;
 	Bit16u pspseg,envseg,loadseg,memsize=0xffff,readsize;
-	Bit16u minsize,maxsize,maxfree=0xffff;
+	Bit16u maxsize,maxfree=0xffff;
 	PhysPt loadaddress;RealPt relocpt;
     Bit32u headersize = 0, imagesize = 0;
 	DOS_ParamBlock block(block_pt);
@@ -344,6 +344,7 @@ bool DOS_Execute(char * name,PhysPt block_pt,Bit8u flags) {
 			DOS_CloseFile(fhandle);
 			return false;
 		}
+		Bit16u minsize;
 		/* Get Memory */		
 		DOS_AllocateMemory(&pspseg,&maxfree);
 		if (iscom) {

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -69,7 +69,6 @@ bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 	char tempdir[DOS_PATHLENGTH];
 	char upname[DOS_PATHLENGTH];
 	Bitu r,w;
-	Bit8u c;
 	*drive = DOS_GetDefaultDrive();
 	/* First get the drive */
 	if (name_int[1]==':') {
@@ -82,7 +81,7 @@ bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 	}
 	r=0;w=0;
 	while (name_int[r]!=0 && (r<DOS_PATHLENGTH)) {
-		c=(Bit8u)name_int[r++];
+		Bit8u c=(Bit8u)name_int[r++];
 		if ((c>='a') && (c<='z')) c-=32;
 		else if (c==' ') continue; /* should be separator */
 		else if (c=='/') c='\\';
@@ -1254,13 +1253,13 @@ Bit8u DOS_FCBRandomWrite(Bit16u seg,Bit16u offset,Bit16u * numRec,bool restore) 
 	Bit16u old_block=0;
 	Bit8u old_rec=0;
 	Bit8u error=0;
-	Bit16u count;
 
 	/* Set the correct record from the random data */
 	fcb.GetRandom(random);
 	fcb.SetRecord((Bit16u)(random / 128u),(Bit8u)(random & 127u));
 	if (restore) fcb.GetRecord(old_block,old_rec);
 	if (*numRec > 0) {
+		Bit16u count;
 		/* Write records */
 		for (count=0; count<*numRec; count++) {
 			error = DOS_FCBWrite(seg,offset,count);// dos_fcbwrite return 0 false when true...
@@ -1300,7 +1299,6 @@ bool DOS_FCBGetFileSize(Bit16u seg,Bit16u offset) {
 bool DOS_FCBDeleteFile(Bit16u seg,Bit16u offset){
 /* Special case: ????????.??? and DOS_ATTR_VOLUME */
     {
-        char shortname[DOS_FCBNAME];
         DOS_FCB fcb(seg,offset);
         Bit8u attr = 0;
         fcb.GetAttr(attr);
@@ -1308,6 +1306,7 @@ bool DOS_FCBDeleteFile(Bit16u seg,Bit16u offset){
         std::string label = Drives[drive]->GetLabel();
 
         if (attr & DOS_ATTR_VOLUME) {
+        char shortname[DOS_FCBNAME];
             fcb.GetVolumeName(shortname);
 
             if (!strcmp(shortname,"???????????")) {

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -671,7 +671,6 @@ bool CMscdex::GetDirectoryEntry(Bit16u drive, bool copyFlag, PhysPt pathname, Ph
 	char	searchName[256];
 	char	entryName[256];
 	bool	foundComplete = false;
-	bool	foundName;
 	bool	nextPart = true;
 	char*	useName = 0;
     Bit8u   entryLength, nameLength;
@@ -700,12 +699,11 @@ bool CMscdex::GetDirectoryEntry(Bit16u drive, bool copyFlag, PhysPt pathname, Ph
 	// get directory position
 	Bit32u dirEntrySector	= mem_readd(defBuffer+offset+2);
 	Bits dirSize		= (Bit32s)mem_readd(defBuffer+offset+10);
-	Bit16u index;
 	while (dirSize>0) {
-		index = 0;
+		Bit16u index = 0;
 		if (!ReadSectors(GetSubUnit(drive),false,dirEntrySector,1,defBuffer)) return false;
 		// Get string part
-		foundName	= false;
+		bool foundName = false;
 		if (nextPart) {
 			if (searchPos) { 
 				useName = searchPos; 

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -729,7 +729,6 @@ private:
         bool tryload = (*error)?true:false;
         *error = 0;
         Bit8u drive;
-        FILE *tmpfile;
         char fullname[DOS_PATHLENGTH];
 
         localDrive* ldp=0;
@@ -739,7 +738,7 @@ private:
             ldp=dynamic_cast<localDrive*>(Drives[drive]);
             if(!ldp) return NULL;
 
-            tmpfile = ldp->GetSystemFilePtr(fullname, "rb");
+            FILE *tmpfile = ldp->GetSystemFilePtr(fullname, "rb");
             if(tmpfile == NULL) {
                 if (!tryload) *error=1;
                 return NULL;
@@ -2634,10 +2633,10 @@ quit:
 };
 
 bool ElTorito_ChecksumRecord(unsigned char *entry/*32 bytes*/) {
-    unsigned int word,chk=0,i;
+    unsigned int chk=0,i;
 
     for (i=0;i < 16;i++) {
-        word = ((unsigned int)entry[0]) + ((unsigned int)entry[1] << 8);
+        unsigned int word = ((unsigned int)entry[0]) + ((unsigned int)entry[1] << 8);
         chk += word;
         entry += 2;
     }
@@ -3504,8 +3503,8 @@ private:
                 }
             }
 
-            DOS_Drive* newDrive = NULL;
             if (!errorMessage) {
+                DOS_Drive* newDrive = NULL;
                 if (vhdImage) {
                     newDrive = new fatDrive(vhdImage, options);
                     vhdImage = NULL;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -300,11 +300,10 @@ extern bool DOSBox_Paused();
 
 static Bitu Normal_Loop(void) {
     bool saved_allow = dosbox_allow_nonrecursive_page_fault;
-    Bit32u ticksNew;
     Bits ret;
 
     if (!menu.hidecycles || menu.showrt) { /* sdlmain.cpp/render.cpp doesn't even maintain the frames count when hiding cycles! */
-        ticksNew = GetTicks();
+        Bit32u ticksNew = GetTicks();
         if (ticksNew >= Ticks) {
             Bit32u interval = ticksNew - ticksLastFramecounter;
             double rtnow = PIC_FullIndex();
@@ -480,11 +479,10 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
         Bit32s ratio = (Bit32s)((ticksScheduled * (CPU_CyclePercUsed * 90 * 1024 / 100 / 100)) / ticksDone);
         Bit32s new_cmax = (Bit32s)CPU_CycleMax;
         Bit64s cproc = (Bit64s)CPU_CycleMax * (Bit64s)ticksScheduled;
-        double ratioremoved = 0.0; //increase scope for logging
         if (cproc > 0) {
             /* ignore the cycles added due to the IO delay code in order
                to have smoother auto cycle adjustments */
-            ratioremoved = (double)CPU_IODelayRemoved / (double)cproc;
+            double ratioremoved = (double)CPU_IODelayRemoved / (double)cproc;
             if (ratioremoved < 1.0) {
                 double ratio_not_removed = 1 - ratioremoved;
                 ratio = (Bit32s)((double)ratio * ratio_not_removed);

--- a/src/fpu/fpu_instructions_x86.h
+++ b/src/fpu/fpu_instructions_x86.h
@@ -1272,7 +1272,6 @@ static void FPU_FSTENV(PhysPt addr){
 
 static void FPU_FLDENV(PhysPt addr){
 	Bit16u tag;
-	Bit32u tagbig;
 	Bitu cw;
 	if(!cpu.code.big) {
 		cw     = mem_readw(addr+0);
@@ -1281,7 +1280,7 @@ static void FPU_FLDENV(PhysPt addr){
 	} else { 
 		cw     = mem_readd(addr+0);
 		fpu.sw = (Bit16u)mem_readd(addr+4);
-		tagbig = mem_readd(addr+8);
+		Bit32u tagbig = mem_readd(addr+8);
 		tag    = static_cast<Bit16u>(tagbig);
 	}
 	FPU_SetTag(tag);


### PR DESCRIPTION
Silences about half of Cppcheck warnings about variables that can have their scopes reduced.