### PR TITLE
Fix for MinGW & HX-DOS builds

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -3055,7 +3055,7 @@ void DOS_Int21_7143(char *name1, char *name2) {
 				case 0x05:
 				case 0x07:
 				{
-#if defined (WIN32)
+#if defined (WIN32) && !defined(HX_DOS)
 					HANDLE hFile = DOS_CreateOpenFile(name1);
 					if (hFile != INVALID_HANDLE_VALUE) {
 						time_t clock = time(NULL), ttime;
@@ -3092,6 +3092,7 @@ void DOS_Int21_7143(char *name1, char *name2) {
 				case 0x04:
 				case 0x06:
 				case 0x08:
+#if !defined(HX_DOS)
 					struct stat status;
 					if (DOS_GetFileAttrEx(name1, &status)) {
 						struct tm * ltime;
@@ -3104,7 +3105,9 @@ void DOS_Int21_7143(char *name1, char *name2) {
 							reg_si = 0;
 						reg_ax=0;
 						CALLBACK_SCF(false);
-					} else {
+					} else
+#endif
+					{
 						CALLBACK_SCF(true);
 						reg_ax=dos.errorcode;
 					}
@@ -3346,7 +3349,7 @@ void DOS_Int21_71a6(char *name1, char *name2) {
     (void)name1;
     (void)name2;
 	char buf[64];
-	unsigned long serial_number=0,st=0,cdate,ctime,adate,atime,mdate,mtime;
+	unsigned long serial_number=0,st=0,cdate=0,ctime=0,adate=0,atime=0,mdate=0,mtime=0;
 	Bit8u entry=(Bit8u)reg_bx, handle;
 	if (entry>=DOS_FILES) {
 		reg_ax=DOSERR_INVALID_HANDLE;
@@ -3365,6 +3368,7 @@ void DOS_Int21_71a6(char *name1, char *name2) {
 #endif
 		struct stat status;
 		if (DOS_GetFileAttrEx(Files[handle]->name, &status, Files[handle]->GetDrive())) {
+#if !defined(HX_DOS)
 			time_t ttime;
 			struct tm * ltime;
 			ttime=status.st_ctime;
@@ -3382,6 +3386,7 @@ void DOS_Int21_71a6(char *name1, char *name2) {
 				mtime=DOS_PackTime((Bit16u)ltime->tm_hour,(Bit16u)ltime->tm_min,(Bit16u)ltime->tm_sec);
 				mdate=DOS_PackDate((Bit16u)(ltime->tm_year+1900),(Bit16u)(ltime->tm_mon+1),(Bit16u)ltime->tm_mday);
 			}
+#endif
 			sprintf(buf,"%-4s%-4s%-4s%-4s%-4s%-4s%-4s%-4s%-4s%-4s%-4s%-4s%-4s",(char*)&st,(char*)&ctime,(char*)&cdate,(char*)&atime,(char*)&adate,(char*)&mtime,(char*)&mdate,(char*)&serial_number,(char*)&st,(char*)&st,(char*)&st,(char*)&st,(char*)&handle);
 			for (int i=32;i<36;i++) buf[i]=0;
 			buf[36]=(char)((Bit32u)status.st_size%256);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5666,7 +5666,7 @@ void PasteClipboard(bool bPressed)
 }
 /// TODO: add menu items here 
 #else // end emendelson from dbDOS; improved by Wengier
-#if defined(WIN32) && defined(C_SDL2) // Add by Wengier
+#if defined(WIN32) // SDL2, MinGW / Added by Wengier
 static std::string strPasteBuffer;
 extern Bit8u* clipAscii;
 extern Bit32u clipSize;


### PR DESCRIPTION
I noticed that the latest code has some building issues for the MinGW and HX-DOS versions, so I fixed them. It should now build properly in these platforms in addition to Visual Studio and GCC on non-Windows OSes.