### PR TITLE
Fix VS2019 compilation

### DIFF
--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -41,16 +41,16 @@ enum PRIORITY_LEVELS {
     PRIORITY_LEVEL_HIGHEST
 };
 
+enum method {
+    METHOD_NONE = 0,
+    METHOD_X11,
+    METHOD_XRANDR,
+    METHOD_WIN98BASE,
+    METHOD_COREGRAPHICS
+};
+
 // Screen DPI and size info
 class ScreenSizeInfo {
-public:
-    enum method {
-        METHOD_NONE=0,
-        METHOD_X11,
-        METHOD_XRANDR,
-        METHOD_WIN98BASE,
-        METHOD_COREGRAPHICS
-    };
 public:
     struct wxh {
         double      width = -1;

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1846,7 +1846,7 @@ public:
 			strcat(msg, "Booting from drive ");
 			strcat(msg, std::string(1, drive).c_str());
 			strcat(msg, "...\r\n");
-			Bit16u s=strlen(msg);
+            Bit16u s = (Bit16u)strlen(msg);
 			DOS_WriteFile(STDERR,(Bit8u*)msg,&s);
 
             if (IS_PC98_ARCH) {

--- a/src/gui/menu_osx.mm
+++ b/src/gui/menu_osx.mm
@@ -473,7 +473,7 @@ void MacOSX_GetWindowDPI(ScreenSizeInfo &info) {
             CGRect drct = CGDisplayBounds(did);
             CGSize dsz = CGDisplayScreenSize(did);
 
-            info.method = ScreenSizeInfo::METHOD_COREGRAPHICS;
+            info.method = METHOD_COREGRAPHICS;
 
             info.screen_position_pixels.x        = drct.origin.x;
             info.screen_position_pixels.y        = drct.origin.y;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -678,11 +678,11 @@ void PrintScreenSizeInfo(void) {
     const char *method = "?";
 
     switch (screen_size_info.method) {
-        case ScreenSizeInfo::METHOD_NONE:       method = "None";        break;
-        case ScreenSizeInfo::METHOD_X11:        method = "X11";         break;
-        case ScreenSizeInfo::METHOD_XRANDR:     method = "XRandR";      break;
-        case ScreenSizeInfo::METHOD_WIN98BASE:  method = "Win98base";   break;
-        case ScreenSizeInfo::METHOD_COREGRAPHICS:method = "CoreGraphics";break;
+        case METHOD_NONE:       method = "None";        break;
+        case METHOD_X11:        method = "X11";         break;
+        case METHOD_XRANDR:     method = "XRandR";      break;
+        case METHOD_WIN98BASE:  method = "Win98base";   break;
+        case METHOD_COREGRAPHICS:method = "CoreGraphics";break;
         default:                                                        break;
     }
 
@@ -714,7 +714,7 @@ void Windows_GetWindowDPI(ScreenSizeInfo &info) {
     HMONITOR mon;
     HWND hwnd;
 
-    info.method = ScreenSizeInfo::METHOD_WIN98BASE;
+    info.method = METHOD_WIN98BASE;
 
     hwnd = GetHWND();
     if (hwnd == NULL) return;

--- a/src/gui/sdlmain_linux.cpp
+++ b/src/gui/sdlmain_linux.cpp
@@ -489,7 +489,7 @@ static bool Linux_TryXRandrGetDPI(ScreenSizeInfo &info,Display *display,Window w
                             result = true;
 
                             /* choose this combo to determine screen size, and dimensions */
-                            info.method = ScreenSizeInfo::METHOD_XRANDR;
+                            info.method = METHOD_XRANDR;
 
                             info.screen_position_pixels.x        = chk->x;
                             info.screen_position_pixels.y        = chk->y;
@@ -556,7 +556,7 @@ void Linux_GetWindowDPI(ScreenSizeInfo &info) {
                 if (rootWindow != 0) {
                     int screen = 0;
 
-                    info.method = ScreenSizeInfo::METHOD_X11;
+                    info.method = METHOD_X11;
 
                     /* found on StackOverflow */
 
@@ -600,7 +600,7 @@ void Linux_GetWindowDPI(ScreenSizeInfo &info) {
                 if (rootWindow != 0) {
                     int screen = 0;
 
-                    info.method = ScreenSizeInfo::METHOD_X11;
+                    info.method = METHOD_X11;
 
                     /* found on StackOverflow */
 


### PR DESCRIPTION
I found what has been causing recent versions of Visual Studio 2019 to error-out when building: the `method` enum in the `ScreenSizeInfo` class. Fixed by moving the enum out of the class.