### PR TITLE
Fix SYS disk corruption (#1543)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,10 @@
 0.83.2
+  - Fixed SYS command not working properly (Wengier) 
   - DOS kernel INT 21h function Set File Attribute no longer
-    allows changing directory and volume label attributes in
-    order to prevent filesystem corruption. This prevents
-    Windows 95 setup from creating WINBOOT.INI and then
-    changing it into a directory with the call.
+    allows changing volume label attributes and fixes directory
+    attributes in order to prevent filesystem corruption.
+    This prevents Windows 95 Setup from creating WINBOOT.INI
+    and then changing it into a directory with the call.
   - FAT driver bugs fixed where a newly created zero length
     file combined with a lseek() can corrupt filesytem
     structures (root directory and/or the second FAT table).

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1562,6 +1562,7 @@ Bits fatDrive::UnMount(void) {
 }
 
 Bit8u fatDrive::GetMediaByte(void) { return loadedDisk->GetBiosType(); }
+bootstrap fatDrive::GetBootBuffer(void) { return bootbuffer; }
 
 bool fatDrive::FileCreate(DOS_File **file, const char *name, Bit16u attributes) {
     if (readonly) {

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -252,6 +252,7 @@ public:
 	Bit32u getFirstFreeClust(void);
 	bool directoryBrowse(Bit32u dirClustNumber, direntry *useEntry, Bit32s entNum, Bit32s start=0);
 	bool directoryChange(Bit32u dirClustNumber, const direntry *useEntry, Bit32s entNum);
+	bootstrap GetBootBuffer(void);
 	imageDisk *loadedDisk = NULL;
 	bool created_successfully = true;
 private:


### PR DESCRIPTION
As discussed in Issue #1543, SYS command can disk image corruption on hard drives. So I fixed it. Tested to confirm it works on FAT drives.