### PR TITLE
Fix Cppcheck warnings

### DIFF
--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -522,14 +522,12 @@ bool fatDrive::getEntryName(const char *fullname, char *entname) {
 }
 
 void fatDrive::UpdateBootVolumeLabel(const char *label) {
-    /* if the extended boot signature is 0x29 there is a copy of the volume label at 0x2B */
-    unsigned char *p = (unsigned char*)(&bootbuffer);
-
-    if (p[0x26] == 0x29) {
+    /* if the extended boot signature at 0x26 (bootcode[0x02]) is 0x29, there is a copy of the volume label at 0x2B (bootcode[0x07]) */
+    if (bootbuffer.bootcode[0x02] == 0x29) {
         unsigned int i = 0;
 
-        while (i < 11 && *label != 0) p[0x2B+(i++)] = toupper(*label++);
-        while (i < 11)                p[0x2B+(i++)] = ' ';
+        while (i < 11 && *label != 0) bootbuffer.bootcode[0x07+(i++)] = toupper(*label++);
+        while (i < 11)                bootbuffer.bootcode[0x07+(i++)] = ' ';
 
         loadedDisk->Write_AbsoluteSector(0+partSectOff,&bootbuffer);
     }

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -674,9 +674,7 @@ void DOSBoxMenu::displaylist_append(displaylist &ls,const DOSBoxMenu::item_handl
 }
 
 void DOSBoxMenu::displaylist_clear(DOSBoxMenu::displaylist &ls) {
-    for (auto &id : ls.disp_list) {
-        id = DOSBoxMenu::unassigned_item_handle;
-    }
+    std::fill(ls.disp_list.begin(), ls.disp_list.end(), DOSBoxMenu::unassigned_item_handle);
 
     ls.disp_list.clear();
     ls.items_changed = true;

--- a/src/ints/qcow2_disk.cpp
+++ b/src/ints/qcow2_disk.cpp
@@ -211,47 +211,34 @@ using namespace std;
 
 //Helper functions for endianness. QCOW format is big endian so we need different functions than those defined in mem.h.
 #if defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)
+    inline Bit16u QCow2Image::host_read16(Bit16u buffer) {
+        return buffer;
+    }
 
+    inline Bit32u QCow2Image::host_read32(Bit32u buffer) {
+        return buffer;
+    }
 
-	inline Bit16u QCow2Image::host_read16(Bit16u buffer) {
-		return buffer;
-	}
-
-
-	inline Bit32u QCow2Image::host_read32(Bit32u buffer) {
-		return buffer;
-	}
-
-
-	inline Bit64u QCow2Image::host_read64(Bit64u buffer) {
-		return buffer;
-	}
-
-
+    inline Bit64u QCow2Image::host_read64(Bit64u buffer) {
+        return buffer;
+    }
 #else
+    inline Bit16u QCow2Image::host_read16(Bit16u buffer) {
+        return (buffer >> 8) | (buffer << 8);
+    }
 
+    inline Bit32u QCow2Image::host_read32(Bit32u buffer) {
+        return (buffer >> 24) | (((buffer >> 16) & 0xff) << 8) |
+            (((buffer >> 8) & 0xff) << 16) | (buffer << 24);
+    }
 
-	inline Bit16u QCow2Image::host_read16(Bit16u buffer) {
-		Bit8u* b = (Bit8u*)&buffer;
-		return (unsigned int)b[1] | ((unsigned int)b[0] << 8u);
-	}
-
-
-	inline Bit32u QCow2Image::host_read32(Bit32u buffer) {
-		Bit8u* b = (Bit8u*)&buffer;
-		return (Bit32u)b[3] | ((Bit32u)b[2] << 8u) | ((Bit32u)b[1] << 16u) | ((Bit32u)b[0] << 24u);
-	}
-
-
-	inline Bit64u QCow2Image::host_read64(Bit64u buffer) {
-		Bit8u* b = (Bit8u*)&buffer;
-		return
-            (unsigned int)b[7] | ((unsigned int)b[6] << 8u) |
-            ((unsigned int)b[5] << 16u) | ((unsigned int)b[4] << 24u) |
-            ((Bit64u)b[3] << 32u) | ((Bit64u)b[2] << 40u) | ((Bit64u)b[1] << 48u) | ((Bit64u)b[0] << 56u);
-	}
-
-
+    inline Bit64u QCow2Image::host_read64(Bit64u buffer) {
+        return
+            (buffer >> 56) | (((buffer >> 48) & 0xff) << 8) |
+            (((buffer >> 40) & 0xff) << 16) | (((buffer >> 32) & 0xff) << 24) |
+            (((buffer >> 24) & 0xff) << 32) | (((buffer >> 16) & 0xff) << 40) |
+            (((buffer >> 8) & 0xff) << 48) | (buffer << 56);
+    }
 #endif
 
 


### PR DESCRIPTION
Fixes a few more Cppcheck warnings.

**objectIndex** : Cppcheck gave these warnings when an `unsigned char*` was used to refer to a variable and then the variable was accessed at a non-zero index. I don't think this caused any problems but Cppcheck is satisfied now, and I was able to clean up the QCow2Image big-endian/little-endian reading functions which were full of unnecessary and inconsistent casts.

The change to `fatDrive::UpdateBootVolumeLabel` was made by checking the bootbuffer structure and counting the bytes to where the access was being made to. It seemed that `p[0x26]` was pointing at `bootbuffer.bootcode[2]`, but you might want to give a double-check that it's correct.

**useStlAgorithm** : This was Cppcheck suggesting that std::fill or std::generate be used instead of a raw loop. Set it to use std::fill just to silence the warning, so it's out of the way when looking through the results.

Compiles and runs.