### PR TITLE
Fix PasteClipboard limitation in SDL2 build and COPY command crash

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -98,12 +98,10 @@
     change the keyboard modifier such as none, alt, ctrl,
     shift, or disable this feature (default). (Wengier)
   - Updated the PasteClipboard feature in SDL1 build
-    to support Unicode text translations. (Wengier)
-  - Fixed the PasteClipboard feature in SDL2 build;
-    a keyboard buffer expansion program like keybuf.com
-    (e.g. "KEYBUF 1024") is recommended to be loaded
-    (just once) before pasting long contents from the
-    Windows clipboard in SDL2 build. (Wengier)
+    to support Unicode text translations; also fixed this
+    feature not working in SDL2 build. The config option
+    "clip_paste_speed" is added to speed up or slow down
+    the pasting speed for different DOS programs (Wengier)
   - Support for DOSLIB2's w95sysrg/w95sysrs utils to
     get/set system registry location in DOS 7+. (Wengier)
   - Long filename support added, adapted from

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -377,8 +377,13 @@ void DOS_Shell::CMD_DELETE(char * args) {
 	else if (!strcasecmp(args,".")||(strlen(args)>1&&(args[strlen(args)-2]==':'||args[strlen(args)-2]=='\\')&&args[strlen(args)-1]=='.')) {
 		args[strlen(args)-1]='*';
 		strcat(args, ".*");
-	} else if (uselfn&&(!strcasecmp(args,"*")||(strlen(args)>1&&(args[strlen(args)-2]==':'||args[strlen(args)-2]=='\\')&&args[strlen(args)-1]=='*')))
-		strcat(args, ".*");
+	} else if (uselfn&&strchr(args, '*')) {
+		char * find_last;
+		find_last=strrchr(args,'\\');
+		if (find_last==NULL) find_last=args;
+		else find_last++;
+		if (strlen(find_last)>0&&args[strlen(args)-1]=='*'&&strchr(find_last, '.')==NULL) strcat(args, ".*");
+	}
 	if (!strcmp(args,"*.*")||(strlen(args)>3&&(!strcmp(args+strlen(args)-4, "\\*.*") || !strcmp(args+strlen(args)-4, ":*.*")))) {
 		if (!optQ1) {
 first_1:
@@ -1313,7 +1318,13 @@ void DOS_Shell::CMD_COPY(char * args) {
 			size_t source_x_len = strlen(source_x);
 			if (source_x_len>0) {
 				if (source_x[source_x_len-1]==':') has_drive_spec = true;
-				else if (uselfn&&source_x[source_x_len-1]=='*'&&strchr(source_x, '.')==NULL) strcat(source_x, ".*");
+				else if (uselfn&&strchr(source_x, '*')) {
+					char * find_last;
+					find_last=strrchr(source_x,'\\');
+					if (find_last==NULL) find_last=source_x;
+					else find_last++;
+					if (strlen(find_last)>0&&source_x[source_x_len-1]=='*'&&strchr(find_last, '.')==NULL) strcat(source_x, ".*");
+				}
 			}
 			if (!has_drive_spec  && !strpbrk(source_p,"*?") ) { //doubt that fu*\*.* is valid
                 char spath[DOS_PATHLENGTH];
@@ -1476,7 +1487,8 @@ void DOS_Shell::CMD_COPY(char * args) {
 					if (ext) { // substitute parts if necessary
 						if (!ext[-1]) { // substitute extension
 							strcat(nameTarget, (uselfn?lname:name) + replacementOffset);
-							strcpy(strchr(nameTarget, '.'), ext);
+							char *p=strchr(nameTarget, '.');
+							strcpy(p==NULL?nameTarget+strlen(nameTarget):p, ext);
 						}
 						if (ext[1] == '*') { // substitute name (so just add the extension)
 							strcat(nameTarget, strchr(uselfn?lname:name, '.'));
@@ -2300,7 +2312,13 @@ void DOS_Shell::CMD_ATTRIB(char *args){
 		else if (!strcasecmp(arg1, "-R")) subr=true;
 		else if (*arg1) {
 			strcpy(sfull, arg1);
-			if (uselfn&&sfull[strlen(sfull)-1]=='*'&&strchr(sfull, '.')==NULL) strcat(sfull, ".*");
+			if (uselfn&&strchr(sfull, '*')) {
+				char * find_last;
+				find_last=strrchr(sfull,'\\');
+				if (find_last==NULL) find_last=sfull;
+				else find_last++;
+				if (sfull[strlen(sfull)-1]=='*'&&strchr(find_last, '.')==NULL) strcat(sfull, ".*");
+			}
 		}
 	} while (*args);
 


### PR DESCRIPTION
I have recently implemented the PasteClipboard feature for the SDL2 build, but as I mentioned previously it required KEYBUF.COM in order to paste long contents from the Windows clipboard. In a private email @emendelson sent me earlier he told me he still hoped this limitation to be removed someday just like the SDL1 build so that he can move his project to SDL2, so here it is. The fix works by combining the original code I wrote and some existing code written for SDL1 build, but completely bypassing the SDL1 keyboard handling code. It only fixes the feature for the SDL2 build, whereas everything in SDL1 build stills works the same as before.

By the way, due to this fix the clip_paste_speed config option that was originally written for SDL1 build now works in SDL2 build too. So "clip_paste_speed" now applies to both SDL1 and SDL2 builds in Windows.

I have also fixed the COPY command crash that happened in certain cases. This occurred in both 0.83.0 and 0.83.1-git. When it happens DOSBox-X quits completely with no warnings. It is now fixed in this pull request.

In addition, I fixed MS-DOS 7+ DEL command with wildcards not working in non-Windows platforms. Previously the code handling this part was only for Windows (within #if defined (WIN32)), but it is now tested in Linux too.