### PR TITLE
Apply Generate_SFN to RENAME and remove trailing dots/spaces for file/dir creation

### DIFF
--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -348,6 +348,7 @@ bool DOS_MakeDir(char const * const dir) {
 		return false;
 	}
 	if (!DOS_MakeName(dir,fulldir,&drive)) return false;
+	while (*(fulldir+strlen(fulldir)-1)=='.'||*(fulldir+strlen(fulldir)-1)==' ') *(fulldir+strlen(fulldir)-1)=0;
 	if(Drives[drive]->MakeDir(fulldir)) return true;
 
 	/* Determine reason for failing */
@@ -392,6 +393,8 @@ bool DOS_Rename(char const * const oldname,char const * const newname) {
 	Bit8u drivenew;char fullnew[DOS_PATHLENGTH];
 	if (!DOS_MakeName(oldname,fullold,&driveold)) return false;
 	if (!DOS_MakeName(newname,fullnew,&drivenew)) return false;
+	while (*(fullnew+strlen(fullnew)-1)=='.'||*(fullnew+strlen(fullnew)-1)==' ') *(fullnew+strlen(fullnew)-1)=0;
+
 	/* No tricks with devices */
 	bool clip=false;
 	if ( (DOS_FindDevice(oldname) != DOS_DEVICES) ||
@@ -679,6 +682,8 @@ bool DOS_CreateFile(char const * name,Bit16u attributes,Bit16u * entry,bool fcb)
 	char fullname[DOS_PATHLENGTH];Bit8u drive;
 	DOS_PSP psp(dos.psp());
 	if (!DOS_MakeName(name,fullname,&drive)) return false;
+	while (*(fullname+strlen(fullname)-1)=='.'||*(fullname+strlen(fullname)-1)==' ') *(fullname+strlen(fullname)-1)=0;
+
 	/* Check for a free file handle */
 	Bit8u handle=(Bit8u)DOS_FILES;Bit8u i;
 	for (i=0;i<DOS_FILES;i++) {

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -348,7 +348,7 @@ bool DOS_MakeDir(char const * const dir) {
 		return false;
 	}
 	if (!DOS_MakeName(dir,fulldir,&drive)) return false;
-	while (*(fulldir+strlen(fulldir)-1)=='.'||*(fulldir+strlen(fulldir)-1)==' ') *(fulldir+strlen(fulldir)-1)=0;
+	while (strlen(fulldir)&&(*(fulldir+strlen(fulldir)-1)=='.'||*(fulldir+strlen(fulldir)-1)==' ')) *(fulldir+strlen(fulldir)-1)=0;
 	if(Drives[drive]->MakeDir(fulldir)) return true;
 
 	/* Determine reason for failing */
@@ -393,7 +393,7 @@ bool DOS_Rename(char const * const oldname,char const * const newname) {
 	Bit8u drivenew;char fullnew[DOS_PATHLENGTH];
 	if (!DOS_MakeName(oldname,fullold,&driveold)) return false;
 	if (!DOS_MakeName(newname,fullnew,&drivenew)) return false;
-	while (*(fullnew+strlen(fullnew)-1)=='.'||*(fullnew+strlen(fullnew)-1)==' ') *(fullnew+strlen(fullnew)-1)=0;
+	while (strlen(fullnew)&&(*(fullnew+strlen(fullnew)-1)=='.'||*(fullnew+strlen(fullnew)-1)==' ') *(fullnew+strlen(fullnew)-1))=0;
 
 	/* No tricks with devices */
 	bool clip=false;
@@ -682,7 +682,7 @@ bool DOS_CreateFile(char const * name,Bit16u attributes,Bit16u * entry,bool fcb)
 	char fullname[DOS_PATHLENGTH];Bit8u drive;
 	DOS_PSP psp(dos.psp());
 	if (!DOS_MakeName(name,fullname,&drive)) return false;
-	while (*(fullname+strlen(fullname)-1)=='.'||*(fullname+strlen(fullname)-1)==' ') *(fullname+strlen(fullname)-1)=0;
+	while (strlen(fullname)&&(*(fullname+strlen(fullname)-1)=='.'||*(fullname+strlen(fullname)-1)==' ')) *(fullname+strlen(fullname)-1)=0;
 
 	/* Check for a free file handle */
 	Bit8u handle=(Bit8u)DOS_FILES;Bit8u i;

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1939,7 +1939,7 @@ bool fatDrive::FileCreate(DOS_File **file, const char *name, Bit16u attributes) 
 		directoryChange(dirClust, &fileEntry, (Bit32s)subEntry);
 	} else {
 		/* Can we even get the name of the file itself? */
-		if(!getEntryName(name, &dirName[0])) return false;
+		if(!getEntryName(name, &dirName[0])||!strlen(trim(dirName))) return false;
 		convToDirFile(&dirName[0], &pathName[0]);
 
 		/* Can we find the base directory? */
@@ -2952,7 +2952,7 @@ bool fatDrive::Rename(const char * oldname, const char * newname) {
 		/* Target doesn't exist, can rename */
 
 		/* Can we even get the name of the file itself? */
-		if(!getEntryName(newname, &dirName2[0])) return false;
+		if(!getEntryName(newname, &dirName2[0])||!strlen(trim(dirName2))) return false;
 		convToDirFile(&dirName2[0], &pathName2[0]);
 
 		/* NTS: "newname" is the full relative path. For LFN creation to work we need only the final element of the path */

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -672,12 +672,10 @@ bool fatDrive::getEntryName(const char *fullname, char *entname) {
 		findFile = findDir;
 		findDir = strtok(NULL,"\\");
 	}
-	if (uselfn) {
-		int j=0;
-		for (int i=0; i<(int)strlen(findFile); i++)
-			if (findFile[i]!=' '&&findFile[i]!='"'&&findFile[i]!='+'&&findFile[i]!='='&&findFile[i]!=','&&findFile[i]!=';'&&findFile[i]!=':'&&findFile[i]!='<'&&findFile[i]!='>'&&findFile[i]!='['&&findFile[i]!=']'&&findFile[i]!='|'&&findFile[i]!='?'&&findFile[i]!='*') findFile[j++]=findFile[i];
-		findFile[j]=0;
-	}
+	int j=0;
+	for (int i=0; i<(int)strlen(findFile); i++)
+		if (findFile[i]!=' '&&findFile[i]!='"'&&findFile[i]!='+'&&findFile[i]!='='&&findFile[i]!=','&&findFile[i]!=';'&&findFile[i]!=':'&&findFile[i]!='<'&&findFile[i]!='>'&&findFile[i]!='['&&findFile[i]!=']'&&findFile[i]!='|'&&findFile[i]!='?'&&findFile[i]!='*') findFile[j++]=findFile[i];
+	findFile[j]=0;
 	if (strlen(findFile)>12)
 		strncpy(entname, findFile, 12);
 	else
@@ -2891,20 +2889,10 @@ bool fatDrive::Rename(const char * oldname, const char * newname) {
 		return false;
 	}
 
-	/* NTS: "newname" is the full relative path. For LFN creation to work we need only the final element of the path */
-	if (uselfn && !force_sfn) {
-		lfn = strrchr(newname,'\\');
-
-		if (lfn != NULL) lfn++; /* step past '\' */
-		else lfn = newname; /* no path elements */
-
-		if (!filename_not_strict_8x3(lfn)) lfn = NULL;
-	}
-
     direntry fileEntry1 = {}, fileEntry2 = {};
 	Bit32u dirClust1, subEntry1, dirClust2, subEntry2;
 	char dirName[DOS_NAMELENGTH_ASCII], dirName2[DOS_NAMELENGTH_ASCII];
-	char pathName[11], pathName2[11];
+	char pathName[11], pathName2[11], path[DOS_PATHLENGTH];
 	lfnRange_t dir_lfn_range;
 	
 	lfnRange.clear();
@@ -2919,6 +2907,26 @@ bool fatDrive::Rename(const char * oldname, const char * newname) {
 		if(getFileDirEntry(newname, &fileEntry2, &dirClust2, &subEntry2)) return false;
 		if(!getEntryName(newname, &dirName2[0])||!strlen(trim(dirName2))) return false;
 		convToDirFile(&dirName2[0], &pathName2[0]);
+
+		/* NTS: "newname" is the full relative path. For LFN creation to work we need only the final element of the path */
+		if (uselfn && !force_sfn) {
+			lfn = strrchr(newname,'\\');
+
+			if (lfn != NULL) {
+				lfn++; /* step past '\' */
+				strcpy(path, newname);
+				*(strrchr(path,'\\')+1)=0;
+			} else {
+				lfn = newname; /* no path elements */
+				*path=0;
+			}
+
+			if (filename_not_strict_8x3(lfn)) {
+				char *sfn=Generate_SFN(path, lfn);
+				if (sfn!=NULL) convToDirFile(sfn, &pathName2[0]);
+			} else
+				lfn = NULL;
+		}
 
 		/* Find directory entry in parent directory */
 		Bit32s fileidx = 2;
@@ -2946,6 +2954,26 @@ bool fatDrive::Rename(const char * oldname, const char * newname) {
 		/* Can we even get the name of the file itself? */
 		if(!getEntryName(newname, &dirName2[0])) return false;
 		convToDirFile(&dirName2[0], &pathName2[0]);
+
+		/* NTS: "newname" is the full relative path. For LFN creation to work we need only the final element of the path */
+		if (uselfn && !force_sfn) {
+			lfn = strrchr(newname,'\\');
+
+			if (lfn != NULL) {
+				lfn++; /* step past '\' */
+				strcpy(path, newname);
+				*(strrchr(path,'\\')+1)=0;
+			} else {
+				lfn = newname; /* no path elements */
+				*path=0;
+			}
+
+			if (filename_not_strict_8x3(lfn)) {
+				char *sfn=Generate_SFN(path, lfn);
+				if (sfn!=NULL) convToDirFile(sfn, &pathName2[0]);
+			} else
+				lfn = NULL;
+		}
 
 		/* Can we find the base directory? */
 		if(!getDirClustNum(newname, &dirClust2, true)) return false;


### PR DESCRIPTION
The Generate_SFN function in my previous pull request did not yet apply to rename, which was recently modified for LFN support. So I applied the function for rename too. Also, Windows 9x does not allow trailing dots and spaces when creating files or dirs, even in LFNs, so I modified the file/dir creation functions to remove the trailing dots and spaces.