### PR TITLE
Fix for HELP's "Message not Found!"

### DIFF
--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -124,7 +124,7 @@ const char * MSG_Get(char const * msg) {
 			return  (*tel).val.c_str();
 		}
 	}
-	return "Message not Found!\n";
+	return msg;
 }
 
 

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -85,9 +85,9 @@ static SHELL_Cmd cmd_list[]={
 {	"FOR",	1,			&DOS_Shell::CMD_FOR,		"SHELL_CMD_FOR_HELP"},
 {	"INT2FDBG",	1,			&DOS_Shell::CMD_INT2FDBG,	"Hook INT 2Fh for debugging purposes"},
 {	"CTTY",		1,			&DOS_Shell::CMD_CTTY,		"Change TTY device"},
-{   "DX-CAPTURE",0,         &DOS_Shell::CMD_DXCAPTURE,  "Run program with video/audio capture\n"},
+{   "DX-CAPTURE",0,         &DOS_Shell::CMD_DXCAPTURE,  "Run program with video/audio capture.\n"},
 #if C_DEBUG
-{	"DEBUGBOX",	0,			&DOS_Shell::CMD_DEBUGBOX,	"Run program, break into debugger at entry point\n"},
+{	"DEBUGBOX",	0,			&DOS_Shell::CMD_DEBUGBOX,	"Run program, break into debugger at entry point.\n"},
 #endif
 {0,0,0,0}
 }; 

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -85,9 +85,9 @@ static SHELL_Cmd cmd_list[]={
 {	"FOR",	1,			&DOS_Shell::CMD_FOR,		"SHELL_CMD_FOR_HELP"},
 {	"INT2FDBG",	1,			&DOS_Shell::CMD_INT2FDBG,	"Hook INT 2Fh for debugging purposes"},
 {	"CTTY",		1,			&DOS_Shell::CMD_CTTY,		"Change TTY device"},
-{   "DX-CAPTURE",0,         &DOS_Shell::CMD_DXCAPTURE,  "Run program with video/audio capture"},
+{   "DX-CAPTURE",0,         &DOS_Shell::CMD_DXCAPTURE,  "Run program with video/audio capture\n"},
 #if C_DEBUG
-{	"DEBUGBOX",	0,			&DOS_Shell::CMD_DEBUGBOX,	"Run program, break into debugger at entry point"},
+{	"DEBUGBOX",	0,			&DOS_Shell::CMD_DEBUGBOX,	"Run program, break into debugger at entry point\n"},
 #endif
 {0,0,0,0}
 }; 


### PR DESCRIPTION
# Description

Fixes `Message not Found!` in `HELP` while these messages effectively exist.

**Does this PR address some issue(s) ?**

none I'm aware of

**Does this PR introduce new feature(s) ?**

no

**Are there any breaking changes ?**

probably not, but not 100% sure

**Additional information**

![dosbox-x_2019-11-07_02-58-13](https://user-images.githubusercontent.com/1537591/68353614-7441ee00-010a-11ea-935e-319e518cb3cd.png)

![dosbox-x_2019-11-07_02-56-58](https://user-images.githubusercontent.com/1537591/68353583-58d6e300-010a-11ea-951f-fabcb670aae7.png)