### PR TITLE
Fluidsynth: use recommended default values

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2234,10 +2234,18 @@ void DOSBOX_SetupConfigSections(void) {
 	Pstring = secprop->Add_string("fluid.cores",Property::Changeable::WhenIdle,"default");
 	Pstring->Set_help("Fluidsynth CPU cores to use, default.");
 
-	Pstring = secprop->Add_string("fluid.periods",Property::Changeable::WhenIdle,"8");
+	#if defined (WIN32)
+		Pstring = secprop->Add_string("fluid.periods",Property::Changeable::WhenIdle,"8");
+    #else
+		Pstring = secprop->Add_string("fluid.periods",Property::Changeable::WhenIdle,"16");
+    #endif
 	Pstring->Set_help("Fluidsynth periods.");
 
-	Pstring = secprop->Add_string("fluid.periodsize",Property::Changeable::WhenIdle,"512");
+	#if defined (WIN32)
+		Pstring = secprop->Add_string("fluid.periodsize",Property::Changeable::WhenIdle,"512");
+	#else
+		Pstring = secprop->Add_string("fluid.periodsize",Property::Changeable::WhenIdle,"64");
+	#endif
 	Pstring->Set_help("Fluidsynth period size.");
 
 	const char *fluidreverb[] = {"no", "yes",0};


### PR DESCRIPTION
# Description
http://www.fluidsynth.org/api/fluidsettings.xml

The current default values for fluid.periods and fluid.periodsize in DOSBox-X are meant for Windows systems, and are not correct for Linux and MacOSX. Adjust the values accordingly.

I have tested this on Linux, and it sounds much better. No testing was done on MacOSX.

### Does this PR address some issue(s) ?

Crackling and popping MIDI music with Linux

### Does this PR introduce new feature(s) ?

Changes to default values when compiled on !WIN32.

### Are there any breaking changes ?

Possible documentation update needed to clarify that default value depends on platform.