### PR TITLE
Improve auto drive mount feature in Windows and fix large files not showing in VS build

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,8 +29,6 @@
   - DIR and VOL commands now display real serial numbers for mounted
     local drives (Windows only) and FAT drives (Wengier)
   - Fixed SYS command not working properly (Wengier) 
-  - MPU401 IRQ fixed to properly default to 2 or 9 in IBM
-    PC/XT/AT mode depending on the "enable slave pic" option (rderooy)
   - DOS kernel INT 21h function Set File Attribute no longer
     allows changing volume label attributes and fixes directory
     attributes in order to prevent filesystem corruption.
@@ -79,9 +77,16 @@
     disabled or enabled from dosbox-x.conf.
   - Improved long filename (LFN) and SetFileAttr/GetFileAttr
     support for PC-98 mode. (Wengier)
+  - Added config option "lfn" to enable/disable long filename
+    (LFN) support if the reported DOS version is at least 7
+  - Added config option "automountall" (default: false) to
+    automatically mount all available Windows drives (Wengier)
   - The copy & paste Windows clipboard text via the right
     mouse button feature now has support for PC-98 mode too
     in addition to other modes. (Wengier)
+  - MPU401 IRQ fixed to properly default to 2 or 9 in IBM
+    PC/XT/AT mode depending on the "enable slave pic" config
+    option (rderooy)
   - Fluidsynth defaults fixed for better more reliable audio
     streaming on Linux and Mac OS X (rderooy)
   - Improved support for FluidSynth MIDI device by porting

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1546,7 +1546,8 @@ dongle    = false
 #                                                     7.1                              MS-DOS 7.1 (Windows 98 pure DOS mode) emulation
 #                                                     LFN (long filename) support will be enabled with an initial DOS version of 7.0 or higher.
 #                                                     
-#                                        automount: Enable automatic mount.
+#                                        automount: Enable automatic drive mounting in Windows.
+#                                     automountall: Automatically mount all available Windows drives at start.
 #                                            int33: Enable INT 33H (mouse) support.
 #   int33 hide host cursor if interrupt subroutine: If set, the cursor on the host will be hidden if the DOS application provides it's own
 #                                                     interrupt subroutine for the mouse driver to call, which is usually an indication that
@@ -1635,6 +1636,7 @@ keep private area on boot                        = false
 private area in umb                              = true
 ver                                              = 
 automount                                        = true
+automountall                                     = false
 int33                                            = true
 int33 hide host cursor if interrupt subroutine   = true
 int33 hide host cursor when polling              = false

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1546,6 +1546,8 @@ dongle    = false
 #                                                     7.1                              MS-DOS 7.1 (Windows 98 pure DOS mode) emulation
 #                                                     LFN (long filename) support will be enabled with an initial DOS version of 7.0 or higher.
 #                                                     
+#                                              lfn: Enable long filename support. This option has no effect unless the reported DOS version is 7.0 or higher at any time.
+#                                                     Disabling LFNs on MS-DOS 7.0 and higher simulates running in pure DOS mode without the Windows 9x/ME kernel VFAT driver providing LFNs.
 #                                        automount: Enable automatic drive mounting in Windows.
 #                                     automountall: Automatically mount all available Windows drives at start.
 #                                            int33: Enable INT 33H (mouse) support.

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -57,8 +57,8 @@ typedef wchar_t host_cnv_char_t;
 #  define ht_stat_t struct _stat
 #  define ht_stat(x,y) _wstat(x,y)
 # else
-#  define ht_stat_t struct _stat64i32 /* WTF Microsoft?? Why aren't _stat and _wstat() consistent on stat struct type? */
-#  define ht_stat(x,y) _wstat64i32(x,y)
+#  define ht_stat_t struct _stat64 /* WTF Microsoft?? Why aren't _stat and _wstat() consistent on stat struct type? */
+#  define ht_stat(x,y) _wstat64(x,y)
 # endif
 # define ht_access(x,y) _waccess(x,y)
 # define ht_strdup(x) _wcsdup(x)

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3080,7 +3080,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pbool = secprop->Add_bool("automount",Property::Changeable::WhenIdle,true);
     Pbool->Set_help("Enable automatic drive mounting in Windows.");
 
-    Pbool = secprop->Add_bool("automountall",Property::Changeable::WhenIdle,false);
+    Pbool = secprop->Add_bool("automountall",Property::Changeable::OnlyAtStart,false);
     Pbool->Set_help("Automatically mount all available Windows drives at start.");
 
     Pbool = secprop->Add_bool("int33",Property::Changeable::WhenIdle,true);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3078,7 +3078,10 @@ void DOSBOX_SetupConfigSections(void) {
                     "Disabling LFNs on MS-DOS 7.0 and higher simulates running in pure DOS mode without the Windows 9x/ME kernel VFAT driver providing LFNs.");
 
     Pbool = secprop->Add_bool("automount",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("Enable automatic mount.");
+    Pbool->Set_help("Enable automatic drive mounting in Windows.");
+
+    Pbool = secprop->Add_bool("automountall",Property::Changeable::WhenIdle,false);
+    Pbool->Set_help("Automatically mount all available Windows drives at start.");
 
     Pbool = secprop->Add_bool("int33",Property::Changeable::WhenIdle,true);
     Pbool->Set_help("Enable INT 33H (mouse) support.");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -467,11 +467,11 @@ void DOS_Shell::Run(void) {
         if (machine == MCH_HERC || machine == MCH_MDA) WriteOut(MSG_Get("SHELL_STARTUP_HERC"));
         WriteOut(MSG_Get("SHELL_STARTUP_END"));
 #if defined(WIN32)
-		if (!control->SecureMode())
+		if (!control->opt_securemode&&!control->SecureMode())
 		{
 			const Section_prop* sec = 0; sec = static_cast<Section_prop*>(control->GetSection("dos"));
 			if(sec->Get_bool("automountall")) {
-				DWORD drives = GetLogicalDrives();
+				Bit32u drives = GetLogicalDrives();
 				char name[4]="A:\\";
 				for (int i=0; i<25; i++) {
 					if ((drives & (1<<i)) && !Drives[i])

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -888,11 +888,14 @@ bool DOS_Shell::Execute(char* name, const char* args) {
             const Section_prop* sec = 0; sec = static_cast<Section_prop*>(control->GetSection("dos"));
 			if(!sec->Get_bool("automount")) { WriteOut(MSG_Get("SHELL_EXECUTE_DRIVE_NOT_FOUND"),toupper(name[0])); return true; }
 			// automount: attempt direct letter to drive map.
-			if((GetDriveType(name)==3) && (strcasecmp(name,"c:")==0)) WriteOut(MSG_Get("SHELL_EXECUTE_DRIVE_ACCESS_WARNING_WIN"));
+			int type=GetDriveType(name);
+			if(type==DRIVE_FIXED && (strcasecmp(name,"C:")==0)) WriteOut(MSG_Get("SHELL_EXECUTE_DRIVE_ACCESS_WARNING_WIN"));
 first_1:
-			if(GetDriveType(name)==5) WriteOut(MSG_Get("SHELL_EXECUTE_DRIVE_ACCESS_CDROM"),toupper(name[0]));
-			else if(GetDriveType(name)==2) WriteOut(MSG_Get("SHELL_EXECUTE_DRIVE_ACCESS_FLOPPY"),toupper(name[0]));
-			else if((GetDriveType(name)==3)||(GetDriveType(name)==4)||(GetDriveType(name)==6)) WriteOut(MSG_Get("SHELL_EXECUTE_DRIVE_ACCESS_FIXED"),toupper(name[0]));
+			if(type==DRIVE_CDROM) WriteOut(MSG_Get("SHELL_EXECUTE_DRIVE_ACCESS_CDROM"),toupper(name[0]));
+			else if(type==DRIVE_REMOVABLE && (strcasecmp(name,"A:")==0||strcasecmp(name,"B:")==0)) WriteOut(MSG_Get("SHELL_EXECUTE_DRIVE_ACCESS_FLOPPY"),toupper(name[0]));
+			else if(type==DRIVE_REMOVABLE) WriteOut(MSG_Get("SHELL_EXECUTE_DRIVE_ACCESS_REMOVABLE"),toupper(name[0]));
+			else if(type==DRIVE_REMOTE) WriteOut(MSG_Get("SHELL_EXECUTE_DRIVE_ACCESS_NETWORK"),toupper(name[0]));
+			else if((type==DRIVE_FIXED)||(type==DRIVE_RAMDISK)) WriteOut(MSG_Get("SHELL_EXECUTE_DRIVE_ACCESS_FIXED"),toupper(name[0]));
 			else { WriteOut(MSG_Get("SHELL_EXECUTE_DRIVE_NOT_FOUND"),toupper(name[0])); return true; }
 
 first_2:
@@ -940,8 +943,8 @@ continue_1:
 			char mountstring[DOS_PATHLENGTH+CROSS_LEN+20];
 			sprintf(mountstring,"MOUNT %s ",name);
 
-			if(GetDriveType(name)==5) strcat(mountstring,"-t cdrom ");
-			else if(GetDriveType(name)==2) strcat(mountstring,"-t floppy ");
+			if(type==DRIVE_CDROM) strcat(mountstring,"-t cdrom ");
+			else if(type==DRIVE_REMOVABLE && (strcasecmp(name,"A:")==0||strcasecmp(name,"B:")==0)) strcat(mountstring,"-t floppy ");
 			strcat(mountstring,name);
 			strcat(mountstring,"\\");
 //			if(GetDriveType(name)==5) strcat(mountstring," -ioctl");


### PR DESCRIPTION
There is currently already the auto drive mount feature when you manually enter a drive letter such as "D:" in the DOSBox-X shell (in the Windows platform), but it cannot automatically detect and mount all available Windows drives at start. So I improved the auto drive mount feature to make this possible. It is disabled by default, but it can be activated by setting the "automountall=true" config option (unless the secure mode is enabled). Also, I noticed that in Visual Studio builds (but not in MinGW builds) very large files (>2GB) on local drives may not show up in the directory list at all. So I fixed this. DOS will always report a maximum size of 4GB for files though.