### PR TITLE
Display real serial numbers for local and FAT drives

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,8 @@
   - Added DOS IOCTL read/write logical device track functions
     so that FORMAT.COM is able to verify and modify the partition
     table to successfully format a hard drive image.
+  - DIR and VOL command now display real serial numbers for mounted
+    local and FAT drives (Wengier)
   - Fixed SYS command not working properly (Wengier) 
   - MPU401 IRQ fixed to properly default to 2 or 9 in IBM
     PC/XT/AT mode depending on the "enable slave pic" option (rderooy)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,8 +22,8 @@
   - Added DOS IOCTL read/write logical device track functions
     so that FORMAT.COM is able to verify and modify the partition
     table to successfully format a hard drive image.
-  - DIR and VOL command now display real serial numbers for mounted
-    local and FAT drives (Wengier)
+  - DIR and VOL commands now display real serial numbers for mounted
+    local drives (Windows only) and FAT drives (Wengier)
   - Fixed SYS command not working properly (Wengier) 
   - MPU401 IRQ fixed to properly default to 2 or 9 in IBM
     PC/XT/AT mode depending on the "enable slave pic" option (rderooy)

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -3510,12 +3510,12 @@ void DOS_Int21_71a6(const char *name1, const char *name2) {
 		if (Drives[drive]) {
 			if (!strncmp(Drives[drive]->GetInfo(),"fatDrive ",9)) {
 				fatDrive* fdp = dynamic_cast<fatDrive*>(Drives[drive]);
-				serial_number=fdp->GetSerial();
+				if (fdp != NULL) serial_number=fdp->GetSerial();
 			}
 #if defined (WIN32)
 			if (!strncmp(Drives[drive]->GetInfo(),"local ",6)) {
 				localDrive* ldp = dynamic_cast<localDrive*>(Drives[drive]);
-				serial_number=ldp->GetSerial();
+				if (ldp != NULL) serial_number=ldp->GetSerial();
 			}
 #endif
 		}

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -3494,7 +3494,7 @@ void DOS_Int21_71a6(const char *name1, const char *name2) {
     (void)name1;
     (void)name2;
 	char buf[64];
-	unsigned long serial_number=0,st=0,cdate=0,ctime=0,adate=0,atime=0,mdate=0,mtime=0;
+	unsigned long serial_number=0x1234,st=0,cdate=0,ctime=0,adate=0,atime=0,mdate=0,mtime=0;
 	Bit8u entry=(Bit8u)reg_bx, handle;
 	if (entry>=DOS_FILES) {
 		reg_ax=DOSERR_INVALID_HANDLE;
@@ -3506,11 +3506,19 @@ void DOS_Int21_71a6(const char *name1, const char *name2) {
 		if (Files[i] && psp.FindEntryByHandle(i)==entry)
 			handle=i;
 	if (handle < DOS_FILES && Files[handle] && Files[handle]->name!=NULL) {
-		char volume[] = "A:\\";
-		volume[0]+=Files[handle]->GetDrive();
+		Bit8u drive=Files[handle]->GetDrive();
+		if (Drives[drive]) {
+			if (!strncmp(Drives[drive]->GetInfo(),"fatDrive ",9)) {
+				fatDrive* fdp = dynamic_cast<fatDrive*>(Drives[drive]);
+				serial_number=fdp->GetSerial();
+			}
 #if defined (WIN32)
-		GetVolumeInformation(volume, NULL, 0, &serial_number, NULL, NULL, NULL, 0);
+			if (!strncmp(Drives[drive]->GetInfo(),"local ",6)) {
+				localDrive* ldp = dynamic_cast<localDrive*>(Drives[drive]);
+				serial_number=ldp->GetSerial();
+			}
 #endif
+		}
 		struct stat status;
 		if (DOS_GetFileAttrEx(Files[handle]->name, &status, Files[handle]->GetDrive())) {
 #if !defined(HX_DOS)

--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -212,7 +212,18 @@ bool DOS_IOCTL_AX440D_CH08(Bit8u drive) {
                 if(drive<2) buf2[4] = '2'; //FAT12 for floppies
 
                 //mem_writew(ptr+0,0);			//Info level (call value)
-                mem_writed(ptr+2,0x1234);		//Serial number
+				unsigned long serial_number=0x1234;
+				if (!strncmp(Drives[drive]->GetInfo(),"fatDrive ",9)) {
+					fatDrive* fdp = dynamic_cast<fatDrive*>(Drives[drive]);
+					serial_number=fdp->GetSerial();
+				}
+#if defined (WIN32)
+				if (!strncmp(Drives[drive]->GetInfo(),"local ",6)) {
+					localDrive* ldp = dynamic_cast<localDrive*>(Drives[drive]);
+					serial_number=ldp->GetSerial();
+				}
+#endif
+                mem_writed(ptr+2,serial_number);		//Serial number
                 MEM_BlockWrite(ptr+6,buffer,11);//volumename
                 MEM_BlockWrite(ptr+0x11,buf2,8);//filesystem
             }

--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -34,7 +34,7 @@ bool DOS_IOCTL_AX440D_CH08(Bit8u drive) {
                 //mem_writeb(ptr+0,0);					// special functions (call value)
                 mem_writeb(ptr+1,(drive>=2)?0x05:0x07);	// type: hard disk(5), 1.44 floppy(7)
                 mem_writew(ptr+2,(drive>=2)?0x01:0x00);	// attributes: bit 0 set for nonremovable
-                mem_writew(ptr+4,(drive>=2)?0x3FF:0x50);// num of cylinders
+                mem_writew(ptr+4,(drive>=2)?0x3FF:0x50);// number of cylinders
                 mem_writeb(ptr+6,0x00);					// media type (00=other type)
                 // bios parameter block following
                 fatDrive *fdp;
@@ -50,7 +50,7 @@ bool DOS_IOCTL_AX440D_CH08(Bit8u drive) {
                 }
                 if (usereal) {
                     if (fdp->loadedDisk != NULL)
-                        mem_writew(ptr+4,fdp->loadedDisk->cylinders);           // num of cylinders
+                        mem_writew(ptr+4,fdp->loadedDisk->cylinders);				// number of cylinders
 
                     if (bpb.is_fat32()) {
                         /* Windows 98 behavior: Some of the FAT32 BPB fields are translated into FAT16 BPB fields even though those fields are zero in the actual BPB */
@@ -215,15 +215,15 @@ bool DOS_IOCTL_AX440D_CH08(Bit8u drive) {
 				unsigned long serial_number=0x1234;
 				if (!strncmp(Drives[drive]->GetInfo(),"fatDrive ",9)) {
 					fatDrive* fdp = dynamic_cast<fatDrive*>(Drives[drive]);
-					serial_number=fdp->GetSerial();
+					if (fdp != NULL) serial_number=fdp->GetSerial();
 				}
 #if defined (WIN32)
 				if (!strncmp(Drives[drive]->GetInfo(),"local ",6)) {
 					localDrive* ldp = dynamic_cast<localDrive*>(Drives[drive]);
-					serial_number=ldp->GetSerial();
+					if (ldp != NULL) serial_number=ldp->GetSerial();
 				}
 #endif
-                mem_writed(ptr+2,serial_number);		//Serial number
+                mem_writed(ptr+2,serial_number);//Serial number
                 MEM_BlockWrite(ptr+6,buffer,11);//volumename
                 MEM_BlockWrite(ptr+0x11,buf2,8);//filesystem
             }

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -2134,6 +2134,10 @@ HANDLE fatDrive::CreateOpenFile(const char* name) {
 }
 #endif
 
+unsigned long fatDrive::GetSerial() {
+	return BPB.v.BPB_VolID?BPB.v.BPB_VolID:0x1234;
+}
+
 bool fatDrive::directoryBrowse(Bit32u dirClustNumber, direntry *useEntry, Bit32s entNum, Bit32s start/*=0*/) {
 	direntry sectbuf[MAX_DIRENTS_PER_SECTOR];	/* 16 directory entries per 512 byte sector */
 	Bit32u entryoffset = 0;	/* Index offset within sector */

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -944,6 +944,21 @@ HANDLE localDrive::CreateOpenFile(const char* name) {
 		DOS_SetError((Bit16u)GetLastError());
 	return handle;
 }
+
+unsigned long localDrive::GetSerial() {
+	char newname[CROSS_LEN];
+	strcpy(newname,basedir);
+	CROSS_FILENAME(newname);
+	dirCache.ExpandName(newname);
+	if (strlen(newname)>2&&newname[1]==':') {
+		unsigned long serial_number=0x1234;
+		char volume[] = "A:\\";
+		volume[0]=newname[0];
+		GetVolumeInformation(volume, NULL, 0, &serial_number, NULL, NULL, NULL, 0);
+		return serial_number;
+		
+	}
+}
 #endif
 
 bool localDrive::MakeDir(const char * dir) {

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -76,6 +76,7 @@ public:
 	virtual unsigned long GetCompressedSize(char* name);
 #if defined (WIN32)
 	virtual HANDLE CreateOpenFile(char const* const name);
+	virtual unsigned long GetSerial();
 #endif
 	virtual bool Rename(const char * oldname,const char * newname);
 	virtual bool AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,Bit16u * _total_clusters,Bit16u * _free_clusters);
@@ -360,6 +361,7 @@ public:
 #if defined (WIN32)
 	virtual HANDLE CreateOpenFile(char const* const name);
 #endif
+	virtual unsigned long GetSerial();
 	virtual bool Rename(const char * oldname,const char * newname);
 	virtual bool AllocationInfo(Bit16u * _bytes_sector,Bit8u * _sectors_cluster,Bit16u * _total_clusters,Bit16u * _free_clusters);
 	virtual bool AllocationInfo32(Bit32u * _bytes_sector,Bit32u * _sectors_cluster,Bit32u * _total_clusters,Bit32u * _free_clusters);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -2513,7 +2513,18 @@ void DOS_Shell::CMD_VOL(char *args){
 		WriteOut(MSG_Get("SHELL_CMD_VOL_SERIAL_LABEL"),bufin);
 
 	WriteOut(MSG_Get("SHELL_CMD_VOL_SERIAL"));
-	WriteOut("0000-1234\n"); // fake serial number
+	unsigned long serial_number=0x1234;
+	if (!strncmp(Drives[drive]->GetInfo(),"fatDrive ",9)) {
+		fatDrive* fdp = dynamic_cast<fatDrive*>(Drives[drive]);
+		if (fdp != NULL) serial_number=fdp->GetSerial();
+	}
+#if defined (WIN32)
+	if (!strncmp(Drives[drive]->GetInfo(),"local ",6)) {
+		localDrive* ldp = dynamic_cast<localDrive*>(Drives[drive]);
+		if (ldp != NULL) serial_number=ldp->GetSerial();
+	}
+#endif
+	WriteOut("%04X-%04X\n", serial_number/0x10000, serial_number%0x10000);
 	return;
 }
 


### PR DESCRIPTION
I noticed that commands like DIR and VOL (and external tools too) always report "0000-1234" as the volume label in DOSBox-X, so I updated the code to display real serial numbers for local drives and FAT drives whenever possible. Support for serial numbers in mounted local drives is Windows-only though.