### PR TITLE
Minor cleanup

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -183,8 +183,6 @@ void CPU_Core_Dynrec_Cache_Close(void);
 bool CPU_IsDynamicCore(void);
 
 void menu_update_cputype(void) {
-	Section_prop * cpu_section = static_cast<Section_prop *>(control->GetSection("cpu"));
-	const std::string cpu_sec_type = cpu_section->Get_string("cputype");
     bool allow_prefetch = false;
     bool allow_pre386 = false;
 
@@ -3862,7 +3860,6 @@ void init_vm86_fake_io() {
 	phys_writeb((PhysPt)(phys+wo+0x00),(Bit8u)0x66);	/* OUT DX,EAX */
 	phys_writeb((PhysPt)(phys+wo+0x01),(Bit8u)0xEF);
 	phys_writeb((PhysPt)(phys+wo+0x02),(Bit8u)0xCB);	/* RETF */
-	wo += 3;
 }
 
 Bitu CPU_ForceV86FakeIO_In(Bitu port,Bitu len) {

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -4008,7 +4008,7 @@ void DBGBlock::set_data_view(unsigned int view) {
 
 void DEBUG_SetupConsole(void) {
 	if (dbg.win_main == NULL) {
-        DEBUG_ShowMsg("DEBUG_SetupConsole initializing GUI");
+        LOG(LOG_MISC, LOG_DEBUG)("DEBUG_SetupConsole initializing GUI");
 
         dbg.set_data_view(DBGBlock::DATV_SEGMENTED);
 
@@ -4027,7 +4027,7 @@ void DEBUG_ShutDown(Section * /*sec*/) {
 	CBreakpoint::DeleteAll();
 	CDebugVar::DeleteAll();
 	if (dbg.win_main != NULL) {
-        DEBUG_ShowMsg("DEBUG_Shutdown freeing ncurses state");
+        LOG(LOG_MISC, LOG_DEBUG)("DEBUG_Shutdown freeing ncurses state");
 		curs_set(old_cursor_state);
 
         void DEBUG_GUI_DestroySubWindows(void);
@@ -4055,7 +4055,7 @@ void DEBUG_ReinitCallback(void) {
 void DEBUG_Init() {
 	DOSBoxMenu::item *item;
 
-    DEBUG_ShowMsg("Initializing debug system");
+    LOG(LOG_MISC, LOG_DEBUG)("Initializing debug system");
 
 	/* Add some keyhandlers */
 	#if defined(MACOSX)

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -594,7 +594,6 @@ imageDisk::imageDisk(FILE *imgFile, Bit8u *imgName, Bit32u imgSizeK, bool isHard
                                 hddsize >= sectorsize && (hddsize/1024) <= (imgSizeK+4)) {
 
                                 sector_size = sectorsize;
-                                imgSizeK -= (ofs / 1024);
                                 image_base = ofs;
                                 image_length -= ofs;
                                 LOG_MSG("HDI header: sectorsize is %u bytes/sector, header is %u bytes, hdd size (plus header) is %u bytes",
@@ -1567,7 +1566,7 @@ imageDiskVFD::imageDiskVFD(FILE *imgFile, Bit8u *imgName, Bit32u imgSizeK, bool 
                 }
             }
 
-            Bit8u i=0;
+            Bit8u i;
             if (sector_size != 0) {
                 i=0;
                 while (DiskGeometryList[i].ksize != 0) {

--- a/src/ints/bios_vhd.cpp
+++ b/src/ints/bios_vhd.cpp
@@ -328,7 +328,7 @@ Bit8u imageDiskVHD::Write_AbsoluteSector(Bit32u sectnum, const void * data) {
 		if (!copiedFooter) {
 			//write backup of footer at start of file (should already exist, but we never checked to be sure it is readable or matches the footer we used)
 			if (fseeko64(diskimg, (off_t)0, SEEK_SET)) return 0x05;
-			if (fwrite(originalFooter.cookie, sizeof(Bit8u), 512, diskimg) != 512) return 0x05;
+			if (fwrite(&originalFooter, sizeof(Bit8u), 512, diskimg) != 512) return 0x05;
 			copiedFooter = true;
 			//flush the data to disk after writing the backup footer
 			if (fflush(diskimg)) return 0x05;
@@ -339,7 +339,7 @@ Bit8u imageDiskVHD::Write_AbsoluteSector(Bit32u sectnum, const void * data) {
 		if (fseeko64(diskimg, (off_t)newFooterPosition + 512, SEEK_SET)) return 0x05;
 		//now write the footer
 		if (fseeko64(diskimg, (off_t)newFooterPosition, SEEK_SET)) return 0x05;
-		if (fwrite(originalFooter.cookie, sizeof(Bit8u), 512, diskimg) != 512) return 0x05;
+		if (fwrite(&originalFooter, sizeof(Bit8u), 512, diskimg) != 512) return 0x05;
 		//save the new block location and new footer position
 		Bit32u newBlockSectorNumber = (Bit32u)((footerPosition + 511ul) / 512ul);
 		footerPosition = newFooterPosition;


### PR DESCRIPTION
1. Restore the 3 debug-level log messages in debug.cpp that I replaced the other day. I though debug-level log messages weren't working correctly but they are.

2. Fix some CppCheck warnings.

- Buffer out-of-range warnings in `bios_vhd.cpp` caused by telling `fwrite` to write 512 bytes to an 8-byte array at the start of a struct. Now the struct itself is used, accomplishing the same behavior without the warning.

- Remove some unused variable assignments.