### PR TITLE
Control clipboard paste speed

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3069,6 +3069,11 @@ void DOSBOX_SetupConfigSections(void) {
             "If unset or invalid, the default name CLIP$ will be used (e.g. \"TYPE CLIP$\" shows the clipboard contents).\n"
 			"It has no effect if \"dos clipboard device enable\" is false, and it is deactivated if the secure mode is enabled.");
 
+    Pint = secprop->Add_int("dos clipboard paste speed", Property::Changeable::WhenIdle, 20);
+    Pint->Set_help("Set keyboard speed for pasting from the windows clipboard.\n"
+        "If the default setting of 20 causes lost keystrokes, increase the number.\n"
+        "Or experiment with decreasing the number for applications that accept keystrokes quickly.");
+
     secprop=control->AddSection_prop("ipx",&Null_Init,true);
     Pbool = secprop->Add_bool("ipx",Property::Changeable::WhenIdle, false);
     Pbool->Set_help("Enable ipx over UDP/IP emulation.");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5315,8 +5315,13 @@ void GFX_Events() {
     // keystrokes get lost in the spew. (Prob b/c of DI usage on Win32, sadly..)
     // while (PasteClipboardNext());
     // Doesn't really matter though, it's fast enough as it is...
+    int paste_speed = 20;
+    Section* sec = control->GetSection("dos");
+    Section_prop* section = static_cast<Section_prop*>(sec);
+    paste_speed = (unsigned int)section->Get_int("dos clipboard paste speed");
+
     static Bitu iPasteTicker = 0;
-    if ((iPasteTicker++ % 20) == 0) // emendelson: was %2, %20 is good for WP51
+    if ((iPasteTicker++ % paste_speed) == 0) // emendelson: was %2, %20 is good for WP51
         PasteClipboardNext();   // end added emendelson from dbDOS
 #endif
 }


### PR DESCRIPTION
Adds a configuration setting to increase or decrease the speed of pasting from the DOS clipboard.

# Description

This adjusts the speed of keystroke-pasting in the clipboard paste function. Some applications can't handle the default speed; some can handle faster input.

Since I don't know anything about coding, it's probable that this can be done better than what I've posted here. But it seems to work.