### PR TITLE
Fix Cppcheck warnings

### DIFF
--- a/src/aviwriter/avi_writer.cpp
+++ b/src/aviwriter/avi_writer.cpp
@@ -808,7 +808,7 @@ int avi_writer_emit_opendml_indexes(avi_writer *w) {
             /* start an AVISUPERINDEX */
             out_chunks = 0;
             if ((superindex = avi_writer_stream_alloc_superindex(w,s)) == 0ULL) {
-                fprintf(stderr,"Cannot alloc superindex for %u\n",s->index);
+                fprintf(stderr,"Cannot alloc superindex for %d\n",s->index);
                 break;
             }
 

--- a/src/aviwriter/avi_writer.cpp
+++ b/src/aviwriter/avi_writer.cpp
@@ -660,8 +660,8 @@ int avi_writer_update_avi_and_stream_headers(avi_writer *w) {
             unsigned int nlength=0;
 
             if (s->format != NULL && s->format_len >= sizeof(windows_WAVEFORMAT)) {
-                windows_WAVEFORMAT *w = (windows_WAVEFORMAT*)(s->format);
-                unsigned int nss = __le_u16(&w->nBlockAlign);
+                windows_WAVEFORMAT *wf = (windows_WAVEFORMAT*)(s->format);
+                unsigned int nss = __le_u16(&wf->nBlockAlign);
                 if (nss != 0) nlength = s->sample_write_offset / nss;
             }
             else {

--- a/src/aviwriter/riff.cpp
+++ b/src/aviwriter/riff.cpp
@@ -566,7 +566,7 @@ void riff_stack_debug_print(FILE *fp,int level,riff_chunk *chunk) {
 		riff_stack_fourcc_to_str(chunk->fourcc,tmp);
 		fprintf(fp,"'%s' ",tmp);
 	}
-	fprintf(fp,"hdr=%lld data=%lld len=%lu data-end=%lld",
+	fprintf(fp,"hdr=%llu data=%llu len=%lu data-end=%llu",
 		(unsigned long long)(chunk->absolute_header_offset),
 		(unsigned long long)(chunk->absolute_data_offset),
 		(unsigned long)(chunk->data_length),

--- a/src/cpu/core_full/load.h
+++ b/src/cpu/core_full/load.h
@@ -348,7 +348,6 @@ l_M_Ed:
 	case D_PUSHAw:
 		if (CPU_ArchitectureType<CPU_ARCHTYPE_80186) goto illegalopcode;
 		{
-			Bit32u old_esp = reg_esp;
 			try {
 				Bit16u old_sp = (CPU_ArchitectureType >= CPU_ARCHTYPE_286 ? reg_sp : (reg_sp-10));
 				Push_16(reg_ax);Push_16(reg_cx);Push_16(reg_dx);Push_16(reg_bx);
@@ -363,7 +362,6 @@ l_M_Ed:
 		} goto nextopcode;
 	case D_PUSHAd:
 		{
-			Bit32u old_esp = reg_esp;
 			try {
 				Bit32u tmpesp = reg_esp;
 				Push_32(reg_eax);Push_32(reg_ecx);Push_32(reg_edx);Push_32(reg_ebx);
@@ -379,7 +377,6 @@ l_M_Ed:
 	case D_POPAw:
 		if (CPU_ArchitectureType<CPU_ARCHTYPE_80186) goto illegalopcode;
 		{
-			Bit32u old_esp = reg_esp;
 			try {
 				reg_di=Pop_16();reg_si=Pop_16();reg_bp=Pop_16();Pop_16();//Don't save SP
 				reg_bx=Pop_16();reg_dx=Pop_16();reg_cx=Pop_16();reg_ax=Pop_16();
@@ -393,7 +390,6 @@ l_M_Ed:
 		} goto nextopcode;
 	case D_POPAd:
 		{
-			Bit32u old_esp = reg_esp;
 			try {
 				reg_edi=Pop_32();reg_esi=Pop_32();reg_ebp=Pop_32();Pop_32();//Don't save ESP
 				reg_ebx=Pop_32();reg_edx=Pop_32();reg_ecx=Pop_32();reg_eax=Pop_32();
@@ -508,8 +504,6 @@ l_M_Ed:
 		}
 	case D_LEAVEw:
 		{
-			Bit32u old_esp = reg_esp;
-
 			reg_esp &= cpu.stack.notmask;
 			reg_esp |= reg_ebp&cpu.stack.mask;
 			try {
@@ -523,8 +517,6 @@ l_M_Ed:
 		} goto nextopcode;
 	case D_LEAVEd:
 		{
-			Bit32u old_esp = reg_esp;
-
 			reg_esp &= cpu.stack.notmask;
 			reg_esp |= reg_ebp&cpu.stack.mask;
 			try {

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -3802,31 +3802,25 @@ Bit16u CPU_FindDecoderType( CPU_Decoder *decoder )
 }
 
 // TODO: This looks to be unused
-CPU_Decoder *CPU_IndexDecoderType( Bit16u decoder_idx )
+CPU_Decoder* CPU_IndexDecoderType(Bit16u decoder_idx)
 {
-	CPU_Decoder *cpudecoder;
-
-
-	cpudecoder = 0;
-	switch( decoder_idx ) {
-		case 0: cpudecoder = &CPU_Core_Normal_Run; break;
-		case 1: cpudecoder = &CPU_Core_Prefetch_Run; break;
+    switch (decoder_idx) {
+    case 0: return &CPU_Core_Normal_Run;
+    case 1: return &CPU_Core_Prefetch_Run;
 #if !defined(C_EMSCRIPTEN)
-		case 2: cpudecoder = &CPU_Core_Simple_Run; break;
-		case 3: cpudecoder = &CPU_Core_Full_Run; break;
+    case 2: return &CPU_Core_Simple_Run;
+    case 3: return &CPU_Core_Full_Run;
 #endif
 #if C_DYNAMIC_X86
-		case 4: cpudecoder = &CPU_Core_Dyn_X86_Run; break;
+    case 4: return &CPU_Core_Dyn_X86_Run;
 #endif
-		case 100: cpudecoder = &CPU_Core_Normal_Trap_Run; break;
+    case 100: return &CPU_Core_Normal_Trap_Run;
 #if C_DYNAMIC_X86
-		case 101: cpudecoder = &CPU_Core_Dyn_X86_Trap_Run; break;
+    case 101: return &CPU_Core_Dyn_X86_Trap_Run;
 #endif
-		case 200: cpudecoder = &HLT_Decode; break;
-	}
-
-
-	return cpudecoder;
+    case 200: return &HLT_Decode;
+    default: return 0;
+    }
 }
 
 Bitu vm86_fake_io_seg = 0xF000;	/* unused area in BIOS for IO instruction */

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -167,7 +167,8 @@ static void LogEMUMachine(void) {
     DEBUG_ShowMsg("Emulator machine:");
 
     {
-        const char *m = "?",*svga = "";
+        const char *m = "?";
+        const char *cardName = "";
 
         switch (machine) {
             case MCH_HERC:      m="Hercules";   break;
@@ -185,14 +186,14 @@ static void LogEMUMachine(void) {
         }
 
         switch (svgaCard) {
-            case SVGA_None:             svga="";                break;
-            case SVGA_S3Trio:           svga="S3 Trio";         break;
-            case SVGA_TsengET4K:        svga="Tseng ET4000";    break;
-            case SVGA_TsengET3K:        svga="Tseng ET3000";    break;
-            case SVGA_ParadisePVGA1A:   svga="Paradise PVGA1A"; break;
+            case SVGA_None:             cardName ="";                break;
+            case SVGA_S3Trio:           cardName ="S3 Trio";         break;
+            case SVGA_TsengET4K:        cardName ="Tseng ET4000";    break;
+            case SVGA_TsengET3K:        cardName ="Tseng ET3000";    break;
+            case SVGA_ParadisePVGA1A:   cardName ="Paradise PVGA1A"; break;
         }
 
-        DEBUG_ShowMsg("Machine: %s %s",m,svga);
+        DEBUG_ShowMsg("Machine: %s %s",m, cardName);
     }
 
     DEBUG_EndPagedContent();
@@ -4151,14 +4152,14 @@ bool CDebugVar::LoadVars(char* name)
 	}
 
 	for (Bit16u i=0; i<num; i++) {
-		char name[16];
+		char name2[16];
 		// name
-		if (fread(name,16,1,f) != 1) break;
+		if (fread(name2,16,1,f) != 1) break;
 		// adr
 		PhysPt adr;
 		if (fread(&adr,sizeof(adr),1,f) != 1) break;
 		// insert
-		InsertVariable(name,adr);
+		InsertVariable(name2,adr);
 	}
 	fclose(f);
 	return true;

--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -787,7 +787,7 @@ bool device_CON::Write(const Bit8u * data,Bit16u * size) {
                 count++;
                 continue;
             } else if (data[count] == 0x1A && IS_PC98_ARCH) {
-                Bit8u page = real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
+                page = real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
 
                 /* it also redraws the function key row */
                 update_pc98_function_row(pc98_function_row_mode,true);
@@ -795,7 +795,7 @@ bool device_CON::Write(const Bit8u * data,Bit16u * size) {
                 INT10_ScrollWindow(0,0,255,255,0,ansi.attr,page);
                 Real_INT10_SetCursorPos(0,0,page);
             } else if (data[count] == 0x1E && IS_PC98_ARCH) {
-                Bit8u page = real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
+                page = real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
 
                 Real_INT10_SetCursorPos(0,0,page);
             } else { 
@@ -813,7 +813,7 @@ bool device_CON::Write(const Bit8u * data,Bit16u * size) {
                     break;
                 case '*':/* PC-98: clear screen (same code path as CTRL+Z) */
                     if (IS_PC98_ARCH) {
-                        Bit8u page = real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
+                        page = real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
 
                         /* it also redraws the function key row */
                         update_pc98_function_row(pc98_function_row_mode,true);

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -2553,7 +2553,7 @@ public:
             }
 
             if (sg != 0 && sg < minimum_mcb_free) {
-                Bit16u tmp = minimum_mcb_free - sg;
+                tmp = minimum_mcb_free - sg;
                 if (!DOS_ResizeMemory(sg,&tmp)) {
                     LOG(LOG_MISC,LOG_DEBUG)("    WARNING: cannot resize min free pad");
                 }

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -975,9 +975,9 @@ checkext:
 		string++;
 	}
 savefcb:
-	if (!hasdrive & !(parser & PARSE_DFLT_DRIVE)) fcb_name.part.drive[0] = 0;
-	if (!hasname & !(parser & PARSE_BLNK_FNAME)) strcpy(fcb_name.part.name,"        ");
-	if (!hasext & !(parser & PARSE_BLNK_FEXT)) strcpy(fcb_name.part.ext,"   ");
+	if (!hasdrive && !(parser & PARSE_DFLT_DRIVE)) fcb_name.part.drive[0] = 0;
+	if (!hasname && !(parser & PARSE_BLNK_FNAME)) strcpy(fcb_name.part.name,"        ");
+	if (!hasext && !(parser & PARSE_BLNK_FEXT)) strcpy(fcb_name.part.ext,"   ");
 	fcb.SetName((unsigned char)fcb_name.part.drive[0],fcb_name.part.name,fcb_name.part.ext);
 	fcb.ClearBlockRecsize(); //Undocumented bonus work.
 	*change=(Bit8u)(string-string_begin);

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1526,9 +1526,9 @@ public:
                 CPU_Push16(BIOS_bootfail_code_offset & 0xF); /* offset */
 
                 /* clear the text layer */
-                for (unsigned int i=0;i < (80*25*2);i += 2) {
-                    mem_writew(0xA0000+i,0x0000);
-                    mem_writew(0xA2000+i,0x00E1);
+                for (i=0;i < (80*25*2);i += 2) {
+                    mem_writew((PhysPt)(0xA0000+i),0x0000);
+                    mem_writew((PhysPt)(0xA2000+i),0x00E1);
                 }
 
                 /* hide the cursor */
@@ -1563,7 +1563,7 @@ public:
                  *        So, apparently you cannot put a 1.44MB image in drive A:
                  *        and a 1.2MB image in drive B: */
 
-                for (unsigned int i=0;i < 2;i++) {
+                for (i=0;i < 2;i++) {
                     if (imageDiskList[i] != NULL) {
                         disk_equip |= (0x0111u << i); /* 320KB[15:12] 1MB[11:8] 640KB[7:4] unit[1:0] */
                         disk_equip_144 |= (1u << i);
@@ -1571,11 +1571,11 @@ public:
                     }
                 }
 
-                for (unsigned int i=0;i < 2;i++) {
+                for (i=0;i < 2;i++) {
                     if (imageDiskList[i+2] != NULL) {
                         scsi_equip |= (1u << i);
 
-                        Bit16u m = 0x460u + (i * 4u);
+                        Bit16u m = 0x460u + ((Bit16u)i * 4u);
 
                         mem_writeb(m+0u,sects);
                         mem_writeb(m+1u,heads);

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -331,7 +331,7 @@ public:
                     if (free_size_cyl>65534) free_size_cyl=65534;
                     if (total_size_cyl<free_size_cyl) total_size_cyl=free_size_cyl+10;
                     if (total_size_cyl>65534) total_size_cyl=65534;
-                    sprintf(teststr,"512,32,%d,%d",total_size_cyl,free_size_cyl);
+                    sprintf(teststr,"512,32,%u,%u",total_size_cyl,free_size_cyl);
                 }
                 str_size=teststr;
             }

--- a/src/dos/dos_tables.cpp
+++ b/src/dos/dos_tables.cpp
@@ -367,7 +367,7 @@ void DOS_SetupTables(void) {
         //
         //        The byte values seem to match drive letter assignment, as noted:
         //        [https://github.com/joncampbell123/dosbox-x/issues/1226]
-        for (unsigned int i=0;i < 0x10;i++) real_writeb(0x60,0x6C+i,0);
+        for (i=0;i < 0x10;i++) real_writeb(0x60,0x6C+i,0);
         real_writeb(0x60,0x6C,0xA0);    /* hard drive */
         real_writeb(0x60,0x6D,0x90);    /* floppy drive */
     }

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -562,10 +562,10 @@ void fatDrive::SetLabel(const char *label, bool /*iscdrom*/, bool /*updatable*/)
                 memset(&sectbuf[di],0,sizeof(sectbuf[di]));
                 sectbuf[di].attrib = DOS_ATTR_VOLUME;
                 {
-                    unsigned int i = 0;
+                    unsigned int j = 0;
                     const char *s = label;
-                    while (i < 11 && *s != 0) sectbuf[di].entryname[i++] = toupper(*s++);
-                    while (i < 11)            sectbuf[di].entryname[i++] = ' ';
+                    while (j < 11 && *s != 0) sectbuf[di].entryname[j++] = toupper(*s++);
+                    while (j < 11)            sectbuf[di].entryname[j++] = ' ';
                 }
                 writeSector((Bit32u)(firstRootDirSect+(i/dirent_per_sector)),sectbuf);
 		        labelCache.SetLabel(label, false, true);

--- a/src/gui/midi_win32.h
+++ b/src/gui/midi_win32.h
@@ -109,7 +109,6 @@ public:
 			if (configmidi.fail() && total) {
 				lowcase(strconf);
 				for(unsigned int i = 0; i< total;i++) {
-					MIDIOUTCAPS mididev;
 					midiOutGetDevCaps(i, &mididev, sizeof(MIDIOUTCAPS));
 					std::string devname(mididev.szPname);
 					lowcase(devname);

--- a/src/gui/render_templates_sai.h
+++ b/src/gui/render_templates_sai.h
@@ -20,11 +20,11 @@ static inline int conc2d(GetResult,SBPP)(PTYPE A, PTYPE B, PTYPE C, PTYPE D) {
 	const bool ac = (A==C);
 	const bool bc = (B==C);
 	const int x1 = ac;
-	const int y1 = (bc & !ac);
+	const int y1 = (bc && !ac);
 	const bool ad = (A==D);
 	const bool bd = (B==D);
 	const int x2 = ad;
-	const int y2 = (bd & !ad);
+	const int y2 = (bd && !ad);
 	const int x = x1+x2;
 	const int y = y1+y2;
 	static const int rmap[3][3] = {

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -3683,7 +3683,7 @@ void BIND_MappingEvents(void) {
 
                 size_t tmpl;
 #if defined(C_SDL2)
-                tmpl = (size_t)sprintf(tmp,"%c%02x: scan=%u sym=%u mod=%xh name=%s",
+                tmpl = (size_t)sprintf(tmp,"%c%02x: scan=%d sym=%d mod=%xh name=%s",
                     (event.type == SDL_KEYDOWN ? 'D' : 'U'),
                     event_count&0xFF,
                     s.scancode,

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1096,11 +1096,8 @@ public:
          */
 
         // activate if we exceed user-defined deadzone
-        const auto joystick = this->GetJoystick();
-        const auto axis = this->GetAxis();
-        const auto positive = this->GetPositive();
-        const auto deadzone = GetJoystickDeadzone((int)joystick, (int)axis, positive);
-        
+        const auto deadzone = GetJoystickDeadzone((int)this->GetJoystick(), (int)this->GetAxis(), this->GetPositive());
+
         if (_value > deadzone && event->IsTrigger()) 
             _value = 25000 + 1;
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2645,10 +2645,10 @@ void GFX_SwitchFullScreen(void)
 #ifdef WIN32
     if (menu.startup) // NOTE should be always true I suppose ???
     {
-        auto vsync = static_cast<Section_prop *>(control->GetSection("vsync"));
-        if (vsync)
+        auto vsyncProp = static_cast<Section_prop *>(control->GetSection("vsync"));
+        if (vsyncProp)
         {
-            auto vsyncMode = vsync->Get_string("vsyncmode");
+            auto vsyncMode = vsyncProp->Get_string("vsyncmode");
             if (!strcmp(vsyncMode, "host")) SetVal("vsync", "vsyncmode", "host");
         }
     }
@@ -8365,7 +8365,6 @@ fresh_boot:
             /* new code: fire event */
             DispatchVMEvent(VM_EVENT_RESET);
 
-            extern bool custom_bios;
             if (custom_bios) {
                 /* need to relocate BIOS allocations */
                 void ROMBIOS_InitForCustomBIOS(void);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -6437,7 +6437,7 @@ bool dos_pc98_clock_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * con
 
     {
         char tmp1[64];
-        sprintf(tmp1,"%u",atoi(ts));
+        sprintf(tmp1,"%d",atoi(ts));
         tmp += tmp1;
     }
 
@@ -6736,7 +6736,7 @@ bool overscan_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const men
     int f = atoi(menuitem->get_text().c_str()); /* Off becomes 0 */
     char tmp[64];
 
-    sprintf(tmp,"%u",f);
+    sprintf(tmp,"%d",f);
     SetVal("sdl", "overscan", tmp);
     change_output(7);
     return true;
@@ -6902,7 +6902,7 @@ bool video_frameskip_common_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::it
     int f = atoi(menuitem->get_text().c_str()); /* Off becomes 0 */
     char tmp[64];
 
-    sprintf(tmp,"%u",f);
+    sprintf(tmp,"%d",f);
     SetVal("render", "frameskip", tmp);
     return true;
 }

--- a/src/hardware/dbopl.cpp
+++ b/src/hardware/dbopl.cpp
@@ -1264,7 +1264,7 @@ void Chip::Setup( Bit32u rate ) {
 		Bit8u index, shift;
 		EnvelopeSelect( i, index, shift );
 		//Original amount of samples the attack would take
-		Bit32s original = (Bit32s)((Bit32u)( (AttackSamplesTable[ index ] << shift) / scale));
+		Bit32s originalAmount = (Bit32s)((Bit32u)( (AttackSamplesTable[ index ] << shift) / scale));
 		 
 		Bit32s guessAdd = (Bit32s)((Bit32u)( scale * (EnvelopeIncreaseTable[ index ] << ( RATE_SH - shift - 3 ))));
 		Bit32s bestAdd = guessAdd;
@@ -1273,7 +1273,7 @@ void Chip::Setup( Bit32u rate ) {
 			Bit32s volume = ENV_MAX;
 			Bit32s samples = 0;
 			Bit32u count = 0;
-			while ( volume > 0 && samples < original * 2 ) {
+			while ( volume > 0 && samples < originalAmount * 2 ) {
 				count += (Bit32u)guessAdd;
 				Bit32s change = (Bit32s)(count >> RATE_SH);
 				count &= RATE_MASK;
@@ -1283,7 +1283,7 @@ void Chip::Setup( Bit32u rate ) {
 				samples++;
 
 			}
-			Bit32s diff = original - samples;
+			Bit32s diff = originalAmount - samples;
 			Bit32u lDiff = labs( diff );
 			//Init last on first pass
 			if ( lDiff < bestDiff ) {
@@ -1294,7 +1294,7 @@ void Chip::Setup( Bit32u rate ) {
 					break;
 			}
 			//Linear correction factor, not exactly perfect but seems to work
-			double correct = (original - diff) / (double)original;
+			double correct = (originalAmount - diff) / (double)originalAmount;
 			guessAdd = (Bit32s)(guessAdd * correct);
 			//Below our target
 			if ( diff < 0 ) {

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -674,7 +674,7 @@ void DMA_Reset(Section* /*sec*/) {
 	if (enable_1st_dma) {
         if (IS_PC98_ARCH) {
             /* install handlers for ports 0x21-0x29 odd */
-            for (unsigned int i=0;i < 5;i++) {
+            for (i=0;i < 5;i++) {
                 DmaControllers[0]->DMA_WriteHandler[0x10+i].Install(0x21+(i*2u),DMA_Write_Port,IO_MB,1);
                 DmaControllers[0]->DMA_ReadHandler[0x10+i].Install(0x21+(i*2u),DMA_Read_Port,IO_MB,1);
             }

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -193,29 +193,29 @@ void KEYBOARD_AUX_Event(float x,float y,Bitu buttons,int scrollwheel) {
 
     if (keyb.ps2mouse.reporting && keyb.ps2mouse.mode == MM_STREAM) {
         if ((keyb.used+4) < KEYBUFSIZE) {
-            int x,y;
+            int x2,y2;
 
-            x = (int)(keyb.ps2mouse.acx * (1 << keyb.ps2mouse.resolution));
-            x /= 16; /* FIXME: Or else the cursor is WAY too sensitive in Windows 3.1 */
-            if (x < -256) x = -256;
-            else if (x > 255) x = 255;
+            x2 = (int)(keyb.ps2mouse.acx * (1 << keyb.ps2mouse.resolution));
+            x2 /= 16; /* FIXME: Or else the cursor is WAY too sensitive in Windows 3.1 */
+            if (x2 < -256) x2 = -256;
+            else if (x2 > 255) x2 = 255;
 
-            y = -((int)(keyb.ps2mouse.acy * (1 << keyb.ps2mouse.resolution)));
-            y /= 16; /* FIXME: Or else the cursor is WAY too sensitive in Windows 3.1 */
-            if (y < -256) y = -256;
-            else if (y > 255) y = 255;
+            y2 = -((int)(keyb.ps2mouse.acy * (1 << keyb.ps2mouse.resolution)));
+            y2 /= 16; /* FIXME: Or else the cursor is WAY too sensitive in Windows 3.1 */
+            if (y2 < -256) y2 = -256;
+            else if (y2 > 255) y2 = 255;
 
             KEYBOARD_AddBuffer(AUX|
-                ((y == -256 || y == 255) ? 0x80 : 0x00) |   /* Y overflow */
-                ((x == -256 || x == 255) ? 0x40 : 0x00) |   /* X overflow */
-                (y & 0x100 ? 0x20 : 0x00) |         /* Y sign bit */
-                (x & 0x100 ? 0x10 : 0x00) |         /* X sign bit */
+                ((y2 == -256 || y2 == 255) ? 0x80 : 0x00) |   /* Y overflow */
+                ((x2 == -256 || x2 == 255) ? 0x40 : 0x00) |   /* X overflow */
+                (y2 & 0x100 ? 0x20 : 0x00) |         /* Y sign bit */
+                (x2 & 0x100 ? 0x10 : 0x00) |         /* X sign bit */
                 0x08 |                      /* always 1? */
                 (keyb.ps2mouse.m ? 4 : 0) |         /* M */
                 (keyb.ps2mouse.r ? 2 : 0) |         /* R */
                 (keyb.ps2mouse.l ? 1 : 0));         /* L */
-            KEYBOARD_AddBuffer(AUX|(x&0xFF));
-            KEYBOARD_AddBuffer(AUX|(y&0xFF));
+            KEYBOARD_AddBuffer(AUX|(x2&0xFF));
+            KEYBOARD_AddBuffer(AUX|(y2&0xFF));
             if (keyb.ps2mouse.intellimouse_btn45) {
                 KEYBOARD_AddBuffer(AUX|(scrollwheel&0xFF)); /* TODO: 4th & 5th buttons */
             }

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -858,7 +858,6 @@ static IO_WriteHandleObject WriteHandler[4];
 
 void PIC_Reset(Section *sec) {
     (void)sec;//UNUSED
-    Bitu i;
 
     ReadHandler[0].Uninstall();
     ReadHandler[1].Uninstall();
@@ -923,7 +922,7 @@ void PIC_Reset(Section *sec) {
     /* Setup pic0 and pic1 with initial values like DOS has normally */
     PIC_Ticks=0;
     PIC_IRQCheck=0;
-    for (i=0;i<2;i++) {
+    for (Bitu i=0;i<2;i++) {
         pics[i].auto_eoi=false;
         pics[i].rotate_on_auto_eoi=false;
         pics[i].request_issr=false;

--- a/src/hardware/reSID/spline.h
+++ b/src/hardware/reSID/spline.h
@@ -150,9 +150,9 @@ void interpolate_brute_force(double x1, double y1, double x2, double y2,
   cubic_coefficients(x1, y1, x2, y2, k1, k2, a, b, c, d);
   
   // Calculate each point.
-  for (double x = x1; x <= x2; x += res) {
-    double y = ((a*x + b)*x + c)*x + d;
-    plot(x, y);
+  for (double xCoord = x1; xCoord <= x2; xCoord += res) {
+    double yCoord = ((a* xCoord + b)* xCoord + c)* xCoord + d;
+    plot(xCoord, yCoord);
   }
 }
 
@@ -168,15 +168,15 @@ void interpolate_forward_difference(double x1, double y1, double x2, double y2,
   double a, b, c, d;
   cubic_coefficients(x1, y1, x2, y2, k1, k2, a, b, c, d);
   
-  double y = ((a*x1 + b)*x1 + c)*x1 + d;
+  double yCoord = ((a*x1 + b)*x1 + c)*x1 + d;
   double dy = (3*a*(x1 + res) + 2*b)*x1*res + ((a*res + b)*res + c)*res;
   double d2y = (6*a*(x1 + res) + 2*b)*res*res;
   double d3y = 6*a*res*res*res;
     
   // Calculate each point.
-  for (double x = x1; x <= x2; x += res) {
-    plot(x, y);
-    y += dy; dy += d2y; d2y += d3y;
+  for (double xCoord = x1; xCoord <= x2; xCoord += res) {
+    plot(xCoord, yCoord);
+    yCoord += dy; dy += d2y; d2y += d3y;
   }
 }
 

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -909,8 +909,7 @@ void VGA_Reset(Section*) {
              * A lot of DOSBox's VGA emulation code assumes power-of-2 VRAM sizes especially when wrapping
              * memory addresses with (a & (vmemsize - 1)) type code. */
             if (!is_power_of_2(vga.mem.memsize)) {
-                Bitu i = int_log2(vga.mem.memsize) + 1u;
-                vga.mem.memsize = 1u << i;
+                vga.mem.memsize = 1u << (int_log2(vga.mem.memsize) + 1u);
                 LOG(LOG_VGA,LOG_WARN)("VGA RAM size requested is not a power of 2, rounding up to %uKB",vga.mem.memsize>>10);
             }
         }

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -675,16 +675,16 @@ static Bit8u * Alt_VGA_256color_2x4bit_Draw_Line(Bitu /*vidstart*/, Bitu /*line*
         count--;
 
         while (count > 0u) {
-            const unsigned int addr = vga.draw_2[0].crtc_addr_fetch_and_advance();
-            VGA_Latch pixels(*vga.draw_2[0].drawptr<Bit32u>(addr << vga.config.addr_shift));
-            Alt_VGA_256color_2x4bit_Draw_CharClock<8>(temps,pixels,cur,nex);
+            const unsigned int addr2 = vga.draw_2[0].crtc_addr_fetch_and_advance();
+            VGA_Latch pixels2(*vga.draw_2[0].drawptr<Bit32u>(addr2 << vga.config.addr_shift));
+            Alt_VGA_256color_2x4bit_Draw_CharClock<8>(temps,pixels2,cur,nex);
             count--;
         }
 
         /* the top nibble of the first pixel past the end is visible on real hardware */
         {
-            const unsigned int addr = vga.draw_2[0].crtc_addr_fetch_and_advance();
-            VGA_Latch pixels(*vga.draw_2[0].drawptr<Bit32u>(addr << vga.config.addr_shift));
+            const unsigned int addr2 = vga.draw_2[0].crtc_addr_fetch_and_advance();
+            VGA_Latch pixels2(*vga.draw_2[0].drawptr<Bit32u>(addr << vga.config.addr_shift));
             Alt_VGA_256color_2x4bit_Draw_CharClock<1>(temps,pixels,cur,nex);
         }
     }
@@ -928,7 +928,7 @@ static Bit8u * VGA_Draw_VGA_Line_Xlat32_HWMouse( Bitu vidstart, Bitu /*line*/) {
         // This is used when the mouse cursor partially leaves the screen.
         // It is arranged as bitmap of 16bits of bitA followed by 16bits of bitB, each
         // AB bits corresponding to a cursor pixel. The whole map is 8kB in size.
-        Bit32u* temp = (Bit32u*)VGA_Draw_Xlat32_Linear_Line(vidstart, 0);
+        Bit32u* temp2 = (Bit32u*)VGA_Draw_Xlat32_Linear_Line(vidstart, 0);
         //memcpy(TempLine, &vga.mem.linear[ vidstart ], vga.draw.width);
 
         // the index of the bit inside the cursor bitmap we start at:
@@ -941,7 +941,7 @@ static Bit8u * VGA_Draw_VGA_Line_Xlat32_HWMouse( Bitu vidstart, Bitu /*line*/) {
         // stay at the right position in the pattern
         if (cursorMemStart & 0x2) cursorMemStart--;
         Bitu cursorMemEnd = cursorMemStart + (Bitu)((64 - vga.s3.hgc.posx) >> 2);
-        Bit32u* xat = &temp[vga.s3.hgc.originx]; // mouse data start pos. in scanline
+        Bit32u* xat = &temp2[vga.s3.hgc.originx]; // mouse data start pos. in scanline
         for (Bitu m = cursorMemStart; m < cursorMemEnd; (m&1)?(m+=3):m++) {
             // for each byte of cursor data
             Bit8u bitsA = vga.mem.linear[m];
@@ -960,7 +960,7 @@ static Bit8u * VGA_Draw_VGA_Line_Xlat32_HWMouse( Bitu vidstart, Bitu /*line*/) {
                 xat++;
             }
         }
-        return (Bit8u*)temp;
+        return (Bit8u*)temp2;
     }
 }
 

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1030,7 +1030,6 @@ Bitu read_herc_status(Bitu /*port*/,Bitu /*iolen*/) {
 
 
 void VGA_SetupOther(void) {
-	Bitu i;
 	memset( &vga.tandy, 0, sizeof( vga.tandy ));
 	vga.attr.disabled = 0;
 	vga.config.bytes_skip=0;
@@ -1048,12 +1047,12 @@ void VGA_SetupOther(void) {
 
 	if (machine==MCH_CGA || machine==MCH_AMSTRAD || IS_TANDY_ARCH) {
 		extern Bit8u int10_font_08[256 * 8];
-		for (i=0;i<256;i++)	memcpy(&vga.draw.font[i*32],&int10_font_08[i*8],8);
+		for (Bitu i=0;i<256;i++)	memcpy(&vga.draw.font[i*32],&int10_font_08[i*8],8);
 		vga.draw.font_tables[0]=vga.draw.font_tables[1]=vga.draw.font;
 	}
     if (machine==MCH_MCGA) { // MCGA uses a 8x16 font, through double-scanning as if 8x8 CGA text mode
         extern Bit8u int10_font_16[256 * 16];
-        for (i=0;i<256;i++)	memcpy(&vga.draw.font[i*32],&int10_font_16[i*16],16);
+        for (Bitu i=0;i<256;i++)	memcpy(&vga.draw.font[i*32],&int10_font_16[i*16],16);
         vga.draw.font_tables[0]=vga.draw.font_tables[1]=vga.draw.font;
     }
 	if (machine==MCH_CGA || IS_TANDY_ARCH || machine==MCH_HERC || machine==MCH_MDA) {
@@ -1062,7 +1061,7 @@ void VGA_SetupOther(void) {
 	}
 	if (machine==MCH_HERC || machine==MCH_MDA) {
 		extern Bit8u int10_font_14[256 * 14];
-		for (i=0;i<256;i++)	memcpy(&vga.draw.font[i*32],&int10_font_14[i*14],14);
+		for (Bitu i=0;i<256;i++)	memcpy(&vga.draw.font[i*32],&int10_font_14[i*14],14);
 		vga.draw.font_tables[0]=vga.draw.font_tables[1]=vga.draw.font;
 		MAPPER_AddHandler(HercBlend,MK_nothing,0,"hercblend","Herc Blend");
 		MAPPER_AddHandler(CycleHercPal,MK_nothing,0,"hercpal","Herc Pal");

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -686,8 +686,6 @@ void XGA_DrawWait(Bitu val, Bitu len) {
 					for(Bitu k = 0; k < chunks; k++) { // chunks counter
 						xga.waitcmd.newline = false;
 						for(Bitu n = 0; n < chunksize; n++) { // pixels
-							Bitu mixmode;
-							
 							// This formula can rule the world ;)
 							Bitu mask = (Bitu)1ul << (Bitu)((((n&0xF8u)+(8u-(n&0x7u)))-1u)+chunksize*k);
 							if(val&mask) mixmode = xga.foremix;

--- a/src/hardware/voodoo_emu.cpp
+++ b/src/hardware/voodoo_emu.cpp
@@ -135,7 +135,7 @@ void raster_generic(UINT32 TMUS, UINT32 TEXMODE0, UINT32 TEXMODE1, void *destbas
 					INT32 y, const poly_extent *extent,	const void *extradata)
 {
 	const poly_extra_data *extra = (const poly_extra_data *)extradata;
-	voodoo_state *v = extra->state;
+	v = extra->state;
 	stats_block *stats = &v->thread_stats[0];
 	DECLARE_DITHER_POINTERS;
 	INT32 startx = extent->startx;
@@ -3728,7 +3728,7 @@ static raster_info *find_rasterizer(voodoo_state *v, int texcount)
 static void raster_fastfill(void *destbase, INT32 y, const poly_extent *extent, const void *extradata)
 {
 	const poly_extra_data *extra = (const poly_extra_data *)extradata;
-	voodoo_state *v = extra->state;
+	v = extra->state;
 	stats_block *stats = &v->thread_stats[0];
 	INT32 startx = extent->startx;
 	INT32 stopx = extent->stopx;

--- a/src/hardware/voodoo_opengl.cpp
+++ b/src/hardware/voodoo_opengl.cpp
@@ -203,7 +203,7 @@ void ogl_get_fog_blend(voodoo_state* v, INT32 wfloat, INT32 ITERZ, INT64 ITERW, 
 
 void ogl_get_vertex_data(INT32 x, INT32 y, const void *extradata, ogl_vertex_data *vd) {
 	const poly_extra_data *extra = (const poly_extra_data *)extradata;
-	voodoo_state *v=(voodoo_state*)extra->state;
+	v=(voodoo_state*)extra->state;
 	INT32 iterr, iterg, iterb, itera;
 	INT32 iterz;
 	INT64 iterw;
@@ -220,7 +220,7 @@ void ogl_get_vertex_data(INT32 x, INT32 y, const void *extradata, ogl_vertex_dat
 	iterw = extra->startw + ((dy * extra->dwdy)>>4) + ((dx * extra->dwdx)>>4);
 
 	for (Bitu i=0; i<extra->texcount; i++) {
-		INT64 iters,itert,iterw;
+		INT64 iters,itert,iterw2;
 		UINT32 smax,tmax;
 		INT64 s, t;
 		INT32 lod=0;
@@ -236,14 +236,14 @@ void ogl_get_vertex_data(INT32 x, INT32 y, const void *extradata, ogl_vertex_dat
 		smax = (v->tmu[i].wmask >> ilod) + 1;
 		tmax = (v->tmu[i].hmask >> ilod) + 1;
 
-		iterw = v->tmu[i].startw + ((dy * v->tmu[i].dwdy)>>4) + ((dx * v->tmu[i].dwdx)>>4);
+		iterw2 = v->tmu[i].startw + ((dy * v->tmu[i].dwdy)>>4) + ((dx * v->tmu[i].dwdx)>>4);
 		iters = v->tmu[i].starts + ((dy * v->tmu[i].dsdy)>>4) + ((dx * v->tmu[i].dsdx)>>4);
 		itert = v->tmu[i].startt + ((dy * v->tmu[i].dtdy)>>4) + ((dx * v->tmu[i].dtdx)>>4);
 
 		/* determine the S/T/LOD values for this texture */
 		if (TEXMODE_ENABLE_PERSPECTIVE(texmode))
 		{
-			INT64 oow = fast_reciplog((iterw), &lod);
+			INT64 oow = fast_reciplog((iterw2), &lod);
 			s = (oow * (iters)) >> 29;
 			t = (oow * (itert)) >> 29;
 			lod += LODBASE;
@@ -265,14 +265,14 @@ void ogl_get_vertex_data(INT32 x, INT32 y, const void *extradata, ogl_vertex_dat
 			lod = v->tmu[i].lodmax;
 
 		/* clamp W */
-		if (TEXMODE_CLAMP_NEG_W(texmode) && (iterw) < 0)
+		if (TEXMODE_CLAMP_NEG_W(texmode) && (iterw2) < 0)
 			s = t = 0;
 
 		if (s != 0) vd->m[i].s = (float)((float)s/(float)(smax*(1u<<(18u+ilod))));
 		else vd->m[i].s = 0.0f;
 		if (t != 0) vd->m[i].t = (float)((float)t/(float)(tmax*(1u<<(18u+ilod))));
 		else vd->m[i].t = 0.0f;
-		if (iterw != 0) vd->m[i].w = (float)((float)iterw/(float)(0xffffff));
+		if (iterw2 != 0) vd->m[i].w = (float)((float)iterw2/(float)(0xffffff));
 		else vd->m[i].w = 0.0f;
 
 		vd->m[i].sw = vd->m[i].s * vd->m[i].w;
@@ -379,7 +379,7 @@ UINT32 calculate_palsum(UINT32 tmunum) {
 }
 
 void ogl_cache_texture(const poly_extra_data *extra, ogl_texture_data *td) {
-	voodoo_state *v=(voodoo_state*)extra->state;
+	v=(voodoo_state*)extra->state;
 
 	INT32 smax, tmax;
 	UINT32 *texrgbp;
@@ -421,7 +421,6 @@ void ogl_cache_texture(const poly_extra_data *extra, ogl_texture_data *td) {
 						valid_texid = false;
 //						LOG_MSG("texture removed... size %d",t->second.ids->size());
 						if (t->second.ids->size() > 8) {
-							std::map<const UINT32, GLuint>::iterator u;
 							for (u=t->second.ids->begin(); u!=t->second.ids->end(); ++u) {
 								glDeleteTextures(1,&u->second);
 							}
@@ -563,7 +562,7 @@ void ogl_printInfoLog(GLhandleARB obj)
 }
 
 void ogl_sh_tex_combine(std::string *strFShader, const int TMU, const poly_extra_data *extra) {
-	voodoo_state *v=(voodoo_state*)extra->state;
+	v=(voodoo_state*)extra->state;
 
 	UINT32 TEXMODE     = v->tmu[TMU].reg[textureMode].u;
 
@@ -667,7 +666,7 @@ void ogl_sh_tex_combine(std::string *strFShader, const int TMU, const poly_extra
 }
 
 void ogl_sh_color_path(std::string *strFShader, const poly_extra_data *extra) {
-	voodoo_state *v=(voodoo_state*)extra->state;
+	v=(voodoo_state*)extra->state;
 
 	UINT32 FBZCOLORPATH = v->reg[fbzColorPath].u;
 	UINT32 FBZMODE = v->reg[fbzMode].u;
@@ -876,7 +875,7 @@ void ogl_sh_color_path(std::string *strFShader, const poly_extra_data *extra) {
 }
 
 void ogl_sh_fog(std::string *strFShader, const poly_extra_data *extra) {
-	voodoo_state *v=(voodoo_state*)extra->state;
+	v=(voodoo_state*)extra->state;
 
 	UINT32 FOGMODE = v->reg[fogMode].u;
 
@@ -932,7 +931,7 @@ void ogl_sh_fog(std::string *strFShader, const poly_extra_data *extra) {
 
 
 void ogl_shaders(const poly_extra_data *extra) {
-	voodoo_state *v=(voodoo_state*)extra->state;
+	v=(voodoo_state*)extra->state;
 
 	GLint res;
 	std::string strVShader, strFShader;
@@ -1119,7 +1118,7 @@ void ogl_shaders(const poly_extra_data *extra) {
 
 
 void voodoo_ogl_draw_triangle(poly_extra_data *extra) {
-	voodoo_state *v=extra->state;
+	v=extra->state;
 	ogl_texture_data td[2];
 	ogl_vertex_data vd[3];
 

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -422,7 +422,6 @@ void dosbox_integration_trigger_read() {
             /* TODO: This should also be hidden behind an enable switch, so that rogue DOS development
              *       can't retaliate if the user wants to capture video or screenshots. */
 #if (C_SSHOT)
-            extern Bitu CaptureState;
             dosbox_int_register = 0x00000000; // available
             if (CaptureState & CAPTURE_IMAGE)
                 dosbox_int_register |= 1 << 0; // Image capture is in progress
@@ -3443,7 +3442,6 @@ static Bitu INT18_PC98_Handler(void) {
 
                 if ((reg_bh & 0x30) == 0x30) { // 640x480
                     if ((reg_al & 0xC) == 0x0C) { // 31KHz sync
-                        extern bool pc98_31khz_mode;
                         void PC98_Set31KHz_480line(void);
                         pc98_31khz_mode = true;
                         PC98_Set31KHz_480line();
@@ -3511,13 +3509,11 @@ static Bitu INT18_PC98_Handler(void) {
                             LOG_MSG("PC-98 change in hsync frequency to %uHz",(reg_al & 0x04) ? 31 : 24);
 
                             if (reg_al & 4) {
-                                extern bool pc98_31khz_mode;
                                 void PC98_Set31KHz(void);
                                 pc98_31khz_mode = true;
                                 PC98_Set31KHz();
                             }
                             else {
-                                extern bool pc98_31khz_mode;
                                 void PC98_Set24KHz(void);
                                 pc98_31khz_mode = false;
                                 PC98_Set24KHz();
@@ -8374,41 +8370,41 @@ private:
 
         {
             char tmp[512];
-            const char *cpu = "?";
+            const char *cpuType = "?";
 
             switch (CPU_ArchitectureType) {
                 case CPU_ARCHTYPE_8086:
-                    cpu = "8086";
+                    cpuType = "8086";
                     break;
                 case CPU_ARCHTYPE_80186:
-                    cpu = "80186";
+                    cpuType = "80186";
                     break;
                 case CPU_ARCHTYPE_286:
-                    cpu = "286";
+                    cpuType = "286";
                     break;
                 case CPU_ARCHTYPE_386:
-                    cpu = "386";
+                    cpuType = "386";
                     break;
                 case CPU_ARCHTYPE_486OLD:
-                    cpu = "486 (older generation)";
+                    cpuType = "486 (older generation)";
                     break;
                 case CPU_ARCHTYPE_486NEW:
-                    cpu = "486 (later generation)";
+                    cpuType = "486 (later generation)";
                     break;
                 case CPU_ARCHTYPE_PENTIUM:
-                    cpu = "Pentium";
+                    cpuType = "Pentium";
                     break;
                 case CPU_ARCHTYPE_P55CSLOW:
-                    cpu = "Pentium MMX";
+                    cpuType = "Pentium MMX";
                     break;
                 case CPU_ARCHTYPE_MIXED:
-                    cpu = "Auto (mixed)";
+                    cpuType = "Auto (mixed)";
                     break;
             }
 
             extern bool enable_fpu;
 
-            sprintf(tmp,"%s CPU present",cpu);
+            sprintf(tmp,"%s CPU present",cpuType);
             BIOS_Int10RightJustifiedPrint(x,y,tmp);
             if (enable_fpu) BIOS_Int10RightJustifiedPrint(x,y," with FPU");
             BIOS_Int10RightJustifiedPrint(x,y,"\n");
@@ -8871,7 +8867,7 @@ public:
 
                 phys_writeb(0xE8000 + 0x0DD8 + (PhysPt)i,0);
 
-                for (size_t i=0;i < sizeof(pc98_epson_check_2);i++)
+                for (i=0;i < sizeof(pc98_epson_check_2);i++)
                     phys_writeb(0xF5200 + 0x018E + (PhysPt)i,(Bit8u)pc98_epson_check_2[i]);
             }
         }

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -1033,7 +1033,6 @@ static Bitu INT13_DiskHandler(void) {
                 CALLBACK_SCF(true);
                 return CBRET_NONE;
             }
-            Bit32u tmpheads, tmpcyl, tmpsect, tmpsize;
             imageDiskList[drivenum]->Get_Geometry(&tmpheads, &tmpcyl, &tmpsect, &tmpsize);
             Bit64u largesize = tmpheads*tmpcyl*tmpsect*tmpsize;
             largesize/=512;
@@ -1173,7 +1172,6 @@ static Bitu INT13_DiskHandler(void) {
         if (bufsz > 0x1E) bufsz = 0x1E;
         else bufsz = 0x1A;
 
-        Bit32u tmpheads, tmpcyl, tmpsect, tmpsize;
         imageDiskList[drivenum]->Get_Geometry(&tmpheads, &tmpcyl, &tmpsect, &tmpsize);
 
         real_writew(segat,bufptr+0x00,bufsz);

--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -842,7 +842,6 @@ static Bit8u MemoryRegion(void) {
 
 
 static Bitu INT67_Handler(void) {
-	Bitu i;
 	switch (reg_ah) {
 	case 0x40:		/* Get Status */
 		reg_ah=EMM_NO_ERROR;	
@@ -877,7 +876,7 @@ static Bitu INT67_Handler(void) {
 		break;
 	case 0x4b:		/* Get Handle Count */
 		reg_bx=0;
-		for (i=0;i<EMM_MAX_HANDLES;i++) if (emm_handles[i].pages!=NULL_HANDLE) reg_bx++;
+		for (int i=0;i<EMM_MAX_HANDLES;i++) if (emm_handles[i].pages!=NULL_HANDLE) reg_bx++;
 		reg_ah=EMM_NO_ERROR;
 		break;
 	case 0x4c:		/* Get Pages for one Handle */

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -504,7 +504,7 @@ void BitmapFont::drawChar(Drawable *d, const Char c) const {
 
 	for (int row = height-h; row < height; row++, move(rs-w*col_step)) {
 		for (int col = 0; col < w; col++, move(col_step)) {
-			if (!background_set ^ !(*ptr&(1<<bit)))
+			if (!background_set != !(*ptr&(1<<bit)))
 				out.drawPixel(col,row);
 		}
 	}

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -914,7 +914,7 @@ void CONFIG::Run(void) {
 				Section* sec = control->GetSection(pvars[0].c_str());
 				if (!sec) {
 					// not a section: little duplicate from above
-					Section* sec=control->GetSectionFromProperty(pvars[0].c_str());
+					sec=control->GetSectionFromProperty(pvars[0].c_str());
 					if (sec) pvars.insert(pvars.begin(),std::string(sec->GetName()));
 					else {
 						WriteOut(MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"));

--- a/src/mt32/Part.cpp
+++ b/src/mt32/Part.cpp
@@ -59,7 +59,7 @@ Part::Part(Synth *useSynth, unsigned int usePartNum) {
 		// Nasty hack for rhythm
 		timbreTemp = NULL;
 	} else {
-		sprintf(name, "Part %d", partNum + 1);
+		sprintf(name, "Part %u", partNum + 1);
 		timbreTemp = &synth->mt32ram.timbreTemp[partNum];
 	}
 	currentInstr[0] = 0;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -86,11 +86,11 @@ void AutoexecObject::Install(const std::string &in) {
 		safe_strncpy(buf2, buf.c_str(), n + 1);
 		if((strncasecmp(buf2,"set ",4) == 0) && (strlen(buf2) > 4)){
 			char* after_set = buf2 + 4;//move to variable that is being set
-			char* test = strpbrk(after_set,"=");
-			if(!test) {first_shell->SetEnv(after_set,"");return;}
-			*test++ = 0;
+			char* test2 = strpbrk(after_set,"=");
+			if(!test2) {first_shell->SetEnv(after_set,"");return;}
+			*test2++ = 0;
 			//If the shell is running/exists update the environment
-			first_shell->SetEnv(after_set,test);
+			first_shell->SetEnv(after_set,test2);
 		}
 		delete [] buf2;
 	}
@@ -148,9 +148,9 @@ void AutoexecObject::Uninstall() {
 			// If it's a environment variable remove it from there as well
 			if ((strncasecmp(buf2,"set ",4) == 0) && (strlen(buf2) > 4)){
 				char* after_set = buf2 + 4;//move to variable that is being set
-				char* test = strpbrk(after_set,"=");
-				if (!test) continue;
-				*test = 0;
+				char* test2 = strpbrk(after_set,"=");
+				if (!test2) continue;
+				*test2 = 0;
 				stringset = true;
 				//If the shell is running/exists update the environment
 				if (first_shell) first_shell->SetEnv(after_set,"");

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1867,7 +1867,7 @@ void DOS_Shell::CMD_ADDKEY(char * args){
 			core = 3;
 		} else if (!strcasecmp(word,"full")) {
 			core = 4;
-		} else if (word[0] == 'k' && word[1] == 'p' && word[2] & !word[3]) {
+		} else if (word[0] == 'k' && word[1] == 'p' && word[2] && !word[3]) {
 			word[0] = 151+word[2]-'0';
 			word[1] = 0;
 		} else if (word[0] == 'f' && word[1]) {

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -613,18 +613,18 @@ static void FormatNumber(Bit32u num,char * buf) {
 	num/=1000;
 	numg=num;
 	if (numg) {
-		sprintf(buf,"%d,%03d,%03d,%03d",numg,numm,numk,numb);
+		sprintf(buf,"%u,%03u,%03u,%03u",numg,numm,numk,numb);
 		return;
 	}
 	if (numm) {
-		sprintf(buf,"%d,%03d,%03d",numm,numk,numb);
+		sprintf(buf,"%u,%03u,%03u",numm,numk,numb);
 		return;
 	}
 	if (numk) {
-		sprintf(buf,"%d,%03d",numk,numb);
+		sprintf(buf,"%u,%03u",numk,numb);
 		return;
 	}
-	sprintf(buf,"%d",numb);
+	sprintf(buf,"%u",numb);
 }
 
 struct DtaResult {

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1794,11 +1794,11 @@ void DOS_Shell::CMD_ADDKEY(char * args){
 		char *word=StripWord(args);
 		KBD_KEYS scankey = (KBD_KEYS)0;
 		char *tail;
-		bool alt = false, control = false, shift = false;
+		bool alt = false, ctrl = false, shift = false;
 		while (word[1] == '-') {
 			switch (word[0]) {
 				case 'c':
-					control = true;
+					ctrl = true;
 					word += 2;
 					break;
 				case 's':
@@ -1926,7 +1926,7 @@ void DOS_Shell::CMD_ADDKEY(char * args){
 				if (delay == 0) KEYBOARD_AddKey(KBD_leftshift,true);
 				else PIC_AddEvent(&delayed_press,delay++,KBD_leftshift);
 			}
-			if (control) {
+			if (ctrl) {
 				if (delay == 0) KEYBOARD_AddKey(KBD_leftctrl,true);
 				else PIC_AddEvent(&delayed_press,delay++,KBD_leftctrl);
 			}
@@ -1943,7 +1943,7 @@ void DOS_Shell::CMD_ADDKEY(char * args){
 				if (delay+duration == 0) KEYBOARD_AddKey(KBD_leftalt,false);
 				else PIC_AddEvent(&delayed_release,delay+++duration,KBD_leftalt);
 			}
-			if (control) {
+			if (ctrl) {
 				if (delay+duration == 0) KEYBOARD_AddKey(KBD_leftctrl,false);
 				else PIC_AddEvent(&delayed_release,delay+++duration,KBD_leftctrl);
 			}

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -720,16 +720,16 @@ void DOS_Shell::ProcessCmdLineEnvVarStitution(char *line) {
 				 * So the below code has funny conditions to match Win95's weird rules on what
 				 * consitutes valid or invalid %variable% names. */
 				if (*r == '%' && ((spaces > 0 && chars == 0) || (spaces == 0 && chars > 0))) {
-					std::string temp;
+					std::string temp2;
 
 					/* valid name found. substitute */
 					*r++ = 0; /* ASCIIZ snip */
-					if (GetEnvStr(name,temp)) {
-						size_t equ_pos = temp.find_first_of('=');
+					if (GetEnvStr(name,temp2)) {
+						size_t equ_pos = temp2.find_first_of('=');
 						if (equ_pos != std::string::npos) {
-							const char *base = temp.c_str();
+							const char *base = temp2.c_str();
 							const char *value = base + equ_pos + 1;
-							const char *fence = base + temp.length();
+							const char *fence = base + temp2.length();
 							assert(value >= base && value <= fence);
 							size_t len = (size_t)(fence-value);
 


### PR DESCRIPTION
Fix **clarifyCondition** warnings (these are about arithmetic operators being used where logical operators are expected)
Fix **invalidPrintfArgType** warnings (these are about `%d` or `%u`, etc. in `printf` calls not matching up with the types of the variables that are used for them)
Fix **shadowVariable** warnings (these are about local variables shadowing other same-name variables)

Builds and runs.