### PR TITLE
Fix more Cppcheck warnings

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -233,7 +233,7 @@ public:
 	// Create a hard drive image of a specified geometry
 	imageDiskMemory(Bit16u cylinders, Bit16u heads, Bit16u sectors, Bit16u sectorSize);
 	// Create a floppy image of a specified geometry
-	imageDiskMemory(diskGeo floppyGeometry);
+	imageDiskMemory(diskGeo& floppyGeometry);
 	// Create a copy-on-write memory image of an existing image
 	imageDiskMemory(imageDisk* underlyingImage);
 	virtual ~imageDiskMemory();

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -158,7 +158,7 @@ public:
 	virtual Bit8u Read_AbsoluteSector(Bit32u sectnum, void * data);
 	virtual Bit8u Write_AbsoluteSector(Bit32u sectnum, const void * data);
 
-	imageDiskNFD(FILE *imgFile, Bit8u *imgName, Bit32u imgSizeK, bool isHardDisk, unsigned int rev);
+	imageDiskNFD(FILE *imgFile, Bit8u *imgName, Bit32u imgSizeK, bool isHardDisk, unsigned int revision);
 	virtual ~imageDiskNFD();
 
     struct vfdentry {
@@ -231,7 +231,7 @@ public:
 	// Create a hard drive image of a specified size; automatically select c/h/s
 	imageDiskMemory(Bit32u imgSizeK);
 	// Create a hard drive image of a specified geometry
-	imageDiskMemory(Bit16u cylinders, Bit16u heads, Bit16u sectors, Bit16u sectorSize);
+	imageDiskMemory(Bit16u cylinders, Bit16u heads, Bit16u sectors, Bit16u sector_size);
 	// Create a floppy image of a specified geometry
 	imageDiskMemory(diskGeo& floppyGeometry);
 	// Create a copy-on-write memory image of an existing image
@@ -279,7 +279,7 @@ public:
 	VHDTypes vhdType;
 	virtual Bit8u Read_AbsoluteSector(Bit32u sectnum, void * data);
 	virtual Bit8u Write_AbsoluteSector(Bit32u sectnum, const void * data);
-	static ErrorCodes Open(const char* fileName, const bool readOnly, imageDisk** imageDisk);
+	static ErrorCodes Open(const char* fileName, const bool readOnly, imageDisk** disk);
 	static VHDTypes GetVHDType(const char* fileName);
 	virtual ~imageDiskVHD();
 
@@ -340,7 +340,7 @@ private:
 
 	imageDiskVHD() : imageDisk(ID_VHD) { }
 	static ErrorCodes TryOpenParent(const char* childFileName, const ParentLocatorEntry &entry, Bit8u* data, const Bit32u dataLength, imageDisk** disk, const Bit8u* uniqueId);
-	static ErrorCodes Open(const char* fileName, const bool readOnly, imageDisk** imageDisk, const Bit8u* matchUniqueId);
+	static ErrorCodes Open(const char* fileName, const bool readOnly, imageDisk** disk, const Bit8u* matchUniqueId);
 	virtual bool loadBlock(const Bit32u blockNumber);
 	static bool convert_UTF16_for_fopen(std::string &string, const void* data, const Bit32u dataLength);
 

--- a/include/callback.h
+++ b/include/callback.h
@@ -72,7 +72,7 @@ bool CALLBACK_Setup(Bitu callback,CallBack_Handler handler,Bitu type,const char*
 Bitu CALLBACK_Setup(Bitu callback,CallBack_Handler handler,Bitu type,PhysPt addr,const char* descr);
 
 void CALLBACK_SetDescription(Bitu nr, const char* descr);
-const char* CALLBACK_GetDescription(Bitu callback);
+const char* CALLBACK_GetDescription(Bitu nr);
 
 void CALLBACK_SCF(bool val);
 void CALLBACK_SZF(bool val);

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -133,8 +133,8 @@ bool CPU_READ_CRX(Bitu cr,Bit32u & retvalue);
 bool CPU_WRITE_DRX(Bitu dr,Bitu value);
 bool CPU_READ_DRX(Bitu dr,Bit32u & retvalue);
 
-bool CPU_WRITE_TRX(Bitu dr,Bitu value);
-bool CPU_READ_TRX(Bitu dr,Bit32u & retvalue);
+bool CPU_WRITE_TRX(Bitu tr,Bitu value);
+bool CPU_READ_TRX(Bitu tr,Bit32u & retvalue);
 
 Bitu CPU_SMSW(void);
 bool CPU_LMSW(Bitu word);

--- a/include/cross.h
+++ b/include/cross.h
@@ -77,7 +77,7 @@ public:
 	static void GetPlatformConfigName(std::string& in);
 	static void CreatePlatformConfigDir(std::string& in);
 	static void ResolveHomedir(std::string & temp_line);
-	static void CreateDir(std::string const& temp);
+	static void CreateDir(std::string const& in);
 	static bool IsPathAbsolute(std::string const& in);
 };
 

--- a/include/dma.h
+++ b/include/dma.h
@@ -129,8 +129,8 @@ public:
 	void Clear_Request(void) {
 		request=false;
 	}
-	Bitu Read(Bitu size, Bit8u * buffer);
-	Bitu Write(Bitu size, Bit8u * buffer);
+	Bitu Read(Bitu want, Bit8u * buffer);
+	Bitu Write(Bitu want, Bit8u * buffer);
 };
 
 class DmaController {

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -163,13 +163,13 @@ enum { HAND_NONE=0,HAND_FILE,HAND_DEVICE};
 
 /* Routines for File Class */
 void DOS_SetupFiles (void);
-bool DOS_ReadFile(Bit16u handle,Bit8u * data,Bit16u * amount, bool fcb = false);
-bool DOS_WriteFile(Bit16u handle,Bit8u * data,Bit16u * amount,bool fcb = false);
-bool DOS_SeekFile(Bit16u handle,Bit32u * pos,Bit32u type,bool fcb = false);
+bool DOS_ReadFile(Bit16u entry,Bit8u * data,Bit16u * amount, bool fcb = false);
+bool DOS_WriteFile(Bit16u entry,Bit8u * data,Bit16u * amount,bool fcb = false);
+bool DOS_SeekFile(Bit16u entry,Bit32u * pos,Bit32u type,bool fcb = false);
 /* ert, 20100711: Locking extensions */
 bool DOS_LockFile(Bit16u entry,Bit8u mode,Bit32u pos,Bit32u size);
-bool DOS_CloseFile(Bit16u handle,bool fcb = false);
-bool DOS_FlushFile(Bit16u handle);
+bool DOS_CloseFile(Bit16u entry,bool fcb = false);
+bool DOS_FlushFile(Bit16u entry);
 bool DOS_DuplicateEntry(Bit16u entry,Bit16u * newentry);
 bool DOS_ForceDuplicateEntry(Bit16u entry,Bit16u newentry);
 bool DOS_GetFileDate(Bit16u entry, Bit16u* otime, Bit16u* odate);
@@ -178,7 +178,7 @@ bool DOS_SetFileDate(Bit16u entry, Bit16u ntime, Bit16u ndate);
 /* Routines for Drive Class */
 bool DOS_OpenFile(char const * name,Bit8u flags,Bit16u * entry,bool fcb = false);
 bool DOS_OpenFileExtended(char const * name, Bit16u flags, Bit16u createAttr, Bit16u action, Bit16u *entry, Bit16u* status);
-bool DOS_CreateFile(char const * name,Bit16u attribute,Bit16u * entry, bool fcb = false);
+bool DOS_CreateFile(char const * name,Bit16u attributes,Bit16u * entry, bool fcb = false);
 bool DOS_UnlinkFile(char const * const name);
 bool DOS_FindFirst(char *search,Bit16u attr,bool fcb_findfirst=false);
 bool DOS_FindNext(void);
@@ -208,9 +208,9 @@ Bit8u DOS_FindDevice(char const * name);
 void DOS_SetupDevices(void);
 
 /* Execute and new process creation */
-bool DOS_NewPSP(Bit16u pspseg,Bit16u size);
-bool DOS_ChildPSP(Bit16u pspseg,Bit16u size);
-bool DOS_Execute(char * name,PhysPt block,Bit8u flags);
+bool DOS_NewPSP(Bit16u segment,Bit16u size);
+bool DOS_ChildPSP(Bit16u segment,Bit16u size);
+bool DOS_Execute(char * name,PhysPt block_pt,Bit8u flags);
 void DOS_Terminate(Bit16u pspseg,bool tsr,Bit8u exitcode);
 
 /* Memory Handling Routines */
@@ -231,8 +231,8 @@ bool DOS_FCBCreate(Bit16u seg,Bit16u offset);
 bool DOS_FCBClose(Bit16u seg,Bit16u offset);
 bool DOS_FCBFindFirst(Bit16u seg,Bit16u offset);
 bool DOS_FCBFindNext(Bit16u seg,Bit16u offset);
-Bit8u DOS_FCBRead(Bit16u seg,Bit16u offset, Bit16u numBlocks);
-Bit8u DOS_FCBWrite(Bit16u seg,Bit16u offset,Bit16u numBlocks);
+Bit8u DOS_FCBRead(Bit16u seg,Bit16u offset, Bit16u recno);
+Bit8u DOS_FCBWrite(Bit16u seg,Bit16u offset,Bit16u recno);
 Bit8u DOS_FCBRandomRead(Bit16u seg,Bit16u offset,Bit16u * numRec,bool restore);
 Bit8u DOS_FCBRandomWrite(Bit16u seg,Bit16u offset,Bit16u * numRec,bool restore);
 bool DOS_FCBGetFileSize(Bit16u seg,Bit16u offset);
@@ -359,7 +359,7 @@ protected:
 class DOS_PSP :public MemStruct {
 public:
 	DOS_PSP						(Bit16u segment)		{ SetPt(segment);seg=segment;};
-	void	MakeNew				(Bit16u memSize);
+	void	MakeNew				(Bit16u mem_size);
 	void	CopyFileTable		(DOS_PSP* srcpsp,bool createchildpsp);
 	Bit16u	FindFreeFileEntry	(void);
 	void	CloseFiles			(void);
@@ -456,9 +456,9 @@ public:
 class DOS_InfoBlock:public MemStruct {
 public:
     DOS_InfoBlock() : seg(0) {};
-	void SetLocation(Bit16u  seg);
+	void SetLocation(Bit16u  segment);
     void SetFirstDPB(Bit32u _first_dpb);
-	void SetFirstMCB(Bit16u _first_mcb);
+	void SetFirstMCB(Bit16u _firstmcb);
 	void SetBuffers(Bit16u x,Bit16u y);
 	void SetCurDirStruct(Bit32u _curdirstruct);
 	void SetFCBTable(Bit32u _fcbtable);
@@ -536,11 +536,11 @@ class DOS_DTA:public MemStruct{
 public:
 	DOS_DTA(RealPt addr) { SetPt(addr); }
 
-	void SetupSearch(Bit8u _sdrive,Bit8u _sattr,char * _pattern);
+	void SetupSearch(Bit8u _sdrive,Bit8u _sattr,char * pattern);
 	void SetResult(const char * _name,Bit32u _size,Bit16u _date,Bit16u _time,Bit8u _attr);
 	
 	Bit8u GetSearchDrive(void);
-	void GetSearchParams(Bit8u & _sattr,char * _spattern);
+	void GetSearchParams(Bit8u & attr,char * pattern);
 	void GetResult(char * _name,Bit32u & _size,Bit16u & _date,Bit16u & _time,Bit8u & _attr);
 
 	void	SetDirID(Bit16u entry)			{ sSave(sDTA,dirID,entry); };

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -139,7 +139,7 @@ private:
 
 class localFile : public DOS_File {
 public:
-	localFile(const char* name, FILE * handle);
+	localFile(const char* _name, FILE * handle);
 	bool Read(Bit8u * data,Bit16u * size);
 	bool Write(const Bit8u * data,Bit16u * size);
 	bool Seek(Bit32u * pos,Bit32u type);
@@ -173,7 +173,7 @@ public:
 
 	enum TDirSort { NOSORT, ALPHABETICAL, DIRALPHABETICAL, ALPHABETICALREV, DIRALPHABETICALREV };
 
-	void		SetBaseDir			(const char* path, DOS_Drive *drive);
+	void		SetBaseDir			(const char* baseDir, DOS_Drive *drive);
 	void		SetDirSort			(TDirSort sort) { sortDirType = sort; };
 	bool		OpenDir				(const char* path, Bit16u& id);
 	bool		ReadDir				(Bit16u id, char* &result);
@@ -186,12 +186,12 @@ public:
 	bool		FindNext			(Bit16u id, char* &result);
 
 	void		CacheOut			(const char* path, bool ignoreLastDir = false);
-	void		AddEntry			(const char* path, bool checkExist = false);
+	void		AddEntry			(const char* path, bool checkExists = false);
 	void		DeleteEntry			(const char* path, bool ignoreLastDir = false);
 
 	void		EmptyCache			(void);
 	void		MediaChange			(void);
-	void		SetLabel			(const char* name,bool cdrom,bool allowupdate);
+	void		SetLabel			(const char* vname,bool cdrom,bool allowupdate);
 	char*		GetLabel			(void) { return label; };
 
 	class CFileInfo {
@@ -223,16 +223,16 @@ private:
 	void DeleteFileInfo(CFileInfo *dir);
 
 	bool		RemoveTrailingDot	(char* shortname);
-	Bits		GetLongName		(CFileInfo* info, char* shortname);
-	void		CreateShortName		(CFileInfo* dir, CFileInfo* info);
-	Bitu		CreateShortNameID	(CFileInfo* dir, const char* name);
+	Bits		GetLongName		(CFileInfo* curDir, char* shortName);
+	void		CreateShortName		(CFileInfo* curDir, CFileInfo* info);
+	Bitu		CreateShortNameID	(CFileInfo* curDir, const char* name);
 	int		CompareShortname	(const char* compareName, const char* shortName);
 	bool		SetResult		(CFileInfo* dir, char * &result, Bitu entryNr);
-	bool		IsCachedIn		(CFileInfo* dir);
+	bool		IsCachedIn		(CFileInfo* curDir);
 	CFileInfo*	FindDirInfo		(const char* path, char* expandedPath);
 	bool		RemoveSpaces		(char* str);
-	bool		OpenDir			(CFileInfo* dir, const char* path, Bit16u& id);
-	void		CreateEntry		(CFileInfo* dir, const char* name, bool query_directory);
+	bool		OpenDir			(CFileInfo* dir, const char* expand, Bit16u& id);
+	void		CreateEntry		(CFileInfo* dir, const char* name, bool is_directory);
 	void		CopyEntry		(CFileInfo* dir, CFileInfo* from);
 	Bit16u		GetFreeID		(CFileInfo* dir);
 	void		Clear			(void);

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -79,7 +79,7 @@
 # define HAS_LONG_DOUBLE		1
 #endif
 
-GCC_ATTRIBUTE(noreturn) void		E_Exit(const char * message,...) GCC_ATTRIBUTE( __format__(__printf__, 1, 2));
+GCC_ATTRIBUTE(noreturn) void		E_Exit(const char * format,...) GCC_ATTRIBUTE( __format__(__printf__, 1, 2));
 
 typedef Bits cpu_cycles_count_t;
 typedef Bitu cpu_cycles_countu_t;

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -24,21 +24,21 @@
 #endif
 
 void FPU_ESC0_Normal(Bitu rm);
-void FPU_ESC0_EA(Bitu func,PhysPt ea);
+void FPU_ESC0_EA(Bitu rm,PhysPt addr);
 void FPU_ESC1_Normal(Bitu rm);
-void FPU_ESC1_EA(Bitu func,PhysPt ea);
+void FPU_ESC1_EA(Bitu rm,PhysPt addr);
 void FPU_ESC2_Normal(Bitu rm);
-void FPU_ESC2_EA(Bitu func,PhysPt ea);
+void FPU_ESC2_EA(Bitu rm,PhysPt addr);
 void FPU_ESC3_Normal(Bitu rm);
-void FPU_ESC3_EA(Bitu func,PhysPt ea);
+void FPU_ESC3_EA(Bitu rm,PhysPt addr);
 void FPU_ESC4_Normal(Bitu rm);
-void FPU_ESC4_EA(Bitu func,PhysPt ea);
+void FPU_ESC4_EA(Bitu rm,PhysPt addr);
 void FPU_ESC5_Normal(Bitu rm);
-void FPU_ESC5_EA(Bitu func,PhysPt ea);
+void FPU_ESC5_EA(Bitu rm,PhysPt addr);
 void FPU_ESC6_Normal(Bitu rm);
-void FPU_ESC6_EA(Bitu func,PhysPt ea);
+void FPU_ESC6_EA(Bitu rm,PhysPt addr);
 void FPU_ESC7_Normal(Bitu rm);
-void FPU_ESC7_EA(Bitu func,PhysPt ea);
+void FPU_ESC7_EA(Bitu rm,PhysPt addr);
 
 /* Floating point register, in the form the native host uses for "double".
  * This is slightly less precise than the 80-bit extended IEEE used by Intel,

--- a/include/hardware.h
+++ b/include/hardware.h
@@ -35,7 +35,7 @@ enum OPL_Mode {
 
 extern Bitu CaptureState;
 
-void OPL_Init(Section* sec,OPL_Mode mode);
+void OPL_Init(Section* sec,OPL_Mode oplmode);
 void CMS_Init(Section* sec);
 void OPL_ShutDown(Section* sec);
 void CMS_ShutDown(Section* sec);

--- a/include/ide.h
+++ b/include/ide.h
@@ -13,8 +13,8 @@ extern void (*ide_inits[MAX_IDE_CONTROLLERS])(Section *);
 void IDE_Auto(signed char &index,bool &slave);
 void IDE_CDROM_Attach(signed char index,bool slave,unsigned char drive_index);
 void IDE_CDROM_Detach(unsigned char drive_index);
-void IDE_Hard_Disk_Attach(signed char index,bool slave,unsigned char bios_drive_index);
-void IDE_Hard_Disk_Detach(unsigned char bios_drive_index);
+void IDE_Hard_Disk_Attach(signed char index,bool slave,unsigned char bios_disk_index);
+void IDE_Hard_Disk_Detach(unsigned char bios_disk_index);
 void IDE_ResetDiskByBIOS(unsigned char disk);
 
 #endif

--- a/include/logging.h
+++ b/include/logging.h
@@ -70,7 +70,7 @@ public:
 	static void Init();
 	static void Exit();
 
-	void operator() (char const* buf, ...) GCC_ATTRIBUTE(__format__(__printf__, 2, 3));  //../src/debug/debug_gui.cpp
+	void operator() (char const* format, ...) GCC_ATTRIBUTE(__format__(__printf__, 2, 3));  //../src/debug/debug_gui.cpp
 };
 
 void					DEBUG_ShowMsg(char const* format,...) GCC_ATTRIBUTE(__format__(__printf__, 1, 2));

--- a/include/mem.h
+++ b/include/mem.h
@@ -42,7 +42,7 @@ extern HostPt               MemBase;
 
 HostPt                      GetMemBase(void);
 bool                        MEM_A20_Enabled(void);
-void                        MEM_A20_Enable(bool enable);
+void                        MEM_A20_Enable(bool enabled);
 
 /* Memory management / EMS mapping */
 Bitu                        MEM_FreeTotal(void);           //Free 4 kb pages
@@ -146,13 +146,13 @@ static INLINE void var_write(Bit64u * const var, const Bit64u val) {
 
 /* The Folowing six functions are slower but they recognize the paged memory system */
 
-Bit8u  mem_readb(const PhysPt pt);
-Bit16u mem_readw(const PhysPt pt);
-Bit32u mem_readd(const PhysPt pt);
+Bit8u  mem_readb(const PhysPt address);
+Bit16u mem_readw(const PhysPt address);
+Bit32u mem_readd(const PhysPt address);
 
-void mem_writeb(const PhysPt pt,const Bit8u val);
-void mem_writew(const PhysPt pt,const Bit16u val);
-void mem_writed(const PhysPt pt,const Bit32u val);
+void mem_writeb(const PhysPt address,const Bit8u val);
+void mem_writew(const PhysPt address,const Bit16u val);
+void mem_writed(const PhysPt address,const Bit32u val);
 
 void phys_writes(PhysPt addr, const char* string, Bitu length);
 

--- a/include/menu.h
+++ b/include/menu.h
@@ -19,7 +19,7 @@
 #include <string>
 #include "config.h"
 #include "menudef.h"
-void SetVal(const std::string secname, std::string preval, const std::string val);
+void SetVal(const std::string& secname, const std::string& preval, const std::string& val);
 
 #include <SDL_video.h>
 
@@ -43,7 +43,7 @@ void MountDrive_2(char drive, const char drive2[DOS_PATHLENGTH], std::string dri
 void MENU_Check_Drive(HMENU handle, int cdrom, int floppy, int local, int image, int automount, int umount, char drive);
 bool MENU_SetBool(std::string secname, std::string value);
 void MENU_swapstereo(bool enabled);
-void* GetSetSDLValue(int isget, std::string target, void* setval);
+void* GetSetSDLValue(int isget, std::string& target, void* setval);
 void GFX_SetTitle(Bit32s cycles, Bits frameskip, Bits timing, bool paused);
 void change_output(int output);
 void res_input(bool type, const char * res);
@@ -367,7 +367,7 @@ class DOSBoxMenu {
                 inline mapper_event_t get_mapper_event(void) const {
                     return mapper_event;
                 }
-                inline item &set_mapper_event(const mapper_event_t e) {
+                inline item& set_mapper_event(const mapper_event_t& e) {
                     mapper_event = e;
                     return *this;
                 }

--- a/include/paging.h
+++ b/include/paging.h
@@ -39,11 +39,11 @@ class PageDirectory;
 
 typedef PageHandler* (MEM_CalloutHandler)(MEM_CalloutObject &co,Bitu phys_page);
 
-void MEM_RegisterHandler(Bitu phys_page,PageHandler *handler,Bitu phys_range=1);
+void MEM_RegisterHandler(Bitu phys_page,PageHandler *handler,Bitu page_range=1);
 
-void MEM_FreeHandler(Bitu phys_page,Bitu phys_range=1);
+void MEM_FreeHandler(Bitu phys_page,Bitu page_range=1);
 
-void MEM_InvalidateCachedHandler(Bitu phys_page,Bitu phys_range=1);
+void MEM_InvalidateCachedHandler(Bitu phys_page,Bitu range=1);
 
 static const Bitu MEMMASK_ISA_20BIT = 0x000000FFU; /* ISA 20-bit decode (20 - 12 = 8) */
 static const Bitu MEMMASK_ISA_24BIT = 0x00000FFFU; /* ISA 24-bit decode (24 - 12 = 12) */

--- a/include/programs.h
+++ b/include/programs.h
@@ -112,7 +112,7 @@ public:
 	DOS_PSP * psp;                                      //! DOS kernel Program Segment Prefix associated with this program at runtime
 	virtual void Run(void)=0;                           //! Run() method, called when the program is run. Subclass must override this
 	bool GetEnvStr(const char * entry,std::string & result); //! Return an environment variable by name
-	bool GetEnvNum(Bitu num,std::string & result);      //! Return an environment variable by index
+	bool GetEnvNum(Bitu want_num,std::string & result);      //! Return an environment variable by index
 	Bitu GetEnvCount(void);                             //! Return the number of enviormental variables
 	bool SetEnv(const char * entry,const char * new_string); //! Set environment variable
 	void WriteOut(const char * format,...);				//! Write to standard output 
@@ -123,6 +123,6 @@ public:
 };
 
 typedef void (PROGRAMS_Main)(Program * * make);
-void PROGRAMS_MakeFile(char const * const name,PROGRAMS_Main * main);
+void PROGRAMS_MakeFile(char const * const name,PROGRAMS_Main * SDL_main);
 
 #endif

--- a/include/qcow2_disk.h
+++ b/include/qcow2_disk.h
@@ -52,7 +52,7 @@ public:
 	
 	static QCow2Header read_header(FILE* qcow2File);
 
-	QCow2Image(QCow2Header qcow2Header, FILE *qcow2File, const char* imageName, Bit32u sectorSizeBytes);
+	QCow2Image(QCow2Header& qcow2Header, FILE *qcow2File, const char* imageName, Bit32u sectorSizeBytes);
 
 	virtual ~QCow2Image();
 	
@@ -123,7 +123,7 @@ class QCow2Disk : public imageDisk{
 
 public:
 	
-	QCow2Disk(QCow2Image::QCow2Header qcow2Header, FILE *qcow2File, Bit8u *imgName, Bit32u imgSizeK, Bit32u sectorSizeBytes, bool isHardDisk);
+	QCow2Disk(QCow2Image::QCow2Header& qcow2Header, FILE *qcow2File, Bit8u *imgName, Bit32u imgSizeK, Bit32u sectorSizeBytes, bool isHardDisk);
 
 	virtual ~QCow2Disk();
 	

--- a/include/serialport.h
+++ b/include/serialport.h
@@ -207,7 +207,7 @@ public:
 	void Write_LCR(Bit8u data);
 	void Write_MCR(Bit8u data);
 	// Really old hardware seems to have the delta part of this register writable
-	void Write_MSR(Bit8u data);
+	void Write_MSR(Bit8u val);
 	void Write_SPR(Bit8u data);
 	void Write_reserved(Bit8u data, Bit8u address);
 
@@ -245,7 +245,7 @@ public:
 	
 	void Init_Registers();
 	
-	bool Putchar(Bit8u data, bool wait_dtr, bool wait_rts, Bitu timeout);
+	bool Putchar(Bit8u data, bool wait_dsr, bool wait_cts, Bitu timeout);
 	bool Getchar(Bit8u* data, Bit8u* lsr, bool wait_dsr, Bitu timeout);
 
 	DOS_Device* mydosdevice;

--- a/include/setup.h
+++ b/include/setup.h
@@ -123,7 +123,7 @@ public:
 
 	Property(std::string const& _propname, Changeable::Value when):propname(_propname),is_modified(false),change(when) { use_global_config_str=false; }
 	void Set_values(const char * const * in);
-	void Set_help(std::string const& str);
+	void Set_help(std::string const& in);
 	char const* Get_help();
 	virtual	bool SetValue(std::string const& str)=0;
 	Value const& GetValue() const { return value;}
@@ -174,7 +174,7 @@ public:
 	int getMin() { return min;}
 	int getMax() { return max;}
 	void SetMinMax(Value const& min,Value const& max) {this->min = min; this->max=max;}
-	bool SetValue(std::string const& in);
+	bool SetValue(std::string const& input);
 	virtual ~Prop_int(){ }
 	virtual bool CheckValue(Value const& in, bool warn);
 	// Override SetVal, so it takes min,max in account when there are no suggested values
@@ -214,7 +214,7 @@ public:
 		:Property(_propname,when) {
 		default_value = value = _value;
 	}
-	bool SetValue(std::string const& in);
+	bool SetValue(std::string const& input);
 	virtual ~Prop_bool(){ }
 };
 
@@ -224,7 +224,7 @@ public:
 		:Property(_propname,when) {
 		default_value = value = _value;
 	}
-	bool SetValue(std::string const& in);
+	bool SetValue(std::string const& input);
 	virtual bool CheckValue(Value const& in, bool warn);
 	virtual ~Prop_string(){ }
 };
@@ -236,7 +236,7 @@ public:
 		default_value = value = _value;
 		realpath = _value;
 	}
-	bool SetValue(std::string const& in);
+	bool SetValue(std::string const& input);
 	virtual ~Prop_path(){ }
 };
 
@@ -246,7 +246,7 @@ public:
 		:Property(_propname,when) {
 		default_value = value = _value;
 	}
-	bool SetValue(std::string const& in);
+	bool SetValue(std::string const& input);
 	virtual ~Prop_hex(){ }
 };
 
@@ -292,7 +292,7 @@ public:
  *       (i.e. we want high-level stuff to cleanup first and low level
  *       stuff like logging to cleanup last). */
 extern std::list<Function_wrapper> exitfunctions;
-void AddExitFunction(SectionFunction func,const char *funcname,bool canchange=false);
+void AddExitFunction(SectionFunction func,const char *name,bool canchange=false);
 
 /* for use with AddExitFunction and a name of a function.
  * this turns it into function pointer and function name. it turns one param into two. */
@@ -418,7 +418,7 @@ class Section_line: public Section{
 public:
 	Section_line(std::string const& _sectionname):Section(_sectionname){}
 	virtual ~Section_line() { };
-	virtual bool HandleInputline(std::string const& gegevens);
+	virtual bool HandleInputline(std::string const& line);
 	virtual void PrintData(FILE* outfile,bool everything=false);
 	virtual std::string GetPropValue(std::string const& _property) const;
 	std::string data;

--- a/include/shell.h
+++ b/include/shell.h
@@ -114,7 +114,7 @@ public:
 
     /*! \brief      Process and execute command (internal or external)
      */
-	void DoCommand(char * cmd);
+	void DoCommand(char * line);
 
     /*! \brief      Execute a command
      */

--- a/include/support.h
+++ b/include/support.h
@@ -47,7 +47,7 @@ char * lowcase(char * str);
 
 bool ScanCMDBool(char * cmd,char const * const check);
 char * ScanCMDRemain(char * cmd);
-char * StripWord(char *&cmd);
+char * StripWord(char *&line);
 Bits ConvDecWord(char * word);
 Bits ConvHexWord(char * word);
 

--- a/include/video.h
+++ b/include/video.h
@@ -58,7 +58,7 @@ void GFX_Events(void);
 void GFX_SetPalette(Bitu start,Bitu count,GFX_PalEntry * entries);
 Bitu GFX_GetBestMode(Bitu flags);
 Bitu GFX_GetRGB(Bit8u red,Bit8u green,Bit8u blue);
-Bitu GFX_SetSize(Bitu width,Bitu height,Bitu flags,double scalex,double scaley,GFX_CallBack_t cb);
+Bitu GFX_SetSize(Bitu width,Bitu height,Bitu flags,double scalex,double scaley,GFX_CallBack_t callback);
 void GFX_TearDown(void);
 
 void GFX_ResetScreen(void);

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -420,7 +420,7 @@ private:
 
 public: 
 	static void       InsertVariable(char* name, PhysPt adr);
-	static CDebugVar* FindVar       (PhysPt adr);
+	static CDebugVar* FindVar       (PhysPt pt);
 	static void       DeleteAll     ();
 	static bool       SaveVars      (char* name);
 	static bool       LoadVars      (char* name);

--- a/src/debug/debug_inc.h
+++ b/src/debug/debug_inc.h
@@ -98,8 +98,8 @@ public:
     int name_to_win(const char *name);
     WINDOW *get_active_win(void);
     int win_find_order(int wnd);
-    int win_prev_by_order(int ord);
-    int win_next_by_order(int ord);
+    int win_prev_by_order(int order);
+    int win_next_by_order(int order);
     void swap_order(int o1,int o2);
     void next_window(void);
 };

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -76,7 +76,7 @@ typedef struct SCtrl {
     Bit8u           vol[4];
 } TCtrl;
 
-extern int CDROM_GetMountType(char* path, int force);
+extern int CDROM_GetMountType(char* path, int forceCD);
 
 //! \brief Base CD-ROM interface class
 //!

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -99,7 +99,7 @@ public:
 	bool		GetUPC				(Bit8u subUnit, Bit8u& attr, char* upc);
 
 	void		InitNewMedia		(Bit8u subUnit);
-	bool		PlayAudioSector		(Bit8u subUnit, Bit32u start, Bit32u length);
+	bool		PlayAudioSector		(Bit8u subUnit, Bit32u sector, Bit32u length);
 	bool		PlayAudioMSF		(Bit8u subUnit, Bit32u start, Bit32u length);
 	bool		StopAudio			(Bit8u subUnit);
 	bool		GetAudioStatus		(Bit8u subUnit, bool& playing, bool& pause, TMSF& start, TMSF& end);
@@ -112,15 +112,15 @@ public:
 	void		ReplaceDrive		(CDROM_Interface* newCdrom, Bit8u subUnit);
 	void		GetDrives			(PhysPt data);
 	void		GetDriverInfo		(PhysPt data);
-	bool		GetVolumeName		(Bit8u subUnit, char* name);
+	bool		GetVolumeName		(Bit8u subUnit, char* data);
 	bool		GetFileName			(Bit16u drive, Bit16u pos, PhysPt data);
 	bool		GetDirectoryEntry	(Bit16u drive, bool copyFlag, PhysPt pathname, PhysPt buffer, Bit16u& error);
 	bool		ReadVTOC			(Bit16u drive, Bit16u volume, PhysPt data, Bit16u& offset, Bit16u& error);
 	bool		ReadSectors			(Bit16u drive, Bit32u sector, Bit16u num, PhysPt data);
 	bool		ReadSectors			(Bit8u subUnit, bool raw, Bit32u sector, Bit16u num, PhysPt data);
-	bool		ReadSectorsMSF		(Bit8u subUnit, bool raw, Bit32u sector, Bit16u num, PhysPt data);
+	bool		ReadSectorsMSF		(Bit8u subUnit, bool raw, Bit32u start, Bit16u num, PhysPt data);
 	bool		SendDriverRequest	(Bit16u drive, PhysPt data);
-	bool		IsValidDrive		(Bit16u drive);
+	bool		IsValidDrive		(Bit16u _drive);
 	bool		GetCDInfo			(Bit8u subUnit, Bit8u& tr1, Bit8u& tr2, TMSF& leadOut);
 	Bit32u		GetVolumeSize		(Bit8u subUnit);
 	bool		GetTrackInfo		(Bit8u subUnit, Bit8u track, Bit8u& attr, TMSF& start);

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -3242,7 +3242,7 @@ private:
         }
     }
 
-    bool PrepElTorito(const std::string type, const char &el_torito_cd_drive, unsigned long &el_torito_floppy_base, unsigned char &el_torito_floppy_type) {
+    bool PrepElTorito(const std::string& type, const char &el_torito_cd_drive, unsigned long &el_torito_floppy_base, unsigned char &el_torito_floppy_type) {
         el_torito_floppy_base = ~0UL;
         el_torito_floppy_type = 0xFF;
 

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1875,7 +1875,7 @@ bool fatDrive::directoryChange(Bit32u dirClustNumber, direntry *useEntry, Bit32s
 	}
 }
 
-bool fatDrive::addDirectoryEntry(Bit32u dirClustNumber, direntry useEntry) {
+bool fatDrive::addDirectoryEntry(Bit32u dirClustNumber, direntry& useEntry) {
 	direntry sectbuf[MAX_DIRENTS_PER_SECTOR]; /* 16 directory entries per 512 byte sector */
 	Bit32u tmpsector;
 	Bit16u dirPos = 0;

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -83,7 +83,7 @@ public:
 	Virtual_File(Bit8u * in_data,Bit32u in_size);
 	bool Read(Bit8u * data,Bit16u * size);
 	bool Write(const Bit8u * data,Bit16u * size);
-	bool Seek(Bit32u * pos,Bit32u type);
+	bool Seek(Bit32u * new_pos,Bit32u type);
 	bool Close();
 	Bit16u GetInformation(void);
 private:

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -38,7 +38,7 @@ public:
 	static void CycleDisks(int drive, bool notify);
 	static void CycleAllDisks(void);
 	static void CycleAllCDs(void);
-	static void Init(Section* sec);
+	static void Init(Section* s);
 	
 	static void SaveState( std::ostream& stream );
 	static void LoadState( std::istream& stream );
@@ -76,7 +76,7 @@ public:
 	virtual Bits UnMount(void);
 	virtual char const * GetLabel(){return dirCache.GetLabel();};
 	virtual void SetLabel(const char *label, bool iscdrom, bool updatable) { dirCache.SetLabel(label,iscdrom,updatable); };
-	virtual void *opendir(const char *dir);
+	virtual void *opendir(const char *name);
 	virtual void closedir(void *handle);
 	virtual bool read_directory_first(void *handle, char* entry_name, bool& is_directory);
 	virtual bool read_directory_next(void *handle, char* entry_name, bool& is_directory);
@@ -423,7 +423,7 @@ struct isoDirEntry {
 
 class isoDrive : public DOS_Drive {
 public:
-	isoDrive(char driveLetter, const char* device_name, Bit8u mediaid, int &error);
+	isoDrive(char driveLetter, const char* fileName, Bit8u mediaid, int &error);
 	~isoDrive();
 	virtual bool FileOpen(DOS_File **file, const char *name, Bit32u flags);
 	virtual bool FileCreate(DOS_File **file, const char *name, Bit16u attributes);
@@ -431,7 +431,7 @@ public:
 	virtual bool RemoveDir(const char *dir);
 	virtual bool MakeDir(const char *dir);
 	virtual bool TestDir(const char *dir);
-	virtual bool FindFirst(const char *_dir, DOS_DTA &dta, bool fcb_findfirst);
+	virtual bool FindFirst(const char *dir, DOS_DTA &dta, bool fcb_findfirst);
 	virtual bool FindNext(DOS_DTA &dta);
 	virtual bool GetFileAttr(const char *name, Bit16u *attr);
 	virtual bool Rename(const char * oldname,const char * newname);
@@ -452,9 +452,9 @@ private:
 	bool loadImage();
 	bool lookupSingle(isoDirEntry *de, const char *name, Bit32u sectorStart, Bit32u length);
 	bool lookup(isoDirEntry *de, const char *path);
-	int  UpdateMscdex(char driveLetter, const char* physicalPath, Bit8u& subUnit);
+	int  UpdateMscdex(char driveLetter, const char* path, Bit8u& subUnit);
 	int  GetDirIterator(const isoDirEntry* de);
-	bool GetNextDirEntry(const int dirIterator, isoDirEntry* de);
+	bool GetNextDirEntry(const int dirIteratorHandle, isoDirEntry* de);
 	void FreeDirIterator(const int dirIterator);
 	bool ReadCachedSector(Bit8u** buffer, const Bit32u sector);
 	

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -248,7 +248,7 @@ private:
 	bool FindNextInternal(Bit32u dirClustNumber, DOS_DTA & dta, direntry *foundEntry);
 	bool getDirClustNum(const char * dir, Bit32u * clustNum, bool parDir);
 	bool getFileDirEntry(char const * const filename, direntry * useEntry, Bit32u * dirClust, Bit32u * subEntry);
-	bool addDirectoryEntry(Bit32u dirClustNumber, direntry useEntry);
+	bool addDirectoryEntry(Bit32u dirClustNumber, direntry& useEntry);
 	void zeroOutCluster(Bit32u clustNumber);
 	bool getEntryName(const char *fullname, char *entname);
 	friend void DOS_Shell::CMD_SUBST(char* args); 	

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -58,7 +58,7 @@ bool                                                GFX_GetPreventFullscreen(voi
 void                                                RENDER_CallBack( GFX_CallBackFunctions_t function );
 bool                                                OpenGL_using(void);
 
-void                                                MAPPER_TriggerEventByName(const std::string name);
+void                                                MAPPER_TriggerEventByName(const std::string& name);
 void                                                RENDER_CallBack( GFX_CallBackFunctions_t function );
 
 const DOSBoxMenu::mapper_event_t                    DOSBoxMenu::unassigned_mapper_event; /* empty std::string */
@@ -1175,7 +1175,7 @@ void SetScaleForced(bool forced)
 }
 
 // Sets the scaler to use.
-void SetScaler(scalerOperation_t op, Bitu size, std::string prefix)
+void SetScaler(scalerOperation_t op, Bitu size, std::string& prefix)
 {
     auto value = prefix + (render.scale.forced ? " forced" : "");
     SetVal("render", "scaler", value);
@@ -1199,7 +1199,7 @@ std::string MSCDEX_Output(int num) {
     }
 }
 
-void SetVal(const std::string secname, std::string preval, const std::string val) {
+void SetVal(const std::string& secname, const std::string& preval, const std::string& val) {
     if(preval=="keyboardlayout" && !dos_kernel_disabled) {
         DOS_MCB mcb(dos.psp()-1);
         static char name[9];
@@ -1695,7 +1695,8 @@ void MSG_WM_COMMAND_handle(SDL_SysWMmsg &Message) {
         }
     }
 #endif
-    if (!menu.gui || GetSetSDLValue(1, "desktop.fullscreen", 0)) return;
+    std::string fullScreenString = std::string("desktop.fullscreen");
+    if (!menu.gui || GetSetSDLValue(1, fullScreenString, 0)) return;
     if (!GetMenu(GetHWND())) return;
 #if DOSBOXMENU_TYPE == DOSBOXMENU_HMENU
     if (mainMenu.mainMenuWM_COMMAND((unsigned int)LOWORD(Message.wParam))) return;

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1150,7 +1150,7 @@ public:
 class ConfigurationWindow : public GUI::ToplevelWindow {
 public:
     GUI::Button *closeButton;
-    ConfigurationWindow(GUI::Screen *parent, GUI::Size x, GUI::Size y, GUI::String title) :
+    ConfigurationWindow(GUI::Screen *parent, GUI::Size x, GUI::Size y, GUI::String& title) :
         GUI::ToplevelWindow(parent, (int)x, (int)y, 30/*initial*/, 30/*initial*/, title) {
         cfg_windows_active.clear();
 
@@ -1288,9 +1288,10 @@ public:
 static void UI_Execute(GUI::ScreenSDL *screen) {
     SDL_Surface *sdlscreen;
     SDL_Event event;
+    GUI::String configString = GUI::String("DOSBox Configuration");
 
     sdlscreen = screen->getSurface();
-    auto *cfg_wnd = new ConfigurationWindow(screen, 30, 30, "DOSBox Configuration");
+    auto *cfg_wnd = new ConfigurationWindow(screen, 30, 30, configString);
     cfg_wnd->raise();
 
     // event loop
@@ -1347,6 +1348,7 @@ static void UI_Select(GUI::ScreenSDL *screen, int select) {
     Section_prop *section = NULL;
     Section *sec = NULL;
     SDL_Event event;
+    GUI::String configString = GUI::String("DOSBox Configuration");
 
     sdlscreen = screen->getSurface();
     switch (select) {
@@ -1396,7 +1398,7 @@ static void UI_Select(GUI::ScreenSDL *screen, int select) {
             new SaveLangDialog(screen, 90, 100, "Save Language File...");
             break;
         case 10: {
-            auto *np = new ConfigurationWindow(screen, 30, 30, "DOSBox Configuration");
+            auto *np = new ConfigurationWindow(screen, 30, 30, configString);
             np->raise();
             } break;
         case 11:

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2697,7 +2697,7 @@ static void DrawText(Bitu x,Bitu y,const char * text,Bit8u color,Bit8u bkcolor/*
 }
 
 
-void MAPPER_TriggerEventByName(const std::string name) {
+void MAPPER_TriggerEventByName(const std::string& name) {
     CEvent *event = get_mapper_event_by_name(name);
     if (event != NULL) {
         if (event->type == CEvent::handler_event_t) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4532,7 +4532,7 @@ bool GFX_IsFullscreen(void) {
     return sdl.desktop.fullscreen;
 }
 
-void* GetSetSDLValue(int isget, std::string target, void* setval) {
+void* GetSetSDLValue(int isget, std::string& target, void* setval) {
     if (target == "wait_on_error") {
         if (isget) return (void*) sdl.wait_on_error;
         else sdl.wait_on_error = setval;
@@ -6934,8 +6934,9 @@ bool autolock_mouse_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * co
 bool doublebuf_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
     (void)menuitem;//UNUSED
-    SetVal("sdl", "fulldouble", (GetSetSDLValue(1, "desktop.doublebuf", 0)) ? "false" : "true"); res_init();
-    mainMenu.get_item("doublebuf").check(!!GetSetSDLValue(1, "desktop.doublebuf", 0)).refresh_item(mainMenu);
+    std::string doubleBufString = std::string("desktop.doublebuf");
+    SetVal("sdl", "fulldouble", (GetSetSDLValue(1, doubleBufString, 0)) ? "false" : "true"); res_init();
+    mainMenu.get_item("doublebuf").check(!!GetSetSDLValue(1, doubleBufString, 0)).refresh_item(mainMenu);
     return true;
 }
 
@@ -7988,6 +7989,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         }
 
         /* more */
+        std::string doubleBufString = std::string("desktop.doublebuf");
 #if !defined(C_EMSCRIPTEN)
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"show_console").set_text("Show console").set_callback_function(show_console_menu_callback);
 #endif
@@ -7998,7 +8000,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_winlogo").set_text("Logo key").set_callback_function(sendkey_preset_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_winmenu").set_text("Menu key").set_callback_function(sendkey_preset_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_cad").set_text("Ctrl+Alt+Del").set_callback_function(sendkey_preset_menu_callback);
-        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"doublebuf").set_text("Double Buffering (Fullscreen)").set_callback_function(doublebuf_menu_callback).check(!!GetSetSDLValue(1, "desktop.doublebuf", 0));
+        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"doublebuf").set_text("Double Buffering (Fullscreen)").set_callback_function(doublebuf_menu_callback).check(!!GetSetSDLValue(1, doubleBufString, 0));
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"alwaysontop").set_text("Always on top").set_callback_function(alwaysontop_menu_callback).check(is_always_on_top());
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"showdetails").set_text("Show details").set_callback_function(showdetails_menu_callback).check(!menu.hidecycles && !menu.showrt);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"highdpienable").set_text("High DPI enable").set_callback_function(highdpienable_menu_callback).check(dpi_aware_enable);

--- a/src/hardware/adlib.h
+++ b/src/hardware/adlib.h
@@ -86,7 +86,7 @@ struct Chip {
 	//Last selected register
 	Timer timer[2];
 	//Check for it being a write to the timer
-	bool Write( Bit32u addr, Bit8u val );
+	bool Write( Bit32u reg, Bit8u val );
 	//Read the current timer state, will use current double
 	Bit8u Read( );
 	//poll counter

--- a/src/hardware/dbopl.h
+++ b/src/hardware/dbopl.h
@@ -236,13 +236,13 @@ struct Chip {
 
 	Bit32u WriteAddr( Bit32u port, Bit8u val );
 
-	void GenerateBlock2( Bitu samples, Bit32s* output );
-	void GenerateBlock3( Bitu samples, Bit32s* output );
+	void GenerateBlock2( Bitu total, Bit32s* output );
+	void GenerateBlock3( Bitu total, Bit32s* output );
 
 	//Update the synth handlers in all channels
 	void UpdateSynths();
 	void Generate( Bit32u samples );
-	void Setup( Bit32u r );
+	void Setup( Bit32u rate );
 
 	Chip();
 };

--- a/src/hardware/mame/fmopl.h
+++ b/src/hardware/mame/fmopl.h
@@ -48,7 +48,7 @@ unsigned char ym3812_read(void *chip, int a);
 int  ym3812_timer_over(void *chip, int c);
 void ym3812_update_one(void *chip, OPLSAMPLE *buffer, int length);
 
-void ym3812_set_timer_handler(void *chip, OPL_TIMERHANDLER TimerHandler, device_t *device);
+void ym3812_set_timer_handler(void *chip, OPL_TIMERHANDLER timer_handler, device_t *device);
 void ym3812_set_irq_handler(void *chip, OPL_IRQHANDLER IRQHandler, device_t *device);
 void ym3812_set_update_handler(void *chip, OPL_UPDATEHANDLER UpdateHandler, device_t *device);
 

--- a/src/hardware/mame/ymf262.h
+++ b/src/hardware/mame/ymf262.h
@@ -30,9 +30,9 @@ void ymf262_reset_chip(void *chip);
 int  ymf262_write(void *chip, int a, int v);
 unsigned char ymf262_read(void *chip, int a);
 int  ymf262_timer_over(void *chip, int c);
-void ymf262_update_one(void *chip, OPL3SAMPLE **buffers, int length);
+void ymf262_update_one(void *_chip, OPL3SAMPLE **buffers, int length);
 
-void ymf262_set_timer_handler(void *chip, OPL3_TIMERHANDLER TimerHandler, device_t *device);
+void ymf262_set_timer_handler(void *chip, OPL3_TIMERHANDLER timer_handler, device_t *device);
 void ymf262_set_irq_handler(void *chip, OPL3_IRQHANDLER IRQHandler, device_t *device);
 void ymf262_set_update_handler(void *chip, OPL3_UPDATEHANDLER UpdateHandler, device_t *device);
 

--- a/src/hardware/snd_pc98/sound/opngen.h
+++ b/src/hardware/snd_pc98/sound/opngen.h
@@ -174,8 +174,8 @@ void opngen_setextch(UINT chnum, REG8 data);
 void opngen_setreg(REG8 chbase, UINT reg, REG8 value);
 void opngen_keyon(UINT chnum, REG8 value);
 
-void SOUNDCALL opngen_getpcm(void *hdl, SINT32 *buf, UINT count);
-void SOUNDCALL opngen_getpcmvr(void *hdl, SINT32 *buf, UINT count);
+void SOUNDCALL opngen_getpcm(void *hdl, SINT32 *pcm, UINT count);
+void SOUNDCALL opngen_getpcmvr(void *hdl, SINT32 *pcm, UINT count);
 
 #ifdef __cplusplus
 }

--- a/src/hardware/snd_pc98/sound/rhythm.h
+++ b/src/hardware/snd_pc98/sound/rhythm.h
@@ -19,7 +19,7 @@ void rhythm_setvol(UINT vol);
 void rhythm_reset(RHYTHM rhy);
 void rhythm_bind(RHYTHM rhy);
 void rhythm_update(RHYTHM rhy);
-void rhythm_setreg(RHYTHM rhy, UINT reg, REG8 val);
+void rhythm_setreg(RHYTHM rhy, UINT reg, REG8 value);
 
 #ifdef __cplusplus
 }

--- a/src/hardware/snd_pc98/x11/dosio.h
+++ b/src/hardware/snd_pc98/x11/dosio.h
@@ -76,8 +76,8 @@ short file_delete_c(const OEMCHAR *sjis);
 short file_attr_c(const OEMCHAR *sjis);
 
 void file_cpyname(char *dst, const char *src, int maxlen);
-void file_catname(char *path, const char *sjis, int maxlen);
-BOOL file_cmpname(const char *path, const char *sjis);
+void file_catname(char *path, const char *filename, int maxlen);
+BOOL file_cmpname(const char *path, const char *path2);
 OEMCHAR *file_getname(const OEMCHAR *path);
 void file_cutname(OEMCHAR *path);
 OEMCHAR *file_getext(const OEMCHAR *path);

--- a/src/hardware/voodoo_emu.cpp
+++ b/src/hardware/voodoo_emu.cpp
@@ -124,7 +124,7 @@ static raster_info *add_rasterizer(voodoo_state *v, const raster_info *cinfo);
 static raster_info *find_rasterizer(voodoo_state *v, int texcount);
 
 /* generic rasterizers */
-static void raster_fastfill(void *dest, INT32 scanline, const poly_extent *extent, const void *extradata);
+static void raster_fastfill(void *destbase, INT32 y, const poly_extent *extent, const void *extradata);
 
 
 /***************************************************************************

--- a/src/ints/bios_memdisk.cpp
+++ b/src/ints/bios_memdisk.cpp
@@ -113,7 +113,7 @@ imageDiskMemory::imageDiskMemory(Bit32u imgSizeK) : imageDisk(ID_MEMORY), total_
 }
 
 // Create a floppy image of a specified geometry
-imageDiskMemory::imageDiskMemory(diskGeo floppyGeometry) : imageDisk(ID_MEMORY), total_sectors(0), underlyingImage(NULL) {
+imageDiskMemory::imageDiskMemory(diskGeo& floppyGeometry) : imageDisk(ID_MEMORY), total_sectors(0), underlyingImage(NULL) {
 	init(floppyGeometry, false, 0);
 }
 

--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -560,8 +560,8 @@ static Bit8u EMM_ReleaseMemory(Bit16u handle) {
 
 static Bit8u EMM_SavePageMap(Bit16u handle) {
 	/* Check for valid handle */
-	if (handle>=EMM_MAX_HANDLES || emm_handles[handle].pages==NULL_HANDLE) {
-		if (handle!=0) return EMM_INVALID_HANDLE;
+	if (handle>=EMM_MAX_HANDLES || (handle != 0 && emm_handles[handle].pages==NULL_HANDLE)) {
+		return EMM_INVALID_HANDLE;
 	}
 	/* Check for previous save */
 	if (emm_handles[handle].saved_page_map) return EMM_PAGE_MAP_SAVED;
@@ -589,8 +589,8 @@ static Bit8u EMM_RestoreMappingTable(void) {
 }
 static Bit8u EMM_RestorePageMap(Bit16u handle) {
 	/* Check for valid handle */
-	if (handle>=EMM_MAX_HANDLES || emm_handles[handle].pages==NULL_HANDLE) {
-		if (handle!=0) return EMM_INVALID_HANDLE;
+	if (handle>=EMM_MAX_HANDLES || (handle != 0 && emm_handles[handle].pages==NULL_HANDLE)) {
+		return EMM_INVALID_HANDLE;
 	}
 	/* Check for previous save */
 	if (!emm_handles[handle].saved_page_map) return EMM_NO_SAVED_PAGE_MAP;

--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -249,7 +249,7 @@ RealPt INT10_EGA_RIL_GetVersionPt(void);
 void INT10_EGA_RIL_ReadRegister(Bit8u & bl, Bit16u dx);
 void INT10_EGA_RIL_WriteRegister(Bit8u & bl, Bit8u bh, Bit16u dx);
 void INT10_EGA_RIL_ReadRegisterRange(Bit8u ch, Bit8u cl, Bit16u dx, PhysPt dst);
-void INT10_EGA_RIL_WriteRegisterRange(Bit8u ch, Bit8u cl, Bit16u dx, PhysPt dst);
+void INT10_EGA_RIL_WriteRegisterRange(Bit8u ch, Bit8u cl, Bit16u dx, PhysPt src);
 void INT10_EGA_RIL_ReadRegisterSet(Bit16u cx, PhysPt tbl);
 void INT10_EGA_RIL_WriteRegisterSet(Bit16u cx, PhysPt tbl);
 

--- a/src/ints/qcow2_disk.cpp
+++ b/src/ints/qcow2_disk.cpp
@@ -56,7 +56,7 @@ using namespace std;
 
 
 //Public Constructor.
-	QCow2Image::QCow2Image(QCow2Image::QCow2Header qcow2Header, FILE *qcow2File, const char* imageName, Bit32u sectorSizeBytes) : file(qcow2File), header(qcow2Header), sector_size(sectorSizeBytes), backing_image(NULL)
+	QCow2Image::QCow2Image(QCow2Image::QCow2Header& qcow2Header, FILE *qcow2File, const char* imageName, Bit32u sectorSizeBytes) : file(qcow2File), header(qcow2Header), sector_size(sectorSizeBytes), backing_image(NULL)
 	{
 		cluster_mask = mask64(header.cluster_bits);
 		cluster_size = cluster_mask + 1;
@@ -446,7 +446,7 @@ using namespace std;
 
 
 //Public Constructor.
-	QCow2Disk::QCow2Disk(QCow2Image::QCow2Header qcow2Header, FILE *qcow2File, Bit8u *imgName, Bit32u imgSizeK, Bit32u sectorSizeBytes, bool isHardDisk) : imageDisk(qcow2File, imgName, imgSizeK, isHardDisk), qcowImage(qcow2Header, qcow2File, (const char*) imgName, sectorSizeBytes){
+	QCow2Disk::QCow2Disk(QCow2Image::QCow2Header& qcow2Header, FILE *qcow2File, Bit8u *imgName, Bit32u imgSizeK, Bit32u sectorSizeBytes, bool isHardDisk) : imageDisk(qcow2File, imgName, imgSizeK, isHardDisk), qcowImage(qcow2Header, qcow2File, (const char*) imgName, sectorSizeBytes){
 	}
 
 

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -947,7 +947,7 @@ public:
 	/** \p cb is not copied. */
 	static void add(Timer_Callback *cb, const Ticks ticks) { timers.insert(std::pair<const Ticks,Timer_Callback *>(ticks+Timer::ticks,cb)); }
 
-	static void remove(const Timer_Callback *const cb);
+	static void remove(const Timer_Callback *const timer);
 
 	/// Return current time (ticks since application start)
 	static Ticks now() { return ticks; }
@@ -1043,7 +1043,7 @@ public:
 	Uint32 getTime() { return current_time; }
 
 	/// Process an SDL event. Returns \c true if event was handled.
-	bool event(const SDL_Event& ev);
+	bool event(const SDL_Event& event);
 };
 #endif
 

--- a/src/mt32/AReverbModel.h
+++ b/src/mt32/AReverbModel.h
@@ -38,7 +38,7 @@ protected:
 	Bit32u index;
 
 public:
-	RingBuffer(const Bit32u size);
+	RingBuffer(const Bit32u newsize);
 	virtual ~RingBuffer();
 	float next();
 	bool isEmpty() const;
@@ -47,7 +47,7 @@ public:
 
 class AllpassFilter : public RingBuffer {
 public:
-	AllpassFilter(const Bit32u size);
+	AllpassFilter(const Bit32u useSize);
 	float process(const float in);
 };
 
@@ -56,7 +56,7 @@ class CombFilter : public RingBuffer {
 	float filterFactor;
 
 public:
-	CombFilter(const Bit32u size);
+	CombFilter(const Bit32u useSize);
 	void process(const float in);
 	float getOutputAt(const Bit32u outIndex) const;
 	void setFeedbackFactor(const float useFeedbackFactor);

--- a/src/mt32/DelayReverb.h
+++ b/src/mt32/DelayReverb.h
@@ -42,7 +42,7 @@ public:
 	~DelayReverb();
 	void open();
 	void close();
-	void setParameters(Bit8u time, Bit8u level);
+	void setParameters(Bit8u newTime, Bit8u newLevel);
 	void process(const float *inLeft, const float *inRight, float *outLeft, float *outRight, unsigned long numSamples);
 	bool isActive() const;
 

--- a/src/mt32/LA32WaveGenerator.h
+++ b/src/mt32/LA32WaveGenerator.h
@@ -176,13 +176,13 @@ class LA32WaveGenerator {
 
 public:
 	// Initialise the WG engine for generation of synth partial samples and set up the invariant parameters
-	void initSynth(const bool sawtoothWaveform, const Bit8u pulseWidth, const Bit8u resonance);
+	void initSynth(const bool useSawtoothWaveform, const Bit8u usePulseWidth, const Bit8u useResonance);
 
 	// Initialise the WG engine for generation of PCM partial samples and set up the invariant parameters
-	void initPCM(const Bit16s * const pcmWaveAddress, const Bit32u pcmWaveLength, const bool pcmWaveLooped, const bool pcmWaveInterpolated);
+	void initPCM(const Bit16s * const usePCMWaveAddress, const Bit32u usePCMWaveLength, const bool usePCMWaveLooped, const bool usePCMWaveInterpolated);
 
 	// Update parameters with respect to TVP, TVA and TVF, and generate next sample
-	void generateNextSample(const Bit32u amp, const Bit16u pitch, const Bit32u cutoff);
+	void generateNextSample(const Bit32u useAmp, const Bit16u usePitch, const Bit32u useCutoffVal);
 
 	// WG output in the log-space consists of two components which are to be added (or ring modulated) in the linear-space afterwards
 	LogSample getOutputLogSample(const bool first) const;
@@ -218,25 +218,25 @@ public:
 	// ringModulated should be set to false for the structures with mixing or stereo output
 	// ringModulated should be set to true for the structures with ring modulation
 	// mixed is used for the structures with ring modulation and indicates whether the master partial output is mixed to the ring modulator output
-	void init(const bool ringModulated, const bool mixed);
+	void init(const bool useRingModulated, const bool useMixed);
 
 	// Initialise the WG engine for generation of synth partial samples and set up the invariant parameters
-	void initSynth(const PairType master, const bool sawtoothWaveform, const Bit8u pulseWidth, const Bit8u resonance);
+	void initSynth(const PairType useMaster, const bool sawtoothWaveform, const Bit8u pulseWidth, const Bit8u resonance);
 
 	// Initialise the WG engine for generation of PCM partial samples and set up the invariant parameters
 	void initPCM(const PairType master, const Bit16s * const pcmWaveAddress, const Bit32u pcmWaveLength, const bool pcmWaveLooped);
 
 	// Update parameters with respect to TVP, TVA and TVF, and generate next sample
-	void generateNextSample(const PairType master, const Bit32u amp, const Bit16u pitch, const Bit32u cutoff);
+	void generateNextSample(const PairType useMaster, const Bit32u amp, const Bit16u pitch, const Bit32u cutoff);
 
 	// Perform mixing / ring modulation and return the result
 	Bit16s nextOutSample();
 
 	// Deactivate the WG engine
-	void deactivate(const PairType master);
+	void deactivate(const PairType useMaster);
 
 	// Return active state of the WG engine
-	bool isActive(const PairType master) const;
+	bool isActive(const PairType useMaster) const;
 };
 
 } // namespace MT32Emu

--- a/src/mt32/Part.h
+++ b/src/mt32/Part.h
@@ -36,7 +36,7 @@ public:
 	void prepend(Poly *poly);
 	void append(Poly *poly);
 	Poly *takeFirst();
-	void remove(Poly * const poly);
+	void remove(Poly * const polyToRemove);
 };
 
 class Part {
@@ -80,7 +80,7 @@ protected:
 	const char *getName() const;
 
 public:
-	Part(Synth *synth, unsigned int usePartNum);
+	Part(Synth *useSynth, unsigned int usePartNum);
 	virtual ~Part();
 	void reset();
 	void setDataEntryMSB(unsigned char midiDataEntryMSB);
@@ -101,8 +101,8 @@ public:
 	virtual void setPan(unsigned int midiPan);
 	Bit32s getPitchBend() const;
 	void setBend(unsigned int midiBend);
-	virtual void setProgram(unsigned int midiProgram);
-	void setHoldPedal(bool pedalval);
+	virtual void setProgram(unsigned int patchNum);
+	void setHoldPedal(bool pressed);
 	void stopPedalHold();
 	void updatePitchBenderRange();
 	virtual void refresh();
@@ -136,11 +136,11 @@ class RhythmPart: public Part {
 	// This caches the timbres/settings in use by the rhythm part
 	PatchCache drumCache[85][4];
 public:
-	RhythmPart(Synth *synth, unsigned int usePartNum);
+	RhythmPart(Synth *useSynth, unsigned int usePartNum);
 	void refresh();
-	void refreshTimbre(unsigned int timbreNum);
+	void refreshTimbre(unsigned int absTimbreNum);
 	void setTimbre(TimbreParam *timbre);
-	void noteOn(unsigned int key, unsigned int velocity);
+	void noteOn(unsigned int midiKey, unsigned int velocity);
 	void noteOff(unsigned int midiKey);
 	unsigned int getAbsTimbreNum() const;
 	void setPan(unsigned int midiPan);

--- a/src/mt32/Partial.h
+++ b/src/mt32/Partial.h
@@ -79,7 +79,7 @@ public:
 	Partial *pair;
 	bool alreadyOutputed = false;
 
-	Partial(Synth *synth, int debugPartialNum);
+	Partial(Synth *useSynth, int useDebugPartialNum);
 	~Partial();
 
 	int debugGetPartialNum() const;
@@ -90,7 +90,7 @@ public:
 	bool isActive() const;
 	void activate(int part);
 	void deactivate(void);
-	void startPartial(const Part *part, Poly *usePoly, const PatchCache *useCache, const MemParams::RhythmTemp *rhythmTemp, Partial *pairPartial);
+	void startPartial(const Part *part, Poly *usePoly, const PatchCache *usePatchCache, const MemParams::RhythmTemp *rhythmTemp, Partial *pairPartial);
 	void startAbort();
 	void startDecayAll();
 	bool shouldReverb();

--- a/src/mt32/PartialManager.h
+++ b/src/mt32/PartialManager.h
@@ -35,7 +35,7 @@ private:
 
 public:
 
-	PartialManager(Synth *synth, Part **parts);
+	PartialManager(Synth *useSynth, Part **useParts);
 	~PartialManager();
 	Partial *allocPartial(int partNum);
 	unsigned int getFreePartialCount(void);

--- a/src/mt32/Poly.h
+++ b/src/mt32/Poly.h
@@ -49,7 +49,7 @@ private:
 
 public:
 	Poly(Synth *useSynth, Part *usePart);
-	void reset(unsigned int key, unsigned int velocity, bool sustain, Partial **partials);
+	void reset(unsigned int newKey, unsigned int newVelocity, bool newSustain, Partial **newPartials);
 	bool noteOff(bool pedalHeld);
 	bool stopPedalHold();
 	bool startDecay();

--- a/src/mt32/Synth.h
+++ b/src/mt32/Synth.h
@@ -247,7 +247,7 @@ protected:
 	// Callbacks for reporting various errors and information
 	virtual void onErrorControlROM() {}
 	virtual void onErrorPCMROM() {}
-	virtual void showLCDMessage(const char *message);
+	virtual void showLCDMessage(const char *data);
 	virtual void onDeviceReset() {}
 	virtual void onDeviceReconfig() {}
 	virtual void onNewReverbMode(Bit8u /* mode */) {}
@@ -363,8 +363,8 @@ private:
 	bool loadPCMROM(const ROMImage &pcmROMImage);
 
 	bool initPCMList(Bit16u mapAddress, Bit16u count);
-	bool initTimbres(Bit16u mapAddress, Bit16u offset, int timbreCount, int startTimbre, bool compressed);
-	bool initCompressedTimbre(int drumNum, const Bit8u *mem, unsigned int memLen);
+	bool initTimbres(Bit16u mapAddress, Bit16u offset, int count, int startTimbre, bool compressed);
+	bool initCompressedTimbre(int timbreNum, const Bit8u *src, unsigned int srcLen);
 
 	void refreshSystemMasterTune();
 	void refreshSystemReverbParameters();
@@ -406,11 +406,11 @@ public:
 	void playSysex(const Bit8u *sysex, Bit32u len);
 	void playSysexWithoutFraming(const Bit8u *sysex, Bit32u len);
 	void playSysexWithoutHeader(unsigned char device, unsigned char command, const Bit8u *sysex, Bit32u len);
-	void writeSysex(unsigned char channel, const Bit8u *sysex, Bit32u len);
+	void writeSysex(unsigned char device, const Bit8u *sysex, Bit32u len);
 
-	void setReverbEnabled(bool reverbEnabled);
+	void setReverbEnabled(bool newReverbEnabled);
 	bool isReverbEnabled() const;
-	void setReverbOverridden(bool reverbOverridden);
+	void setReverbOverridden(bool newReverbOverridden);
 	bool isReverbOverridden() const;
 	void setDACInputMode(DACInputMode mode);
 
@@ -436,7 +436,7 @@ public:
 
 	const Partial *getPartial(unsigned int partialNum) const;
 
-	void setPartialLimit( unsigned int partialLimit );
+	void setPartialLimit( unsigned int _partialLimit );
 	unsigned int getPartialLimit() const;
 	
 	void readMemory(Bit32u addr, Bit32u len, Bit8u *data);

--- a/src/mt32/TVA.h
+++ b/src/mt32/TVA.h
@@ -78,8 +78,8 @@ private:
 	void nextPhase();
 
 public:
-	TVA(const Partial *partial, LA32Ramp *ampRamp);
-	void reset(const Part *part, const TimbreParam::PartialParam *partialParam, const MemParams::RhythmTemp *rhythmTemp);
+	TVA(const Partial *usePartial, LA32Ramp *useAmpRamp);
+	void reset(const Part *newPart, const TimbreParam::PartialParam *newPartialParam, const MemParams::RhythmTemp *newRhythmTemp);
 	void handleInterrupt();
 	void recalcSustain();
 	void startDecay();

--- a/src/mt32/TVF.h
+++ b/src/mt32/TVF.h
@@ -37,8 +37,8 @@ private:
 	void nextPhase();
 
 public:
-	TVF(const Partial *partial, LA32Ramp *cutoffModifierRamp);
-	void reset(const TimbreParam::PartialParam *partialParam, Bit32u basePitch);
+	TVF(const Partial *usePartial, LA32Ramp *useCutoffModifierRamp);
+	void reset(const TimbreParam::PartialParam *newPartialParam, Bit32u basePitch);
 	// Returns the base cutoff (without envelope modification).
 	// The base cutoff is calculated when reset() is called and remains static
 	// for the lifetime of the partial.

--- a/src/mt32/TVP.h
+++ b/src/mt32/TVP.h
@@ -55,8 +55,8 @@ private:
 	void nextPhase();
 	void process();
 public:
-	TVP(const Partial *partial);
-	void reset(const Part *part, const TimbreParam::PartialParam *partialParam);
+	TVP(const Partial *usePartial);
+	void reset(const Part *usePart, const TimbreParam::PartialParam *usePartialParam);
 	Bit32u getBasePitch() const;
 	Bit16u nextPitch();
 	void startDecay();

--- a/src/mt32/freeverb/allpass.h
+++ b/src/mt32/freeverb/allpass.h
@@ -15,7 +15,7 @@ public:
 	                allpass();
 	        void    setbuffer(float *buf, int size);
 	        void    deletebuffer();
-	inline  float   process(float inp);
+	inline  float   process(float input);
 	        void    mute();
 	        void    setfeedback(float val);
 	        float   getfeedback();

--- a/src/mt32/freeverb/comb.h
+++ b/src/mt32/freeverb/comb.h
@@ -16,7 +16,7 @@ public:
 	                comb();
 	        void    setbuffer(float *buf, int size);
 	        void    deletebuffer();
-	inline  float   process(float inp);
+	inline  float   process(float input);
 	        void    mute();
 	        void    setdamp(float val);
 	        float   getdamp();

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -888,7 +888,7 @@ void DOS_Shell::CMD_DIR(char * args) {
 struct copysource {
 	std::string filename;
 	bool concat;
-	copysource(std::string filein,bool concatin):
+	copysource(std::string& filein,bool concatin):
 		filename(filein),concat(concatin){ };
 	copysource():filename(""),concat(false){ };
 };
@@ -896,7 +896,7 @@ struct copysource {
 
 void DOS_Shell::CMD_COPY(char * args) {
 	HELP("COPY");
-	static char defaulttarget[] = ".";
+	static std::string defaulttarget = ".";
 	StripSpaces(args);
 	/* Command uses dta so set it to our internal dta */
 	RealPt save_dta=dos.dta();
@@ -949,7 +949,8 @@ void DOS_Shell::CMD_COPY(char * args) {
 						strcat(source_x,"\\*.*");
 				}
 			}
-			sources.push_back(copysource(source_x,(plus)?true:false));
+            std::string source_xString = std::string(source_x);
+			sources.push_back(copysource(source_xString,(plus)?true:false));
 			source_p = plus;
 		} while(source_p && *source_p);
 	}
@@ -1770,7 +1771,7 @@ void DOS_Shell::CMD_VOL(char *args){
 	return;
 }
 
-void SetVal(const std::string secname, std::string preval, const std::string val);
+void SetVal(const std::string& secname, const std::string& preval, const std::string& val);
 static void delayed_press(Bitu key) { KEYBOARD_AddKey((KBD_KEYS)key,true); }
 static void delayed_release(Bitu key) { KEYBOARD_AddKey((KBD_KEYS)key,false); }
 static void delayed_sdlpress(Bitu core) {

--- a/vs2015/sdlnet/SDL_net.h
+++ b/vs2015/sdlnet/SDL_net.h
@@ -137,7 +137,7 @@ extern DECLSPEC IPaddress * SDLCALL SDLNet_TCP_GetPeerAddress(TCPsocket sock);
    is less than the amount of data sent, then either the remote connection was
    closed, or an unknown socket error occurred.
 */
-extern DECLSPEC int SDLCALL SDLNet_TCP_Send(TCPsocket sock, const void *data,
+extern DECLSPEC int SDLCALL SDLNet_TCP_Send(TCPsocket sock, const void *datap,
 		int len);
 
 /* Receive up to 'maxlen' bytes of data over the non-server socket 'sock',
@@ -328,12 +328,12 @@ extern DECLSPEC void SDLCALL SDLNet_FreeSocketSet(SDLNet_SocketSet set);
 /***********************************************************************/
 
 /* Write a 16/32 bit value to network packet buffer */
-extern DECLSPEC void SDLCALL SDLNet_Write16(Uint16 value, void *area);
-extern DECLSPEC void SDLCALL SDLNet_Write32(Uint32 value, void *area);
+extern DECLSPEC void SDLCALL SDLNet_Write16(Uint16 value, void *areap);
+extern DECLSPEC void SDLCALL SDLNet_Write32(Uint32 value, void *areap);
 
 /* Read a 16/32 bit value from network packet buffer */
-extern DECLSPEC Uint16 SDLCALL SDLNet_Read16(void *area);
-extern DECLSPEC Uint32 SDLCALL SDLNet_Read32(void *area);
+extern DECLSPEC Uint16 SDLCALL SDLNet_Read16(void *areap);
+extern DECLSPEC Uint32 SDLCALL SDLNet_Read32(void *areap);
 
 /***********************************************************************/
 /* Error reporting functions                                           */


### PR DESCRIPTION
**passedByValue**: Warnings where Cppcheck suggests a large value be passed by reference for performance. All fixed.

**arrayIndexOutofBoundsCond**: Warning about accessing an array out of bounds. This is actually a false positive by Cppcheck but fixing the warning makes the check more logical since `if (handle!=0)` needn't be checked if `handle>=EMM_MAX_HANDLES` is true.

**funcArgNamesDifferent**: Means that function argument name is different in the declaration and the definition. I matched them all to the definition, so I wouldn't have to do changes to the names within the function bodies. All fixed.

Compiles and runs.