### PR TITLE
Added -set command-line option to set config option(s), improved PC-98 mode 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,9 @@
 0.83.2
+  - Added -set command-line option to change config options.
+    It can be specified multiple times for multiple options,
+    overridding any options in the config file. For example,
+    the command "dosbox-x.exe -set machine=pc98" will force
+    DOSBox-X to start in PC-98 mode. (Wengier)
   - Re-added full drive menu items for the Windows platform.
     The "Boot from drive" item (A:, C: and D: drives only)
     should work in other platforms too. The BOOT command is
@@ -9,6 +14,7 @@
     and EGA/VGA detection failure with SuperCalc 3 and
     SuperCalc 4. This option, enabled by default, can be
     disabled or enabled from dosbox.conf.
+  - Improved long filename support for PC-98 mode. (Wengier)
   - The copy & paste Windows clipboard text via the right
     mouse button feature now has limited support for PC-98
     mode too in addition to other modes. (Wengier)

--- a/include/control.h
+++ b/include/control.h
@@ -121,6 +121,7 @@ public:
     std::string opt_editconf,opt_opensaves,opt_opencaptures,opt_lang;
     std::vector<std::string> config_file_list;
     std::vector<std::string> opt_c;
+    std::vector<std::string> opt_set;
 
     bool opt_disable_dpi_awareness;
     bool opt_disable_numlock_check;

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -466,33 +466,29 @@ search:
 
 		_splitpath (path, drive2, dir, fname, ext);
 
-		if((!strcmp(ext,".ima")) || (!strcmp(ext,".img")) || (!strcmp(ext,".iso")) || (!strcmp(ext,".cue")) || (!strcmp(ext,".bin")) || (!strcmp(ext,".mdf"))) {
-			char type[15];
-			if(!strcmp(ext,".img"))
-				strcpy(type,"");
-			else if(!strcmp(ext,".ima"))
-				strcpy(type,"-t floppy ");
-			else
-				strcpy(type,"-t iso ");
-			char mountstring[DOS_PATHLENGTH+CROSS_LEN+20];
-			strcpy(mountstring,"IMGMOUNT ");
-			strcat(mountstring,type);
-			char temp_str[4] = { 0,0,0 };
-			temp_str[0]=' ';
-			temp_str[1]=drive;
-			temp_str[2]=' ';
-			strcat(mountstring,temp_str);
-			strcat(mountstring,path);
-			strcat(mountstring," >nul");
-			DOS_Shell temp;
-			temp.ParseLine(mountstring);
-			if (!Drives[drive-'A']) {
-				drive_warn="Drive "+str+": was not mounted successfully.";
-				MessageBox(GetHWND(),drive_warn.c_str(),"Error",MB_OK);
-				return;
-			}
-		} else
-			LOG_MSG("GUI: Unsupported filename extension.");
+		char type[15];
+		if(!strcasecmp(ext,".ima"))
+			strcpy(type,"-t floppy ");
+		else if((!strcasecmp(ext,".iso")) || (!strcasecmp(ext,".cue")) || (!strcasecmp(ext,".bin")) || (!strcasecmp(ext,".mdf")))
+			strcpy(type,"-t iso ");
+		else
+			strcpy(type,"");
+		char mountstring[DOS_PATHLENGTH+CROSS_LEN+20];
+		strcpy(mountstring,"IMGMOUNT ");
+		strcat(mountstring,type);
+		char temp_str[3] = { 0,0,0 };
+		temp_str[0]=drive;
+		temp_str[1]=' ';
+		strcat(mountstring,temp_str);
+		strcat(mountstring,path);
+		strcat(mountstring," >nul");
+		DOS_Shell temp;
+		temp.ParseLine(mountstring);
+		if (!Drives[drive-'A']) {
+			drive_warn="Drive "+str+": failed to mounted.";
+			MessageBox(GetHWND(),drive_warn.c_str(),"Error",MB_OK);
+			return;
+		}
 	}
 	SetCurrentDirectory( Temp_CurrentDir );
 #endif
@@ -1850,7 +1846,7 @@ public:
 			strcat(msg, "Booting from drive ");
 			strcat(msg, std::string(1, drive).c_str());
 			strcat(msg, "...\r\n");
-			Bit8u out;Bit16u s=strlen(msg);
+			Bit16u s=strlen(msg);
 			DOS_WriteFile(STDERR,(Bit8u*)msg,&s);
 
             if (IS_PC98_ARCH) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -6443,6 +6443,8 @@ bool DOSBOX_parse_argv() {
             fprintf(stderr,"  -exit                                   Exit after executing AUTOEXEC.BAT\n");
             fprintf(stderr,"  -c <command string>                     Execute this command in addition to AUTOEXEC.BAT.\n");
             fprintf(stderr,"                                          Make sure to surround the command in quotes to cover spaces.\n");
+            fprintf(stderr,"  -set <section property=value>           Sets the config option (overriding the config file).\n");
+            fprintf(stderr,"                                          Make sure to surround the string in quotes to cover spaces.\n");
             fprintf(stderr,"  -break-start                            Break into debugger at startup\n");
             fprintf(stderr,"  -time-limit <n>                         Kill the emulator after 'n' seconds\n");
             fprintf(stderr,"  -fastbioslogo                           Fast BIOS logo (skip 1-second pause)\n");
@@ -6459,6 +6461,10 @@ bool DOSBOX_parse_argv() {
         else if (optname == "c") {
             if (!control->cmdline->NextOptArgv(tmp)) return false;
             control->opt_c.push_back(tmp);
+        }
+        else if (optname == "set") {
+            if (!control->cmdline->NextOptArgv(tmp)) return false;
+            control->opt_set.push_back(tmp);
         }
         else if (optname == "alt-vga") {
             control->opt_alt_vga_render = true;
@@ -7918,6 +7924,109 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
             Cross::GetPlatformConfigName(tmp);
             control->ParseConfigFile((config_path + tmp).c_str());
         }
+		
+		MSG_Add("PROGRAM_CONFIG_PROPERTY_ERROR","No such section or property.\n");
+		MSG_Add("PROGRAM_CONFIG_NO_PROPERTY","There is no property %s in section %s.\n");
+		MSG_Add("PROGRAM_CONFIG_SET_SYNTAX","The syntax for -set option is incorrect.\n");
+		for (auto it=control->opt_set.begin(); it!=control->opt_set.end();it++) { /* -set switches */
+			// add rest of command
+			std::string rest;
+			std::vector<std::string> pvars;
+			pvars.clear();
+			pvars.push_back(trim((char *)(*it).c_str()));
+			if (!strlen(pvars[0].c_str())) continue;
+			if (pvars[0][0]=='%'||pvars[0][0]=='\0'||pvars[0][0]=='#'||pvars[0][0]=='\n') continue;
+
+
+			// attempt to split off the first word
+			std::string::size_type spcpos = pvars[0].find_first_of(' ');
+			if (spcpos>1&&pvars[0].c_str()[spcpos-1]==',')
+				spcpos=pvars[0].find_first_of(' ', spcpos+1);
+
+			std::string::size_type equpos = pvars[0].find_first_of('=');
+
+			if ((equpos != std::string::npos) && 
+				((spcpos == std::string::npos) || (equpos < spcpos))) {
+				// If we have a '=' possibly before a ' ' split on the =
+				pvars.insert(pvars.begin()+1,pvars[0].substr(equpos+1));
+				pvars[0].erase(equpos);
+				// As we had a = the first thing must be a property now
+				Section* sec=control->GetSectionFromProperty(pvars[0].c_str());
+				if (sec) pvars.insert(pvars.begin(),std::string(sec->GetName()));
+				else {
+					LOG_MSG(MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"));
+					continue;
+				}
+				// order in the vector should be ok now
+			} else {
+				if (equpos != std::string::npos && spcpos < equpos) {
+					// ' ' before a possible '=', split on the ' '
+					pvars.insert(pvars.begin()+1,pvars[0].substr(spcpos+1));
+					pvars[0].erase(spcpos);
+				}
+				// check if the first parameter is a section or property
+				Section* sec = control->GetSection(pvars[0].c_str());
+				if (!sec) {
+					// not a section: little duplicate from above
+					sec=control->GetSectionFromProperty(pvars[0].c_str());
+					if (sec) pvars.insert(pvars.begin(),std::string(sec->GetName()));
+					else {
+						LOG_MSG(MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"));
+						continue;
+					}
+				} else {
+					// first of pvars is most likely a section, but could still be gus
+					// have a look at the second parameter
+					if (pvars.size() < 2) {
+						LOG_MSG(MSG_Get("PROGRAM_CONFIG_SET_SYNTAX"));
+						continue;
+					}
+					std::string::size_type equpos2 = pvars[1].find_first_of('=');
+					if (equpos2 != std::string::npos) {
+						// split on the =
+						pvars.insert(pvars.begin()+2,pvars[1].substr(equpos2+1));
+						pvars[1].erase(equpos2);
+					}
+					// is this a property?
+					Section* sec2 = control->GetSectionFromProperty(pvars[1].c_str());
+					if (!sec2) {
+						// not a property, 
+						Section* sec3 = control->GetSectionFromProperty(pvars[0].c_str());
+						if (sec3) {
+							// section and property name are identical
+							pvars.insert(pvars.begin(),pvars[0]);
+						} // else has been checked above already
+					}
+				}
+			}
+			if(pvars.size() < 3) {
+				LOG_MSG(MSG_Get("PROGRAM_CONFIG_SET_SYNTAX"));
+				continue;
+			}
+			// check if the property actually exists in the section
+			Section* sec2 = control->GetSectionFromProperty(pvars[1].c_str());
+			if (!sec2) {
+				LOG_MSG(MSG_Get("PROGRAM_CONFIG_NO_PROPERTY"),
+					pvars[1].c_str(),pvars[0].c_str());
+				continue;
+			}
+			// Input has been parsed (pvar[0]=section, [1]=property, [2]=value)
+			// now execute
+			Section* tsec = control->GetSection(pvars[0]);
+			std::string value(pvars[2]);
+			//Due to parsing there can be a = at the start of value.
+			while (value.size() && (value.at(0) ==' ' ||value.at(0) =='=') ) value.erase(0,1);
+			for(Bitu i = 3; i < pvars.size(); i++) value += (std::string(" ") + pvars[i]);
+			if (value.empty() ) {
+				LOG_MSG(MSG_Get("PROGRAM_CONFIG_SET_SYNTAX"));
+				continue;
+			}
+			std::string inputline = pvars[1] + "=" + value;
+			
+			bool change_success = tsec->HandleInputline(inputline.c_str());
+			if (!change_success) LOG_MSG("Cannot set \"%s\"\n", inputline.c_str());
+		}
+
 
 #if (ENVIRON_LINKED)
         /* -- parse environment block (why?) */


### PR DESCRIPTION
There is currently no way to specify config option(s) when starting DOSBox-X, except by putting them in the config file. To overcome this I decided to add the -set command-line option to do achieve this. Like the -c command-line option, the -set command-line can be specified multiple times for multiple options, overriding any options in the config file. For example, the command:
 
``dosbox-x.exe -set machine=pc98``

Will start DOSBox-X in PC-98 mode regardless of the config setting in dosbox-x.conf.

``dosbox-x.exe -set machine=cga -set fullscreen=true``

Will start DOSBox-X in CGA mode and also in full-screen mode.

The usage of the -set command-line is the same as "config -set", so you can specify a section or property with spaces in quotes. For example:

``dosbox-x.exe -set "dos dos clipboard device enable=true"``

Will enable support for the CLIP$ device.

I also improved Shift-JIS support in PC-98 mode as mentioned in Issue #1515, including GetFileAttr, SetFileAttr, and DIR command in PC-98 LFN mode. 