### PR TITLE
Extended SFN-only mode for SFN calls

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 0.83.2
-  - Added LFN creation code to FAT driver, and added support
-    for creating directories (with MKDIR) with long filenames.
+  - Implemented LFN support for FAT driver, so that it is now
+    possible to view directory list, open files, create
+    directoires etc with long filenames on FAT drives.
   - FAT driver cleaned up and fixed to avoid edge cases that
     can corrupt directory entries and leave lost clusters
     on the disk, also fixed to always report root directory

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,8 @@
 0.83.2
   - Implemented LFN support for FAT driver, so that it is now
-    possible to view directory list, open files, create
-    directoires etc with long filenames on FAT drives.
+    possible to show directory list, open/view files, create
+    directories etc with long filenames on FAT12/16/32 drives
+    just like on mounted local drives.
   - FAT driver cleaned up and fixed to avoid edge cases that
     can corrupt directory entries and leave lost clusters
     on the disk, also fixed to always report root directory

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -172,7 +172,7 @@ extern unsigned int ENV_KEEPFREE;// = 83;
 DOS_Block dos;
 DOS_InfoBlock dos_infoblock;
 
-extern bool force, dos_kernel_disabled;
+extern bool force_sfn, dos_kernel_disabled;
 
 Bit16u DOS_Block::psp() {
 	if (dos_kernel_disabled) {
@@ -1195,6 +1195,7 @@ static Bitu DOS_21Handler(void) {
             break;
         case 0x39:      /* MKDIR Create directory */
             MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
+			force_sfn = true;
             if (DOS_MakeDir(name1)) {
                 reg_ax=0x05;    /* ax destroyed */
                 CALLBACK_SCF(false);
@@ -1202,9 +1203,11 @@ static Bitu DOS_21Handler(void) {
                 reg_ax=dos.errorcode;
                 CALLBACK_SCF(true);
             }
+			force_sfn = false;
             break;
         case 0x3a:      /* RMDIR Remove directory */
             MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
+			force_sfn = true;
             if  (DOS_RemoveDir(name1)) {
                 reg_ax=0x05;    /* ax destroyed */
                 CALLBACK_SCF(false);
@@ -1213,6 +1216,7 @@ static Bitu DOS_21Handler(void) {
                 CALLBACK_SCF(true);
                 LOG(LOG_MISC,LOG_NORMAL)("Remove dir failed on %s with error %X",name1,dos.errorcode);
             }
+			force_sfn = false;
             break;
         case 0x3b:      /* CHDIR Set current directory */
             MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
@@ -1239,13 +1243,13 @@ static Bitu DOS_21Handler(void) {
 		{
             unmask_irq0 |= disk_io_unmask_irq0;
             MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
-			force = true;
 			Bit8u oldal=reg_al;
+			force_sfn = true;
             if (DOS_OpenFile(name1,reg_al,&reg_ax)) {
-				force = false;
+				force_sfn = false;
                 CALLBACK_SCF(false);
             } else {
-				force = false;
+				force_sfn = false;
 				if (uselfn&&DOS_OpenFile(name1,oldal,&reg_ax)) {
 					CALLBACK_SCF(false);
 					break;
@@ -1254,7 +1258,7 @@ static Bitu DOS_21Handler(void) {
                 CALLBACK_SCF(true);
             }
             diskio_delay(1024);
-			force = false;
+			force_sfn = false;
             break;
 		}
         case 0x3e:      /* CLOSE Close file */
@@ -1345,12 +1349,14 @@ static Bitu DOS_21Handler(void) {
         case 0x41:                  /* UNLINK Delete file */
             unmask_irq0 |= disk_io_unmask_irq0;
             MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
+			force_sfn = true;
             if (DOS_UnlinkFile(name1)) {
                 CALLBACK_SCF(false);
             } else {
                 reg_ax=dos.errorcode;
                 CALLBACK_SCF(true);
             }
+			force_sfn = false;
             diskio_delay(1024);
             break;
         case 0x42:                  /* LSEEK Set current file position */

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -49,7 +49,7 @@ extern char *dos_clipboard_device_name;
 Bitu DOS_FILES = 127;
 DOS_File ** Files = NULL;
 DOS_Drive * Drives[DOS_DRIVES] = {NULL};
-bool force = false;
+bool force_sfn = false;
 int sdrive = 0;
 
 /* This is the LFN filefind handle that is currently being used, with normal values between
@@ -115,7 +115,7 @@ bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 		Bit8u c=(Bit8u)name_int[r++];
 		if (c=='/') c='\\';
 		else if (c=='"') {q++;continue;}
-		else if (uselfn&&!force) {
+		else if (uselfn&&!force_sfn) {
 			if (c==' ' && q/2*2 == q) continue;
 		} else {
 			if ((c>='a') && (c<='z')) c-=32;
@@ -186,7 +186,7 @@ bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 			lastdir=(Bit32u)strlen(fullname);
 
 			if (lastdir!=0) strcat(fullname,"\\");
-			if (!uselfn||force) {
+			if (!uselfn||force_sfn) {
 				char * ext=strchr(tempdir,'.');
 				if (ext) {
 					if(strchr(ext+1,'.')) { 
@@ -201,9 +201,9 @@ bool DOS_MakeName(char const * const name,char * const fullname,Bit8u * drive) {
 					}
 					
 					ext[4] = 0;
-					// if((strlen(tempdir) - strlen(ext)) > 8) memmove(tempdir + 8, ext, 5);
+					if((strlen(tempdir) - strlen(ext)) > 8) memmove(tempdir + 8, ext, 5);
                 } else {
-                    // tempdir[8] = 0;
+                    tempdir[8] = 0;
                 }
 			}
 

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -43,7 +43,7 @@
 
 static Bit16u dpos[256];
 static Bit32u dnum[256];
-extern bool wpcolon;
+extern bool wpcolon, force_sfn;
 extern int lfn_filefind_handle;
 
 /* Assuming an LFN call, if the name is not strict 8.3 uppercase, return true.
@@ -1929,7 +1929,7 @@ bool fatDrive::FileUnlink(const char * name) {
 	}
 
 	if(!getFileDirEntry(name, &fileEntry, &dirClust, &subEntry)) return false;
-	if(uselfn&&(strchr(name, '*')||strchr(name, '?'))) {
+	if(uselfn&&!force_sfn&&(strchr(name, '*')||strchr(name, '?'))) {
 		char dir[DOS_PATHLENGTH], pattern[DOS_PATHLENGTH], fullname[DOS_PATHLENGTH], temp[DOS_PATHLENGTH];
 		strcpy(fullname, name);
 		char * find_last=strrchr(fullname,'\\');
@@ -2596,7 +2596,7 @@ bool fatDrive::MakeDir(const char *dir) {
 	if(!allocateCluster(dummyClust, 0)) return false;
 
 	/* NTS: "dir" is the full relative path. For LFN creation to work we need only the final element of the path */
-	if (uselfn && true/*TODO Wengier: If mkdir call from LFN API*/) {
+	if (uselfn && !force_sfn) {
 		lfn = strrchr(dir,'\\');
 
 		if (lfn != NULL) lfn++; /* step past '\' */

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -78,7 +78,7 @@ static host_cnv_char_t cpcnv_temp[4096];
 static host_cnv_char_t cpcnv_ltemp[4096];
 static Bit16u ldid[256];
 static std::string ldir[256];
-extern bool rsize, freesizecap;
+extern bool rsize, freesizecap, force_sfn;
 extern int lfn_filefind_handle;
 extern unsigned long totalc, freec;
 
@@ -582,7 +582,7 @@ bool localDrive::FileUnlink(const char * name) {
 
 	if (ht_unlink(host_name)) {
 		//Unlink failed for some reason try finding it.
-		if (uselfn&&strchr(name, '*')&&strchr(fullname, '*')) { // Wildcard delete as used by MS-DOS 7+ "DEL *.*"
+		if (uselfn&&!force_sfn&&strchr(name, '*')&&strchr(fullname, '*')) { // Wildcard delete as used by MS-DOS 7+ "DEL *.*"
 #if defined (WIN32)
 			SHFILEOPSTRUCT op={0};
 			op.wFunc = FO_DELETE;


### PR DESCRIPTION
In the previous code (besides FindFirst/FindNext) the SFN-only mode was only added for the SFN call of opening files through the use of the force variable. I renamed this variable to a more descriptive name of "force_sfn" and also extended to other SFN calls including UNLINK/MKDIR/RMDIR too in order to make it more complete.