### PR TITLE
Display real serial numbers for mounted CD-ROM drives (Windows) and other improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,11 +36,13 @@
     that FORMAT.COM is able to verify and modify the partition table
     to successfully format a hard drive image. Also added stub to
     DOS IOCTL "format device track" for FORMAT.COM.
+  - You can now force unmount a drive and then mount it to a new
+    directory in one command, e.g. "MOUNT C C:\DOS -U" (Wengier)
   - REN command can now rename directories (in addition to files) on
     FAT drives just like on local drives (Wengier)
   - Several improvements to DEL command, such as a new /F option to
     force delete of read-only files, and improved handling when the
-    argument is a directory. (Wengier)
+    argument is a directory (Wengier)
   - DIR and VOL commands now display real serial numbers for mounted
     local drives (Windows only) and FAT drives (Wengier)
   - IMGMOUNT command (without parameters) now lists mounted FAT/ISO

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -3529,8 +3529,8 @@ void DOS_Int21_71a6(const char *name1, const char *name2) {
 				if (fdp != NULL) serial_number=fdp->GetSerial();
 			}
 #if defined (WIN32)
-			if (!strncmp(Drives[drive]->GetInfo(),"local ",6)) {
-				localDrive* ldp = dynamic_cast<localDrive*>(Drives[drive]);
+			if (!strncmp(Drives[drive]->GetInfo(),"local ",6) || !strncmp(Drives[drive]->GetInfo(),"CDRom ",6)) {
+				localDrive* ldp = !strncmp(Drives[drive]->GetInfo(),"local ",6)?dynamic_cast<localDrive*>(Drives[drive]):dynamic_cast<cdromDrive*>(Drives[drive]);
 				if (ldp != NULL) serial_number=ldp->GetSerial();
 			}
 #endif

--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -224,8 +224,8 @@ bool DOS_IOCTL_AX440D_CH08(Bit8u drive,bool query) {
 					if (fdp != NULL) serial_number=fdp->GetSerial();
 				}
 #if defined (WIN32)
-				if (!strncmp(Drives[drive]->GetInfo(),"local ",6)) {
-					localDrive* ldp = dynamic_cast<localDrive*>(Drives[drive]);
+				if (!strncmp(Drives[drive]->GetInfo(),"local ",6) || !strncmp(Drives[drive]->GetInfo(),"CDRom ",6)) {
+					localDrive* ldp = !strncmp(Drives[drive]->GetInfo(),"local ",6)?dynamic_cast<localDrive*>(Drives[drive]):dynamic_cast<cdromDrive*>(Drives[drive]);
 					if (ldp != NULL) serial_number=ldp->GetSerial();
 				}
 #endif

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -748,9 +748,9 @@ public:
 
             if (!cmd->FindCommand(2,temp_line)) goto showusage;
             if (!temp_line.size()) goto showusage;
-			if (!strcasecmp(temp_line.c_str(), "-u")) {
+			if (cmd->FindExist("-u",true)) {
 				WriteOut(UnmountHelper(i_drive), toupper(i_drive));
-				return;
+				if (!cmd->FindCommand(2,temp_line)||!temp_line.size()) return;
 			}
             if(path_relative_to_last_config && control->configfiles.size() && !Cross::IsPathAbsolute(temp_line)) {
 		        std::string lastconfigdir(control->configfiles[control->configfiles.size()-1]);

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <algorithm>
 #include <string>
 #include <vector>
 #include "programs.h"
@@ -678,6 +679,7 @@ public:
 
         std::string type="dir";
         cmd->FindString("-t",type,true);
+		std::transform(type.begin(), type.end(), type.begin(), ::tolower);
         bool iscdrom = (type =="cdrom"); //Used for mscdex bug cdrom label name emulation
         if (type=="floppy" || type=="dir" || type=="cdrom") {
             Bit16u sizes[4];
@@ -3318,6 +3320,8 @@ public:
         }
         //get the type
         cmd->FindString("-t", type, true);
+		std::transform(type.begin(), type.end(), type.begin(), ::tolower);
+
         if (type == "cdrom") type = "iso"; //Tiny hack for people who like to type -t cdrom
         if (!(type == "floppy" || type == "hdd" || type == "iso" || type == "ram")) {
             WriteOut(MSG_Get("PROGRAM_IMGMOUNT_TYPE_UNSUPPORTED"), type.c_str());
@@ -3350,6 +3354,7 @@ public:
         //default fstype is fat
         std::string fstype="fat";
         cmd->FindString("-fs",fstype,true);
+		std::transform(fstype.begin(), fstype.end(), fstype.begin(), ::tolower);
         
         Bitu sizes[4] = { 0,0,0,0 };
         int reserved_cylinders=0;
@@ -3364,6 +3369,7 @@ public:
 
         /* DOSBox-X: we allow "-ide" to allow controlling which IDE controller and slot to attach the hard disk/CD-ROM to */
         cmd->FindString("-ide",ideattach,true);
+		std::transform(ideattach.begin(), ideattach.end(), ideattach.begin(), ::tolower);
 
         if (ideattach == "auto") {
             if (type != "floppy") {

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -86,7 +86,7 @@ bool filename_not_strict_8x3(const char *n) {
 }
 
 char sfn[DOS_NAMELENGTH_ASCII];
-/* Generate 8.3 names from LFNs, with tilde usage (from ~1 to ~999). */
+/* Generate 8.3 names from LFNs, with tilde usage (from ~1 to ~9999). */
 char* fatDrive::Generate_SFN(const char *path, const char *name) {
 	if (!filename_not_8x3(name)) {
 		strcpy(sfn, name);
@@ -103,15 +103,15 @@ char* fatDrive::Generate_SFN(const char *path, const char *name) {
 	if (!strlen(lfn)) return NULL;
 	direntry fileEntry = {};
 	Bit32u dirClust, subEntry;
-	int k=1, i, t=1000;
-	while (k<1000) {
+	int k=1, i, t=10000;
+	while (k<10000) {
 		n=lfn;
-		if (t>strlen(n)||k==1||k==10||k==100) {
+		if (t>strlen(n)||k==1||k==10||k==100||k==1000) {
 			i=0;
 			*sfn=0;
 			while (*n == '.'||*n == ' ') n++;
 			while (strlen(n)&&(*(n+strlen(n)-1)=='.'||*(n+strlen(n)-1)==' ')) *(n+strlen(n)-1)=0;
-			while (*n != 0 && *n != '.' && i<(k<10?6:(k<100?5:4))) {
+			while (*n != 0 && *n != '.' && i<(k<10?6:(k<100?5:(k<1000?4:3)))) {
 				if (*n == ' ') {
 					n++;
 					continue;
@@ -131,12 +131,17 @@ char* fatDrive::Generate_SFN(const char *path, const char *name) {
 		else if (k<100) {
 			sfn[i++]='0'+(k/10);
 			sfn[i++]='0'+(k%10);
-		} else {
+		} else if (k<1000) {
 			sfn[i++]='0'+(k/100);
 			sfn[i++]='0'+((k%100)/10);
 			sfn[i++]='0'+(k%10);
+		} else {
+			sfn[i++]='0'+(k/1000);
+			sfn[i++]='0'+((k%1000)/100);
+			sfn[i++]='0'+((k%100)/10);
+			sfn[i++]='0'+(k%10);
 		}
-		if (t>strlen(n)||k==1||k==10||k==100) {
+		if (t>strlen(n)||k==1||k==10||k==100||k==1000) {
 			char *p=strrchr(n, '.');
 			if (p!=NULL) {
 				sfn[i++]='.';

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -1654,6 +1654,9 @@ unsigned long cdromDrive::GetCompressedSize(char* name) {
 HANDLE cdromDrive::CreateOpenFile(const char* name) {
 		return localDrive::CreateOpenFile(name);
 }
+unsigned long cdromDrive::GetSerial() {
+		return localDrive::GetSerial();
+}
 #endif
 
 bool cdromDrive::FindFirst(const char * _dir,DOS_DTA & dta,bool /*fcb_findfirst*/) {

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -508,6 +508,7 @@ public:
 	virtual unsigned long GetCompressedSize(char* name);
 #if defined (WIN32)
 	virtual HANDLE CreateOpenFile(char const* const name);
+	virtual unsigned long GetSerial();
 #endif
 	virtual bool FindFirst(const char * _dir,DOS_DTA & dta,bool fcb_findfirst=false);
 	virtual void SetDir(const char* path);

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -180,6 +180,7 @@ static bool is_filename_8by3w(const wchar_t* fname) {
     /* Is the first part 8 chars or less? */
     i=0;
     while (*fname != 0 && *fname != L'.') {
+		if (*fname<=32||*fname==127||*fname==L'"'||*fname==L'+'||*fname==L'='||*fname==L','||*fname==L';'||*fname==L':'||*fname==L'<'||*fname==L'>'||*fname==L'|'||*fname==L'?'||*fname==L'*') return false;
 		if (IS_PC98_ARCH && (*fname & 0xFF00u) != 0u && (*fname & 0xFCu) != 0x08u) i++;
 		fname++; i++; 
 	}
@@ -190,6 +191,7 @@ static bool is_filename_8by3w(const wchar_t* fname) {
     /* Is the second part 3 chars or less? A second '.' also makes it a LFN */
     i=0;
     while (*fname != 0 && *fname != L'.') {
+		if (*fname<=32||*fname==127||*fname==L'"'||*fname==L'+'||*fname==L'='||*fname==L','||*fname==L';'||*fname==L':'||*fname==L'<'||*fname==L'>'||*fname==L'|'||*fname==L'?'||*fname==L'*') return false;
 		if (IS_PC98_ARCH && (*fname & 0xFF00u) != 0u && (*fname & 0xFCu) != 0x08u) i++;
 		fname++; i++;
 	}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -2588,8 +2588,8 @@ void DOS_Shell::CMD_VOL(char *args){
 		if (fdp != NULL) serial_number=fdp->GetSerial();
 	}
 #if defined (WIN32)
-	if (!strncmp(Drives[drive]->GetInfo(),"local ",6)) {
-		localDrive* ldp = dynamic_cast<localDrive*>(Drives[drive]);
+	if (!strncmp(Drives[drive]->GetInfo(),"local ",6) || !strncmp(Drives[drive]->GetInfo(),"CDRom ",6)) {
+		localDrive* ldp = !strncmp(Drives[drive]->GetInfo(),"local ",6)?dynamic_cast<localDrive*>(Drives[drive]):dynamic_cast<cdromDrive*>(Drives[drive]);
 		if (ldp != NULL) serial_number=ldp->GetSerial();
 	}
 #endif


### PR DESCRIPTION
I had previously added support for displaying real serial numbers for mounted local drives (Windows only) and FAT drives. But it did not work if a local drive is mounted as CD-ROM (e.g "MOUNT E E:\ -T CDROM"). So I fixed this. Also, the -U option for MOUNT command can now be used to force unmount a drive (if already mounted) and then mount to a new directory in one command, e.g. (e.g "MOUNT E E:\ -U").

I also extended the SFN name creation on FAT drives max limit from ~999 to ~9999.