### PR TITLE
Suppress "unable to remove" error and rewrite LFN wildcard delete for all drives

### DIFF
--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -226,7 +226,7 @@ bool Virtual_Drive::FindFirst(const char * _dir,DOS_DTA & dta,bool fcb_findfirst
     (void)_dir;//UNUSED
 	search_file=first_file;
 	Bit8u attr;char pattern[CROSS_LEN];
-    dta.GetSearchParams(attr,pattern,false);
+    dta.GetSearchParams(attr,pattern,uselfn);
 	if (attr == DOS_ATTR_VOLUME) {
 		dta.SetResult(GetLabel(),GetLabel(),0,0,0,DOS_ATTR_VOLUME);
 		return true;
@@ -241,7 +241,7 @@ bool Virtual_Drive::FindFirst(const char * _dir,DOS_DTA & dta,bool fcb_findfirst
 
 bool Virtual_Drive::FindNext(DOS_DTA & dta) {
 	Bit8u attr;char pattern[CROSS_LEN];
-    dta.GetSearchParams(attr,pattern,false);
+    dta.GetSearchParams(attr,pattern,uselfn);
 	while (search_file) {
 		if (WildFileCmp(search_file->name,pattern)) {
 			dta.SetResult(search_file->name,search_file->lname,search_file->size,search_file->date,search_file->time,DOS_ATTR_ARCHIVE);


### PR DESCRIPTION
The previous REN/RENAME command had a bug that if the SFN name remained the same after rename, the "unable to remove" error may appear in certain situations even if the file was successfully renamed. So I fixed this issue. Also, I rewrote the LFN wildcard delete function (for MS-DOS 7+ "DEL \*.\*") for all drives (in dos_files.cpp) instead of replying on drive/operating-system dependent code (in drive_fat.cpp and drive_local.cpp). So it should work for all drives and systems.