### PR TITLE
Port FluidSynth code from DOSBox ECE, and fix issues #1499, #1503 and #1505

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 0.83.2
   - Improved support for FluidSynth MIDI device by porting
-    code from DOSBox ECE. (Wengier)
+    code from DOSBox ECE. Set "mididevice=fluidsynth" along
+    with other required options such as "fluid.soundfont"
+    in dosbox-x.conf to use it. The previous config setting
+    "mididevice=synth" is still supported for alternative
+    implementation of FluidSynth. (Wengier)
 
 0.83.1
   - Sound Blaster emulation fixed to better handle Goldplay

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 0.83.2
-  - 
+  - Improved support for FluidSynth MIDI device by porting
+    code from DOSBox ECE. (Wengier)
+
 0.83.1
   - Sound Blaster emulation fixed to better handle Goldplay
     mode detection false positive in 1994 demoscene demo

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ DOSBox-X Manual (always use the latest version from [dosbox-x.com](http://dosbox
 
 DOSBox-X is a cross-platform DOS emulator based on the DOSBox project (www.dosbox.com)
 
-For more information please read the user guide in the [DOSBox-X Wiki](https://github.com/joncampbell123/dosbox-x/wiki).
+For more information about DOSBox-X, please read the user guide in the [DOSBox-X Wiki](https://github.com/joncampbell123/dosbox-x/wiki).
 
-This project has a Code of Conduct in CODE_OF_CONDUCT.md, please read it.
+This project has a Code of Conduct in [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), please read it.
 
 I am rewriting this README, and new information will be added over time --J.C.
 

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -838,81 +838,123 @@ blocksize       = 1024
 prebuffer       = 25
 
 [midi]
-#              mpu401: Type of MPU-401 to emulate.
-#                        Possible values: intelligent, uart, none.
-#             mpubase: The IO address of the MPU-401.
-#                        Set to 0 to use a default I/O address.
-#                        300h to 330h are for use with IBM PC mode.
-#                        C0D0h to F8D0h (in steps of 800h) are for use with NEC PC-98 mode (MPU98).
-#                        80D2h through 80DEh are for use with NEC PC-98 Sound Blaster 16 MPU-401 emulation.
-#                        If not assigned (0), 330h is the default for IBM PC and E0D0h is the default for PC-98.
-#                        Possible values: 0, 300, 310, 320, 330, 332, 334, 336, 340, 360, c0d0, c8d0, d0d0, d8d0, e0d0, e8d0, f0d0, f8d0, 80d2, 80d4, 80d6, 80d8, 80da, 80dc, 80de.
-#          mididevice: Device that will receive the MIDI data from MPU-401. Use "synth" for FluidSynth.
-#                        Possible values: default, win32, alsa, oss, coreaudio, coremidi, mt32, synth, timidity, none.
-#          midiconfig: Special configuration options for the device driver. This is usually the id or part of the name of the device you want to use (find the id/name with mixer/listmidi).
-#                        Or in the case of coreaudio or synth, you can specify a soundfont here.
-#                        When using a Roland MT-32 rev. 0 as midi output device, some games may require a delay in order to prevent 'buffer overflow' issues.
-#                        In that case, add 'delaysysex', for example: midiconfig=2 delaysysex
-#                        See the README/Manual for more details.
-#          samplerate: Sample rate for MIDI synthesizer, if applicable.
-#                        Possible values: 44100, 48000, 32000, 22050, 16000, 11025, 8000, 49716.
-#              mpuirq: MPU-401 IRQ. -1 to automatically choose.
-#         mt32.romdir: Name of the directory where MT-32 Control and PCM ROM files can be found. Emulation requires these files to work.
+#                mpu401: Type of MPU-401 to emulate.
+#                          Possible values: intelligent, uart, none.
+#               mpubase: The IO address of the MPU-401.
+#                          Set to 0 to use a default I/O address.
+#                          300h to 330h are for use with IBM PC mode.
+#                          C0D0h to F8D0h (in steps of 800h) are for use with NEC PC-98 mode (MPU98).
+#                          80D2h through 80DEh are for use with NEC PC-98 Sound Blaster 16 MPU-401 emulation.
+#                          If not assigned (0), 330h is the default for IBM PC and E0D0h is the default for PC-98.
+#                          Possible values: 0, 300, 310, 320, 330, 332, 334, 336, 340, 360, c0d0, c8d0, d0d0, d8d0, e0d0, e8d0, f0d0, f8d0, 80d2, 80d4, 80d6, 80d8, 80da, 80dc, 80de.
+#            mididevice: Device that will receive the MIDI data from MPU-401.
+#                          Possible values: default, win32, alsa, oss, coreaudio, coremidi, mt32, synth, fluidsynth, timidity, none.
+#            midiconfig: Special configuration options for the device driver. This is usually the id or part of the name of the device you want to use (find the id/name with mixer/listmidi).
+#                          Or in the case of coreaudio or synth, you can specify a soundfont here.
+#                          When using a Roland MT-32 rev. 0 as midi output device, some games may require a delay in order to prevent 'buffer overflow' issues.
+#                          In that case, add 'delaysysex', for example: midiconfig=2 delaysysex
+#                          See the README/Manual for more details.
+#            samplerate: Sample rate for MIDI synthesizer, if applicable.
+#                          Possible values: 44100, 48000, 32000, 22050, 16000, 11025, 8000, 49716.
+#                mpuirq: MPU-401 IRQ. -1 to automatically choose.
+#           mt32.romdir: Name of the directory where MT-32 Control and PCM ROM files can be found. Emulation requires these files to work.
 #                          Accepted file names are as follows:
 #                            MT32_CONTROL.ROM or CM32L_CONTROL.ROM - control ROM file.
 #                            MT32_PCM.ROM or CM32L_PCM.ROM - PCM ROM file.
-# mt32.reverse.stereo: Reverse stereo channels for MT-32 output
-#                        Possible values: off, on.
-#        mt32.verbose: MT-32 debug logging
-#                        Possible values: off, on.
-#         mt32.thread: MT-32 rendering in separate thread
-#                        Possible values: off, on.
-#            mt32.dac: MT-32 DAC input emulation mode
-#                        Nice = 0 - default
-#                        Produces samples at double the volume, without tricks.
-#                        Higher quality than the real devices
-#                        
-#                        Pure = 1
-#                        Produces samples that exactly match the bits output from the emulated LA32.
-#                        Nicer overdrive characteristics than the DAC hacks (it simply clips samples within range)
-#                        Much less likely to overdrive than any other mode.
-#                        Half the volume of any of the other modes, meaning its volume relative to the reverb
-#                        output when mixed together directly will sound wrong. So, reverb level must be lowered.
-#                        Perfect for developers while debugging :)
-#                        
-#                        GENERATION1 = 2
-#                        Re-orders the LA32 output bits as in early generation MT-32s (according to Wikipedia).
-#                        Bit order at DAC (where each number represents the original LA32 output bit number, and XX means the bit is always low):
-#                        15 13 12 11 10 09 08 07 06 05 04 03 02 01 00 XX
-#                        
-#                        GENERATION2 = 3
-#                        Re-orders the LA32 output bits as in later geneerations (personally confirmed on my CM-32L - KG).
-#                        Bit order at DAC (where each number represents the original LA32 output bit number):
-#                        15 13 12 11 10 09 08 07 06 05 04 03 02 01 00 14
-#                        
-#                        Possible values: 0, 1, 2, 3, auto.
-#    mt32.reverb.mode: MT-32 reverb mode
-#                        Possible values: 0, 1, 2, 3, auto.
-#    mt32.reverb.time: MT-32 reverb decaying time
-#                        Possible values: 0, 1, 2, 3, 4, 5, 6, 7.
-#   mt32.reverb.level: MT-32 reverb level
-#                        Possible values: 0, 1, 2, 3, 4, 5, 6, 7.
-#       mt32.partials: MT-32 max partials allowed (0-256)
-mpu401              = intelligent
-mpubase             = 0
-mididevice          = default
-midiconfig          = 
-samplerate          = 44100
-mpuirq              = -1
-mt32.romdir         = 
-mt32.reverse.stereo = off
-mt32.verbose        = off
-mt32.thread         = off
-mt32.dac            = auto
-mt32.reverb.mode    = auto
-mt32.reverb.time    = 5
-mt32.reverb.level   = 3
-mt32.partials       = 32
+#   mt32.reverse.stereo: Reverse stereo channels for MT-32 output
+#                          Possible values: off, on.
+#          mt32.verbose: MT-32 debug logging
+#                          Possible values: off, on.
+#           mt32.thread: MT-32 rendering in separate thread
+#                          Possible values: off, on.
+#              mt32.dac: MT-32 DAC input emulation mode
+#                          Nice = 0 - default
+#                          Produces samples at double the volume, without tricks.
+#                          Higher quality than the real devices
+#                          
+#                          Pure = 1
+#                          Produces samples that exactly match the bits output from the emulated LA32.
+#                          Nicer overdrive characteristics than the DAC hacks (it simply clips samples within range)
+#                          Much less likely to overdrive than any other mode.
+#                          Half the volume of any of the other modes, meaning its volume relative to the reverb
+#                          output when mixed together directly will sound wrong. So, reverb level must be lowered.
+#                          Perfect for developers while debugging :)
+#                          
+#                          GENERATION1 = 2
+#                          Re-orders the LA32 output bits as in early generation MT-32s (according to Wikipedia).
+#                          Bit order at DAC (where each number represents the original LA32 output bit number, and XX means the bit is always low):
+#                          15 13 12 11 10 09 08 07 06 05 04 03 02 01 00 XX
+#                          
+#                          GENERATION2 = 3
+#                          Re-orders the LA32 output bits as in later geneerations (personally confirmed on my CM-32L - KG).
+#                          Bit order at DAC (where each number represents the original LA32 output bit number):
+#                          15 13 12 11 10 09 08 07 06 05 04 03 02 01 00 14
+#                          
+#                          Possible values: 0, 1, 2, 3, auto.
+#      mt32.reverb.mode: MT-32 reverb mode
+#                          Possible values: 0, 1, 2, 3, auto.
+#      mt32.reverb.time: MT-32 reverb decaying time
+#                          Possible values: 0, 1, 2, 3, 4, 5, 6, 7.
+#     mt32.reverb.level: MT-32 reverb level
+#                          Possible values: 0, 1, 2, 3, 4, 5, 6, 7.
+#         mt32.partials: MT-32 max partials allowed (0-256)
+#          fluid.driver: Driver to use with Fluidsynth, not needed under Windows. Available drivers depend on what Fluidsynth was compiled with.
+#                          Possible values: pulseaudio, alsa, oss, coreaudio, dsound, portaudio, sndman, jack, file, default.
+#       fluid.soundfont: Soundfont to use with Fluidsynth. One must be specified.
+#      fluid.samplerate: Sample rate to use with Fluidsynth.
+#            fluid.gain: Fluidsynth gain.
+#       fluid.polyphony: Fluidsynth polyphony.
+#           fluid.cores: Fluidsynth CPU cores to use, default.
+#         fluid.periods: Fluidsynth periods.
+#      fluid.periodsize: Fluidsynth period size.
+#          fluid.reverb: Fluidsynth use reverb.
+#                          Possible values: no, yes.
+#          fluid.chorus: Fluidsynth use chorus.
+#                          Possible values: no, yes.
+# fluid.reverb,roomsize: Fluidsynth reverb room size.
+#  fluid.reverb.damping: Fluidsynth reverb damping.
+#    fluid.reverb.width: Fluidsynth reverb width.
+#    fluid.reverb.level: Fluidsynth reverb level.
+#   fluid.chorus.number: Fluidsynth chorus voices
+#    fluid.chorus.level: Fluidsynth chorus level.
+#    fluid.chorus.speed: Fluidsynth chorus speed.
+#    fluid.chorus.depth: Fluidsynth chorus depth.
+#     fluid.chorus.type: Fluidsynth chorus type. 0 is sine wave, 1 is triangle wave.
+#                            Possible values: 0, 1.
+mpu401                = intelligent
+mpubase               = 0
+mididevice            = default
+midiconfig            = 
+samplerate            = 44100
+mpuirq                = -1
+mt32.romdir           = 
+mt32.reverse.stereo   = off
+mt32.verbose          = off
+mt32.thread           = off
+mt32.dac              = auto
+mt32.reverb.mode      = auto
+mt32.reverb.time      = 5
+mt32.reverb.level     = 3
+mt32.partials         = 32
+fluid.driver          = default
+fluid.soundfont       = 
+fluid.samplerate      = 48000
+fluid.gain            = .6
+fluid.polyphony       = 256
+fluid.cores           = default
+fluid.periods         = 8
+fluid.periodsize      = 512
+fluid.reverb          = yes
+fluid.chorus          = yes
+fluid.reverb,roomsize = .61
+fluid.reverb.damping  = .23
+fluid.reverb.width    = .76
+fluid.reverb.level    = .57
+fluid.chorus.number   = 3
+fluid.chorus.level    = 1.2
+fluid.chorus.speed    = .3
+fluid.chorus.depth    = 8.0
+fluid.chorus.type     = 0
 
 [sblaster]
 #                                           sbtype: Type of Soundblaster to emulate. gb is Gameblaster.

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -515,7 +515,9 @@ public:
 #endif
                 }
                 if (is_physfs) {
+					WriteOut(MSG_Get("PROGRAM_IMGMOUNT_CANT_CREATE_PHYSFS"));
                     LOG_MSG("ERROR:This build does not support physfs");
+					return;
                 } else {
 					if (Drives[drive-'A']) {
 						WriteOut(MSG_Get("PROGRAM_MOUNT_ALREADY_MOUNTED"),drive,Drives[drive-'A']->GetInfo());
@@ -547,7 +549,9 @@ public:
                 if(temp_line == "/") WriteOut(MSG_Get("PROGRAM_MOUNT_WARNING_OTHER"));
 #endif
                 if (is_physfs) {
+					WriteOut(MSG_Get("PROGRAM_IMGMOUNT_CANT_CREATE_PHYSFS"));
                     LOG_MSG("ERROR:This build does not support physfs");
+					return;
                 } else {
                     newdrive=new localDrive(temp_line.c_str(),sizes[0],bit8size,sizes[2],sizes[3],mediaid);
                     newdrive->nocachedir = nocachedir;
@@ -4548,7 +4552,7 @@ void DOS_SetupPrograms(void) {
     MSG_Add("PROGRAM_MOUNT_UMOUNT_SUCCESS","Drive %c has successfully been removed.\n");
     MSG_Add("PROGRAM_MOUNT_UMOUNT_NUMBER_SUCCESS","Drive number %c has successfully been removed.\n");
     MSG_Add("PROGRAM_MOUNT_UMOUNT_NO_VIRTUAL","Virtual Drives can not be unMOUNTed.\n");
-    MSG_Add("PROGRAM_MOUNT_WARNING_WIN","\033[31;1mMounting c:\\ is NOT recommended. Please mount a (sub)directory next time.\033[0m\n");
+    MSG_Add("PROGRAM_MOUNT_WARNING_WIN","\033[31;1mMounting C:\\ is NOT recommended. Please mount a (sub)directory next time.\033[0m\n");
     MSG_Add("PROGRAM_MOUNT_WARNING_OTHER","\033[31;1mMounting / is NOT recommended. Please mount a (sub)directory next time.\033[0m\n");
 
     MSG_Add("PROGRAM_LOADFIX_ALLOC","%d kb allocated.\n");
@@ -4838,7 +4842,8 @@ void DOS_SetupPrograms(void) {
     MSG_Add("PROGRAM_IMGMOUNT_FILE_NOT_FOUND","Image file not found.\n");
     MSG_Add("PROGRAM_IMGMOUNT_MOUNT","To mount directories, use the \033[34;1mMOUNT\033[0m command, not the \033[34;1mIMGMOUNT\033[0m command.\n");
     MSG_Add("PROGRAM_IMGMOUNT_ALREADY_MOUNTED","Drive already mounted at that letter.\n");
-    MSG_Add("PROGRAM_IMGMOUNT_CANT_CREATE","Can't create drive from file.\n");
+    MSG_Add("PROGRAM_IMGMOUNT_CANT_CREATE","Cannot create drive from file.\n");
+    MSG_Add("PROGRAM_IMGMOUNT_CANT_CREATE_PHYSFS","Cannot create PhysFS drive.\n");
     MSG_Add("PROGRAM_IMGMOUNT_MOUNT_NUMBER","Drive number %d mounted as %s\n");
     MSG_Add("PROGRAM_IMGMOUNT_NON_LOCAL_DRIVE", "The image must be on a host or local drive.\n");
     MSG_Add("PROGRAM_IMGMOUNT_MULTIPLE_NON_CUEISO_FILES", "Using multiple files is only supported for cue/iso images.\n");

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -1095,7 +1095,8 @@ bool localDrive::AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,
 		bool res=false;
 #if defined(WIN32)
 		struct _diskfree_t df = {0};
-		res = _getdiskfree(toupper(basedir[0])-'A'+1, &df) == 0;
+		Bit8u drive=strlen(basedir)>1&&basedir[1]==':'?toupper(basedir[0])-'A'+1:0;
+		res = _getdiskfree(drive>26?0:drive, &df) == 0;
 		if (res) {
 			unsigned long total = df.total_clusters * df.sectors_per_cluster;
 			int ratio = total > 2097120 ? 64 : (total > 1048560 ? 32 : (total > 524280 ? 16 : (total > 262140 ? 8 : (total > 131070 ? 4 : (total > 65535 ? 2 : 1)))));

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1007,7 +1007,11 @@ void DOSBOX_SetupConfigSections(void) {
     const char* cputype_values[] = {"auto", "8086", "8086_prefetch", "80186", "80186_prefetch", "286", "286_prefetch", "386", "386_prefetch", "486old", "486old_prefetch", "486", "486_prefetch", "pentium", "pentium_mmx", "ppro_slow", 0};
     const char* rates[] = {  "44100", "48000", "32000","22050", "16000", "11025", "8000", "49716", 0 };
     const char* oplrates[] = {   "44100", "49716", "48000", "32000","22050", "16000", "11025", "8000", 0 };
-    const char* devices[] = { "default", "win32", "alsa", "oss", "coreaudio", "coremidi", "mt32", "synth", "timidity", "none", 0}; // FIXME: add some way to offer the actually available choices.
+#ifdef C_FLUIDSYNTH
+    const char* devices[] = { "default", "win32", "alsa", "oss", "coreaudio", "coremidi", "mt32", "synth", "fluidsynth", "timidity", "none", 0};
+#else
+    const char* devices[] = { "default", "win32", "alsa", "oss", "coreaudio", "coremidi", "mt32", "timidity", "none", 0}; // FIXME: add some way to offer the actually available choices.
+#endif
     const char* apmbiosversions[] = { "auto", "1.0", "1.1", "1.2", 0 };
     const char *mt32log[] = {"off", "on",0};
     const char *mt32thread[] = {"off", "on",0};
@@ -2128,7 +2132,7 @@ void DOSBOX_SetupConfigSections(void) {
 
     Pstring = secprop->Add_string("mididevice",Property::Changeable::WhenIdle,"default");
     Pstring->Set_values(devices);
-    Pstring->Set_help("Device that will receive the MIDI data from MPU-401. Use \"synth\" for FluidSynth.");
+    Pstring->Set_help("Device that will receive the MIDI data from MPU-401.");
 
     Pstring = secprop->Add_string("midiconfig",Property::Changeable::WhenIdle,"");
     Pstring->Set_help("Special configuration options for the device driver. This is usually the id or part of the name of the device you want to use (find the id/name with mixer/listmidi).\n"
@@ -2204,6 +2208,73 @@ void DOSBOX_SetupConfigSections(void) {
     Pint = secprop->Add_int("mt32.partials",Property::Changeable::WhenIdle,32);
     Pint->SetMinMax(0,256);
     Pint->Set_help("MT-32 max partials allowed (0-256)");
+
+#ifdef C_FLUIDSYNTH
+	const char *fluiddrivers[] = {"pulseaudio", "alsa", "oss", "coreaudio", "dsound", "portaudio", "sndman", "jack", "file", "default",0};
+	Pstring = secprop->Add_string("fluid.driver",Property::Changeable::WhenIdle,"default");
+	Pstring->Set_values(fluiddrivers);
+	Pstring->Set_help("Driver to use with Fluidsynth, not needed under Windows. Available drivers depend on what Fluidsynth was compiled with.");
+
+	Pstring = secprop->Add_string("fluid.soundfont",Property::Changeable::WhenIdle,"");
+	Pstring->Set_help("Soundfont to use with Fluidsynth. One must be specified.");
+
+	Pstring = secprop->Add_string("fluid.samplerate",Property::Changeable::WhenIdle,"48000");
+	Pstring->Set_help("Sample rate to use with Fluidsynth.");
+
+	Pstring = secprop->Add_string("fluid.gain",Property::Changeable::WhenIdle,".6");
+	Pstring->Set_help("Fluidsynth gain.");
+
+	Pint = secprop->Add_int("fluid.polyphony",Property::Changeable::WhenIdle,256);
+	Pint->Set_help("Fluidsynth polyphony.");
+
+	Pstring = secprop->Add_string("fluid.cores",Property::Changeable::WhenIdle,"default");
+	Pstring->Set_help("Fluidsynth CPU cores to use, default.");
+
+	Pstring = secprop->Add_string("fluid.periods",Property::Changeable::WhenIdle,"8");
+	Pstring->Set_help("Fluidsynth periods.");
+
+	Pstring = secprop->Add_string("fluid.periodsize",Property::Changeable::WhenIdle,"512");
+	Pstring->Set_help("Fluidsynth period size.");
+
+	const char *fluidreverb[] = {"no", "yes",0};
+	Pstring = secprop->Add_string("fluid.reverb",Property::Changeable::WhenIdle,"yes");	
+	Pstring->Set_values(fluidreverb);
+	Pstring->Set_help("Fluidsynth use reverb.");
+
+	const char *fluidchorus[] = {"no", "yes",0};
+	Pstring = secprop->Add_string("fluid.chorus",Property::Changeable::WhenIdle,"yes");	
+	Pstring->Set_values(fluidchorus);
+	Pstring->Set_help("Fluidsynth use chorus.");
+
+	Pstring = secprop->Add_string("fluid.reverb,roomsize",Property::Changeable::WhenIdle,".61");
+	Pstring->Set_help("Fluidsynth reverb room size.");
+
+	Pstring = secprop->Add_string("fluid.reverb.damping",Property::Changeable::WhenIdle,".23");
+	Pstring->Set_help("Fluidsynth reverb damping.");
+
+	Pstring = secprop->Add_string("fluid.reverb.width",Property::Changeable::WhenIdle,".76");
+	Pstring->Set_help("Fluidsynth reverb width.");
+
+	Pstring = secprop->Add_string("fluid.reverb.level",Property::Changeable::WhenIdle,".57");
+	Pstring->Set_help("Fluidsynth reverb level.");
+
+	Pint = secprop->Add_int("fluid.chorus.number",Property::Changeable::WhenIdle,3);	
+	Pint->Set_help("Fluidsynth chorus voices");
+
+	Pstring = secprop->Add_string("fluid.chorus.level",Property::Changeable::WhenIdle,"1.2");
+	Pstring->Set_help("Fluidsynth chorus level.");
+
+	Pstring = secprop->Add_string("fluid.chorus.speed",Property::Changeable::WhenIdle,".3");
+	Pstring->Set_help("Fluidsynth chorus speed.");
+
+	Pstring = secprop->Add_string("fluid.chorus.depth",Property::Changeable::WhenIdle,"8.0");
+	Pstring->Set_help("Fluidsynth chorus depth.");
+
+	const char *fluidchorustypes[] = {"0", "1",0};
+	Pint = secprop->Add_int("fluid.chorus.type",Property::Changeable::WhenIdle,0);
+	Pint->Set_values(fluidchorustypes);
+	Pint->Set_help("Fluidsynth chorus type. 0 is sine wave, 1 is triangle wave.");
+#endif
 
     secprop=control->AddSection_prop("sblaster",&Null_Init,true);//done
     

--- a/src/gui/midi.cpp
+++ b/src/gui/midi.cpp
@@ -614,9 +614,9 @@ public:
 				}
 			}
 			if (handler == NULL)
-				LOG(LOG_MISC,LOG_DEBUG)("MIDI:Can't find device:%s, finding default handler.",dev);
+				LOG_MSG("MIDI:Cannot find device:%s. Finding default handler.",dev);
 			else if (!opened)
-				LOG(LOG_MISC,LOG_WARN)("MIDI:Can't open device:%s with config:%s.",dev,conf);
+				LOG_MSG("MIDI:Cannot open device:%s with config:%s. Finding default handler.",dev,conf);
 		}
 
 		if (!opened) {
@@ -628,7 +628,7 @@ public:
 
 		if (!opened) {
 			// This shouldn't be possible
-			LOG(LOG_MISC,LOG_WARN)("MIDI:Couldn't open a handler");
+			LOG_MSG("MIDI:Could not open a handler");
 			return;
 		}
 

--- a/src/gui/midi_synth.h
+++ b/src/gui/midi_synth.h
@@ -18,6 +18,8 @@
 
 #include <fluidsynth.h>
 #include <math.h>
+#include <string.h>
+#include "control.h"
 
 /* Protect against multiple inclusions */
 #ifndef MIXER_BUFSIZE
@@ -211,3 +213,115 @@ public:
 };
 
 MidiHandler_synth Midi_synth;
+
+class MidiHandler_fluidsynth : public MidiHandler {
+private:
+	std::string soundfont;
+	int soundfont_id;
+	fluid_settings_t *settings;
+	fluid_synth_t *synth;
+	fluid_audio_driver_t* adriver;
+public:
+	MidiHandler_fluidsynth() : MidiHandler() {};
+	const char* GetName(void) { return "fluidsynth"; }
+	void PlaySysex(Bit8u * sysex, Bitu len) {
+		fluid_synth_sysex(synth, (char*)sysex, len, NULL, NULL, NULL, 0);
+	}
+
+	void PlayMsg(Bit8u * msg) {
+		unsigned char chanID = msg[0] & 0x0F;
+		switch (msg[0] & 0xF0) {
+		case 0x80:
+			fluid_synth_noteoff(synth, chanID, msg[1]);
+			break;
+		case 0x90:
+			fluid_synth_noteon(synth, chanID, msg[1], msg[2]);
+			break;
+		case 0xB0:
+			fluid_synth_cc(synth, chanID, msg[1], msg[2]);
+			break;
+		case 0xC0:
+			fluid_synth_program_change(synth, chanID, msg[1]);
+			break;
+		case 0xD0:
+			fluid_synth_channel_pressure(synth, chanID, msg[1]);
+			break;
+		case 0xE0: {
+			long theBend = ((long)msg[1] + (long)(msg[2] << 7));
+			fluid_synth_pitch_bend(synth, chanID, theBend);
+		}
+				   break;
+		default:
+			LOG(LOG_MISC, LOG_WARN)("MIDI:fluidsynth: Unknown Command: %08lx", (long)msg);
+			break;
+		}
+	}
+
+	void Close(void) {
+		if (soundfont_id >= 0) {
+			fluid_synth_sfunload(synth, soundfont_id, 0);
+		}
+		delete_fluid_audio_driver(adriver);
+		delete_fluid_synth(synth);
+		delete_fluid_settings(settings);
+	}
+
+	bool Open(const char * conf) {
+		Section_prop *section = static_cast<Section_prop *>(control->GetSection("midi"));
+		soundfont.assign(section->Get_string("fluid.soundfont"));
+		settings = new_fluid_settings();
+		if (strcmp(section->Get_string("fluid.driver"), "default") != 0) {
+			fluid_settings_setstr(settings, "audio.driver", section->Get_string("fluid.driver"));
+		}
+		fluid_settings_setnum(settings, "synth.sample-rate", atof(section->Get_string("fluid.samplerate")));
+		fluid_settings_setnum(settings, "synth.gain", atof(section->Get_string("fluid.gain")));
+		fluid_settings_setint(settings, "synth.polyphony", section->Get_int("fluid.polyphony"));
+		if (strcmp(section->Get_string("fluid.driver"), "default") != 0) {
+			fluid_settings_setnum(settings, "synth.cpu-cores", atof(section->Get_string("fluid.cores")));
+		}
+		fluid_settings_setnum(settings, "audio.periods", atof(section->Get_string("fluid.periods")));
+		fluid_settings_setnum(settings, "audio.period-size", atof(section->Get_string("fluid.periodsize")));
+		fluid_settings_setstr(settings, "synth.reverb.active", section->Get_string("fluid.reverb"));
+		fluid_settings_setstr(settings, "synth.chorus.active", section->Get_string("fluid.chorus"));
+
+		synth = new_fluid_synth(settings);
+		if (!synth) {
+			LOG_MSG("MIDI:fluidsynth: Can't open synthesiser");
+			delete_fluid_settings(settings);
+			return false;
+		}
+
+		adriver = new_fluid_audio_driver(settings, synth);
+		if (!adriver) {
+			LOG_MSG("MIDI:fluidsynth: Can't create audio driver");
+			delete_fluid_synth(synth);
+			delete_fluid_settings(settings);
+			return false;
+		}
+
+		fluid_synth_set_reverb(synth, atof(section->Get_string("fluid.reverb.roomsize")), atof(section->Get_string("fluid.reverb.damping")), atof(section->Get_string("fluid.reverb.width")), atof(section->Get_string("fluid.reverb.level")));
+
+		fluid_synth_set_chorus(synth, section->Get_int("fluid.chorus.number"), atof(section->Get_string("fluid.chorus.level")), atof(section->Get_string("fluid.chorus.speed")), atof(section->Get_string("fluid.chorus.depth")), section->Get_int("fluid.chorus.type"));
+
+		/* Optionally load a soundfont */
+		if (!soundfont.empty()) {
+			soundfont_id = fluid_synth_sfload(synth, soundfont.c_str(), 1);
+			if (soundfont_id == FLUID_FAILED) {
+				/* Just consider this a warning (fluidsynth already prints) */
+				soundfont.clear();
+				soundfont_id = -1;
+			}
+			else {
+				LOG_MSG("MIDI:fluidsynth: loaded soundfont: %s",
+					soundfont.c_str());
+			}
+		}
+		else {
+			soundfont_id = -1;
+			LOG_MSG("MIDI:fluidsynth: no soundfont loaded");
+		}
+		return true;
+	}
+};
+
+MidiHandler_fluidsynth Midi_fluidsynth;

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -3431,7 +3431,7 @@ static Bitu INT18_PC98_Handler(void) {
                 unsigned char b597 = mem_readb(0x597);
                 unsigned char tstat = mem_readb(0x53C);
                 unsigned char b54C = mem_readb(0x54C);
-                unsigned char ret = 0x05; // according to NP2
+                unsigned char ret = 0x05; // according to NP2
 
                 // assume the same as AH=42h
                 while (!(IO_ReadB(0x60) & 0x20/*vertical retrace*/)) {
@@ -6189,7 +6189,7 @@ static Bitu INT15_Handler(void) {
                     //       on APM idle calls? Allow selection between "nothing" "hlt"
                     //       and "software delay".
                     if (!(reg_flags&0x200)) {
-                        LOG_MSG("APM BIOS warning: CPU IDLE called with IF=0, not HLTing\n");
+                        LOG(LOG_BIOS,LOG_WARN)("APM BIOS warning: CPU IDLE called with IF=0, not HLTing\n");
                     }
                     else if (cpudecoder == &HLT_Decode) { /* do not re-execute HLT, it makes DOSBox hang */
                         LOG_MSG("APM BIOS warning: CPU IDLE HLT within HLT (DOSBox core failure)\n");


### PR DESCRIPTION
As mentioned by @rderooy in Issue #1499, the FluidSynth support in DOSBox ECE is better than in DOSBox-X, so I decided to port the code from it. It can be enabled by setting "mididevice=fluidsynth" along with other required options e.g. ("fluid.driver" and "fluid.soundfont") in dosbox-x.conf to use it. The previous config setting "mididevice=synth" is still supported for an alternative implementation of FluidSynth.

Also improved the logging as mentioned in both Issue #1499 and #1503. It also fixed the DIR bug when a path like /dos is mounted instead of C:\DOS in Windows as mentioned in Issue #1505.