### PR TITLE
Brighter properties + line break for clarity.

### DIFF
--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -697,7 +697,7 @@ public:
             Property *p;
             int i = 0;
             while ((p = sec->Get_prop(i++))) {
-                msg += std::string("\033[34m")+p->propname+":\033[0m "+p->Get_help()+"\n";
+                msg += std::string("\033[37;1m")+p->propname+":\033[0m\n"+p->Get_help()+"\n\n";
             }
             if (!msg.empty()) msg.replace(msg.end()-1,msg.end(),"");
             setText(msg);


### PR DESCRIPTION
# Description

Better GUI help, brighter property name + line break for clarity.

**Does this PR address some issue(s) ?**

no

**Does this PR introduce new feature(s) ?**

See description.

**Are there any breaking changes ?**

Probably not, text is still fully rendered to the end

**Additional information**

http://www.lihaoyi.com/post/BuildyourownCommandLinewithANSIescapecodes.html#colors

Now something else appears ! There are line breaks everywhere in the docs, probably someone had in mind that old school idea but now it looks weird. IMO, there shouldn't be any and whoever is editing dosbox.conf should leverage _line wrap_ in its text editor instead ! If that ever has to be changed, many places to update in perspective...

Old version:
![dosbox-x_2019-11-07_01-56-40](https://user-images.githubusercontent.com/1537591/68351053-9afc2680-0102-11ea-8515-5d299458e894.png)

New version:
![dosbox-x_2019-11-07_01-56-44](https://user-images.githubusercontent.com/1537591/68351057-9d5e8080-0102-11ea-9664-9a28f6edcad1.png)

I picked white since it's really contrasted but maybe you'll prefer something else (dark red/magenta?), for reference:

![dosbox-x_2019-11-07_01-49-01](https://user-images.githubusercontent.com/1537591/68351091-b7985e80-0102-11ea-9042-3065182cd2de.png)

![dosbox-x_2019-11-07_01-49-02](https://user-images.githubusercontent.com/1537591/68351092-b7985e80-0102-11ea-8393-10682c788385.png)

![dosbox-x_2019-11-07_01-49-03](https://user-images.githubusercontent.com/1537591/68351093-b7985e80-0102-11ea-9424-0d4de4e5d043.png)

![dosbox-x_2019-11-07_01-49-04](https://user-images.githubusercontent.com/1537591/68351094-b830f500-0102-11ea-922b-4bfe2b610140.png)

![dosbox-x_2019-11-07_01-49-05](https://user-images.githubusercontent.com/1537591/68351095-b830f500-0102-11ea-9d76-7fbf2de074f4.png)

![dosbox-x_2019-11-07_01-49-06](https://user-images.githubusercontent.com/1537591/68351096-b830f500-0102-11ea-9307-a73fd247ca1e.png)

![dosbox-x_2019-11-07_01-49-07](https://user-images.githubusercontent.com/1537591/68351097-b830f500-0102-11ea-8a55-4ff9ad67aec4.png)

![dosbox-x_2019-11-07_01-49-08](https://user-images.githubusercontent.com/1537591/68351098-b830f500-0102-11ea-928c-60cfb367c58d.png)

![dosbox-x_2019-11-07_01-49-09](https://user-images.githubusercontent.com/1537591/68351099-b830f500-0102-11ea-8b09-58e804eb4c7e.png)

![dosbox-x_2019-11-07_01-49-10](https://user-images.githubusercontent.com/1537591/68351102-b8c98b80-0102-11ea-9f78-52977dcfcbfd.png)

![dosbox-x_2019-11-07_01-49-11](https://user-images.githubusercontent.com/1537591/68351103-b8c98b80-0102-11ea-9c06-1cbdef14ca13.png)

![dosbox-x_2019-11-07_01-49-12](https://user-images.githubusercontent.com/1537591/68351105-b8c98b80-0102-11ea-9464-de47ad33722c.png)

![dosbox-x_2019-11-07_01-49-13](https://user-images.githubusercontent.com/1537591/68351107-b8c98b80-0102-11ea-8a81-cb9cf84e5837.png)

![dosbox-x_2019-11-07_01-49-14](https://user-images.githubusercontent.com/1537591/68351108-b8c98b80-0102-11ea-9bce-5e331736175d.png)

![dosbox-x_2019-11-07_01-49-15](https://user-images.githubusercontent.com/1537591/68351109-b8c98b80-0102-11ea-86bc-add8658c8bea.png)

![dosbox-x_2019-11-07_01-49-16](https://user-images.githubusercontent.com/1537591/68351110-b9622200-0102-11ea-9e9e-23b074ff1b7f.png)
