### PR TITLE
Fix hanging on Windows RT, block dynarec on RT 8.x

### DIFF
--- a/include/regs.h
+++ b/include/regs.h
@@ -62,7 +62,7 @@ struct Segment {
 enum SegNames { es=0,cs,ss,ds,fs,gs};
 
 struct Segments {
-	Bit16u val[8];
+	Bitu val[8];
 	PhysPt phys[8];
 	PhysPt limit[8];
 	bool expanddown[8];

--- a/vs2015/config.h
+++ b/vs2015/config.h
@@ -137,7 +137,6 @@
 /* #undef C_SDL2 */
 
 /* Define to 1 to use opengl display output support */
-/* TODO: Windows SDK ARM32 and ARM64 doesn't provide opengl32.lib, find alternatives */
 #if !defined(_M_ARM64) && !defined (_M_ARM)
 # define C_OPENGL 1
 #endif


### PR DESCRIPTION
# Description

**Does this PR address some issue(s) ?**
Fixes #1418 

**Does this PR introduce new feature(s) ?**
Fixes hanging on startup on Windows ARM32, introduced from https://github.com/joncampbell123/dosbox-x/commit/2ff361fed30368b085a0797dd9aaa7e666d1a760.
Blocks access to dynarec on WinRT 8.x, until it is working properly.

**Are there any breaking changes ?**
No.

**Additional information**
Dynarec on Windows ARM32 works, but only on Windows 10.
Windows RT 8.x only runs ARMv7 Thumb-2 code, which we don't have a backend for.
Attempting to use dynarec on RT will result in an instant crash.

Related #1019 
