### PR TITLE
Code cleanup

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -54,7 +54,7 @@ public:
 	BatchFile(DOS_Shell * host,char const* const resolved_name,char const* const entered_name, char const * const cmd_line);
 	virtual ~BatchFile();
 	virtual bool ReadLine(char * line);
-	bool Goto(char * where);
+	bool Goto(const char * where);
 	void Shift(void);
 	Bit16u file_handle;
 	Bit32u location;
@@ -118,7 +118,7 @@ public:
 
     /*! \brief      Execute a command
      */
-	bool Execute(char * name,char * args);
+    bool Execute(char* name, const char* args);
 
 	/*! \brief      Checks if it matches a hardware-property */
 	bool CheckConfig(char* cmd_in,char*line);

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -653,11 +653,6 @@ void CPU_CheckSegments(void) {
 class TaskStateSegment {
 public:
 	TaskStateSegment() {
-		valid=false;
-        base = 0;
-        is386 = 0;
-        limit = 0;
-        selector = 0;
 	}
 	bool IsValid(void) {
 		return valid;
@@ -712,11 +707,11 @@ public:
 	}
 
 	TSS_Descriptor desc;
-	Bitu selector;
-	PhysPt base;
-	Bitu limit;
-	Bitu is386;
-	bool valid;
+	Bitu selector = 0;
+	PhysPt base = 0;
+	Bitu limit = 0;
+	Bitu is386 = 0;
+	bool valid = false;
 };
 
 TaskStateSegment cpu_tss;

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -263,7 +263,7 @@ void menu_update_cputype(void) {
 }
 
 void menu_update_core(void) {
-	Section_prop * cpu_section = static_cast<Section_prop *>(control->GetSection("cpu"));
+	const Section_prop * cpu_section = static_cast<Section_prop *>(control->GetSection("cpu"));
 	const std::string cpu_sec_type = cpu_section->Get_string("cputype");
     bool allow_dynamic = false;
 
@@ -488,7 +488,7 @@ void Descriptor::Load(PhysPt address) {
 }
 void Descriptor:: Save(PhysPt address) {
 	cpu.mpl=0;
-	Bit32u* data = (Bit32u*)&saved;
+	const Bit32u* data = (Bit32u*)&saved;
 	mem_writed(address,*data);
 	mem_writed(address+4,*(data+1));
 	cpu.mpl=3;
@@ -1291,7 +1291,7 @@ do_interrupt:
 			E_Exit("Illegal descriptor type %X for int %X",(int)gate.Type(),(int)num);
 		}
 		}
-		catch (GuestPageFaultException &pf) {
+		catch (const GuestPageFaultException &pf) {
             (void)pf;//UNUSED
 			LOG_MSG("CPU_Interrupt() interrupted");
 			CPU_SetSegGeneral(ss,old_ss);
@@ -1371,7 +1371,7 @@ void CPU_IRET(bool use32,Bit32u oldeip) {
 					CPU_SetFlags(new_flags,FMASK_NORMAL|FLAG_NT);
 				}
 				}
-				catch (GuestPageFaultException &pf) {
+				catch (const GuestPageFaultException &pf) {
                     (void)pf;//UNUSED
                     LOG_MSG("CPU_IRET() interrupted prot vm86");
 					reg_esp = orig_esp;
@@ -1433,7 +1433,7 @@ void CPU_IRET(bool use32,Bit32u oldeip) {
 				LOG(LOG_CPU,LOG_NORMAL)("IRET:Back to V86: CS:%X IP %X SS:%X SP %X FLAGS:%X",SegValue(cs),reg_eip,SegValue(ss),reg_esp,reg_flags);	
 				return;
 				}
-				catch (GuestPageFaultException &pf) {
+				catch (const GuestPageFaultException &pf) {
                     (void)pf;//UNUSED
                     LOG_MSG("CPU_IRET() interrupted prot use32");
 					reg_esp = orig_esp;
@@ -1666,7 +1666,7 @@ void CPU_CALL(bool use32,Bitu selector,Bitu offset,Bit32u oldeip) {
 			reg_eip=(Bit32u)offset;
 		}
 		}
-		catch (GuestPageFaultException &pf) {
+		catch (const GuestPageFaultException &pf) {
             (void)pf;//UNUSED
 			reg_esp = old_esp;
 			reg_eip = old_eip;
@@ -1720,7 +1720,7 @@ call_code:
 				reg_eip=(Bit32u)offset;
 			}
 			}
-			catch (GuestPageFaultException &pf) {
+			catch (const GuestPageFaultException &pf) {
                 (void)pf;//UNUSED
                 reg_esp = old_esp;
 				reg_eip = old_eip;
@@ -1881,7 +1881,7 @@ call_code:
 						CPU_Push16(oldeip);
 					}
 					}
-					catch (GuestPageFaultException &pf) {
+					catch (const GuestPageFaultException &pf) {
                         (void)pf;//UNUSED
                         reg_esp = old_esp;
 						reg_eip = old_eip;
@@ -1951,7 +1951,7 @@ void CPU_RET(bool use32,Bitu bytes,Bit32u oldeip) {
 		if (!cpu_allow_big16) cpu.code.big=false;
 		return;
 		}
-		catch (GuestPageFaultException &pf) {
+		catch (const GuestPageFaultException &pf) {
             (void)pf;//UNUSED
             LOG_MSG("CPU_RET() interrupted real/vm86");
 			reg_esp = orig_esp;
@@ -2012,7 +2012,7 @@ RET_same_level:
 				selector=CPU_Pop32() & 0xffff;
 			}
 			}
-			catch (GuestPageFaultException &pf) {
+			catch (const GuestPageFaultException &pf) {
                 (void)pf;//UNUSED
                 LOG_MSG("CPU_RET() interrupted prot rpl==cpl");
 				reg_esp = orig_esp;
@@ -2072,7 +2072,7 @@ RET_same_level:
 				n_ss = CPU_Pop16();
 			}
 			}
-			catch (GuestPageFaultException &pf) {
+			catch (const GuestPageFaultException &pf) {
                 (void)pf;//UNUSED
                 LOG_MSG("CPU_RET() interrupted prot #2");
 				reg_esp = orig_esp;
@@ -2870,7 +2870,7 @@ void CPU_SyncCycleMaxToProp(void) {
     char tmp[64];
 
     Section* sec=control->GetSection("cpu");
-	Section_prop * secprop = static_cast<Section_prop *>(sec);
+	const Section_prop * secprop = static_cast<Section_prop *>(sec);
     Prop_multival* p = secprop->Get_multival("cycles");
     Property* prop = p->GetSection()->Get_prop("type");
     sprintf(tmp,"%llu",(unsigned long long)CPU_CycleMax);
@@ -3112,7 +3112,7 @@ private:
 	static bool inited;
 public:
 	CPU(Section* configuration):Module_base(configuration) {
-		Section_prop * section=static_cast<Section_prop *>(configuration);
+		const Section_prop * section=static_cast<Section_prop *>(configuration);
 		DOSBoxMenu::item *item;
 
 		if(inited) {
@@ -3237,7 +3237,7 @@ public:
 		CPU_JMP(false,0,0,0);					//Setup the first cpu core
 	}
 	bool Change_Config(Section* newconfig){
-		Section_prop * section=static_cast<Section_prop *>(newconfig);
+		const Section_prop * section=static_cast<Section_prop *>(newconfig);
 		CPU_AutoDetermineMode=CPU_AUTODETERMINE_NONE;
 		//CPU_CycleLeft=0;//needed ?
 		CPU_Cycles=0;
@@ -3539,7 +3539,7 @@ public:
 
     // weitek coprocessor emulation?
         if (CPU_ArchitectureType == CPU_ARCHTYPE_386 || CPU_ArchitectureType == CPU_ARCHTYPE_486OLD || CPU_ArchitectureType == CPU_ARCHTYPE_486NEW) {
-	        Section_prop *dsection = static_cast<Section_prop *>(control->GetSection("dosbox"));
+	        const Section_prop *dsection = static_cast<Section_prop *>(control->GetSection("dosbox"));
 
             enable_weitek = dsection->Get_bool("weitek");
             if (enable_weitek) {

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -740,7 +740,6 @@ public:
             }
         }
     }
-public:
     /*! \brief      Array of disk images to add to floppy swaplist
      */
     imageDisk* newDiskSwap[MAX_SWAPPABLE_DISKS] = {};
@@ -2830,7 +2829,6 @@ bool FDC_UnassignINT13Disk(unsigned char drv);
 class IMGMOUNT : public Program {
 public:
     std::vector<std::string> options;
-public:
     void Run(void) {
         //Hack To allow long commandlines
         ChangeToLongCmd();

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1635,7 +1635,7 @@ bool fatDrive::FileUnlink(const char * name) {
 		}
 		int fbak=faux;
 		faux=256;
-		imgDTA->SetupSearch(0,0xffff & ~DOS_ATTR_VOLUME & ~DOS_ATTR_DIRECTORY,pattern);
+		imgDTA->SetupSearch((Bit8u)0,(Bit8u)(0xffff & ~DOS_ATTR_VOLUME & ~DOS_ATTR_DIRECTORY),pattern);
 		imgDTA->SetDirID(0);
 		direntry foundEntry;
 		std::vector<std::string> cdirs;

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -79,7 +79,7 @@ private:
 };
 
 void time_t_to_DOS_DateTime(Bit16u &t,Bit16u &d,time_t unix_time) {
-    struct tm *tm = localtime(&unix_time);
+    const struct tm *tm = localtime(&unix_time);
     if (tm == NULL) return;
 
     /* NTS: tm->tm_year = years since 1900,
@@ -1063,7 +1063,7 @@ void fatDrive::UpdateDPB(unsigned char dos_drive) {
     }
 }
 
-void fatDrive::fatDriveInit(const char *sysFilename, Bit32u bytesector, Bit32u cylsector, Bit32u headscyl, Bit32u cylinders, Bit64u filesize, std::vector<std::string> &options) {
+void fatDrive::fatDriveInit(const char *sysFilename, Bit32u bytesector, Bit32u cylsector, Bit32u headscyl, Bit32u cylinders, Bit64u filesize, const std::vector<std::string> &options) {
 	Bit32u startSector;
 	bool pc98_512_to_1024_allow = false;
     int opt_partition_index = -1;
@@ -1149,7 +1149,7 @@ void fatDrive::fatDriveInit(const char *sysFilename, Bit32u bytesector, Bit32u c
                 }
 
                 i = (unsigned int)opt_partition_index;
-                _PC98RawPartition *pe = (_PC98RawPartition*)(ipltable+(i * 32));
+                const _PC98RawPartition *pe = (_PC98RawPartition*)(ipltable+(i * 32));
 
                 /* unfortunately start and end are in C/H/S geometry, so we have to translate.
                  * this is why it matters so much to read the geometry from the HDI header.
@@ -1174,7 +1174,7 @@ void fatDrive::fatDriveInit(const char *sysFilename, Bit32u bytesector, Bit32u c
             }
             else {
                 for (i=0;i < max_entries;i++) {
-                    _PC98RawPartition *pe = (_PC98RawPartition*)(ipltable+(i * 32));
+                    const _PC98RawPartition *pe = (_PC98RawPartition*)(ipltable+(i * 32));
 
                     if (pe->mid == 0 && pe->sid == 0 &&
                             pe->ipl_sect == 0 && pe->ipl_head == 0 && pe->ipl_cyl == 0 &&
@@ -1980,7 +1980,7 @@ bool fatDrive::directoryBrowse(Bit32u dirClustNumber, direntry *useEntry, Bit32s
 	return true;
 }
 
-bool fatDrive::directoryChange(Bit32u dirClustNumber, direntry *useEntry, Bit32s entNum) {
+bool fatDrive::directoryChange(Bit32u dirClustNumber, const direntry *useEntry, Bit32s entNum) {
 	direntry sectbuf[MAX_DIRENTS_PER_SECTOR];	/* 16 directory entries per 512 byte sector */
 	Bit32u entryoffset = 0;	/* Index offset within sector */
 	Bit32u tmpsector = 0;
@@ -2020,7 +2020,7 @@ bool fatDrive::directoryChange(Bit32u dirClustNumber, direntry *useEntry, Bit32s
 	}
 }
 
-bool fatDrive::addDirectoryEntry(Bit32u dirClustNumber, direntry& useEntry) {
+bool fatDrive::addDirectoryEntry(Bit32u dirClustNumber, const direntry& useEntry) {
 	direntry sectbuf[MAX_DIRENTS_PER_SECTOR]; /* 16 directory entries per 512 byte sector */
 	Bit32u tmpsector;
 	Bit16u dirPos = 0;

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -57,7 +57,6 @@ public:
     void Flush(void);
 	bool UpdateDateTimeFromHost(void);   
 	Bit32u GetSeekPos(void);
-public:
 	Bit32u firstCluster;
 	Bit32u seekpos = 0;
 	Bit32u filelength;
@@ -71,8 +70,9 @@ public:
     bool modified = false;
 	bool loadedSector = false;
 	fatDrive *myDrive;
-private:
+
 #if 0/*unused*/
+private:
     enum { NONE,READ,WRITE } last_action;
 	Bit16u info;
 #endif

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -59,17 +59,17 @@ public:
 	Bit32u GetSeekPos(void);
 public:
 	Bit32u firstCluster;
-	Bit32u seekpos;
+	Bit32u seekpos = 0;
 	Bit32u filelength;
-	Bit32u currentSector;
-	Bit32u curSectOff;
+	Bit32u currentSector = 0;
+	Bit32u curSectOff = 0;
 	Bit8u sectorBuffer[SECTOR_SIZE_MAX];
 	/* Record of where in the directory structure this file is located */
-	Bit32u dirCluster;
-	Bit32u dirIndex;
+	Bit32u dirCluster = 0;
+	Bit32u dirIndex = 0;
 
-    bool modified;
-	bool loadedSector;
+    bool modified = false;
+	bool loadedSector = false;
 	fatDrive *myDrive;
 private:
 #if 0/*unused*/
@@ -108,20 +108,10 @@ static void convToDirFile(const char *filename, char *filearray) {
 	}
 }
 
-fatFile::fatFile(const char* /*name*/, Bit32u startCluster, Bit32u fileLen, fatDrive *useDrive) {
+fatFile::fatFile(const char* /*name*/, Bit32u startCluster, Bit32u fileLen, fatDrive *useDrive) : firstCluster(startCluster), filelength(fileLen), myDrive(useDrive) {
 	Bit32u seekto = 0;
-	firstCluster = startCluster;
-	myDrive = useDrive;
-	filelength = fileLen;
-    modified = false;
 	open = true;
-	loadedSector = false;
-	curSectOff = 0;
-	seekpos = 0;
 	memset(&sectorBuffer[0], 0, sizeof(sectorBuffer));
-    currentSector = 0;
-    dirCluster = 0;
-    dirIndex = 0;
 	
 	if(filelength > 0) {
 		Seek(&seekto, DOS_SEEK_SET);
@@ -912,8 +902,7 @@ struct _PC98RawPartition {
 };
 #pragma pack(pop)
 
-fatDrive::fatDrive(const char *sysFilename, Bit32u bytesector, Bit32u cylsector, Bit32u headscyl, Bit32u cylinders, std::vector<std::string> &options) : loadedDisk(NULL) {
-	created_successfully = true;
+fatDrive::fatDrive(const char* sysFilename, Bit32u bytesector, Bit32u cylsector, Bit32u headscyl, Bit32u cylinders, std::vector<std::string>& options) {
 	FILE *diskfile;
 	Bit32u filesize;
 	
@@ -985,7 +974,7 @@ fatDrive::fatDrive(const char *sysFilename, Bit32u bytesector, Bit32u cylsector,
     fatDriveInit(sysFilename, bytesector, cylsector, headscyl, cylinders, filesize, options);
 }
 
-fatDrive::fatDrive(imageDisk *sourceLoadedDisk, std::vector<std::string> &options) : loadedDisk(NULL) {
+fatDrive::fatDrive(imageDisk *sourceLoadedDisk, std::vector<std::string> &options) {
 	if (sourceLoadedDisk == 0) {
 		created_successfully = false;
 		return;

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -214,7 +214,7 @@ class fatDrive : public DOS_Drive {
 public:
 	fatDrive(const char * sysFilename, Bit32u bytesector, Bit32u cylsector, Bit32u headscyl, Bit32u cylinders, std::vector<std::string> &options);
 	fatDrive(imageDisk *sourceLoadedDisk, std::vector<std::string> &options);
-    void fatDriveInit(const char *sysFilename, Bit32u bytesector, Bit32u cylsector, Bit32u headscyl, Bit32u cylinders, Bit64u filesize, std::vector<std::string> &options);
+    void fatDriveInit(const char *sysFilename, Bit32u bytesector, Bit32u cylsector, Bit32u headscyl, Bit32u cylinders, Bit64u filesize, const std::vector<std::string> &options);
     virtual ~fatDrive();
 	virtual bool FileOpen(DOS_File * * file,const char * name,Bit32u flags);
 	virtual bool FileCreate(DOS_File * * file,const char * name,Bit16u attributes);
@@ -251,7 +251,7 @@ public:
 	void deleteClustChain(Bit32u startCluster, Bit32u bytePos);
 	Bit32u getFirstFreeClust(void);
 	bool directoryBrowse(Bit32u dirClustNumber, direntry *useEntry, Bit32s entNum, Bit32s start=0);
-	bool directoryChange(Bit32u dirClustNumber, direntry *useEntry, Bit32s entNum);
+	bool directoryChange(Bit32u dirClustNumber, const direntry *useEntry, Bit32s entNum);
 	imageDisk *loadedDisk = NULL;
 	bool created_successfully = true;
 private:
@@ -261,7 +261,7 @@ private:
 	bool FindNextInternal(Bit32u dirClustNumber, DOS_DTA & dta, direntry *foundEntry);
 	bool getDirClustNum(const char * dir, Bit32u * clustNum, bool parDir);
 	bool getFileDirEntry(char const * const filename, direntry * useEntry, Bit32u * dirClust, Bit32u * subEntry);
-	bool addDirectoryEntry(Bit32u dirClustNumber, direntry& useEntry);
+	bool addDirectoryEntry(Bit32u dirClustNumber, const direntry& useEntry);
 	void zeroOutCluster(Bit32u clustNumber);
 	bool getEntryName(const char *fullname, char *entname);
 	friend void DOS_Shell::CMD_SUBST(char* args); 	

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -252,8 +252,8 @@ public:
 	Bit32u getFirstFreeClust(void);
 	bool directoryBrowse(Bit32u dirClustNumber, direntry *useEntry, Bit32s entNum, Bit32s start=0);
 	bool directoryChange(Bit32u dirClustNumber, direntry *useEntry, Bit32s entNum);
-	imageDisk *loadedDisk;
-	bool created_successfully;
+	imageDisk *loadedDisk = NULL;
+	bool created_successfully = true;
 private:
 	Bit32u getClusterValue(Bit32u clustNum);
 	void setClusterValue(Bit32u clustNum, Bit32u clustValue);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -264,7 +264,7 @@ void                INT10_Init(Section*);
 void                PRINTER_Init(Section*);
 #endif
 
-signed long long time_to_clockdom(ClockDomain &src,double t) {
+signed long long time_to_clockdom(const ClockDomain &src,double t) {
     signed long long lt = (signed long long)t;
 
     lt *= (signed long long)src.freq;
@@ -385,7 +385,7 @@ static Bitu Normal_Loop(void) {
             }
         }
     }
-    catch (GuestPageFaultException& pf) {
+    catch (const GuestPageFaultException& pf) {
         Bitu FillFlags(void);
 
         ret = 0;
@@ -3293,7 +3293,7 @@ void DOSBOX_SetupConfigSections(void) {
     MSG_Add("CONFIG_SUGGESTED_VALUES", "Possible values");
 }
 
-int utf8_encode(char **ptr,char *fence,uint32_t code) {
+int utf8_encode(char **ptr, const char *fence, uint32_t code) {
     int uchar_size=1;
     char *p = *ptr;
 
@@ -3412,7 +3412,7 @@ int utf8_decode(const char **ptr,const char *fence) {
     return ret;
 }
 
-int utf16le_encode(char **ptr,char *fence,uint32_t code) {
+int utf16le_encode(char **ptr, const char *fence, uint32_t code) {
     char *p = *ptr;
 
     if (!p) return UTF8ERR_NO_ROOM;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -520,7 +520,7 @@ private:
 public:
 	AUTOEXEC(Section* configuration):Module_base(configuration) {
 		/* Register a virtual AUTOEXEC.BAT file */
-		Section_line * section=static_cast<Section_line *>(configuration);
+		const Section_line * section=static_cast<Section_line *>(configuration);
 
 		/* Check -securemode switch to disable mount/imgmount/boot after running autoexec.bat */
 		bool secure = control->opt_securemode;
@@ -555,7 +555,7 @@ public:
         }
 
 		/* add stuff from the configfile unless -noautexec or -securemode is specified. */
-		char * extra = const_cast<char*>(section->data.c_str());
+		const char * extra = const_cast<char*>(section->data.c_str());
 		if (extra && !secure && !control->opt_noautoexec) {
 			/* detect if "echo off" is the first line */
 			size_t firstline_length = strcspn(extra,"\r\n");
@@ -1329,7 +1329,7 @@ void SHELL_Init() {
 
     /* settings */
     {
-        Section_prop * section=static_cast<Section_prop *>(control->GetSection("dos"));
+        const Section_prop * section=static_cast<Section_prop *>(control->GetSection("dos"));
         enable_config_as_shell_commands = section->Get_bool("shell configuration as commands");
     }
 }

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -116,7 +116,7 @@ void AutoexecObject::CreateAutoexec(void) {
 	size_t auto_len;
 	for(auto_it it = autoexec_strings.begin(); it != autoexec_strings.end(); ++it) {
 
-		std::string linecopy = (*it);
+		std::string linecopy = *it;
 		std::string::size_type offset = 0;
 		//Lets have \r\n as line ends in autoexec.bat.
 		while(offset < linecopy.length()) {

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -154,7 +154,7 @@ emptyline:
 	return true;	
 }
 
-bool BatchFile::Goto(char * where) {
+bool BatchFile::Goto(const char * where) {
 	//Open bat file and search for the where string
 	if (!DOS_OpenFile(filename.c_str(),128,&file_handle)) {
 		LOG(LOG_MISC,LOG_ERROR)("SHELL:Goto Can't open BatchFile %s",filename.c_str());
@@ -188,7 +188,7 @@ again:
 			nospace++;
 
 		//label is until space/=/eol
-		char* const beginlabel = nospace;
+		const char* beginlabel = nospace;
 		while(*nospace && !isspace(*reinterpret_cast<unsigned char*>(nospace)) && (*nospace != '=')) 
 			nospace++;
 

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -481,7 +481,7 @@ void DOS_Shell::InputCommand(char * line) {
 						int q=0, r=0, k=0;
 
                         // get completion mask
-                        char *p_completion_start = strrchr(line, ' ');
+                        const char *p_completion_start = strrchr(line, ' ');
 						while (p_completion_start) {
 	                        q=0;
 	                        char *i;
@@ -494,7 +494,7 @@ void DOS_Shell::InputCommand(char * line) {
 	                    }
 						char c[]={'<','>','|'};
 						for (unsigned int j=0; j<sizeof(c); j++) {
-							char *sp = strrchr(line, c[j]);
+							const char *sp = strrchr(line, c[j]);
 							while (sp) {
 								q=0;
 								char *i;
@@ -518,7 +518,7 @@ void DOS_Shell::InputCommand(char * line) {
                         }
 						k=completion_index;
 
-                        char *path;
+                        const char *path;
 						if ((path = strrchr(line+completion_index,':'))) completion_index = (Bit16u)(path-line+1);
                         if ((path = strrchr(line+completion_index,'\\'))) completion_index = (Bit16u)(path-line+1);
                         if ((path = strrchr(line+completion_index,'/'))) completion_index = (Bit16u)(path-line+1);
@@ -543,10 +543,10 @@ void DOS_Shell::InputCommand(char * line) {
                         }
                         if (p_completion_start) {
                             safe_strncpy(mask, p_completion_start,DOS_PATHLENGTH);
-                            char* dot_pos=strrchr(mask,'.');
-                            char* bs_pos=strrchr(mask,'\\');
-                            char* fs_pos=strrchr(mask,'/');
-                            char* cl_pos=strrchr(mask,':');
+                            const char* dot_pos = strrchr(mask, '.');
+                            const char* bs_pos = strrchr(mask, '\\');
+                            const char* fs_pos = strrchr(mask, '/');
+                            const char* cl_pos = strrchr(mask, ':');
                             // not perfect when line already contains wildcards, but works
                             if ((dot_pos-bs_pos>0) && (dot_pos-fs_pos>0) && (dot_pos-cl_pos>0))
                                 strncat(mask, "*",DOS_PATHLENGTH - 1);
@@ -608,7 +608,7 @@ void DOS_Shell::InputCommand(char * line) {
                                 if (dir_only) { //Handle the dir only case different (line starts with cd)
 									if(att & DOS_ATTR_DIRECTORY) l_completion.push_back(qlname);
                                 } else {
-                                    char *ext = strrchr(name, '.'); // file extension
+                                    const char *ext = strrchr(name, '.'); // file extension
                                     if (ext && (strcmp(ext, ".BAT") == 0 || strcmp(ext, ".COM") == 0 || strcmp(ext, ".EXE") == 0))
                                         // we add executables to the a seperate list and place that list infront of the normal files
                                         executable.push_front(qlname);
@@ -727,7 +727,8 @@ void DOS_Shell::InputCommand(char * line) {
  * Buffer pointed to by "line" must be at least CMD_MAXLINE+1 bytes long! */
 void DOS_Shell::ProcessCmdLineEnvVarStitution(char *line) {
 	char temp[CMD_MAXLINE]; /* <- NTS: Currently 4096 which is very generous indeed! */
-	char *w=temp,*wf=temp+sizeof(temp)-1;
+    char* w = temp;
+    const char* wf = temp + sizeof(temp) - 1;
 	char *r=line;
 
 	/* initial scan: is there anything to substitute? */
@@ -742,7 +743,7 @@ void DOS_Shell::ProcessCmdLineEnvVarStitution(char *line) {
 	}
 
 	/* copy the string down up to that point */
-	for (char *c=line;c < r;) {
+    for (const char* c = line; c < r;) {
 		assert(w < wf);
 		*w++ = *c++;
 	}
@@ -759,7 +760,7 @@ void DOS_Shell::ProcessCmdLineEnvVarStitution(char *line) {
 				else break;
 			}
 			else {
-				char *name = r; /* store pointer, 'r' is first char of the name following '%' */
+                const char* name = r; /* store pointer, 'r' is first char of the name following '%' */
 				int spaces = 0,chars = 0;
 
 				/* continue scanning for the ending '%'. variable names are apparently meant to be
@@ -826,7 +827,7 @@ void DOS_Shell::ProcessCmdLineEnvVarStitution(char *line) {
 					while (*r == ' ') r++; /* skip spaces */
 					name--; /* step "name" back to cover the first '%' we found */
 
-					for (char *c=name;c < r;) {
+                    for (const char* c = name; c < r;) {
 						if (w >= wf) goto overflow;
 						*w++ = *c++;
 					}
@@ -858,11 +859,11 @@ overflow:
 }
 
 std::string full_arguments = "";
-bool DOS_Shell::Execute(char * name,char * args) {
+bool DOS_Shell::Execute(char* name, const char* args) {
 /* return true  => don't check for hardware changes in do_command 
  * return false =>       check for hardware changes in do_command */
 	char fullname[DOS_PATHLENGTH+4]; //stores results from Which
-	char* p_fullname;
+    const char* p_fullname;
 	char line[CMD_MAXLINE];
 	if(strlen(args)!= 0){
 		if(*args != ' '){ //put a space in front
@@ -884,7 +885,7 @@ bool DOS_Shell::Execute(char * name,char * args) {
 		if (strrchr(name,'\\')) { WriteOut(MSG_Get("SHELL_EXECUTE_ILLEGAL_COMMAND"),name); return true; }
 		if (!DOS_SetDrive(toupper(name[0])-'A')) {
 #ifdef WIN32
-			Section_prop * sec=0; sec=static_cast<Section_prop *>(control->GetSection("dos"));
+            const Section_prop* sec = 0; sec = static_cast<Section_prop*>(control->GetSection("dos"));
 			if(!sec->Get_bool("automount")) { WriteOut(MSG_Get("SHELL_EXECUTE_DRIVE_NOT_FOUND"),toupper(name[0])); return true; }
 			// automount: attempt direct letter to drive map.
 			if((GetDriveType(name)==3) && (strcasecmp(name,"c:")==0)) WriteOut(MSG_Get("SHELL_EXECUTE_DRIVE_ACCESS_WARNING_WIN"));
@@ -965,7 +966,8 @@ continue_1:
 	{
 		//Check if the result will fit in the parameters. Else abort
 		if(strlen(fullname) >( DOS_PATHLENGTH - 1) ) return false;
-		char temp_name[DOS_PATHLENGTH+4],* temp_fullname;
+        char temp_name[DOS_PATHLENGTH + 4];
+        const char* temp_fullname;
 		//try to add .com, .exe and .bat extensions to filename
 		
 		strcpy(temp_name,fullname);


### PR DESCRIPTION
Some code cleanup, using static analysis tools.

1. Using "const" for unmodified values
2. Using class initialization or constructor list initialization instead of assignment within constructor bodies
3. Removing pointless access specifiers
4. Other minor cleanup