### PR TITLE
Silence redundant assignment warnings

### DIFF
--- a/src/cpu/core_normal/prefix_0f_mmx.h
+++ b/src/cpu/core_normal/prefix_0f_mmx.h
@@ -978,7 +978,6 @@
 		dest->ub.b3 = src.ub.b1;
 		dest->ub.b2 = dest->ub.b1;
 		dest->ub.b1 = src.ub.b0;
-		dest->ub.b0 = dest->ub.b0;
 		break;
 	}
 	CASE_0F_D(0x61)												/* PUNPCKLWD Pq,Qq */
@@ -995,7 +994,6 @@
 		dest->uw.w3 = src.uw.w1;
 		dest->uw.w2 = dest->uw.w1;
 		dest->uw.w1 = src.uw.w0;
-		dest->uw.w0 = dest->uw.w0;
 		break;
 	}
 	CASE_0F_D(0x62)												/* PUNPCKLDQ Pq,Qq */

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -614,14 +614,14 @@ void DEBUG_ShowMsg(char const* format,...) {
     /* remove newlines if present */
     while (len > 0 && buf[len-1] == '\n') buf[--len] = 0;
 
-	if (do_LOG_stderr || debuglog == NULL)
-		stderrlog = true;
-
 #if C_DEBUG
 	if (dbg.win_out != NULL)
 		stderrlog = false;
     else
         stderrlog = true;
+#else
+	if (do_LOG_stderr || debuglog == NULL)
+		stderrlog = true;
 #endif
 
 	if (debuglog != NULL) {

--- a/src/debug/debug_win32.cpp
+++ b/src/debug/debug_win32.cpp
@@ -32,11 +32,10 @@
 */
 static void ResizeConsole( HANDLE hConsole, SHORT xSize, SHORT ySize ) {   
 	CONSOLE_SCREEN_BUFFER_INFO csbi; // Hold Current Console Buffer Info 
-	BOOL bSuccess;   
 	SMALL_RECT srWindowRect;         // Hold the New Console Size 
 	COORD coordScreen;    
 	
-	bSuccess = GetConsoleScreenBufferInfo( hConsole, &csbi );
+	GetConsoleScreenBufferInfo( hConsole, &csbi );
 	
 	// Get the Largest Size we can size the Console Window to 
 	coordScreen = GetLargestConsoleWindowSize( hConsole );
@@ -54,20 +53,19 @@ static void ResizeConsole( HANDLE hConsole, SHORT xSize, SHORT ySize ) {
 	// Console Window First, then the Buffer 
 	if( (DWORD)csbi.dwSize.X * csbi.dwSize.Y > (DWORD) xSize * ySize)
 	{
-		bSuccess = SetConsoleWindowInfo( hConsole, TRUE, &srWindowRect );
-		bSuccess = SetConsoleScreenBufferSize( hConsole, coordScreen );
+		SetConsoleWindowInfo( hConsole, TRUE, &srWindowRect );
+		SetConsoleScreenBufferSize( hConsole, coordScreen );
 	}
 	
 	// If the Current Buffer is Smaller than what we want, Resize the 
 	// Buffer First, then the Console Window 
 	if( (DWORD)csbi.dwSize.X * csbi.dwSize.Y < (DWORD) xSize * ySize )
 	{
-		bSuccess = SetConsoleScreenBufferSize( hConsole, coordScreen );
-		bSuccess = SetConsoleWindowInfo( hConsole, TRUE, &srWindowRect );
+		SetConsoleScreenBufferSize( hConsole, coordScreen );
+		SetConsoleWindowInfo( hConsole, TRUE, &srWindowRect );
 	}
 	
-	// If the Current Buffer *is* the Size we want, Don't do anything! 
-    (void)bSuccess;//UNUSED
+	// If the Current Buffer *is* the Size we want, Don't do anything!
 	return;
    }
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1957,7 +1957,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pmulti_remain->SetValue("auto",/*init*/true);
     Pstring->Set_values(cyclest);
 
-    Pstring = Pmulti_remain->GetSection()->Add_string("parameters",Property::Changeable::Always,"");
+    Pmulti_remain->GetSection()->Add_string("parameters",Property::Changeable::Always,"");
 
     Pint = secprop->Add_int("cycleup",Property::Changeable::Always,10);
     Pint->SetMinMax(1,1000000);
@@ -2625,7 +2625,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring = Pmulti_remain->GetSection()->Add_string("type",Property::Changeable::WhenIdle,"dummy");
     Pmulti_remain->SetValue("dummy",/*init*/true);
     Pstring->Set_values(serials);
-    Pstring = Pmulti_remain->GetSection()->Add_string("parameters",Property::Changeable::WhenIdle,"");
+    Pmulti_remain->GetSection()->Add_string("parameters",Property::Changeable::WhenIdle,"");
     Pmulti_remain->Set_help(
         "set type of device connected to com port.\n"
         "Can be disabled, dummy, modem, nullmodem, directserial.\n"
@@ -2643,21 +2643,21 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring = Pmulti_remain->GetSection()->Add_string("type",Property::Changeable::WhenIdle,"dummy");
     Pmulti_remain->SetValue("dummy",/*init*/true);
     Pstring->Set_values(serials);
-    Pstring = Pmulti_remain->GetSection()->Add_string("parameters",Property::Changeable::WhenIdle,"");
+    Pmulti_remain->GetSection()->Add_string("parameters",Property::Changeable::WhenIdle,"");
     Pmulti_remain->Set_help("see serial1");
 
     Pmulti_remain = secprop->Add_multiremain("serial3",Property::Changeable::WhenIdle," ");
     Pstring = Pmulti_remain->GetSection()->Add_string("type",Property::Changeable::WhenIdle,"disabled");
     Pmulti_remain->SetValue("disabled",/*init*/true);
     Pstring->Set_values(serials);
-    Pstring = Pmulti_remain->GetSection()->Add_string("parameters",Property::Changeable::WhenIdle,"");
+    Pmulti_remain->GetSection()->Add_string("parameters",Property::Changeable::WhenIdle,"");
     Pmulti_remain->Set_help("see serial1");
 
     Pmulti_remain = secprop->Add_multiremain("serial4",Property::Changeable::WhenIdle," ");
     Pstring = Pmulti_remain->GetSection()->Add_string("type",Property::Changeable::WhenIdle,"disabled");
     Pmulti_remain->SetValue("disabled",/*init*/true);
     Pstring->Set_values(serials);
-    Pstring = Pmulti_remain->GetSection()->Add_string("parameters",Property::Changeable::WhenIdle,"");
+    Pmulti_remain->GetSection()->Add_string("parameters",Property::Changeable::WhenIdle,"");
     Pmulti_remain->Set_help("see serial1");
 
 #if C_PRINTER
@@ -3146,7 +3146,7 @@ void DOSBOX_SetupConfigSections(void) {
                 "         Setting the IRQ to one already occupied by another device or IDE controller will trigger \"resource conflict\" errors in Windows 95.\n"
                 "         Using IRQ 9, 12, 13, or IRQ 2-7 may cause problems with MS-DOS CD-ROM drivers.");
 
-        Phex = secprop->Add_hex("io",Property::Changeable::WhenIdle,0/*use IDE default*/);
+        secprop->Add_hex("io",Property::Changeable::WhenIdle,0/*use IDE default*/);
         if (i == 0) Pint->Set_help("Base I/O port for IDE controller. Set to 0 for default.\n"
                 "WARNING: Setting the I/O port to non-standard values will not work unless the guest OS is using the ISA PnP BIOS to detect the IDE controller.\n"
                 "         Using any port other than 1F0, 170, 1E8 or 168 can prevent MS-DOS CD-ROM drivers from detecting the IDE controller.");

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -450,8 +450,6 @@ void RENDER_Reset( void ) {
             simpleBlock = &ScaleNormal4x;
         else if (render.scale.size == 10 && !(dblh || dblw) && render.scale.hardware)
             simpleBlock = &ScaleNormal5x;
-        else
-            simpleBlock = &ScaleNormal1x;
         /* Maybe override them */
 #if RENDER_USE_ADVANCED_SCALERS>0
         switch (render.scale.op) {

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -991,7 +991,6 @@ public:
             chan=chan->next;
         }
         if (cmd->FindExist("/NOSHOW")) return;
-        chan=mixer.channels;
         WriteOut("Channel  Main    Main(dB)\n");
         ShowVolume("MASTER",mixer.mastervol[0],mixer.mastervol[1]);
         ShowVolume("RECORD",mixer.recordvol[0],mixer.recordvol[1]);

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -525,7 +525,6 @@ void PCSPEAKER_SetType(bool pit_clock_gate_enabled, bool pit_output_enabled) {
 			break;
 		case 3:
 			spkr.pit_mode3_counting = 1;
-			spkr.pit_new_max = spkr.pit_new_max;
 			spkr.pit_new_half=spkr.pit_new_max/2;
 			spkr.pit_index = 0;
 			spkr.pit_max = spkr.pit_new_max;

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -744,7 +744,6 @@ void TIMER_BIOS_INIT_Configure() {
     pit[1].output = true;
     pit[1].gate = true;
 	pit[1].bcd = false;
-	pit[1].write_state = 1;
 	pit[1].read_state = 1;
 	pit[1].go_read_latch = true;
 	pit[1].cntr = 18;
@@ -757,7 +756,6 @@ void TIMER_BIOS_INIT_Configure() {
     pit[2].output = true;
     pit[2].gate = false;
 	pit[2].bcd = false;
-	pit[2].write_state = 1;
 	pit[2].read_state = 1;
 	pit[2].go_read_latch = true;
 	pit[2].cntr = 18;

--- a/src/hardware/voodoo_emu.cpp
+++ b/src/hardware/voodoo_emu.cpp
@@ -1310,7 +1310,7 @@ static void update_statistics(voodoo_state *v, bool accumulate)
 
 void register_w(UINT32 offset, UINT32 data) {
 //	voodoo_reg reg;
-	UINT32 regnum  = (offset) & 0xff;
+	UINT32 regnum;
 	UINT32 chips   = (offset>>8) & 0xf;
 //	reg.u = data;
 

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -1779,7 +1779,6 @@ imageDiskD88::imageDiskD88(FILE *imgFile, Bit8u *imgName, Bit32u imgSizeK, bool 
     reserved_cylinders = 0;
     diskSizeK = imgSizeK;
     diskimg = imgFile;
-    active = false;
 
     if (imgName != NULL)
         diskname = (const char*)imgName;
@@ -2077,7 +2076,6 @@ imageDiskNFD::imageDiskNFD(FILE *imgFile, Bit8u *imgName, Bit32u imgSizeK, bool 
     reserved_cylinders = 0;
     diskSizeK = imgSizeK;
     diskimg = imgFile;
-    active = false;
 
     if (imgName != NULL)
         diskname = (const char*)imgName;

--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -1408,8 +1408,6 @@ static void SetupVCPI() {
 		XMS_EnableA20(true);
 	}
 
-	vcpi.enabled=false;
-
 	vcpi.ems_handle=0;	// use EMM system handle for VCPI data
 
 	vcpi.enabled=true;

--- a/vs2015/libpdcurses/pdcurses/window.c
+++ b/vs2015/libpdcurses/pdcurses/window.c
@@ -435,7 +435,6 @@ WINDOW *dupwin(WINDOW *win)
     new->_pary = win->_pary;
     new->_parent = win->_parent;
     new->_bkgd = win->_bkgd;
-    new->_flags = win->_flags;
 
     return new;
 }

--- a/vs2015/sdl/src/video/SDL_gamma.c
+++ b/vs2015/sdl/src/video/SDL_gamma.c
@@ -96,7 +96,6 @@ int SDL_SetGamma(float red, float green, float blue)
 	SDL_VideoDevice *video = current_video;
 	SDL_VideoDevice *this  = current_video;	
 
-	succeeded = -1;
 	/* Prefer using SetGammaRamp(), as it's more flexible */
 	{
 		Uint16 ramp[3][256];
@@ -122,7 +121,6 @@ int SDL_GetGamma(float *red, float *green, float *blue)
 	SDL_VideoDevice *video = current_video;
 	SDL_VideoDevice *this  = current_video;	
 
-	succeeded = -1;
 	/* Prefer using GetGammaRamp(), as it's more flexible */
 	{
 		Uint16 ramp[3][256];


### PR DESCRIPTION
Silences several redundant variable assignment warnings generated by Cppcheck. Shouldn't change behavior.