### PR TITLE
Config file cleanup: move PC-98 related settings to the new [pc98] section

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 0.83.2
+  - Added [config] section in dosbox-x.conf to resemble DOS's
+    CONFIG.SYS file, although it currently only supports BREAK,
+    LASTDRIVE and REM commands (Wengier)
   - Moved PC-98 related config options from [dosbox] and [dos]
-    sections to a new [pc98] section. (Wengier)
+    sections to the new [pc98] section. (Wengier)
   - Config option "dpi aware" now supports the "auto" setting
     to auto-decide on the best setting for the platform. This
     fixes very small window issue on e.g. Surface tablets.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.83.2
+  - Moved PC-98 related config options from [dosbox] and [dos]
+    sections to a new [pc98] section. (Wengier)
   - Config option "dpi aware" now supports the "auto" setting
     to auto-decide on the best setting for the platform. This
     fixes very small window issue on e.g. Surface tablets.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,8 +2,11 @@
   - Added [config] section in dosbox-x.conf to resemble DOS's
     CONFIG.SYS file, although it currently only supports BREAK,
     LASTDRIVE and REM commands (Wengier)
-  - Moved PC-98 related config options from [dosbox] and [dos]
-    sections to the new [pc98] section. (Wengier)
+  - Moved PC-98 related config options (starting with "pc-98 ")
+    from [dosbox] and [dos] sections to its own [pc98] section.
+    Existing dosbox-x.conf/dosbox.conf files will need to move
+    those settings ("pc-98 ...") to the new [pc98] section in
+    order to keep these setting continue to work (Wengier)
   - Config option "dpi aware" now supports the "auto" setting
     to auto-decide on the best setting for the platform. This
     fixes very small window issue on e.g. Surface tablets.

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1885,6 +1885,7 @@ cd-rom insertion delay  = 0
 [config]
 rem                     = This section is designed to resemble the DOS CONFIG.SYS file, although it currently only supports a limited number of CONFIG.SYS options.
 break                   = off
+numlock                 =
 lastdrive               = a
 
 [autoexec]

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -3,6 +3,64 @@
 # They are used to (briefly) document the effect of each option.
 # To write out ALL options, use command 'config -all' with -wc or -writeconf options.
 
+
+[sdl]
+#        fullscreen: Start DOSBox-X directly in fullscreen. (Press ALT-Enter to go back)
+#        fulldouble: Use double buffering in fullscreen. It can reduce screen flickering, but it can also result in a slow DOSBox-X.
+#    fullresolution: What resolution to use for fullscreen: original, desktop or a fixed size (e.g. 1024x768).
+#                        Using your monitor's native resolution with aspect=true might give the best results.
+#                        If you end up with small window on a large screen, try an output different from surface.
+#  windowresolution: Scale the window to this size IF the output device supports hardware scaling.
+#                        (output=surface does not!)
+#            output: What video system to use for output.
+#                      Possible values: surface, overlay, opengl, openglnb, openglhq, ddraw.
+#          autolock: Mouse will automatically lock, if you click on the screen. (Press CTRL-F10 to unlock)
+# autolock_feedback: Autolock status feedback type, i.e. visual, auditive, none.
+#                      Possible values: none, beep, flash.
+# clip_key_modifier: Change the keyboard modifier for the Windows clipboard copy/paste function using the right mouse button.
+#                      Set to "none" if no modifier is desired. Set to "disabled" will disable this feature (default).
+#                      Possible values: none, alt, lalt, ralt, ctrl, lctrl, rctrl, shift, lshift, rshift, disabled.
+#  clip_paste_speed: Set keyboard speed for pasting from the Windows clipboard.
+#                      If the default setting of 20 causes lost keystrokes, increase the number.
+#                      Or experiment with decreasing the number for applications that accept keystrokes quickly.
+#       sensitivity: Mouse sensitivity. The optional second parameter specifies vertical sensitivity (e.g. 100,-50).
+#   mouse_emulation: When is mouse emulated ?
+#                      integration: when not locked
+#                      locked:      when locked
+#                      always:      every time
+#                      never:       at no time
+#                      If disabled, the mouse position in DOSBox-X is exactly where the host OS reports it.
+#                      When using a high DPI mouse, the emulation of mouse movement can noticeably reduce the
+#                      sensitiveness of your device, i.e. the mouse is slower but more precise.
+#                      Possible values: integration, locked, always, never.
+#       waitonerror: Wait before closing the console if DOSBox-X has an error.
+#          priority: Priority levels for DOSBox-X. Second entry behind the comma is for when DOSBox-X is not focused/minimized.
+#                        pause is only valid for the second entry.
+#                      Possible values: lowest, lower, normal, higher, highest, pause.
+#        mapperfile: File used to load/save the key/event mappings from. Resetmapper only works with the default value.
+#      usescancodes: Avoid usage of symkeys, might not work on all operating systems.
+#          overscan: Width of overscan border (0 to 10). (works only if output=surface)
+#          titlebar: Change the string displayed in the DOSBox-X title bar.
+#          showmenu: Whether to show the menu bar (if supported). Default true.
+fullscreen        = false
+fulldouble        = false
+fullresolution    = desktop
+windowresolution  = original
+output            = surface
+autolock          = false
+autolock_feedback = beep
+clip_key_modifier = disabled
+clip_paste_speed  = 20
+sensitivity       = 100
+mouse_emulation   = locked
+waitonerror       = true
+priority          = higher,normal
+mapperfile        = mapper-0.83.2.map
+usescancodes      = false
+overscan          = 0
+titlebar          = 
+showmenu          = true
+
 [log]
 #     logfile: file where the log messages will be saved to
 #         vga: Enable/Disable logging of this type.
@@ -82,63 +140,6 @@ pci         = false
 sst         = false
 int21       = false
 fileio      = false
-
-[sdl]
-#        fullscreen: Start DOSBox-X directly in fullscreen. (Press ALT-Enter to go back)
-#        fulldouble: Use double buffering in fullscreen. It can reduce screen flickering, but it can also result in a slow DOSBox-X.
-#    fullresolution: What resolution to use for fullscreen: original, desktop or a fixed size (e.g. 1024x768).
-#                        Using your monitor's native resolution with aspect=true might give the best results.
-#                        If you end up with small window on a large screen, try an output different from surface.
-#  windowresolution: Scale the window to this size IF the output device supports hardware scaling.
-#                        (output=surface does not!)
-#            output: What video system to use for output.
-#                      Possible values: surface, overlay, opengl, openglnb, openglhq, ddraw.
-#          autolock: Mouse will automatically lock, if you click on the screen. (Press CTRL-F10 to unlock)
-# autolock_feedback: Autolock status feedback type, i.e. visual, auditive, none.
-#                      Possible values: none, beep, flash.
-# clip_key_modifier: Change the keyboard modifier for the Windows clipboard copy/paste function using the right mouse button.
-#                      Set to "none" if no modifier is desired. Set to "disabled" will disable this feature (default).
-#                      Possible values: none, alt, lalt, ralt, ctrl, lctrl, rctrl, shift, lshift, rshift, disabled.
-#  clip_paste_speed: Set keyboard speed for pasting from the Windows clipboard.
-#                      If the default setting of 20 causes lost keystrokes, increase the number.
-#                      Or experiment with decreasing the number for applications that accept keystrokes quickly.
-#       sensitivity: Mouse sensitivity. The optional second parameter specifies vertical sensitivity (e.g. 100,-50).
-#   mouse_emulation: When is mouse emulated ?
-#                      integration: when not locked
-#                      locked:      when locked
-#                      always:      every time
-#                      never:       at no time
-#                      If disabled, the mouse position in DOSBox-X is exactly where the host OS reports it.
-#                      When using a high DPI mouse, the emulation of mouse movement can noticeably reduce the
-#                      sensitiveness of your device, i.e. the mouse is slower but more precise.
-#                      Possible values: integration, locked, always, never.
-#       waitonerror: Wait before closing the console if DOSBox-X has an error.
-#          priority: Priority levels for DOSBox-X. Second entry behind the comma is for when DOSBox-X is not focused/minimized.
-#                        pause is only valid for the second entry.
-#                      Possible values: lowest, lower, normal, higher, highest, pause.
-#        mapperfile: File used to load/save the key/event mappings from. Resetmapper only works with the default value.
-#      usescancodes: Avoid usage of symkeys, might not work on all operating systems.
-#          overscan: Width of overscan border (0 to 10). (works only if output=surface)
-#          titlebar: Change the string displayed in the DOSBox-X title bar.
-#          showmenu: Whether to show the menu bar (if supported). Default true.
-fullscreen        = false
-fulldouble        = false
-fullresolution    = desktop
-windowresolution  = original
-output            = surface
-autolock          = false
-autolock_feedback = beep
-clip_key_modifier = disabled
-clip_paste_speed  = 20
-sensitivity       = 100
-mouse_emulation   = locked
-waitonerror       = true
-priority          = higher,normal
-mapperfile        = mapper-0.83.2.map
-usescancodes      = false
-overscan          = 0
-titlebar          = 
-showmenu          = true
 
 [dosbox]
 #                                          language: Select another language file.
@@ -309,65 +310,6 @@ showmenu          = true
 #                                                          24: 16MB aliasing. Common on 386SX systems (CPU had 24 external address bits)
 #                                                              or 386DX and 486 systems where the CPU communicated directly with the ISA bus (A24-A31 tied off)
 #                                                          26: 64MB aliasing. Some 486s had only 26 external address bits, some motherboards tied off A26-A31
-#                       pc-98 BIOS copyright string: If set, the PC-98 BIOS copyright string is placed at E800:0000. Enable this for software that detects PC-98 vs Epson.
-#                       pc-98 int 1b fdc timer wait: If set, INT 1Bh floppy access will wait for the timer to count down before returning.
-#                                                      This is needed for Ys II to run without crashing.
-#                        pc-98 pic init to read isr: If set, the programmable interrupt controllers are initialized by default (if PC-98 mode)
-#                                                      so that the in-service interrupt status can be read immediately. There seems to be a common
-#                                                      convention in PC-98 games to program and/or assume this mode for cooperative interrupt handling.
-#                                                      This option is enabled by default for best compatibility with PC-98 games.
-#                                    pc-98 fm board: In PC-98 mode, selects the FM music board to emulate.
-#                                                      Possible values: auto, off, false, board14, board26k, board86, board86c.
-#                                pc-98 fm board irq: If set, helps to determine the IRQ of the FM board. A setting of zero means to auto-determine the IRQ.
-#                            pc-98 fm board io port: If set, helps to determine the base I/O port of the FM board. A setting of zero means to auto-determine the port number.
-#                                  pc-98 sound bios: Set Sound BIOS enabled bit in MEMSW 4 for some games that require it.
-#                                                      TODO: Real emulation of PC-9801-26K/86 Sound BIOS
-#                    pc-98 load sound bios rom file: If set, load SOUND.ROM if available and prsent that to the guest instead of trying to emulate directly.
-#                                                      This is strongly recommended, and is default enabled.
-#                                                      SOUND.ROM is a snapshot of the FM board BIOS taken from real PC-98 hardware.
-#                            pc-98 buffer page flip: If set, the game's request to page flip will be delayed to vertical retrace, which can eliminate tearline artifacts.
-#                                                      Note that this is NOT the behavior of actual hardware. This option is provided for the user's preference.
-#                     pc-98 enable 256-color planar: Allow 256-color planar graphics mode if set, disable if not set.
-#                                                      This is a form of memory access in 256-color mode that existed for a short
-#                                                      time before later PC-9821 models removed it. This option must be enabled
-#                                                      to use DOSBox-X with Windows 3.1 and it's built-in 256-color driver.
-#                            pc-98 enable 256-color: Allow 256-color graphics mode if set, disable if not set
-#                             pc-98 enable 16-color: Allow 16-color graphics mode if set, disable if not set
-#                                 pc-98 enable grcg: Allow GRCG graphics functions if set, disable if not set
-#                                  pc-98 enable egc: Allow EGC graphics functions if set, disable if not set
-#                          pc-98 enable 188 user cg: Allow 188+ user-defined CG cells if set
-#                           pc-98 start gdc at 5mhz: Start GDC at 5MHz if set, 2.5MHz if clear. May be required for some games.
-#                       pc-98 allow scanline effect: If set, PC-98 emulation will allow the DOS application to enable the 'scanline effect'
-#                                                      in 200-line graphics modes upconverted to 400-line raster display. When enabled, odd
-#                                                      numbered scanlines are blanked instead of doubled
-#                                   pc-98 bus mouse: Enable PC-98 bus mouse emulation. Disabling this option does not disable INT 33h emulation.
-#                                  pc-98 video mode: Specify the preferred PC-98 video mode.
-#                                                      Valid values are 15, 24, or 31 for each specific horizontal refresh rate on the platform.
-#                                                      24khz is default and best supported at this time.
-#                                                      15khz is not implemented at this time.
-#                                                      31khz is experimental at this time.
-#                                                      Possible values: , 24khz, 31khz, 15khz.
-#                         pc-98 timer always cycles: This controls PIT 1 PC speaker behavior related to turning the output on and off.
-#                                                      Default setting is 'auto' to let the emulator choose for you.
-#                                                      true:  PIT 1 will always cycle whether or not the speaker is on (PC-9801 behavior).
-#                                                      false: PIT 1 will only cycle when the speaker is on (PC-9821 behavior).
-#                                                      Some older games will require the PC-9801 behavior to function properly.
-#                                                      Possible values: true, false, 1, 0, auto.
-#                      pc-98 timer master frequency: 8254 timer clock frequency (NEC PC-98). Depending on the CPU frequency the clock frequency is one of two common values.
-#                                                      If your setting is neither of the below the closest appropriate value will be chosen.
-#                                                      This setting affects the master clock rate that DOS applications must divide down from to program the timer
-#                                                      at the correct rate, which affects timer interrupt, PC speaker, and the COM1 RS-232C serial port baud rate.
-#                                                      8MHz is treated as an alias for 4MHz and 10MHz is treated as an alias for 5MHz.
-#                                                          0: Use default (auto)
-#                                                          4: 1.996MHz (as if 4MHz or multiple thereof CPU clock)
-#                                                          5: 2.457MHz (as if 5MHz or multiple thereof CPU clock)
-#          pc-98 allow 4 display partition graphics: According to NEC graphics controller documentation, graphics mode is supposed to support only
-#                                                      2 display partitions. Some games rely on hardware flaws that allowed 4 partitions.
-#                                                         -1: Default (choose automatically)
-#                                                          0: Disable
-#                                                          1: Enable
-#                   pc-98 force ibm keyboard layout: Force to use a default keyboard layout like IBM US-English for PC-98 emulation.
-#                                                      Will only work with apps and games using BIOS for keyboard.
 #                                        nocachedir: If set, MOUNT commands will mount with -nocachedir by default.
 #                                       freesizecap: If set, the value of MOUNT -freesize will be applied only if the actual free size is greater than the specified value.
 #                 leading colon write protect image: If set, BOOT and IMGMOUNT commands will put an image file name with a leading colon (:) in write-protect mode.
@@ -555,29 +497,6 @@ dos mem limit                                     = 0
 isa memory hole at 512kb                          = false
 reboot delay                                      = -1
 memalias                                          = 0
-pc-98 BIOS copyright string                       = false
-pc-98 int 1b fdc timer wait                       = false
-pc-98 pic init to read isr                        = true
-pc-98 fm board                                    = auto
-pc-98 fm board irq                                = 0
-pc-98 fm board io port                            = 0
-pc-98 sound bios                                  = false
-pc-98 load sound bios rom file                    = true
-pc-98 buffer page flip                            = false
-pc-98 enable 256-color planar                     = true
-pc-98 enable 256-color                            = true
-pc-98 enable 16-color                             = true
-pc-98 enable grcg                                 = true
-pc-98 enable egc                                  = true
-pc-98 enable 188 user cg                          = true
-pc-98 start gdc at 5mhz                           = false
-pc-98 allow scanline effect                       = true
-pc-98 bus mouse                                   = true
-pc-98 video mode                                  = 
-pc-98 timer always cycles                         = auto
-pc-98 timer master frequency                      = 0
-pc-98 allow 4 display partition graphics          = -1
-pc-98 force ibm keyboard layout                   = false
 nocachedir                                        = false
 freesizecap                                       = true
 leading colon write protect image                 = true
@@ -642,6 +561,94 @@ resize only on vga active display width increase  = false
 enable pci bus                                    = true
 vga palette update on full load                   = true
 ignore odd-even mode in non-cga modes             = false
+
+[pc98]
+#                       pc-98 BIOS copyright string: If set, the PC-98 BIOS copyright string is placed at E800:0000. Enable this for software that detects PC-98 vs Epson.
+#                       pc-98 int 1b fdc timer wait: If set, INT 1Bh floppy access will wait for the timer to count down before returning.
+#                                                      This is needed for Ys II to run without crashing.
+#                        pc-98 pic init to read isr: If set, the programmable interrupt controllers are initialized by default (if PC-98 mode)
+#                                                      so that the in-service interrupt status can be read immediately. There seems to be a common
+#                                                      convention in PC-98 games to program and/or assume this mode for cooperative interrupt handling.
+#                                                      This option is enabled by default for best compatibility with PC-98 games.
+#                                    pc-98 fm board: In PC-98 mode, selects the FM music board to emulate.
+#                                                      Possible values: auto, off, false, board14, board26k, board86, board86c.
+#                                pc-98 fm board irq: If set, helps to determine the IRQ of the FM board. A setting of zero means to auto-determine the IRQ.
+#                            pc-98 fm board io port: If set, helps to determine the base I/O port of the FM board. A setting of zero means to auto-determine the port number.
+#                                  pc-98 sound bios: Set Sound BIOS enabled bit in MEMSW 4 for some games that require it.
+#                                                      TODO: Real emulation of PC-9801-26K/86 Sound BIOS
+#                    pc-98 load sound bios rom file: If set, load SOUND.ROM if available and prsent that to the guest instead of trying to emulate directly.
+#                                                      This is strongly recommended, and is default enabled.
+#                                                      SOUND.ROM is a snapshot of the FM board BIOS taken from real PC-98 hardware.
+#                            pc-98 buffer page flip: If set, the game's request to page flip will be delayed to vertical retrace, which can eliminate tearline artifacts.
+#                                                      Note that this is NOT the behavior of actual hardware. This option is provided for the user's preference.
+#                     pc-98 enable 256-color planar: Allow 256-color planar graphics mode if set, disable if not set.
+#                                                      This is a form of memory access in 256-color mode that existed for a short
+#                                                      time before later PC-9821 models removed it. This option must be enabled
+#                                                      to use DOSBox-X with Windows 3.1 and it's built-in 256-color driver.
+#                            pc-98 enable 256-color: Allow 256-color graphics mode if set, disable if not set
+#                             pc-98 enable 16-color: Allow 16-color graphics mode if set, disable if not set
+#                                 pc-98 enable grcg: Allow GRCG graphics functions if set, disable if not set
+#                                  pc-98 enable egc: Allow EGC graphics functions if set, disable if not set
+#                          pc-98 enable 188 user cg: Allow 188+ user-defined CG cells if set
+#                           pc-98 start gdc at 5mhz: Start GDC at 5MHz if set, 2.5MHz if clear. May be required for some games.
+#                       pc-98 allow scanline effect: If set, PC-98 emulation will allow the DOS application to enable the 'scanline effect'
+#                                                      in 200-line graphics modes upconverted to 400-line raster display. When enabled, odd
+#                                                      numbered scanlines are blanked instead of doubled
+#                                   pc-98 bus mouse: Enable PC-98 bus mouse emulation. Disabling this option does not disable INT 33h emulation.
+#                                  pc-98 video mode: Specify the preferred PC-98 video mode.
+#                                                      Valid values are 15, 24, or 31 for each specific horizontal refresh rate on the platform.
+#                                                      24khz is default and best supported at this time.
+#                                                      15khz is not implemented at this time.
+#                                                      31khz is experimental at this time.
+#                                                      Possible values: , 24khz, 31khz, 15khz.
+#                         pc-98 timer always cycles: This controls PIT 1 PC speaker behavior related to turning the output on and off.
+#                                                      Default setting is 'auto' to let the emulator choose for you.
+#                                                      true:  PIT 1 will always cycle whether or not the speaker is on (PC-9801 behavior).
+#                                                      false: PIT 1 will only cycle when the speaker is on (PC-9821 behavior).
+#                                                      Some older games will require the PC-9801 behavior to function properly.
+#                                                      Possible values: true, false, 1, 0, auto.
+#                      pc-98 timer master frequency: 8254 timer clock frequency (NEC PC-98). Depending on the CPU frequency the clock frequency is one of two common values.
+#                                                      If your setting is neither of the below the closest appropriate value will be chosen.
+#                                                      This setting affects the master clock rate that DOS applications must divide down from to program the timer
+#                                                      at the correct rate, which affects timer interrupt, PC speaker, and the COM1 RS-232C serial port baud rate.
+#                                                      8MHz is treated as an alias for 4MHz and 10MHz is treated as an alias for 5MHz.
+#                                                          0: Use default (auto)
+#                                                          4: 1.996MHz (as if 4MHz or multiple thereof CPU clock)
+#                                                          5: 2.457MHz (as if 5MHz or multiple thereof CPU clock)
+#          pc-98 allow 4 display partition graphics: According to NEC graphics controller documentation, graphics mode is supposed to support only
+#                                                      2 display partitions. Some games rely on hardware flaws that allowed 4 partitions.
+#                                                         -1: Default (choose automatically)
+#                                                          0: Disable
+#                                                          1: Enable
+#                   pc-98 force ibm keyboard layout: Force to use a default keyboard layout like IBM US-English for PC-98 emulation.
+#                                                      Will only work with apps and games using BIOS for keyboard.
+#           pc-98 show graphics layer on initialize: If PC-98 mode and INT 33h emulation is enabled, the graphics layer will be automatically enabled
+#                                                      at driver startup AND when INT 33h AX=0 is called. This is NEC MOUSE.COM behavior and default
+#                                                      enabled. To emulate other drivers like QMOUSE that do not follow this behavior, set to false.
+pc-98 BIOS copyright string                       = false
+pc-98 int 1b fdc timer wait                       = false
+pc-98 pic init to read isr                        = true
+pc-98 fm board                                    = auto
+pc-98 fm board irq                                = 0
+pc-98 fm board io port                            = 0
+pc-98 sound bios                                  = false
+pc-98 load sound bios rom file                    = true
+pc-98 buffer page flip                            = false
+pc-98 enable 256-color planar                     = true
+pc-98 enable 256-color                            = true
+pc-98 enable 16-color                             = true
+pc-98 enable grcg                                 = true
+pc-98 enable egc                                  = true
+pc-98 enable 188 user cg                          = true
+pc-98 start gdc at 5mhz                           = false
+pc-98 allow scanline effect                       = true
+pc-98 bus mouse                                   = true
+pc-98 video mode                                  = 
+pc-98 timer always cycles                         = auto
+pc-98 timer master frequency                      = 0
+pc-98 allow 4 display partition graphics          = -1
+pc-98 force ibm keyboard layout                   = false
+pc-98 show graphics layer on initialize           = true
 
 [render]
 #               frameskip: How many frames DOSBox-X skips before drawing one.
@@ -1559,9 +1566,6 @@ dongle    = false
 #                                                     hidden the cursor in the guest, as long as the DOS application is polling position
 #                                                     and button status. This can be useful for DOS programs that draw the cursor on their
 #                                                     own instead of using the mouse driver, including most games and DeluxePaint II.
-#          pc-98 show graphics layer on initialize: If PC-98 mode and INT 33h emulation is enabled, the graphics layer will be automatically enabled
-#                                                     at driver startup AND when INT 33h AX=0 is called. This is NEC MOUSE.COM behavior and default
-#                                                     enabled. To emulate other drivers like QMOUSE that do not follow this behavior, set to false.
 #                   int33 disable cell granularity: If set, the mouse pointer position is reported at full precision (as if 640x200 coordinates) in all modes.
 #                                                     If not set, the mouse pointer position is rounded to the top-left corner of a character cell in text modes.
 #                                                     This option is OFF by default.
@@ -1644,7 +1648,6 @@ automountall                                     = false
 int33                                            = true
 int33 hide host cursor if interrupt subroutine   = true
 int33 hide host cursor when polling              = false
-pc-98 show graphics layer on initialize          = true
 int33 disable cell granularity                   = false
 int 13 extensions                                = true
 biosps2                                          = true

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1882,6 +1882,11 @@ cd-rom spinup time      = 0
 cd-rom spindown timeout = 0
 cd-rom insertion delay  = 0
 
+[config]
+REM                     = This section is designed to resemble the DOS CONFIG.SYS file, although it currently only supports a limited number of CONFIG.SYS options.
+BREAK                   = off
+LASTDRIVE               = a
+
 [autoexec]
 # Lines in this section will be run at startup.
 # You can put your MOUNT lines here.

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1883,9 +1883,9 @@ cd-rom spindown timeout = 0
 cd-rom insertion delay  = 0
 
 [config]
-REM                     = This section is designed to resemble the DOS CONFIG.SYS file, although it currently only supports a limited number of CONFIG.SYS options.
-BREAK                   = off
-LASTDRIVE               = a
+rem                     = This section is designed to resemble the DOS CONFIG.SYS file, although it currently only supports a limited number of CONFIG.SYS options.
+break                   = off
+lastdrive               = a
 
 [autoexec]
 # Lines in this section will be run at startup.

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -67,7 +67,8 @@ void DOS_ParamBlock::SaveData(void) {
 	sSave(sExec,initcsip,exec.initcsip);
 }
 
-
+extern bool startup_state_numlock;
+extern void SetNumLock(void);
 void DOS_InfoBlock::SetLocation(Bit16u segment) {
 	seg = segment;
 	pt=PhysMake(seg,0);
@@ -84,6 +85,11 @@ void DOS_InfoBlock::SetLocation(Bit16u segment) {
 		char *dosbreak = (char *)section->Get_string("break");
 		if (!strcasecmp(dosbreak, "on"))
 			dos.breakcheck=true;
+#ifdef WIN32
+		char *numlock = (char *)section->Get_string("numlock");
+		if (!strcasecmp(numlock, "off")&&startup_state_numlock || !strcasecmp(numlock, "on")&&!startup_state_numlock)
+			SetNumLock();
+#endif
 	}
 
 	sSave(sDIB,regCXfrom5e,(Bit16u)0);

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -78,10 +78,10 @@ void DOS_InfoBlock::SetLocation(Bit16u segment) {
 	Bit8u drives=1;
 	Section_prop *section = static_cast<Section_prop *>(control->GetSection("config"));
 	if (section !=NULL) {
-		char *lastdrive = (char *)section->Get_string("LASTDRIVE");
+		char *lastdrive = (char *)section->Get_string("lastdrive");
 		if (strlen(lastdrive)==1&&lastdrive[0]>='a'&&lastdrive[0]<='z')
 			drives=lastdrive[0]-'a'+1;
-		char *dosbreak = (char *)section->Get_string("BREAK");
+		char *dosbreak = (char *)section->Get_string("break");
 		if (!strcasecmp(dosbreak, "on"))
 			dos.breakcheck=true;
 	}

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -24,6 +24,7 @@
 #include "dos_inc.h"
 #include "support.h"
 #include "drives.h"
+#include "control.h"
 
 Bit8u sattr[260], fattr;
 char sname[260][LFN_NAMELENGTH+1],storect[CTBUF];
@@ -73,6 +74,17 @@ void DOS_InfoBlock::SetLocation(Bit16u segment) {
 	/* Clear the initial Block */
 	for(Bit8u i=0;i<sizeof(sDIB);i++) mem_writeb(pt+i,0xff);
 	for(Bit8u i=0;i<14;i++) mem_writeb(pt+i,0);
+	
+	Bit8u drives=1;
+	Section_prop *section = static_cast<Section_prop *>(control->GetSection("config"));
+	if (section !=NULL) {
+		char *lastdrive = (char *)section->Get_string("LASTDRIVE");
+		if (strlen(lastdrive)==1&&lastdrive[0]>='a'&&lastdrive[0]<='z')
+			drives=lastdrive[0]-'a'+1;
+		char *dosbreak = (char *)section->Get_string("BREAK");
+		if (!strcasecmp(dosbreak, "on"))
+			dos.breakcheck=true;
+	}
 
 	sSave(sDIB,regCXfrom5e,(Bit16u)0);
 	sSave(sDIB,countLRUcache,(Bit16u)0);
@@ -81,7 +93,7 @@ void DOS_InfoBlock::SetLocation(Bit16u segment) {
 	sSave(sDIB,protFCBs,(Bit16u)0);
 	sSave(sDIB,specialCodeSeg,(Bit16u)0);
 	sSave(sDIB,joindedDrives,(Bit8u)0);
-	sSave(sDIB,lastdrive,(Bit8u)0x01);//increase this if you add drives to cds-chain
+	sSave(sDIB,lastdrive,(Bit8u)drives);//increase this if you add drives to cds-chain
 
 	sSave(sDIB,diskInfoBuffer,RealMake(segment,offsetof(sDIB,diskBufferHeadPt)));
 	sSave(sDIB,setverPtr,(Bit32u)0);

--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -27,7 +27,7 @@
 #include "debug.h"
 #include "cpu.h"
 
-const char * RunningProgram="DOSBOX";
+const char * RunningProgram="DOSBOX-X";
 
 #ifdef _MSC_VER
 #pragma pack(1)
@@ -99,7 +99,7 @@ void DOS_UpdatePSPName(void) {
 	static char name[9];
 	mcb.GetFileName(name);
 	name[8] = 0;
-	if (!strlen(name)) strcpy(name,"DOSBOX");
+	if (!strlen(name)) strcpy(name,"DOSBOX-X");
 	for(Bitu i = 0;i < 8;i++) { //Don't put garbage in the title bar. Mac OS X doesn't like it
 		if (name[i] == 0) break;
 		if ( !isprint(*reinterpret_cast<unsigned char*>(&name[i])) ) name[i] = '?';

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -1224,7 +1224,14 @@ Bit8u localDrive::GetMediaByte(void) {
 bool localDrive::isRemote(void) {
 	if (remote==1) return true;
 	if (remote==0) return false;
-	/* Automatically detect if called by SCANDISK.EXE and return true (tested with the program from MS-DOS 6.20 to Windows ME) */
+	char psp_name[9];
+	DOS_MCB psp_mcb(dos.psp()-1);
+	psp_mcb.GetFileName(psp_name);
+	if (strcmp(psp_name, "SCANDISK") == 0) {
+		/* Check for SCANDISK.EXE and return true (Wengier) */
+		return true;
+	}
+	/* Automatically detect if called by SCANDISK.EXE even if it is renamed (tested with the program from MS-DOS 6.20 to Windows ME) */
 	if (dos.version.major >= 5 && reg_sp >=0x4000 && mem_readw(SegPhys(ss)+reg_sp)/0x100 == 0x1 && mem_readw(SegPhys(ss)+reg_sp+2)/0x100 >= 0xB && mem_readw(SegPhys(ss)+reg_sp+2)/0x100 <= 0x12)
 		return true;
 	return false;
@@ -1682,7 +1689,7 @@ void cdromDrive::SetDir(const char* path) {
 }
 
 bool cdromDrive::isRemote(void) {
-	return true;
+	return localDrive::isRemote();
 }
 
 bool cdromDrive::isRemovable(void) {

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -346,8 +346,14 @@ bool Virtual_Drive::isRemote(void) {
     else if (!strcmp(opt,"0") || !strcmp(opt,"false")) {
         return false;
     }
-
-    /* Automatically detect if called by SCANDISK.EXE and return true (tested with the program from MS-DOS 6.20 to Windows ME) */
+	char psp_name[9];
+	DOS_MCB psp_mcb(dos.psp()-1);
+	psp_mcb.GetFileName(psp_name);
+	if (strcmp(psp_name, "SCANDISK") == 0) {
+		/* Check for SCANDISK.EXE and return true (Wengier) */
+		return true;
+	}
+	/* Automatically detect if called by SCANDISK.EXE even if it is renamed (tested with the program from MS-DOS 6.20 to Windows ME) */
     if (dos.version.major >= 5 && reg_sp >=0x4000 && mem_readw(SegPhys(ss)+reg_sp)/0x100 == 0x1 && mem_readw(SegPhys(ss)+reg_sp+2)/0x100 >= 0xB && mem_readw(SegPhys(ss)+reg_sp+2)/0x100 <= 0x12)
 		return true;
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3364,10 +3364,10 @@ void DOSBOX_SetupConfigSections(void) {
     /* CONFIG.SYS options (stub) */
     secprop=control->AddSection_prop("config",&Null_Init,false);
 
-    Pstring = secprop->Add_string("REM",Property::Changeable::OnlyAtStart,"This section is designed to resemble the DOS CONFIG.SYS file, although it currently only supports a limited number of CONFIG.SYS options.");
-    Pstring = secprop->Add_string("BREAK",Property::Changeable::OnlyAtStart,"off");
+    Pstring = secprop->Add_string("rem",Property::Changeable::OnlyAtStart,"This section is designed to resemble the DOS CONFIG.SYS file, although it currently only supports a limited number of CONFIG.SYS options.");
+    Pstring = secprop->Add_string("break",Property::Changeable::OnlyAtStart,"off");
     Pstring->Set_values(ps1opt);
-    Pstring = secprop->Add_string("LASTDRIVE",Property::Changeable::OnlyAtStart,"a");
+    Pstring = secprop->Add_string("lastdrive",Property::Changeable::OnlyAtStart,"a");
     Pstring->Set_values(driveletters);
 
     //TODO ?

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1013,6 +1013,7 @@ void DOSBOX_SetupConfigSections(void) {
     const char* devices[] = { "default", "win32", "alsa", "oss", "coreaudio", "coremidi", "mt32", "timidity", "none", 0}; // FIXME: add some way to offer the actually available choices.
 #endif
     const char* apmbiosversions[] = { "auto", "1.0", "1.1", "1.2", 0 };
+    const char* driveletters[] = { "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", 0};
     const char *mt32log[] = {"off", "on",0};
     const char *mt32thread[] = {"off", "on",0};
     const char *mt32ReverseStereo[] = {"off", "on",0};
@@ -3359,6 +3360,15 @@ void DOSBOX_SetupConfigSections(void) {
                 "auto-insert notification triggers properly.\n"
                 "Set to 0 to use controller or CD-ROM drive-specific default.");
     }
+
+    /* CONFIG.SYS options (stub) */
+    secprop=control->AddSection_prop("config",&Null_Init,false);
+
+    Pstring = secprop->Add_string("REM",Property::Changeable::OnlyAtStart,"");
+    Pstring = secprop->Add_string("BREAK",Property::Changeable::OnlyAtStart,"off");
+    Pstring->Set_values(ps1opt);
+    Pstring = secprop->Add_string("LASTDRIVE",Property::Changeable::OnlyAtStart,"a");
+    Pstring->Set_values(driveletters);
 
     //TODO ?
     control->AddSection_line("autoexec",&Null_Init);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1420,113 +1420,6 @@ void DOSBOX_SetupConfigSections(void) {
         "        or 386DX and 486 systems where the CPU communicated directly with the ISA bus (A24-A31 tied off)\n"
         "    26: 64MB aliasing. Some 486s had only 26 external address bits, some motherboards tied off A26-A31");
 
-    Pbool = secprop->Add_bool("pc-98 BIOS copyright string",Property::Changeable::WhenIdle,false);
-    Pbool->Set_help("If set, the PC-98 BIOS copyright string is placed at E800:0000. Enable this for software that detects PC-98 vs Epson.");
-
-    Pbool = secprop->Add_bool("pc-98 int 1b fdc timer wait",Property::Changeable::WhenIdle,false);
-    Pbool->Set_help("If set, INT 1Bh floppy access will wait for the timer to count down before returning.\n"
-                    "This is needed for Ys II to run without crashing.");
-
-    Pbool = secprop->Add_bool("pc-98 pic init to read isr",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("If set, the programmable interrupt controllers are initialized by default (if PC-98 mode)\n"
-                    "so that the in-service interrupt status can be read immediately. There seems to be a common\n"
-                    "convention in PC-98 games to program and/or assume this mode for cooperative interrupt handling.\n"
-                    "This option is enabled by default for best compatibility with PC-98 games.");
-
-    Pstring = secprop->Add_string("pc-98 fm board",Property::Changeable::Always,"auto");
-    Pstring->Set_values(pc98fmboards);
-    Pstring->Set_help("In PC-98 mode, selects the FM music board to emulate.");
-
-    Pint = secprop->Add_int("pc-98 fm board irq", Property::Changeable::WhenIdle,0);
-    Pint->Set_help("If set, helps to determine the IRQ of the FM board. A setting of zero means to auto-determine the IRQ.");
-
-    Phex = secprop->Add_hex("pc-98 fm board io port", Property::Changeable::WhenIdle,0);
-    Phex->Set_help("If set, helps to determine the base I/O port of the FM board. A setting of zero means to auto-determine the port number.");
-
-    Pbool = secprop->Add_bool("pc-98 sound bios",Property::Changeable::WhenIdle,false);
-    Pbool->Set_help("Set Sound BIOS enabled bit in MEMSW 4 for some games that require it.\n"
-                    "TODO: Real emulation of PC-9801-26K/86 Sound BIOS");
-
-    Pbool = secprop->Add_bool("pc-98 load sound bios rom file",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("If set, load SOUND.ROM if available and prsent that to the guest instead of trying to emulate directly.\n"
-                    "This is strongly recommended, and is default enabled.\n"
-                    "SOUND.ROM is a snapshot of the FM board BIOS taken from real PC-98 hardware.");
-
-    Pbool = secprop->Add_bool("pc-98 buffer page flip",Property::Changeable::WhenIdle,false);
-    Pbool->Set_help("If set, the game's request to page flip will be delayed to vertical retrace, which can eliminate tearline artifacts.\n"
-                    "Note that this is NOT the behavior of actual hardware. This option is provided for the user's preference.");
-
-    Pbool = secprop->Add_bool("pc-98 enable 256-color planar",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("Allow 256-color planar graphics mode if set, disable if not set.\n"
-                    "This is a form of memory access in 256-color mode that existed for a short\n"
-                    "time before later PC-9821 models removed it. This option must be enabled\n"
-                    "to use DOSBox-X with Windows 3.1 and it's built-in 256-color driver.");
-
-    Pbool = secprop->Add_bool("pc-98 enable 256-color",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("Allow 256-color graphics mode if set, disable if not set");
-
-    Pbool = secprop->Add_bool("pc-98 enable 16-color",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("Allow 16-color graphics mode if set, disable if not set");
-
-    Pbool = secprop->Add_bool("pc-98 enable grcg",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("Allow GRCG graphics functions if set, disable if not set");
-
-    Pbool = secprop->Add_bool("pc-98 enable egc",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("Allow EGC graphics functions if set, disable if not set");
-
-    Pbool = secprop->Add_bool("pc-98 enable 188 user cg",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("Allow 188+ user-defined CG cells if set");
-
-    Pbool = secprop->Add_bool("pc-98 start gdc at 5mhz",Property::Changeable::WhenIdle,false);
-    Pbool->Set_help("Start GDC at 5MHz if set, 2.5MHz if clear. May be required for some games.");
-
-    Pbool = secprop->Add_bool("pc-98 allow scanline effect",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("If set, PC-98 emulation will allow the DOS application to enable the 'scanline effect'\n"
-                    "in 200-line graphics modes upconverted to 400-line raster display. When enabled, odd\n"
-                    "numbered scanlines are blanked instead of doubled");
-
-    Pbool = secprop->Add_bool("pc-98 bus mouse",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("Enable PC-98 bus mouse emulation. Disabling this option does not disable INT 33h emulation.");
-
-    Pstring = secprop->Add_string("pc-98 video mode",Property::Changeable::WhenIdle,"");
-    Pstring->Set_values(pc98videomodeopt);
-    Pstring->Set_help("Specify the preferred PC-98 video mode.\n"
-                      "Valid values are 15, 24, or 31 for each specific horizontal refresh rate on the platform.\n"
-                      "24khz is default and best supported at this time.\n"
-                      "15khz is not implemented at this time.\n"
-                      "31khz is experimental at this time.");
-
-    Pstring = secprop->Add_string("pc-98 timer always cycles",Property::Changeable::WhenIdle,"auto");
-    Pstring->Set_values(truefalseautoopt);
-    Pstring->Set_help("This controls PIT 1 PC speaker behavior related to turning the output on and off.\n"
-                      "Default setting is 'auto' to let the emulator choose for you.\n"
-                      "true:  PIT 1 will always cycle whether or not the speaker is on (PC-9801 behavior).\n"
-                      "false: PIT 1 will only cycle when the speaker is on (PC-9821 behavior).\n"
-                      "Some older games will require the PC-9801 behavior to function properly.");
-
-    Pint = secprop->Add_int("pc-98 timer master frequency", Property::Changeable::WhenIdle,0);
-    Pint->SetMinMax(0,2457600);
-    Pint->Set_help("8254 timer clock frequency (NEC PC-98). Depending on the CPU frequency the clock frequency is one of two common values.\n"
-                   "If your setting is neither of the below the closest appropriate value will be chosen.\n"
-                   "This setting affects the master clock rate that DOS applications must divide down from to program the timer\n"
-                   "at the correct rate, which affects timer interrupt, PC speaker, and the COM1 RS-232C serial port baud rate.\n"
-                   "8MHz is treated as an alias for 4MHz and 10MHz is treated as an alias for 5MHz.\n"
-                   "    0: Use default (auto)\n"
-                   "    4: 1.996MHz (as if 4MHz or multiple thereof CPU clock)\n"
-                   "    5: 2.457MHz (as if 5MHz or multiple thereof CPU clock)");
-
-    Pint = secprop->Add_int("pc-98 allow 4 display partition graphics", Property::Changeable::WhenIdle,-1);
-    Pint->SetMinMax(-1,1);
-    Pint->Set_help("According to NEC graphics controller documentation, graphics mode is supposed to support only\n"
-                   "2 display partitions. Some games rely on hardware flaws that allowed 4 partitions.\n"
-                   "   -1: Default (choose automatically)\n"
-                   "    0: Disable\n"
-                   "    1: Enable");
-
-    Pbool = secprop->Add_bool("pc-98 force ibm keyboard layout",Property::Changeable::WhenIdle,false);
-    Pbool->Set_help("Force to use a default keyboard layout like IBM US-English for PC-98 emulation.\n"
-                    "Will only work with apps and games using BIOS for keyboard.");
-
     Pbool = secprop->Add_bool("nocachedir",Property::Changeable::WhenIdle,false);
     Pbool->Set_help("If set, MOUNT commands will mount with -nocachedir by default.");
 
@@ -1813,6 +1706,125 @@ void DOSBOX_SetupConfigSections(void) {
     Pbool->Set_help("Some demoscene productions use VGA Mode X but accidentally enable odd/even mode.\n"
                     "Setting this option can correct for that and render the demo properly.\n"
                     "This option forces VGA emulation to ignore odd/even mode except in text and CGA modes.");
+					
+    secprop=control->AddSection_prop("pc98",&Null_Init);
+	Pbool = secprop->Add_bool("pc-98 BIOS copyright string",Property::Changeable::WhenIdle,false);
+    Pbool->Set_help("If set, the PC-98 BIOS copyright string is placed at E800:0000. Enable this for software that detects PC-98 vs Epson.");
+
+    Pbool = secprop->Add_bool("pc-98 int 1b fdc timer wait",Property::Changeable::WhenIdle,false);
+    Pbool->Set_help("If set, INT 1Bh floppy access will wait for the timer to count down before returning.\n"
+                    "This is needed for Ys II to run without crashing.");
+
+    Pbool = secprop->Add_bool("pc-98 pic init to read isr",Property::Changeable::WhenIdle,true);
+    Pbool->Set_help("If set, the programmable interrupt controllers are initialized by default (if PC-98 mode)\n"
+                    "so that the in-service interrupt status can be read immediately. There seems to be a common\n"
+                    "convention in PC-98 games to program and/or assume this mode for cooperative interrupt handling.\n"
+                    "This option is enabled by default for best compatibility with PC-98 games.");
+
+    Pstring = secprop->Add_string("pc-98 fm board",Property::Changeable::Always,"auto");
+    Pstring->Set_values(pc98fmboards);
+    Pstring->Set_help("In PC-98 mode, selects the FM music board to emulate.");
+
+    Pint = secprop->Add_int("pc-98 fm board irq", Property::Changeable::WhenIdle,0);
+    Pint->Set_help("If set, helps to determine the IRQ of the FM board. A setting of zero means to auto-determine the IRQ.");
+
+    Phex = secprop->Add_hex("pc-98 fm board io port", Property::Changeable::WhenIdle,0);
+    Phex->Set_help("If set, helps to determine the base I/O port of the FM board. A setting of zero means to auto-determine the port number.");
+
+    Pbool = secprop->Add_bool("pc-98 sound bios",Property::Changeable::WhenIdle,false);
+    Pbool->Set_help("Set Sound BIOS enabled bit in MEMSW 4 for some games that require it.\n"
+                    "TODO: Real emulation of PC-9801-26K/86 Sound BIOS");
+
+    Pbool = secprop->Add_bool("pc-98 load sound bios rom file",Property::Changeable::WhenIdle,true);
+    Pbool->Set_help("If set, load SOUND.ROM if available and prsent that to the guest instead of trying to emulate directly.\n"
+                    "This is strongly recommended, and is default enabled.\n"
+                    "SOUND.ROM is a snapshot of the FM board BIOS taken from real PC-98 hardware.");
+
+    Pbool = secprop->Add_bool("pc-98 buffer page flip",Property::Changeable::WhenIdle,false);
+    Pbool->Set_help("If set, the game's request to page flip will be delayed to vertical retrace, which can eliminate tearline artifacts.\n"
+                    "Note that this is NOT the behavior of actual hardware. This option is provided for the user's preference.");
+
+    Pbool = secprop->Add_bool("pc-98 enable 256-color planar",Property::Changeable::WhenIdle,true);
+    Pbool->Set_help("Allow 256-color planar graphics mode if set, disable if not set.\n"
+                    "This is a form of memory access in 256-color mode that existed for a short\n"
+                    "time before later PC-9821 models removed it. This option must be enabled\n"
+                    "to use DOSBox-X with Windows 3.1 and it's built-in 256-color driver.");
+
+    Pbool = secprop->Add_bool("pc-98 enable 256-color",Property::Changeable::WhenIdle,true);
+    Pbool->Set_help("Allow 256-color graphics mode if set, disable if not set");
+
+    Pbool = secprop->Add_bool("pc-98 enable 16-color",Property::Changeable::WhenIdle,true);
+    Pbool->Set_help("Allow 16-color graphics mode if set, disable if not set");
+
+    Pbool = secprop->Add_bool("pc-98 enable grcg",Property::Changeable::WhenIdle,true);
+    Pbool->Set_help("Allow GRCG graphics functions if set, disable if not set");
+
+    Pbool = secprop->Add_bool("pc-98 enable egc",Property::Changeable::WhenIdle,true);
+    Pbool->Set_help("Allow EGC graphics functions if set, disable if not set");
+
+    Pbool = secprop->Add_bool("pc-98 enable 188 user cg",Property::Changeable::WhenIdle,true);
+    Pbool->Set_help("Allow 188+ user-defined CG cells if set");
+
+    Pbool = secprop->Add_bool("pc-98 start gdc at 5mhz",Property::Changeable::WhenIdle,false);
+    Pbool->Set_help("Start GDC at 5MHz if set, 2.5MHz if clear. May be required for some games.");
+
+    Pbool = secprop->Add_bool("pc-98 allow scanline effect",Property::Changeable::WhenIdle,true);
+    Pbool->Set_help("If set, PC-98 emulation will allow the DOS application to enable the 'scanline effect'\n"
+                    "in 200-line graphics modes upconverted to 400-line raster display. When enabled, odd\n"
+                    "numbered scanlines are blanked instead of doubled");
+
+    Pbool = secprop->Add_bool("pc-98 bus mouse",Property::Changeable::WhenIdle,true);
+    Pbool->Set_help("Enable PC-98 bus mouse emulation. Disabling this option does not disable INT 33h emulation.");
+
+    Pstring = secprop->Add_string("pc-98 video mode",Property::Changeable::WhenIdle,"");
+    Pstring->Set_values(pc98videomodeopt);
+    Pstring->Set_help("Specify the preferred PC-98 video mode.\n"
+                      "Valid values are 15, 24, or 31 for each specific horizontal refresh rate on the platform.\n"
+                      "24khz is default and best supported at this time.\n"
+                      "15khz is not implemented at this time.\n"
+                      "31khz is experimental at this time.");
+
+    Pstring = secprop->Add_string("pc-98 timer always cycles",Property::Changeable::WhenIdle,"auto");
+    Pstring->Set_values(truefalseautoopt);
+    Pstring->Set_help("This controls PIT 1 PC speaker behavior related to turning the output on and off.\n"
+                      "Default setting is 'auto' to let the emulator choose for you.\n"
+                      "true:  PIT 1 will always cycle whether or not the speaker is on (PC-9801 behavior).\n"
+                      "false: PIT 1 will only cycle when the speaker is on (PC-9821 behavior).\n"
+                      "Some older games will require the PC-9801 behavior to function properly.");
+
+    Pint = secprop->Add_int("pc-98 timer master frequency", Property::Changeable::WhenIdle,0);
+    Pint->SetMinMax(0,2457600);
+    Pint->Set_help("8254 timer clock frequency (NEC PC-98). Depending on the CPU frequency the clock frequency is one of two common values.\n"
+                   "If your setting is neither of the below the closest appropriate value will be chosen.\n"
+                   "This setting affects the master clock rate that DOS applications must divide down from to program the timer\n"
+                   "at the correct rate, which affects timer interrupt, PC speaker, and the COM1 RS-232C serial port baud rate.\n"
+                   "8MHz is treated as an alias for 4MHz and 10MHz is treated as an alias for 5MHz.\n"
+                   "    0: Use default (auto)\n"
+                   "    4: 1.996MHz (as if 4MHz or multiple thereof CPU clock)\n"
+                   "    5: 2.457MHz (as if 5MHz or multiple thereof CPU clock)");
+
+    Pint = secprop->Add_int("pc-98 allow 4 display partition graphics", Property::Changeable::WhenIdle,-1);
+    Pint->SetMinMax(-1,1);
+    Pint->Set_help("According to NEC graphics controller documentation, graphics mode is supposed to support only\n"
+                   "2 display partitions. Some games rely on hardware flaws that allowed 4 partitions.\n"
+                   "   -1: Default (choose automatically)\n"
+                   "    0: Disable\n"
+                   "    1: Enable");
+
+    Pbool = secprop->Add_bool("pc-98 force ibm keyboard layout",Property::Changeable::WhenIdle,false);
+    Pbool->Set_help("Force to use a default keyboard layout like IBM US-English for PC-98 emulation.\n"
+                    "Will only work with apps and games using BIOS for keyboard.");
+
+    /* Explanation: NEC's mouse driver MOUSE.COM enables the graphics layer on startup and when INT 33h AX=0 is called.
+     *              Some games by "Orange House" assume this behavior and do not make any effort on their
+     *              own to show and enable graphics. Without this option, those games will not show any
+     *              graphics. PC-98 systems have been confirmed to boot up with the graphics layer disabled
+     *              and set to 640x200 8-color planar mode. This has been confirmed on real hardware.
+     *              See also [https://github.com/joncampbell123/dosbox-x/issues/1305] */
+    Pbool = secprop->Add_bool("pc-98 show graphics layer on initialize",Property::Changeable::WhenIdle,true);
+    Pbool->Set_help("If PC-98 mode and INT 33h emulation is enabled, the graphics layer will be automatically enabled\n"
+                    "at driver startup AND when INT 33h AX=0 is called. This is NEC MOUSE.COM behavior and default\n"
+                    "enabled. To emulate other drivers like QMOUSE that do not follow this behavior, set to false.");
 
     secprop=control->AddSection_prop("render",&Null_Init,true);
     Pint = secprop->Add_int("frameskip",Property::Changeable::Always,0);
@@ -3085,17 +3097,6 @@ void DOSBOX_SetupConfigSections(void) {
                     "hidden the cursor in the guest, as long as the DOS application is polling position\n"
                     "and button status. This can be useful for DOS programs that draw the cursor on their\n"
                     "own instead of using the mouse driver, including most games and DeluxePaint II.");
-
-    /* Explanation: NEC's mouse driver MOUSE.COM enables the graphics layer on startup and when INT 33h AX=0 is called.
-     *              Some games by "Orange House" assume this behavior and do not make any effort on their
-     *              own to show and enable graphics. Without this option, those games will not show any
-     *              graphics. PC-98 systems have been confirmed to boot up with the graphics layer disabled
-     *              and set to 640x200 8-color planar mode. This has been confirmed on real hardware.
-     *              See also [https://github.com/joncampbell123/dosbox-x/issues/1305] */
-    Pbool = secprop->Add_bool("pc-98 show graphics layer on initialize",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("If PC-98 mode and INT 33h emulation is enabled, the graphics layer will be automatically enabled\n"
-                    "at driver startup AND when INT 33h AX=0 is called. This is NEC MOUSE.COM behavior and default\n"
-                    "enabled. To emulate other drivers like QMOUSE that do not follow this behavior, set to false.");
 
     Pbool = secprop->Add_bool("int33 disable cell granularity",Property::Changeable::WhenIdle,false);
     Pbool->Set_help("If set, the mouse pointer position is reported at full precision (as if 640x200 coordinates) in all modes.\n"

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3364,7 +3364,7 @@ void DOSBOX_SetupConfigSections(void) {
     /* CONFIG.SYS options (stub) */
     secprop=control->AddSection_prop("config",&Null_Init,false);
 
-    Pstring = secprop->Add_string("REM",Property::Changeable::OnlyAtStart,"");
+    Pstring = secprop->Add_string("REM",Property::Changeable::OnlyAtStart,"This section is designed to resemble the DOS CONFIG.SYS file, although it currently only supports a limited number of CONFIG.SYS options.");
     Pstring = secprop->Add_string("BREAK",Property::Changeable::OnlyAtStart,"off");
     Pstring->Set_values(ps1opt);
     Pstring = secprop->Add_string("LASTDRIVE",Property::Changeable::OnlyAtStart,"a");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1055,6 +1055,7 @@ void DOSBOX_SetupConfigSections(void) {
     const char *qualityno[] = { "0", "1", "2", "3", 0 };
     const char* tandys[] = { "auto", "on", "off", 0};
     const char* ps1opt[] = { "on", "off", 0};
+    const char* numopt[] = { "on", "off", "", 0};
     const char* truefalseautoopt[] = { "true", "false", "1", "0", "auto", 0};
     const char* pc98fmboards[] = { "auto", "off", "false", "board14", "board26k", "board86", "board86c", 0};
     const char* pc98videomodeopt[] = { "", "24khz", "31khz", "15khz", 0};
@@ -3367,6 +3368,8 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring = secprop->Add_string("rem",Property::Changeable::OnlyAtStart,"This section is designed to resemble the DOS CONFIG.SYS file, although it currently only supports a limited number of CONFIG.SYS options.");
     Pstring = secprop->Add_string("break",Property::Changeable::OnlyAtStart,"off");
     Pstring->Set_values(ps1opt);
+    Pstring = secprop->Add_string("numlock",Property::Changeable::OnlyAtStart,"");
+    Pstring->Set_values(numopt);
     Pstring = secprop->Add_string("lastdrive",Property::Changeable::OnlyAtStart,"a");
     Pstring->Set_values(driveletters);
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3626,9 +3626,9 @@ static void GUI_StartUp() {
     GFX_Stop();
 
 #if defined(C_SDL2)
-    SDL_SetWindowTitle(sdl.window,"DOSBox");
+    SDL_SetWindowTitle(sdl.window,"DOSBox-X");
 #else
-    SDL_WM_SetCaption("DOSBox",VERSION);
+    SDL_WM_SetCaption("DOSBox-X",VERSION);
 #endif
 
     /* Please leave the Splash screen stuff in working order in DOSBox. We spend a lot of time making DOSBox. */
@@ -6863,9 +6863,9 @@ void update_capture_fmt_menu(void);
 bool capture_fmt_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem);
 
 void update_pc98_clock_pit_menu(void) {
-    Section_prop * dosbox_section = static_cast<Section_prop *>(control->GetSection("dosbox"));
+    Section_prop * pc98_section = static_cast<Section_prop *>(control->GetSection("pc98"));
 
-    int pc98rate = dosbox_section->Get_int("pc-98 timer master frequency");
+    int pc98rate = pc98_section->Get_int("pc-98 timer master frequency");
     if (pc98rate > 6) pc98rate /= 2;
     if (pc98rate == 0) pc98rate = 5; /* Pick the most likely to work with DOS games (FIXME: This is a GUESS!! Is this correct?) */
     else if (pc98rate < 5) pc98rate = 4;
@@ -6895,8 +6895,8 @@ bool dos_pc98_clock_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * con
         tmp += tmp1;
     }
 
-    Section_prop * dosbox_section = static_cast<Section_prop *>(control->GetSection("dosbox"));
-    dosbox_section->HandleInputline(tmp.c_str());
+    Section_prop * pc98_section = static_cast<Section_prop *>(control->GetSection("pc98"));
+    pc98_section->HandleInputline(tmp.c_str());
 
     TIMER_OnPowerOn(NULL);
     TIMER_OnEnterPC98_Phase2_UpdateBDA();
@@ -6999,11 +6999,11 @@ bool vid_pc98_5mhz_gdc_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * 
         gdc_clock_1 = gdc_5mhz_mode;
         gdc_clock_2 = gdc_5mhz_mode;
 
-        Section_prop * dosbox_section = static_cast<Section_prop *>(control->GetSection("dosbox"));
+        Section_prop * pc98_section = static_cast<Section_prop *>(control->GetSection("pc98"));
         if (gdc_5mhz_mode)
-            dosbox_section->HandleInputline("pc-98 start gdc at 5mhz=1");
+            pc98_section->HandleInputline("pc-98 start gdc at 5mhz=1");
         else
-            dosbox_section->HandleInputline("pc-98 start gdc at 5mhz=0");
+            pc98_section->HandleInputline("pc-98 start gdc at 5mhz=0");
 
         mainMenu.get_item("pc98_5mhz_gdc").check(gdc_5mhz_mode).refresh_item(mainMenu);
     }
@@ -7019,11 +7019,11 @@ bool vid_pc98_200scanline_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item
 
         pc98_allow_scanline_effect = !pc98_allow_scanline_effect;
 
-        Section_prop * dosbox_section = static_cast<Section_prop *>(control->GetSection("dosbox"));
+        Section_prop * pc98_section = static_cast<Section_prop *>(control->GetSection("pc98"));
         if (pc98_allow_scanline_effect)
-            dosbox_section->HandleInputline("pc-98 allow scanline effect=1");
+            pc98_section->HandleInputline("pc-98 allow scanline effect=1");
         else
-            dosbox_section->HandleInputline("pc-98 allow scanline effect=0");
+            pc98_section->HandleInputline("pc-98 allow scanline effect=0");
 
         mainMenu.get_item("pc98_allow_200scanline").check(pc98_allow_scanline_effect).refresh_item(mainMenu);
     }
@@ -7040,11 +7040,11 @@ bool vid_pc98_4parts_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * co
 
         updateGDCpartitions4(!pc98_allow_4_display_partitions);
 
-        Section_prop * dosbox_section = static_cast<Section_prop *>(control->GetSection("dosbox"));
+        Section_prop * pc98_section = static_cast<Section_prop *>(control->GetSection("pc98"));
         if (pc98_allow_4_display_partitions)
-            dosbox_section->HandleInputline("pc-98 allow 4 display partition graphics=1");
+            pc98_section->HandleInputline("pc-98 allow 4 display partition graphics=1");
         else
-            dosbox_section->HandleInputline("pc-98 allow 4 display partition graphics=0");
+            pc98_section->HandleInputline("pc-98 allow 4 display partition graphics=0");
 
         mainMenu.get_item("pc98_allow_4partitions").check(pc98_allow_4_display_partitions).refresh_item(mainMenu);
     }
@@ -7065,11 +7065,11 @@ bool vid_pc98_enable_188user_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::i
         enable_pc98_188usermod = !enable_pc98_188usermod;
         gdc_egc_enable_update_vars();
 
-        Section_prop * dosbox_section = static_cast<Section_prop *>(control->GetSection("dosbox"));
+        Section_prop * pc98_section = static_cast<Section_prop *>(control->GetSection("pc98"));
         if (enable_pc98_188usermod)
-            dosbox_section->HandleInputline("pc-98 enable 188 user cg=1");
+            pc98_section->HandleInputline("pc-98 enable 188 user cg=1");
         else
-            dosbox_section->HandleInputline("pc-98 enable 188 user cg=0");
+            pc98_section->HandleInputline("pc-98 enable 188 user cg=0");
 
         mainMenu.get_item("pc98_enable_188user").check(enable_pc98_188usermod).refresh_item(mainMenu);
     }
@@ -7090,18 +7090,18 @@ bool vid_pc98_enable_egc_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item 
         enable_pc98_egc = !enable_pc98_egc;
         gdc_egc_enable_update_vars();
 
-        Section_prop * dosbox_section = static_cast<Section_prop *>(control->GetSection("dosbox"));
+        Section_prop * pc98_section = static_cast<Section_prop *>(control->GetSection("pc98"));
         if (enable_pc98_egc) {
-            dosbox_section->HandleInputline("pc-98 enable egc=1");
+            pc98_section->HandleInputline("pc-98 enable egc=1");
 
             if(!enable_pc98_grcg) { //Also enable GRCG if GRCG is disabled when enabling EGC
                 enable_pc98_grcg = !enable_pc98_grcg;
                 mem_writeb(0x54C,(enable_pc98_grcg ? 0x02 : 0x00) | (enable_pc98_16color ? 0x04 : 0x00));   
-                dosbox_section->HandleInputline("pc-98 enable grcg=1");
+                pc98_section->HandleInputline("pc-98 enable grcg=1");
             }
         }
         else
-            dosbox_section->HandleInputline("pc-98 enable egc=0");
+            pc98_section->HandleInputline("pc-98 enable egc=0");
 
         mainMenu.get_item("pc98_enable_egc").check(enable_pc98_egc).refresh_item(mainMenu);
         mainMenu.get_item("pc98_enable_grcg").check(enable_pc98_grcg).refresh_item(mainMenu);
@@ -7121,17 +7121,17 @@ bool vid_pc98_enable_grcg_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item
         enable_pc98_grcg = !enable_pc98_grcg;
         gdc_grcg_enable_update_vars();
 
-        Section_prop * dosbox_section = static_cast<Section_prop *>(control->GetSection("dosbox"));
+        Section_prop * pc98_section = static_cast<Section_prop *>(control->GetSection("pc98"));
         if (enable_pc98_grcg)
-            dosbox_section->HandleInputline("pc-98 enable grcg=1");
+            pc98_section->HandleInputline("pc-98 enable grcg=1");
         else
-            dosbox_section->HandleInputline("pc-98 enable grcg=0");
+            pc98_section->HandleInputline("pc-98 enable grcg=0");
 
         if ((!enable_pc98_grcg) && enable_pc98_egc) { // Also disable EGC if switching off GRCG
             void gdc_egc_enable_update_vars(void);
             enable_pc98_egc = !enable_pc98_egc;
             gdc_egc_enable_update_vars();   
-            dosbox_section->HandleInputline("pc-98 enable egc=0");
+            pc98_section->HandleInputline("pc-98 enable egc=0");
         }
 
         mainMenu.get_item("pc98_enable_egc").check(enable_pc98_egc).refresh_item(mainMenu);
@@ -7152,11 +7152,11 @@ bool vid_pc98_enable_analog_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::it
         enable_pc98_16color = !enable_pc98_16color;
         gdc_16color_enable_update_vars();
 
-        Section_prop * dosbox_section = static_cast<Section_prop *>(control->GetSection("dosbox"));
+        Section_prop * pc98_section = static_cast<Section_prop *>(control->GetSection("pc98"));
         if (enable_pc98_16color)
-            dosbox_section->HandleInputline("pc-98 enable 16-color=1");
+            pc98_section->HandleInputline("pc-98 enable 16-color=1");
         else
-            dosbox_section->HandleInputline("pc-98 enable 16-color=0");
+            pc98_section->HandleInputline("pc-98 enable 16-color=0");
 
         mainMenu.get_item("pc98_enable_analog").check(enable_pc98_16color).refresh_item(mainMenu);
     }
@@ -7175,11 +7175,11 @@ bool vid_pc98_enable_analog256_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu:
         enable_pc98_256color = !enable_pc98_256color;
         gdc_16color_enable_update_vars();
 
-        Section_prop * dosbox_section = static_cast<Section_prop *>(control->GetSection("dosbox"));
+        Section_prop * pc98_section = static_cast<Section_prop *>(control->GetSection("pc98"));
         if (enable_pc98_256color)
-            dosbox_section->HandleInputline("pc-98 enable 256-color=1");
+            pc98_section->HandleInputline("pc-98 enable 256-color=1");
         else
-            dosbox_section->HandleInputline("pc-98 enable 256-color=0");
+            pc98_section->HandleInputline("pc-98 enable 256-color=0");
 
         mainMenu.get_item("pc98_enable_analog256").check(enable_pc98_256color).refresh_item(mainMenu);
     }
@@ -7898,8 +7898,8 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         CheckScrollLockState();
 
         /* -- setup the config sections for config parsing */
-        LOG::SetupConfigSection();
         SDL_SetupConfigSection();
+        LOG::SetupConfigSection();
         DOSBOX_SetupConfigSections();
 
         /* -- Parse configuration files */

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -2411,10 +2411,9 @@ static void write_pbfdb_mouse(Bitu port,Bitu val,Bitu /*iolen*/) {
 void KEYBOARD_OnEnterPC98(Section *sec) {
     (void)sec;//UNUSED
 
-    {
-        Section_prop *section=static_cast<Section_prop *>(control->GetSection("dosbox"));
-        enable_pc98_bus_mouse = section->Get_bool("pc-98 bus mouse");
-    }
+	Section_prop * pc98_section=static_cast<Section_prop *>(control->GetSection("pc98"));
+	assert(pc98_section != NULL);
+	enable_pc98_bus_mouse = pc98_section->Get_bool("pc-98 bus mouse");
 
     /* TODO: Keyboard interface change, layout change. */
 
@@ -2431,8 +2430,7 @@ void KEYBOARD_OnEnterPC98(Section *sec) {
             WriteHandler_8255prn_PC98[i].Uninstall();
         }
         
-        Section_prop *section=static_cast<Section_prop *>(control->GetSection("dosbox"));
-        pc98_force_ibm_layout = section->Get_bool("pc-98 force ibm keyboard layout");
+        pc98_force_ibm_layout = pc98_section->Get_bool("pc-98 force ibm keyboard layout");
         if(pc98_force_ibm_layout)
             LOG_MSG("Forcing PC-98 keyboard to use IBM US-English like default layout");
     }

--- a/src/hardware/pc98_fm.cpp
+++ b/src/hardware/pc98_fm.cpp
@@ -372,7 +372,8 @@ bool PC98_FM_SoundBios_Enabled(void) {
 
 void PC98_FM_OnEnterPC98(Section *sec) {
     (void)sec;//UNUSED
-    Section_prop * section=static_cast<Section_prop *>(control->GetSection("dosbox"));
+    Section_prop * pc98_section=static_cast<Section_prop *>(control->GetSection("pc98"));
+	assert(pc98_section != NULL);
     bool was_pc98fm_init = pc98fm_init;
 
     if (!pc98fm_init) {
@@ -383,7 +384,7 @@ void PC98_FM_OnEnterPC98(Section *sec) {
 
         soundbios_callback.Uninstall();
 
-        board = section->Get_string("pc-98 fm board");
+        board = pc98_section->Get_string("pc-98 fm board");
         if (board == "off" || board == "false") {
             /* Don't enable Sound BIOS if sound board itself is disabled. */
             pc98_soundbios_enabled = false;
@@ -391,11 +392,11 @@ void PC98_FM_OnEnterPC98(Section *sec) {
             return;		
         }
 
-        irq = section->Get_int("pc-98 fm board irq");
-        baseio = (unsigned int)section->Get_hex("pc-98 fm board io port");
+        irq = pc98_section->Get_int("pc-98 fm board irq");
+        baseio = (unsigned int)pc98_section->Get_hex("pc-98 fm board io port");
 
-        pc98_soundbios_enabled = section->Get_bool("pc-98 sound bios");
-        pc98_soundbios_rom_load = section->Get_bool("pc-98 load sound bios rom file");
+        pc98_soundbios_enabled = pc98_section->Get_bool("pc-98 sound bios");
+        pc98_soundbios_rom_load = pc98_section->Get_bool("pc-98 load sound bios rom file");
         pc98_set_msw4_soundbios();
 
         if (pc98_soundbios_enabled) {

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -953,8 +953,11 @@ void PIC_Reset(Section *sec) {
      *        which is not necessarily initialized into this mode and may return
      *        the IRR register instead, causing the game to misinterpret
      *        incoming interrupts as in-service. */
-    if (IS_PC98_ARCH && section->Get_bool("pc-98 pic init to read isr"))
-        pics[0].request_issr = pics[1].request_issr = true;
+    if (IS_PC98_ARCH) {
+		Section_prop * pc98_section = static_cast<Section_prop *>(control->GetSection("pc98"));
+		if (pc98_section != NULL && pc98_section->Get_bool("pc-98 pic init to read isr"))
+			pics[0].request_issr = pics[1].request_issr = true;
+	}
 
     /* IBM: IRQ 0-15 is INT 0x08-0x0F, 0x70-0x7F
      * PC-98: IRQ 0-15 is INT 0x08-0x17 */

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -882,8 +882,8 @@ void TIMER_BIOS_INIT_Configure() {
 }
 
 void TIMER_OnPowerOn(Section*) {
-	Section_prop * section=static_cast<Section_prop *>(control->GetSection("dosbox"));
-	assert(section != NULL);
+	Section_prop * pc98_section=static_cast<Section_prop *>(control->GetSection("pc98"));
+	assert(pc98_section != NULL);
 
 	// log
 	LOG(LOG_MISC,LOG_DEBUG)("TIMER_OnPowerOn(): Reinitializing PIT timer emulation");
@@ -966,7 +966,7 @@ void TIMER_OnPowerOn(Section*) {
         int pc98rate;
 
         {
-            const char *s = section->Get_string("pc-98 timer always cycles");
+            const char *s = pc98_section->Get_string("pc-98 timer always cycles");
 
             if (!strcmp(s,"true") || !strcmp(s,"1"))
                 speaker_clock_lock_on = true; // PC-9801 behavior
@@ -977,7 +977,7 @@ void TIMER_OnPowerOn(Section*) {
         }
 
         /* PC-98 has two different rates: 5/10MHz base or 8MHz base. Let the user choose via dosbox.conf */
-        pc98rate = section->Get_int("pc-98 timer master frequency");
+        pc98rate = pc98_section->Get_int("pc-98 timer master frequency");
         if (pc98rate > 6) pc98rate /= 2;
         if (pc98rate == 0) pc98rate = 5; /* Pick the most likely to work with DOS games (FIXME: This is a GUESS!! Is this correct?) */
         else if (pc98rate < 5) pc98rate = 4;

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -604,6 +604,8 @@ Bit32u MEM_get_address_bits();
 
 void VGA_Reset(Section*) {
     Section_prop * section=static_cast<Section_prop *>(control->GetSection("dosbox"));
+	Section_prop * pc98_section=static_cast<Section_prop *>(control->GetSection("pc98"));
+	
     bool lfb_default = false;
     string str;
     int i;
@@ -613,7 +615,7 @@ void VGA_Reset(Section*) {
 
     LOG(LOG_MISC,LOG_DEBUG)("VGA_Reset() reinitializing VGA emulation");
 
-    GDC_display_plane_wait_for_vsync = section->Get_bool("pc-98 buffer page flip");
+    GDC_display_plane_wait_for_vsync = pc98_section->Get_bool("pc-98 buffer page flip");
 
     enable_pci_vga = section->Get_bool("pci vga");
 
@@ -705,14 +707,14 @@ void VGA_Reset(Section*) {
     if (IS_VGA_ARCH && svgaCard == SVGA_S3Trio && cpu_addr_bits < 31 && S3_LFB_BASE < 0x1000000ul) /* below 16MB and memalias == 31 bits */
         LOG(LOG_VGA,LOG_WARN)("S3 linear framebuffer warning: A linear framebuffer below the 16MB mark in physical memory when memalias < 31 is known to have problems with the Windows 3.1 S3 driver");
 
-    pc98_allow_scanline_effect = section->Get_bool("pc-98 allow scanline effect");
+    pc98_allow_scanline_effect = pc98_section->Get_bool("pc-98 allow scanline effect");
     mainMenu.get_item("pc98_allow_200scanline").check(pc98_allow_scanline_effect).refresh_item(mainMenu);
 
     // whether the GDC is running at 2.5MHz or 5.0MHz.
     // Some games require the GDC to run at 5.0MHz.
     // To enable these games we default to 5.0MHz.
     // NTS: There are also games that refuse to run if 5MHz switched on (TH03)
-    gdc_5mhz_mode = section->Get_bool("pc-98 start gdc at 5mhz");
+    gdc_5mhz_mode = pc98_section->Get_bool("pc-98 start gdc at 5mhz");
     mainMenu.get_item("pc98_5mhz_gdc").check(gdc_5mhz_mode).refresh_item(mainMenu);
 
     // record the initial setting.
@@ -721,12 +723,12 @@ void VGA_Reset(Section*) {
     // initial setting.
     gdc_5mhz_mode_initial = gdc_5mhz_mode;
 
-    enable_pc98_egc = section->Get_bool("pc-98 enable egc");
-    enable_pc98_grcg = section->Get_bool("pc-98 enable grcg");
-    enable_pc98_16color = section->Get_bool("pc-98 enable 16-color");
-    enable_pc98_256color = section->Get_bool("pc-98 enable 256-color");
-    enable_pc98_188usermod = section->Get_bool("pc-98 enable 188 user cg");
-    enable_pc98_256color_planar = section->Get_bool("pc-98 enable 256-color planar");
+    enable_pc98_egc = pc98_section->Get_bool("pc-98 enable egc");
+    enable_pc98_grcg = pc98_section->Get_bool("pc-98 enable grcg");
+    enable_pc98_16color = pc98_section->Get_bool("pc-98 enable 16-color");
+    enable_pc98_256color = pc98_section->Get_bool("pc-98 enable 256-color");
+    enable_pc98_188usermod = pc98_section->Get_bool("pc-98 enable 188 user cg");
+    enable_pc98_256color_planar = pc98_section->Get_bool("pc-98 enable 256-color planar");
 
 #if 0//TODO: Do not enforce until 256-color mode is fully implemented.
      //      Some users out there may expect the EGC, GRCG, 16-color options to disable the emulation.
@@ -758,7 +760,7 @@ void VGA_Reset(Section*) {
         }
     }
 
-    str = section->Get_string("pc-98 video mode");
+    str = pc98_section->Get_string("pc-98 video mode");
     if (str == "31khz")
         pc98_31khz_mode = true;
     else if (str == "15khz")/*TODO*/
@@ -767,7 +769,7 @@ void VGA_Reset(Section*) {
         pc98_31khz_mode = false;
     //TODO: Announce 31-KHz mode in BIOS config area. --yksoft1
     
-    i = section->Get_int("pc-98 allow 4 display partition graphics");
+    i = pc98_section->Get_int("pc-98 allow 4 display partition graphics");
     pc98_allow_4_display_partitions = (i < 0/*auto*/ || i == 1/*on*/);
     mainMenu.get_item("pc98_allow_4partitions").check(pc98_allow_4_display_partitions).refresh_item(mainMenu);
     // TODO: "auto" will default to true if old PC-9801, false if PC-9821, or

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -8595,8 +8595,9 @@ public:
 
         { // TODO: Eventually, move this to BIOS POST or init phase
             Section_prop * section=static_cast<Section_prop *>(control->GetSection("dosbox"));
+			Section_prop * pc98_section=static_cast<Section_prop *>(control->GetSection("pc98"));
 
-            enable_pc98_copyright_string = section->Get_bool("pc-98 BIOS copyright string");
+            enable_pc98_copyright_string = pc98_section->Get_bool("pc-98 BIOS copyright string");
 
             // NTS: This setting is also valid in PC-98 mode. According to Undocumented PC-98 by Webtech,
             //      there's nothing at I/O port E9h. I will move the I/O port in PC-98 mode if there is in
@@ -8612,7 +8613,7 @@ public:
 
             // for PC-98: When accessing the floppy through INT 1Bh, when enabled, run through a waiting loop to make sure
             //     the timer count is not too high on exit (Ys II)
-            enable_fdc_timer_hack = section->Get_bool("pc-98 int 1b fdc timer wait");
+            enable_fdc_timer_hack = pc98_section->Get_bool("pc-98 int 1b fdc timer wait");
 
             {
                 std::string s = section->Get_string("unhandled irq handler");

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -1758,6 +1758,7 @@ void BIOS_PS2Mouse_Startup(Section *sec) {
 void MOUSE_Startup(Section *sec) {
     (void)sec;//UNUSED
     Section_prop *section=static_cast<Section_prop *>(control->GetSection("dos"));
+	Section_prop * pc98_section=static_cast<Section_prop *>(control->GetSection("pc98"));
     RealPt i33loc=0;
 
     /* TODO: Needs to check for mouse, and fail to do anything if neither PS/2 nor serial mouse emulation enabled */
@@ -1766,7 +1767,7 @@ void MOUSE_Startup(Section *sec) {
 
     en_int33_hide_if_polling=section->Get_bool("int33 hide host cursor when polling");
 
-    en_int33_pc98_show_graphics=section->Get_bool("pc-98 show graphics layer on initialize");
+    en_int33_pc98_show_graphics=pc98_section->Get_bool("pc-98 show graphics layer on initialize");
 
     en_int33=section->Get_bool("int33");
     if (!en_int33) {


### PR DESCRIPTION
I noticed that in the dosbox-x.reference.conf file there are more than 20 PC-98 related settings. They all begin with "pc-98 " - most of them in the [dosbox] section, and another in the [dos] section. So I decided to clean them up by making a separate [pc98] section, and move all these PC-98 related settings to this section in the config file.

I also moved the [sdl] section in dosbox-x.reference.conf to the top, instead of [log]. The [log] section is only useful for developers and very technical users, whereas the [sdl] section is apparently useful for all users. Putting the [log] section on top can scare away some users I think.

In addition, for the auto setting the isRemote() function in drive_local.cpp and drive_virtual.cpp now check for the DOS executable name "SCANDISK", in addition to the check on the stack. The stack check is still useful even if the executable name has been renamed to some other names so it is kept as is.

Tested to ensure the code works.