### PR TITLE
Fix more Cppcheck warnings

### DIFF
--- a/src/aviwriter/riff.cpp
+++ b/src/aviwriter/riff.cpp
@@ -394,7 +394,7 @@ int riff_stack_read(riff_stack *s,riff_chunk *c,void *buf,size_t len) {
 		int64_t rem = c->data_length - c->read_offset;
 		if (rem > (int64_t)len) rem = (int64_t)len;
 		len = (size_t)rem;
-		if (len <= 0) return 0;
+		if (len == 0) return 0;
 		if (c->absolute_data_offset == ((int64_t)(-1))) return 0;
 		if (s->seek(s,c->absolute_data_offset+c->read_offset) != (c->absolute_data_offset+c->read_offset)) return 0;
 		rd = s->read(s,buf,len);

--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -405,7 +405,7 @@ restart_prefix:
 			dyn_mov_byte_imm(opcode&3,(opcode>>2)&1,decode_fetchb());
 			break;
 		case 0xb8:case 0xb9:case 0xba:case 0xbb:case 0xbc:case 0xbd:case 0xbe:case 0xbf:	
-			dyn_mov_word_imm(opcode&7);break;
+			dyn_mov_word_imm(opcode&7);
 			break;
 
 		// 'shiftop []/reg8,imm8/1/cl'

--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -555,7 +555,7 @@ restart_prefix:
 		case 0xfb:		//STI
 			gen_call_function_raw(CPU_STI);
 			dyn_check_exception(FC_RETOP);
-			if (max_opcodes<=0) max_opcodes=1;		//Allow 1 extra opcode
+			if (max_opcodes==0) max_opcodes=1;		//Allow 1 extra opcode
 			break;
 
 		case 0xfc:		//CLD

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -3335,8 +3335,10 @@ public:
 				std::istringstream stream(type);
 				int rmdval=0;
 				stream >> rmdval;
-				if(rmdval) CPU_CycleMax=(Bit32s)rmdval;
-				if(rmdval) CPU_CyclesSet=(Bit32s)rmdval;
+				if(rmdval) {
+					CPU_CycleMax=(Bit32s)rmdval;
+					CPU_CyclesSet=(Bit32s)rmdval;
+				}
 			}
 			CPU_CycleAutoAdjust=false;
 		}

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -4095,7 +4095,7 @@ void CDebugVar::InsertVariable(char* name, PhysPt adr)
 void CDebugVar::DeleteAll(void) 
 {
 	std::vector<CDebugVar*>::iterator i;
-	for(i=varList.begin(); i != varList.end(); i++) {
+	for(i=varList.begin(); i != varList.end(); ++i) {
 		CDebugVar* bp = static_cast<CDebugVar*>(*i);
 		delete bp;
 	}
@@ -4126,7 +4126,7 @@ bool CDebugVar::SaveVars(char* name) {
 
 	std::vector<CDebugVar*>::iterator i;
 	CDebugVar* bp;
-	for(i=varList.begin(); i != varList.end(); i++) {
+	for(i=varList.begin(); i != varList.end(); ++i) {
 		bp = static_cast<CDebugVar*>(*i);
 		// name
 		fwrite(bp->GetName(),1,16,f);

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -252,11 +252,11 @@ void DEBUG_RefreshPage(char scroll) {
 	if (dbg.win_out == NULL) return;
 
 	while (scroll < 0 && logBuffPos!=logBuff.begin()) {
-        logBuffPos--;
+        --logBuffPos;
         scroll++;
     }
 	while (scroll > 0 && logBuffPos!=logBuff.end()) {
-        logBuffPos++;
+        ++logBuffPos;
         scroll--;
     }
 
@@ -282,7 +282,7 @@ void DEBUG_RefreshPage(char scroll) {
      *
      *      rem_lines starts out as the number of lines in the subwin. */
     if (i != logBuff.begin()) {
-        i--;
+        --i;
 
         wattrset(dbg.win_out,0);
         while (rem_lines > 0) {
@@ -291,7 +291,7 @@ void DEBUG_RefreshPage(char scroll) {
             DBGUI_DrawDebugOutputLine(rem_lines,*i);
 
             if (i != logBuff.begin())
-                i--;
+                --i;
             else
                 break;
         }
@@ -649,7 +649,7 @@ void DEBUG_ShowMsg(char const* format,...) {
 	logBuff.push_back(buf);
 	if (logBuff.size() > MAX_LOG_BUFFER) {
         logBuffHasDiscarded = true;
-        if (logBuffPos == logBuff.begin()) logBuffPos++; /* keep the iterator valid */
+        if (logBuffPos == logBuff.begin()) ++logBuffPos; /* keep the iterator valid */
 		logBuff.pop_front();
     }
 

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -260,7 +260,7 @@ int CDROM_Interface_Image::GetTrack(int sector)
 		Track &curr = *i;
 		Track &next = *(i + 1);
 		if (curr.start <= sector && sector < next.start) return curr.number;
-		i++;
+		++i;
 	}
 	return -1;
 }
@@ -596,7 +596,7 @@ bool CDROM_Interface_Image::AddTrack(Track &curr, int &shift, int prestart, int 
 bool CDROM_Interface_Image::HasDataTrack(void)
 {
 	//Data track has attribute 0x40
-	for(track_it it = tracks.begin(); it != tracks.end(); it++) {
+	for(track_it it = tracks.begin(); it != tracks.end(); ++it) {
 		if ((*it).attr == 0x40) return true;
 	}
 	return false;
@@ -706,7 +706,7 @@ void CDROM_Interface_Image::ClearTracks()
 			delete curr.file;
 			last = curr.file;
 		}
-		i++;
+		++i;
 	}
 	tracks.clear();
 }

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -152,6 +152,7 @@ DOS_File& DOS_File::operator= (const DOS_File& orig) {
         open = orig.open;
         hdrive = orig.hdrive;
         drive = orig.drive;
+        newtime = orig.newtime;
         if (name) {
             delete[] name; name = 0;
         }

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -1145,7 +1145,6 @@ Bit8u DOS_FCBRead(Bit16u seg,Bit16u offset,Bit16u recno) {
 	if (++cur_rec>127u) { cur_block++;cur_rec=0; }
 	fcb.SetRecord(cur_block,cur_rec);
 	if (toread==rec_size) return FCB_SUCCESS;
-	if (toread==0) return FCB_READ_NODATA;
 	return FCB_READ_PARTIAL;
 }
 

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -80,7 +80,7 @@ bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 		return false; 
 	}
 	r=0;w=0;
-	while (name_int[r]!=0 && (r<DOS_PATHLENGTH)) {
+	while (r<DOS_PATHLENGTH && name_int[r]!=0) {
 		Bit8u c=(Bit8u)name_int[r++];
 		if ((c>='a') && (c<='z')) c-=32;
 		else if (c==' ') continue; /* should be separator */

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -67,7 +67,7 @@ void DOS_AddMultiplexHandler(MultiplexHandler * handler) {
 }
 
 void DOS_DelMultiplexHandler(MultiplexHandler * handler) {
-	for(Multiplex_it it =Multiplex.begin();it != Multiplex.end();it++) {
+	for(Multiplex_it it =Multiplex.begin();it != Multiplex.end();++it) {
 		if(*it == handler) {
 			Multiplex.erase(it);
 			return;
@@ -76,7 +76,7 @@ void DOS_DelMultiplexHandler(MultiplexHandler * handler) {
 }
 
 static Bitu INT2F_Handler(void) {
-	for(Multiplex_it it = Multiplex.begin();it != Multiplex.end();it++)
+	for(Multiplex_it it = Multiplex.begin();it != Multiplex.end();++it)
 		if( (*it)() ) return CBRET_NONE;
    
 	LOG(LOG_DOSMISC,LOG_ERROR)("DOS:INT 2F Unhandled call AX=%4X",reg_ax);

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -176,7 +176,7 @@ CMscdex::CMscdex(void) {
 CMscdex::~CMscdex(void) {
 	defaultBufSeg = 0;
 	for (Bit16u i=0; i<GetNumDrives(); i++) {
-		delete (cdrom)[i];
+		delete cdrom[i];
 		cdrom[i] = 0;
 	}
 }
@@ -211,7 +211,7 @@ int CMscdex::RemoveDrive(Bit16u _drive)
 	}
 
 	if (idx == MSCDEX_MAX_DRIVES || (idx!=0 && idx!=GetNumDrives()-1)) return 0;
-	delete (cdrom)[idx];
+	delete cdrom[idx];
 	if (idx==0) {
 		for (Bit16u i=0; i<GetNumDrives(); i++) {
 			if (i == MSCDEX_MAX_DRIVES-1) {

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2206,10 +2206,12 @@ restart_int:
             host_writew(&sbuf[0x1a],h);
             // hidden sectors
             host_writed(&sbuf[0x1c],(Bit32u)bootsect_pos);
-            // sectors (large disk) - this is the same as partition length in MBR
-            if(mediadesc == 0xF8) host_writed(&sbuf[0x20],sectors-s);
-            // BIOS drive
-            if(mediadesc == 0xF8) sbuf[0x24]=0x80;
+            if(mediadesc == 0xF8) {
+                // sectors (large disk) - this is the same as partition length in MBR
+                host_writed(&sbuf[0x20],sectors-s);
+                // BIOS drive
+                sbuf[0x24]=0x80;
+            }
             else sbuf[0x24]=0x00;
             // ext. boot signature
             sbuf[0x26]=0x29;

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2869,7 +2869,7 @@ public:
         }
         else if (ideattach != "none" && isdigit(ideattach[0]) && ideattach[0] > '0') { /* takes the form [controller]<m/s> such as: 1m for primary master */
             ide_index = ideattach[0] - '1';
-            if (ideattach.length() >= 1) ide_slave = (ideattach[1] == 's');
+            if (ideattach.length() >= 2) ide_slave = (ideattach[1] == 's');
             LOG_MSG("IDE: index %d slave=%d",ide_index,ide_slave?1:0);
         }
 

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -537,9 +537,8 @@ bool localDrive::GetSystemFilename(char *sysName, char const * const dosName) {
     return false;
 #else
     strcpy(sysName,host_name);
+    return true;
 #endif
-
-	return true;
 }
 
 bool localDrive::FileUnlink(const char * name) {

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -508,7 +508,7 @@ FILE * localDrive::GetSystemFilePtr(char const * const name, char const * const 
     unsigned int tis;
 
     // "type" always has ANSI chars (like "rb"), nothing fancy
-    for (tis=0;type[tis] != 0 && tis < 7;tis++) wtype[tis] = (wchar_t)type[tis];
+    for (tis=0;tis < 7 && type[tis] != 0;tis++) wtype[tis] = (wchar_t)type[tis];
     assert(tis < 7); // guard
     wtype[tis] = 0;
 

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -675,9 +675,7 @@ void DOSBoxMenu::displaylist_append(displaylist &ls,const DOSBoxMenu::item_handl
 
 void DOSBoxMenu::displaylist_clear(DOSBoxMenu::displaylist &ls) {
     for (auto &id : ls.disp_list) {
-        if (id != DOSBoxMenu::unassigned_item_handle) {
-            id = DOSBoxMenu::unassigned_item_handle;
-        }
+        id = DOSBoxMenu::unassigned_item_handle;
     }
 
     ls.disp_list.clear();
@@ -1721,18 +1719,14 @@ void DOSBoxMenu::item::showItem(DOSBoxMenu &menu,bool show) {
 
 DOSBoxMenu::item &DOSBoxMenu::item::setHilight(DOSBoxMenu &menu,bool hi) {
     (void)menu;//UNUSED
-    if (itemHilight != hi) {
-        itemHilight = hi;
-    }
+    itemHilight = hi;
 
     return *this;
 }
 
 DOSBoxMenu::item &DOSBoxMenu::item::setHover(DOSBoxMenu &menu,bool ho) {
     (void)menu;//UNUSED
-    if (itemHover != ho) {
-        itemHover = ho;
-    }
+    itemHover = ho;
 
     return *this;
 }

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -782,7 +782,7 @@ void RENDER_SetSize(Bitu width,Bitu height,Bitu bpp,float fps,double scrn_ratio)
     } else if(ratio < 0.75) {
         dblw=true;
         ratio *= 2.0;
-    } else if(!dblw && !dblh && (width < 370) && (height < 280)) {
+    } else if(width < 370 && height < 280) {
         dblw=true; dblh=true;
     }
     LOG_MSG("pixratio %1.3f, dw %s, dh %s",ratio,dblw?"true":"false",dblh?"true":"false");

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -639,7 +639,7 @@ void CEvent::AddBind(CBind * bind) {
     bind->event=this;
 }
 void CEvent::DeActivateAll(void) {
-    for (CBindList_it bit=bindlist.begin();bit!=bindlist.end();bit++) {
+    for (CBindList_it bit=bindlist.begin();bit!=bindlist.end();++bit) {
         (*bit)->DeActivateBind(true);
     }
 }
@@ -1883,19 +1883,19 @@ protected:
 void CBindGroup::ActivateBindList(CBindList * list,Bits value,bool ev_trigger) {
     Bitu validmod=0;
     CBindList_it it;
-    for (it=list->begin();it!=list->end();it++) {
+    for (it=list->begin();it!=list->end();++it) {
         if (((*it)->mods & mapper.mods) == (*it)->mods) {
             if (validmod<(*it)->mods) validmod=(*it)->mods;
         }
     }
-    for (it=list->begin();it!=list->end();it++) {
+    for (it=list->begin();it!=list->end();++it) {
         if (validmod==(*it)->mods) (*it)->ActivateBind(value,ev_trigger);
     }
 }
 
 void CBindGroup::DeactivateBindList(CBindList * list,bool ev_trigger) {
     CBindList_it it;
-    for (it=list->begin();it!=list->end();it++) {
+    for (it=list->begin();it!=list->end();++it) {
         (*it)->DeActivateBind(ev_trigger);
     }
 }
@@ -2092,7 +2092,7 @@ public:
             break;
         case BB_Next:
             if (mapper.abindit!=mapper.aevent->bindlist.end()) 
-                mapper.abindit++;
+                ++mapper.abindit;
             if (mapper.abindit==mapper.aevent->bindlist.end()) 
                 mapper.abindit=mapper.aevent->bindlist.begin();
             SetActiveBind(*(mapper.abindit));
@@ -2773,7 +2773,7 @@ static void DrawButtons(void) {
     SDL_FillRect(mapper.surface,0,CLR_BLACK);
     SDL_LockSurface(mapper.surface);
 #endif
-    for (CButton_it but_it = buttons.begin();but_it!=buttons.end();but_it++) {
+    for (CButton_it but_it = buttons.begin();but_it!=buttons.end();++but_it) {
         (*but_it)->Draw();
     }
 #if defined(C_SDL2)
@@ -3101,7 +3101,7 @@ static void CreateLayout(void) {
     AddModButton(PX(6),PY(17),50,20,"Host",4);
     /* Create Handler buttons */
     Bitu xpos=3;Bitu ypos=11;
-    for (CHandlerEventVector_it hit=handlergroup.begin();hit!=handlergroup.end();hit++) {
+    for (CHandlerEventVector_it hit=handlergroup.begin();hit!=handlergroup.end();++hit) {
         unsigned int columns = ((unsigned int)strlen((*hit)->ButtonName()) + 9U) / 10U;
         if ((xpos+columns-1)>6) {
             xpos=3;ypos++;
@@ -3158,7 +3158,7 @@ static void CreateStringBind(char * line,bool loading=false) {
     if (*line == 0) return;
     char * eventname=StripWord(line);
     CEvent * event;
-    for (CEventVector_it ev_it=events.begin();ev_it!=events.end();ev_it++) {
+    for (CEventVector_it ev_it=events.begin();ev_it!=events.end();++ev_it) {
         if (!strcasecmp((*ev_it)->GetName(),eventname)) {
             event=*ev_it;
             goto foundevent;
@@ -3178,7 +3178,7 @@ static void CreateStringBind(char * line,bool loading=false) {
 foundevent:
     CBind * bind;
     for (char * bindline=StripWord(line);*bindline;bindline=StripWord(line)) {
-        for (CBindGroup_it it=bindgroups.begin();it!=bindgroups.end();it++) {
+        for (CBindGroup_it it=bindgroups.begin();it!=bindgroups.end();++it) {
             bind=(*it)->CreateConfigBind(bindline);
             if (bind) {
                 event->AddBind(bind);
@@ -3377,7 +3377,7 @@ static void CreateDefaultBinds(void) {
 # endif
 #endif
 
-    for (CHandlerEventVector_it hit=handlergroup.begin();hit!=handlergroup.end();hit++) {
+    for (CHandlerEventVector_it hit=handlergroup.begin();hit!=handlergroup.end();++hit) {
         (*hit)->MakeDefaultBind(buffer);
         CreateStringBind(buffer);
     }
@@ -3424,7 +3424,7 @@ void MAPPER_AddHandler(MAPPER_Handler * handler,MapKeys key,Bitu mods,char const
     strcat(tempname,eventname);
 
     //Check if it already exists=> if so return.
-    for(CHandlerEventVector_it it=handlergroup.begin();it!=handlergroup.end();it++) {
+    for(CHandlerEventVector_it it=handlergroup.begin();it!=handlergroup.end();++it) {
         if(strcmp((*it)->buttonname,buttonname) == 0) {
             if (ret_menuitem != NULL)
                 *ret_menuitem = &mainMenu.get_item(std::string("mapper_") + std::string(eventname));
@@ -3494,10 +3494,10 @@ static void MAPPER_SaveBinds(void) {
         return;
     }
     char buf[128];
-    for (CEventVector_it event_it=events.begin();event_it!=events.end();event_it++) {
+    for (CEventVector_it event_it=events.begin();event_it!=events.end();++event_it) {
         CEvent * event=*(event_it);
         fprintf(savefile,"%s ",event->GetName());
-        for (CBindList_it bind_it=event->bindlist.begin();bind_it!=event->bindlist.end();bind_it++) {
+        for (CBindList_it bind_it=event->bindlist.begin();bind_it!=event->bindlist.end();++bind_it) {
             CBind * bind=*(bind_it);
             bind->ConfigName(buf);
             bind->AddFlags(buf);
@@ -3522,7 +3522,7 @@ static bool MAPPER_LoadBinds(void) {
 }
 
 void MAPPER_CheckEvent(SDL_Event * event) {
-    for (CBindGroup_it it=bindgroups.begin();it!=bindgroups.end();it++) {
+    for (CBindGroup_it it=bindgroups.begin();it!=bindgroups.end();++it) {
         if ((*it)->CheckEvent(event)) return;
     }
 
@@ -3536,7 +3536,7 @@ void MAPPER_CheckEvent(SDL_Event * event) {
 
 void Mapper_MouseInputEvent(SDL_Event &event) {
     /* Check the press */
-    for (CButton_it but_it = buttons.begin();but_it!=buttons.end();but_it++) {
+    for (CButton_it but_it = buttons.begin();but_it!=buttons.end();++but_it) {
         if ((*but_it)->OnTop(event.button.x,event.button.y)) {
             (*but_it)->Click();
         }
@@ -3699,7 +3699,7 @@ void BIND_MappingEvents(void) {
             /* fall through to mapper UI processing */
         default:
             if (mapper.addbind) {
-                for (CBindGroup_it it=bindgroups.begin();it!=bindgroups.end();it++) {
+                for (CBindGroup_it it=bindgroups.begin();it!=bindgroups.end();++it) {
                     CBind * newbind=(*it)->CreateEventBind(&event);
                     if (!newbind) continue;
                     mapper.aevent->AddBind(newbind);
@@ -3835,14 +3835,14 @@ void MAPPER_UpdateJoysticks(void) {
 #endif
 
 void MAPPER_LosingFocus(void) {
-    for (CEventVector_it evit=events.begin();evit!=events.end();evit++) {
+    for (CEventVector_it evit=events.begin();evit!=events.end();++evit) {
         if(*evit != caps_lock_event && *evit != num_lock_event)
             (*evit)->DeActivateAll();
     }
 }
 
 void MAPPER_ReleaseAllKeys(void) {
-    for (CEventVector_it evit=events.begin();evit!=events.end();evit++) {
+    for (CEventVector_it evit=events.begin();evit!=events.end();++evit) {
         if ((*evit)->active) {
             LOG_MSG("Release");
             (*evit)->Active(false);
@@ -4064,11 +4064,11 @@ void MAPPER_Init(void) {
     CreateLayout();
     CreateBindGroups();
     if (!MAPPER_LoadBinds()) CreateDefaultBinds();
-    for (CButton_it but_it = buttons.begin(); but_it != buttons.end(); but_it++) {
+    for (CButton_it but_it = buttons.begin(); but_it != buttons.end(); ++but_it) {
         (*but_it)->BindColor();
     }
     if (SDL_GetModState()&KMOD_CAPS) {
-        for (CBindList_it bit=caps_lock_event->bindlist.begin();bit!=caps_lock_event->bindlist.end();bit++) {
+        for (CBindList_it bit=caps_lock_event->bindlist.begin();bit!=caps_lock_event->bindlist.end();++bit) {
 #if SDL_VERSION_ATLEAST(1, 2, 14)
             (*bit)->ActivateBind(32767,true,false);
             (*bit)->DeActivateBind(false);
@@ -4078,7 +4078,7 @@ void MAPPER_Init(void) {
         }
     }
     if (SDL_GetModState()&KMOD_NUM) {
-        for (CBindList_it bit=num_lock_event->bindlist.begin();bit!=num_lock_event->bindlist.end();bit++) {
+        for (CBindList_it bit=num_lock_event->bindlist.begin();bit!=num_lock_event->bindlist.end();++bit) {
 #if SDL_VERSION_ATLEAST(1, 2, 14)
             (*bit)->ActivateBind(32767,true,false);
             (*bit)->DeActivateBind(false);

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -3711,10 +3711,8 @@ IDEController::~IDEController() {
 
 static void IDE_PC98_Select(Bitu val) {
     val &= 1;
-    if (pc98_ide_select != val) {
-        pc98_ide_select = val;
-        // TODO: IRQ raise by signal
-    }
+    pc98_ide_select = val;
+    // TODO: IRQ raise by signal
 }
 
 static void ide_pc98ctlio_w(Bitu port,Bitu val,Bitu iolen) {

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -2196,13 +2196,12 @@ static bool pc98_mouse_tick_scheduled = false;
 static void pc98_mouse_tick_event(Bitu val) {
     (void)val;
 
-    /* Generate interrupt */
-    if (p7fd8_8255_mouse_int_enable)
+    if (p7fd8_8255_mouse_int_enable) {
+        /* Generate interrupt */
         PIC_ActivateIRQ(MOUSE_IRQ);
-
-    /* keep the periodic interrupt going */
-    if (p7fd8_8255_mouse_int_enable)
+        /* keep the periodic interrupt going */
         PIC_AddEvent(pc98_mouse_tick_event,pc98_mouse_tick_interval_ms());
+    }
     else
         pc98_mouse_tick_scheduled = false;
 }

--- a/src/hardware/mame/ymf262.cpp
+++ b/src/hardware/mame/ymf262.cpp
@@ -1777,8 +1777,8 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 					if (chip->timer_handler) (chip->timer_handler)(chip->TimerParam,0,period);
 				}
 			}
-#endif
 		break;
+#endif
 		case 0x08:  /* x,NTS,x,x, x,x,x,x */
 			chip->nts = v;
 		break;

--- a/src/hardware/mame/ymf262.cpp
+++ b/src/hardware/mame/ymf262.cpp
@@ -1490,19 +1490,6 @@ static inline void set_mul(OPL3 *chip,int slot,int v)
 		//else normal 2 operator function
 		switch(chan_no)
 		{
-		case 0: case 1: case 2:
-		case 9: case 10: case 11:
-			if (CH->extended)
-			{
-				/* normal */
-				CALC_FCSLOT(CH,SLOT);
-			}
-			else
-			{
-				/* normal */
-				CALC_FCSLOT(CH,SLOT);
-			}
-		break;
 		case 3: case 4: case 5:
 		case 12: case 13: case 14:
 			if ((CH-3)->extended)
@@ -1553,19 +1540,6 @@ static inline void set_ksl_tl(OPL3 *chip,int slot,int v)
 		//else normal 2 operator function
 		switch(chan_no)
 		{
-		case 0: case 1: case 2:
-		case 9: case 10: case 11:
-			if (CH->extended)
-			{
-				/* normal */
-				SLOT->TLL = SLOT->TL + (CH->ksl_base>>SLOT->ksl);
-			}
-			else
-			{
-				/* normal */
-				SLOT->TLL = SLOT->TL + (CH->ksl_base>>SLOT->ksl);
-			}
-		break;
 		case 3: case 4: case 5:
 		case 12: case 13: case 14:
 			if ((CH-3)->extended)

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -71,10 +71,8 @@ struct PIT_Block {
     read_counter_result     last_counter;       /* what to return when gate == false (not counting) */
 
     void set_output(bool on) {
-        if (output != on) {
-            output = on;
-            // TODO: Event callback
-        }
+        output = on;
+        // TODO: Event callback
     }
 
     void set_next_counter(Bitu new_cntr) {

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -1196,10 +1196,8 @@ Bitu XGA_Read(Bitu port, Bitu len) {
 		case 0x8118:
 		case 0x9ae8:
 			return 0x400; // nothing busy
-			break;
 		case 0x81ec: // S3 video data processor
-			return 0x00007000; 
-			break;
+			return 0x00007000;
 		case 0x83da:
 			{
 				Bits delaycyc = CPU_CycleMax/5000;
@@ -1207,7 +1205,6 @@ Bitu XGA_Read(Bitu port, Bitu len) {
 				CPU_Cycles -= delaycyc;
 				CPU_IODelayRemoved += delaycyc;
 				return vga_read_p3da(0,0);
-				break;
 			}
 		case 0x83d4:
 			if(len==1) return vga_read_p3d4(0,0);
@@ -1224,16 +1221,12 @@ Bitu XGA_Read(Bitu port, Bitu len) {
 			return XGA_Read_Multifunc();
 		case 0xa2e8:
 			return XGA_GetDualReg(xga.backcolor);
-			break;
 		case 0xa6e8:
 			return XGA_GetDualReg(xga.forecolor);
-			break;
 		case 0xaae8:
 			return XGA_GetDualReg(xga.writemask);
-			break;
 		case 0xaee8:
 			return XGA_GetDualReg(xga.readmask);
-			break;
 		default:
 			//LOG_MSG("XGA: Read from port %x, len %x", port, len);
 			break;

--- a/src/hardware/voodoo_emu.cpp
+++ b/src/hardware/voodoo_emu.cpp
@@ -2779,18 +2779,14 @@ UINT32 register_r(UINT32 offset)
 			//result |= v->fbi.vblank << 6;
 			result |= (Voodoo_GetRetrace() ? 0x40u : 0u);
 
-
-			/* bit 7 is FBI graphics engine busy */
-			if (v->pci.op_pending)
+			if (v->pci.op_pending) {
+				/* bit 7 is FBI graphics engine busy */
 				result |= 1 << 7;
-
-			/* bit 8 is TREX busy */
-			if (v->pci.op_pending)
+				/* bit 8 is TREX busy */
 				result |= 1 << 8;
-
-			/* bit 9 is overall busy */
-			if (v->pci.op_pending)
+				/* bit 9 is overall busy */
 				result |= 1 << 9;
+			}
 
 			/* bits 11:10 specifies which buffer is visible */
 			result |= (UINT32)(v->fbi.frontbuf << 10);

--- a/src/hardware/voodoo_opengl.cpp
+++ b/src/hardware/voodoo_opengl.cpp
@@ -422,7 +422,7 @@ void ogl_cache_texture(const poly_extra_data *extra, ogl_texture_data *td) {
 //						LOG_MSG("texture removed... size %d",t->second.ids->size());
 						if (t->second.ids->size() > 8) {
 							std::map<const UINT32, GLuint>::iterator u;
-							for (u=t->second.ids->begin(); u!=t->second.ids->end(); u++) {
+							for (u=t->second.ids->begin(); u!=t->second.ids->end(); ++u) {
 								glDeleteTextures(1,&u->second);
 							}
 							t->second.ids->clear();
@@ -534,7 +534,7 @@ void ogl_cache_texture(const poly_extra_data *extra, ogl_texture_data *td) {
 void voodoo_ogl_invalidate_paltex(void) {
 	std::map<const UINT32, ogl_texmap>::iterator t;
 	for (int j=0; j<2; j++) {
-		for (t=textures[j].begin(); t!=textures[j].end(); t++) {
+		for (t=textures[j].begin(); t!=textures[j].end(); ++t) {
 			if ((t->second.format == 0x05) || (t->second.format == 0x0e)) {
 				t->second.valid_pal = false;
 			}
@@ -1304,7 +1304,7 @@ void voodoo_ogl_texture_clear(UINT32 texbase, int TMU) {
 		VOGL_ClearBeginMode();
 		if (t->second.ids != NULL) {
 			std::map<const UINT32, GLuint>::iterator u;
-			for (u=t->second.ids->begin(); u!=t->second.ids->end(); u++) {
+			for (u=t->second.ids->begin(); u!=t->second.ids->end(); ++u) {
 				glDeleteTextures(1,&u->second);
 			}
 			delete t->second.ids;
@@ -1825,10 +1825,10 @@ void voodoo_ogl_leave(bool leavemode) {
 
 	std::map<const UINT32, ogl_texmap>::iterator t;
 	for (int j=0; j<2; j++) {
-		for (t=textures[j].begin(); t!=textures[j].end(); t++) {
+		for (t=textures[j].begin(); t!=textures[j].end(); ++t) {
 			if (t->second.ids != NULL) {
 				std::map<const UINT32, GLuint>::iterator u;
-				for (u=t->second.ids->begin(); u!=t->second.ids->end(); u++) {
+				for (u=t->second.ids->begin(); u!=t->second.ids->end(); ++u) {
 					glDeleteTextures(1,&u->second);
 				}
 				if (!t->second.ids->empty()) t->second.ids->clear();

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -1327,7 +1327,7 @@ imageDiskVFD::vfdentry *imageDiskVFD::findSector(Bit8u head,Bit8u track,Bit8u se
             (ent.sizebyte == szb || req_sector_size == ~0U))
             return &(*i);
 
-        i++;
+        ++i;
     }
 
     return NULL;
@@ -1724,7 +1724,7 @@ imageDiskD88::vfdentry *imageDiskD88::findSector(Bit8u head,Bit8u track,Bit8u se
             (ent.sector_size == req_sector_size || req_sector_size == ~0U))
             return &(*i);
 
-        i++;
+        ++i;
     }
 
     return NULL;
@@ -2020,7 +2020,7 @@ imageDiskNFD::vfdentry *imageDiskNFD::findSector(Bit8u head,Bit8u track,Bit8u se
             (ent.sector_size == req_sector_size || req_sector_size == ~0U))
             return &(*i);
 
-        i++;
+        ++i;
     }
 
     return NULL;

--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -1753,7 +1753,7 @@ public:
 	}
 	
 	~EMS() {
-		if (ems_type<=0) return;
+		if (ems_type==0) return;
 
 		/* Undo Biosclearing */
 		BIOS_ZeroExtendedSize(false);

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -999,7 +999,7 @@ bool Load_Anex86_Font(void) {
     FILE *fp = NULL;
 
     /* ANEX86.BMP accurate dump of actual font */
-    if (!fp) fp = fopen("anex86.bmp","rb");
+    fp = fopen("anex86.bmp","rb");
     if (!fp) fp = fopen("ANEX86.bmp","rb");
     if (!fp) fp = fopen("ANEX86.BMP","rb");
 

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -1925,12 +1925,10 @@ dac_text16:
 		}
 
         /* SVGA text modes need the 256k+ access bit */
-        if (CurMode->mode >= 0x100 && !int10.vesa_nolfb)
+        if (CurMode->mode >= 0x100 && !int10.vesa_nolfb) {
             reg_31 |= 8; /* enable 256k+ access */
-
-        /* whether to enable the linear framebuffer */
-        if (CurMode->mode >= 0x100 && !int10.vesa_nolfb)
             s3_mode |= 0x10; /* enable LFB */
+        }
 
 		IO_Write(crtc_base,0x3a);IO_Write(crtc_base+1u,reg_3a);
 		IO_Write(crtc_base,0x31);IO_Write(crtc_base+1u,reg_31);	//Enable banked memory and 256k+ access

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -619,9 +619,7 @@ void Mouse_CursorMoved(float xrel,float yrel,float x,float y,bool emulate) {
 
         /* PC-98 mouse */
         if (IS_PC98_ARCH) pc98_mouse_movement_apply(xrel,yrel);
-    }
 
-    if (user_cursor_locked) {
         mouse.mickey_x += (dx * mouse.mickeysPerPixel_x);
         mouse.mickey_y += (dy * mouse.mickeysPerPixel_y);
         if (mouse.mickey_x >= 32768.0) mouse.mickey_x -= 65536.0;

--- a/src/ints/qcow2_disk.cpp
+++ b/src/ints/qcow2_disk.cpp
@@ -73,6 +73,7 @@ using namespace std;
             size_t readResult = fread(backing_file_name, header.backing_file_size, 1, file);
             if (readResult != 1) {
                 LOG(LOG_IO, LOG_ERROR) ("Reading error in QCow2Image constructor\n");
+                delete[] backing_file_name;
                 return;
             }
 			if (backing_file_name[0] != 0x2F){

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -856,7 +856,7 @@ bool Window::mouseMoved(int x, int y)
 	bool end = (i == children.rend());
 	while (!end) {
 		Window *w = *i;
-		i++;
+		++i;
 		end = (i == children.rend());
 		if (w->visible && x >= w->x && x <= w->x+w->width
 			&& y >= w->y && y <= w->y+w->height
@@ -891,7 +891,7 @@ bool Window::mouseDownOutside(MouseButton button) {
 				handled = true;
 		}
 
-		i++;
+		++i;
 	}
 
     return handled;
@@ -922,7 +922,7 @@ bool Window::mouseDown(int x, int y, MouseButton button)
             handled |= w->mouseDownOutside(button);
         }
 
-		i++;
+		++i;
 	}
 
 	mouseChild = NULL;

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -45,7 +45,7 @@ typedef list<MessageBlock>::iterator itmb;
 
 void MSG_Add(const char * _name, const char* _val) {
 	/* Find the message */
-	for(itmb tel=Lang.begin();tel!=Lang.end();tel++) {
+	for(itmb tel=Lang.begin();tel!=Lang.end();++tel) {
 		if((*tel).name==_name) { 
 //			LOG_MSG("double entry for %s",_name); //Message file might be loaded before default text messages
 			return;
@@ -57,7 +57,7 @@ void MSG_Add(const char * _name, const char* _val) {
 
 void MSG_Replace(const char * _name, const char* _val) {
 	/* Find the message */
-	for(itmb tel=Lang.begin();tel!=Lang.end();tel++) {
+	for(itmb tel=Lang.begin();tel!=Lang.end();++tel) {
 		if((*tel).name==_name) { 
 			Lang.erase(tel);
 			break;
@@ -118,7 +118,7 @@ void LoadMessageFile(const char * fname) {
 }
 
 const char * MSG_Get(char const * msg) {
-	for(itmb tel=Lang.begin();tel!=Lang.end();tel++){	
+	for(itmb tel=Lang.begin();tel!=Lang.end();++tel){
 		if((*tel).name==msg)
 		{
 			return  (*tel).val.c_str();
@@ -131,7 +131,7 @@ const char * MSG_Get(char const * msg) {
 bool MSG_Write(const char * location) {
 	FILE* out=fopen(location,"w+t");
 	if(out==NULL) return false;//maybe an error?
-	for(itmb tel=Lang.begin();tel!=Lang.end();tel++){
+	for(itmb tel=Lang.begin();tel!=Lang.end();++tel){
 		fprintf(out,":%s\n%s\n.\n",(*tel).name.c_str(),(*tel).val.c_str());
 	}
 	fclose(out);

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -235,7 +235,7 @@ string Value::ToString() const {
 
 bool Property::CheckValue(Value const& in, bool warn) {
     if (suggested_values.empty()) return true;
-    for(iter it = suggested_values.begin();it != suggested_values.end();it++) {
+    for(iter it = suggested_values.begin();it != suggested_values.end();++it) {
         if ( (*it) == in) { //Match!
             return true;
         }
@@ -610,7 +610,7 @@ Prop_multival_remain* Section_prop::Add_multiremain(std::string const& _propname
 }
 
 int Section_prop::Get_int(string const&_propname) const {
-    for(const_it tel=properties.begin();tel!=properties.end();tel++) {
+    for(const_it tel=properties.begin();tel!=properties.end();++tel) {
         if ((*tel)->propname==_propname) {
             return ((*tel)->GetValue());
         }
@@ -619,7 +619,7 @@ int Section_prop::Get_int(string const&_propname) const {
 }
 
 bool Section_prop::Get_bool(string const& _propname) const {
-    for(const_it tel=properties.begin();tel!=properties.end();tel++) {
+    for(const_it tel=properties.begin();tel!=properties.end();++tel) {
         if ((*tel)->propname==_propname) {
             return ((*tel)->GetValue());
         }
@@ -628,7 +628,7 @@ bool Section_prop::Get_bool(string const& _propname) const {
 }
 
 double Section_prop::Get_double(string const& _propname) const {
-    for(const_it tel=properties.begin();tel!=properties.end();tel++) {
+    for(const_it tel=properties.begin();tel!=properties.end();++tel) {
         if ((*tel)->propname==_propname) {
             return ((*tel)->GetValue());
         }
@@ -637,7 +637,7 @@ double Section_prop::Get_double(string const& _propname) const {
 }
 
 Prop_path* Section_prop::Get_path(string const& _propname) const {
-    for(const_it tel=properties.begin();tel!=properties.end();tel++) {
+    for(const_it tel=properties.begin();tel!=properties.end();++tel) {
         if ((*tel)->propname==_propname) {
             Prop_path* val = dynamic_cast<Prop_path*>((*tel));
             if (val) return val; else return NULL;
@@ -647,7 +647,7 @@ Prop_path* Section_prop::Get_path(string const& _propname) const {
 }
 
 Prop_multival* Section_prop::Get_multival(string const& _propname) const {
-    for(const_it tel=properties.begin();tel!=properties.end();tel++) {
+    for(const_it tel=properties.begin();tel!=properties.end();++tel) {
         if ((*tel)->propname==_propname) {
             Prop_multival* val = dynamic_cast<Prop_multival*>((*tel));
             if (val) return val; else return NULL;
@@ -657,7 +657,7 @@ Prop_multival* Section_prop::Get_multival(string const& _propname) const {
 }
 
 Prop_multival_remain* Section_prop::Get_multivalremain(string const& _propname) const {
-    for(const_it tel=properties.begin();tel!=properties.end();tel++) {
+    for(const_it tel=properties.begin();tel!=properties.end();++tel) {
         if ((*tel)->propname==_propname) {
             Prop_multival_remain* val = dynamic_cast<Prop_multival_remain*>((*tel));
             if (val) return val; else return NULL;
@@ -667,14 +667,14 @@ Prop_multival_remain* Section_prop::Get_multivalremain(string const& _propname) 
 }
 
 Property* Section_prop::Get_prop(int index) {
-    for(it tel=properties.begin();tel!=properties.end();tel++) {
+    for(it tel=properties.begin();tel!=properties.end();++tel) {
         if (!index--) return (*tel);
     }
     return NULL;
 }
 
 Property* Section_prop::Get_prop(string const& _propname) {
-    for(it tel=properties.begin();tel!=properties.end();tel++) {
+    for(it tel=properties.begin();tel!=properties.end();++tel) {
         if ((*tel)->propname==_propname) {
             return (*tel);
         }
@@ -683,7 +683,7 @@ Property* Section_prop::Get_prop(string const& _propname) {
 }
 
 const char* Section_prop::Get_string(string const& _propname) const {
-    for(const_it tel=properties.begin();tel!=properties.end();tel++) {
+    for(const_it tel=properties.begin();tel!=properties.end();++tel) {
         if ((*tel)->propname==_propname) {
             return ((*tel)->GetValue());
         }
@@ -691,7 +691,7 @@ const char* Section_prop::Get_string(string const& _propname) const {
     return "";
 }
 Hex Section_prop::Get_hex(string const& _propname) const {
-    for(const_it tel=properties.begin();tel!=properties.end();tel++) {
+    for(const_it tel=properties.begin();tel!=properties.end();++tel) {
         if ((*tel)->propname==_propname) {
             return ((*tel)->GetValue());
         }
@@ -715,11 +715,11 @@ bool Section_prop::HandleInputline(string const& gegevens) {
 	   ) val = val.substr(1,length - 2);
     /* trim the results incase there were spaces somewhere */
     trim(name);trim(val);
-    for(it tel = properties.begin();tel != properties.end();tel++) {
+    for(it tel = properties.begin();tel != properties.end();++tel) {
         if (!strcasecmp((*tel)->propname.c_str(),name.c_str())) {
             if (!((*tel)->SetValue(val))) return false;
 
-            for (std::list<SectionFunction>::iterator i=onpropchange.begin();i!=onpropchange.end();i++)
+            for (std::list<SectionFunction>::iterator i=onpropchange.begin();i!=onpropchange.end();++i)
                 (*i)(this);
 
             return true;
@@ -732,12 +732,12 @@ void Section_prop::PrintData(FILE* outfile,bool everything) {
     /* Now print out the individual section entries */
     size_t len = 0;
     // Determine maximum length of the props in this section
-    for(const_it tel = properties.begin();tel != properties.end();tel++) {
+    for(const_it tel = properties.begin();tel != properties.end();++tel) {
         if ((*tel)->propname.length() > len)
             len = (*tel)->propname.length();
     }
 
-    for(const_it tel = properties.begin();tel != properties.end();tel++) {
+    for(const_it tel = properties.begin();tel != properties.end();++tel) {
         if (!everything && !(*tel)->modified()) continue;
 
         fprintf(outfile,"%-*s = %s\n", (unsigned int)len, (*tel)->propname.c_str(), (*tel)->GetValue().ToString().c_str());
@@ -745,7 +745,7 @@ void Section_prop::PrintData(FILE* outfile,bool everything) {
 }
 
 string Section_prop::GetPropValue(string const& _property) const {
-    for(const_it tel=properties.begin();tel!=properties.end();tel++) {
+    for(const_it tel=properties.begin();tel!=properties.end();++tel) {
         if (!strcasecmp((*tel)->propname.c_str(),_property.c_str())) {
             return (*tel)->GetValue().ToString();
         }
@@ -781,7 +781,7 @@ bool Config::PrintConfig(char const * const configfilename,bool everything) cons
     /* Print start of configfile and add a return to improve readibility. */
     fprintf(outfile,MSG_Get("CONFIGFILE_INTRO"),VERSION);
     fprintf(outfile,"\n");
-    for (const_it tel=sectionlist.begin(); tel!=sectionlist.end(); tel++) {
+    for (const_it tel=sectionlist.begin(); tel!=sectionlist.end(); ++tel) {
         /* Print out the Section header */
         strcpy(temp,(*tel)->GetName());
         lowcase(temp);
@@ -938,7 +938,7 @@ void DispatchVMEvent(enum vm_event event) {
     LOG(LOG_MISC,LOG_DEBUG)("Dispatching VM event %s",GetVMEventName(event));
 
     vm_dispatch_state.begin_event(event);
-    for (std::list<Function_wrapper>::iterator i=vm_event_functions[event].begin();i!=vm_event_functions[event].end();i++) {
+    for (std::list<Function_wrapper>::iterator i=vm_event_functions[event].begin();i!=vm_event_functions[event].end();++i) {
         LOG(LOG_MISC,LOG_DEBUG)("Calling event %s handler (%p) '%s'",GetVMEventName(event),(void*)((uintptr_t)((*i).function)),(*i).name.c_str());
         (*i).function(NULL);
     }
@@ -950,28 +950,28 @@ Config::~Config() {
     std::list<Section*>::iterator it; // FIXME: You guys do realize C++ STL provides reverse_iterator?
 
     while ((it=sectionlist.end()) != sectionlist.begin()) {
-        it--;
+        --it;
         delete (*it);
         sectionlist.erase(it);
     }
 }
 
 Section* Config::GetSection(int index) {
-    for (it tel=sectionlist.begin(); tel!=sectionlist.end(); tel++) {
+    for (it tel=sectionlist.begin(); tel!=sectionlist.end(); ++tel) {
         if (!index--) return (*tel);
     }
     return NULL;
 }
 
 Section* Config::GetSection(string const& _sectionname) const{
-    for (const_it tel=sectionlist.begin(); tel!=sectionlist.end(); tel++) {
+    for (const_it tel=sectionlist.begin(); tel!=sectionlist.end(); ++tel) {
         if (!strcasecmp((*tel)->GetName(),_sectionname.c_str())) return (*tel);
     }
     return NULL;
 }
 
 Section* Config::GetSectionFromProperty(char const * const prop) const{
-    for (const_it tel=sectionlist.begin(); tel!=sectionlist.end(); tel++) {
+    for (const_it tel=sectionlist.begin(); tel!=sectionlist.end(); ++tel) {
         if ((*tel)->GetPropValue(prop) != NO_SUCH_PROPERTY) return (*tel);
     }
     return NULL;
@@ -1067,7 +1067,7 @@ bool CommandLine::FindExist(char const * const name,bool remove) {
 bool CommandLine::FindHex(char const * const name,int & value,bool remove) {
     cmd_it it,it_next;
     if (!(FindEntry(name,it,true))) return false;
-    it_next=it;it_next++;
+    it_next=it;++it_next;
     sscanf((*it_next).c_str(),"%X",(unsigned int*)(&value));
     if (remove) cmds.erase(it,++it_next);
     return true;
@@ -1076,7 +1076,7 @@ bool CommandLine::FindHex(char const * const name,int & value,bool remove) {
 bool CommandLine::FindInt(char const * const name,int & value,bool remove) {
     cmd_it it,it_next;
     if (!(FindEntry(name,it,true))) return false;
-    it_next=it;it_next++;
+    it_next=it;++it_next;
     value=atoi((*it_next).c_str());
     if (remove) cmds.erase(it,++it_next);
     return true;
@@ -1085,7 +1085,7 @@ bool CommandLine::FindInt(char const * const name,int & value,bool remove) {
 bool CommandLine::FindString(char const * const name,std::string & value,bool remove) {
     cmd_it it,it_next;
     if (!(FindEntry(name,it,true))) return false;
-    it_next=it;it_next++;
+    it_next=it;++it_next;
     value=*it_next;
     if (remove) cmds.erase(it,++it_next);
     return true;
@@ -1095,7 +1095,7 @@ bool CommandLine::FindCommand(unsigned int which,std::string & value) {
     if (which<1) return false;
     if (which>cmds.size()) return false;
     cmd_it it=cmds.begin();
-    for (;which>1;which--) it++;
+    for (;which>1;--which) it++;
     value=(*it);
     return true;
 }
@@ -1109,7 +1109,7 @@ bool CommandLine::FindEntry(char const * const name,cmd_it & it,bool neednext) {
         if (*name == '-' && d[0] == '-' && d[1] == '-') d++;
 
         if (!strcasecmp(d,name)) {
-            cmd_it itnext=it;itnext++;
+            cmd_it itnext=it;++itnext;
             if (neednext && (itnext==cmds.end())) return false;
             return true;
         }
@@ -1119,7 +1119,7 @@ bool CommandLine::FindEntry(char const * const name,cmd_it & it,bool neednext) {
 
 bool CommandLine::FindStringBegin(char const* const begin,std::string & value, bool remove) {
     size_t len = strlen(begin);
-    for (cmd_it it=cmds.begin();it!=cmds.end();it++) {
+    for (cmd_it it=cmds.begin();it!=cmds.end();++it) {
         if (strncmp(begin,(*it).c_str(),len)==0) {
             value=((*it).c_str() + len);
             if (remove) cmds.erase(it);
@@ -1132,8 +1132,8 @@ bool CommandLine::FindStringBegin(char const* const begin,std::string & value, b
 bool CommandLine::FindStringRemain(char const * const name,std::string & value) {
     cmd_it it;value="";
     if (!FindEntry(name,it)) return false;
-    it++;
-    for (;it!=cmds.end();it++) {
+    ++it;
+    for (;it!=cmds.end();++it) {
         value+=" ";
         value+=(*it);
     }
@@ -1148,7 +1148,7 @@ bool CommandLine::FindStringRemainBegin(char const * const name,std::string & va
     cmd_it it;value="";
     if (!FindEntry(name,it)) {
         size_t len = strlen(name);
-            for (it=cmds.begin();it!=cmds.end();it++) {
+            for (it=cmds.begin();it!=cmds.end();++it) {
                 if (strncasecmp(name,(*it).c_str(),len)==0) {
                     std::string temp = (*it).c_str() + len;
                     //Restore quotes for correct parsing in later stages
@@ -1161,8 +1161,8 @@ bool CommandLine::FindStringRemainBegin(char const * const name,std::string & va
             }
         if ( it == cmds.end()) return false;
     }
-    it++;
-    for (;it!=cmds.end();it++) {
+    ++it;
+    for (;it!=cmds.end();++it) {
         value += " ";
         std::string temp = *it;
         if (temp.find(" ") != std::string::npos)
@@ -1177,7 +1177,7 @@ bool CommandLine::GetStringRemain(std::string & value) {
     if (!cmds.size()) return false;
 
     cmd_it it=cmds.begin();value=(*it++);
-    for(;it != cmds.end();it++) {
+    for(;it != cmds.end();++it) {
         value+=" ";
         value+=(*it);
     }
@@ -1205,7 +1205,7 @@ void CommandLine::EatCurrentArgv(void) {
 }
 
 void CommandLine::NextArgv(void) {
-    if (opt_scan != cmds.end()) opt_scan++;
+    if (opt_scan != cmds.end()) ++opt_scan;
 }
 
 bool CommandLine::NextOptArgv(std::string &argv) {
@@ -1217,7 +1217,7 @@ bool CommandLine::NextOptArgv(std::string &argv) {
     if (opt_scan == cmds.end()) return false;
     argv = *opt_scan;
     if (opt_eat_argv) opt_scan = cmds.erase(opt_scan);
-    else opt_scan++;
+    else ++opt_scan;
     return true;
 }
 
@@ -1265,7 +1265,7 @@ bool CommandLine::GetOpt(std::string &name) {
             /* MS-DOS style /option. Example: /A /OPT /HAX /BLAH */
             name = str+1; /* copy to caller minus leaking slash, then erase/skip */
             if (opt_eat_argv) opt_scan = cmds.erase(opt_scan);
-            else opt_scan++;
+            else ++opt_scan;
             return true;
         }
         else if ((opt_style == CommandLine::either || opt_style == CommandLine::gnu || opt_style == CommandLine::gnu_getopt) && *str == '-') {
@@ -1286,7 +1286,7 @@ bool CommandLine::GetOpt(std::string &name) {
                     /* assign to single-char parse then eat the argv */
                     opt_gnu_getopt_singlechar = str;
                     if (opt_eat_argv) opt_scan = cmds.erase(opt_scan);
-                    else opt_scan++;
+                    else ++opt_scan;
 
                     /* if we parse a single-char switch, great */
                     if (GetOptGNUSingleCharCheck(name))
@@ -1302,11 +1302,11 @@ bool CommandLine::GetOpt(std::string &name) {
 
             name = str; /* copy to caller, then erase/skip */
             if (opt_eat_argv) opt_scan = cmds.erase(opt_scan);
-            else opt_scan++;
+            else ++opt_scan;
             return true;
         }
         else {
-            opt_scan++;
+            ++opt_scan;
         }
     }
 
@@ -1318,7 +1318,7 @@ void CommandLine::EndOpt() {
 }
 
 void CommandLine::FillVector(std::vector<std::string> & vector) {
-    for(cmd_it it=cmds.begin(); it != cmds.end(); it++) {
+    for(cmd_it it=cmds.begin(); it != cmds.end(); ++it) {
         vector.push_back((*it));
     }
     // add back the \" if the parameter contained a space
@@ -1373,7 +1373,7 @@ int CommandLine::GetParameterFromList(const char* const params[], std::vector<st
                 break;
             }
         cmd_it itold = it;
-        it++;
+        ++it;
         cmds.erase(itold);
 
     }
@@ -1404,7 +1404,7 @@ const std::string& CommandLine::GetRawCmdline(void) {
 Bit16u CommandLine::Get_arglength() {
     if (cmds.empty()) return 0;
     Bit16u i=1;
-    for(cmd_it it=cmds.begin();it != cmds.end();it++)
+    for(cmd_it it=cmds.begin();it != cmds.end();++it)
         i+=(*it).size() + 1;
     return --i;
 }

--- a/src/mt32/Poly.cpp
+++ b/src/mt32/Poly.cpp
@@ -116,11 +116,9 @@ void Poly::terminate() {
 			partial->deactivate();
 		}
 	}
-	if (state != POLY_Inactive) {
-		// FIXME: Throw out lots of debug output - this should never happen
-		// (Deactivating the partials above should've made them each call partialDeactivated(), ultimately changing the state to POLY_Inactive)
-		state = POLY_Inactive;
-	}
+	// FIXME: Throw out lots of debug output - this should never happen
+	// (Deactivating the partials above should've made them each call partialDeactivated(), ultimately changing the state to POLY_Inactive)
+	state = POLY_Inactive;
 }
 
 void Poly::backupCacheToPartials(PatchCache cache[4]) {

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -108,7 +108,7 @@ void AutoexecObject::CreateAutoexec(void) {
 	//Create a new autoexec.bat
 	autoexec_data[0] = 0;
 	size_t auto_len;
-	for(auto_it it = autoexec_strings.begin(); it != autoexec_strings.end(); it++) {
+	for(auto_it it = autoexec_strings.begin(); it != autoexec_strings.end(); ++it) {
 
 		std::string linecopy = (*it);
 		std::string::size_type offset = 0;
@@ -156,11 +156,11 @@ void AutoexecObject::Uninstall() {
 			if (stringset && first_shell && first_shell->bf && first_shell->bf->filename.find("AUTOEXEC.BAT") != std::string::npos) {
 				//Replace entry with spaces if it is a set and from autoexec.bat, as else the location counter will be off.
 				*it = buf.assign(buf.size(),' ');
-				it++;
+				++it;
 			} else {
 				it = autoexec_strings.erase(it);
 			}
-		} else it++;
+		} else ++it;
 	}
 	installed=false;
 	this->CreateAutoexec();

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -806,7 +806,7 @@ void DOS_Shell::CMD_DIR(char * args) {
 		std::reverse(results.begin(), results.end());
 	}
 
-	for (std::vector<DtaResult>::iterator iter = results.begin(); iter != results.end(); iter++) {
+	for (std::vector<DtaResult>::iterator iter = results.begin(); iter != results.end(); ++iter) {
 
 		char * name = iter->name;
 		Bit32u size = iter->size;

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -347,17 +347,17 @@ void DOS_Shell::InputCommand(char * line) {
                 str_len = str_index = len;
                 size = (unsigned int)CMD_MAXLINE - str_index - 2u;
                 DOS_WriteFile(STDOUT, (Bit8u *)line, &len);
-                it_history ++;
+                ++it_history;
                 break;
 
             case 0x5000:	/* DOWN */
                 if (l_history.empty() || it_history == l_history.begin()) break;
 
                 // not very nice but works ..
-                it_history --;
+                --it_history;
                 if (it_history == l_history.begin()) {
                     // no previous commands in history
-                    it_history ++;
+                    ++it_history;
 
                     // remove current command from history
                     if (current_hist) {
@@ -365,7 +365,7 @@ void DOS_Shell::InputCommand(char * line) {
                         l_history.pop_front();
                     }
                     break;
-                } else it_history --;
+                } else --it_history;
 
                 for (;str_index>0; str_index--) {
                     // removes all characters
@@ -376,7 +376,7 @@ void DOS_Shell::InputCommand(char * line) {
                 str_len = str_index = len;
                 size = (unsigned int)CMD_MAXLINE - str_index - 2u;
                 DOS_WriteFile(STDOUT, (Bit8u *)line, &len);
-                it_history ++;
+                ++it_history;
 
                 break;
             case 0x5300:/* DELETE */
@@ -397,7 +397,7 @@ void DOS_Shell::InputCommand(char * line) {
             case 0x0F00:	/* Shift-Tab */
                 if (l_completion.size()) {
                     if (it_completion == l_completion.begin()) it_completion = l_completion.end (); 
-                    it_completion--;
+                    --it_completion;
 
                     if (it_completion->length()) {
                         for (;str_index > completion_index; str_index--) {
@@ -453,7 +453,7 @@ void DOS_Shell::InputCommand(char * line) {
             case'\t':
                 {
                     if (l_completion.size()) {
-                        it_completion ++;
+                        ++it_completion;
                         if (it_completion == l_completion.end()) it_completion = l_completion.begin();
                     } else {
                         // build new completion list

--- a/vs2015/libpdcurses/pdcurses/addstr.c
+++ b/vs2015/libpdcurses/pdcurses/addstr.c
@@ -73,7 +73,7 @@ int waddnstr(WINDOW *win, const char *str, int n)
     if (!win || !str)
         return ERR;
 
-    while (str[i] && (i < n || n < 0))
+    while ((i < n || n < 0) && str[i])
     {
 #ifdef PDC_WIDE
         wchar_t wch;

--- a/vs2015/sdl/src/stdlib/SDL_string.c
+++ b/vs2015/sdl/src/stdlib/SDL_string.c
@@ -1115,7 +1115,7 @@ static size_t SDL_PrintString(char *text, const char *string, size_t maxlen)
 int SDL_vsnprintf(char *text, size_t maxlen, const char *fmt, va_list ap)
 {
     char *textstart = text;
-    if ( maxlen <= 0 ) {
+    if ( maxlen == 0 ) {
         return 0;
     }
     --maxlen; /* For the trailing '\0' */

--- a/vs2015/sdl/src/video/windib/SDL_dibevents.c
+++ b/vs2015/sdl/src/video/windib/SDL_dibevents.c
@@ -1017,7 +1017,7 @@ int InitParentWindow(void) {
 				return 0;
 			}
 
-			if (--patience <= 0)
+			if (--patience == 0)
 				break;
 			else
 				Sleep(100);


### PR DESCRIPTION
Fixes more Cppcheck warnings. Compiles and runs. Here's a description of the warning types:

**duplicateBreak**: `break`, `return`, etc. statements are placed sequentially so the second one never runs

**unsignedLessThanZero**: There is an unnecessary check of whether an unsigned value is < 0

**duplicateCondition**:  The same condition is checked for multiple times and can be merged into one.

**duplicateConditionalAssign**: Code like "if (a != b) { a = b; }", which is logically equivalent to just "a= b;"

**postFixOperator**: For non-primitive types, putting ++ or -- as a prefix rather than a postfix can be more efficient because as a postfix a copy of the previous value and some extra code is involved (according to Cppcheck)

**duplicateBranch**: "if" and "else" branches have the same code.

**operatorEqVarError**: an assignment missing from the = operator (this is again for the `DOS_File` = operator that I added a missing assignment for in another PR. There was another value assignment that was also missing)

**identicalConditionAfterEarlyExit**: A condition check identical to an earlier one is never reached because the earlier check exits from the checking.

**arrayIndexThenCheck**: A comparison exists like "if (array[x] = y && x > 0)", where the check on the variable that will be used to access the array should come before the array is checked (is in reverse order compared to how it should be).

**containerOutOfBounds**: Potential access out of the bounds of an array

**memLeak**: Memory leak

**knownConditionTrueFalse**: A true/false check exists where the value being checked is always either true or false