### PR TITLE
Fix warnings

### DIFF
--- a/include/setup.h
+++ b/include/setup.h
@@ -23,6 +23,8 @@
 #ifdef _MSC_VER
 //#pragma warning ( disable : 4786 )
 //#pragma warning ( disable : 4290 )
+#undef max
+#undef min
 #endif
 
 
@@ -161,15 +163,12 @@ protected:
 class Prop_int:public Property {
 public:
 	Prop_int(std::string const& _propname,Changeable::Value when, int _value)
-		:Property(_propname,when) {
+		:Property(_propname,when), min (-1), max(-1) {
 		default_value = value = _value;
-		min = max = -1;
 	}
 	Prop_int(std::string const&  _propname,Changeable::Value when, int _min,int _max,int _value)
-		:Property(_propname,when) {
+		:Property(_propname,when), min(_min), max(_max) {
 		default_value = value = _value;
-		min = _min;
-		max = _max;
 	}
 	int getMin() { return min;}
 	int getMax() { return max;}
@@ -187,16 +186,13 @@ private:
 class Prop_double:public Property {
 public:
 	Prop_double(std::string const & _propname, Changeable::Value when, double _value)
-		:Property(_propname,when){
+		:Property(_propname,when), min(-1.0), max(-1.0) {
 		default_value = value = _value;
-		min = max = -1.0;
 	}
 	Prop_double(std::string const & propname, Changeable::Value when, double _value, double _min, double _max)
-		:Property(propname, when)
+		:Property(propname, when), min(_min), max(_max)
 	{
 		default_value = value = _value;
-		min = _min;
-		max = _max;
 	}
 	double getMin() const { return min; }
 	double getMax() const { return max; }
@@ -232,9 +228,8 @@ class Prop_path:public Prop_string{
 public:
 	std::string realpath;
 	Prop_path(std::string const& _propname, Changeable::Value when, char const * const _value)
-		:Prop_string(_propname,when,_value) {
+		:Prop_string(_propname,when,_value), realpath(_value) {
 		default_value = value = _value;
-		realpath = _value;
 	}
 	bool SetValue(std::string const& input);
 	virtual ~Prop_path(){ }

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -3116,7 +3116,7 @@ public:
 		DOSBoxMenu::item *item;
 
 		if(inited) {
-			Change_Config(configuration);
+			CPU::Change_Config(configuration);
 			return;
 		}
 //		Section_prop * section=static_cast<Section_prop *>(configuration);
@@ -3233,7 +3233,7 @@ public:
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cputype_ppro_slow").
             set_text("Pentium Pro").set_callback_function(CpuType_ByName);
 
-		Change_Config(configuration);	
+		CPU::Change_Config(configuration);	
 		CPU_JMP(false,0,0,0);					//Setup the first cpu core
 	}
 	bool Change_Config(Section* newconfig){

--- a/src/dos/cdrom.cpp
+++ b/src/dos/cdrom.cpp
@@ -39,7 +39,7 @@ CDROM_Interface_SDL::CDROM_Interface_SDL(void) {
 }
 
 CDROM_Interface_SDL::~CDROM_Interface_SDL(void) {
-	StopAudio();
+	CDROM_Interface_SDL::StopAudio();
 #if !defined(C_SDL2)
 	SDL_CDClose(cd);
 	cd		= 0;

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1326,20 +1326,20 @@ void fatDrive::fatDriveInit(const char *sysFilename, Bit32u bytesector, Bit32u c
     /* Many HDI images indicate a disk format of 256 or 512 bytes per sector combined with a FAT filesystem
      * that indicates 1024 bytes per sector. */
     if (pc98_512_to_1024_allow &&
-         bootbuffer.bytespersector != getSectSize() &&
-         bootbuffer.bytespersector >  getSectSize() &&
-        (bootbuffer.bytespersector %  getSectSize()) == 0) {
+         bootbuffer.bytespersector != fatDrive::getSectSize() &&
+         bootbuffer.bytespersector >  fatDrive::getSectSize() &&
+        (bootbuffer.bytespersector %  fatDrive::getSectSize()) == 0) {
         unsigned int ratioshift = 1;
 
-        while ((unsigned int)(bootbuffer.bytespersector >> ratioshift) > getSectSize())
+        while ((unsigned int)(bootbuffer.bytespersector >> ratioshift) > fatDrive::getSectSize())
             ratioshift++;
 
         unsigned int ratio = 1u << ratioshift;
 
         LOG_MSG("Disk indicates %u bytes/sector, FAT filesystem indicates %u bytes/sector. Ratio=%u:1 shift=%u",
-                getSectSize(),bootbuffer.bytespersector,ratio,ratioshift);
+                fatDrive::getSectSize(),bootbuffer.bytespersector,ratio,ratioshift);
 
-        if ((unsigned int)(bootbuffer.bytespersector >> ratioshift) == getSectSize()) {
+        if ((unsigned int)(bootbuffer.bytespersector >> ratioshift) == fatDrive::getSectSize()) {
             assert(ratio >= 2);
 
             /* we can hack things in place IF the starting sector is an even number */
@@ -1356,7 +1356,7 @@ void fatDrive::fatDriveInit(const char *sysFilename, Bit32u bytesector, Bit32u c
     }
 
     /* NTS: PC-98 floppies (the 1024 byte/sector format) do not have magic bytes */
-    if (getSectSize() == 512 && !IS_PC98_ARCH) {
+    if (fatDrive::getSectSize() == 512 && !IS_PC98_ARCH) {
         if ((bootbuffer.magic1 != 0x55) || (bootbuffer.magic2 != 0xaa)) {
             /* Not a FAT filesystem */
             LOG_MSG("Loaded image has no valid magicnumbers at the end!");
@@ -1422,10 +1422,10 @@ void fatDrive::fatDriveInit(const char *sysFilename, Bit32u bytesector, Bit32u c
     /* another fault of this code is that it assumes the sector size of the medium matches
      * the bytespersector value of the MS-DOS filesystem. if they don't match, problems
      * will result. */
-    if (bootbuffer.bytespersector != getSectSize()) {
+    if (bootbuffer.bytespersector != fatDrive::getSectSize()) {
         LOG_MSG("FAT bytes/sector %u does not match disk image bytes/sector %u",
             (unsigned int)bootbuffer.bytespersector,
-            (unsigned int)getSectSize());
+            (unsigned int)fatDrive::getSectSize());
 		created_successfully = false;
         return;
     }

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -1232,7 +1232,7 @@ Bit32u localFile::GetSeekPos() {
 localFile::localFile(const char* _name, FILE * handle) {
 	fhandle=handle;
 	open=true;
-	UpdateDateTimeFromHost();
+	localFile::UpdateDateTimeFromHost();
 
 	attr=DOS_ATTR_ARCHIVE;
 	last_action=NONE;

--- a/src/gui/midi_mt32.h
+++ b/src/gui/midi_mt32.h
@@ -79,7 +79,7 @@ public:
 	MidiHandler_mt32() : chan(NULL), synth(NULL), thread(NULL), synthMutex(NULL), procIdleSem(NULL), mixerReqSem(NULL), open(false) {}
 
 	~MidiHandler_mt32() {
-		Close();
+		MidiHandler_mt32::Close();
 	}
 
 	const char *GetName(void) {

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -1209,7 +1209,7 @@ IDEATAPICDROMDevice::IDEATAPICDROMDevice(IDEController *c,unsigned char drive_in
     memset(sector, 0, sizeof(sector));
 
     memset(sense,0,sizeof(sense));
-    set_sense(/*SK=*/0);
+    IDEATAPICDROMDevice::set_sense(/*SK=*/0);
 
     /* FIXME: Spinup/down times should be dosbox.conf configurable, if the DOSBox gamers
      *        care more about loading times than emulation accuracy. */

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -169,7 +169,7 @@ public:
 
 class IDEATADevice:public IDEDevice {
 public:
-    IDEATADevice(IDEController *c,unsigned char bios_disk_index);
+    IDEATADevice(IDEController *c,unsigned char disk_index);
     virtual ~IDEATADevice();
     virtual void writecommand(uint8_t cmd);
 public:
@@ -190,7 +190,7 @@ public:
     Bitu multiple_sector_max,multiple_sector_count;
     Bitu heads,sects,cyls,headshr,progress_count;
     Bitu phys_heads,phys_sects,phys_cyls;
-    unsigned char sector[512*128];
+    unsigned char sector[512 * 128] = {};
     Bitu sector_i,sector_total;
     bool geo_translate;
 };
@@ -2036,15 +2036,12 @@ void IDEATADevice::generate_identify_device() {
     sector[511] = 0 - csum;
 }
 
-IDEATADevice::IDEATADevice(IDEController *c,unsigned char bios_disk_index) : IDEDevice(c) {
-    this->bios_disk_index = bios_disk_index;
+IDEATADevice::IDEATADevice(IDEController *c,unsigned char disk_index)
+    : IDEDevice(c), id_serial("8086"), id_firmware_rev("8086"), id_model("DOSBox IDE disk"), bios_disk_index(disk_index) {
     sector_i = sector_total = 0;
 
     headshr = 0;
     type = IDE_TYPE_HDD;
-    id_serial = "8086";
-    id_firmware_rev = "8086";
-    id_model = "DOSBox IDE disk";
     multiple_sector_max = sizeof(sector) / 512;
     multiple_sector_count = 1;
     geo_translate = false;

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -1002,7 +1002,7 @@ bool ISAPnPDevice::alloc(size_t sz) {
 }
 
 ISAPnPDevice::~ISAPnPDevice() {
-    alloc(0);
+    ISAPnPDevice::alloc(0);
 }
 
 void ISAPnPDevice::begin_write_res() {

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -1572,7 +1572,7 @@ public:
 	/** If \p width is given, the resulting label is a word-wrapped multiline label */
 	template <typename STR> Label(Window *parent, int x, int y, const STR text, int width = 0, const Font *font = Font::getFont("default"), RGB color = Color::Text) :
 		Window(parent, x, y, (width?width:1), 1), font(font), color(color), text(text), interpret(width != 0)
-	{ resize(); tabbable = false; }
+	{ Label::resize(); tabbable = false; }
 
 	/// Set a new text. Size of the label is adjusted accordingly.
 	template <typename STR> void setText(const STR text) { this->text = text; resize(); }
@@ -2024,10 +2024,10 @@ public:
 	 *  always the screen the logical parent resides on. */
 	template <typename STR> Menu(Window *parent, int x, int y, const STR name) :
 		TransientWindow(parent,x,y,4,4), ActionEventSource(name), selected(-1)
-		{ setVisible(false); tabbable = false; }
+		{ Menu::setVisible(false); tabbable = false; }
 
 	~Menu() {
-		setVisible(false);
+		Menu::setVisible(false);
 	}
 
 	/// Paint button.

--- a/src/mt32/AReverbModel.cpp
+++ b/src/mt32/AReverbModel.cpp
@@ -162,7 +162,7 @@ void CombFilter::setFilterFactor(const float useFilterFactor) {
 AReverbModel::AReverbModel(const ReverbMode mode) : allpasses(NULL), combs(NULL), currentSettings(*REVERB_SETTINGS[mode]), lpfAmp(0.0F), wetLevel(0.0F) {}
 
 AReverbModel::~AReverbModel() {
-	close();
+	AReverbModel::close();
 }
 
 void AReverbModel::open() {

--- a/src/mt32/FreeverbModel.cpp
+++ b/src/mt32/FreeverbModel.cpp
@@ -23,13 +23,8 @@
 
 namespace MT32Emu {
 
-FreeverbModel::FreeverbModel(float useScaleTuning, float useFiltVal, float useWet, Bit8u useRoom, float useDamp) {
-	freeverb = NULL;
-	scaleTuning = useScaleTuning;
-	filtVal = useFiltVal;
-	wet = useWet;
-	room = useRoom;
-	damp = useDamp;
+FreeverbModel::FreeverbModel(float useScaleTuning, float useFiltVal, float useWet, Bit8u useRoom, float useDamp)
+    :freeverb(NULL), scaleTuning(useScaleTuning), filtVal(useFiltVal), wet(useWet), room(useRoom), damp(useDamp) {
 }
 
 FreeverbModel::~FreeverbModel() {

--- a/src/mt32/Part.cpp
+++ b/src/mt32/Part.cpp
@@ -46,7 +46,7 @@ static const float floatKeyfollow[17] = {
 RhythmPart::RhythmPart(Synth *useSynth, unsigned int usePartNum): Part(useSynth, usePartNum) {
 	strcpy(name, "Rhythm");
 	rhythmTemp = &synth->mt32ram.rhythmTemp[0];
-	refresh();
+	RhythmPart::refresh();
 }
 
 Part::Part(Synth *useSynth, unsigned int usePartNum) {


### PR DESCRIPTION
Fixes **useInitializationList** Cppcheck warnings. Also includes a few from SonarLint, and an uninitialized array warning from SonarLint.

Fixes **virtualCallInConstructor** Cppcheck warnings, for calls from constructors or destructors to overridable functions.

Also a question @joncampbell123 , Cppcheck gives a lot of warnings for two situations where I am not sure that you would want the fix. They are for functions with a single parameter that lack the **explicit** keyword, and for overriding functions that lack the **override** keyword. Both are easy fixes but neither of these keywords seem to be being used in the DOSBox-X source.