### PR TITLE
Generate 8.3 names from SFN on FAT drives

### DIFF
--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -113,8 +113,10 @@ char* fatDrive::Generate_SFN(const char *path, const char *name) {
 		while (*(n+strlen(n)-1)=='.'||*(n+strlen(n)-1)==' ') *(n+strlen(n)-1)=0;
 		int i=0;
 		while (*n != 0 && *n != '.' && i<(k<10?6:(k<100?5:4))) {
-			if (*n == ' ')
+			if (*n == ' ') {
+				n++;
 				continue;
+			}
 			if (*n=='"'||*n=='+'||*n=='='||*n==','||*n==';'||*n==':'||*n=='<'||*n=='>'||*n=='['||*n==']'||*n=='|'||*n=='?'||*n=='*') {
 				sfn[i++]='_';
 				n++;
@@ -139,8 +141,10 @@ char* fatDrive::Generate_SFN(const char *path, const char *name) {
 			while (*n == '.') n++;
 			int j=0;
 			while (*n != 0 && j++<3) {
-				if (*n == ' ')
+				if (*n == ' ') {
+					n++;
 					continue;
+				}
 				if (*n=='"'||*n=='+'||*n=='='||*n==','||*n==';'||*n==':'||*n=='<'||*n=='>'||*n=='['||*n==']'||*n=='|'||*n=='?'||*n=='*') {
 					sfn[i++]='_';
 					n++;

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -409,6 +409,7 @@ public:
 	imageDisk *loadedDisk = NULL;
 	bool created_successfully = true;
 private:
+	char* Generate_SFN(const char *path, const char *name);
 	Bit32u getClusterValue(Bit32u clustNum);
 	void setClusterValue(Bit32u clustNum, Bit32u clustValue);
 	Bit32u getClustFirstSect(Bit32u clustNum);


### PR DESCRIPTION
So I have written the Generate_SFN function for FAT drives, which will automatically generate 8.3 names from LFNs. For example, "long file name.txt" will by default generate the 8.3 name ```LONGFI~1.TXT```, but if ```LONGFI~1.TXT``` already exists, then it will generate the 8.3 name ```LONGFI~2.TXT``` instead, and so on, currently up to \~999. Also, special characters such as "+" and "=" will be replaced with "_", and spaces will be skipped. Should work with file and directory creation.