### PR TITLE
Variable renaming and support for "lfn=autostart"

### DIFF
--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1547,7 +1547,8 @@ dongle    = false
 #                                                     LFN (long filename) support will be enabled with a reported DOS version of 7.0 or higher with "lfn=auto" (default).
 #                                                     
 #                                              lfn: Enable long filename support. If set to auto (default), it is enabled if the reported DOS version is at least 7.0.
-#                                                     Possible values: true, false, auto.
+#                                                     If set to autostart, the builtin VER command won't activate/disactivate LFN support according to the reported DOS version.
+#                                                     Possible values: true, false, auto, autostart.
 #                                        automount: Enable automatic drive mounting in Windows.
 #                                     automountall: Automatically mount all available Windows drives at start.
 #                                            int33: Enable INT 33H (mouse) support.

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -23,10 +23,11 @@
 #include "mem.h"
 #include "dos_inc.h"
 #include "support.h"
+#include "drives.h"
 
 Bit8u sattr[260], fattr;
 char sname[260][LFN_NAMELENGTH+1],storect[CTBUF];
-extern int faux;
+extern int lfn_filefind_handle;
 
 struct finddata {
        Bit8u attr;
@@ -397,13 +398,13 @@ void DOS_DTA::SetupSearch(Bit8u _sdrive,Bit8u _sattr,char * pattern) {
 	sSave(sDTA,sattr,_sattr);
 
 	int i;
-	if (faux<256) {
-		sattr[faux]=_sattr;
+	if (lfn_filefind_handle<LFN_FILEFIND_NONE) {
+		sattr[lfn_filefind_handle]=_sattr;
 		for (i=0;i<LFN_NAMELENGTH;i++) {
 			if (pattern[i]==0) break;
-				sname[faux][i]=pattern[i];
+				sname[lfn_filefind_handle][i]=pattern[i];
 		}
-		while (i<=LFN_NAMELENGTH) sname[faux][i++]=0;
+		while (i<=LFN_NAMELENGTH) sname[lfn_filefind_handle][i++]=0;
 	}
     for (i=0;i<11;i++) mem_writeb(pt+offsetof(sDTA,spname)+i,0);
 	
@@ -466,9 +467,9 @@ Bit8u DOS_DTA::GetSearchDrive(void) {
 }
 
 void DOS_DTA::GetSearchParams(Bit8u & attr,char * pattern, bool lfn) {
-    if (lfn&&faux<256) {
-		attr=sattr[faux];
-        memcpy(pattern,sname[faux],LFN_NAMELENGTH);
+    if (lfn&&lfn_filefind_handle<LFN_FILEFIND_NONE) {
+		attr=sattr[lfn_filefind_handle];
+        memcpy(pattern,sname[lfn_filefind_handle],LFN_NAMELENGTH);
         pattern[LFN_NAMELENGTH]=0;
     } else {
 		attr=(Bit8u)sGet(sDTA,sattr);

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -30,7 +30,7 @@
 
 char fullname[LFN_NAMELENGTH];
 static Bit16u sdid[256];
-extern int faux;
+extern int lfn_filefind_handle;
 
 using namespace std;
 
@@ -272,10 +272,10 @@ bool isoDrive::FindFirst(const char *dir, DOS_DTA &dta, bool fcb_findfirst) {
 	int dirIterator = GetDirIterator(&de);
 	bool isRoot = (*dir == 0);
 	dirIterators[dirIterator].root = isRoot;
-	if (faux>=255)
+	if (lfn_filefind_handle>=LFN_FILEFIND_MAX)
 		dta.SetDirID((Bit16u)dirIterator);
 	else
-		sdid[faux]=dirIterator;
+		sdid[lfn_filefind_handle]=dirIterator;
 
 	Bit8u attr;
 	char pattern[CROSS_LEN];
@@ -300,7 +300,7 @@ bool isoDrive::FindNext(DOS_DTA &dta) {
 	char pattern[CROSS_LEN], findName[DOS_NAMELENGTH_ASCII], lfindName[ISO_MAXPATHNAME];
     dta.GetSearchParams(attr, pattern, uselfn);
 	
-	int dirIterator = faux>=255?dta.GetDirID():(sdid?sdid[faux]:0);
+	int dirIterator = lfn_filefind_handle>=LFN_FILEFIND_MAX?dta.GetDirID():(sdid?sdid[lfn_filefind_handle]:0);
 	bool isRoot = dirIterators[dirIterator].root;
 	
     isoDirEntry de = {};

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -79,7 +79,7 @@ static host_cnv_char_t cpcnv_ltemp[4096];
 static Bit16u ldid[256];
 static std::string ldir[256];
 extern bool rsize, freesizecap;
-extern int faux;
+extern int lfn_filefind_handle;
 extern unsigned long totalc, freec;
 
 bool String_ASCII_TO_HOST(host_cnv_char_t *d/*CROSS_LEN*/,const char *s/*CROSS_LEN*/) {
@@ -682,12 +682,12 @@ bool localDrive::FindFirst(const char * _dir,DOS_DTA & dta,bool fcb_findfirst) {
 		DOS_SetError(DOSERR_PATH_NOT_FOUND);
 		return false;
 	}
-	if (faux>=255) {
+	if (lfn_filefind_handle>=LFN_FILEFIND_MAX) {
 		dta.SetDirID(id);
 		strcpy(srchInfo[id].srch_dir,tempDir);
 	} else {
-		ldid[faux]=id;
-		ldir[faux]=tempDir;
+		ldid[lfn_filefind_handle]=id;
+		ldir[lfn_filefind_handle]=tempDir;
 	}
 	
 	Bit8u sAttr;
@@ -735,20 +735,20 @@ bool localDrive::FindNext(DOS_DTA & dta) {
 	Bit8u find_attr;
 
     dta.GetSearchParams(srch_attr,srch_pattern,uselfn);
-	Bit16u id = faux>=255?dta.GetDirID():ldid[faux];
+	Bit16u id = lfn_filefind_handle>=LFN_FILEFIND_MAX?dta.GetDirID():ldid[lfn_filefind_handle];
 
 again:
     if (!dirCache.FindNext(id,dir_ent,ldir_ent)) {
-		if (faux<255) {
-			ldid[faux]=0;
-			ldir[faux]="";
+		if (lfn_filefind_handle<LFN_FILEFIND_MAX) {
+			ldid[lfn_filefind_handle]=0;
+			ldir[lfn_filefind_handle]="";
 		}
 		DOS_SetError(DOSERR_NO_MORE_FILES);
 		return false;
 	}
     if(!WildFileCmp(dir_ent,srch_pattern)&&!LWildFileCmp(ldir_ent,srch_pattern)) goto again;
 
-	strcpy(full_name,faux>=255?srchInfo[id].srch_dir:(ldir[faux]!=""?ldir[faux].c_str():"\\"));
+	strcpy(full_name,lfn_filefind_handle>=LFN_FILEFIND_MAX?srchInfo[id].srch_dir:(ldir[lfn_filefind_handle]!=""?ldir[lfn_filefind_handle].c_str():"\\"));
 	strcpy(lfull_name,full_name);
 	
 	strcat(full_name,dir_ent);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1045,7 +1045,7 @@ void DOSBOX_SetupConfigSections(void) {
         "d2",  "d4",  "d6",  "d8",  "da",  "dc",  "de",             /* NEC PC-98   (base+(port << 8) i.e. 00D2h base, 2CD2h is DSP) */
         0 };
     const char* ems_settings[] = { "true", "emsboard", "emm386", "false", 0};
-    const char* lfn_settings[] = { "true", "false", "auto", 0};
+    const char* lfn_settings[] = { "true", "false", "auto", "autostart", 0};
     const char* irqsgus[] = { "5", "3", "7", "9", "10", "11", "12", 0 };
     const char* irqssb[] = { "7", "5", "3", "9", "10", "11", "12", 0 };
     const char* dmasgus[] = { "3", "0", "1", "5", "6", "7", 0 };
@@ -3068,7 +3068,8 @@ void DOSBOX_SetupConfigSections(void) {
 
     Pstring = secprop->Add_string("lfn",Property::Changeable::WhenIdle,"auto");
     Pstring->Set_values(lfn_settings);
-    Pstring->Set_help("Enable long filename support. If set to auto (default), it is enabled if the reported DOS version is at least 7.0.");
+    Pstring->Set_help("Enable long filename support. If set to auto (default), it is enabled if the reported DOS version is at least 7.0.\n"
+                      "If set to autostart, the builtin VER command won't activate/disactivate LFN support according to the reported DOS version.");
 
     Pbool = secprop->Add_bool("automount",Property::Changeable::WhenIdle,true);
     Pbool->Set_help("Enable automatic drive mounting in Windows.");

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -993,8 +993,9 @@ void CONFIG::Run(void) {
 							if (!strcasecmp(inputline.substr(0, 4).c_str(), "lfn=")) {
 								if (!strcmp(section->Get_string("lfn"), "true")) enablelfn=1;
 								else if (!strcmp(section->Get_string("lfn"), "false")) enablelfn=0;
+								else if (!strcmp(section->Get_string("lfn"), "autostart")) enablelfn=-2;
 								else enablelfn=-1;
-								uselfn = enablelfn==1 || (enablelfn == -1 && dos.version.major>6);
+								uselfn = enablelfn==1 || ((enablelfn == -1 || enablelfn == -2) && dos.version.major>6);
 							} else if (!strcasecmp(inputline.substr(0, 4).c_str(), "ver=")) {
 								std::string ver = section->Get_string("ver");
 								if (!ver.empty()) {
@@ -1007,7 +1008,7 @@ void CONFIG::Run(void) {
 											if (isdigit(*s))
 												dos.version.minor=(*(s-1)=='.'&&strlen(s)==1?10:1)*(int)strtoul(s,(char**)(&s),10);
 										}
-										uselfn = enablelfn==1 || (enablelfn == -1 && dos.version.major>6);
+										uselfn = enablelfn==1 || ((enablelfn == -1 || enablelfn == -2) && dos.version.major>6);
 									}
 								}
 							}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -98,7 +98,7 @@ static SHELL_Cmd cmd_list[]={
 {0,0,0,0}
 }; 
 
-extern int enablelfn, faux;
+extern int enablelfn, lfn_filefind_handle;
 extern bool date_host_forced, usecon, rsize;
 extern unsigned long freec;
 
@@ -923,14 +923,14 @@ static bool doDir(DOS_Shell * shell, char * args, DOS_DTA dta, char * numformat,
     if (*(sargs+strlen(sargs)-1) != '\\') strcat(sargs,"\\");
 
 	Bit32u cbyte_count=0,cfile_count=0,w_count=0;
-	int fbak=faux;
-	faux=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
+	int fbak=lfn_filefind_handle;
+	lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
 	bool ret=DOS_FindFirst(args,0xffff & ~DOS_ATTR_VOLUME), found=true, first=true;
-	faux=fbak;
+	lfn_filefind_handle=fbak;
 	if (ret) {
 		std::vector<DtaResult> results;
 
-		faux=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
+		lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
 		do {    /* File name and extension */
 			DtaResult result;
 			dta.GetResult(result.name,result.lname,result.size,result.date,result.time,result.attr);
@@ -951,7 +951,7 @@ static bool doDir(DOS_Shell * shell, char * args, DOS_DTA dta, char * numformat,
 			results.push_back(result);
 
 		} while ( (ret=DOS_FindNext()) );
-		faux=fbak;
+		lfn_filefind_handle=fbak;
 
 		if (optON) {
 			// Sort by name
@@ -2478,7 +2478,7 @@ void DOS_Shell::CMD_VER(char *args) {
 			dos.version.major = (Bit8u)(atoi(word));
 			dos.version.minor = (Bit8u)(atoi(args));
 		}
-		uselfn = enablelfn==1 || (enablelfn == -1 && dos.version.major>6);
+		if (enablelfn != -2) uselfn = enablelfn==1 || (enablelfn == -1 && dos.version.major>6);
 	} else WriteOut(MSG_Get("SHELL_CMD_VER_VER"),VERSION,SDL_STRING,dos.version.major,dos.version.minor);
 }
 


### PR DESCRIPTION
So I have finished the renaming of the "faux" variable to "lfn_filefind_handle". Tested to ensure it works.

Also, I added support for the "lfn=autostart" option, which is same as "lfn=auto" except that the VER command won't activate/disactivate LFN support (only dosbox-x.conf's "ver=" will do when DOSBox-X starts).