### PR TITLE
Further fix for Fluidsynth default values and support changing the new "lfn" option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,13 +5,13 @@
   - FAT driver cleaned up and fix to avoid edge cases that
     can corrupt directory entries and leave lost clusters
     on the disk.
-  - INT AH=36h fixed to convert free space but maintain a
-    cluster size (bytes/sector * sectors/cluster) that is less
-    than 64KB to avoid divide by 0 crashes with FORMAT.COM /S
   - IMGMOUNT auto geometry detection will assume LBA disk
     and fake C/H/S geometry if the disk is 4GB or larger,
     the MBR lacks executable code, or the first partition
     is Windows 98-style LBA FAT16 or FAT32.
+  - INT AH=36h fixed to convert free space but maintain a
+    cluster size (bytes/sector * sectors/cluster) that is less
+    than 64KB to avoid divide by 0 crashes with FORMAT.COM /S
   - Added FAT32 free/total disk space API for FAT driver, and
     updated INT 21h AX=7303h to call it. FAT driver now provides
     FAT32 extended disk free/total through FAT32 API and 2GB
@@ -94,7 +94,7 @@
     PC/XT/AT mode depending on the "enable slave pic" config
     option (rderooy)
   - Fluidsynth defaults fixed for better more reliable audio
-    streaming on Linux and Mac OS X (rderooy)
+    streaming on Linux and Mac OS X (Wengier and rderooy)
   - Improved support for FluidSynth MIDI device by porting
     code from DOSBox ECE. Set "mididevice=fluidsynth" along
     with other required options such as "fluid.soundfont"

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -907,9 +907,9 @@ prebuffer       = 25
 #      fluid.samplerate: Sample rate to use with Fluidsynth.
 #            fluid.gain: Fluidsynth gain.
 #       fluid.polyphony: Fluidsynth polyphony.
-#           fluid.cores: Fluidsynth CPU cores to use, default.
-#         fluid.periods: Fluidsynth periods.
-#      fluid.periodsize: Fluidsynth period size.
+#           fluid.cores: Fluidsynth CPU cores to use, or default.
+#         fluid.periods: Fluidsynth periods, or default.
+#      fluid.periodsize: Fluidsynth period size, or default.
 #          fluid.reverb: Fluidsynth use reverb.
 #                          Possible values: no, yes.
 #          fluid.chorus: Fluidsynth use chorus.
@@ -945,8 +945,8 @@ fluid.samplerate      = 48000
 fluid.gain            = .6
 fluid.polyphony       = 256
 fluid.cores           = default
-fluid.periods         = 16
-fluid.periodsize      = 64
+fluid.periods         = default
+fluid.periodsize      = default
 fluid.reverb          = yes
 fluid.chorus          = yes
 fluid.reverb.roomsize = .61

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2232,21 +2232,13 @@ void DOSBOX_SetupConfigSections(void) {
 	Pint->Set_help("Fluidsynth polyphony.");
 
 	Pstring = secprop->Add_string("fluid.cores",Property::Changeable::WhenIdle,"default");
-	Pstring->Set_help("Fluidsynth CPU cores to use, default.");
+	Pstring->Set_help("Fluidsynth CPU cores to use, or default.");
 
-	#if defined (WIN32)
-		Pstring = secprop->Add_string("fluid.periods",Property::Changeable::WhenIdle,"8");
-    #else
-		Pstring = secprop->Add_string("fluid.periods",Property::Changeable::WhenIdle,"16");
-    #endif
-	Pstring->Set_help("Fluidsynth periods.");
+	Pstring = secprop->Add_string("fluid.periods",Property::Changeable::WhenIdle,"default");
+	Pstring->Set_help("Fluidsynth periods, or default.");
 
-	#if defined (WIN32)
-		Pstring = secprop->Add_string("fluid.periodsize",Property::Changeable::WhenIdle,"512");
-	#else
-		Pstring = secprop->Add_string("fluid.periodsize",Property::Changeable::WhenIdle,"64");
-	#endif
-	Pstring->Set_help("Fluidsynth period size.");
+	Pstring = secprop->Add_string("fluid.periodsize",Property::Changeable::WhenIdle,"default");
+	Pstring->Set_help("Fluidsynth period size, or default.");
 
 	const char *fluidreverb[] = {"no", "yes",0};
 	Pstring = secprop->Add_string("fluid.reverb",Property::Changeable::WhenIdle,"yes");	

--- a/src/gui/midi_synth.h
+++ b/src/gui/midi_synth.h
@@ -284,14 +284,30 @@ public:
 		if (strcmp(section->Get_string("fluid.cores"), "default") != 0) {
 			fluid_settings_setnum(settings, "synth.cpu-cores", atof(section->Get_string("fluid.cores")));
 		}
+		
+		std::string period=section->Get_string("fluid.periods"), periodsize=section->Get_string("fluid.periodsize");
+		if (period=="default") {
+#if defined (WIN32)
+			period="8";
+#else
+			period="16";
+#endif
+		}
+		if (periodsize=="default") {
+#if defined (WIN32)
+			periodsize="512";
+#else
+			periodsize="64";
+#endif
+		}
 #if !defined (FLUIDSYNTH_VERSION_MAJOR) || FLUIDSYNTH_VERSION_MAJOR >= 2
-		fluid_settings_setint(settings, "audio.periods", atoi(section->Get_string("fluid.periods")));
-		fluid_settings_setint(settings, "audio.period-size", atoi(section->Get_string("fluid.periodsize")));
+		fluid_settings_setint(settings, "audio.periods", atoi(period.c_str()));
+		fluid_settings_setint(settings, "audio.period-size", atoi(periodsize.c_str()));
 		fluid_settings_setint(settings, "synth.reverb.active", !strcmp(section->Get_string("fluid.reverb"), "yes")?1:0);
 		fluid_settings_setint(settings, "synth.chorus.active", !strcmp(section->Get_string("fluid.chorus"), "yes")?1:0);
 #else
-		fluid_settings_setnum(settings, "audio.periods", atof(section->Get_string("fluid.periods")));
-		fluid_settings_setnum(settings, "audio.period-size", atof(section->Get_string("fluid.periodsize")));
+		fluid_settings_setnum(settings, "audio.periods", atof(period.c_str()));
+		fluid_settings_setnum(settings, "audio.period-size", atof(periodsize.c_str()));
 		fluid_settings_setstr(settings, "synth.reverb.active", section->Get_string("fluid.reverb"));
 		fluid_settings_setstr(settings, "synth.chorus.active", section->Get_string("fluid.chorus"));
 #endif

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -991,19 +991,24 @@ void CONFIG::Run(void) {
 						} else if (!strcasecmp(pvars[0].c_str(), "sdl")) {
 							modifier = section->Get_string("clip_key_modifier");
 							paste_speed = section->Get_int("clip_paste_speed");
-						} else if (!strcasecmp(inputline.substr(0, 4).c_str(), "ver=")) {
-							std::string ver = section->Get_string("ver");
-							if (!ver.empty()) {
-								const char *s = ver.c_str();
-								if (isdigit(*s)) {
-									dos.version.minor=0;
-									dos.version.major=(int)strtoul(s,(char**)(&s),10);
-									if (*s == '.' || *s == ' ') {
-										s++;
-										if (isdigit(*s))
-											dos.version.minor=(*(s-1)=='.'&&strlen(s)==1?10:1)*(int)strtoul(s,(char**)(&s),10);
+						} else if (!strcasecmp(pvars[0].c_str(), "dos")) {
+							if (!strcasecmp(inputline.substr(0, 4).c_str(), "lfn=")) {
+								enablelfn = section->Get_bool("lfn");
+								uselfn = enablelfn && (dos.version.major>6);
+							} else if (!strcasecmp(inputline.substr(0, 4).c_str(), "ver=")) {
+								std::string ver = section->Get_string("ver");
+								if (!ver.empty()) {
+									const char *s = ver.c_str();
+									if (isdigit(*s)) {
+										dos.version.minor=0;
+										dos.version.major=(int)strtoul(s,(char**)(&s),10);
+										if (*s == '.' || *s == ' ') {
+											s++;
+											if (isdigit(*s))
+												dos.version.minor=(*(s-1)=='.'&&strlen(s)==1?10:1)*(int)strtoul(s,(char**)(&s),10);
+										}
+										uselfn = enablelfn && (dos.version.major>6);
 									}
-									uselfn = enablelfn && (dos.version.major>6);
 								}
 							}
 						}


### PR DESCRIPTION
The previous pull request #1548 by @rderooy tried to fix the default values of Fluidsynth for different platforms (Windows or non-Windows), but I have noticed an issue with the fix: the dosbox-x.reference.conf file will use either the Windows value or the non-Windows value, thus it is not portable. So I improved his fix by adding a value "default" for these options, which will adjust accordingly at DOSBox-X startup for different platforms. This will make the config file itself portable.

In addition, I made it possible to change the newly added "lfn" config option with the "config -set" command.