### PR TITLE
Fix ADDKEY not setting full core after a delay

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.82.25 (next)
+  - Fixed ADDKEY "full" command not turning on the
+    full core when used with a delay. (Allofich)
   - INT 10h AX=101Ah Get Video DAC color-page state fixed
     to restore display after blanking it due to Attribute
     Controller read and write operations. This fixes

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1777,7 +1777,7 @@ static void delayed_sdlpress(Bitu core) {
 	if(core==1) SetVal("cpu","core","normal");
 	else if(core==2) SetVal("cpu","core","simple");
 	else if(core==3) SetVal("cpu","core","dynamic");
-	else if(core==3) SetVal("cpu","core","full");
+	else if(core==4) SetVal("cpu","core","full");
 }
 // ADDKEY patch was created by Moe
 void DOS_Shell::CMD_ADDKEY(char * args){


### PR DESCRIPTION
What looks like a typo was preventing the `ADDKEY` command from setting the full core if you used it in conjunction with a delay using `p`.

Ex.:
At the DOS prompt, type:

```ADDKEY p1 full```

In master, the core will not change. With this PR fix, it will. The other cores and `full` without using `p` are already working.