### PR TITLE
Fix VS2019 compiler warnings

### DIFF
--- a/vs2015/libpdcurses/pdcurses/insstr.c
+++ b/vs2015/libpdcurses/pdcurses/insstr.c
@@ -81,7 +81,7 @@ int winsnstr(WINDOW *win, const char *str, int n)
     if (!win || !str)
         return ERR;
 
-    len = strlen(str);
+    len = (int)strlen(str);
 
     if (n < 0 || n < len)
         n = len;

--- a/vs2015/libpdcurses/pdcurses/instr.c
+++ b/vs2015/libpdcurses/pdcurses/instr.c
@@ -90,7 +90,7 @@ int winnstr(WINDOW *win, char *str, int n)
     src = win->_y[win->_cury] + win->_curx;
 
     for (i = 0; i < n; i++)
-        str[i] = src[i] & A_CHARTEXT;
+        str[i] = (char)(src[i] & A_CHARTEXT);
 
     str[i] = '\0';
 

--- a/vs2015/libpdcurses/pdcurses/slk.c
+++ b/vs2015/libpdcurses/pdcurses/slk.c
@@ -297,7 +297,7 @@ char *slk_label(int labnum)
         return (char *)0;
 
     for (i = 0, p = slk[labnum - 1].label; *p; i++)
-        temp[i] = *p++;
+        temp[i] = (char)*p++;
 
     temp[i] = '\0';
 #endif

--- a/vs2015/libpdcurses/wincon/pdcclip.c
+++ b/vs2015/libpdcurses/wincon/pdcclip.c
@@ -73,7 +73,7 @@ int PDC_getclipboard(char **contents, long *length)
 #ifdef PDC_WIDE
     len = wcslen((wchar_t *)handle) * 3;
 #else
-    len = strlen((char *)handle);
+    len = (long)strlen((char *)handle);
 #endif
     *contents = (char *)GlobalAlloc(GMEM_FIXED, len + 1);
 

--- a/vs2015/libpdcurses/wincon/pdcdisp.c
+++ b/vs2015/libpdcurses/wincon/pdcdisp.c
@@ -147,7 +147,7 @@ void _set_ansi_color(short f, short b, attr_t attr)
         if (!pdc_conemu)
             SetConsoleMode(pdc_con_out, 0x0015);
 
-        WriteConsoleA(pdc_con_out, esc, strlen(esc), NULL, NULL);
+        WriteConsoleA(pdc_con_out, esc, (DWORD)strlen(esc), NULL, NULL);
 
         if (!pdc_conemu)
             SetConsoleMode(pdc_con_out, 0x0010);
@@ -226,7 +226,7 @@ void _new_packet(attr_t attr, int lineno, int x, int len, const chtype *srcp)
             ch = ' ';
 
         if (ansi)
-            buffer.text[j] = ch & A_CHARTEXT;
+            buffer.text[j] = (char)(ch & A_CHARTEXT);
         else
         {
             buffer.ci[j].Attributes = mapped_attr;

--- a/vs2015/libpdcurses/wincon/pdcscrn.c
+++ b/vs2015/libpdcurses/wincon/pdcscrn.c
@@ -3,6 +3,7 @@
 #include "pdcwin.h"
 
 #include <stdlib.h>
+#include <VersionHelpers.h>
 
 /* COLOR_PAIR to attribute encoding table. */
 
@@ -391,7 +392,7 @@ int PDC_scr_open(int argc, char **argv)
         exit(1);
     }
 
-    is_nt = !(GetVersion() & 0x80000000);
+    is_nt = IsWindowsXPOrGreater();
 
     str = getenv("ConEmuANSI");
     pdc_conemu = !!str;


### PR DESCRIPTION
Addresses Visual Studio 2019 compiler warnings that began appearing for the `libpdcurses` library in the solution.