### PR TITLE
Cleanup

### DIFF
--- a/include/regs.h
+++ b/include/regs.h
@@ -135,7 +135,7 @@ enum {
 //macros to convert a 3-bit register index to the correct register
 #define reg_8l(reg) (cpu_regs.regs[(reg)].byte[BL_INDEX])
 #define reg_8h(reg) (cpu_regs.regs[(reg)].byte[BH_INDEX])
-#define reg_8(reg) ((reg) & 4 ? reg_8h((reg) & 3) : reg_8l((reg) & 3))
+#define reg_8(reg) ((reg & 4) ? reg_8h((reg) & 3) : reg_8l((reg) & 3))
 #define reg_16(reg) (cpu_regs.regs[(reg)].word[W_INDEX])
 #define reg_32(reg) (cpu_regs.regs[(reg)].dword[DW_INDEX])
 

--- a/src/cpu/core_dynrec/decoder_opcodes.h
+++ b/src/cpu/core_dynrec/decoder_opcodes.h
@@ -35,7 +35,7 @@ static void dyn_dop_ebgb(DualOps op) {
 		dyn_fill_ea(FC_ADDR);
 		gen_protect_addr_reg();
 		dyn_read_byte_canuseword(FC_ADDR,FC_OP1);
-		MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP2,decode.modrm.reg&3,(decode.modrm.reg>>2)&1);
+		MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP2,decode.modrm.reg&3,((decode.modrm.reg>>2)&1));
 		dyn_dop_byte_gencall(op);
 
 		if ((op!=DOP_CMP) && (op!=DOP_TEST)) {
@@ -43,10 +43,10 @@ static void dyn_dop_ebgb(DualOps op) {
 			dyn_write_byte(FC_ADDR,FC_RETOP);
 		}
 	} else {
-		MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP1,decode.modrm.rm&3,(decode.modrm.rm>>2)&1);
-		MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP2,decode.modrm.reg&3,(decode.modrm.reg>>2)&1);
+		MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP1,decode.modrm.rm&3,((decode.modrm.rm>>2)&1));
+		MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP2,decode.modrm.reg&3,((decode.modrm.reg>>2)&1));
 		dyn_dop_byte_gencall(op);
-		if ((op!=DOP_CMP) && (op!=DOP_TEST)) MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_RETOP,decode.modrm.rm&3,(decode.modrm.rm>>2)&1);
+		if ((op!=DOP_CMP) && (op!=DOP_TEST)) MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_RETOP,decode.modrm.rm&3,((decode.modrm.rm>>2)&1));
 	}
 }
 
@@ -54,11 +54,11 @@ static void dyn_dop_ebgb_mov(void) {
 	dyn_get_modrm();
 	if (decode.modrm.mod<3) {
 		dyn_fill_ea(FC_ADDR);
-		MOV_REG_BYTE_TO_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.reg&3,(decode.modrm.reg>>2)&1);
+		MOV_REG_BYTE_TO_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.reg&3,((decode.modrm.reg>>2)&1));
 		dyn_write_byte(FC_ADDR,FC_TMP_BA1);
 	} else {
-		MOV_REG_BYTE_TO_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.reg&3,(decode.modrm.reg>>2)&1);
-		MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.rm&3,(decode.modrm.rm>>2)&1);
+		MOV_REG_BYTE_TO_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.reg&3,((decode.modrm.reg>>2)&1));
+		MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.rm&3,((decode.modrm.rm>>2)&1));
 	}
 }
 
@@ -70,7 +70,7 @@ static void dyn_dop_ebib_mov(void) {
 		dyn_write_byte(FC_ADDR,FC_TMP_BA1);
 	} else {
 		gen_mov_byte_to_reg_low_imm(FC_TMP_BA1,decode_fetchb());
-		MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.rm&3,(decode.modrm.rm>>2)&1);
+		MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.rm&3,((decode.modrm.rm>>2)&1));
 	}
 }
 
@@ -80,16 +80,16 @@ static void dyn_dop_ebgb_xchg(void) {
 		dyn_fill_ea(FC_ADDR);
 		gen_protect_addr_reg();
 		dyn_read_byte(FC_ADDR,FC_TMP_BA1);
-		MOV_REG_BYTE_TO_HOST_REG_LOW(FC_TMP_BA2,decode.modrm.reg&3,(decode.modrm.reg>>2)&1);
+		MOV_REG_BYTE_TO_HOST_REG_LOW(FC_TMP_BA2,decode.modrm.reg&3,((decode.modrm.reg>>2)&1));
 
-		MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.reg&3,(decode.modrm.reg>>2)&1);
+		MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.reg&3,((decode.modrm.reg>>2)&1));
 		gen_restore_addr_reg();
 		dyn_write_byte(FC_ADDR,FC_TMP_BA2);
 	} else {
-		MOV_REG_BYTE_TO_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.rm&3,(decode.modrm.rm>>2)&1);
-		MOV_REG_BYTE_TO_HOST_REG_LOW(FC_TMP_BA2,decode.modrm.reg&3,(decode.modrm.reg>>2)&1);
-		MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.reg&3,(decode.modrm.reg>>2)&1);
-		MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_TMP_BA2,decode.modrm.rm&3,(decode.modrm.rm>>2)&1);
+		MOV_REG_BYTE_TO_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.rm&3,((decode.modrm.rm>>2)&1));
+		MOV_REG_BYTE_TO_HOST_REG_LOW(FC_TMP_BA2,decode.modrm.reg&3,((decode.modrm.reg>>2)&1));
+		MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.reg&3,((decode.modrm.reg>>2)&1));
+		MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_TMP_BA2,decode.modrm.rm&3,((decode.modrm.rm>>2)&1));
 	}
 }
 
@@ -98,14 +98,14 @@ static void dyn_dop_gbeb(DualOps op) {
 	if (decode.modrm.mod<3) {
 		dyn_fill_ea(FC_ADDR);
 		dyn_read_byte_canuseword(FC_ADDR,FC_OP2);
-		MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP1,decode.modrm.reg&3,(decode.modrm.reg>>2)&1);
+		MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP1,decode.modrm.reg&3,((decode.modrm.reg>>2)&1));
 		dyn_dop_byte_gencall(op);
-		if ((op!=DOP_CMP) && (op!=DOP_TEST)) MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_RETOP,decode.modrm.reg&3,(decode.modrm.reg>>2)&1);
+		if ((op!=DOP_CMP) && (op!=DOP_TEST)) MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_RETOP,decode.modrm.reg&3,((decode.modrm.reg>>2)&1));
 	} else {
-		MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP2,decode.modrm.rm&3,(decode.modrm.rm>>2)&1);
-		MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP1,decode.modrm.reg&3,(decode.modrm.reg>>2)&1);
+		MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP2,decode.modrm.rm&3,((decode.modrm.rm>>2)&1));
+		MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP1,decode.modrm.reg&3,((decode.modrm.reg>>2)&1));
 		dyn_dop_byte_gencall(op);
-		if ((op!=DOP_CMP) && (op!=DOP_TEST)) MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_RETOP,decode.modrm.reg&3,(decode.modrm.reg>>2)&1);
+		if ((op!=DOP_CMP) && (op!=DOP_TEST)) MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_RETOP,decode.modrm.reg&3,((decode.modrm.reg>>2)&1));
 	}
 }
 
@@ -114,10 +114,10 @@ static void dyn_dop_gbeb_mov(void) {
 	if (decode.modrm.mod<3) {
 		dyn_fill_ea(FC_ADDR);
 		dyn_read_byte(FC_ADDR,FC_TMP_BA1);
-		MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.reg&3,(decode.modrm.reg>>2)&1);
+		MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.reg&3,((decode.modrm.reg>>2)&1));
 	} else {
-		MOV_REG_BYTE_TO_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.rm&3,(decode.modrm.rm>>2)&1);
-		MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.reg&3,(decode.modrm.reg>>2)&1);
+		MOV_REG_BYTE_TO_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.rm&3,((decode.modrm.rm>>2)&1));
+		MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.reg&3,((decode.modrm.reg>>2)&1));
 	}
 }
 
@@ -359,7 +359,7 @@ static void dyn_movx_ev_gb(bool sign) {
 		gen_extend_byte(sign,FC_TMP_BA1);
 		MOV_REG_WORD_FROM_HOST_REG(FC_TMP_BA1,decode.modrm.reg,decode.big_op);
 	} else {
-		MOV_REG_BYTE_TO_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.rm&3,(decode.modrm.rm>>2)&1);
+		MOV_REG_BYTE_TO_HOST_REG_LOW(FC_TMP_BA1,decode.modrm.rm&3,((decode.modrm.rm>>2)&1));
 		gen_extend_byte(sign,FC_TMP_BA1);
 		MOV_REG_WORD_FROM_HOST_REG(FC_TMP_BA1,decode.modrm.reg,decode.big_op);
 	}
@@ -629,7 +629,7 @@ static void dyn_grp2_eb(grp2_types type) {
 		gen_protect_addr_reg();
 		dyn_read_byte_canuseword(FC_ADDR,FC_OP1);
 	} else {
-		MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP1,decode.modrm.rm&3,(decode.modrm.rm>>2)&1);
+		MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP1,decode.modrm.rm&3,((decode.modrm.rm>>2)&1));
 	}
 	switch (type) {
 	case grp2_1:
@@ -654,7 +654,7 @@ static void dyn_grp2_eb(grp2_types type) {
 		gen_restore_addr_reg();
 		dyn_write_byte(FC_ADDR,FC_RETOP);
 	} else {
-		MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_RETOP,decode.modrm.rm&3,(decode.modrm.rm>>2)&1);
+		MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_RETOP,decode.modrm.rm&3,((decode.modrm.rm>>2)&1));
 	}
 }
 
@@ -709,7 +709,7 @@ static void dyn_grp3_eb(void) {
 		if ((decode.modrm.reg==2) || (decode.modrm.reg==3)) gen_protect_addr_reg();
 		dyn_read_byte_canuseword(FC_ADDR,FC_OP1);
 	} else {
-		MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP1,decode.modrm.rm&3,(decode.modrm.rm>>2)&1);
+		MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP1,decode.modrm.rm&3,((decode.modrm.rm>>2)&1));
 	}
 	switch (decode.modrm.reg) {
 	case 0x0:	// test eb,ib
@@ -742,7 +742,7 @@ static void dyn_grp3_eb(void) {
 		gen_restore_addr_reg();
 		dyn_write_byte(FC_ADDR,FC_RETOP);
 	} else {
-		MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_RETOP,decode.modrm.rm&3,(decode.modrm.rm>>2)&1);
+		MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_RETOP,decode.modrm.rm&3,((decode.modrm.rm>>2)&1));
 	}
 }
 
@@ -809,9 +809,9 @@ static bool dyn_grp4_eb(void) {
 			gen_restore_addr_reg();
 			dyn_write_byte(FC_ADDR,FC_RETOP);
 		} else {
-			MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP1,decode.modrm.rm&3,(decode.modrm.rm>>2)&1);
+			MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(FC_OP1,decode.modrm.rm&3,((decode.modrm.rm>>2)&1));
 			dyn_sop_byte_gencall(decode.modrm.reg==0 ? SOP_INC : SOP_DEC);
-			MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_RETOP,decode.modrm.rm&3,(decode.modrm.rm>>2)&1);
+			MOV_REG_BYTE_FROM_HOST_REG_LOW(FC_RETOP,decode.modrm.rm&3,((decode.modrm.rm>>2)&1));
 		}
 		break;
 	case 0x7:		//CALBACK Iw

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -1110,7 +1110,7 @@ void CPU_Interrupt(Bitu num,Bitu type,Bit32u oldeip) {
 		Descriptor gate;
 		if (!cpu.idt.GetDescriptor(num<<3,gate)) {
 			// zone66
-			CPU_Exception(EXCEPTION_GP,num*8+2+(type&CPU_INT_SOFTWARE)?0:1);
+			CPU_Exception(EXCEPTION_GP,num*8+2+((type&CPU_INT_SOFTWARE)?0:1));
 			return;
 		}
 
@@ -1135,7 +1135,7 @@ void CPU_Interrupt(Bitu num,Bitu type,Bit32u oldeip) {
 			{
 				CPU_CHECK_COND(!gate.saved.seg.p,
 					"INT:Gate segment not present",
-					EXCEPTION_NP,num*8+2+(type&CPU_INT_SOFTWARE)?0:1)
+					EXCEPTION_NP,num*8+2+((type&CPU_INT_SOFTWARE)?0:1))
 
 				Descriptor cs_desc;
 				Bitu gate_sel=gate.GetSelector();
@@ -1145,12 +1145,12 @@ void CPU_Interrupt(Bitu num,Bitu type,Bit32u oldeip) {
 					EXCEPTION_GP,(type&CPU_INT_SOFTWARE)?0:1)
 				CPU_CHECK_COND(!cpu.gdt.GetDescriptor(gate_sel,cs_desc),
 					"INT:Gate with CS beyond limit",
-					EXCEPTION_GP,(gate_sel & 0xfffc)+(type&CPU_INT_SOFTWARE)?0:1)
+					EXCEPTION_GP,(gate_sel & 0xfffc)+((type&CPU_INT_SOFTWARE)?0:1))
 
 				Bitu cs_dpl=cs_desc.DPL();
 				CPU_CHECK_COND(cs_dpl>cpu.cpl,
 					"Interrupt to higher privilege",
-					EXCEPTION_GP,(gate_sel & 0xfffc)+(type&CPU_INT_SOFTWARE)?0:1)
+					EXCEPTION_GP,(gate_sel & 0xfffc)+((type&CPU_INT_SOFTWARE)?0:1))
 				switch (cs_desc.Type()) {
 				case DESC_CODE_N_NC_A:	case DESC_CODE_N_NC_NA:
 				case DESC_CODE_R_NC_A:	case DESC_CODE_R_NC_NA:
@@ -1158,7 +1158,7 @@ void CPU_Interrupt(Bitu num,Bitu type,Bit32u oldeip) {
 						/* Prepare for gate to inner level */
 						CPU_CHECK_COND(!cs_desc.saved.seg.p,
 							"INT:Inner level:CS segment not present",
-							EXCEPTION_NP,(gate_sel & 0xfffc)+(type&CPU_INT_SOFTWARE)?0:1)
+							EXCEPTION_NP,(gate_sel & 0xfffc)+((type&CPU_INT_SOFTWARE)?0:1))
 						CPU_CHECK_COND((reg_flags & FLAG_VM) && (cs_dpl!=0),
 							"V86 interrupt calling codesegment with DPL>0",
 							EXCEPTION_GP,gate_sel & 0xfffc)
@@ -1176,10 +1176,10 @@ void CPU_Interrupt(Bitu num,Bitu type,Bit32u oldeip) {
 						Descriptor n_ss_desc;
 						CPU_CHECK_COND(!cpu.gdt.GetDescriptor(n_ss,n_ss_desc),
 							"INT:Gate with SS beyond limit",
-							EXCEPTION_TS,(n_ss & 0xfffc)+(type&CPU_INT_SOFTWARE)?0:1)
+							EXCEPTION_TS,(n_ss & 0xfffc)+((type&CPU_INT_SOFTWARE)?0:1))
 						CPU_CHECK_COND(((n_ss & 3)!=cs_dpl) || (n_ss_desc.DPL()!=cs_dpl),
 							"INT:Inner level with CS_DPL!=SS_DPL and SS_RPL",
-							EXCEPTION_TS,(n_ss & 0xfffc)+(type&CPU_INT_SOFTWARE)?0:1)
+							EXCEPTION_TS,(n_ss & 0xfffc)+((type&CPU_INT_SOFTWARE)?0:1))
 
 						// check if stack segment is a writable data segment
 						switch (n_ss_desc.Type()) {
@@ -1191,7 +1191,7 @@ void CPU_Interrupt(Bitu num,Bitu type,Bit32u oldeip) {
 						}
 						CPU_CHECK_COND(!n_ss_desc.saved.seg.p,
 							"INT:Inner level with nonpresent SS",
-							EXCEPTION_SS,(n_ss & 0xfffc)+(type&CPU_INT_SOFTWARE)?0:1)
+							EXCEPTION_SS,(n_ss & 0xfffc)+((type&CPU_INT_SOFTWARE)?0:1))
 
 						// commit point
 						Segs.expanddown[ss]=n_ss_desc.GetExpandDown();
@@ -1235,7 +1235,7 @@ void CPU_Interrupt(Bitu num,Bitu type,Bit32u oldeip) {
 					/* Prepare stack for gate to same priviledge */
 					CPU_CHECK_COND(!cs_desc.saved.seg.p,
 							"INT:Same level:CS segment not present",
-						EXCEPTION_NP,(gate_sel & 0xfffc)+(type&CPU_INT_SOFTWARE)?0:1)
+						EXCEPTION_NP,(gate_sel & 0xfffc)+((type&CPU_INT_SOFTWARE)?0:1))
 					if ((reg_flags & FLAG_VM) && (cs_dpl<cpu.cpl))
 						E_Exit("V86 interrupt doesn't change to pl0");	// or #GP(cs_sel)
 
@@ -1276,7 +1276,7 @@ do_interrupt:
 		case DESC_TASK_GATE:
 			CPU_CHECK_COND(!gate.saved.seg.p,
 				"INT:Gate segment not present",
-				EXCEPTION_NP,num*8+2+(type&CPU_INT_SOFTWARE)?0:1)
+				EXCEPTION_NP,num*8+2+((type&CPU_INT_SOFTWARE)?0:1))
 
 			CPU_SwitchTask(gate.GetSelector(),TSwitch_CALL_INT,oldeip);
 			if (type & CPU_INT_HAS_ERROR) {

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -2089,8 +2089,8 @@ bool ParseCommand(char* str) {
             DEBUG_ShowMsg("color-plane-en=%02xh color-select=%02xh index=%02xh",
                 vga.attr.color_plane_enable,    vga.attr.color_select,  vga.attr.index);
             DEBUG_ShowMsg("disabled-by-index=%u disabled-by-idx1-bit5=%u index-written=%u",
-                vga.attr.disabled & 1 ? 1 : 0,
-                vga.attr.disabled & 2 ? 1 : 0,
+                (vga.attr.disabled & 1) ? 1 : 0,
+                (vga.attr.disabled & 2) ? 1 : 0,
                 vga.internal.attrindex);
 
             cpptmp = " ";

--- a/src/gui/render_templates_hq.h
+++ b/src/gui/render_templates_hq.h
@@ -82,6 +82,9 @@ static inline void conc2d(InitLUTs,SBPP)(void)
 		int Y = (r + g + b) >> 2;
 		int u = 128 + ((r - b) >> 2);
 		int v = 128 + ((-r + 2 * g - b) >> 3);
-		_RGBtoYUV[color] = (Bit32u)((Y << 16) | (u << 8) | v);
+        if (_RGBtoYUV != NULL)
+            _RGBtoYUV[color] = (Bit32u)((Y << 16) | (u << 8) | v);
+        else
+            E_Exit("Memory allocation failed in conc2d");
 	}
 }

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2562,10 +2562,10 @@ public:
         sprintf(buf,"%s \"key %d%s%s%s%s\"",
             entry,
             (int)key,
-            defmod & 1 ? " mod1" : "",
-            defmod & 2 ? " mod2" : "",
-            defmod & 4 ? " mod3" : "",
-            defmod & 8 ? " host" : ""
+            (defmod & 1) ? " mod1" : "",
+            (defmod & 2) ? " mod2" : "",
+            (defmod & 4) ? " mod3" : "",
+            (defmod & 8) ? " host" : ""
         );
     }
 #else

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -173,8 +173,8 @@ static void DMA_Write_Port(Bitu port,Bitu val,Bitu /*iolen*/) {
         else if (port == 0x29) { /* auto bank increment */
             pc98_port_29h = (Bit8u)val;
             DmaControllers[0]->GetChannel(val & 3)->page_bank_increment_wraparound =
-                (val & 0x08 ? 0xF0 : 0x00) +
-                (val & 0x04 ? 0x0F : 0x00);
+                ((val & 0x08) ? 0xF0 : 0x00) +
+                ((val & 0x04) ? 0x0F : 0x00);
 #if 0
             LOG_MSG("DMA channel %u page auto increment mask %x",
                 (unsigned int)(val&3u),

--- a/src/hardware/floppy.cpp
+++ b/src/hardware/floppy.cpp
@@ -717,8 +717,8 @@ void FloppyController::on_fdc_in_command() {
 			 * current physical cylinder position must be within range of the image. request must have MFM bit set. */
 			dma = GetDMAChannel(DMA);
 			if (dev != NULL && dma != NULL && dev->motor && dev->select && image != NULL && (in_cmd[0]&0x40)/*MFM=1*/ &&
-				current_cylinder[devidx] < image->cylinders && (in_cmd[1]&4U?1U:0U) <= image->heads &&
-				(in_cmd[1]&4U?1U:0U) == in_cmd[3] && in_cmd[2] == current_cylinder[devidx] &&
+				current_cylinder[devidx] < image->cylinders && ((in_cmd[1]&4U)?1U:0U) <= image->heads &&
+				((in_cmd[1]&4U)?1U:0U) == in_cmd[3] && in_cmd[2] == current_cylinder[devidx] &&
 				in_cmd[5] <= FLOPPY_MAX_SECTOR_SIZE_SZCODE && in_cmd[4] > 0U && in_cmd[4] <= image->sectors) {
 				unsigned char sector[FLOPPY_MAX_SECTOR_SIZE];
 				bool fail = false;
@@ -836,8 +836,8 @@ void FloppyController::on_fdc_in_command() {
              * sector numbers. */
 			dma = GetDMAChannel(DMA);
 			if (dev != NULL && dma != NULL && dev->motor && dev->select && image != NULL && (in_cmd[0]&0x40)/*MFM=1*/ &&
-				current_cylinder[devidx] < image->cylinders && (in_cmd[1]&4U?1U:0U) <= image->heads &&
-				(in_cmd[1]&4U?1U:0U) == in_cmd[3] && in_cmd[2] == current_cylinder[devidx] &&
+				current_cylinder[devidx] < image->cylinders && ((in_cmd[1]&4U)?1U:0U) <= image->heads &&
+				((in_cmd[1]&4U)?1U:0U) == in_cmd[3] && in_cmd[2] == current_cylinder[devidx] &&
 				in_cmd[5] <= FLOPPY_MAX_SECTOR_SIZE_SZCODE && in_cmd[4] > 0U) {
 				unsigned char sector[FLOPPY_MAX_SECTOR_SIZE];
 				bool fail = false;
@@ -1013,7 +1013,7 @@ void FloppyController::on_fdc_in_command() {
 			 * current physical cylinder position must be within range of the image. request must have MFM bit set. */
             ST[0] &= ~0x20;
 			if (dev != NULL && dev->motor && dev->select && image != NULL && (in_cmd[0]&0x40)/*MFM=1*/ &&
-				current_cylinder[devidx] < image->cylinders && (in_cmd[1]&4U?1U:0U) <= image->heads) {
+				current_cylinder[devidx] < image->cylinders && ((in_cmd[1]&4U)?1U:0U) <= image->heads) {
 				int ns = (int)floor(dev->floppy_image_motor_position() * image->sectors);
 				/* TODO: minor delay to emulate time for one sector to pass under the head */
 				reset_res();
@@ -1021,7 +1021,7 @@ void FloppyController::on_fdc_in_command() {
 				out_res[1] = ST[1];
 				out_res[2] = ST[2];
 				out_res[3] = current_cylinder[devidx];
-				out_res[4] = (in_cmd[1]&4?1:0);
+				out_res[4] = ((in_cmd[1]&4)?1:0);
 				out_res[5] = ns + 1;		/* the sector passing under the head at this time */
                 {
                     unsigned int sz = (unsigned int)image->sector_size;

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -1820,7 +1820,7 @@ void GUS_DMA_Event_Transfer(DmaChannel *chan,Bitu dmawords) {
 	}
 
 	LOG(LOG_MISC,LOG_DEBUG)("GUS DMA transfer %lu bytes, GUS RAM address 0x%lx %u-bit DMA %u-bit PCM (ctrl=0x%02x) tcount=%u",
-		(unsigned long)step,(unsigned long)dmaaddr,myGUS.DMAControl & 0x4 ? 16 : 8,myGUS.DMAControl & 0x40 ? 16 : 8,myGUS.DMAControl,chan->tcount);
+		(unsigned long)step,(unsigned long)dmaaddr,(myGUS.DMAControl & 0x4) ? 16 : 8,(myGUS.DMAControl & 0x40) ? 16 : 8,myGUS.DMAControl,chan->tcount);
 
 	if (step > 0) {
 		dmaaddr += (unsigned int)step;

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -894,8 +894,8 @@ void IDEATAPICDROMDevice::on_atapi_busy_time() {
                 if (!common_spinup_response(/*spin up*/true,/*wait*/false)) {
                     count = 0x03;
                     state = IDE_DEV_READY;
-                    feature = ((sense[2]&0xF) << 4) | (sense[2]&0xF ? 0x04/*abort*/ : 0x00);
-                    status = IDE_STATUS_DRIVE_READY|(sense[2]&0xF ? IDE_STATUS_ERROR:IDE_STATUS_DRIVE_SEEK_COMPLETE);
+                    feature = ((sense[2]&0xF) << 4) | ((sense[2]&0xF) ? 0x04/*abort*/ : 0x00);
+                    status = IDE_STATUS_DRIVE_READY|((sense[2]&0xF) ? IDE_STATUS_ERROR:IDE_STATUS_DRIVE_SEEK_COMPLETE);
                     controller->raise_irq();
                     allow_writing = true;
                     return;
@@ -1501,8 +1501,8 @@ void IDEATAPICDROMDevice::atapi_cmd_completion() {
 
             count = 0x03;
             state = IDE_DEV_READY;
-            feature = ((sense[2]&0xF) << 4) | (sense[2]&0xF ? 0x04/*abort*/ : 0x00);
-            status = IDE_STATUS_DRIVE_READY|(sense[2]&0xF ? IDE_STATUS_ERROR:IDE_STATUS_DRIVE_SEEK_COMPLETE);
+            feature = ((sense[2]&0xF) << 4) | ((sense[2]&0xF) ? 0x04/*abort*/ : 0x00);
+            status = IDE_STATUS_DRIVE_READY|((sense[2]&0xF) ? IDE_STATUS_ERROR:IDE_STATUS_DRIVE_SEEK_COMPLETE);
             controller->raise_irq();
             allow_writing = true;
             break;
@@ -1535,8 +1535,8 @@ void IDEATAPICDROMDevice::atapi_cmd_completion() {
             else {
                 count = 0x03;
                 state = IDE_DEV_READY;
-                feature = ((sense[2]&0xF) << 4) | (sense[2]&0xF ? 0x04/*abort*/ : 0x00);
-                status = IDE_STATUS_DRIVE_READY|(sense[2]&0xF ? IDE_STATUS_ERROR:IDE_STATUS_DRIVE_SEEK_COMPLETE);
+                feature = ((sense[2]&0xF) << 4) | ((sense[2]&0xF) ? 0x04/*abort*/ : 0x00);
+                status = IDE_STATUS_DRIVE_READY|((sense[2]&0xF) ? IDE_STATUS_ERROR:IDE_STATUS_DRIVE_SEEK_COMPLETE);
                 controller->raise_irq();
                 allow_writing = true;
             }
@@ -1582,8 +1582,8 @@ void IDEATAPICDROMDevice::atapi_cmd_completion() {
             else {
                 count = 0x03;
                 state = IDE_DEV_READY;
-                feature = ((sense[2]&0xF) << 4) | (sense[2]&0xF ? 0x04/*abort*/ : 0x00);
-                status = IDE_STATUS_DRIVE_READY|(sense[2]&0xF ? IDE_STATUS_ERROR:IDE_STATUS_DRIVE_SEEK_COMPLETE);
+                feature = ((sense[2]&0xF) << 4) | ((sense[2]&0xF) ? 0x04/*abort*/ : 0x00);
+                status = IDE_STATUS_DRIVE_READY|((sense[2]&0xF) ? IDE_STATUS_ERROR:IDE_STATUS_DRIVE_SEEK_COMPLETE);
                 controller->raise_irq();
                 allow_writing = true;
             }
@@ -1621,8 +1621,8 @@ void IDEATAPICDROMDevice::atapi_cmd_completion() {
             else {
                 count = 0x03;
                 state = IDE_DEV_READY;
-                feature = ((sense[2]&0xF) << 4) | (sense[2]&0xF ? 0x04/*abort*/ : 0x00);
-                status = IDE_STATUS_DRIVE_READY|(sense[2]&0xF ? IDE_STATUS_ERROR:IDE_STATUS_DRIVE_SEEK_COMPLETE);
+                feature = ((sense[2]&0xF) << 4) | ((sense[2]&0xF) ? 0x04/*abort*/ : 0x00);
+                status = IDE_STATUS_DRIVE_READY|((sense[2]&0xF) ? IDE_STATUS_ERROR:IDE_STATUS_DRIVE_SEEK_COMPLETE);
                 controller->raise_irq();
                 allow_writing = true;
             }
@@ -1639,8 +1639,8 @@ void IDEATAPICDROMDevice::atapi_cmd_completion() {
             else {
                 count = 0x03;
                 state = IDE_DEV_READY;
-                feature = ((sense[2]&0xF) << 4) | (sense[2]&0xF ? 0x04/*abort*/ : 0x00);
-                status = IDE_STATUS_DRIVE_READY|(sense[2]&0xF ? IDE_STATUS_ERROR:IDE_STATUS_DRIVE_SEEK_COMPLETE);
+                feature = ((sense[2]&0xF) << 4) | ((sense[2]&0xF) ? 0x04/*abort*/ : 0x00);
+                status = IDE_STATUS_DRIVE_READY|((sense[2]&0xF) ? IDE_STATUS_ERROR:IDE_STATUS_DRIVE_SEEK_COMPLETE);
                 controller->raise_irq();
                 allow_writing = true;
             }
@@ -1657,8 +1657,8 @@ void IDEATAPICDROMDevice::atapi_cmd_completion() {
             else {
                 count = 0x03;
                 state = IDE_DEV_READY;
-                feature = ((sense[2]&0xF) << 4) | (sense[2]&0xF ? 0x04/*abort*/ : 0x00);
-                status = IDE_STATUS_DRIVE_READY|(sense[2]&0xF ? IDE_STATUS_ERROR:IDE_STATUS_DRIVE_SEEK_COMPLETE);
+                feature = ((sense[2]&0xF) << 4) | ((sense[2]&0xF) ? 0x04/*abort*/ : 0x00);
+                status = IDE_STATUS_DRIVE_READY|((sense[2]&0xF) ? IDE_STATUS_ERROR:IDE_STATUS_DRIVE_SEEK_COMPLETE);
                 controller->raise_irq();
                 allow_writing = true;
             }
@@ -1677,8 +1677,8 @@ void IDEATAPICDROMDevice::atapi_cmd_completion() {
             else {
                 count = 0x03;
                 state = IDE_DEV_READY;
-                feature = ((sense[2]&0xF) << 4) | (sense[2]&0xF ? 0x04/*abort*/ : 0x00);
-                status = IDE_STATUS_DRIVE_READY|(sense[2]&0xF ? IDE_STATUS_ERROR:IDE_STATUS_DRIVE_SEEK_COMPLETE);
+                feature = ((sense[2]&0xF) << 4) | ((sense[2]&0xF) ? 0x04/*abort*/ : 0x00);
+                status = IDE_STATUS_DRIVE_READY|((sense[2]&0xF) ? IDE_STATUS_ERROR:IDE_STATUS_DRIVE_SEEK_COMPLETE);
                 controller->raise_irq();
                 allow_writing = true;
             }

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -208,8 +208,8 @@ void KEYBOARD_AUX_Event(float x,float y,Bitu buttons,int scrollwheel) {
             KEYBOARD_AddBuffer(AUX|
                 ((y2 == -256 || y2 == 255) ? 0x80 : 0x00) |   /* Y overflow */
                 ((x2 == -256 || x2 == 255) ? 0x40 : 0x00) |   /* X overflow */
-                (y2 & 0x100 ? 0x20 : 0x00) |         /* Y sign bit */
-                (x2 & 0x100 ? 0x10 : 0x00) |         /* X sign bit */
+                ((y2 & 0x100) ? 0x20 : 0x00) |         /* Y sign bit */
+                ((x2 & 0x100) ? 0x10 : 0x00) |         /* X sign bit */
                 0x08 |                      /* always 1? */
                 (keyb.ps2mouse.m ? 4 : 0) |         /* M */
                 (keyb.ps2mouse.r ? 2 : 0) |         /* R */

--- a/src/hardware/mame/fmopl.cpp
+++ b/src/hardware/mame/fmopl.cpp
@@ -1731,7 +1731,7 @@ void FM_OPL::WriteReg(int r, int v)
 		/* FB,C */
 		if( (r&0x0f) > 8) return;
 		CH = &P_CH[r&0x0f];
-		CH->SLOT[SLOT1].FB  = (v>>1)&7 ? ((v>>1)&7) + 7 : 0;
+		CH->SLOT[SLOT1].FB  = ((v>>1)&7) ? ((v>>1)&7) + 7 : 0;
 		CH->SLOT[SLOT1].CON = v&1;
 		CH->SLOT[SLOT1].connect1 = CH->SLOT[SLOT1].CON ? &output[0] : &phase_modulation;
 		break;

--- a/src/hardware/mame/ymf262.cpp
+++ b/src/hardware/mame/ymf262.cpp
@@ -2089,7 +2089,7 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 
 		chip->pan_ctrl_value[ (r&0xf) + ch_offset ] = v;    /* store control value for OPL3/OPL2 mode switching on the fly */
 
-		CH->SLOT[SLOT1].FB  = (v>>1)&7 ? ((v>>1)&7) + 7 : 0;
+		CH->SLOT[SLOT1].FB  = ((v>>1)&7) ? ((v>>1)&7) + 7 : 0;
 		CH->SLOT[SLOT1].CON = v&1;
 
 		if( chip->OPL3_mode & 1 )

--- a/src/hardware/pc98_fm.cpp
+++ b/src/hardware/pc98_fm.cpp
@@ -122,15 +122,15 @@ static std::map<UINT,CBUS4PORT> cbuscore_map;
 
 void pc98_fm86_write(Bitu port,Bitu val,Bitu iolen) {
     (void)iolen;//UNUSED
-    auto &cbusm = cbuscore_map[port];
-    auto &func = cbusm.out;
+    const auto &cbusm = cbuscore_map[port];
+    const auto &func = cbusm.out;
     if (func) func(port,val);
 }
 
 Bitu pc98_fm86_read(Bitu port,Bitu iolen) {
     (void)iolen;//UNUSED
-    auto &cbusm = cbuscore_map[port];
-    auto &func = cbusm.inp;
+    const auto &cbusm = cbuscore_map[port];
+    const auto &func = cbusm.inp;
     if (func) return func(port);
     return ~0ul;
 }

--- a/src/hardware/reSID/sid.cpp
+++ b/src/hardware/reSID/sid.cpp
@@ -679,7 +679,7 @@ void SID2::clock(cycle_count delta_t)
 
       // Clock on MSB off if MSB is on, clock on MSB on if MSB is off.
       reg24 delta_accumulator =
-	(accumulator & 0x800000 ? 0x1000000 : 0x800000) - accumulator;
+	((accumulator & 0x800000) ? 0x1000000 : 0x800000) - accumulator;
 
       cycle_count delta_t_next = (cycle_count)((unsigned int)delta_accumulator / (unsigned int)freq);
       if (delta_accumulator%freq) {

--- a/src/hardware/serialport/directserial.cpp
+++ b/src/hardware/serialport/directserial.cpp
@@ -314,10 +314,10 @@ void CDirectSerial::updatePortConfig (Bit16u divider, Bit8u lcr) {
 void CDirectSerial::updateMSR () {
 	int new_status = SERIAL_getmodemstatus(comport);
 
-	setCTS(new_status&SERIAL_CTS? true:false);
-	setDSR(new_status&SERIAL_DSR? true:false);
-	setRI(new_status&SERIAL_RI? true:false);
-	setCD(new_status&SERIAL_CD? true:false);
+	setCTS((new_status&SERIAL_CTS)? true:false);
+	setDSR((new_status&SERIAL_DSR)? true:false);
+	setRI((new_status&SERIAL_RI)? true:false);
+	setCD((new_status&SERIAL_CD)? true:false);
 }
 
 void CDirectSerial::transmitByte (Bit8u val, bool first) {

--- a/src/hardware/serialport/directserial.cpp
+++ b/src/hardware/serialport/directserial.cpp
@@ -38,6 +38,7 @@ CDirectSerial::CDirectSerial (Bitu id, CommandLine* cmd)
 
 	rx_retry = 0;
     rx_retry_max = 0;
+    rx_state = 0;
 
 	std::string tmpstring;
 	if(!cmd->FindStringBegin("realport:",tmpstring,false)) return;

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -734,11 +734,11 @@ Bitu CSerial::Read_MCR () {
 void CSerial::Write_MCR (Bit8u data) {
 	// WARNING: At the time setRTSDTR is called rts and dsr members are still wrong.
 	if (data&FIFO_FLOWCONTROL) LOG_MSG("Warning: tried to activate hardware handshake.");
-	bool new_dtr = data & MCR_DTR_MASK? true:false;
-	bool new_rts = data & MCR_RTS_MASK? true:false;
-	bool new_op1 = data & MCR_OP1_MASK? true:false;
-	bool new_op2 = data & MCR_OP2_MASK? true:false;
-	bool new_loopback = data & MCR_LOOPBACK_Enable_MASK? true:false;
+	bool new_dtr = (data & MCR_DTR_MASK)? true:false;
+	bool new_rts = (data & MCR_RTS_MASK)? true:false;
+	bool new_op1 = (data & MCR_OP1_MASK)? true:false;
+	bool new_op2 = (data & MCR_OP2_MASK)? true:false;
+	bool new_loopback = (data & MCR_LOOPBACK_Enable_MASK)? true:false;
 	if (loopback != new_loopback) {
 		if (new_loopback) setRTSDTR(false,false);
 		else setRTSDTR(new_rts,new_dtr);

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -1511,7 +1511,6 @@ bool debugpollvga_rtp_menu_callback(DOSBoxMenu * const xmenu, DOSBoxMenu::item *
 }
 
 void VGA_Init() {
-    string str;
     Bitu i,j;
 
     vga.other.mcga_mode_control = 0;

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -1221,8 +1221,10 @@ public:
         else {
             if (len > 65535) E_Exit("ISAPNP_SysDevNode data too long");
             raw = new unsigned char[(size_t)len+1u];
-            if (ir == NULL) E_Exit("ISAPNP_SysDevNode cannot allocate buffer");
-            memcpy(raw,ir,(size_t)len);
+            if (ir == NULL)
+                E_Exit("ISAPNP_SysDevNode cannot allocate buffer");
+            else
+                memcpy(raw, ir, (size_t)len);
             raw_len = len;
             raw[len] = 0;
             own = true;

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -875,11 +875,11 @@ static Bitu INT13_DiskHandler(void) {
         break;
     case 0x3: /* Write sectors */
         
-        if(driveInactive(drivenum)) {
+        if(driveInactive(drivenum) || !imageDiskList[drivenum]) {
             reg_ah = 0xff;
             CALLBACK_SCF(true);
             return CBRET_NONE;
-        }                     
+        }
 
         /* INT 13h is limited to 512 bytes/sector (as far as I know).
          * The sector buffer in this function is limited to 512 bytes/sector,

--- a/src/ints/int10_memory.cpp
+++ b/src/ints/int10_memory.cpp
@@ -128,7 +128,7 @@ void INT10_LoadFont(PhysPt font,bool reload,Bit16u count,Bitu offset,Bitu map,Bi
             Bit8u cur_col=CURSOR_POS_COL(page);
 
             if (cur_row >= rows)
-                INT10_SetCursorPos(rows-1,cur_col,page);
+                INT10_SetCursorPos((Bit8u)(rows-1),cur_col,page);
         }
 	}
 }

--- a/src/ints/int10_pal.cpp
+++ b/src/ints/int10_pal.cpp
@@ -396,13 +396,13 @@ void INT10_SetColorSelect(Bit8u val) {
 		switch(vga.mode) {
 		case M_TANDY2:
 			IO_Write(VGAREG_TDY_ADDRESS, 0x11);
-			IO_Write(VGAREG_PCJR_DATA, val&1? 0xf:0);
+			IO_Write(VGAREG_PCJR_DATA, (val&1)? 0xf:0);
 			break;
 		case M_TANDY4:
 			for(Bit8u i = 0x11; i < 0x14; i++) {
 				const Bit8u t4_table[] = {0,2,4,6, 0,3,5,0xf};
 				IO_Write(VGAREG_TDY_ADDRESS, i);
-				IO_Write(VGAREG_PCJR_DATA, t4_table[(i-0x10)+(val&1? 4:0)]);
+				IO_Write(VGAREG_PCJR_DATA, t4_table[(i-0x10)+((val&1)? 4:0)]);
 			}
 			break;
 		default:

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1096,7 +1096,7 @@ bool CommandLine::FindCommand(unsigned int which,std::string & value) {
     if (which<1) return false;
     if (which>cmds.size()) return false;
     cmd_it it=cmds.begin();
-    for (;which>1;--which) it++;
+    for (;which>1;--which) ++it;
     value=(*it);
     return true;
 }

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -220,7 +220,10 @@ Bitu DOS_Shell::GetRedirection(char *s, char **ifn, char **ofn,bool * append) {
 //			else 
 //				*lr=0;
 			t = (char*)malloc((size_t)(lr-*ofn+1)); // FIXME: *ofn is signed char, so if extended ASCII, could cause an error here!
-			safe_strncpy(t,*ofn,lr-*ofn+1); // FIXME: *ofn is signed char, so if extended ASCII, could cause an error here!
+            if (t != NULL)
+                safe_strncpy(t, *ofn, lr - *ofn + 1); // FIXME: *ofn is signed char, so if extended ASCII, could cause an error here!
+            else
+                E_Exit("Memory allocation failed in GetRedirection");
 			*ofn=t;
 			continue;
 		case '<':
@@ -234,7 +237,10 @@ Bitu DOS_Shell::GetRedirection(char *s, char **ifn, char **ofn,bool * append) {
 //			else 
 //				*lr=0;
 			t = (char*)malloc((size_t)(lr-*ifn+1)); // FIXME: *ofn is signed char, so if extended ASCII, could cause an error here!
-			safe_strncpy(t,*ifn,lr-*ifn+1); // FIXME: *ofn is signed char, so if extended ASCII, could cause an error here!
+            if (t != NULL)
+                safe_strncpy(t, *ifn, lr - *ifn + 1); // FIXME: *ofn is signed char, so if extended ASCII, could cause an error here!
+            else
+                E_Exit("Memory allocation failed in GetRedirection");
 			*ifn=t;
 			continue;
 		case '|':

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -135,7 +135,11 @@ bool DOS_Shell::CheckConfig(char* cmd_in,char*line) {
 	}
 	char newcom[1024]; newcom[0] = 0; strcpy(newcom,"z:\\config -set ");
 	strcat(newcom,test->GetName());	strcat(newcom," ");
-	strcat(newcom,cmd_in);strcat(newcom,line);
+	strcat(newcom,cmd_in);
+    if (line != NULL)
+        strcat(newcom, line);
+    else
+        E_Exit("'line' in CheckConfig is NULL");
 	DoCommand(newcom);
 	return true;
 }
@@ -1687,7 +1691,7 @@ void DOS_Shell::CMD_ATTRIB(char *args){
 
 void DOS_Shell::CMD_PROMPT(char *args){
 	HELP("PROMPT");
-	if(args && *args && strlen(args)) {
+	if(args && *args) {
 		args++;
 		SetEnv("PROMPT",args);
 	} else
@@ -1697,12 +1701,13 @@ void DOS_Shell::CMD_PROMPT(char *args){
 
 void DOS_Shell::CMD_PATH(char *args){
 	HELP("PATH");
-	if(args && *args && strlen(args)){
+	if(args && *args){
 		char pathstring[DOS_PATHLENGTH+CROSS_LEN+20]={ 0 };
 		strcpy(pathstring,"set PATH=");
-		while(args && *args && (*args=='='|| *args==' ')) 
+		while(args && (*args=='='|| *args==' ')) 
 		     args++;
-		strcat(pathstring,args);
+        if (args)
+            strcat(pathstring,args);
 		this->ParseLine(pathstring);
 		return;
 	} else {
@@ -1738,7 +1743,7 @@ void DOS_Shell::CMD_VER(char *args) {
 void DOS_Shell::CMD_VOL(char *args){
 	HELP("VOL");
 	Bit8u drive=DOS_GetDefaultDrive();
-	if(args && *args && strlen(args)){
+	if(args && *args){
 		args++;
 		Bit32u argLen = (Bit32u)strlen(args);
 		switch (args[argLen-1]) {

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -485,7 +485,7 @@ void DOS_Shell::InputCommand(char * line) {
 
                         // build the completion list
                         char mask[DOS_PATHLENGTH] = {0};
-                        if (strlen(p_completion_start) + 3 >= DOS_PATHLENGTH) {
+                        if (p_completion_start && strlen(p_completion_start) + 3 >= DOS_PATHLENGTH) {
                             //Beep;
                             break;
                         }


### PR DESCRIPTION
Fixes for warnings.

1. Fixed VS2019 editor warnings about potential NULL references, mostly for after `malloc`.  and uninitialized variables.

2. Removed unnecessary `strlen` calls like
`if(args && *args && strlen(args))`
where `args` is a char pointer and `*args` evaluating to true means that it has length > 0.

3. Fixed the single build warning currently appearing in the VS2019 build, for type conversion.

4. Removed an uninitialized and unused string variable.

5. Fixed CppCheck "clarifyCalculation" warnings for a&b?c:d, that it should be written as either (a&b)?c:d or a&(b?c:d). As far as I saw in all cases (a&b)?c:d was the appropriate format for the code, which in confirming with an online c++ compiler is the default behavior if no parentheses are used, so behavior should be unchanged.

6. Fixed postfixOperator warning. CppCheck says it can be slightly faster to use postfix operators with non-primitives because otherwise a copy of the previous value will usually be kept around and some extra code will be created.

7. Fix constVariable warnings.