### PR TITLE
Make "lfn=auto" the default setting for LFN support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,9 @@
 0.83.2
-  - FAT driver fixed to always report root directory as a
-    directory through the GetFileAttribute INT 21h call,
-    needed by MOVE.EXE and XCOPY.EXE to work properly.
-  - FAT driver cleaned up and fix to avoid edge cases that
+  - FAT driver cleaned up and fixed to avoid edge cases that
     can corrupt directory entries and leave lost clusters
-    on the disk.
+    on the disk, also fixed to always report root directory
+    as a directory through the GetFileAttribute INT 21h call,
+    needed by MOVE.EXE and XCOPY.EXE to work properly.
   - IMGMOUNT auto geometry detection will assume LBA disk
     and fake C/H/S geometry if the disk is 4GB or larger,
     the MBR lacks executable code, or the first partition
@@ -84,7 +83,8 @@
   - Improved long filename (LFN) and SetFileAttr/GetFileAttr
     support for PC-98 mode. (Wengier)
   - Added config option "lfn" to enable/disable long filename
-    (LFN) support if the reported DOS version is at least 7
+    (LFN) support. With default setting of "auto", LFN support
+    is enabled if the reported DOS version is at least 7.0.
   - Added config option "automountall" (default: false) to
     automatically mount all available Windows drives (Wengier)
   - The copy & paste Windows clipboard text via the right

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1544,10 +1544,9 @@ dongle    = false
 #                                                     6.22                             MS-DOS 6.22 emulation
 #                                                     7.0                              MS-DOS 7.0 (Windows 95 pure DOS mode) emulation
 #                                                     7.1                              MS-DOS 7.1 (Windows 98 pure DOS mode) emulation
-#                                                     LFN (long filename) support will be enabled with an initial DOS version of 7.0 or higher.
+#                                                     LFN (long filename) support will be enabled with a reported DOS version of 7.0 or higher with "lfn=auto" (default).
 #                                                     
-#                                              lfn: Enable long filename support. This option has no effect unless the reported DOS version is 7.0 or higher at any time.
-#                                                     Disabling LFNs on MS-DOS 7.0 and higher simulates running in pure DOS mode without the Windows 9x/ME kernel VFAT driver providing LFNs.
+#                                              lfn: Enable long filename support. If set to auto (default), it is enabled if the reported DOS version is at least 7.0.
 #                                        automount: Enable automatic drive mounting in Windows.
 #                                     automountall: Automatically mount all available Windows drives at start.
 #                                            int33: Enable INT 33H (mouse) support.
@@ -1637,7 +1636,7 @@ keep umb on boot                                 = false
 keep private area on boot                        = false
 private area in umb                              = true
 ver                                              = 
-lfn                                              = true
+lfn                                              = auto
 automount                                        = true
 automountall                                     = false
 int33                                            = true

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1537,7 +1537,7 @@ dongle    = false
 #                        keep private area on boot: If set, keep the DOSBox-X private area around after boot (Mainline DOSBox behavior). If clear, unmap and discard the private area when you boot an operating system.
 #                              private area in umb: If set, keep private DOS segment in upper memory block, usually segment 0xC800 (Mainline DOSBox behavior)
 #                                                     If clear, place private DOS segment at the base of system memory (just below the MCB)
-#                                              ver: Set DOS version. Specify as major.minor format. A single number is treated as the major version (LFN patch compat). Common settings are:
+#                                              ver: Set DOS version. Specify as major.minor format. A single number is treated as the major version (compatible with LFN support). Common settings are:
 #                                                     auto (or unset)                  Pick a DOS kernel version automatically
 #                                                     3.3                              MS-DOS 3.3 emulation (not tested!)
 #                                                     5.0                              MS-DOS 5.0 emulation (recommended for DOS gaming)
@@ -1547,6 +1547,7 @@ dongle    = false
 #                                                     LFN (long filename) support will be enabled with a reported DOS version of 7.0 or higher with "lfn=auto" (default).
 #                                                     
 #                                              lfn: Enable long filename support. If set to auto (default), it is enabled if the reported DOS version is at least 7.0.
+#                                                     Possible values: true, false, auto.
 #                                        automount: Enable automatic drive mounting in Windows.
 #                                     automountall: Automatically mount all available Windows drives at start.
 #                                            int33: Enable INT 33H (mouse) support.

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -2183,9 +2183,7 @@ nextfile:
 		goto nextfile;
 	}
 
-	// HACK: Drive emulation seems to REQUIRE a LFN, or else 8.3 names have no name and funny things happen.
-	//       This is contrary to actual Windows 9x/ME behavior where files with 8.3 names usually have no LFN
-	//       and none is returned.
+	// Drive emulation does not need to require a LFN in case there is no corresponding 8.3 names.
 	if (lfind_name[0] == 0) strcpy(lfind_name,find_name);
 
 	//dta.SetResult(find_name, sectbuf[entryoffset].entrysize, sectbuf[entryoffset].crtDate, sectbuf[entryoffset].crtTime, sectbuf[entryoffset].attrib);

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -628,7 +628,7 @@ nextfile:
 	readSector(tmpsector,sectbuf);
 	dirPos++;
 
-	if (dos.version.major >= 7) {
+	if (uselfn) {
 		/* skip LFN entries */
 		if ((sectbuf[entryoffset].attrib & 0x3F) == 0x0F)
 			goto nextfile;
@@ -2114,7 +2114,7 @@ nextfile:
 
     //TODO What about attrs = DOS_ATTR_VOLUME|DOS_ATTR_DIRECTORY ?
 	if (attrs == DOS_ATTR_VOLUME) {
-		if (dos.version.major >= 7) {
+		if (uselfn) {
 			/* skip LFN entries */
 			if ((sectbuf[entryoffset].attrib & 0x3F) == 0x0F)
 				goto nextfile;
@@ -2122,7 +2122,7 @@ nextfile:
 
 		if (!(sectbuf[entryoffset].attrib & DOS_ATTR_VOLUME)) goto nextfile;
 		labelCache.SetLabel(find_name, false, true);
-	} else if (dos.version.major >= 7 && (sectbuf[entryoffset].attrib & 0x3F) == 0x0F) { /* long filename piece */
+	} else if (uselfn && (sectbuf[entryoffset].attrib & 0x3F) == 0x0F) { /* long filename piece */
 		struct direntry_lfn *dlfn = (struct direntry_lfn*)(&sectbuf[entryoffset]);
 
 		/* assume last entry comes first, because that's how Windows 9x does it and that is how you're supposed to do it according to Microsoft */

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -2178,7 +2178,7 @@ nextfile:
 	}
 
 	/* Compare name to search pattern. Skip long filename match if no long filename given. */
-	if (!(WildFileCmp(find_name,srch_pattern) || (lfind_name[0] != 0 && LWildFileCmp(lfind_name,srch_pattern)))) {
+	if (!(WildFileCmp(find_name,srch_pattern) || LWildFileCmp(lfind_name,srch_pattern))) {
 		lfn_max_ord = 0;
 		goto nextfile;
 	}

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -628,7 +628,7 @@ nextfile:
 	readSector(tmpsector,sectbuf);
 	dirPos++;
 
-	if (uselfn) {
+	if (dos.version.major >= 7 || uselfn) {
 		/* skip LFN entries */
 		if ((sectbuf[entryoffset].attrib & 0x3F) == 0x0F)
 			goto nextfile;
@@ -2114,7 +2114,7 @@ nextfile:
 
     //TODO What about attrs = DOS_ATTR_VOLUME|DOS_ATTR_DIRECTORY ?
 	if (attrs == DOS_ATTR_VOLUME) {
-		if (uselfn) {
+		if (dos.version.major >= 7 || uselfn) {
 			/* skip LFN entries */
 			if ((sectbuf[entryoffset].attrib & 0x3F) == 0x0F)
 				goto nextfile;

--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -126,7 +126,7 @@ checkext:
 
 bool LWildFileCmp(const char * file, const char * wild)
 {
-    if (!uselfn) return false;
+    if (!uselfn||*file == 0) return false;
     char file_name[256];
     char file_ext[256];
     char wild_name[256];

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3063,11 +3063,10 @@ void DOSBOX_SetupConfigSections(void) {
             "6.22                             MS-DOS 6.22 emulation\n"
             "7.0                              MS-DOS 7.0 (Windows 95 pure DOS mode) emulation\n"
             "7.1                              MS-DOS 7.1 (Windows 98 pure DOS mode) emulation\n"
-            "LFN (long filename) support will be enabled with an initial DOS version of 7.0 or higher.\n");
+            "LFN (long filename) support will be enabled with a reported DOS version of 7.0 or higher with \"lfn=auto\" (default).\n");
 
-    Pbool = secprop->Add_bool("lfn",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("Enable long filename support. This option has no effect unless the reported DOS version is 7.0 or higher at any time.\n"
-                    "Disabling LFNs on MS-DOS 7.0 and higher simulates running in pure DOS mode without the Windows 9x/ME kernel VFAT driver providing LFNs.");
+    Pstring = secprop->Add_string("lfn",Property::Changeable::WhenIdle,"auto");
+    Pstring->Set_help("Enable long filename support. If set to auto (default), it is enabled if the reported DOS version is at least 7.0.");
 
     Pbool = secprop->Add_bool("automount",Property::Changeable::WhenIdle,true);
     Pbool->Set_help("Enable automatic drive mounting in Windows.");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3057,7 +3057,7 @@ void DOSBOX_SetupConfigSections(void) {
             "If clear, place private DOS segment at the base of system memory (just below the MCB)");
 
     Pstring = secprop->Add_string("ver",Property::Changeable::WhenIdle,"");
-    Pstring->Set_help("Set DOS version. Specify as major.minor format. A single number is treated as the major version (LFN patch compat). Common settings are:\n"
+    Pstring->Set_help("Set DOS version. Specify as major.minor format. A single number is treated as the major version (compatible with LFN support). Common settings are:\n"
             "auto (or unset)                  Pick a DOS kernel version automatically\n"
             "3.3                              MS-DOS 3.3 emulation (not tested!)\n"
             "5.0                              MS-DOS 5.0 emulation (recommended for DOS gaming)\n"

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1045,6 +1045,7 @@ void DOSBOX_SetupConfigSections(void) {
         "d2",  "d4",  "d6",  "d8",  "da",  "dc",  "de",             /* NEC PC-98   (base+(port << 8) i.e. 00D2h base, 2CD2h is DSP) */
         0 };
     const char* ems_settings[] = { "true", "emsboard", "emm386", "false", 0};
+    const char* lfn_settings[] = { "true", "false", "auto", 0};
     const char* irqsgus[] = { "5", "3", "7", "9", "10", "11", "12", 0 };
     const char* irqssb[] = { "7", "5", "3", "9", "10", "11", "12", 0 };
     const char* dmasgus[] = { "3", "0", "1", "5", "6", "7", 0 };
@@ -3066,6 +3067,7 @@ void DOSBOX_SetupConfigSections(void) {
             "LFN (long filename) support will be enabled with a reported DOS version of 7.0 or higher with \"lfn=auto\" (default).\n");
 
     Pstring = secprop->Add_string("lfn",Property::Changeable::WhenIdle,"auto");
+    Pstring->Set_values(lfn_settings);
     Pstring->Set_help("Enable long filename support. If set to auto (default), it is enabled if the reported DOS version is at least 7.0.");
 
     Pbool = secprop->Add_bool("automount",Property::Changeable::WhenIdle,true);

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -35,9 +35,7 @@
 
 Bitu call_program;
 
-extern bool enablelfn;
-
-extern int paste_speed;
+extern int enablelfn, paste_speed;
 extern const char *modifier;
 extern bool dos_kernel_disabled, force_nocachedir, freesizecap, wpcolon;
 
@@ -993,8 +991,10 @@ void CONFIG::Run(void) {
 							paste_speed = section->Get_int("clip_paste_speed");
 						} else if (!strcasecmp(pvars[0].c_str(), "dos")) {
 							if (!strcasecmp(inputline.substr(0, 4).c_str(), "lfn=")) {
-								enablelfn = section->Get_bool("lfn");
-								uselfn = enablelfn && (dos.version.major>6);
+								if (!strcmp(section->Get_string("lfn"), "true")) enablelfn=1;
+								else if (!strcmp(section->Get_string("lfn"), "false")) enablelfn=0;
+								else enablelfn=-1;
+								uselfn = enablelfn==1 || (enablelfn == -1 && dos.version.major>6);
 							} else if (!strcasecmp(inputline.substr(0, 4).c_str(), "ver=")) {
 								std::string ver = section->Get_string("ver");
 								if (!ver.empty()) {
@@ -1007,7 +1007,7 @@ void CONFIG::Run(void) {
 											if (isdigit(*s))
 												dos.version.minor=(*(s-1)=='.'&&strlen(s)==1?10:1)*(int)strtoul(s,(char**)(&s),10);
 										}
-										uselfn = enablelfn && (dos.version.major>6);
+										uselfn = enablelfn==1 || (enablelfn == -1 && dos.version.major>6);
 									}
 								}
 							}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -98,7 +98,7 @@ static SHELL_Cmd cmd_list[]={
 {0,0,0,0}
 }; 
 
-extern int faux;
+extern int enablelfn, faux;
 extern bool date_host_forced, usecon, rsize;
 extern unsigned long freec;
 
@@ -2478,6 +2478,7 @@ void DOS_Shell::CMD_VER(char *args) {
 			dos.version.major = (Bit8u)(atoi(word));
 			dos.version.minor = (Bit8u)(atoi(args));
 		}
+		uselfn = enablelfn==1 || (enablelfn == -1 && dos.version.major>6);
 	} else WriteOut(MSG_Get("SHELL_CMD_VER_VER"),VERSION,SDL_STRING,dos.version.major,dos.version.minor);
 }
 


### PR DESCRIPTION
In the current code the newly added lfn config option seems to require a reported DOS version of 7.0. While I think this indeed should be the default setting, it does not need to be a requirement, since the reported DOS version may be changed sometimes to solve a certain issue that is not LFN related. For example, with the existing code you can already set the reported version to 6.0 while keeping LFN support enabled, since the VER command will not enable or disable LFN support:

```
config -set lfn=true
ver set 6.0
```

So I updated the code to make "lfn=auto" the default setting, which will enable LFN support if the reported DOS is at least 7.0 at any time (either with VER or with "CONFIG -set" command), but you can manually override the setting by setting "lfn=true" or "lfn=false", which will enable or disable LFN support regardless of the reported DOS version. While I think the LFN feature and the reported DOS version should be related by default, this does not have to always be the case.