### PR TITLE
"dpi aware=auto" for MinGW build (too)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 0.83.2
   - Config option "dpi aware" now supports the "auto" setting
-    to auto-decide on the best setting for the platform.
+    to auto-decide on the best setting for the platform. This
+    fixes very small window issue on e.g. Surface tablets.
   - Implemented LFN support for FAT driver, so that it is now
     possible to view directory list, create or open files and
     directories etc with long filenames on FAT12/16/32 drives

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -210,7 +210,7 @@ void E_Exit(const char * format,...) {
 	va_end(msg);
 	strcat(buf,"\n");
 	LOG_MSG("E_Exit: %s\n",buf);
-#if defined(WIN32) && !defined(C_SDL2)
+#if defined(WIN32)
 	/* Most Windows users DON'T run DOSBox-X from the command line! */
 	MessageBox(GetHWND(), buf, "E_Exit", MB_OK | MB_ICONEXCLAMATION);
 #endif


### PR DESCRIPTION
In the previous pull request I have made "dpi aware=auto" for Visual Studio builds (only). This pull request will make it work for the MinGW build too (tested with MinGW 64-bit).

Also, I made the MessageBox for E_EXIT appear in SDL2 build too just like SDL1 build for the Windows platform. Tested with VS2015 SDL2 build.