### PR TITLE
Auto-redirect PC-98 related settings to [pc98] section and improve handling of [config] section

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,15 +1,19 @@
 0.83.2
   - Added [config] section in dosbox-x.conf to resemble DOS's
-    CONFIG.SYS file, although it currently only supports BREAK,
-    LASTDRIVE and REM commands (Wengier)
+    CONFIG.SYS file. It currently only supports REM, BREAK, 
+    SET, DEVICE/DEVICEHIGH, INSTALL/INSTALLHIGH and LASTDRIVE
+    commands. The file CONFIG.SYS will appear on the Z: drive.
+    It is possible to bypass the [config] section with the
+    -noconfig command-line option (Wengier)
   - Moved PC-98 related config options (starting with "pc-98 ")
     from [dosbox] and [dos] sections to its own [pc98] section.
-    Existing dosbox-x.conf/dosbox.conf files will need to move
-    those settings ("pc-98 ...") to the new [pc98] section in
-    order to keep these setting continue to work (Wengier)
+    These options in existing dosbox-x.conf/dosbox.conf files
+    will be automatically redirected to the [pc98] section from
+    the other sections when DOSBox-X starts (Wengier)
   - Config option "dpi aware" now supports the "auto" setting
     to auto-decide on the best setting for the platform. This
-    fixes very small window issue on e.g. Surface tablets.
+    fixes very small window issue on high DPI devices such as
+    Surface tablets. (Wengier)
   - Implemented LFN support for FAT driver, so that it is now
     possible to view directory list, create or open files and
     directories etc with long filenames on FAT12/16/32 drives
@@ -88,6 +92,7 @@
     unless the PC speaker output is not emitting anything
     audible anyway (Fix for Sopwith 1 and 2).
   - Added ALIAS command to define or display aliases.
+  - Improved handling of quotes in some commands. (Wengier)
   - Added -set command-line option to change config options.
     It can be specified multiple times for multiple options,
     overriding any options in the config file. For example,

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,7 +11,8 @@
     will be automatically redirected to the [pc98] section from
     the other sections when DOSBox-X starts (Wengier)
   - The user directory DOSBox-X uses has been changed from e.g.
-    ~/.dosbox to ~/.config/dosbox-x (Wengier)
+    ~/.dosbox to ~/.config/dosbox-x. It will be read *after*
+    the dosbox-x.conf file in the current directory (Wengier)
   - Config option "dpi aware" now supports the "auto" setting
     to auto-decide on the best setting for the platform. This
     fixes very small window issue on high DPI devices such as

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,11 @@
 0.83.2
   - Added [config] section in dosbox-x.conf to resemble DOS's
-    CONFIG.SYS file. It currently  supports REM, BREAK, FILES,
+    CONFIG.SYS file. It currently supports REM, BREAK, FILES,
     SET, DEVICE/DEVICEHIGH, INSTALL/INSTALLHIGH and LASTDRIVE
-    commands. The file CONFIG.SYS will appear on the Z: drive.
-    It is possible to bypass the [config] section with the
-    -noconfig command-line option (Wengier)
+    commands. The file CONFIG.SYS will appear on the Z: drive,
+    similar to the AUTOEXEC.BAT file. It is possible to bypass
+    the [config] section with the -noconfig command-line option
+    or with the secure mode enabled (Wengier)
   - Moved PC-98 related config options (starting with "pc-98 ")
     from [dosbox] and [dos] sections to its own [pc98] section.
     These options in existing dosbox-x.conf/dosbox.conf files

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 0.83.2
   - Added [config] section in dosbox-x.conf to resemble DOS's
-    CONFIG.SYS file. It currently only supports REM, BREAK, 
+    CONFIG.SYS file. It currently  supports REM, BREAK, FILES,
     SET, DEVICE/DEVICEHIGH, INSTALL/INSTALLHIGH and LASTDRIVE
     commands. The file CONFIG.SYS will appear on the Z: drive.
     It is possible to bypass the [config] section with the

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,8 @@
     These options in existing dosbox-x.conf/dosbox.conf files
     will be automatically redirected to the [pc98] section from
     the other sections when DOSBox-X starts (Wengier)
+  - The user directory DOSBox-X uses has been changed from e.g.
+    ~/.dosbox to ~/.config/dosbox-x (Wengier)
   - Config option "dpi aware" now supports the "auto" setting
     to auto-decide on the best setting for the platform. This
     fixes very small window issue on high DPI devices such as

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1883,10 +1883,10 @@ cd-rom insertion delay  = 0
 [config]
 #     break: Sets or clears extended CTRL+C checking.
 #              Possible values: on, off.
-#   numlock: Initial state of the NumLock key.
+#   numlock: Sets the initial state of the NumLock key.
 #              Possible values: on, off, .
 #     files: Number of file handles available to DOS programs.
-# lastdrive: Maximum number of drives that can be accessed.
+# lastdrive: The maximum drive letter that can be accessed.
 #              Possible values: a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z.
 rem       = This section is designed to resemble the DOS CONFIG.SYS file, although not all CONFIG.SYS options are currently supported.
 break     = off

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1584,7 +1584,6 @@ dongle    = false
 #                                                     
 #                                     filenamechar: Enable filename char table
 #                          collating and uppercase: Enable collating and uppercase table
-#                                            files: Number of file handles available to DOS programs. (equivalent to "files=" in config.sys)
 #  con device use int 16h to detect keyboard input: If set, use INT 16h to detect keyboard input (MS-DOS 6.22 behavior). If clear, detect keyboard input by
 #                                                     peeking into the BIOS keyboard buffer (Mainline DOSBox behavior). You will need to set this
 #                                                     option for programs that hook INT 16h to handle keyboard input ahead of the DOS console.
@@ -1657,7 +1656,6 @@ keyboardlayout                                   = auto
 dbcs                                             = true
 filenamechar                                     = true
 collating and uppercase                          = true
-files                                            = 127
 con device use int 16h to detect keyboard input  = true
 zero memory on int 21h memory allocation         = false
 dos clipboard device enable                      = false
@@ -1892,6 +1890,7 @@ cd-rom insertion delay  = 0
 rem       = This section is designed to resemble the DOS CONFIG.SYS file, although not all CONFIG.SYS options are currently supported.
 break     = off
 numlock   = 
+files     = 127
 lastdrive = a
 
 [autoexec]

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1881,11 +1881,12 @@ cd-rom spindown timeout = 0
 cd-rom insertion delay  = 0
 
 [config]
-#     break: 
+#     break: Sets or clears extended CTRL+C checking.
 #              Possible values: on, off.
-#   numlock: 
+#   numlock: Initial state of the NumLock key.
 #              Possible values: on, off, .
-# lastdrive: 
+#     files: Number of file handles available to DOS programs.
+# lastdrive: Maximum number of drives that can be accessed.
 #              Possible values: a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z.
 rem       = This section is designed to resemble the DOS CONFIG.SYS file, although not all CONFIG.SYS options are currently supported.
 break     = off

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1889,7 +1889,7 @@ cd-rom insertion delay  = 0
 #              Possible values: on, off, .
 # lastdrive: 
 #              Possible values: a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z.
-rem       = This section is designed to resemble the DOS CONFIG.SYS file, although it currently only supports a limited number of CONFIG.SYS options.
+rem       = This section is designed to resemble the DOS CONFIG.SYS file, although not all CONFIG.SYS options are currently supported.
 break     = off
 numlock   = 
 lastdrive = a

--- a/include/control.h
+++ b/include/control.h
@@ -79,6 +79,7 @@ public:
         opt_console = false;
         opt_logint21 = false;
         opt_userconf = false;
+        opt_noconfig = false;
         opt_noconsole = false;
         opt_logfileio = false;
         opt_eraseconf = false;
@@ -144,6 +145,7 @@ public:
     bool opt_printconf;
     bool opt_logint21;
     bool opt_userconf;
+    bool opt_noconfig;
     bool opt_console;
     bool opt_startui;
     bool opt_showrt;

--- a/include/setup.h
+++ b/include/setup.h
@@ -381,6 +381,7 @@ public:
 	virtual void PrintData(FILE* outfile,bool everything=false);
 	virtual std::string GetPropValue(std::string const& _property) const;
 	virtual ~Section_prop();
+	std::string data;
 };
 
 class Prop_multival:public Property{

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -2792,7 +2792,6 @@ public:
             }
         }
 
-		DOS_FILES = (unsigned int)section->Get_int("files");
 		DOS_SetupFiles();								/* Setup system File tables */
 		DOS_SetupDevices();							/* Setup dos devices */
 		DOS_SetupTables();

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -78,7 +78,7 @@ void DOS_InfoBlock::SetLocation(Bit16u segment) {
 	
 	Bit8u drives=1;
 	Section_prop *section = static_cast<Section_prop *>(control->GetSection("config"));
-	if (section !=NULL) {
+	if (section != NULL && !control->opt_noconfig && !control->opt_securemode && !control->SecureMode()) {
 		char *lastdrive = (char *)section->Get_string("lastdrive");
 		if (strlen(lastdrive)==1&&lastdrive[0]>='a'&&lastdrive[0]<='z')
 			drives=lastdrive[0]-'a'+1;

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -77,12 +77,14 @@ void DOS_InfoBlock::SetLocation(Bit16u segment) {
 	for(Bit8u i=0;i<14;i++) mem_writeb(pt+i,0);
 	
 	Bit8u drives=1;
+	DOS_FILES=127;
 	Section_prop *section = static_cast<Section_prop *>(control->GetSection("config"));
 	if (section != NULL && !control->opt_noconfig && !control->opt_securemode && !control->SecureMode()) {
 		char *lastdrive = (char *)section->Get_string("lastdrive");
 		if (strlen(lastdrive)==1&&lastdrive[0]>='a'&&lastdrive[0]<='z')
 			drives=lastdrive[0]-'a'+1;
 		char *dosbreak = (char *)section->Get_string("break");
+		DOS_FILES = (unsigned int)section->Get_int("files");
 		if (!strcasecmp(dosbreak, "on"))
 			dos.breakcheck=true;
 #ifdef WIN32

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3365,7 +3365,7 @@ void DOSBOX_SetupConfigSections(void) {
     /* CONFIG.SYS options (stub) */
     secprop=control->AddSection_prop("config",&Null_Init,false);
 
-    Pstring = secprop->Add_string("rem",Property::Changeable::OnlyAtStart,"This section is designed to resemble the DOS CONFIG.SYS file, although it currently only supports a limited number of CONFIG.SYS options.");
+    Pstring = secprop->Add_string("rem",Property::Changeable::OnlyAtStart,"This section is designed to resemble the DOS CONFIG.SYS file, although not all CONFIG.SYS options are currently supported.");
     Pstring = secprop->Add_string("break",Property::Changeable::OnlyAtStart,"off");
     Pstring->Set_values(ps1opt);
     Pstring = secprop->Add_string("numlock",Property::Changeable::OnlyAtStart,"");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3368,6 +3368,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring = secprop->Add_string("numlock",Property::Changeable::OnlyAtStart,"");
     Pstring->Set_values(numopt);
     Pint = secprop->Add_int("files",Property::Changeable::OnlyAtStart,127);
+    Pint->Set_help("Number of file handles available to DOS programs.");
     Pstring = secprop->Add_string("lastdrive",Property::Changeable::OnlyAtStart,"a");
     Pstring->Set_values(driveletters);
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3365,11 +3365,14 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring = secprop->Add_string("rem",Property::Changeable::OnlyAtStart,"This section is designed to resemble the DOS CONFIG.SYS file, although not all CONFIG.SYS options are currently supported.");
     Pstring = secprop->Add_string("break",Property::Changeable::OnlyAtStart,"off");
     Pstring->Set_values(ps1opt);
+	Pstring->Set_help("Sets or clears extended CTRL+C checking.");
     Pstring = secprop->Add_string("numlock",Property::Changeable::OnlyAtStart,"");
+	Pstring->Set_help("Initial state of NUMLOCK.");
     Pstring->Set_values(numopt);
     Pint = secprop->Add_int("files",Property::Changeable::OnlyAtStart,127);
     Pint->Set_help("Number of file handles available to DOS programs.");
     Pstring = secprop->Add_string("lastdrive",Property::Changeable::OnlyAtStart,"a");
+	Pstring->Set_help("Maximum number of drives that can be accessed.");
     Pstring->Set_values(driveletters);
 
     //TODO ?

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3364,10 +3364,10 @@ void DOSBOX_SetupConfigSections(void) {
 
     Pstring = secprop->Add_string("rem",Property::Changeable::OnlyAtStart,"This section is designed to resemble the DOS CONFIG.SYS file, although not all CONFIG.SYS options are currently supported.");
     Pstring = secprop->Add_string("break",Property::Changeable::OnlyAtStart,"off");
-    Pstring->Set_values(ps1opt);
 	Pstring->Set_help("Sets or clears extended CTRL+C checking.");
+    Pstring->Set_values(ps1opt);
     Pstring = secprop->Add_string("numlock",Property::Changeable::OnlyAtStart,"");
-	Pstring->Set_help("Initial state of NUMLOCK.");
+	Pstring->Set_help("Initial state of the NumLock key.");
     Pstring->Set_values(numopt);
     Pint = secprop->Add_int("files",Property::Changeable::OnlyAtStart,127);
     Pint->Set_help("Number of file handles available to DOS programs.");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3137,9 +3137,6 @@ void DOSBOX_SetupConfigSections(void) {
     Pbool = secprop->Add_bool("collating and uppercase",Property::Changeable::OnlyAtStart,true);
     Pbool->Set_help("Enable collating and uppercase table");
 
-    Pint = secprop->Add_int("files",Property::Changeable::OnlyAtStart,127);
-    Pint->Set_help("Number of file handles available to DOS programs. (equivalent to \"files=\" in config.sys)");
-
     // DEPRECATED, REMOVE
     Pbool = secprop->Add_bool("con device use int 16h to detect keyboard input",Property::Changeable::OnlyAtStart,true);
     Pbool->Set_help("If set, use INT 16h to detect keyboard input (MS-DOS 6.22 behavior). If clear, detect keyboard input by\n"
@@ -3370,6 +3367,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring->Set_values(ps1opt);
     Pstring = secprop->Add_string("numlock",Property::Changeable::OnlyAtStart,"");
     Pstring->Set_values(numopt);
+    Pint = secprop->Add_int("files",Property::Changeable::OnlyAtStart,127);
     Pstring = secprop->Add_string("lastdrive",Property::Changeable::OnlyAtStart,"a");
     Pstring->Set_values(driveletters);
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3367,12 +3367,12 @@ void DOSBOX_SetupConfigSections(void) {
 	Pstring->Set_help("Sets or clears extended CTRL+C checking.");
     Pstring->Set_values(ps1opt);
     Pstring = secprop->Add_string("numlock",Property::Changeable::OnlyAtStart,"");
-	Pstring->Set_help("Initial state of the NumLock key.");
+	Pstring->Set_help("Sets the initial state of the NumLock key.");
     Pstring->Set_values(numopt);
     Pint = secprop->Add_int("files",Property::Changeable::OnlyAtStart,127);
     Pint->Set_help("Number of file handles available to DOS programs.");
     Pstring = secprop->Add_string("lastdrive",Property::Changeable::OnlyAtStart,"a");
-	Pstring->Set_help("Maximum number of drives that can be accessed.");
+	Pstring->Set_help("The maximum drive letter that can be accessed.");
     Pstring->Set_values(driveletters);
 
     //TODO ?

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -89,7 +89,7 @@ void Cross::GetPlatformConfigDir(std::string& in) {
 #elif defined(RISCOS)
 	in = "/<Choices$Write>/DosBox-X";
 #elif !defined(HX_DOS)
-	in = "~/.dosbox-x";
+	in = "~/.config/dosbox-x";
 	ResolveHomedir(in);
 #endif
 	in += CROSS_FILESPLIT;
@@ -123,7 +123,7 @@ void Cross::CreatePlatformConfigDir(std::string& in) {
 	in = "/<Choices$Write>/DosBox-X";
 	mkdir(in.c_str(),0700);
 #elif !defined(HX_DOS)
-	in = "~/.dosbox-x";
+	in = "~/.config/dosbox-x";
 	ResolveHomedir(in);
 	mkdir(in.c_str(),0700);
 #endif

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -700,7 +700,12 @@ Hex Section_prop::Get_hex(string const& _propname) const {
     return 0;
 }
 
+static bool configfile=false;
 bool Section_prop::HandleInputline(string const& gegevens) {
+	if (configfile) {
+		if (!data.empty()) data += "\n"; //Add return to previous line in buffer
+		data += gegevens;
+	}
     string str1 = gegevens;
     string::size_type loc = str1.find('=');
     if (loc == string::npos) return false;
@@ -1000,6 +1005,7 @@ bool Config::ParseConfigFile(char const * const configfilename) {
     string gegevens;
     Section* currentsection = NULL;
     Section* testsec = NULL;
+	configfile=true;
     while (getline(in,gegevens)) {
 
         /* strip leading/trailing whitespace */
@@ -1034,6 +1040,7 @@ bool Config::ParseConfigFile(char const * const configfilename) {
             break;
         }
     }
+	configfile=false;
     current_config_dir.clear();//So internal changes don't use the path information
     return true;
 }

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -30,8 +30,11 @@
 #include "support.h"
 #include "builtin.h"
 #include "mapper.h"
+#include "../dos/drives.h"
 #include <unistd.h>
 #include <time.h>
+#include <string>
+#include <sstream>
 #include "build_timestamp.h"
 
 extern bool enable_config_as_shell_commands;
@@ -64,7 +67,9 @@ static void SHELL_ProgramStart_First_shell(DOS_Shell * * make) {
 	*make = new DOS_Shell;
 }
 
+#define CONFIG_SIZE 4096
 #define AUTOEXEC_SIZE 4096
+static char config_data[CONFIG_SIZE] = { 0 };
 static char autoexec_data[AUTOEXEC_SIZE] = { 0 };
 static std::list<std::string> autoexec_strings;
 typedef std::list<std::string>::iterator auto_it;
@@ -469,6 +474,56 @@ void DOS_Shell::Run(void) {
 #if defined(WIN32)
 		if (!control->opt_securemode&&!control->SecureMode())
 		{
+			if (!control->opt_noconfig) {
+				Section_prop *section = static_cast<Section_prop *>(control->GetSection("config"));
+				const char * extra = const_cast<char*>(section->data.c_str());
+				strcpy(config_data, "");
+				if (extra) {
+					std::istringstream in(extra);
+					char linestr[CROSS_LEN+1], cmdstr[CROSS_LEN], valstr[CROSS_LEN], tmpstr[CROSS_LEN];
+					char *cmd=cmdstr, *val=valstr, *tmp=tmpstr, *p;
+					if (in)	for (std::string line; std::getline(in, line); ) {
+						if (line.length()>CROSS_LEN) {
+							strncpy(linestr, line.c_str(), CROSS_LEN);
+							linestr[CROSS_LEN]=0;
+						} else
+							strcpy(linestr, line.c_str());
+						p=strchr(linestr, '=');
+						if (p!=NULL) {
+							*p=0;
+							strcpy(cmd, linestr);
+							strcpy(val, p+1);
+							trim(cmd);
+							trim(val);
+							if (strlen(config_data)+strlen(cmd)+strlen(val)+3<CONFIG_SIZE) {
+								strcat(config_data, cmd);
+								strcat(config_data, "=");
+								strcat(config_data, val);
+								strcat(config_data, "\r\n");
+							}
+							if (!strncasecmp(cmd, "set ", 4))
+								DoCommand((char *)(std::string(cmd)+"="+std::string(val)).c_str());
+							else if (!strcasecmp(cmd, "install")||!strcasecmp(cmd, "installhigh")||!strcasecmp(cmd, "device")||!strcasecmp(cmd, "devicehigh")) {
+								strcpy(tmp, val);
+								char *name=StripArg(tmp);
+								if (!*name||!DOS_FileExists(name)) {
+									WriteOut("The following file is missing or corrupted: %s\n", name);
+									continue;
+								}
+								if (!strcasecmp(cmd, "install")) {
+									DoCommand(val);
+								} else if (!strcasecmp(cmd, "installhigh"))
+									DoCommand((char *)("lh "+std::string(val)).c_str());
+								else if (!strcasecmp(cmd, "device")) {
+									DoCommand((char *)("device "+std::string(val)).c_str());
+								} else if (!strcasecmp(cmd, "devicehigh"))
+									DoCommand((char *)("lh device "+std::string(val)).c_str());
+							}
+						}
+					}
+				}
+				VFILE_Register("CONFIG.SYS",(Bit8u *)config_data,(Bit32u)strlen(config_data));
+			}
 			const Section_prop* sec = 0; sec = static_cast<Section_prop*>(control->GetSection("dos"));
 			if(sec->Get_bool("automountall")) {
 				Bit32u drives = GetLogicalDrives();

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -481,7 +481,29 @@ continue_1:
 	if (!DOS_Canonicalize(args,full)) { WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));dos.dta(save_dta);return; }
 	int fbak=lfn_filefind_handle;
 	lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
-    bool res=DOS_FindFirst(args,0xffff & ~DOS_ATTR_VOLUME);
+	char path[DOS_PATHLENGTH], spath[DOS_PATHLENGTH], pattern[DOS_PATHLENGTH], *r=strrchr(args, '\\');
+	if (r!=NULL) {
+		*r=0;
+		strcpy(path, args);
+		strcat(path, "\\");
+		strcpy(pattern, r+1);
+		*r='\\';
+	} else {
+		strcpy(path, "");
+		strcpy(pattern, args);
+	}
+	int k=0;
+	for (int i=0;i<(int)strlen(pattern);i++)
+		if (pattern[i]!='\"')
+			pattern[k++]=pattern[i];
+	pattern[k]=0;
+	strcpy(spath, path);
+	if (strchr(path,'\"')) {
+		DOS_GetSFNPath(path, spath, false);
+		if (!strlen(spath)||spath[strlen(spath)-1]!='\\') strcat(spath, "\\");
+	}
+	std::string pfull=std::string(spath)+std::string(pattern);
+    bool res=DOS_FindFirst((char *)((uselfn&&pfull.length()&&pfull[0]!='"'?"\"":"")+pfull+(uselfn&&pfull.length()&&pfull[pfull.length()-1]!='"'?"\"":"")).c_str(),0xffff & ~DOS_ATTR_VOLUME);
 	if (!res) {
 		lfn_filefind_handle=fbak;
 		WriteOut(MSG_Get("SHELL_CMD_DEL_ERROR"),args);

--- a/windows-installer/setup_preamble.txt
+++ b/windows-installer/setup_preamble.txt
@@ -1,4 +1,4 @@
-Welcome to DOSBox-X, a fork of the DOSBox project !
+Welcome to DOSBox-X, a cross-platform DOS emulater based on the DOSBox project.
 
 Note:
 


### PR DESCRIPTION
The [pc98] section was recently added to the config file, and PC-98 related settings were moved to this section from other sections. But this could break existing config files for PC-98 related options. So I fixed this issue in this pull request by automatically redirecting existing PC-98 related options to the new [pc98] section from the other sections if the config file's [pc98] section is empty when DOSBox-X starts. Thus existing config files will continue to work for these settings.

I also improved the new [config] section to support SET, DEVICE/DEVICEHIGH, INSTALL/INSTALLHIGH commands. For DEVICE/DEVICEHIGH commands, currently it will simply use
the built-in DEVICE.COM program to load the specified device driver(s). The built-in LH command will be used for HIGH options. A example of these commands:

```
INSTALL=MOUNT.COM C: C:\WINDOWS
DEVICE=C:\IFSHLP.SYS
SET TEMP=C:\TEMP
```

A new file named CONFIG.SYS will now appear in the Z: drive for the contents of the [config] section (similar to the AUTOEXEC.BAT file in the Z: drive). A new command-line option -noconfig is added to skip the [config] section. This section will also be skipped if the secure mode is enabled.

I also moved the user directory from ~/.dosbox-x to ~/.config/dosbox-x in order to be XDG complicant, as stated by @rderooy in Issue #1588. But DOSBox-X will always load the dosbox-x.conf file from the current directory first.

Last, I improved the handling of quotes for some commands.