### PR TITLE
Fix Cppcheck uninitMemberVar warnings

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -276,7 +276,7 @@ public:
 		VHD_TYPE_DYNAMIC = 3,
 		VHD_TYPE_DIFFERENCING = 4
 	};
-	VHDTypes vhdType;
+    VHDTypes vhdType = VHD_TYPE_NONE;
 	virtual Bit8u Read_AbsoluteSector(Bit32u sectnum, void * data);
 	virtual Bit8u Write_AbsoluteSector(Bit32u sectnum, const void * data);
 	static ErrorCodes Open(const char* fileName, const bool readOnly, imageDisk** disk);

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -238,18 +238,18 @@ private:
 	void		Clear			(void);
 
 	CFileInfo*	dirBase;
-	char		dirPath				[CROSS_LEN];
-	DOS_Drive*	drive;
-	char		basePath			[CROSS_LEN];
-	bool		dirFirstTime;
+	char		dirPath				[CROSS_LEN] = {};
+	DOS_Drive*	drive = NULL;
+	char		basePath			[CROSS_LEN] = {};
+	bool		dirFirstTime = false;
 	TDirSort	sortDirType;
 	CFileInfo*	save_dir;
-	char		save_path			[CROSS_LEN];
-	char		save_expanded		[CROSS_LEN];
+	char		save_path			[CROSS_LEN] = {};
+	char		save_expanded		[CROSS_LEN] = {};
 
 	Bit16u		srchNr;
 	CFileInfo*	dirSearch			[MAX_OPENDIRS];
-	char		dirSearchName		[MAX_OPENDIRS];
+	char		dirSearchName		[MAX_OPENDIRS] = {};
 	CFileInfo*	dirFindFirst		[MAX_OPENDIRS];
 	Bit16u		nextFreeFindFirst;
 

--- a/include/menu.h
+++ b/include/menu.h
@@ -212,7 +212,7 @@ class DOSBoxMenu {
                     unsigned int        enabled:1;
                     unsigned int        checked:1;
                     unsigned int        in_use:1;
-                } status;
+                } status = {};
             protected:
                 callback_t              callback_func = unassigned_callback;
                 mapper_event_t          mapper_event = unassigned_mapper_event;

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -93,10 +93,11 @@ private:
 		Bit16u required_flags,forbidden_flags;
 		Bit16u required_userflags,forbidden_userflags;
 	} current_layout_planes[layout_pages-4];
-	Bit8u additional_planes,used_lock_modifiers;
+    Bit8u additional_planes = 0;
+    Bit8u used_lock_modifiers;
 
 	// diacritics table
-	Bit8u diacritics[2048];
+    Bit8u diacritics[2048] = {};
 	Bit16u diacritics_entries;
 	Bit16u diacritics_character;
 	Bit16u user_keys;

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -114,6 +114,9 @@ fatFile::fatFile(const char* /*name*/, Bit32u startCluster, Bit32u fileLen, fatD
 	curSectOff = 0;
 	seekpos = 0;
 	memset(&sectorBuffer[0], 0, sizeof(sectorBuffer));
+    currentSector = 0;
+    dirCluster = 0;
+    dirIndex = 0;
 	
 	if(filelength > 0) {
 		Seek(&seekto, DOS_SEEK_SET);

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -256,12 +256,12 @@ class Capture {
 	Bit8u ToRaw[256];
 	Bit8u delay256;
 	Bit8u delayShift8;
-	RawHeader header;
+    RawHeader header = {};
 
 	FILE*	handle;				//File used for writing
 	Bit32u	startTicks;			//Start used to check total raw length on end
 	Bit32u	lastTicks;			//Last ticks when last last cmd was added
-	Bit8u	buf[1024];	//16 added for delay commands and what not
+    Bit8u   buf[1024] = {};     //16 added for delay commands and what not
 	Bit32u	bufUsed;
 #if 0//unused
     Bit8u	cmd[2];				//Last cmd's sent to either ports
@@ -457,6 +457,8 @@ skipWrite:
 		cache = _cache;
 		handle = 0;
 		bufUsed = 0;
+        startTicks = 0;
+        lastTicks = 0;
 		MakeTables();
 	}
 	~Capture() {

--- a/src/hardware/dbopl.cpp
+++ b/src/hardware/dbopl.cpp
@@ -612,6 +612,15 @@ Operator::Operator() {
 	reg60 = 0;
 	reg80 = 0;
 	regE0 = 0;
+    waveBase = 0;
+    waveMask = 0;
+    waveStart = 0;
+    vibrato = 0;
+    attackAdd = 0;
+    decayAdd = 0;
+    rateIndex = 0;
+    tremoloMask = 0;
+    vibStrength = 0;
 	SetState( OFF );
 	rateZero = (1 << OFF);
 	sustainLevel = ENV_MAX;

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -390,6 +390,7 @@ DmaChannel::DmaChannel(Bit8u num, bool dma16) {
 	callback = NULL;
 	channum = num;
 	DMA16 = dma16 ? 0x1 : 0x0;
+    transfer_mode = 0;
 
     if (isadma128k >= 0)
         Set128KMode(isadma128k > 0); // user's choice

--- a/src/hardware/floppy.cpp
+++ b/src/hardware/floppy.cpp
@@ -80,12 +80,12 @@ public:
 	bool register_pnp;
 /* FDC internal registers */
 	uint8_t ST[4];			/* ST0..ST3 */
-	uint8_t current_cylinder[4];
+    uint8_t current_cylinder[4] = {};
 /* buffers */
-	uint8_t in_cmd[16];
+    uint8_t in_cmd[16] = {};
 	uint8_t in_cmd_len;
 	uint8_t in_cmd_pos;
-	uint8_t out_res[16];
+    uint8_t out_res[16] = {};
 	uint8_t out_res_len;
 	uint8_t out_res_pos;
 	unsigned int motor_steps;
@@ -458,6 +458,9 @@ FloppyController::FloppyController(Section* configuration,unsigned char index):M
 	busy_status = 0;
 	for (i=0;i < 4;i++) positioning[i] = false;
 	for (i=0;i < 4;i++) ST[i] = 0x00;
+    irq_pending = false;
+    motor_steps = 0;
+    motor_dir = 0;
 	reset_io();
 
 	digital_output_register = 0;

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1194,7 +1194,7 @@ public:
 	};
 public:
 	struct mixcontrol	mixpair[8];		// pairs 1-5 and Master
-	struct volpair		volpair[5];		// pairs 1-5 scaled by master
+    struct volpair		volpair[5] = {};	// pairs 1-5 scaled by master
 	uint8_t			addr_attenuator = 0;	// which attenuator is selected
 	uint8_t			addr_control = 0;		// which control is selected
 } GUS_ICS2101;

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -1199,6 +1199,14 @@ void IDEATAPICDROMDevice::set_sense(unsigned char SK,unsigned char ASC,unsigned 
 IDEATAPICDROMDevice::IDEATAPICDROMDevice(IDEController *c,unsigned char drive_index) : IDEDevice(c) {
     this->drive_index = drive_index;
     sector_i = sector_total = 0;
+    atapi_to_host = false;
+    host_maximum_byte_count = 0;
+    LBA = 0;
+    TransferLength = 0;
+    memset(atapi_cmd, 0, sizeof(atapi_cmd));
+    atapi_cmd_i = 0;
+    atapi_cmd_total = 0;
+    memset(sector, 0, sizeof(sector));
 
     memset(sense,0,sizeof(sense));
     set_sense(/*SK=*/0);
@@ -2040,6 +2048,13 @@ IDEATADevice::IDEATADevice(IDEController *c,unsigned char bios_disk_index) : IDE
     multiple_sector_max = sizeof(sector) / 512;
     multiple_sector_count = 1;
     geo_translate = false;
+    heads = 0;
+    sects = 0;
+    cyls = 0;
+    progress_count = 0;
+    phys_heads = 0;
+    phys_sects = 0;
+    phys_cyls = 0;
 }
 
 IDEATADevice::~IDEATADevice() {

--- a/src/hardware/mame/saa1099.cpp
+++ b/src/hardware/mame/saa1099.cpp
@@ -155,6 +155,7 @@ saa1099_device::saa1099_device(const machine_config &mconfig, const char *tag, d
 	, m_sync_state(0)
 	, m_selected_reg(0)
 	, m_sample_rate(0.0)
+    , m_master_clock(0)
 {
 	FILL_ARRAY( m_noise_params );
 	FILL_ARRAY( m_env_enable );

--- a/src/hardware/reSID/wave.cpp
+++ b/src/hardware/reSID/wave.cpp
@@ -26,6 +26,8 @@
 WaveformGenerator::WaveformGenerator()
 {
   sync_source = this;
+  sync_dest = NULL;
+  waveform = 0;
 
   set_chip_model(MOS6581);
 

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -1090,6 +1090,26 @@ void CSerial::Init_Registers () {
 CSerial::CSerial(Bitu id, CommandLine* cmd) {
 	idnumber=id;
 	Bit16u base = serial_baseaddr[id];
+    InstallationSuccessful = false;
+    bytetime = 0;
+    waiting_interrupts = 0;
+    baud_divider = 0;
+    IER = 0;
+    irq_active = false;
+    ISR = 0;
+    LCR = 0;
+    dtr = false;
+    rts = false;
+    op1 = false;
+    op2 = false;
+    loopback = false;
+    LSR = 0;
+    SPR = 0;
+    loopback_data = 0;
+    errors_in_fifo = 0;
+    rx_interrupt_threshold = 0;
+    FCR = 0;
+    sync_guardtime = false;
 
     d_cts=false;		// bit0: deltaCTS
     d_dsr=false;		// bit1: deltaDSR

--- a/src/hardware/vga_pc98_gdc.cpp
+++ b/src/hardware/vga_pc98_gdc.cpp
@@ -103,6 +103,9 @@ void pc98_port68_command_write(unsigned char b);
 
 PC98_GDC_state::PC98_GDC_state() {
     memset(param_ram,0,sizeof(param_ram));
+    memset(cmd_parm_tmp, 0, sizeof(cmd_parm_tmp));
+    memset(rfifo, 0, sizeof(rfifo));
+    memset(fifo, 0, sizeof(fifo));
 
     // make a display partition area to cover the screen, whatever it is.
     param_ram[0] = 0x00;        // SAD=0
@@ -115,6 +118,9 @@ PC98_GDC_state::PC98_GDC_state() {
     doublescan = false;
     param_ram_wptr = 0;
     display_partition = 0;
+    display_partition_rem_lines = 0;
+    active_display_lines = 0;
+    active_display_words_per_line = 0;
     row_line = 0;
     row_height = 16;
     scan_address = 0;
@@ -122,6 +128,7 @@ PC98_GDC_state::PC98_GDC_state() {
     proc_step = 0xFF;
     display_enable = true;
     display_mode = 0;
+    display_pitch = 0;
     cursor_enable = true;
     cursor_blink_state = 0;
     cursor_blink_count = 0;
@@ -132,6 +139,12 @@ PC98_GDC_state::PC98_GDC_state() {
     dynamic_ram_refresh = 0;
     cursor_blink = true;
     idle = false;
+    horizontal_sync_width = 0;
+    vertical_sync_width = 0;
+    horizontal_front_porch_width = 0;
+    horizontal_back_porch_width = 0;
+    vertical_front_porch_width = 0;
+    vertical_back_porch_width = 0;
     reset_fifo();
     reset_rfifo();
 }

--- a/src/mt32/DelayReverb.cpp
+++ b/src/mt32/DelayReverb.cpp
@@ -50,6 +50,12 @@ static const Bit32u BUFFER_SIZE = 16384;
 
 DelayReverb::DelayReverb() {
 	buf = NULL;
+    bufIx = 0;
+    delayLeft = 0;
+    delayRight = 0;
+    delayFeedback = 0;
+    amp = 0;
+    feedback = 0;
 	setParameters(0, 0);
 
 

--- a/src/mt32/freeverb/revmodel.cpp
+++ b/src/mt32/freeverb/revmodel.cpp
@@ -35,6 +35,7 @@ revmodel::revmodel(float scaletuning)
 	roomsize = (initialroom*scaleroom) + offsetroom;
 	width = initialwidth;
 	mode = initialmode;
+    filtval = 0;
 	update();
 
 	// Buffer will be full of rubbish - so we MUST mute them

--- a/src/mt32/sha1/sha1.h
+++ b/src/mt32/sha1/sha1.h
@@ -78,7 +78,7 @@ class SHA1
         unsigned Length_Low;                // Message length in bits
         unsigned Length_High;               // Message length in bits
 
-        unsigned char Message_Block[64];    // 512-bit message blocks
+        unsigned char Message_Block[64] = {};    // 512-bit message blocks
         int Message_Block_Index;            // Index into message block array
 
         bool Computed;                      // Is the digest computed?


### PR DESCRIPTION
Fixes all **uninitMemberVar** warnings issued by Cppcheck, for uninitialized member variables. Compiles and runs.