### PR TITLE
Fix Pause + Reset system, FluidSynth logging, and support mouse copy/paste in PC-98 mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 0.83.2
-  - The Windows clipboard copy & paste via the right mouse
-    button feature now supports PC-98 mode too. (Wengier)
+  - The copy & paste Windows clipboard text via the right
+    mouse button feature now supports PC-98 mode too just
+    like the standard mode. (Wengier)
   - Improved support for FluidSynth MIDI device by porting
     code from DOSBox ECE. Set "mididevice=fluidsynth" along
     with other required options such as "fluid.soundfont"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.83.2
+  - The Windows clipboard copy & paste via the right mouse
+    button feature now supports PC-98 mode too. (Wengier)
   - Improved support for FluidSynth MIDI device by porting
     code from DOSBox ECE. Set "mididevice=fluidsynth" along
     with other required options such as "fluid.soundfont"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 0.83.2
   - The copy & paste Windows clipboard text via the right
-    mouse button feature now supports PC-98 mode too just
-    like the standard mode. (Wengier)
+    mouse button feature now has limited support for PC-98
+    mode too in addition to other modes. (Wengier)
   - Improved support for FluidSynth MIDI device by porting
     code from DOSBox ECE. Set "mididevice=fluidsynth" along
     with other required options such as "fluid.soundfont"

--- a/src/gui/midi.cpp
+++ b/src/gui/midi.cpp
@@ -634,7 +634,7 @@ public:
 
 		midi.available=true;
 		midi.handler=handler;
-		LOG(LOG_MISC,LOG_DEBUG)("MIDI:Opened device:%s",handler->GetName());
+		LOG_MSG("MIDI:Opened device:%s",handler->GetName());
 
 		// force reset to prevent crashes (when not properly shutdown)
 		// ex. Roland VSC = unexpected hard system crash

--- a/src/gui/midi_synth.h
+++ b/src/gui/midi_synth.h
@@ -268,7 +268,12 @@ public:
 
 	bool Open(const char * conf) {
 		Section_prop *section = static_cast<Section_prop *>(control->GetSection("midi"));
-		soundfont.assign(section->Get_string("fluid.soundfont"));
+		const char * sf = section->Get_string("fluid.soundfont");
+		if (!*sf) {
+			LOG_MSG("MIDI:fluidsynth: SoundFont not specified");
+			return false;
+		}
+		soundfont.assign(sf);
 		settings = new_fluid_settings();
 		if (strcmp(section->Get_string("fluid.driver"), "default") != 0) {
 			fluid_settings_setstr(settings, "audio.driver", section->Get_string("fluid.driver"));
@@ -312,13 +317,12 @@ public:
 				soundfont_id = -1;
 			}
 			else {
-				LOG_MSG("MIDI:fluidsynth: loaded soundfont: %s",
-					soundfont.c_str());
+				LOG_MSG("MIDI:fluidsynth: Loaded SoundFont: %s", soundfont.c_str());
 			}
 		}
 		else {
 			soundfont_id = -1;
-			LOG_MSG("MIDI:fluidsynth: no soundfont loaded");
+			LOG_MSG("MIDI:fluidsynth: No SoundFont loaded");
 		}
 		return true;
 	}

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -957,6 +957,7 @@ static bool IsFullscreen() {
 
 bool is_paused = false;
 bool unpause_now = false;
+bool pausewithinterrupts_enable = false;
 #if DOSBOXMENU_TYPE == DOSBOXMENU_NSMENU
 int pause_menu_item_tag = -1;
 #endif
@@ -3111,6 +3112,15 @@ static void OutputString(Bitu x,Bitu y,const char * text,Bit32u color,Bit32u col
 
 void ResetSystem(bool pressed) {
     if (!pressed) return;
+	
+	if (is_paused) {
+		is_paused = false;
+		mainMenu.get_item("mapper_pause").check(false).refresh_item(mainMenu);
+	}
+	if (pausewithinterrupts_enable) {
+        pausewithinterrupts_enable = false;
+		mainMenu.get_item("mapper_pauseints").check(false).refresh_item(mainMenu);
+	}
 
     throw int(3);
 }
@@ -3349,7 +3359,7 @@ static void GUI_StartUp() {
     else if (feedback == "flash")
         sdl.mouse.autolock_feedback = AUTOLOCK_FEEDBACK_FLASH;
 
-	modifier = section->Get_string("clip_key_modifier");
+    modifier = section->Get_string("clip_key_modifier");
     paste_speed = (unsigned int)section->Get_int("clip_paste_speed");
 
     Prop_multival* p3 = section->Get_multival("sensitivity");
@@ -7220,8 +7230,6 @@ bool scaler_set_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const m
 }
 
 void CALLBACK_Idle(void);
-
-bool pausewithinterrupts_enable = false;
 
 void PauseWithInterruptsEnabled(Bitu /*val*/) {
     /* we can ONLY do this when the CPU is either in real mode or v86 mode.

--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -524,7 +524,7 @@ void ReadCharAttr(Bit16u col,Bit16u row,Bit8u page,Bit16u * result) {
         {
             // Compute the address  
             Bit16u address=((row*80)+col)*2;
-            // Write the char 
+            // read the char 
             PhysPt where = CurMode->pstart+address;
             *result=mem_readw(where);
         }

--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -520,6 +520,15 @@ void ReadCharAttr(Bit16u col,Bit16u row,Bit8u page,Bit16u * result) {
             *result=mem_readw(where);
         }
         return;
+    case M_PC98:
+        {
+            // Compute the address  
+            Bit16u address=((row*80)+col)*2;
+            // Write the char 
+            PhysPt where = CurMode->pstart+address;
+            *result=mem_readw(where);
+        }
+        return;
     case M_CGA4:
     case M_CGA2:
     case M_TANDY16:

--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -520,15 +520,6 @@ void ReadCharAttr(Bit16u col,Bit16u row,Bit8u page,Bit16u * result) {
             *result=mem_readw(where);
         }
         return;
-    case M_PC98:
-        {
-            // Compute the address  
-            Bit16u address=((row*80)+col)*2;
-            // read the char 
-            PhysPt where = CurMode->pstart+address;
-            *result=mem_readw(where);
-        }
-        return;
     case M_CGA4:
     case M_CGA2:
     case M_TANDY16:

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -735,7 +735,12 @@ const char* Mouse_GetSelected(int x1, int y1, int x2, int y2, int w, int h) {
 	text[0]=0;
 	for (int i=r1; i<=r2; i++) {
 		for (int j=c1; j<=c2; j++) {
-			ReadCharAttr(j,i,page,&result);
+			if (IS_PC98_ARCH) {
+				Bit16u address=((i*80)+j)*2;
+				PhysPt where = CurMode->pstart+address;
+				result=mem_readw(where);
+			} else
+				ReadCharAttr(j,i,page,&result);
 			sprintf(str,"%c",result);
 			if (str[0]==0) continue;
 			strcat(text,str);

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -711,7 +711,14 @@ uint8_t Mouse_GetButtonState(void) {
 char text[50*81];
 const char* Mouse_GetSelected(int x1, int y1, int x2, int y2, int w, int h) {
 	Bit8u page = real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
-	Bit16u c=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS), r=(Bit16u)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
+	Bit16u c=0, r=0;
+	if (IS_PC98_ARCH) {
+		c=80;
+		r=real_readb(0x60,0x113) & 0x01 ? 25 : 20;
+	} else {
+		c=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
+		r=(Bit16u)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
+	}
 	int c1=c*x1/w, r1=r*y1/h, c2=c*x2/w, r2=r*y2/h, t;
 	char str[2];
 	if (c1>c2) {
@@ -741,7 +748,14 @@ const char* Mouse_GetSelected(int x1, int y1, int x2, int y2, int w, int h) {
 
 void Mouse_Select(int x1, int y1, int x2, int y2, int w, int h) {
 	Bit8u page = real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
-	Bit16u c=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS), r=(Bit16u)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
+	Bit16u c=0, r=0;
+	if (IS_PC98_ARCH) {
+		c=80;
+		r=real_readb(0x60,0x113) & 0x01 ? 25 : 20;
+	} else {
+		c=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
+		r=(Bit16u)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
+	}
 	int c1=c*x1/w, r1=r*y1/h, c2=c*x2/w, r2=r*y2/h, t;
 	if (c1>c2) {
 		t=c1;
@@ -754,13 +768,26 @@ void Mouse_Select(int x1, int y1, int x2, int y2, int w, int h) {
 		r2=t;
 	}
 	for (int i=r1; i<=r2; i++)
-		for (int j=c1; j<=c2; j++)
-			real_writeb(0xb800,(i*c+j)*2+1,real_readb(0xb800,(i*c+j)*2+1)^119);
+		for (int j=c1; j<=c2; j++) {
+			if (IS_PC98_ARCH) {
+				Bit16u address=((i*80)+j)*2;
+				PhysPt where = CurMode->pstart+address;
+                mem_writeb(where+0x2000,mem_readb(where+0x2000)^16);
+			} else
+				real_writeb(0xb800,(i*c+j)*2+1,real_readb(0xb800,(i*c+j)*2+1)^119);
+		}
 }
 
 void Restore_Text(int x1, int y1, int x2, int y2, int w, int h) {
 	Bit8u page = real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
-	Bit16u c=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS), r=(Bit16u)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
+	Bit16u c=0, r=0;
+	if (IS_PC98_ARCH) {
+		c=80;
+		r=real_readb(0x60,0x113) & 0x01 ? 25 : 20;
+	} else {
+		c=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
+		r=(Bit16u)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
+	}
 	int c1=c*x1/w, r1=r*y1/h, c2=c*x2/w, r2=r*y2/h, t;
 	if (c1>c2) {
 		t=c1;
@@ -773,8 +800,14 @@ void Restore_Text(int x1, int y1, int x2, int y2, int w, int h) {
 		r2=t;
 	}
 	for (int i=r1; i<=r2; i++)
-		for (int j=c1; j<=c2; j++)
-			real_writeb(0xb800,(i*c+j)*2+1,real_readb(0xb800,(i*c+j)*2+1)^119);
+		for (int j=c1; j<=c2; j++) {
+			if (IS_PC98_ARCH) {
+				Bit16u address=((i*80)+j)*2;
+				PhysPt where = CurMode->pstart+address;
+                mem_writeb(where+0x2000,mem_readb(where+0x2000)^16);
+			} else
+				real_writeb(0xb800,(i*c+j)*2+1,real_readb(0xb800,(i*c+j)*2+1)^119);
+		}
 }
 #endif
 


### PR DESCRIPTION
I noticed that in most builds of DOSBox-X there is a bug when you reset the guest system while it is currently paused. The internal DOS will be reset, but in the menu "Pause" remains checked even though it is no longer paused, and the "Pause" option is no longer usable in DOSBox-X. So I made a pull request to fix this. It also fixes the logging issue (and the resulting delay) related to FluidSynth support. In addition, the Windows clipboard copy & paste via the right mouse click feature now supports PC-98 mode too just like the regular mode.