### PR TITLE
INT 2F installation checks cleanup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.83.1
+  - Corrected return value when using option to
+    fake the installation of SHARE. (Allofich)
   - Added code to EMS emulation to print specific
     debug information when a PC-98 specific call is
     made to remap segment B000h to either system


### PR DESCRIPTION
Cleanup, and one correction, for INT 2F calls.

1. Catch AX=0x4860, which was logged as an unhandled call here:
https://github.com/joncampbell123/dosbox-x/issues/1434

Information:
http://www.oldlinux.org/Linux.old/docs/interrupts/int-html/rb-4800.htm
I confirmed that MS-DOS 6.22 doesn't modify any registers in response to this call.

2. Remove the FIXME comment for when ANSI.SYS is not resident in MS-DOS.  (Are you OK with it? I checked and double-checked that in MS-DOS 6.22, no registers are modified in this case)

3. Change some returns of false to return true. If the INT 2F handler function returns false, this causes DOSBox-X to log an error that the call is unhandled, which I don't think we want if we are handling it appropriately by just returning without doing anything.

4. SHARE.EXE installation check incorrectly set AX to 0xFFFF when returning that SHARE is installed.
http://www.oldlinux.org/Linux.old/docs/interrupts/int-html/rb-4284.htm
just says that AL is set to 0xFF, and I confirmed this to be the case on MS-DOS 6.22.
This check was also returning false if SHARE is not being faked as installed, which would log an error, so I fixed that, too.

5. Formatting cleanup.