### PR TITLE
RPM: Add support for desktop file, icon and metainfo

### DIFF
--- a/dosbox-x.appdata.xml
+++ b/dosbox-x.appdata.xml
@@ -1,0 +1,30 @@
+?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>dosbox-x.desktop</id>
+  <project_license>GPL-2.0</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>DOSBox-X</name>
+  <summary>x86/DOS emulator with sound and graphics</summary>
+  <description>
+    <p>
+    DOSBox-X is an enhanced DOSBox fork with more accurate emulation, including the ability
+    to run Windows 95 and 98. It also adds support for the NEC PC-98.
+    </p>
+    <p>
+    DOSBox-X emulates a legacy IBM PC and DOS environment, and has many emulation options and features such as:
+    <ul>
+    <li>8086, 286, 386, 486, Pentium, Pentium MMX and Pentium Pro CPU options</li>
+    <li>Mounting host directory, Harddisk Images, Diskette Images and CD-ROM images</li>
+    <li>ISO9660, FAT12, FAT16 and FAT32 filesystem support including long filenames</li>
+    <li>MDA, CGA, Hercules, EGA, MCGA, VGA and S3/ET3000/ET4000 SVGA video adapter emulation</li>
+    <li>Various SoundBlaster models, Gravis Ultrasound, Disney Sound source and more audio options</li>
+    <li>MT-32 and MIDI support and emulation options</li>
+    <li>Printer support and emulation options</li>
+    <li>Network emulation (NE2000)</li>
+    <li>Support for running Windows 3.1, Windows 95 and Windows 98</li>
+    </ul>
+    With the help of DOSBox-X, it can run plenty of the old classics that don't run on your new computer!
+    </p>
+  /description>
+  <url type="homepage">https://www.dosbox-x.com</url>
+</component>

--- a/dosbox-x.desktop
+++ b/dosbox-x.desktop
@@ -1,0 +1,8 @@
+Desktop Entry]
+Name=DOSBox-X
+Comment=An enhanced x86/DOS emulator with sound/graphics
+Exec=dosbox-x
+Icon=dosbox-x.png
+Terminal=false
+Type=Application
+Categories=System;Emulator;

--- a/dosbox-x.spec.in
+++ b/dosbox-x.spec.in
@@ -10,6 +10,17 @@ Group: Applications/Emulators
 Source0: @PACKAGE_NAME@-@PACKAGE_VERSION@.tar.xz
 
 %description
+DOSBox-X is a cross-platform DOS emulator based on DOSBox.
+Like DOSBox, it emulates a PC necessary for running many MS-DOS
+games and applications that simply cannot be run on modern PCs
+and operating systems. However, while the main focus of DOSBox
+is for running DOS games, DOSBox-X goes much further than this.
+Started as a fork of the DOSBox project, it retains compatibility
+with the wide base of DOS games and DOS gaming DOSBox was
+designed for. But it is also a platform for emulating DOS
+applications, including emulating the environments to run
+Windows 3.x, 9x and ME and software written for those versions
+of Windows.
 
 %prep
 %autosetup -n dosbox-x
@@ -20,9 +31,25 @@ Source0: @PACKAGE_NAME@-@PACKAGE_VERSION@.tar.xz
 %check
 
 %install
-%make_install
+%make_install DESTDIR=%{buildroot}
+
+desktop-file-install \
+%if 0%{?fedora} && 0%{?fedora} < 19
+  --vendor fedora            \
+%endif
+  --dir=%{buildroot}%{_datadir}/applications \
+  %{SOURCE1}
+
+mkdir -p %{buildroot}%{_datadir}/icons/hicolor/48x48/apps
+install -p -m 0644 %SOURCE2 %{buildroot}%{_datadir}/icons/hicolor/48x48/apps
+mkdir -p %{buildroot}%{_datadir}/metainfo
+install -p -m 0644 %SOURCE3 %{buildroot}%{_datadir}/metainfo
 
 %files
 %{_bindir}/*
-%{_datadir}/dosbox-x/*
+%{_datadir}/applications/*
+%{_datadir}/icons/hicolor/*/apps/dosbox-x.png
+%{_datadir}/metainfo/*
+%{_datadir}/dosbox-x
+
 

--- a/make-rpm.sh.in
+++ b/make-rpm.sh.in
@@ -25,6 +25,9 @@ tar="../@PACKAGE_NAME@-@PACKAGE_VERSION@.tar.xz"
 
 tar -cvJf "$tar" --exclude=\*.git --exclude=\*.tar.xz --exclude=\*.a --exclude=\*.la --exclude=\*.Po --exclude=\*.o -C .. dosbox-x || exit 1
 cp -vf "$tar" ~/rpmbuild/SOURCES/ || exit 1
+cp -vf dosbox-x.desktop ~/rpmbuild/SOURCES/ || exit 1
+cp -vf dosbox-x.appdata.xml ~/rpmbuild/SOURCES/ || exit 1
+cp -vf src/dosbox.png ~/rpmbuild/SOURCES/dosbox-x.png || exit 1
 rpmbuild -bb dosbox-x.spec || exit 1
 rm -v "$tar" || exit 1
 mv -v ~/rpmbuild/RPMS/$arch/@PACKAGE_NAME@-*@PACKAGE_VERSION@*.rpm "$dir/" || exit 1


### PR DESCRIPTION
# Description
When building an RPM, it now adds the .desktop file and icon which where missing. I also added a metainfo which these days is required by distributions (if it ever got to that).

The only issue is that the icon file is rather low-res. Just 48x48. These days a higher resolution icon is normally required by distributions, such as 256x256.

**Does this PR address some issue(s) ?**
https://github.com/joncampbell123/dosbox-x/issues/1426
https://github.com/joncampbell123/dosbox-x/issues/649

