### PR TITLE
IMGMOUNT command (with argument) to list mounted FAT/ISO drives and drive numbers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,7 +33,9 @@
     FAT drives just like on local drives (Wengier)
   - DIR and VOL commands now display real serial numbers for mounted
     local drives (Windows only) and FAT drives (Wengier)
-  - Fixed SYS command not working properly (Wengier) 
+  - IMGMOUNT command (without parameters) now lists mounted FAT/ISO
+    drives as well as mounted drive numbers (Wengier)
+  - Fixed SYS command not working properly (Wengier)
   - DOS kernel INT 21h function Set File Attribute no longer
     allows changing volume label attributes and fixes directory
     attributes in order to prevent filesystem corruption.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,7 +34,8 @@
   - DIR and VOL commands now display real serial numbers for mounted
     local drives (Windows only) and FAT drives (Wengier)
   - IMGMOUNT command (without parameters) now lists mounted FAT/ISO
-    drives as well as mounted drive numbers (Wengier)
+    drives and mounted drive numbers, also SUBST command (without
+    parameters) now lists mounted local drives (Wengier)
   - Fixed SYS command not working properly (Wengier)
   - DOS kernel INT 21h function Set File Attribute no longer
     allows changing volume label attributes and fixes directory

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -3315,7 +3315,7 @@ void DOS_Int21_714e(char *name1, char *name2) {
 		lfn_filefind_handle=LFN_FILEFIND_NONE;
 		int error=dos.errorcode;
 		Bit16u attribute = 0;
-		if (!b&&DOS_GetFileAttr(name2, &attribute) && (attribute&DOS_ATTR_DIRECTORY)) {
+		if (!b&&!(strlen(name2)==3&&*(name2+1)==':'&&*(name2+2)=='\\')&&DOS_GetFileAttr(name2, &attribute) && (attribute&DOS_ATTR_DIRECTORY)) {
 			strcat(name2,"\\*.*");
 			lfn_filefind_handle=handle;
 			b=DOS_FindFirst(name2,reg_cx,false);

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -862,7 +862,7 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_COPY_CONFIRM","Overwrite %s (Yes/No/All)?");
 	MSG_Add("SHELL_CMD_COPY_NOSPACE","Insufficient disk space - %s\n");
 	MSG_Add("SHELL_CMD_COPY_ERROR","Error in copying file %s\n");
-	MSG_Add("SHELL_CMD_SUBST_DRIVE_LIST","To list all currently mounted drives, use MOUNT command without a parameter.\n");
+	MSG_Add("SHELL_CMD_SUBST_DRIVE_LIST","The currently mounted local drives are:\n");
 	MSG_Add("SHELL_CMD_SUBST_NO_REMOVE","Unable to remove, drive not in use.\n");
 	MSG_Add("SHELL_CMD_SUBST_IN_USE","Target drive is already in use.\n");
 	MSG_Add("SHELL_CMD_SUBST_NOT_LOCAL","It is only possible to use SUBST on local drives.\n");


### PR DESCRIPTION
I noticed that MOUNT command without parameters will list mounted drives, but IMGMOUNT command without parameters will show its usage. Apparently this is not consistent  (both "MOUNT /?" and "IMGMOUNT /?" will show their usages though). I fixed this so that IMGMOUNT command (without parameters) will list mounted FAT/ISO drives and mounted drive numbers.

I also fixed the issue that entering "C:" as the directory name opens a file (or subdirectory) in it instead of listing the files in C: for FAT drives in MS-DOS 7.x EDIT as mentioned in Issue #1547.