### PR TITLE
Fix missing .conf help messages and some warnings

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3158,13 +3158,13 @@ void DOSBOX_SetupConfigSections(void) {
                 "         Setting the IRQ to one already occupied by another device or IDE controller will trigger \"resource conflict\" errors in Windows 95.\n"
                 "         Using IRQ 9, 12, 13, or IRQ 2-7 may cause problems with MS-DOS CD-ROM drivers.");
 
-        secprop->Add_hex("io",Property::Changeable::WhenIdle,0/*use IDE default*/);
-        if (i == 0) Pint->Set_help("Base I/O port for IDE controller. Set to 0 for default.\n"
+        Phex = secprop->Add_hex("io",Property::Changeable::WhenIdle,0/*use IDE default*/);
+        if (i == 0) Phex->Set_help("Base I/O port for IDE controller. Set to 0 for default.\n"
                 "WARNING: Setting the I/O port to non-standard values will not work unless the guest OS is using the ISA PnP BIOS to detect the IDE controller.\n"
                 "         Using any port other than 1F0, 170, 1E8 or 168 can prevent MS-DOS CD-ROM drivers from detecting the IDE controller.");
 
         Phex = secprop->Add_hex("altio",Property::Changeable::WhenIdle,0/*use IDE default*/);
-        if (i == 0) Pint->Set_help("Alternate I/O port for IDE controller (alt status, etc). Set to 0 for default.\n"
+        if (i == 0) Phex->Set_help("Alternate I/O port for IDE controller (alt status, etc). Set to 0 for default.\n"
                 "WARNING: Setting the I/O port to non-standard values will not work unless the guest OS is using the ISA PnP BIOS to detect the IDE controller.\n"
                 "         For best compatability set this value to io+0x206, for example, io=1F0 altio=3F6.\n"
                 "         The primary IDE controller will not claim port 3F7 if the primary floppy controller is enabled due to I/O port overlap in the 3F0-3F7 range.");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -352,7 +352,7 @@ void DOS_Shell::Run(void) {
 	char input_line[CMD_MAXLINE] = {0};
 	std::string line;
 	if (cmd->FindStringRemainBegin("/C",line)) {
-		strcpy(input_line,line.c_str());
+		strncpy(input_line,line.c_str(),CMD_MAXLINE);
 		char* sep = strpbrk(input_line,"\r\n"); //GTA installer
 		if (sep) *sep = 0;
 		DOS_Shell temp;
@@ -380,7 +380,7 @@ void DOS_Shell::Run(void) {
     }
 
 	if (cmd->FindString("/INIT",line,true)) {
-		strcpy(input_line,line.c_str());
+		strncpy(input_line,line.c_str(),CMD_MAXLINE);
 		line.erase();
 		ParseLine(input_line);
 	}
@@ -1159,7 +1159,7 @@ void SHELL_Init() {
 	CommandTail tail;
 	tail.count=(Bit8u)strlen(init_line);
 	memset(&tail.buffer, 0, 127);
-	strcpy(tail.buffer,init_line);
+	strncpy(tail.buffer,init_line,127);
 	MEM_BlockWrite(PhysMake(psp_seg,128),&tail,128);
 	
 	/* Setup internal DOS Variables */

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -103,7 +103,7 @@ emptyline:
 				cmd_read++;
 				size_t name_len = strlen(file_name);
 				if (((size_t)(cmd_write - line) + name_len) < (CMD_MAXLINE - 1)) {
-					strcpy(cmd_write,file_name);
+					strncpy(cmd_write,file_name,CMD_MAXLINE);
 					cmd_write += name_len;
 				}
 				continue;
@@ -118,7 +118,7 @@ emptyline:
 				if (!cmd->FindCommand((unsigned int)next,word)) continue;
 				size_t name_len = strlen(word.c_str());
 				if (((size_t)(cmd_write - line) + name_len) < (CMD_MAXLINE - 1)) {
-					strcpy(cmd_write,word.c_str());
+					strncpy(cmd_write,word.c_str(),CMD_MAXLINE);
 					cmd_write += name_len;
 				}
 				continue;
@@ -135,7 +135,7 @@ emptyline:
 					equals++;
 					size_t name_len = strlen(equals);
 					if (((size_t)(cmd_write - line) + name_len) < (CMD_MAXLINE - 1)) {
-						strcpy(cmd_write,equals);
+						strncpy(cmd_write,equals,CMD_MAXLINE);
 						cmd_write += name_len;
 					}
 				}


### PR DESCRIPTION
The following help messages for `io` and `altio` weren't appearing in the .conf like with other settings because of a couple mistakes.

```
#    io: Base I/O port for IDE controller. Set to 0 for default.
#          WARNING: Setting the I/O port to non-standard values will not work unless the guest OS is using the ISA PnP BIOS to detect the IDE controller.
#                   Using any port other than 1F0, 170, 1E8 or 168 can prevent MS-DOS CD-ROM drivers from detecting the IDE controller.
# altio: Alternate I/O port for IDE controller (alt status, etc). Set to 0 for default.
#          WARNING: Setting the I/O port to non-standard values will not work unless the guest OS is using the ISA PnP BIOS to detect the IDE controller.
#                   For best compatability set this value to io+0x206, for example, io=1F0 altio=3F6.
#                   The primary IDE controller will not claim port 3F7 if the primary floppy controller is enabled due to I/O port overlap in the 3F0-3F7 range.
```

Also fix some (not all) warnings about `strcpy` being insecure.