### PR TITLE
Fix display for RE-DOS command and add help infos

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,4 @@
 0.83.1
-  - PC speaker: Mode 3 (square wave) and a counter value
-    of 1 produces a low frequency square wave. Ulrasonic
-    frequencies do not begin until count == 2. This fixes
-    helicopter noises in Paratrooper.
   - dosbox-x.conf is now recognized as the default config
     file name in addition to dosbox.conf (Wengier)
   - Tandy DAC output fixed to slowly ramp last sample to
@@ -47,6 +43,10 @@
     Linux and Unix systems through the user-writable
     file mode bits of the filesystem.
   - Fixed PC DOS 2000 crash during installation.
+  - PC speaker: Mode 3 (square wave) and a counter value
+    of 1 produces a low frequency square wave. Ulrasonic
+    frequencies do not begin until count == 2. This fixes
+    helicopter noises in Paratrooper.
   - Fixed PC speaker emulation to allow higher PC speaker
     frequencies (10x the value of pcrate) to reduce
     hiss/noise/aliasing noise that occurs when games
@@ -83,6 +83,7 @@
     overwriting files, and it now supports /Y and /-Y
     options to change this behavior, which can also be
     set from the COPYCMD environment variable. (Wengier)
+  - Added or fixed help infos for some commands (Wengier) 
   - Added support for DOS programs to communicate
     with the clipboard in Windows builds. If the
     "dos clipboard device enable" setting in

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,7 @@
     inside DOSBox-X before using pipes (Wengier)
   - Improved redirections using "<" or ">" (Wengier)
   - Improved Ctrl+C handling in some commands (Wengier)
+  - Improved Tab completion in the command shell (Wengier)
   - Improved -get & -set options for the CONFIG command,
     e.g. support for config options with spaces (Wengier)
   - Improved REN (or RENAME) command to support wildcards

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -83,7 +83,8 @@
     overwriting files, and it now supports /Y and /-Y
     options to change this behavior, which can also be
     set from the COPYCMD environment variable. (Wengier)
-  - Added or fixed help infos for some commands (Wengier) 
+  - Added or fixed help information and/or error messages
+    for some commands. (Wengier) 
   - Added support for DOS programs to communicate
     with the clipboard in Windows builds. If the
     "dos clipboard device enable" setting in

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -3058,7 +3058,7 @@ public:
             }
             else {
                 if (AttachToBiosAndIdeByIndex(newImage, (unsigned char)driveIndex, (unsigned char)ide_index, ide_slave)) {
-                    WriteOut(MSG_Get("PROGRAM_IMGMOUNT_MOUNT_NUMBER"), drive - '0', (!paths.empty()) ? (wpcolon&&paths[0].length()>1&&paths[0].c_str()[0]==':'?paths[0].c_str()+1:paths[0].c_str()) : "");
+                    WriteOut(MSG_Get("PROGRAM_IMGMOUNT_MOUNT_NUMBER"), drive - '0', (!paths.empty()) ? (wpcolon&&paths[0].length()>1&&paths[0].c_str()[0]==':'?paths[0].c_str()+1:paths[0].c_str()) : (el_torito != ""?el_torito.c_str():"-"));
 
                     if (paths.size() > 1) {
                         for (size_t si=0;si < MAX_SWAPPABLE_DISKS;si++) {

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -1589,6 +1589,10 @@ class REDOS : public Program {
 public:
     /*! \brief      Program entry point, when the command is run */
     void Run(void) {
+		if (cmd->FindExist("/?", false) || cmd->FindExist("-?", false)) {
+			WriteOut("Restarts the kernel of DOSBox-X's emulated DOS.\n\nRE-DOS\n");
+			return;
+		}
         throw int(6);
     }
 };

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -436,7 +436,9 @@ void DOS_Shell::RunInternal(void) {
 void DOS_Shell::Run(void) {
 	char input_line[CMD_MAXLINE] = {0};
 	std::string line;
-	if (cmd->FindStringRemainBegin("/C",line)) {
+	bool optC=cmd->FindStringRemainBegin("/C",line), optK=false;
+	if (!optC) optK=cmd->FindStringRemainBegin("/K",line);	
+	if (optC||optK) {
 		input_line[CMD_MAXLINE-1u] = 0;
 		strncpy(input_line,line.c_str(),CMD_MAXLINE-1u);
 		char* sep = strpbrk(input_line,"\r\n"); //GTA installer
@@ -445,6 +447,10 @@ void DOS_Shell::Run(void) {
 		temp.echo = echo;
 		temp.ParseLine(input_line);		//for *.exe *.com  |*.bat creates the bf needed by runinternal;
 		temp.RunInternal();				// exits when no bf is found.
+		if (!optK||temp.exit)
+			return;
+	} else if (cmd->FindStringRemain("/?",line)) {
+		WriteOut(MSG_Get("SHELL_CMD_COMMAND_HELP"));
 		return;
 	}
 
@@ -462,7 +468,7 @@ void DOS_Shell::Run(void) {
         WriteOut(MSG_Get("SHELL_STARTUP_END"));
     }
     else {
-        WriteOut("DOSBox-X command shell %s %s\n\n",VERSION,UPDATED_STR);
+        WriteOut(optK?"\n":"DOSBox-X command shell %s %s\n\n",VERSION,UPDATED_STR);
     }
 
 	if (cmd->FindString("/INIT",line,true)) {
@@ -847,9 +853,9 @@ void SHELL_Init() {
     else {
 // "\xBA To activate the keymapper \033[31mhost+m\033[37m. Host key is F12.                 \xBA\n"
         host_key_help =
-            std::string("\xBA To activate the keymapper \033[31mhost+m\033[37m. Host key is ") +
+            std::string("\033[44;1m\xBA To activate the keymapper \033[31mhost+m\033[37m. Host key is ") +
             (mapper_keybind + "                                     ").substr(0,20) +
-            std::string(" \xBA\n");
+            std::string(" \xBA\033[0m\n");
     }
 
     if (machine == MCH_PC98) {
@@ -898,48 +904,49 @@ void SHELL_Init() {
         MSG_Add("SHELL_STARTUP_BEGIN",
                 "\033[44;1m\xC9\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
                 "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
-                "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xBB\n"
-                "\xBA \033[32mWelcome to DOSBox-X %-8s (%-4s) %-25s\033[37m      \xBA\n"
-                "\xBA                                                                    \xBA\n"
-                "\xBA For a short introduction for new users type: \033[33mINTRO\033[37m                 \xBA\n"
-                "\xBA For supported shell commands type: \033[33mHELP\033[37m                            \xBA\n"
-                "\xBA                                                                    \xBA\n"
-                "\xBA To adjust the emulated CPU speed, use \033[31mhost -\033[37m and \033[31mhost +\033[37m.           \xBA\n");
+                "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xBB\033[0m\n"
+                "\033[44;1m\xBA \033[32mWelcome to DOSBox-X %-8s (%-4s) %-25s\033[37m      \xBA\033[0m\n"
+                "\033[44;1m\xBA                                                                    \xBA\033[0m\n"
+                "\033[44;1m\xBA For a short introduction for new users type: \033[33mINTRO\033[37m                 \xBA\033[0m\n"
+                "\033[44;1m\xBA For supported shell commands type: \033[33mHELP\033[37m                            \xBA\033[0m\n"
+                "\033[44;1m\xBA                                                                    \xBA\033[0m\n"
+                "\033[44;1m\xBA To adjust the emulated CPU speed, use \033[31mhost -\033[37m and \033[31mhost +\033[37m.           \xBA\033[0m\n"
+			   );
         MSG_Replace("SHELL_STARTUP_BEGIN2",
                 host_key_help.c_str());
         MSG_Add("SHELL_STARTUP_BEGIN3",
-                "\xBA For more information read the online guide in the \033[36mDOSBox-X Wiki\033[37m.   \xBA\n"
-                "\xBA                                                                    \xBA\n"
+                "\033[44;1m\xBA For more information read the online guide in the \033[36mDOSBox-X Wiki\033[37m.   \xBA\033[0m\n"
+                "\033[44;1m\xBA                                                                    \xBA\033[0m\n"
                );
         if (!mono_cga) {
-            MSG_Add("SHELL_STARTUP_CGA","\xBA DOSBox-X supports Composite CGA mode.                                \xBA\n"
-                    "\xBA Use \033[31mF12\033[37m to set composite output ON, OFF, or AUTO (default).        \xBA\n"
-                    "\xBA \033[31m(Alt-)F11\033[37m changes hue; \033[31mctrl-alt-F11\033[37m selects early/late CGA model.  \xBA\n"
-                    "\xBA                                                                    \xBA\n"
+            MSG_Add("SHELL_STARTUP_CGA","\033[44;1m\xBA DOSBox-X supports Composite CGA mode.                              \xBA\033[0m\n"
+                    "\033[44;1m\xBA Use \033[31mF12\033[37m to set composite output ON, OFF, or AUTO (default).        \xBA\033[0m\n"
+                    "\033[44;1m\xBA \033[31m(Alt-)F11\033[37m changes hue; \033[31mctrl-alt-F11\033[37m selects early/late CGA model.  \xBA\033[0m\n"
+                    "\033[44;1m\xBA                                                                    \xBA\033[0m\n"
                    );
         } else {
-            MSG_Add("SHELL_STARTUP_CGA","\xBA Use \033[31mF11\033[37m to cycle through green, amber, and white monochrome color, \xBA\n"
-                    "\xBA and \033[31mAlt-F11\033[37m to change contrast/brightness settings.                \xBA\n"
+            MSG_Add("SHELL_STARTUP_CGA","\033[44;1m\xBA Use \033[31mF11\033[37m to cycle through green, amber, and white monochrome color, \xBA\033[0m\n"
+                    "\033[44;1m\xBA and \033[31mAlt-F11\033[37m to change contrast/brightness settings.                \xBA\033[0m\n"
                    );
         }
         MSG_Add("SHELL_STARTUP_PC98","\xBA DOSBox-X is now running in NEC PC-98 emulation mode.               \xBA\n"
                 "\xBA \033[31mPC-98 emulation is INCOMPLETE and CURRENTLY IN DEVELOPMENT.\033[37m        \xBA\n");
-        MSG_Add("SHELL_STARTUP_HERC","\xBA Use F11 to cycle through white, amber, and green monochrome color. \xBA\n"
-                "\xBA Use alt-F11 to toggle horizontal blending (only in graphics mode). \xBA\n"
-                "\xBA                                                                    \xBA\n"
+        MSG_Add("SHELL_STARTUP_HERC","\033[44;1m\xBA Use F11 to cycle through white, amber, and green monochrome color. \xBA\033[0m\n"
+                "\033[44;1m\xBA Use alt-F11 to toggle horizontal blending (only in graphics mode). \xBA\033[0m\n"
+                "\033[44;1m\xBA                                                                    \xBA\033[0m\n"
                );
         MSG_Add("SHELL_STARTUP_DEBUG",
 #if defined(MACOSX)
-                "\xBA Debugger is available, use \033[31malt-F12\033[37m to enter.                       \xBA\n"
+                "\033[44;1m\xBA Debugger is available, use \033[31malt-F12\033[37m to enter.                       \xBA\033[0m\n"
 #else
-                "\xBA Debugger is available, use \033[31malt-Pause\033[37m to enter.                     \xBA\n"
+                "\033[44;1m\xBA Debugger is available, use \033[31malt-Pause\033[37m to enter.                     \xBA\033[0m\n"
 #endif
-                "\xBA                                                                    \xBA\n"
+                "\033[44;1m\xBA                                                                    \xBA\033[0m\n"
                );
         MSG_Add("SHELL_STARTUP_END",
-                "\xBA \033[32mDOSBox-X project \033[33mhttp://dosbox-x.software\033[32m      PentiumPro support \033[37m \xBA\n"
-                "\xBA \033[32mDerived from DOSBox \033[33mhttp://www.dosbox.com\033[37m                          \xBA\n"
-                "\xC8\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
+                "\033[44;1m\xBA \033[32mDOSBox-X project \033[33mhttp://dosbox-x.software\033[32m      PentiumPro support \033[37m \xBA\033[0m\n"
+                "\033[44;1m\xBA \033[32mDerived from DOSBox \033[33mhttp://www.dosbox.com\033[37m                          \xBA\033[0m\n"
+                "\033[44;1m\xC8\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
                 "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
                 "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xBC\033[0m\n"
                 "\033[1m\033[32mHAVE FUN!\033[0m\n"
@@ -1119,7 +1126,7 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_MORE_HELP_LONG","MORE [drive:][path][filename]\nMORE < [drive:][path]filename\ncommand-name | MORE [drive:][path][filename]\n");
 	MSG_Add("SHELL_CMD_TRUENAME_HELP","Finds the fully-expanded name for a file.\n");
 	MSG_Add("SHELL_CMD_TRUENAME_HELP_LONG","TRUENAME file\n");
-
+	MSG_Add("SHELL_CMD_COMMAND_HELP","Starts the DOSBox-X command shell.\n\nThe following options are accepted:\n\n  /C\tExecutes the specified command and returns.\n  /K\tExecutes the specified command and continues running.\n  /INIT\tInitializes the command shell.\n");
 
 	/* Regular startup */
 	call_shellstop=CALLBACK_Allocate();

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -832,6 +832,7 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_SUBST_NO_REMOVE","Unable to remove, drive not in use.\n");
 	MSG_Add("SHELL_CMD_SUBST_IN_USE","Target drive is already in use.\n");
 	MSG_Add("SHELL_CMD_SUBST_NOT_LOCAL","It is only possible to use SUBST on local drives.\n");
+	MSG_Add("SHELL_CMD_SUBST_INVALID_PATH","The specified path is invalid.\n");
 	MSG_Add("SHELL_CMD_SUBST_FAILURE","SUBST: There is an error in your command line.\n");
 
     std::string mapper_keybind = mapper_event_keybind_string("host");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -830,7 +830,9 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_COPY_NOSPACE","Insufficient disk space - %s\n");
 	MSG_Add("SHELL_CMD_COPY_ERROR","Error in copying file %s\n");
 	MSG_Add("SHELL_CMD_SUBST_NO_REMOVE","Unable to remove, drive not in use.\n");
-	MSG_Add("SHELL_CMD_SUBST_FAILURE","SUBST failed. You either made an error in your commandline or the target drive is already used.\nIt's only possible to use SUBST on Local drives\n");
+	MSG_Add("SHELL_CMD_SUBST_IN_USE","Target drive is already in use.\n");
+	MSG_Add("SHELL_CMD_SUBST_NOT_LOCAL","It is only possible to use SUBST on local drives.\n");
+	MSG_Add("SHELL_CMD_SUBST_FAILURE","SUBST: There is an error in your command line.\n");
 
     std::string mapper_keybind = mapper_event_keybind_string("host");
     if (mapper_keybind.empty()) mapper_keybind = "unbound";

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -823,7 +823,8 @@ void SHELL_Init() {
 	MSG_Add("SHELL_EXECUTE_DRIVE_ACCESS_WARNING_WIN","Mounting C:\\ is NOT recommended.\n");
 	MSG_Add("SHELL_EXECUTE_ILLEGAL_COMMAND","Illegal command: %s.\n");
 	MSG_Add("SHELL_CMD_PAUSE","Press any key to continue.\n");
-	MSG_Add("SHELL_CMD_PAUSE_HELP","Waits for 1 keystroke to continue.\n");
+	MSG_Add("SHELL_CMD_PAUSE_HELP","Waits for one keystroke to continue.\n");
+	MSG_Add("SHELL_CMD_PAUSE_HELP_LONG","PAUSE\n");
 	MSG_Add("SHELL_CMD_COPY_FAILURE","Copy failure : %s.\n");
 	MSG_Add("SHELL_CMD_COPY_SUCCESS","   %d File(s) copied.\n");
 	MSG_Add("SHELL_CMD_COPY_CONFIRM","Overwrite %s (Yes/No/All)?");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -826,6 +826,9 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_PAUSE_HELP","Waits for 1 keystroke to continue.\n");
 	MSG_Add("SHELL_CMD_COPY_FAILURE","Copy failure : %s.\n");
 	MSG_Add("SHELL_CMD_COPY_SUCCESS","   %d File(s) copied.\n");
+	MSG_Add("SHELL_CMD_COPY_CONFIRM","Overwrite %s (Yes/No/All)?");
+	MSG_Add("SHELL_CMD_COPY_NOSPACE","Insufficient disk space - %s\n");
+	MSG_Add("SHELL_CMD_COPY_ERROR","Error in copying file %s\n");
 	MSG_Add("SHELL_CMD_SUBST_NO_REMOVE","Unable to remove, drive not in use.\n");
 	MSG_Add("SHELL_CMD_SUBST_FAILURE","SUBST failed. You either made an error in your commandline or the target drive is already used.\nIt's only possible to use SUBST on Local drives\n");
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -820,7 +820,7 @@ void SHELL_Init() {
 	MSG_Add("SHELL_EXECUTE_DRIVE_ACCESS_CDROM","Do you want to give DOSBox-X access to your real CD-ROM drive %c [Y/N]?");
 	MSG_Add("SHELL_EXECUTE_DRIVE_ACCESS_FLOPPY","Do you want to give DOSBox-X access to your real floppy drive %c [Y/N]?");
 	MSG_Add("SHELL_EXECUTE_DRIVE_ACCESS_FIXED","Do you really want to give DOSBox-X access to everything\non your real drive %c [Y/N]?");
-	MSG_Add("SHELL_EXECUTE_DRIVE_ACCESS_WARNING_WIN","Mounting c:\\ is NOT recommended.\n");
+	MSG_Add("SHELL_EXECUTE_DRIVE_ACCESS_WARNING_WIN","Mounting C:\\ is NOT recommended.\n");
 	MSG_Add("SHELL_EXECUTE_ILLEGAL_COMMAND","Illegal command: %s.\n");
 	MSG_Add("SHELL_CMD_PAUSE","Press any key to continue.\n");
 	MSG_Add("SHELL_CMD_PAUSE_HELP","Waits for 1 keystroke to continue.\n");

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -2121,7 +2121,7 @@ void DOS_Shell::CMD_SUBST(char * args) {
         if (strchr(arg.c_str(),'\"')==NULL)
             sprintf(dir,"\"%s\"",arg.c_str());
         else strcpy(dir,arg.c_str());
-        if (!DOS_MakeName(dir,fulldir,&drive)) throw 0;
+        if (!DOS_MakeName(dir,fulldir,&drive)) throw 4;
 	
 		localDrive* ldp=0;
 		if( ( ldp=dynamic_cast<localDrive*>(Drives[drive])) == 0 ) throw 3;
@@ -2145,6 +2145,9 @@ void DOS_Shell::CMD_SUBST(char * args) {
 				break;
 			case 3:
 				WriteOut(MSG_Get("SHELL_CMD_SUBST_NOT_LOCAL"));
+				break;
+			case 4:
+				WriteOut(MSG_Get("SHELL_CMD_SUBST_INVALID_PATH"));
 				break;
 			default:
 				WriteOut(MSG_Get("SHELL_CMD_SUBST_FAILURE"));

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -2113,7 +2113,7 @@ void DOS_Shell::CMD_SUBST(char * args) {
 			this->ParseLine(mountstring);
 			return;
 		}
-		if(Drives[temp_str[0]-'A'] ) throw 0; //targetdrive in use
+		if(Drives[temp_str[0]-'A'] ) throw 2; //targetdrive in use
 		strcat(mountstring,temp_str);
 		strcat(mountstring," ");
 
@@ -2124,7 +2124,7 @@ void DOS_Shell::CMD_SUBST(char * args) {
         if (!DOS_MakeName(dir,fulldir,&drive)) throw 0;
 	
 		localDrive* ldp=0;
-		if( ( ldp=dynamic_cast<localDrive*>(Drives[drive])) == 0 ) throw 0;
+		if( ( ldp=dynamic_cast<localDrive*>(Drives[drive])) == 0 ) throw 3;
 		char newname[CROSS_LEN];   
 		strcpy(newname, ldp->basedir);	   
 		strcat(newname,fulldir);
@@ -2136,10 +2136,18 @@ void DOS_Shell::CMD_SUBST(char * args) {
 		this->ParseLine(mountstring);
 	}
 	catch(int a){
-		if(a == 0) {
-			WriteOut(MSG_Get("SHELL_CMD_SUBST_FAILURE"));
-		} else {
+		switch (a) {
+			case 1:
 		       	WriteOut(MSG_Get("SHELL_CMD_SUBST_NO_REMOVE"));
+				break;
+			case 2:
+				WriteOut(MSG_Get("SHELL_CMD_SUBST_IN_USE"));
+				break;
+			case 3:
+				WriteOut(MSG_Get("SHELL_CMD_SUBST_NOT_LOCAL"));
+				break;
+			default:
+				WriteOut(MSG_Get("SHELL_CMD_SUBST_FAILURE"));
 		}
 		return;
 	}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1328,10 +1328,17 @@ void DOS_Shell::CMD_COPY(char * args) {
 			}
 			if (!has_drive_spec  && !strpbrk(source_p,"*?") ) { //doubt that fu*\*.* is valid
                 char spath[DOS_PATHLENGTH];
-                if (DOS_GetSFNPath(source_p,spath,false) && DOS_FindFirst(spath,0xffff & ~DOS_ATTR_VOLUME)) {
+                if (DOS_GetSFNPath(source_p,spath,false)) {
+					bool root=false;
+					if (strlen(spath)==3&&spath[1]==':'&&spath[2]=='\\') {
+						root=true;
+						strcat(spath, "*.*");
+					}
+					if (DOS_FindFirst(spath,0xffff & ~DOS_ATTR_VOLUME)) {
                     dta.GetResult(name,lname,size,date,time,attr);
-					if (attr & DOS_ATTR_DIRECTORY)
+					if (attr & DOS_ATTR_DIRECTORY || root)
 						strcat(source_x,"\\*.*");
+					}
 				}
 			}
             std::string source_xString = std::string(source_x);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1522,7 +1522,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 					if (!(attr & DOS_ATTR_DIRECTORY) && DOS_FindDevice(nameTarget) == DOS_DEVICES) {
 						if (exist && !optY && !oldsource.concat) {
 							dos.echo=false;
-							WriteOut("Overwrite %s (Yes/No/All)?", nameTarget);
+							WriteOut(MSG_Get("SHELL_CMD_COPY_CONFIRM"), nameTarget);
 							Bit8u c;
 							Bit16u n=1;
 							while (true)
@@ -1544,7 +1544,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 								Drives[drive]->AllocationInfo(&bytes_sector,&sectors_cluster,&total_clusters,&free_clusters);
 								rsize=false;
 								if ((Bitu)bytes_sector * (Bitu)sectors_cluster * (Bitu)(freec?freec:free_clusters)<size) {
-									WriteOut("Insufficient disk space - %s\n", uselfn?lname:name);
+									WriteOut(MSG_Get("SHELL_CMD_COPY_NOSPACE"), uselfn?lname:name);
 									DOS_CloseFile(sourceHandle);
 									ret = DOS_FindNext();
 									continue;
@@ -1603,7 +1603,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 							if (!DOS_CloseFile(sourceHandle)) failed=true;
 							if (!DOS_CloseFile(targetHandle)) failed=true;
 							if (failed)
-                                WriteOut("Error in copying file %s\n",uselfn?lname:name);
+                                WriteOut(MSG_Get("SHELL_CMD_COPY_ERROR"),uselfn?lname:name);
                             else if (strcmp(name,lname)&&uselfn)
                                 WriteOut(" %s [%s]\n",lname,name);
                             else

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -476,7 +476,8 @@ void DOS_Shell::InputCommand(char * line) {
                     } else {
                         // build new completion list
                         // Lines starting with CD will only get directories in the list
-                        bool dir_only = (strncasecmp(line,"CD ",3)==0);
+						bool dir_only = (strncasecmp(line,"CD ",3)==0)||(strncasecmp(line,"MD ",3)==0)||(strncasecmp(line,"RD ",3)==0)||
+								(strncasecmp(line,"CHDIR ",6)==0)||(strncasecmp(line,"MKDIR ",3)==0)||(strncasecmp(line,"RMDIR ",6)==0);
 						int q=0, r=0, k=0;
 
                         // get completion mask

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -475,7 +475,7 @@ void DOS_Shell::InputCommand(char * line) {
                         if (it_completion == l_completion.end()) it_completion = l_completion.begin();
                     } else {
                         // build new completion list
-                        // Lines starting with CD will only get directories in the list
+                        // Lines starting with CD/MD/RD will only get directories in the list
 						bool dir_only = (strncasecmp(line,"CD ",3)==0)||(strncasecmp(line,"MD ",3)==0)||(strncasecmp(line,"RD ",3)==0)||
 								(strncasecmp(line,"CHDIR ",6)==0)||(strncasecmp(line,"MKDIR ",3)==0)||(strncasecmp(line,"RMDIR ",6)==0);
 						int q=0, r=0, k=0;


### PR DESCRIPTION
I found that when using the RE-DOS command to restart the kernel of the emulated DOS, the display of the welcome message box may have some color issues, so I fixed them in this pull request. Tested with the default svga_s3 as well as CGA and PC98 modes to make sure it displays correctly.

Also, I added help messages for the RE-DOS and COMMAND commands when you run them with /?.

In addition, for the Tab completion I made CHDIR, MD/MKDIR and RD/RMDIR commands directory-only just like the CD command.