### PR TITLE
Fixing total size report for mounted CD-ROM drives

### DIFF
--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -179,7 +179,19 @@ bool DOS_IOCTL(void) {
 				mem_writeb(ptr+6,0x00);					// media type (00=other type)
 				// bios parameter block following
 				mem_writew(ptr+7,0x0200);				// bytes per sector (Win3 File Mgr. uses it)
+				mem_writew(ptr+9,(drive>=2)?0x20:0x01);	// sectors per cluster
+				mem_writew(ptr+0xa,0x0001);				// number of reserved sectors
+				mem_writew(ptr+0xc,0x02);				// number of FATs
+				mem_writew(ptr+0xd,(drive>=2)?0x0200:0x00E0);	// number of root entries
+				mem_writew(ptr+0xf,(drive>=2)?0x0000:0x0B40);	// number of small sectors
+				mem_writew(ptr+0x11,(drive>=2)?0xF8:0xF0);		// media type
+				mem_writew(ptr+0x12,(drive>=2)?0x00C9:0x0009);	// sectors per FAT
+				mem_writew(ptr+0x14,(drive>=2)?0x003F:0x0012);	// sectors per track
+				mem_writew(ptr+0x16,(drive>=2)?0x10:0x02);		// number of heads
+				for (int i=0x17; i<0x22; i++)
+					mem_writew(ptr+i,0);
 				break;
+			case 0x40:	/* Set Device parameters */
 			case 0x46:	/* Set volume serial number */
 				break;
 			case 0x66:	/* Get volume serial number */

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -323,7 +323,7 @@ public:
                 str_size="512,32,0,0";
                 mediaid=0xF8;       /* Hard Disk */
             } else if (type=="cdrom") {
-                str_size="2048,1,32765,0";
+                str_size="2048,1,65535,0";
                 mediaid=0xF8;       /* Hard Disk */
             } else {
                 WriteOut(MSG_Get("PROGAM_MOUNT_ILL_TYPE"),type.c_str());
@@ -597,9 +597,9 @@ public:
         return;
 showusage:
 #if defined (WIN32) || defined(OS2)
-       WriteOut(MSG_Get("PROGRAM_MOUNT_USAGE"),"d:\\dosprogs","d:\\dosprogs","d:\\dosprogs","d:\\dosprogs","d:\\dosprogs");
+       WriteOut(MSG_Get("PROGRAM_MOUNT_USAGE"),"d:\\dosprogs","d:\\dosprogs","d:\\dosprogs","d:\\dosprogs","d:\\dosprogs","d:\\dosprogs");
 #else
-       WriteOut(MSG_Get("PROGRAM_MOUNT_USAGE"),"~/dosprogs","~/dosprogs","~/dosprogs","~/dosprogs","~/dosprogs");
+       WriteOut(MSG_Get("PROGRAM_MOUNT_USAGE"),"~/dosprogs","~/dosprogs","~/dosprogs","~/dosprogs","~/dosprogs","~/dosprogs");
 #endif
         return;
     }
@@ -4537,6 +4537,7 @@ void DOS_SetupPrograms(void) {
 		"MOUNT -nocachedir c %s mounts C: without caching the drive.\n"
 		"MOUNT -freesize 128 c %s mounts C: with the specified free disk space.\n"
 		"MOUNT -ro c %s mounts the C: drive in read-only mode.\n"
+		"MOUNT -t cdrom c %s mounts the C: drive as a CD-ROM drive.\n"
 		"MOUNT -u c unmounts the C: drive.\n");
     MSG_Add("PROGRAM_MOUNT_UMOUNT_NOT_MOUNTED","Drive %c isn't mounted.\n");
     MSG_Add("PROGRAM_MOUNT_UMOUNT_SUCCESS","Drive %c has successfully been removed.\n");

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -1072,7 +1072,7 @@ bool localDrive::AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,
 		if (res) {
 			unsigned long total = df.total_clusters * df.sectors_per_cluster;
 			int ratio = total > 2097120 ? 64 : (total > 1048560 ? 32 : (total > 524280 ? 16 : (total > 262140 ? 8 : (total > 131070 ? 4 : (total > 65535 ? 2 : 1)))));
-			*_bytes_sector = 512;
+			*_bytes_sector = df.bytes_per_sector;
 			*_sectors_cluster = ratio;
 			*_total_clusters = total > 4194240? 65535 : df.total_clusters * df.sectors_per_cluster / ratio;
 			*_free_clusters = total > 4194240? 61440 : df.avail_clusters * df.sectors_per_cluster / ratio;
@@ -1084,12 +1084,12 @@ bool localDrive::AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,
 		struct statvfs stat;
 		res = statvfs(basedir, &stat) == 0;
 		if (res) {
-			int ratio = stat.f_blocks / 65535, tmp=ratio;
+			int ratio = stat.f_blocks / 65536, tmp=ratio;
 			*_bytes_sector = 512;
 			*_sectors_cluster = stat.f_bsize/512 > 64? 64 : stat.f_bsize/512;
 			if (ratio>1) {
 				if (ratio * (*_sectors_cluster) > 64) tmp = (*_sectors_cluster+63)/(*_sectors_cluster);
-				*_sectors_cluster = ratio * (*_sectors_cluster) > 64? 64 : ratio;
+				*_sectors_cluster = ratio * (*_sectors_cluster) > 64? 64 : ratio * (*_sectors_cluster);
 				ratio = tmp;
 			}
 			*_total_clusters = stat.f_blocks > 65535? 65535 : stat.f_blocks;


### PR DESCRIPTION
When MOUNTing CD-ROM drives in DOSBox-X, by default the free disk size is always zero, but the total disk size reported may be incorrect. It is now fixed in this commit. The total disk size for mounted floppy or hard drives generally does not have this problem.

Also update the help message of the MOUNT command to mention its "-t cdrom" usage for mounting as CD-ROM drives (although you can also mount a CD-ROM drive on the host system as a standard local drive, which is the default).

P.S. This is my first time to create a pull request. Seems to be simpler than making diff files as done previously.