### PR TITLE
Update dosbox-x.desktop

### DIFF
--- a/dosbox-x.desktop
+++ b/dosbox-x.desktop
@@ -1,4 +1,4 @@
-Desktop Entry]
+[Desktop Entry]
 Name=DOSBox-X
 Comment=An enhanced x86/DOS emulator with sound/graphics
 Exec=dosbox-x


### PR DESCRIPTION
# Description

copy 'n paste error, missing first character. With this the RPM generation works properly, and it installs and works on Fedora, including showing the icon.

I should use the git command line tools instead of the github web interface, to prevent such errors...
