### PR TITLE
Fix GetFileAttr/SetFileAttr/Rename/Tab completion for LFN support

### DIFF
--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -2418,30 +2418,7 @@ bool fatDrive::SetFileAttr(const char *name, Bit16u attr) {
 		return false;
 	}
 
-	if(!getFileDirEntry(name, &fileEntry, &dirClust, &subEntry)) {
-		char dirName[DOS_NAMELENGTH_ASCII];
-		char pathName[11];
-
-		/* Can we even get the name of the directory itself? */
-		if(!getEntryName(name, &dirName[0])) return false;
-		convToDirFile(&dirName[0], &pathName[0]);
-
-		/* Get parent directory starting cluster */
-		if(!getDirClustNum(name, &dirClust, true)) return false;
-
-		/* Find directory entry in parent directory */
-		Bit32s fileidx = 2;
-		if (dirClust==0) fileidx = 0;	// root directory
-		else if (BPB.is_fat32() && dirClust==BPB.v32.BPB_RootClus) fileidx = 0; // root directory FAT32
-		Bit32s last_idx=0;
-		while(directoryBrowse(dirClust, &fileEntry, fileidx, last_idx)) {
-			if(memcmp(&fileEntry.entryname, &pathName[0], 11) == 0) {
-				fileEntry.attrib=(Bit8u)attr;
-				directoryChange(dirClust, &fileEntry, fileidx);
-				return true;
-			}
-			fileidx++;
-		}
+	if(!getFileDirEntry(name, &fileEntry, &dirClust, &subEntry, /*dirOk*/true)) {
 		return false;
 	} else {
 		fileEntry.attrib=(Bit8u)attr;
@@ -2460,29 +2437,7 @@ bool fatDrive::GetFileAttr(const char *name, Bit16u *attr) {
 		return true;
 	}
 
-	if(!getFileDirEntry(name, &fileEntry, &dirClust, &subEntry)) {
-		char dirName[DOS_NAMELENGTH_ASCII];
-		char pathName[11];
-
-		/* Can we even get the name of the directory itself? */
-		if(!getEntryName(name, &dirName[0])) return false;
-		convToDirFile(&dirName[0], &pathName[0]);
-
-		/* Get parent directory starting cluster */
-		if(!getDirClustNum(name, &dirClust, true)) return false;
-
-		/* Find directory entry in parent directory */
-		Bit32s fileidx = 2;
-		if (dirClust==0) fileidx = 0;	// root directory
-		else if (BPB.is_fat32() && dirClust==BPB.v32.BPB_RootClus) fileidx = 0; // root directory FAT32
-		Bit32s last_idx=0; 
-		while(directoryBrowse(dirClust, &fileEntry, fileidx, last_idx)) {
-			if(memcmp(&fileEntry.entryname, &pathName[0], 11) == 0) {
-				*attr=fileEntry.attrib;
-				return true;
-			}
-			fileidx++;
-		}
+	if(!getFileDirEntry(name, &fileEntry, &dirClust, &subEntry, /*dirOk*/true)) {
 		return false;
 	} else *attr=fileEntry.attrib;
 	return true;
@@ -2930,6 +2885,13 @@ bool fatDrive::Rename(const char * oldname, const char * newname) {
 	if(!getEntryName(newname, &dirName2[0])||!strlen(trim(dirName2))) return false;
 	convToDirFile(&dirName2[0], &pathName2[0]);
 
+	/* Can we find the base directory of the new name? (we know the parent dir of oldname in dirClust1) */
+	if(!getDirClustNum(newname, &dirClust2, true)) return false;
+
+	/* Remove old 8.3 SFN entry */
+	fileEntry1.entryname[0] = 0xe5;
+	directoryChange(dirClust1, &fileEntry1, (Bit32s)subEntry1);
+
 	/* NTS: "newname" is the full relative path. For LFN creation to work we need only the final element of the path */
 	if (uselfn && !force_sfn) {
 		lfn = strrchr(newname,'\\');
@@ -2950,17 +2912,10 @@ bool fatDrive::Rename(const char * oldname, const char * newname) {
 			lfn = NULL;
 	}
 
-	/* Can we find the base directory of the new name? (we know the parent dir of oldname in dirClust1) */
-	if(!getDirClustNum(newname, &dirClust2, true)) return false;
-
 	/* add new dirent */
 	memcpy(&fileEntry2, &fileEntry1, sizeof(direntry));
 	memcpy(&fileEntry2.entryname, &pathName2[0], 11);
 	addDirectoryEntry(dirClust2, fileEntry2, lfn);
-
-	/* Remove old 8.3 SFN entry */
-	fileEntry1.entryname[0] = 0xe5;
-	directoryChange(dirClust1, &fileEntry1, (Bit32s)subEntry1);
 
 	/* remove LFNs of old entry only if emulating LFNs or DOS version 7.0.
 	 * Earlier DOS versions ignore LFNs. */

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -412,28 +412,10 @@ void DOS_Shell::CMD_DELETE(char * args) {
 	args = ExpandDot(args,buffer, CROSS_LEN);
 	StripSpaces(args);
 	if (!DOS_Canonicalize(args,full)) { WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));dos.dta(save_dta);return; }
-	bool res;
-	int fbak=lfn_filefind_handle;
 	if (strlen(args)&&args[strlen(args)-1]!='\\') {
 		Bit16u fattr;
 		if (DOS_GetFileAttr(args, &fattr) && (fattr&DOS_ATTR_DIRECTORY))
 			strcat(args, "\\");
-		else {
-			lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
-			res=DOS_FindFirst(args,0xffff & ~DOS_ATTR_VOLUME);
-			if (!res) {
-				lfn_filefind_handle=fbak;
-				WriteOut(MSG_Get("SHELL_CMD_DEL_ERROR"),args);
-				dos.dta(save_dta);
-				return;
-			}
-			lfn_filefind_handle=fbak;
-			if (strlen(args)&&args[strlen(args)-1]!='\\') {
-				dta=dos.dta();
-				dta.GetResult(name,lname,size,date,time,attr);
-				if (attr & DOS_ATTR_DIRECTORY) strcat(args, "\\");
-			}
-		}
 	}
 	if (strlen(args)&&args[strlen(args)-1]=='\\') strcat(args, "*.*");
 	else if (!strcasecmp(args,".")||(strlen(args)>1&&(args[strlen(args)-2]==':'||args[strlen(args)-2]=='\\')&&args[strlen(args)-1]=='.')) {
@@ -497,8 +479,9 @@ first_2:
 continue_1:
 	/* Command uses dta so set it to our internal dta */
 	if (!DOS_Canonicalize(args,full)) { WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));dos.dta(save_dta);return; }
+	int fbak=lfn_filefind_handle;
 	lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
-    res=DOS_FindFirst(args,0xffff & ~DOS_ATTR_VOLUME);
+    bool res=DOS_FindFirst(args,0xffff & ~DOS_ATTR_VOLUME);
 	if (!res) {
 		lfn_filefind_handle=fbak;
 		WriteOut(MSG_Get("SHELL_CMD_DEL_ERROR"),args);
@@ -1485,8 +1468,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 
 		//Find first sourcefile
 		char sPath[DOS_PATHLENGTH];
-		bool r=DOS_GetSFNPath(source.filename.c_str(),sPath,false), ret = r && DOS_FindFirst(const_cast<char*>(sPath),0xffff & ~DOS_ATTR_VOLUME);
-		if (r&&!ret&&strchr(sPath, ' ')) ret = DOS_FindFirst((char *)((source.filename[0]!='"'?"\"":"")+source.filename+(source.filename.c_str()[source.filename.length()-1]!='"'?"\"":"")).c_str(),0xffff & ~DOS_ATTR_VOLUME);
+		bool ret=DOS_GetSFNPath(source.filename.c_str(),sPath,false) && DOS_FindFirst((char *)((strchr(sPath, ' ')&&sPath[0]!='"'&&sPath[0]!='"'?"\"":"")+std::string(sPath)+(strchr(sPath, ' ')&&sPath[strlen(sPath)-1]!='"'?"\"":"")).c_str(),0xffff & ~DOS_ATTR_VOLUME);
 		if (!ret) {
 			WriteOut(MSG_Get("SHELL_CMD_FILE_NOT_FOUND"),const_cast<char*>(source.filename.c_str()));
 			dos.dta(save_dta);

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -30,9 +30,10 @@
 #include "support.h"
 #include "inout.h"
 #include "../ints/int10.h"
+#include "../dos/drives.h"
 #ifdef WIN32
 #include "../dos/cdrom.h"
-#endif 
+#endif
 
 #ifdef _MSC_VER
 # define MIN(a,b) ((a) < (b) ? (a) : (b))
@@ -41,6 +42,8 @@
 # define MIN(a,b) std::min(a,b)
 # define MAX(a,b) std::max(a,b)
 #endif
+
+extern int lfn_filefind_handle;
 
 void DOS_Shell::ShowPrompt(void) {
 	char dir[DOS_PATHLENGTH];
@@ -561,7 +564,10 @@ void DOS_Shell::InputCommand(char * line) {
 						bool res = false;
 						if (DOS_GetSFNPath(mask,smask,false)) {
 							sprintf(mask,"\"%s\"",smask);
+							int fbak=lfn_filefind_handle;
+							lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
 							res = DOS_FindFirst(mask, 0xffff & ~DOS_ATTR_VOLUME);
+							lfn_filefind_handle=fbak;
 						}
                         if (!res) {
                             dos.dta(save_dta);
@@ -616,7 +622,10 @@ void DOS_Shell::InputCommand(char * line) {
 										l_completion.push_back(qlname);
                                 }
                             }
+							int fbak=lfn_filefind_handle;
+							lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
                             res=DOS_FindNext();
+							lfn_filefind_handle=fbak;
                         }
                         /* Add executable list to front of completion list. */
                         std::copy(executable.begin(),executable.end(),std::front_inserter(l_completion));


### PR DESCRIPTION
As mentioned in Issue #1547, LFN directory renaming did not work on FAT drives because GetFileAttr/SetFileAttr did not work properly for directories with long names, so I fixed this. I also fixed the rename code so that it is possible to keep the same 8.3 name when renaming files/directories with long names (e.g. "REN "Program File" "Program Files" may keep the same 8.3 name PROGRA~1). I also fixed the tab completion so that the Tab key should work properly if the current command line contains more than 8 characters.