### PR TITLE
Fix OS-X build

### DIFF
--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -720,7 +720,8 @@ void DOSBoxMenu::displaylist_append(displaylist &ls,const DOSBoxMenu::item_handl
 }
 
 void DOSBoxMenu::displaylist_clear(DOSBoxMenu::displaylist &ls) {
-    std::fill(ls.disp_list.begin(), ls.disp_list.end(), DOSBoxMenu::unassigned_item_handle);
+    uint16_t id = DOSBoxMenu::unassigned_item_handle;
+    std::fill(ls.disp_list.begin(), ls.disp_list.end(), id);
 
     ls.disp_list.clear();
     ls.items_changed = true;


### PR DESCRIPTION
Fixes
https://github.com/joncampbell123/dosbox-x/issues/1392
by moving `DOSBoxMenu::unassigned_item_handle` out from the `std::fill` call.