### PR TITLE
Improve "dpi aware=auto" and virtual drive (Z:) functions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.83.2
+  - Config option "dpi aware" now supports the "auto" setting
+    to auto-decide on the best setting for the platform.
   - Implemented LFN support for FAT driver, so that it is now
     possible to view directory list, create or open files and
     directories etc with long filenames on FAT12/16/32 drives
@@ -36,7 +38,8 @@
   - REN command can now rename directories (in addition to files) on
     FAT drives just like on local drives (Wengier)
   - Several improvements to DEL command, such as a new /F option to
-    force delete of read-only files. (Wengier)
+    force delete of read-only files, and improved handling when the
+    argument is a directory. (Wengier)
   - DIR and VOL commands now display real serial numbers for mounted
     local drives (Windows only) and FAT drives (Wengier)
   - IMGMOUNT command (without parameters) now lists mounted FAT/ISO

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -144,7 +144,7 @@ showmenu          = true
 #                                          language: Select another language file.
 #                                             title: Additional text to place in the title bar of the window
 #                                  enable 8-bit dac: If set, allow VESA BIOS calls in IBM PC mode to set DAC width. Has no effect in PC-98 mode.
-#                                         dpi aware: Set this option (on by default) to indicate to your OS that DOSBox-X is DPI aware.
+#                                         dpi aware: Set this option (auto by default) to indicate to your OS that DOSBox-X is DPI aware.
 #                                                      If it is not set, Windows Vista/7/8/10 and higher may upscale the DOSBox-X window
 #                                                      on higher resolution monitors which is probably not what you want.
 #                                     keyboard hook: Use keyboard hook (currently only on Windows) to catch special keys and synchronize the keyboard LEDs with the host
@@ -513,7 +513,7 @@ showmenu          = true
 language                                          = 
 title                                             = 
 enable 8-bit dac                                  = true
-dpi aware                                         = true
+dpi aware                                         = auto
 keyboard hook                                     = false
 weitek                                            = false
 bochs debug port e9                               = false
@@ -975,9 +975,9 @@ fluid.chorus.type     = 0
 #                                         irq hack: Specify a hack related to the Sound Blaster IRQ to avoid crashes in a handful of games and demos.
 #                                                         none                   Emulate IRQs normally
 #                                                         cs_equ_ds              Do not fire IRQ unless two CPU segment registers match: CS == DS. Read Dosbox-X Wiki or source code for details.
-#                                              dma: The DMA number of the soundblaster. Set to -1 to start DOSBox-X with the IRQ unassigned
+#                                              dma: The DMA number of the soundblaster. Set to -1 to start DOSBox-X with the DMA unassigned
 #                                                     Possible values: 1, 5, 0, 3, 6, 7.
-#                                             hdma: The High DMA number of the soundblaster. Set to -1 to start DOSBox-X with the IRQ unassigned
+#                                             hdma: The High DMA number of the soundblaster. Set to -1 to start DOSBox-X with the High DMA unassigned
 #                                                     Possible values: 1, 5, 0, 3, 6, 7.
 #                                   pic unmask irq: Start the DOS virtual machine with the sound blaster IRQ already unmasked at the PIC.
 #                                                     Some early DOS games/demos that support Sound Blaster expect the IRQ to fire but make

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1122,7 +1122,7 @@ void DOSBOX_SetupConfigSections(void) {
 
     Pstring = secprop->Add_string("dpi aware",Property::Changeable::OnlyAtStart,"auto");
     Pstring->Set_values(truefalseautoopt);
-    Pstring->Set_help("Set this option (on by default) to indicate to your OS that DOSBox-X is DPI aware.\n"
+    Pstring->Set_help("Set this option (auto by default) to indicate to your OS that DOSBox-X is DPI aware.\n"
             "If it is not set, Windows Vista/7/8/10 and higher may upscale the DOSBox-X window\n"
             "on higher resolution monitors which is probably not what you want.");
 
@@ -2319,11 +2319,11 @@ void DOSBOX_SetupConfigSections(void) {
 
     Pint = secprop->Add_int("dma",Property::Changeable::WhenIdle,1);
     Pint->Set_values(dmassb);
-    Pint->Set_help("The DMA number of the soundblaster. Set to -1 to start DOSBox-X with the IRQ unassigned");
+    Pint->Set_help("The DMA number of the soundblaster. Set to -1 to start DOSBox-X with the DMA unassigned");
 
     Pint = secprop->Add_int("hdma",Property::Changeable::WhenIdle,5);
     Pint->Set_values(dmassb);
-    Pint->Set_help("The High DMA number of the soundblaster. Set to -1 to start DOSBox-X with the IRQ unassigned");
+    Pint->Set_help("The High DMA number of the soundblaster. Set to -1 to start DOSBox-X with the High DMA unassigned");
 
     Pbool = secprop->Add_bool("pic unmask irq",Property::Changeable::WhenIdle,false);
     Pbool->Set_help("Start the DOS virtual machine with the sound blaster IRQ already unmasked at the PIC.\n"
@@ -3551,4 +3551,3 @@ int utf16le_decode(const char **ptr,const char *fence) {
     *ptr = p;
     return (int)ret;
 }
-

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -833,11 +833,11 @@ extern "C" void SDL1_hax_SetMenu(HMENU menu);
 #ifdef WIN32
 # define STDOUT_FILE                TEXT("stdout.txt")
 # define STDERR_FILE                TEXT("stderr.txt")
-# define DEFAULT_CONFIG_FILE            "/dosbox.conf"
+# define DEFAULT_CONFIG_FILE            "/dosbox-x.conf"
 #elif defined(MACOSX)
 # define DEFAULT_CONFIG_FILE            "/Library/Preferences/DOSBox Preferences"
 #elif defined(HAIKU)
-#define DEFAULT_CONFIG_FILE "~/config/settings/dosbox/dosbox.conf"
+#define DEFAULT_CONFIG_FILE "~/config/settings/dosbox-x/dosbox-x.conf"
 #else /*linux freebsd*/
 # define DEFAULT_CONFIG_FILE            "/.dosboxrc"
 #endif
@@ -8170,9 +8170,15 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 #if defined(MACOSX)
 				/* Try not to look extra tiny on Retina displays */
 				dpi_aware_enable = false;
-#elif defined(WIN32) && defined(_MSC_VER) && (defined(_M_ARM) || defined(_M_ARM64))
+#elif defined(WIN32) && defined(_MSC_VER)
+				dpi_aware_enable = true;
 				/* Microsoft Surface tablets are really high resolution. Try not to look like a tiny window on them */
-				dpi_aware_enable = false;
+				DPI_AWARENESS_CONTEXT previousDpiContext = SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_SYSTEM_AWARE);
+				if (GetAwarenessFromDpiAwarenessContext(GetThreadDpiAwarenessContext())==DPI_AWARENESS_SYSTEM_AWARE) {
+					UINT dpi=GetDpiForSystem();
+					if (dpi&&dpi/96>1) dpi_aware_enable = false;
+				}
+				if (previousDpiContext!=NULL) SetThreadDpiAwarenessContext(previousDpiContext);
 #else
 				dpi_aware_enable = true;
 #endif
@@ -9315,4 +9321,3 @@ void SDL_GL_SwapBuffers(void) {
     SDL_GL_SwapWindow(sdl.window);
 }
 #endif
-

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -79,17 +79,17 @@ void Cross::GetPlatformResDir(std::string& in) {
 void Cross::GetPlatformConfigDir(std::string& in) {
 #if defined(WIN32) && !defined(HX_DOS)
 	W32_ConfDir(in,false);
-	in += "\\DOSBox";
+	in += "\\DOSBox-X";
 #elif defined(MACOSX)
 	in = "~/Library/Preferences";
 	ResolveHomedir(in);
 #elif defined(HAIKU)
-	in = "~/config/settings/dosbox";
+	in = "~/config/settings/dosbox-x";
 	ResolveHomedir(in);
 #elif defined(RISCOS)
 	in = "/<Choices$Write>/DosBox-X";
 #elif !defined(HX_DOS)
-	in = "~/.dosbox";
+	in = "~/.dosbox-x";
 	ResolveHomedir(in);
 #endif
 	in += CROSS_FILESPLIT;
@@ -97,11 +97,11 @@ void Cross::GetPlatformConfigDir(std::string& in) {
 
 void Cross::GetPlatformConfigName(std::string& in) {
 #ifdef WIN32
-#define DEFAULT_CONFIG_FILE "dosbox-" VERSION ".conf"
+#define DEFAULT_CONFIG_FILE "dosbox-x-" VERSION ".conf"
 #elif defined(MACOSX)
-#define DEFAULT_CONFIG_FILE "DOSBox " VERSION " Preferences"
+#define DEFAULT_CONFIG_FILE "DOSBox-X " VERSION " Preferences"
 #else /*linux freebsd*/
-#define DEFAULT_CONFIG_FILE "dosbox-" VERSION ".conf"
+#define DEFAULT_CONFIG_FILE "dosbox-x-" VERSION ".conf"
 #endif
 	in = DEFAULT_CONFIG_FILE;
 }
@@ -109,21 +109,21 @@ void Cross::GetPlatformConfigName(std::string& in) {
 void Cross::CreatePlatformConfigDir(std::string& in) {
 #if defined(WIN32) && !defined(HX_DOS)
 	W32_ConfDir(in,true);
-	in += "\\DOSBox";
+	in += "\\DOSBox-X";
 	_mkdir(in.c_str());
 #elif defined(MACOSX)
 	in = "~/Library/Preferences";
 	ResolveHomedir(in);
 	//Don't create it. Assume it exists
 #elif defined(HAIKU)
-	in = "~/config/settings/dosbox";
+	in = "~/config/settings/dosbox-x";
 	ResolveHomedir(in);
 	mkdir(in.c_str(),0700);
 #elif defined(RISCOS)
 	in = "/<Choices$Write>/DosBox-X";
 	mkdir(in.c_str(),0700);
 #elif !defined(HX_DOS)
-	in = "~/.dosbox";
+	in = "~/.dosbox-x";
 	ResolveHomedir(in);
 	mkdir(in.c_str(),0700);
 #endif

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -406,7 +406,6 @@ void DOS_Shell::CMD_DELETE(char * args) {
 
 	char full[DOS_PATHLENGTH],sfull[DOS_PATHLENGTH+2];
 	char buffer[CROSS_LEN];
-    char spath[DOS_PATHLENGTH],sargs[DOS_PATHLENGTH+4];
     char name[DOS_NAMELENGTH_ASCII],lname[LFN_NAMELENGTH+1];
     Bit32u size;Bit16u time,date;Bit8u attr;
 	args = ExpandDot(args,buffer, CROSS_LEN);
@@ -414,11 +413,11 @@ void DOS_Shell::CMD_DELETE(char * args) {
 	if (!DOS_Canonicalize(args,full)) { WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));dos.dta(save_dta);return; }
 	if (strlen(args)&&args[strlen(args)-1]!='\\') {
 		Bit16u fattr;
-		if (DOS_GetFileAttr(args, &fattr) && (fattr&DOS_ATTR_DIRECTORY))
+		if (strcmp(args,"*.*")&&DOS_GetFileAttr(args, &fattr) && (fattr&DOS_ATTR_DIRECTORY))
 			strcat(args, "\\");
 	}
 	if (strlen(args)&&args[strlen(args)-1]=='\\') strcat(args, "*.*");
-	else if (!strcasecmp(args,".")||(strlen(args)>1&&(args[strlen(args)-2]==':'||args[strlen(args)-2]=='\\')&&args[strlen(args)-1]=='.')) {
+	else if (!strcmp(args,".")||(strlen(args)>1&&(args[strlen(args)-2]==':'||args[strlen(args)-2]=='\\')&&args[strlen(args)-1]=='.')) {
 		args[strlen(args)-1]='*';
 		strcat(args, ".*");
 	} else if (uselfn&&strchr(args, '*')) {


### PR DESCRIPTION
I noticed that the "dpi aware=auto" setting was recently added for the auto-detecting option, but unfortunately it does not work at all for Surface Pro tablets (x64), which I am currently using. So I improved this option to make it work for Surface Pro by using DPI query functions. Tested to work with Surface Pro 4 x64.

I also improved the functions of the virtual drive (Z:) such as adding LFN handles. I don't think most DOS programs will actually care about this drive, but it is implemented for the sake of completeness.

In addition, I changed the config file in user directory (in addition to dosbox-x.conf in the current directory) to use ~/.dosbox-x/dosbox-x-[version number].conf instead of ~/.dosbox/dosbox-x-[version number].conf.