### PR TITLE
Fix "TYPE longfilename.txt" on FAT drives

### DIFF
--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -53,8 +53,9 @@ bool force = false;
 int sdrive = 0;
 
 /* This is the LFN filefind handle that is currently being used, with normal values between
- * 0 and 254 for LFN calls. The value LFN_FILEFIND_INTERNAL (255) is used internally by LFN
- * handling functions. For non-LFN calls the value is fixed to be LFN_FILEFIND_NONE (256). */
+ * 0 and 254 for LFN calls. The value LFN_FILEFIND_INTERNAL and LFN_FILEFIND_IMG are used
+ * internally by LFN and image handling functions. For non-LFN calls the value is fixed to
+ * be LFN_FILEFIND_NONE as defined in drives.h. */
 int lfn_filefind_handle = LFN_FILEFIND_NONE;
 
 bool shiftjis_lead_byte(int c);

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -690,7 +690,7 @@ bool fatDrive::getFileDirEntry(char const * const filename, direntry * useEntry,
 	}
 
 	int fbak=lfn_filefind_handle;
-	lfn_filefind_handle=LFN_FILEFIND_NONE;
+	lfn_filefind_handle=uselfn?LFN_FILEFIND_IMG:LFN_FILEFIND_NONE;
 	/* Skip if testing in root directory */
 	if ((len>0) && (filename[len-1]!='\\')) {
 		//LOG_MSG("Testing for filename %s", filename);
@@ -752,7 +752,7 @@ bool fatDrive::getDirClustNum(const char *dir, Bit32u *clustNum, bool parDir) {
 		//LOG_MSG("Testing for dir %s", dir);
 		char * findDir = strtok(dirtoken,"\\");
 		while(findDir != NULL) {
-			lfn_filefind_handle=LFN_FILEFIND_NONE;
+			lfn_filefind_handle=uselfn?LFN_FILEFIND_IMG:LFN_FILEFIND_NONE;
 			imgDTA->SetupSearch(0,DOS_ATTR_DIRECTORY,findDir);
 			imgDTA->SetDirID(0);
 			findDir = strtok(NULL,"\\");
@@ -1911,7 +1911,7 @@ bool fatDrive::FileUnlink(const char * name) {
 			strcpy(dir,fullname);
 		}
 		int fbak=lfn_filefind_handle;
-		lfn_filefind_handle=LFN_FILEFIND_NONE;
+		lfn_filefind_handle=uselfn?LFN_FILEFIND_IMG:LFN_FILEFIND_NONE;
 		imgDTA->SetupSearch((Bit8u)0,0xffu & ~DOS_ATTR_VOLUME & ~DOS_ATTR_DIRECTORY/*NTS: Parameter is Bit8u*/,pattern);
 		imgDTA->SetDirID(0);
 		direntry foundEntry;

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -702,7 +702,9 @@ private:
 };
 
 /* No LFN filefind in progress (SFN call). This index is out of range and meant to indicate no LFN call in progress. */
-#define LFN_FILEFIND_NONE           256
+#define LFN_FILEFIND_NONE           258
+/* FAT image handle */
+#define LFN_FILEFIND_IMG            256
 /* Internal handle */
 #define LFN_FILEFIND_INTERNAL       255
 /* Highest valid handle */


### PR DESCRIPTION
So it turns out the "TYPE longfilename.txt" issue on FAT drives is related to the LFN handle. For LFN mode another internal handle needs to be introduced for the temporary imgDTA (which does not exist on other drives). As a result, TYPE should now work with long file names on FAT drives, and EDIT should now be able to enter directories with long filenames on FAT drives.