### PR TITLE
Fix incorrect check for ".vhd"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,8 @@
     they have been changed in configuration GUI (aybe).
   - Some scenarios with command history could display
     garbage characters from previous/next command (aybe).
+  - Fixed all hard disk images created by IMGMAKE having
+    VHD footers. (Allofich)
 0.82.23
   - Serial and parallel file output now disable stdio
     buffering so that output is more immediately

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2262,7 +2262,7 @@ restart_int:
             fwrite(&sbuf,512,1,f);
         }
         // write VHD footer if requested, largely copied from RAW2VHD program, no license was included
-        if((mediadesc == 0xF8) && (temp_line.find(".vhd"))) {
+        if((mediadesc == 0xF8) && (temp_line.find(".vhd")) != std::string::npos) {
             int i;
             Bit8u footer[512];
             // basic information


### PR DESCRIPTION
This line in `dos_programs.cpp` for the `IMGMAKE` program caused a VHD footer to always be created for hard drive images, because the comparison against the return value of `string::find` seems to have been made by someone thinking the return value would be 0 if the string was not found. It will actually return `std::string::npos` in that case, which is the unsigned representation of -1.

With this PR, only hard disk images of type `.vhd` will get the footer.