### PR TITLE
Build script - ensure that Autotools is installed, error out with help message otherwise

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -3,6 +3,14 @@
 echo "Generating build information using aclocal, autoheader, automake and autoconf"
 echo "This may take a while ..."
 
+# If an error occurs, quit the script and inform the user. This ensures scripts
+# like ./build-macosx etc. don't continue on if Autotools isn't installed.
+function finish {
+  echo 'autogen.sh failed to complete: verify that GNU Autotools is installed on the system and try again'
+}
+trap finish EXIT
+set -e
+
 # Regenerate configuration files.
 
 aclocal

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,15 +1,19 @@
 #!/bin/sh
 
-echo "Generating build information using aclocal, autoheader, automake and autoconf"
-echo "This may take a while ..."
-
 # If an error occurs, quit the script and inform the user. This ensures scripts
 # like ./build-macosx etc. don't continue on if Autotools isn't installed.
 function finish {
-  echo 'autogen.sh failed to complete: verify that GNU Autotools is installed on the system and try again'
+  if [ $success -eq 0 ]; then
+    echo 'autogen.sh failed to complete: verify that GNU Autotools is installed on the system and try again'
+  fi
 }
+
+success=0
 trap finish EXIT
 set -e
+
+echo "Generating build information using aclocal, autoheader, automake and autoconf"
+echo "This may take a while ..."
 
 # Regenerate configuration files.
 
@@ -20,3 +24,7 @@ autoconf
 
 echo "Now you are ready to run ./configure."
 echo "You can also run  ./configure --help for extra features to enable/disable."
+
+# Don't quit on errors again from here on out (for calling scripts).
+set +e
+success=1


### PR DESCRIPTION
# Description

This adds a help message to `autogen.sh` informing the user to install Autotools if it fails to run properly.

I noticed that the `build-macosx` script continued even though `autogen.sh` failed. This prevents that from happening.

**Does this PR address some issue(s) ?**

It's only a small quality of life fix for the build script.