### PR TITLE
Cleanup

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -3727,32 +3727,32 @@ void CPU_SaveState(Section *sec) {
             zip_nv_write_hex(*ent,"eip",        reg_eip);
             zip_nv_write_hex(*ent,"eflags",     (unsigned long)reg_flags);
 
-            zip_nv_write_hex(*ent,"es.val",         Segs.val[es]);
+            zip_nv_write_hex(*ent,"es.val",         (unsigned long)Segs.val[es]);
             zip_nv_write_hex(*ent,"es.phys",        Segs.phys[es]);
             zip_nv_write_hex(*ent,"es.limit",       Segs.limit[es]);
             zip_nv_write(*ent,"es.expanddown",      Segs.expanddown[es]);
 
-            zip_nv_write_hex(*ent,"cs.val",         Segs.val[cs]);
+            zip_nv_write_hex(*ent,"cs.val",         (unsigned long)Segs.val[cs]);
             zip_nv_write_hex(*ent,"cs.phys",        Segs.phys[cs]);
             zip_nv_write_hex(*ent,"cs.limit",       Segs.limit[cs]);
             zip_nv_write(*ent,"cs.expanddown",      Segs.expanddown[cs]);
 
-            zip_nv_write_hex(*ent,"ss.val",         Segs.val[ss]);
+            zip_nv_write_hex(*ent,"ss.val",         (unsigned long)Segs.val[ss]);
             zip_nv_write_hex(*ent,"ss.phys",        Segs.phys[ss]);
             zip_nv_write_hex(*ent,"ss.limit",       Segs.limit[ss]);
             zip_nv_write(*ent,"ss.expanddown",      Segs.expanddown[ss]);
 
-            zip_nv_write_hex(*ent,"ds.val",         Segs.val[ds]);
+            zip_nv_write_hex(*ent,"ds.val",         (unsigned long)Segs.val[ds]);
             zip_nv_write_hex(*ent,"ds.phys",        Segs.phys[ds]);
             zip_nv_write_hex(*ent,"ds.limit",       Segs.limit[ds]);
             zip_nv_write(*ent,"ds.expanddown",      Segs.expanddown[ds]);
 
-            zip_nv_write_hex(*ent,"fs.val",         Segs.val[fs]);
+            zip_nv_write_hex(*ent,"fs.val",         (unsigned long)Segs.val[fs]);
             zip_nv_write_hex(*ent,"fs.phys",        Segs.phys[fs]);
             zip_nv_write_hex(*ent,"fs.limit",       Segs.limit[fs]);
             zip_nv_write(*ent,"fs.expanddown",      Segs.expanddown[fs]);
 
-            zip_nv_write_hex(*ent,"gs.val",         Segs.val[gs]);
+            zip_nv_write_hex(*ent,"gs.val",         (unsigned long)Segs.val[gs]);
             zip_nv_write_hex(*ent,"gs.phys",        Segs.phys[gs]);
             zip_nv_write_hex(*ent,"gs.limit",       Segs.limit[gs]);
             zip_nv_write(*ent,"gs.expanddown",      Segs.expanddown[gs]);

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -3127,7 +3127,7 @@ void DOS_Int21_714e(char *name1, char *name2) {
 			return;
 		}
 		Bit16u entry;
-		Bit8u i,handle=DOS_FILES;
+		Bit8u i,handle=(Bit8u)DOS_FILES;
 		for (i=1;i<DOS_FILES;i++) {
 			if (!Files[i]) {
 				handle=i;

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -351,12 +351,12 @@ void DOS_PSP::SetCommandTail(RealPt src) {
 }
 
 void DOS_PSP::StoreCommandTail() {
-	int len=mem_strlen(pt+offsetof(sPSP,cmdtail.buffer));
+	int len=(int)mem_strlen(pt+offsetof(sPSP,cmdtail.buffer));
 	MEM_StrCopy(pt+offsetof(sPSP,cmdtail.buffer),storect,len>CTBUF?CTBUF:len);
 }
 
 void DOS_PSP::RestoreCommandTail() {
-	mem_writeb(pt+offsetof(sPSP,cmdtail.count),strlen(storect)>0?strlen(storect)-1:0);
+	mem_writeb(pt+offsetof(sPSP,cmdtail.count),strlen(storect)>0?(Bit8u)(strlen(storect)-1):0);
 	MEM_BlockWrite(pt+offsetof(sPSP,cmdtail.buffer),storect,strlen(storect));
 }
 

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -287,7 +287,7 @@ public:
 		while (numSpaces--)
 			*(datadst++) = ' ';
 		captUsed += *size;
-		if (Bit16u newsize = datadst - data)											// If data
+		if (Bit16u newsize = (Bit16u)(datadst - data))									// If data
 			{
 			if (rawdata.capacity() < 100000)											// Prevent repetive size allocations
 				rawdata.reserve(100000);
@@ -338,7 +338,7 @@ public:
 		rawdata.erase(rawdata.find_last_not_of(" \n\r\t")+1);							// Remove trailing white space
 		if (!rawdata.size())															// Nothing captured/to do
 			return false;
-		int len = rawdata.size();
+		int len = (int)rawdata.size();
 		if (len > 2 && rawdata[len-3] == 0x0c && rawdata[len-2] == 27 && rawdata[len-1] == 64)	// <ESC>@ after last FF?
 			rawdata.erase(len-2, 2);
 		CommitData();

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -221,7 +221,7 @@ static bool DOS_MultiplexFunctions(void) {
         strcpy(name,"C:\\WINDOWS\\SYSTEM.DAT");
         MEM_BlockWrite(SegPhys(es)+reg_di,name,(Bitu)(strlen(name)+1));
         reg_ax=0;
-        reg_cx=strlen(name);
+        reg_cx=(Bit16u)strlen(name);
         return true;
     case 0x1600:    /* Windows enhanced mode installation check */
         // Leave AX as 0x1600, indicating that neither Windows 3.x enhanced mode, Windows/386 2.x

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -612,7 +612,7 @@ void isoDrive :: MediaChange() {
 
 void isoDrive :: GetLongName(char *ident, char *lfindName) {
     char *c=ident+strlen(ident);
-    int i,j=222-strlen(ident)-6;
+    int i,j=(int)(222-strlen(ident)-6);
     for (i=5;i<j;i++) {
         if (*(c+i)=='N'&&*(c+i+1)=='M'&&*(c+i+2)>0&&*(c+i+3)==1&&*(c+i+4)==0&&*(c+i+5)>0)
             break;


### PR DESCRIPTION
Silences some warnings that recently appeared in the Visual Studio build about value conversions.

~~Also moved a function in the new CLIP code that was declared private but was inside the scope of a `public:`, which the Visual Studio IDE didn't like. (Moved the function to within the scope of the `private:` above the `public:`)~~

Edit: The moving of the function to `private:` was done in master, so that's removed from this PR now.