### PR TITLE
Allow specifying hex values in the debugger by using double quotation marks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,9 @@
 0.82.25 (next)
+  - Allow using "" in the debugger to specify that
+    a hex value should be used rather than the
+    contents of the flag with that name. Allows
+    hex values of AC, AF, CF and DF to be directly
+    specified. (Allofich)
   - 25.COM, 28.COM, and 50.COM now have different
     versions for VGA, EGA, and other IBM compatible
     video machines. 28.COM now correctly sets 28 lines

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -1292,7 +1292,10 @@ Bit32u GetHexValue(char* const str, char* &hex,bool *parsed)
     hex = str;
     while (*hex == ' ') hex++;
 
-    if (strncmp(hex, "EFLAGS", 6) == 0) { hex += 6; regval = (Bit32u)reg_flags; }
+    // The user can enclose a value in double quotations to enter hex values that
+    // would collide with a flag name (AC, AF, CF, and DF).
+    if (*hex == '\"') { hex++; }
+    else if (strncmp(hex, "EFLAGS", 6) == 0) { hex += 6; regval = (Bit32u)reg_flags; }
     else if (strncmp(hex, "FLAGS", 5) == 0) { hex += 5; regval = (Bit32u)reg_flags; }
     else if (strncmp(hex, "IOPL", 4) == 0) { hex += 4; regval = (reg_flags & FLAG_IOPL) >> 12u; }
     else if (strncmp(hex, "CR0", 3) == 0) { hex += 3; regval = (Bit32u)cpu.cr0; }
@@ -1344,7 +1347,7 @@ Bit32u GetHexValue(char* const str, char* &hex,bool *parsed)
     else if (strncmp(hex, "VM", 2) == 0) { hex += 2; regval = GETFLAG(VM); }
     else if (strncmp(hex, "ZF", 2) == 0) { hex += 2; regval = GETFLAG(ZF); }
 
-    while (*hex) {
+    while (*hex && *hex != '\"') {
         if ((*hex >= '0') && (*hex <= '9')) value = (value << 4u) + ((Bit32u)(*hex)) - '0';
         else if ((*hex >= 'A') && (*hex <= 'F')) value = (value << 4u) + ((Bit32u)(*hex)) - 'A' + 10u;
         else {
@@ -1353,6 +1356,11 @@ Bit32u GetHexValue(char* const str, char* &hex,bool *parsed)
                 if (*hex == '-') { hex++; return regval + value - GetHexValue(hex, hex, parsed); }
                 else break; // No valid char
         }
+        hex++;
+    }
+
+    // If there is a closing quote, skip over it.
+    if (*hex == '\"') {
         hex++;
     }
 


### PR DESCRIPTION
For the issue raised at https://www.vogons.org/viewtopic.php?f=41&t=31881&start=1860.

For hex values that have a name collision with flag register names (AC, AF, CF and DF), attempting to specify these hex values with the "sm" command will, in master, take the value of the flag instead.

With this PR, by enclosing the value in double quotation marks, you can specify the hex value instead.

Ex.
`sm 0000:0200 "CF"`
will put the hex value CF at 0000:0200.
`sm 0000:0200 CF`
will put the contents of flag CF at 0000:0200, as it does now.

**Does this PR address some issue(s) ?**

Not an issue here on GitHub, but one reported at the VOGONs forum.

**Are there any breaking changes ?**

Not that I know of.


**Additional information**

I'm sure there are other solutions. If you have another way you prefer I don't mind if you reject this PR.
