### PR TITLE
Implement "drive z is remote=auto" and fix MS-DOS 7+ DIR/S in general

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,9 @@
 0.83.2
-  - Added dosbox.conf option to report drive Z: as a remote
-    drive. This can be used with Windows 95 installs to prevent
-    SCANDISK.EXE from attempting to scan and "repair" drive
-    Z: which not backed by a disk filesystem.
+  - Added config option "drive z is remote" in dosbox-x.conf
+    to report drive Z: as a remote (network) drive. It is
+    "auto" by default, which will try to prevent SCANDISK.EXE
+    from Windows 9x installs to scan and "repair" drive Z:
+    which is not backed by a disk filesystem.
   - Fixed clip_key_modifier setting not working when it is
     set to alt, ctrl or shift in the SDL2 build. (Wengier)
   - Sending "Ctrl+Alt+Del" key from the menu will now reset

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1441,6 +1441,10 @@ dongle    = false
 #                                                     They will not be able to request control however if the DOS kernel is configured to occupy the HMA (DOS=HIGH)
 #                       hard drive data rate limit: Slow down (limit) hard disk throughput. This setting controls the limit in bytes/second.
 #                                                     Set to 0 to disable the limit, or -1 to use a reasonable default.
+#                                drive z is remote: If set, DOS will report drive Z as remote. If not set, DOS will report drive Z as local.
+#                                                     If auto (default), DOS will report drive Z as remote or local depending on the program.
+#                                                     Set this option to true to prevent SCANDISK.EXE from attempting scan and repair drive Z:
+#                                                     which is impossible since Z: is a virtual drive not backed by a disk filesystem.
 #                           hma minimum allocation: Minimum allocation size for HMA in bytes (equivalent to /HMAMIN= parameter).
 #                                         ansi.sys: If set (by default), ANSI.SYS emulation is on. If clear, ANSI.SYS is not emulated and will not appear to be installed.
 #                                                     NOTE: This option has no effect in PC-98 mode where MS-DOS systems integrate ANSI.SYS into the DOS kernel.

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -506,8 +506,8 @@ static Bitu DOS_21Handler(void) {
                 LOG(LOG_DOSMISC,LOG_DEBUG)("DOS:INT 20h/INT 21h AH=00h recovered CS segment %04x",f_cs);
 
                 DOS_Terminate(f_cs,false,0);
-            } else if (reg_sp == 0xE224 && dos.version.major >= 7)
-                /* Wengier: The SP=E224h case fixes the bug that DIR /S from MS-DOS 7.1 may crash hard within DOSBox-X. With this change it should now work properly. */
+            } else if (dos.version.major >= 7 && mem_readw(SegPhys(ss)+reg_sp) >=0x2700 && mem_readw(SegPhys(ss)+reg_sp+2)/0x100 == 0x90 && dos.psp()/0x100 >= 0xCC && dos.psp()/0x100 <= 0xCF)
+                /* Wengier: This case fixes the bug that DIR /S from MS-DOS 7+ could crash hard within DOSBox-X. With this change it should now work properly. */
                 DOS_Terminate(dos.psp(),false,0);
 			else
                 DOS_Terminate(mem_readw(SegPhys(ss)+reg_sp+2),false,0);

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -26,6 +26,7 @@
 #include "support.h"
 #include "control.h"
 #include "cross.h"
+#include "regs.h"
 
 struct VFILE_Block {
 	const char * name;
@@ -319,7 +320,9 @@ bool Virtual_Drive::isRemote(void) {
         return false;
     }
 
-    /* TODO: Automatically detect if called by SCANDISK.EXE and return true */
+    /* Automatically detect if called by SCANDISK.EXE and return true (tested with the program with MS-DOS 6.20 to Windows ME) */
+    if (dos.version.major >= 5 && reg_sp >=0x4000 && mem_readw(SegPhys(ss)+reg_sp)/0x100 == 0x1 && mem_readw(SegPhys(ss)+reg_sp+2)/0x100 >= 0xB && mem_readw(SegPhys(ss)+reg_sp+2)/0x100 <= 0x12)
+		return true;
 
 	return false;
 }

--- a/src/gui/midi_synth.h
+++ b/src/gui/midi_synth.h
@@ -281,13 +281,20 @@ public:
 		fluid_settings_setnum(settings, "synth.sample-rate", atof(section->Get_string("fluid.samplerate")));
 		fluid_settings_setnum(settings, "synth.gain", atof(section->Get_string("fluid.gain")));
 		fluid_settings_setint(settings, "synth.polyphony", section->Get_int("fluid.polyphony"));
-		if (strcmp(section->Get_string("fluid.driver"), "default") != 0) {
+		if (strcmp(section->Get_string("fluid.cores"), "default") != 0) {
 			fluid_settings_setnum(settings, "synth.cpu-cores", atof(section->Get_string("fluid.cores")));
 		}
+#if !defined (FLUIDSYNTH_VERSION_MAJOR) || FLUIDSYNTH_VERSION_MAJOR >= 2
+		fluid_settings_setint(settings, "audio.periods", atoi(section->Get_string("fluid.periods")));
+		fluid_settings_setint(settings, "audio.period-size", atoi(section->Get_string("fluid.periodsize")));
+		fluid_settings_setint(settings, "synth.reverb.active", !strcmp(section->Get_string("fluid.reverb"), "yes")?1:0);
+		fluid_settings_setint(settings, "synth.chorus.active", !strcmp(section->Get_string("fluid.chorus"), "yes")?1:0);
+#else
 		fluid_settings_setnum(settings, "audio.periods", atof(section->Get_string("fluid.periods")));
 		fluid_settings_setnum(settings, "audio.period-size", atof(section->Get_string("fluid.periodsize")));
 		fluid_settings_setstr(settings, "synth.reverb.active", section->Get_string("fluid.reverb"));
 		fluid_settings_setstr(settings, "synth.chorus.active", section->Get_string("fluid.chorus"));
+#endif
 
 		synth = new_fluid_synth(settings);
 		if (!synth) {


### PR DESCRIPTION
I noticed in the latest code the config option "drive z is remote" was added, but the "auto" setting was not yet implemented. So I made effort to implement it. Tested with SCANDISK.EXE from MS-DOS 6.20, 6.22, 7.0 (Windows 95A), 7.1 (Windows 95B and Windows 98 first & second editions) and 8.0 (Windows ME) to confirm it works.

Also, last time I fixed "DIR /S" from MS-DOS 7.1, but by testing various versions of COMMAND.COM from Windows 95/98/Me, it seems that previously it only fixed for specific versions of MS-DOS 7+ COMMAND.COM. So this time I decided to fix the issue in general. Tested with MS-DOS 7+ COMMAND.COM from Windows 95A, Windows 95B, Windows 98 first & second editions and Windows ME to confirm it works.

There is additional minor fix for the FluidSynth driver with FluidSynth 2.x.