### PR TITLE
Fix "SCANDISK A:" and make local drives "auto" by default just like virtual drive

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,4 @@
 0.83.2
-  - Fluidsynth defaults fixed for better more reliable audio
-    streaming on Linux and Mac OS X [rderooy]
   - Added DOS functions for "FAT32 extended" absolute disk
     read and write used by FAT32-aware versions of FORMAT.COM
     and SCANDISK.EXE (shipped with Windows 95 OSR2 or later).
@@ -23,6 +21,10 @@
   - Enabled printer emulation for non-Windows OSes (Linux,
     Mac OS X, etc.). FreeType2 is required to enable
     printer emulation at compile time.
+  - Added command-line option "-o" for MOUNT command so that
+    it can be specified whether to report mounted local drives
+    as remote (network) drives. It is "auto" by default just
+    like the virtual drive Z:.
   - Added config option "drive z is remote" in dosbox-x.conf
     to report drive Z: as a remote (network) drive. It is
     "auto" by default, which will try to prevent SCANDISK.EXE
@@ -51,12 +53,14 @@
     their EGA/VGA detection. This fixes blink attribute
     and EGA/VGA detection failure with SuperCalc 3 and
     SuperCalc 4. This option, enabled by default, can be
-    disabled or enabled from dosbox.conf.
+    disabled or enabled from dosbox-x.conf.
   - Improved long filename (LFN) and SetFileAttr/GetFileAttr
     support for PC-98 mode. (Wengier)
   - The copy & paste Windows clipboard text via the right
     mouse button feature now has support for PC-98 mode too
     in addition to other modes. (Wengier)
+  - Fluidsynth defaults fixed for better more reliable audio
+    streaming on Linux and Mac OS X (rderooy)
   - Improved support for FluidSynth MIDI device by porting
     code from DOSBox ECE. Set "mididevice=fluidsynth" along
     with other required options such as "fluid.soundfont"

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1989,8 +1989,16 @@ static Bitu DOS_21Handler(void) {
             }
             break;
 		case 0x73:
-			if (reg_al==3)
-			{
+			if (dos.version.major < 7) { // MS-DOS 7+ only for AX=73xxh
+				CALLBACK_SCF(true);
+				reg_ax=0x7300;
+			} else if (reg_al==0 && reg_cl<2) {
+				/* Drive locking and flushing */
+				reg_al = reg_cl;
+				reg_ah = 0;
+				CALLBACK_SCF(false);
+			} else if (reg_al==3) {
+				/* Get extended free disk space */
 				MEM_StrCopy(SegPhys(ds)+reg_dx,name1,reg_cx);
 				if (name1[1]==':'&&name1[2]=='\\')
 					reg_dl=name1[0]-'A'+1;
@@ -2027,9 +2035,8 @@ static Bitu DOS_21Handler(void) {
 					CALLBACK_SCF(true);
 				}
 				rsize=false;
-			}
-			else if (reg_al == 5 && reg_cx == 0xFFFF && (dos.version.major > 7 || (dos.version.major == 7 && dos.version.minor >= 10))) {
-				/* Windows 9x FAT32 extended disk read/write */
+			} else if (reg_al == 5 && reg_cx == 0xFFFF && (dos.version.major > 7 || dos.version.minor >= 10)) {
+				/* MS-DOS 7.1+ (Windows 95 OSR2+) FAT32 extended disk read/write */
 				reg_al = reg_dl - 1; /* INT 25h AL 0=A: 1=B:   This interface DL 1=A: 2=B: */
 				if (reg_si & 1)
 					DOS_26Handler_Actual(true/*fat32*/); /* writing */
@@ -2038,8 +2045,7 @@ static Bitu DOS_21Handler(void) {
 
 				/* CF needs to be returned on stack or else it's lost */
 				CALLBACK_SCF(!!(reg_flags & FLAG_CF));
-			}
-			else {
+			} else {
 				LOG(LOG_DOSMISC,LOG_ERROR)("DOS:Unhandled call %02X al=%02X (MS-DOS 7.x function)",reg_ah,reg_al);
 				CALLBACK_SCF(true);
 				reg_ax=0xffff;//FIXME

--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -178,13 +178,14 @@ bool DOS_IOCTL(void) {
 				//mem_writeb(ptr+0,0);					// special functions (call value)
 				mem_writeb(ptr+1,(drive>=2)?0x05:0x07);	// type: hard disk(5), 1.44 floppy(7)
 				mem_writew(ptr+2,(drive>=2)?0x01:0x00);	// attributes: bit 0 set for nonremovable
-				mem_writew(ptr+4,0x0000);				// num of cylinders
+				mem_writew(ptr+4,(drive>=2)?0x3FF:0x50);// num of cylinders
 				mem_writeb(ptr+6,0x00);					// media type (00=other type)
 				// bios parameter block following
-				bool usereal=false;
+				fatDrive *fdp;
 				bootstrap bootbuffer;
+				bool usereal=false;
 				if (!strncmp(Drives[drive]->GetInfo(),"fatDrive ",9)) {
-					fatDrive *fdp = dynamic_cast<fatDrive*>(Drives[drive]);
+					fdp = dynamic_cast<fatDrive*>(Drives[drive]);
 					if (fdp != NULL) {
 						bootbuffer=fdp->GetBootBuffer();
 						if (bootbuffer.bytespersector&&bootbuffer.mediadescriptor)
@@ -192,6 +193,8 @@ bool DOS_IOCTL(void) {
 					}
 				}
 				if (usereal) {
+					if (fdp->loadedDisk != NULL)
+						mem_writew(ptr+4,fdp->loadedDisk->cylinders);			// num of cylinders
 					mem_writew(ptr+7,bootbuffer.bytespersector);				// bytes per sector (Win3 File Mgr. uses it)
 					mem_writew(ptr+9,bootbuffer.sectorspercluster);				// sectors per cluster
 					mem_writew(ptr+0xa,bootbuffer.reservedsectors);				// number of reserved sectors

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -320,7 +320,7 @@ bool Virtual_Drive::isRemote(void) {
         return false;
     }
 
-    /* Automatically detect if called by SCANDISK.EXE and return true (tested with the program with MS-DOS 6.20 to Windows ME) */
+    /* Automatically detect if called by SCANDISK.EXE and return true (tested with the program from MS-DOS 6.20 to Windows ME) */
     if (dos.version.major >= 5 && reg_sp >=0x4000 && mem_readw(SegPhys(ss)+reg_sp)/0x100 == 0x1 && mem_readw(SegPhys(ss)+reg_sp+2)/0x100 >= 0xB && mem_readw(SegPhys(ss)+reg_sp+2)/0x100 <= 0x12)
 		return true;
 

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -91,7 +91,7 @@ public:
 	virtual void EmptyCache(void) { dirCache.EmptyCache(); };
 	virtual void MediaChange() {};
 
-	bool remote = false;
+	int remote = -1;
 
 protected:
 	DOS_Drive_Cache dirCache;


### PR DESCRIPTION
I had noticed earlier that "SCANDISK A:" did not work (it would show "ScanDisk cannot examine drive A." and exit), so I fixed it. The command "SCANDISK A:" should now work fine.

Also, I noticed the new option “-o remote" for MOUNT command, but there was no way to make this "auto" just like the virtual drive Z:, so I updated the code so that it is now "auto" by default just like Z: (i.e. report non-remote drives except for SCANDISK by default), but it can be overridden by "-o remote" or "-o local" to always report as remote or non-remote drives respectively. As a result, Windows 9x/ME Setup should now complete the ScanDisk step normally in case there are local drives mounted with the default setting.

In addition, I added a simple handler for Int21/AX=7300h (drive locking and flushing).

I updated the changelog file to mention the new MOUNT -o option, and grouped the recent FluidSynth updates together.