### PR TITLE
Fix Issue #1495 and rename dosbox.reference.conf

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,7 +23,7 @@ If applicable, add screenshots to help explain your problem.
 **Environment (please complete the following information):**
  - Operating system
  - DOSBox-X release version or commit SHA1 this issue occurred on
- - Used configuration, e.g. ```dosbox.conf```
+ - Used configuration, e.g. ```dosbox-x.conf```
 
 **Additional context**
 Add any other context about the problem here.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -90,7 +90,7 @@
   - Added support for DOS programs to communicate
     with the clipboard in Windows builds. If the
     "dos clipboard device enable" setting in
-    dosbox.conf is set to "true" or "full", a DOS
+    dosbox-x.conf is set to "true" or "full", a DOS
     device (default name: CLIP$) will be added to
     allow bidirectional communications with the
     clipboard (e.g. "DIR >CLIP$" will write the
@@ -100,7 +100,7 @@
     only read or write access for security reasons.
     The DOS device name can also be changed with
     the "dos clipboard device name" setting in
-    dosbox.conf. (Wengier)
+    dosbox-x.conf. (Wengier)
   - Added support for using the right mouse button
     to copy and paste from the Windows clipboard; the
     config option "clip_key_modifier" can be used to
@@ -124,7 +124,7 @@
     memory or video memory. I do not have enough
     test cases or a setup to test what really happens,
     so it will remain a debug message for now.
-  - Added dosbox.conf option to allow emulation of a
+  - Added dosbox-x.conf option to allow emulation of a
     DOS environment that lacks ANSI.SYS. NOTE: The
     option has no effect in PC-98 mode.
   - INT 2Fh now responds to AX=1A00h which is an installation

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 0.83.1
   - dosbox-x.conf is now recognized as the default config
-    file name in addition to dosbox.conf (Wengier)
+    file name in addition to dosbox.conf. The sample config
+    file "dosbox.reference.conf" has been renamed to
+    "dosbox-x.reference.conf" as well (Wengier)
   - Tandy DAC output fixed to slowly ramp last sample to
     zero DC sample (128) when switched off. This fixes
     loud popping (DC offset) problems with Tandy DAC
@@ -1232,7 +1234,7 @@
     to control the base I/O port of the MPU-401 interface.
     The option can be set to "0" to tell DOSBox-X to pick the
     best default. Works in either IBM PC or NEC PC-98 mode.
-    See dosbox.reference.conf for more details.
+    See dosbox-x.reference.conf for more details.
   - Fixed Sound Blaster 16 mixer IRQ/DMA select registers
     to work in PC-98 mode as they apparently do on real
     hardware.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-DOSBox-X Manual (always use the latest version from [dosbox-x.com](dosbox-x.com))
+DOSBox-X Manual (always use the latest version from [dosbox-x.com](http://dosbox-x.com))
 
-DOSBox-X is a fork of the original DOSBox project (www.dosbox.com)
+DOSBox-X is a cross-platform DOS emulator based on the DOSBox project (www.dosbox.com)
 
+For more information please read the user guide in the [DOSBox-X Wiki](https://github.com/joncampbell123/dosbox-x/wiki).
 
 This project has a Code of Conduct in CODE_OF_CONDUCT.md, please read it.
-
-
 
 I am rewriting this README, and new information will be added over time --J.C.
 
@@ -658,7 +657,7 @@ The entry point main() is in src/gui/sdlmain.cpp,
 somewhere closer to the bottom.
 
 
-Configuration and control state (from dosbox.conf and
+Configuration and control state (from dosbox-x.conf and
 the command line) are accessible through a globally
 scoped pointer named "control".
 
@@ -1323,7 +1322,7 @@ Mixer audio framework
 Audio is rendered from all sources once a millisecond (once per tick).
 
 Audio is rendered to 16-bit stereo at the sample rate of the user's
-choice (in dosbox.conf).
+choice (in dosbox-x.conf).
 
 Audio may be rendered within the 1ms tick at any point if code calls
 the MIXER_FillUp() function or FillUp() member of a mixer channel.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ after_build:
   - ps : >-
         $shortHash = $env:APPVEYOR_REPO_COMMIT.Substring(0, 7);
         7z a dosbox-x-windows-$shortHash.zip C:\projects\dosbox-x\vs2015\..\bin\x64\Release\changelog.txt;
-        7z a dosbox-x-windows-$shortHash.zip C:\projects\dosbox-x\vs2015\..\bin\x64\Release\dosbox.reference.conf;
+        7z a dosbox-x-windows-$shortHash.zip C:\projects\dosbox-x\vs2015\..\bin\x64\Release\dosbox-x.reference.conf;
         7z a dosbox-x-windows-$shortHash.zip C:\projects\dosbox-x\vs2015\..\bin\x64\Release\dosbox-x.exe;
         7z a dosbox-x-windows-$shortHash.zip C:\projects\dosbox-x\vs2015\..\bin\x64\Release\FREECG98.BMP;
   

--- a/docs/Windows 3.1/INSTALL.MD
+++ b/docs/Windows 3.1/INSTALL.MD
@@ -17,12 +17,12 @@ Scenario 1
 
 Scenario 2
 
-- Mouse integration driver is installed and defined in dosbox.conf
+- Mouse integration driver is installed and defined in dosbox-x.conf
 - DOSBox-X has been reset at least once with <kbd>F11</kbd>+<kbd>R</kbd>
 
 ### Video
 
-This guide assumes you are using the default DOSBox-X machine `svga_s3` for which DOSBox-X sets video memory to `512Kb` by default. To use higher resolutions and color depths, adjust `vmemsize` in `[dosbox]` accordingly to your needs (see `dosbox.reference.conf`).
+This guide assumes you are using the default DOSBox-X machine `svga_s3` for which DOSBox-X sets video memory to `512Kb` by default. To use higher resolutions and color depths, adjust `vmemsize` in `[dosbox]` accordingly to your needs (see `dosbox-x.reference.conf`).
 
 ## Installation
 
@@ -32,7 +32,7 @@ This guide assumes you are using the default DOSBox-X machine `svga_s3` for whic
 - next to `DOSBox-X.exe`, create a `VirtualHD` directory
 - inside `VirtualHD` create a `WINSETUP` directory
 - extract Windows 3.1 floppies into it ([7-Zip](https://www.7-zip.org/) can extract IMG files)
-- next to `DOSBox-x.exe` create a `dosbox.conf` with the following content:
+- next to `DOSBox-x.exe` create a `dosbox-x.conf` with the following content:
 ```
 [cpu]
 cycles=25000

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -144,13 +144,13 @@ showmenu          = true
 #                                          language: Select another language file.
 #                                             title: Additional text to place in the title bar of the window
 #                                  enable 8-bit dac: If set, allow VESA BIOS calls in IBM PC mode to set DAC width. Has no effect in PC-98 mode.
-#                                         dpi aware: Set this option (on by default) to indicate to your OS that DOSBox is DPI aware.
-#                                                      If it is not set, Windows Vista/7/8/10 and higher may upscale the DOSBox window
+#                                         dpi aware: Set this option (on by default) to indicate to your OS that DOSBox-X is DPI aware.
+#                                                      If it is not set, Windows Vista/7/8/10 and higher may upscale the DOSBox-X window
 #                                                      on higher resolution monitors which is probably not what you want.
 #                                     keyboard hook: Use keyboard hook (currently only on Windows) to catch special keys and synchronize the keyboard LEDs with the host
 #                                            weitek: If set, emulate the Weitek coprocessor. This option only has effect if cputype=386 or cputype=486.
 #                               bochs debug port e9: If set, emulate Bochs debug port E9h. ASCII text written to this I/O port is assumed to be debug output, and logged.
-#                                           machine: The type of machine DOSBox tries to emulate.
+#                                           machine: The type of machine DOSBox-X tries to emulate.
 #                                                      Possible values: hercules, cga, cga_mono, cga_rgb, cga_composite, cga_composite2, tandy, pcjr, ega, vgaonly, svga_s3, svga_et3000, svga_et4000, svga_paradise, vesa_nolfb, vesa_oldvbe, amstrad, pc98, pc9801, pc9821, fm_towns, mcga, mda.
 #                                     svga lfb base: If nonzero, define the physical memory address of the linear framebuffer.
 #                                           pci vga: If set, SVGA is emulated as if a PCI device (when enable pci bus=true)
@@ -187,7 +187,7 @@ showmenu          = true
 #                                                      mpegts-h264                 Use MPEG transport stream + H.264 + AAC audio. Resolution & refresh rate changes can be contained
 #                                                                                  within one file with this choice, however not all software can support mid-stream format changes.
 #                                                      Possible values: default, avi-zmbv, mpegts-h264.
-#                            shell environment size: Size of the initial DOSBox shell environment block, in bytes. This does not affect the environment block of sub-processes spawned from the shell.
+#                            shell environment size: Size of the initial DOSBox-X shell environment block, in bytes. This does not affect the environment block of sub-processes spawned from the shell.
 #                                                      This option has no effect unless dynamic kernel allocation is enabled.
 #                                 private area size: Set DOSBox-X private memory area size. This area contains private memory structures used by the DOS kernel.
 #                                                      It is discarded when you boot into another OS. Mainline DOSBox uses 32KB. Testing shows that it is possible
@@ -278,11 +278,11 @@ showmenu          = true
 #                                      acpi sci irq: IRQ to assign as ACPI system control interrupt. set to -1 to automatically assign.
 #                                       acpi iobase: I/O port base for the ACPI device Power Management registers. Set to 0 for automatic assignment.
 #                                acpi reserved size: Amount of memory at top to reserve for ACPI structures and tables. Set to 0 for automatic assignment.
-#                                           memsize: Amount of memory DOSBox has in megabytes.
+#                                           memsize: Amount of memory DOSBox-X has in megabytes.
 #                                                      This value is best left at its default to avoid problems with some games,
 #                                                      though few games might require a higher value.
 #                                                      There is generally no speed advantage when raising this value.nPrograms that use 286 protected mode like Windows 3.0 in Standard Mode may crash with more than 15MB.
-#                                         memsizekb: Amount of memory DOSBox has in kilobytes.
+#                                         memsizekb: Amount of memory DOSBox-X has in kilobytes.
 #                                                      This value should normally be set to 0.
 #                                                      If nonzero, it is added to the memsize parameter.
 #                                                      Finer grained control of total memory may be useful in

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1365,9 +1365,9 @@ dongle    = false
 [dos]
 #                                              xms: Enable XMS support.
 #                                      xms handles: Number of XMS handles available for the DOS environment, or 0 to use a reasonable default
-#                  shell configuration as commands: Allow entering dosbox.conf configuration parameters as shell commands to get and set settings.
+#                  shell configuration as commands: Allow entering dosbox-x.conf configuration parameters as shell commands to get and set settings.
 #                                                     This is disabled by default to avoid conflicts between commands and executables.
-#                                                     It is recommended to get and set dosbox.conf settings using the CONFIG command instead.
+#                                                     It is recommended to get and set dosbox-x.conf settings using the CONFIG command instead.
 #                                                     Compatibility with DOSBox SVN can be improved by enabling this option.
 #                                              hma: Report through XMS that HMA exists (not necessarily available)
 #                            hma allow reservation: Allow TSR and application (anything other than the DOS kernel) to request control of the HMA.

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -84,8 +84,8 @@ int21       = false
 fileio      = false
 
 [sdl]
-#        fullscreen: Start dosbox directly in fullscreen. (Press ALT-Enter to go back)
-#        fulldouble: Use double buffering in fullscreen. It can reduce screen flickering, but it can also result in a slow DOSBox.
+#        fullscreen: Start DOSBox-X directly in fullscreen. (Press ALT-Enter to go back)
+#        fulldouble: Use double buffering in fullscreen. It can reduce screen flickering, but it can also result in a slow DOSBox-X.
 #    fullresolution: What resolution to use for fullscreen: original, desktop or a fixed size (e.g. 1024x768).
 #                        Using your monitor's native resolution with aspect=true might give the best results.
 #                        If you end up with small window on a large screen, try an output different from surface.
@@ -112,14 +112,14 @@ fileio      = false
 #                      When using a high DPI mouse, the emulation of mouse movement can noticeably reduce the
 #                      sensitiveness of your device, i.e. the mouse is slower but more precise.
 #                      Possible values: integration, locked, always, never.
-#       waitonerror: Wait before closing the console if dosbox has an error.
-#          priority: Priority levels for dosbox. Second entry behind the comma is for when dosbox is not focused/minimized.
+#       waitonerror: Wait before closing the console if DOSBox-X has an error.
+#          priority: Priority levels for DOSBox-X. Second entry behind the comma is for when DOSBox-X is not focused/minimized.
 #                        pause is only valid for the second entry.
 #                      Possible values: lowest, lower, normal, higher, highest, pause.
 #        mapperfile: File used to load/save the key/event mappings from. Resetmapper only works with the default value.
 #      usescancodes: Avoid usage of symkeys, might not work on all operating systems.
 #          overscan: Width of overscan border (0 to 10). (works only if output=surface)
-#          titlebar: Change the string displayed in the DOSBox title bar.
+#          titlebar: Change the string displayed in the DOSBox-X title bar.
 #          showmenu: Whether to show the menu bar (if supported). Default true.
 fullscreen        = false
 fulldouble        = false

--- a/make-windows-release.pl
+++ b/make-windows-release.pl
@@ -41,7 +41,7 @@ my @filelist = ();
 
 my @platforms = ('ARM', 'ARM64', 'Win32', 'x64');
 my @builds = ('Release', 'Release SDL2');
-my @files = ('dosbox.reference.conf', 'dosbox-x.exe', 'FREECG98.bmp', 'changelog.txt', 'shaders');
+my @files = ('dosbox-x.reference.conf', 'dosbox-x.exe', 'FREECG98.bmp', 'changelog.txt', 'shaders');
 
 foreach $platform (@platforms) {
 	foreach $build (@builds) {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,7 @@ bin_PROGRAMS = dosbox-x
 resdir = $(datarootdir)/dosbox-x
 
 res_DATA = \
-	../dosbox.reference.conf \
+	../dosbox-x.reference.conf \
 	../font/FREECG98.BMP \
 	../CHANGELOG
 

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2901,6 +2901,11 @@ public:
             if (!PrepElTorito(type, el_torito_cd_drive, el_torito_floppy_base, el_torito_floppy_type)) return;
         }
 
+		if (temp_line.size() == 1 && isdigit(temp_line[0]) && temp_line[0]>='0' && temp_line[0]<MAX_DISK_IMAGES+'0' && cmd->FindExist("-u",false)) {
+			Unmount(temp_line[0]);
+			return;
+		}
+
         //default fstype is fat
         std::string fstype="fat";
         cmd->FindString("-fs",fstype,true);
@@ -3058,7 +3063,7 @@ public:
             }
             else {
                 if (AttachToBiosAndIdeByIndex(newImage, (unsigned char)driveIndex, (unsigned char)ide_index, ide_slave)) {
-                    WriteOut(MSG_Get("PROGRAM_IMGMOUNT_MOUNT_NUMBER"), drive - '0', (!paths.empty()) ? (wpcolon&&paths[0].length()>1&&paths[0].c_str()[0]==':'?paths[0].c_str()+1:paths[0].c_str()) : (el_torito != ""?el_torito.c_str():"-"));
+                    WriteOut(MSG_Get("PROGRAM_IMGMOUNT_MOUNT_NUMBER"), drive - '0', (!paths.empty()) ? (wpcolon&&paths[0].length()>1&&paths[0].c_str()[0]==':'?paths[0].c_str()+1:paths[0].c_str()) : (el_torito != ""?"El Torito floppy drive":(type == "ram"?"RAM drive":"-")));
 
                     if (paths.size() > 1) {
                         for (size_t si=0;si < MAX_SWAPPABLE_DISKS;si++) {
@@ -3298,13 +3303,14 @@ private:
                 imageDiskList[index]->Release();
                 imageDiskList[index] = NULL;
                 imageDiskChange[index] = true;
+				WriteOut(MSG_Get("PROGRAM_MOUNT_UMOUNT_NUMBER_SUCCESS"), letter);
                 return true;
             }
             WriteOut("No drive loaded at specified point\n");
             return false;
         }
         else {
-            WriteOut("Unknown imgmount unmount usage\n");
+            WriteOut("Incorrect IMGMOUNT unmount usage\n");
             return false;
         }
     }
@@ -4520,27 +4526,29 @@ void DOS_SetupPrograms(void) {
     MSG_Add("PROGRAM_MOUSE_HELP","Turns on/off mouse.\n\nMOUSE [/?] [/U] [/V]\n  /U: Uninstall\n  /V: Reverse Y-axis\n");
     MSG_Add("PROGRAM_MOUNT_CDROMS_FOUND","CDROMs found: %d\n");
     MSG_Add("PROGRAM_MOUNT_STATUS_FORMAT","%-5s  %-58s %-12s\n");
-    MSG_Add("PROGRAM_MOUNT_STATUS_ELTORITO", "Drive %c is mounted as el torito floppy\n");
-    MSG_Add("PROGRAM_MOUNT_STATUS_RAMDRIVE", "Drive %c is mounted as ram drive\n");
+    MSG_Add("PROGRAM_MOUNT_STATUS_ELTORITO", "Drive %c is mounted as El Torito floppy drive\n");
+    MSG_Add("PROGRAM_MOUNT_STATUS_RAMDRIVE", "Drive %c is mounted as RAM drive\n");
     MSG_Add("PROGRAM_MOUNT_STATUS_2","Drive %c is mounted as %s\n");
     MSG_Add("PROGRAM_MOUNT_STATUS_1","The currently mounted drives are:\n");
     MSG_Add("PROGRAM_MOUNT_ERROR_1","Directory %s doesn't exist.\n");
-    MSG_Add("PROGRAM_MOUNT_ERROR_2","%s isn't a directory\n");
+    MSG_Add("PROGRAM_MOUNT_ERROR_2","%s is not a directory\n");
     MSG_Add("PROGRAM_MOUNT_ILL_TYPE","Illegal type %s\n");
     MSG_Add("PROGRAM_MOUNT_ALREADY_MOUNTED","Drive %c already mounted with %s\n");
     MSG_Add("PROGRAM_MOUNT_USAGE",
-        "Usage \033[34;1mMOUNT [option] Drive-Letter Local-Directory\033[0m\n"
+        "Mounts drives from directories or drives in the host system.\n\n"
+        "Usage: \033[34;1mMOUNT [option] Drive-Letter Local-Directory\033[0m\n\n"
         "For example: MOUNT c %s\n"
         "This makes the directory %s act as the C: drive inside DOSBox-X.\n"
-        "The directory has to exist.\n"
+        "The directory has to exist in the host system.\n\n"
 		"Options are accepted. For example:\n"
 		"MOUNT -nocachedir c %s mounts C: without caching the drive.\n"
 		"MOUNT -freesize 128 c %s mounts C: with the specified free disk space.\n"
 		"MOUNT -ro c %s mounts the C: drive in read-only mode.\n"
 		"MOUNT -t cdrom c %s mounts the C: drive as a CD-ROM drive.\n"
 		"MOUNT -u c unmounts the C: drive.\n");
-    MSG_Add("PROGRAM_MOUNT_UMOUNT_NOT_MOUNTED","Drive %c isn't mounted.\n");
+    MSG_Add("PROGRAM_MOUNT_UMOUNT_NOT_MOUNTED","Drive %c is not mounted.\n");
     MSG_Add("PROGRAM_MOUNT_UMOUNT_SUCCESS","Drive %c has successfully been removed.\n");
+    MSG_Add("PROGRAM_MOUNT_UMOUNT_NUMBER_SUCCESS","Drive number %c has successfully been removed.\n");
     MSG_Add("PROGRAM_MOUNT_UMOUNT_NO_VIRTUAL","Virtual Drives can not be unMOUNTed.\n");
     MSG_Add("PROGRAM_MOUNT_WARNING_WIN","\033[31;1mMounting c:\\ is NOT recommended. Please mount a (sub)directory next time.\033[0m\n");
     MSG_Add("PROGRAM_MOUNT_WARNING_OTHER","\033[31;1mMounting / is NOT recommended. Please mount a (sub)directory next time.\033[0m\n");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1122,8 +1122,8 @@ void DOSBOX_SetupConfigSections(void) {
 #else
     Pbool = secprop->Add_bool("dpi aware",Property::Changeable::OnlyAtStart,true);
 #endif
-    Pbool->Set_help("Set this option (on by default) to indicate to your OS that DOSBox is DPI aware.\n"
-            "If it is not set, Windows Vista/7/8/10 and higher may upscale the DOSBox window\n"
+    Pbool->Set_help("Set this option (on by default) to indicate to your OS that DOSBox-X is DPI aware.\n"
+            "If it is not set, Windows Vista/7/8/10 and higher may upscale the DOSBox-X window\n"
             "on higher resolution monitors which is probably not what you want.");
 
     Pbool = secprop->Add_bool("keyboard hook", Property::Changeable::Always, false);
@@ -1138,7 +1138,7 @@ void DOSBOX_SetupConfigSections(void) {
 
     Pstring = secprop->Add_string("machine",Property::Changeable::OnlyAtStart,"svga_s3");
     Pstring->Set_values(machines);
-    Pstring->Set_help("The type of machine DOSBox tries to emulate.");
+    Pstring->Set_help("The type of machine DOSBox-X tries to emulate.");
 
     Phex = secprop->Add_hex("svga lfb base", Property::Changeable::OnlyAtStart, 0);
     Phex->Set_help("If nonzero, define the physical memory address of the linear framebuffer.");
@@ -1201,7 +1201,7 @@ void DOSBOX_SetupConfigSections(void) {
 
     Pint = secprop->Add_int("shell environment size",Property::Changeable::OnlyAtStart,0);
     Pint->SetMinMax(0,65280);
-    Pint->Set_help("Size of the initial DOSBox shell environment block, in bytes. This does not affect the environment block of sub-processes spawned from the shell.\n"
+    Pint->Set_help("Size of the initial DOSBox-X shell environment block, in bytes. This does not affect the environment block of sub-processes spawned from the shell.\n"
             "This option has no effect unless dynamic kernel allocation is enabled.");
 
     Pint = secprop->Add_int("private area size",Property::Changeable::OnlyAtStart,32768); // DOSBox mainline compatible 32KB region
@@ -1370,7 +1370,7 @@ void DOSBOX_SetupConfigSections(void) {
 #endif
     Pint->SetMinMax(1,3584); // 3.5GB
     Pint->Set_help(
-        "Amount of memory DOSBox has in megabytes.\n"
+        "Amount of memory DOSBox-X has in megabytes.\n"
         "This value is best left at its default to avoid problems with some games,\n"
         "though few games might require a higher value.\n"
         "There is generally no speed advantage when raising this value.n"
@@ -1379,7 +1379,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pint = secprop->Add_int("memsizekb", Property::Changeable::WhenIdle,0);
     Pint->SetMinMax(0,524288);
     Pint->Set_help(
-        "Amount of memory DOSBox has in kilobytes.\n"
+        "Amount of memory DOSBox-X has in kilobytes.\n"
         "This value should normally be set to 0.\n"
         "If nonzero, it is added to the memsize parameter.\n"
         "Finer grained control of total memory may be useful in\n"
@@ -2797,9 +2797,9 @@ void DOSBOX_SetupConfigSections(void) {
     Pint->Set_help("Number of XMS handles available for the DOS environment, or 0 to use a reasonable default");
 
     Pbool = secprop->Add_bool("shell configuration as commands",Property::Changeable::WhenIdle,false);
-    Pbool->Set_help("Allow entering dosbox.conf configuration parameters as shell commands to get and set settings.\n"
+    Pbool->Set_help("Allow entering dosbox-x.conf configuration parameters as shell commands to get and set settings.\n"
                     "This is disabled by default to avoid conflicts between commands and executables.\n"
-                    "It is recommended to get and set dosbox.conf settings using the CONFIG command instead.\n"
+                    "It is recommended to get and set dosbox-x.conf settings using the CONFIG command instead.\n"
                     "Compatibility with DOSBox SVN can be improved by enabling this option.");
 
     Pbool = secprop->Add_bool("hma",Property::Changeable::WhenIdle,true);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5775,10 +5775,10 @@ void SDL_SetupConfigSection() {
     Prop_multival* Pmulti;
 
     Pbool = sdl_sec->Add_bool("fullscreen",Property::Changeable::Always,false);
-    Pbool->Set_help("Start dosbox directly in fullscreen. (Press ALT-Enter to go back)");
+    Pbool->Set_help("Start DOSBox-X directly in fullscreen. (Press ALT-Enter to go back)");
      
     Pbool = sdl_sec->Add_bool("fulldouble",Property::Changeable::Always,false);
-    Pbool->Set_help("Use double buffering in fullscreen. It can reduce screen flickering, but it can also result in a slow DOSBox.");
+    Pbool->Set_help("Use double buffering in fullscreen. It can reduce screen flickering, but it can also result in a slow DOSBox-X.");
 
     //Pbool = sdl_sec->Add_bool("sdlresize",Property::Changeable::Always,false);
     //Pbool->Set_help("Makes window resizable (depends on scalers)");
@@ -5871,11 +5871,11 @@ void SDL_SetupConfigSection() {
     Pstring->Set_values(emulation);
 
     Pbool = sdl_sec->Add_bool("waitonerror",Property::Changeable::Always, true);
-    Pbool->Set_help("Wait before closing the console if dosbox has an error.");
+    Pbool->Set_help("Wait before closing the console if DOSBox-X has an error.");
 
     Pmulti = sdl_sec->Add_multi("priority", Property::Changeable::Always, ",");
     Pmulti->SetValue("higher,normal",/*init*/true);
-    Pmulti->Set_help("Priority levels for dosbox. Second entry behind the comma is for when dosbox is not focused/minimized.\n"
+    Pmulti->Set_help("Priority levels for DOSBox-X. Second entry behind the comma is for when DOSBox-X is not focused/minimized.\n"
                      "  pause is only valid for the second entry.");
 
     const char* actt[] = { "lowest", "lower", "normal", "higher", "highest", "pause", 0};
@@ -5907,7 +5907,7 @@ void SDL_SetupConfigSection() {
     Pint->Set_help("Width of overscan border (0 to 10). (works only if output=surface)");
 
     Pstring = sdl_sec->Add_string("titlebar", Property::Changeable::Always, "");
-    Pstring->Set_help("Change the string displayed in the DOSBox title bar.");
+    Pstring->Set_help("Change the string displayed in the DOSBox-X title bar.");
 
     Pbool = sdl_sec->Add_bool("showmenu", Property::Changeable::Always, true);
     Pbool->Set_help("Whether to show the menu bar (if supported). Default true.");

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -28,6 +28,7 @@
 #include "programs.h"
 #include "zipfile.h"
 #include "regs.h"
+#include "../dos/drives.h"
 #ifndef WIN32
 # include <stdlib.h>
 # include <unistd.h>
@@ -1593,6 +1594,9 @@ public:
 			WriteOut("Restarts the kernel of DOSBox-X's emulated DOS.\n\nRE-DOS\n");
 			return;
 		}
+		for (int i=0; i < DOS_DRIVES; i++)
+			if (Drives[i])
+				DriveManager::UnmountDrive(i);
         throw int(6);
     }
 };

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -830,10 +830,11 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_COPY_CONFIRM","Overwrite %s (Yes/No/All)?");
 	MSG_Add("SHELL_CMD_COPY_NOSPACE","Insufficient disk space - %s\n");
 	MSG_Add("SHELL_CMD_COPY_ERROR","Error in copying file %s\n");
+	MSG_Add("SHELL_CMD_SUBST_DRIVE_LIST","To list all currently mounted drives, use MOUNT command without a parameter.\n");
 	MSG_Add("SHELL_CMD_SUBST_NO_REMOVE","Unable to remove, drive not in use.\n");
 	MSG_Add("SHELL_CMD_SUBST_IN_USE","Target drive is already in use.\n");
 	MSG_Add("SHELL_CMD_SUBST_NOT_LOCAL","It is only possible to use SUBST on local drives.\n");
-	MSG_Add("SHELL_CMD_SUBST_INVALID_PATH","The specified path is invalid.\n");
+	MSG_Add("SHELL_CMD_SUBST_INVALID_PATH","The specified drive or path is invalid.\n");
 	MSG_Add("SHELL_CMD_SUBST_FAILURE","SUBST: There is an error in your command line.\n");
 
     std::string mapper_keybind = mapper_event_keybind_string("host");

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -88,6 +88,7 @@ static SHELL_Cmd cmd_list[]={
 {	"FOR",	1,			&DOS_Shell::CMD_FOR,		"SHELL_CMD_FOR_HELP"},
 {	"LFNFOR",	1,			&DOS_Shell::CMD_LFNFOR,		"SHELL_CMD_LFNFOR_HELP"},
 {	"TRUENAME",	1,			&DOS_Shell::CMD_TRUENAME,		"SHELL_CMD_TRUENAME_HELP"},
+// The following are additional commands for debugging purposes in DOSBox-X
 {	"INT2FDBG",	1,			&DOS_Shell::CMD_INT2FDBG,	"Hook INT 2Fh for debugging purposes.\n"},
 {   "DX-CAPTURE",1,         &DOS_Shell::CMD_DXCAPTURE,  "Run program with video/audio capture.\n"},
 #if C_DEBUG
@@ -2105,6 +2106,10 @@ void DOS_Shell::CMD_SUBST(char * args) {
 		StripSpaces(args);
 		std::string arg;
 		CommandLine command(0,args);
+		if (!command.GetCount()) {
+		    WriteOut(MSG_Get("SHELL_CMD_SUBST_DRIVE_LIST"));
+			return;
+		}
 
 		if (command.GetCount() != 2) throw 0 ;
   
@@ -2128,10 +2133,10 @@ void DOS_Shell::CMD_SUBST(char * args) {
         if (strchr(arg.c_str(),'\"')==NULL)
             sprintf(dir,"\"%s\"",arg.c_str());
         else strcpy(dir,arg.c_str());
-        if (!DOS_MakeName(dir,fulldir,&drive)) throw 4;
+        if (!DOS_MakeName(dir,fulldir,&drive)) throw 3;
 	
 		localDrive* ldp=0;
-		if( ( ldp=dynamic_cast<localDrive*>(Drives[drive])) == 0 ) throw 3;
+		if( ( ldp=dynamic_cast<localDrive*>(Drives[drive])) == 0 ) throw 4;
 		char newname[CROSS_LEN];   
 		strcpy(newname, ldp->basedir);	   
 		strcat(newname,fulldir);
@@ -2151,10 +2156,10 @@ void DOS_Shell::CMD_SUBST(char * args) {
 				WriteOut(MSG_Get("SHELL_CMD_SUBST_IN_USE"));
 				break;
 			case 3:
-				WriteOut(MSG_Get("SHELL_CMD_SUBST_NOT_LOCAL"));
+				WriteOut(MSG_Get("SHELL_CMD_SUBST_INVALID_PATH"));
 				break;
 			case 4:
-				WriteOut(MSG_Get("SHELL_CMD_SUBST_INVALID_PATH"));
+				WriteOut(MSG_Get("SHELL_CMD_SUBST_NOT_LOCAL"));
 				break;
 			default:
 				WriteOut(MSG_Get("SHELL_CMD_SUBST_FAILURE"));
@@ -2464,6 +2469,7 @@ void DOS_Shell::CMD_VOL(char *args){
 			}
 			break;
 		default:
+			WriteOut(MSG_Get("SHELL_SYNTAXERROR"));
 			return;
 		}
 	}

--- a/update-dosbox-reference-conf
+++ b/update-dosbox-reference-conf
@@ -1,5 +1,0 @@
-#!/bin/bash
-src/dosbox-x -c 'config -all -wc dosbox.reference.conf' -c 'exit' || exit 1
-sed $'s/$/\r/' 'dosbox.reference.conf' >'dosbox.reference.conf.tmp' || exit 1
-mv -v 'dosbox.reference.conf.tmp' 'dosbox.reference.conf' || exit 1
-

--- a/update-dosbox-x-reference-conf
+++ b/update-dosbox-x-reference-conf
@@ -1,0 +1,5 @@
+#!/bin/bash
+src/dosbox-x -c 'config -all -wc dosbox-x.reference.conf' -c 'exit' || exit 1
+sed $'s/$/\r/' 'dosbox-x.reference.conf' >'dosbox-x.reference.conf.tmp' || exit 1
+mv -v 'dosbox-x.reference.conf.tmp' 'dosbox-x.reference.conf' || exit 1
+

--- a/vs2015/dosbox-x.vcxproj
+++ b/vs2015/dosbox-x.vcxproj
@@ -348,7 +348,7 @@
     </CustomBuildStep>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)\..\font\FREECG98.BMP" "$(OutputPath)\FREECG98.BMP"
-copy "$(SolutionDir)\..\dosbox.reference.conf" "$(OutputPath)\dosbox.reference.conf"
+copy "$(SolutionDir)\..\dosbox-x.reference.conf" "$(OutputPath)\dosbox-x.reference.conf"
 copy "$(SolutionDir)\..\CHANGELOG" "$(OutputPath)\changelog.txt"
 mkdir "$(OutputPath)\shaders"
 copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
@@ -382,7 +382,7 @@ copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
     </CustomBuildStep>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)\..\font\FREECG98.BMP" "$(OutputPath)\FREECG98.BMP"
-copy "$(SolutionDir)\..\dosbox.reference.conf" "$(OutputPath)\dosbox.reference.conf"
+copy "$(SolutionDir)\..\dosbox-x.reference.conf" "$(OutputPath)\dosbox-x.reference.conf"
 copy "$(SolutionDir)\..\CHANGELOG" "$(OutputPath)\changelog.txt"
 mkdir "$(OutputPath)\shaders"
 copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
@@ -412,7 +412,7 @@ copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)\..\font\FREECG98.BMP" "$(OutputPath)\FREECG98.BMP"
-copy "$(SolutionDir)\..\dosbox.reference.conf" "$(OutputPath)\dosbox.reference.conf"
+copy "$(SolutionDir)\..\dosbox-x.reference.conf" "$(OutputPath)\dosbox-x.reference.conf"
 copy "$(SolutionDir)\..\CHANGELOG" "$(OutputPath)\changelog.txt"
 mkdir "$(OutputPath)\shaders"
 copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
@@ -443,7 +443,7 @@ copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)\..\font\FREECG98.BMP" "$(OutputPath)\FREECG98.BMP"
-copy "$(SolutionDir)\..\dosbox.reference.conf" "$(OutputPath)\dosbox.reference.conf"
+copy "$(SolutionDir)\..\dosbox-x.reference.conf" "$(OutputPath)\dosbox-x.reference.conf"
 copy "$(SolutionDir)\..\CHANGELOG" "$(OutputPath)\changelog.txt"
 mkdir "$(OutputPath)\shaders"
 copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
@@ -474,7 +474,7 @@ copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)\..\font\FREECG98.BMP" "$(OutputPath)\FREECG98.BMP"
-copy "$(SolutionDir)\..\dosbox.reference.conf" "$(OutputPath)\dosbox.reference.conf"
+copy "$(SolutionDir)\..\dosbox-x.reference.conf" "$(OutputPath)\dosbox-x.reference.conf"
 copy "$(SolutionDir)\..\CHANGELOG" "$(OutputPath)\changelog.txt"
 mkdir "$(OutputPath)\shaders"
 copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
@@ -507,7 +507,7 @@ copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)\..\font\FREECG98.BMP" "$(OutputPath)\FREECG98.BMP"
-copy "$(SolutionDir)\..\dosbox.reference.conf" "$(OutputPath)\dosbox.reference.conf"
+copy "$(SolutionDir)\..\dosbox-x.reference.conf" "$(OutputPath)\dosbox-x.reference.conf"
 copy "$(SolutionDir)\..\CHANGELOG" "$(OutputPath)\changelog.txt"
 mkdir "$(OutputPath)\shaders"
 copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
@@ -538,7 +538,7 @@ copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)\..\font\FREECG98.BMP" "$(OutputPath)\FREECG98.BMP"
-copy "$(SolutionDir)\..\dosbox.reference.conf" "$(OutputPath)\dosbox.reference.conf"
+copy "$(SolutionDir)\..\dosbox-x.reference.conf" "$(OutputPath)\dosbox-x.reference.conf"
 copy "$(SolutionDir)\..\CHANGELOG" "$(OutputPath)\changelog.txt"
 mkdir "$(OutputPath)\shaders"
 copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
@@ -569,7 +569,7 @@ copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)\..\font\FREECG98.BMP" "$(OutputPath)\FREECG98.BMP"
-copy "$(SolutionDir)\..\dosbox.reference.conf" "$(OutputPath)\dosbox.reference.conf"
+copy "$(SolutionDir)\..\dosbox-x.reference.conf" "$(OutputPath)\dosbox-x.reference.conf"
 copy "$(SolutionDir)\..\CHANGELOG" "$(OutputPath)\changelog.txt"
 mkdir "$(OutputPath)\shaders"
 copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
@@ -606,7 +606,7 @@ copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
     </CustomBuildStep>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)\..\font\FREECG98.BMP" "$(OutputPath)\FREECG98.BMP"
-copy "$(SolutionDir)\..\dosbox.reference.conf" "$(OutputPath)\dosbox.reference.conf"
+copy "$(SolutionDir)\..\dosbox-x.reference.conf" "$(OutputPath)\dosbox-x.reference.conf"
 copy "$(SolutionDir)\..\CHANGELOG" "$(OutputPath)\changelog.txt"
 mkdir "$(OutputPath)\shaders"
 copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
@@ -641,7 +641,7 @@ copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
     </CustomBuildStep>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)\..\font\FREECG98.BMP" "$(OutputPath)\FREECG98.BMP"
-copy "$(SolutionDir)\..\dosbox.reference.conf" "$(OutputPath)\dosbox.reference.conf"
+copy "$(SolutionDir)\..\dosbox-x.reference.conf" "$(OutputPath)\dosbox-x.reference.conf"
 copy "$(SolutionDir)\..\CHANGELOG" "$(OutputPath)\changelog.txt"
 mkdir "$(OutputPath)\shaders"
 copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
@@ -672,7 +672,7 @@ copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)\..\font\FREECG98.BMP" "$(OutputPath)\FREECG98.BMP"
-copy "$(SolutionDir)\..\dosbox.reference.conf" "$(OutputPath)\dosbox.reference.conf"
+copy "$(SolutionDir)\..\dosbox-x.reference.conf" "$(OutputPath)\dosbox-x.reference.conf"
 copy "$(SolutionDir)\..\CHANGELOG" "$(OutputPath)\changelog.txt"
 mkdir "$(OutputPath)\shaders"
 copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
@@ -704,7 +704,7 @@ copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)\..\font\FREECG98.BMP" "$(OutputPath)\FREECG98.BMP"
-copy "$(SolutionDir)\..\dosbox.reference.conf" "$(OutputPath)\dosbox.reference.conf"
+copy "$(SolutionDir)\..\dosbox-x.reference.conf" "$(OutputPath)\dosbox-x.reference.conf"
 copy "$(SolutionDir)\..\CHANGELOG" "$(OutputPath)\changelog.txt"
 mkdir "$(OutputPath)\shaders"
 copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
@@ -736,7 +736,7 @@ copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)\..\font\FREECG98.BMP" "$(OutputPath)\FREECG98.BMP"
-copy "$(SolutionDir)\..\dosbox.reference.conf" "$(OutputPath)\dosbox.reference.conf"
+copy "$(SolutionDir)\..\dosbox-x.reference.conf" "$(OutputPath)\dosbox-x.reference.conf"
 copy "$(SolutionDir)\..\CHANGELOG" "$(OutputPath)\changelog.txt"
 mkdir "$(OutputPath)\shaders"
 copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
@@ -770,7 +770,7 @@ copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)\..\font\FREECG98.BMP" "$(OutputPath)\FREECG98.BMP"
-copy "$(SolutionDir)\..\dosbox.reference.conf" "$(OutputPath)\dosbox.reference.conf"
+copy "$(SolutionDir)\..\dosbox-x.reference.conf" "$(OutputPath)\dosbox-x.reference.conf"
 copy "$(SolutionDir)\..\CHANGELOG" "$(OutputPath)\changelog.txt"
 mkdir "$(OutputPath)\shaders"
 copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
@@ -802,7 +802,7 @@ copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)\..\font\FREECG98.BMP" "$(OutputPath)\FREECG98.BMP"
-copy "$(SolutionDir)\..\dosbox.reference.conf" "$(OutputPath)\dosbox.reference.conf"
+copy "$(SolutionDir)\..\dosbox-x.reference.conf" "$(OutputPath)\dosbox-x.reference.conf"
 copy "$(SolutionDir)\..\CHANGELOG" "$(OutputPath)\changelog.txt"
 mkdir "$(OutputPath)\shaders"
 copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
@@ -834,7 +834,7 @@ copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)\..\font\FREECG98.BMP" "$(OutputPath)\FREECG98.BMP"
-copy "$(SolutionDir)\..\dosbox.reference.conf" "$(OutputPath)\dosbox.reference.conf"
+copy "$(SolutionDir)\..\dosbox-x.reference.conf" "$(OutputPath)\dosbox-x.reference.conf"
 copy "$(SolutionDir)\..\CHANGELOG" "$(OutputPath)\changelog.txt"
 mkdir "$(OutputPath)\shaders"
 copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>


### PR DESCRIPTION
I am creating this pull request to fix Issue #1495 (Disk swap counting bug) as reported by rderooy; also renamed the file dosbox.reference.conf to dosbox-x.reference.conf and changed this name in other files in the repository.

In addition, I cleaned up some messages for the IMGMOUNT command, and some config file comments still using the name "DOSBox" are changed to "DOSBox-X" as well.



