### PR TITLE
Fix SCANDISK free space checking on FAT32 drives, and Issue #1556

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,7 @@
 0.83.2
-  - Shell DIR command updated to use FAT32 free space API
-    to show free space even on FAT32 partitions larger
-    than 2GB, but only if the DOS version is set to 7.10
-    or higher.
+  - Shell DIR command updated to use FAT32 free space API to
+    show free space even on FAT32 partitions larger than 2GB,
+    but only if the DOS version is set to 7.10 or higher.
   - FAT driver now provides FAT32 extended disk free/total
     through FAT32 API and 2GB limited free/total through
     INT 21h AH=36h for older DOS programs.
@@ -10,13 +9,13 @@
     updated INT 21h AX=7303h to call it.
   - Added FAT32 INT21h and IOCTLs needed by Windows 98 versions
     of SCANDISK.EXE and FORMAT.COM.
-  - Added basic FAT32 support to the FAT driver.
+  - Improved FAT32 support to the FAT driver, including direct
+    support for FAT32 drives in the DOSBox-X shell.
   - MPU401 IRQ fixed to properly default to 2 or 9 in IBM
     PC/XT/AT mode depending on the "enable slave pic" option (rderooy)
   - Added DOS functions for "FAT32 extended" absolute disk
     read and write used by FAT32-aware versions of FORMAT.COM
     and SCANDISK.EXE (shipped with Windows 95 OSR2 or later).
-    The FAT driver in DOSBox-X does not yet fully support FAT32.
   - Added stub to DOS IOCTL "format device track" for FORMAT.COM.
   - Added DOS IOCTL read/write logical device track functions
     so that FORMAT.COM is able to verify and modify the partition

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,18 +9,18 @@
     updated INT 21h AX=7303h to call it.
   - Added FAT32 INT21h and IOCTLs needed by Windows 98 versions
     of SCANDISK.EXE and FORMAT.COM.
-  - Improved FAT32 support to the FAT driver, including direct
-    support for FAT32 drives in the DOSBox-X shell.
-  - MPU401 IRQ fixed to properly default to 2 or 9 in IBM
-    PC/XT/AT mode depending on the "enable slave pic" option (rderooy)
   - Added DOS functions for "FAT32 extended" absolute disk
     read and write used by FAT32-aware versions of FORMAT.COM
     and SCANDISK.EXE (shipped with Windows 95 OSR2 or later).
+  - Improved FAT32 support to the FAT driver, including direct
+    support for FAT32 drives in the DOSBox-X shell.
   - Added stub to DOS IOCTL "format device track" for FORMAT.COM.
   - Added DOS IOCTL read/write logical device track functions
     so that FORMAT.COM is able to verify and modify the partition
     table to successfully format a hard drive image.
   - Fixed SYS command not working properly (Wengier) 
+  - MPU401 IRQ fixed to properly default to 2 or 9 in IBM
+    PC/XT/AT mode depending on the "enable slave pic" option (rderooy)
   - DOS kernel INT 21h function Set File Attribute no longer
     allows changing volume label attributes and fixes directory
     attributes in order to prevent filesystem corruption.

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1848,7 +1848,7 @@ public:
              *       (default) or just below the boot sector, or... */
 
             if((bootarea.rawdata[0]==0) && (bootarea.rawdata[1]==0)) {
-                WriteOut_NoParsing("PROGRAM_BOOT_UNABLE");
+                WriteOut(MSG_Get("PROGRAM_BOOT_UNABLE"), drive);
                 return;
             }
 


### PR DESCRIPTION
As discussed recently SCANDISK reports an error in free disk space on FAT32 drives, so I fixed it. Also fixed Issue #1556 to make DIR /S less verbose when there are no files in the subdirectories.

I also cleaned up the changelog to reflect the recent support for FAT32 drives.