### PR TITLE
Fix more warnings

### DIFF
--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -3067,12 +3067,13 @@ Bit32u DEBUG_CheckKeys(void) {
 
                 if (cpudecoder == DEBUG_NullCPUCore)
                     ret = -1; /* DEBUG_Loop() must exit */
+                else
+                    ret = (*cpudecoder)();
 
 				mainMenu.get_item("mapper_debugger").check(false).refresh_item(mainMenu);
 
 				skipFirstInstruction = true; // for heavy debugger
 				CPU_Cycles = 1;
-				ret=(*cpudecoder)();
 
 				// ensure all breakpoints are activated
 				CBreakpoint::ActivateBreakpoints();

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -4145,7 +4145,10 @@ bool CDebugVar::LoadVars(char* name)
 
 	// read number of vars
 	Bit16u num;
-	if (fread(&num,sizeof(num),1,f) != 1) return false;
+	if (fread(&num,sizeof(num),1,f) != 1) {
+		fclose(f);
+		return false;
+	}
 
 	for (Bit16u i=0; i<num; i++) {
 		char name[16];

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -142,21 +142,24 @@ DOS_File::DOS_File(const DOS_File& orig) {
 	}
 }
 
-DOS_File & DOS_File::operator= (const DOS_File & orig) {
-	flags=orig.flags;
-	time=orig.time;
-	date=orig.date;
-	attr=orig.attr;
-	refCtr=orig.refCtr;
-	open=orig.open;
-	hdrive=orig.hdrive;
-	if(name) {
-		delete [] name; name=0;
-	}
-	if(orig.name) {
-		name=new char [strlen(orig.name) + 1];strcpy(name,orig.name);
-	}
-	return *this;
+DOS_File& DOS_File::operator= (const DOS_File& orig) {
+    if (this != &orig) {
+        flags = orig.flags;
+        time = orig.time;
+        date = orig.date;
+        attr = orig.attr;
+        refCtr = orig.refCtr;
+        open = orig.open;
+        hdrive = orig.hdrive;
+        drive = orig.drive;
+        if (name) {
+            delete[] name; name = 0;
+        }
+        if (orig.name) {
+            name = new char[strlen(orig.name) + 1]; strcpy(name, orig.name);
+        }
+    }
+    return *this;
 }
 
 Bit8u DOS_FindDevice(char const * name) {

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2117,11 +2117,13 @@ restart_int:
         }
         if(fseeko64(f,static_cast<off_t>(size - 1ull),SEEK_SET)) {
             WriteOut(MSG_Get("PROGRAM_IMGMAKE_NOT_ENOUGH_SPACE"),size);
+            fclose(f);
             return;
         }
         Bit8u bufferbyte=0;
         if(fwrite(&bufferbyte,1,1,f)!=1) {
             WriteOut(MSG_Get("PROGRAM_IMGMAKE_NOT_ENOUGH_SPACE"),size);
+            fclose(f);
             return;
         }
 

--- a/src/hardware/parport/directlpt_win32.cpp
+++ b/src/hardware/parport/directlpt_win32.cpp
@@ -85,6 +85,7 @@ CDirectLPT::CDirectLPT (Bitu nr, Bit8u initIrq, CommandLine* cmd)
 
      if (inp32fp == NULL) {
           LOG_MSG("GetProcAddress for Inp32 Failed.\n");
+          FreeLibrary(hLib);
           return ;
      }
 
@@ -93,6 +94,7 @@ CDirectLPT::CDirectLPT (Bitu nr, Bit8u initIrq, CommandLine* cmd)
 
      if (oup32fp == NULL) {
           LOG_MSG("GetProcAddress for Oup32 Failed.\n");
+          FreeLibrary(hLib);
           return ;
      }
 
@@ -107,12 +109,14 @@ CDirectLPT::CDirectLPT (Bitu nr, Bit8u initIrq, CommandLine* cmd)
 	if(cmd->FindStringBegin("realbase:",str,false)) {
 		if(sscanf(str.c_str(), "%x",&realbaseaddress)!=1) {
 			LOG_MSG("parallel%d: Invalid realbase parameter.",nr);
+            FreeLibrary(hLib);
 			return;
 		} 
 	}
 
 	if(realbaseaddress>=0x10000) {
 		LOG_MSG("Error: Invalid base address.");
+        FreeLibrary(hLib);
 		return;
 	}
 	/*
@@ -135,6 +139,7 @@ CDirectLPT::CDirectLPT (Bitu nr, Bit8u initIrq, CommandLine* cmd)
 		((realbaseaddress>=0x3f0)&&(realbaseaddress<=0x3f7)) ||	// floppy + prim. HDD
 		((realbaseaddress>=0x370)&&(realbaseaddress<=0x377))) {	// sek. hdd
 		LOG_MSG("Parallel Port: Invalid base address.");
+        FreeLibrary(hLib);
 		return;
 	}
 	/*	
@@ -148,6 +153,7 @@ CDirectLPT::CDirectLPT (Bitu nr, Bit8u initIrq, CommandLine* cmd)
 	if(cmd->FindStringBegin("ecpbase:",str,false)) {
 		if(sscanf(str.c_str(), "%x",&ecpbase)!=1) {
 			LOG_MSG("parallel%d: Invalid realbase parameter.",nr);
+            FreeLibrary(hLib);
 			return;
 		}
 		isECP=true;
@@ -204,6 +210,7 @@ CDirectLPT::CDirectLPT (Bitu nr, Bit8u initIrq, CommandLine* cmd)
 	{
 		LOG_MSG("No parallel port detected at 0x%x!",realbaseaddress);
 		// cannot remember 1
+        FreeLibrary(hLib);
 		return;
 	}
 	
@@ -223,6 +230,7 @@ CDirectLPT::CDirectLPT (Bitu nr, Bit8u initIrq, CommandLine* cmd)
 	{
 		LOG_MSG("No parallel port detected at 0x%x!",realbaseaddress);
 		// cannot remember 0
+        FreeLibrary(hLib);
 		return;
 	}
 	Out32(realbaseaddress+2,controlreg);

--- a/vs2015/sdlnet/SDLnet.c
+++ b/vs2015/sdlnet/SDLnet.c
@@ -213,10 +213,13 @@ int SDLNet_GetLocalAddresses(IPaddress *addresses, int maxcount)
     }
 
     if ((dwRetVal = GetAdaptersInfo(pAdapterInfo, &ulOutBufLen)) == ERROR_BUFFER_OVERFLOW) {
-        pAdapterInfo = (IP_ADAPTER_INFO *) SDL_realloc(pAdapterInfo, ulOutBufLen);
-        if (pAdapterInfo == NULL) {
-			return 0;
+        PIP_ADAPTER_INFO pNewAdapterInfo = (IP_ADAPTER_INFO*)SDL_realloc(pAdapterInfo, ulOutBufLen);
+        if (pNewAdapterInfo == NULL) {
+            SDL_free(pAdapterInfo);
+            return 0;
         }
+        pAdapterInfo = pNewAdapterInfo;
+
 		dwRetVal = GetAdaptersInfo(pAdapterInfo, &ulOutBufLen);
     }
 


### PR DESCRIPTION
1st commit - https://github.com/joncampbell123/dosboxx/commit/f07c520d9edd91231b80ba3a3ce0164641585bb0 caused the assignment of -1 to `ret` above the added code to become ineffective, because `ret` would always be assigned in the added code. Now the code to assign -1 will have an effect again.

2nd commit - Fix some resource leaks for when exiting functions early due to errors.

3rd commit - Fix some warnings in the `DOS_File` "=" operator. Member variable `drive` was not being copied over, and no check was being done that `DOS_File` was not being copied to itself.