### PR TITLE
Fix constStatement warnings

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -52,13 +52,9 @@ public:
 	_LOG(LOG_TYPES type , LOG_SEVERITIES severity) : LOG(type,severity) { }
 };
 # undef LOG
-# if defined (_MSC_VER)
-#  define LOG(X,Y)
-# else
-#  define LOG(X,Y) CPU_LOG
+# define LOG(X,Y) CPU_LOG
 # define CPU_LOG(...)
 # endif
-#endif
 
 bool enable_weitek = false;
 

--- a/src/hardware/parport/directlpt_win32.cpp
+++ b/src/hardware/parport/directlpt_win32.cpp
@@ -53,15 +53,15 @@
 /* Wrapper functions for the function pointers
     - call these functions to perform I/O.
  */
-     short  Inp32 (short portaddr)
+     short Inp32(short portaddr)
      {
-          return (inp32fp)(portaddr);
+         return inp32fp(portaddr);
      }
 
-     void  Out32 (short portaddr, short datum)
+     void Out32(short portaddr, short datum)
      {
-          (oup32fp)(portaddr,datum);
-     } 
+         oup32fp(portaddr, datum);
+     }
 
 //********************************************************
 


### PR DESCRIPTION
Fix **constStatement** Cppcheck warnings.

The original code only defined part of `LOG` for MSVC, leaving off the string message, and the string messages caused warnings in Cppcheck and also another static analysis tool. Removing the MSVC-specific definition gets rid of the warnings and it still works fine for me building with MSVC.

Also an instance of this warning in `directlpt_win32.cpp` happened because of what seem to be unnecessary parentheses.