### PR TITLE
Supress "run-time error R6001" and "Assertion failed!" errors

### DIFF
--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -213,15 +213,23 @@ static bool DOS_MultiplexFunctions(void) {
         reg_ax=0;
         return true;
     case 0x1611:    /* Get shell parameters */
+	{
 		if (dos.version.major < 7) return false;
-        strcpy(name,"COMMAND.COM");
-        MEM_BlockWrite(SegPhys(ds)+reg_di,name,(Bitu)(strlen(name)+1));
-        strcpy(name+1,"Z:\\COMMAND.COM /P");
-		name[0]=(char)strlen(name+1);
-        MEM_BlockWrite(SegPhys(ds)+reg_si,name,(Bitu)(strlen(name)+1));
-        reg_ax=0;
-        reg_bx=0;
-        return true;
+		char psp_name[9];
+		DOS_MCB psp_mcb(dos.psp()-1);
+		psp_mcb.GetFileName(psp_name);
+		if (strcmp(psp_name, "DOSSETUP")) {
+			strcpy(name,"COMMAND.COM");
+			MEM_BlockWrite(SegPhys(ds)+reg_dx,name,(Bitu)(strlen(name)+1));
+			strcpy(name+1,"/P /D");
+			name[0]=(char)strlen(name);
+			MEM_BlockWrite(SegPhys(ds)+reg_si,name,(Bitu)(strlen(name+1)+2));
+			reg_ax=0;
+			reg_bx=0;
+			return true;
+		} else
+			return false;
+	}
     case 0x1612:
 		if (dos.version.major < 7) return false;
         reg_ax=0;

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1969,7 +1969,7 @@ nextfile:
 	entryoffset = (Bit32u)((size_t)dirPos % dirent_per_sector);
 
 	if(dirClustNumber==0) {
-        assert(!BPB.is_fat32());
+        if (BPB.is_fat32()) return false;
 
 		if(dirPos >= BPB.v.BPB_RootEntCnt) {
 			if (faux<255) {
@@ -2485,4 +2485,3 @@ Bit32u fatDrive::GetFirstClusterOffset(void) {
 Bit32u fatDrive::GetHighestClusterNumber(void) {
     return CountOfClusters + 1ul;
 }
-


### PR DESCRIPTION
As mentioned in Issue #1555, Windows 98 SETUP program will show "run-time error R6001" with DOS version 7+. I found the reason is that Windows 98 will call a DOS 7+ function, and if it succeeds, will do some weird things not yet supported by DOSBox-X. By failing the function for Windows 98 SETUP it will no longer show such error message.

Also, I noticed that when using the SRCBOOT.COM tool to save the boot sector of a FAT32 drive, DOSBox-X will pop up a message box with the "Assertion failed!" error, even though it will save the boot sector properly if I click "Ignore". So I fixed this too by suppressing the assertion error.