### PR TITLE
Allow only case-changing for LFN rename and support for "DOS=HIGH, UMB" in [config] section

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 0.83.2
   - Added [config] section in dosbox-x.conf to resemble DOS's
-    CONFIG.SYS file. It currently supports REM, BREAK, FILES,
-    SET, DEVICE/DEVICEHIGH, INSTALL/INSTALLHIGH and LASTDRIVE
+    CONFIG.SYS file. It currently supports REM, BREAK, SET, DOS,
+    FILES, DEVICE/DEVICEHIGH, INSTALL/INSTALLHIGH and LASTDRIVE
     commands. The file CONFIG.SYS will appear on the Z: drive,
     similar to the AUTOEXEC.BAT file. It is possible to bypass
     the [config] section with the -noconfig command-line option

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,11 @@
 0.83.2
   - Added [config] section in dosbox-x.conf to resemble DOS's
-    CONFIG.SYS file. It currently supports REM, BREAK, SET, DOS,
-    FILES, DEVICE/DEVICEHIGH, INSTALL/INSTALLHIGH and LASTDRIVE
-    commands. The file CONFIG.SYS will appear on the Z: drive,
-    similar to the AUTOEXEC.BAT file. It is possible to bypass
-    the [config] section with the -noconfig command-line option
-    or with the secure mode enabled (Wengier)
+    CONFIG.SYS file. It currently supports REM, BREAK, FILES,
+    FCBS, SET, DOS, DEVICE/DEVICEHIGH, INSTALL/INSTALLHIGH and
+    LASTDRIVE commands. The file CONFIG.SYS will appear on the
+    Z: drive, similar to the AUTOEXEC.BAT file. It is possible
+    to bypass the [config] section with the -noconfig command-
+    line option or with the secure mode enabled (Wengier)
   - Moved PC-98 related config options (starting with "pc-98 ")
     from [dosbox] and [dos] sections to its own [pc98] section.
     These options in existing dosbox-x.conf/dosbox.conf files
@@ -17,7 +17,7 @@
   - Config option "dpi aware" now supports the "auto" setting
     to auto-decide on the best setting for the platform. This
     fixes very small window issue on high DPI devices such as
-    Surface tablets. (Wengier)
+    Microsoft Surface tablets. (Wengier)
   - Implemented LFN support for FAT driver, so that it is now
     possible to view directory list, create or open files and
     directories etc with long filenames on FAT12/16/32 drives

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1883,14 +1883,16 @@ cd-rom insertion delay  = 0
 #              Possible values: on, off.
 #   numlock: Sets the initial state of the NumLock key.
 #              Possible values: on, off, .
-#      dos:  Reports whether DOS occupies HMA and allocates UMB memory (if available).
-#     files: Number of file handles available to DOS programs.
+#       dos: Reports whether DOS occupies HMA and allocates UMB memory (if available).
+#      fcbs: Number of FCB handles available to DOS programs (1-255).
+#     files: Number of file handles available to DOS programs (8-255).
 # lastdrive: The maximum drive letter that can be accessed.
 #              Possible values: a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z.
 rem       = This section is designed to resemble the DOS CONFIG.SYS file, although it does not support all CONFIG.SYS options.
 break     = off
 numlock   = 
 dos       = high, umb
+fcbs      = 100
 files     = 127
 lastdrive = a
 

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1457,7 +1457,6 @@ dongle    = false
 #                                         ansi.sys: If set (by default), ANSI.SYS emulation is on. If clear, ANSI.SYS is not emulated and will not appear to be installed.
 #                                                     NOTE: This option has no effect in PC-98 mode where MS-DOS systems integrate ANSI.SYS into the DOS kernel.
 #                                      log console: If set, log DOS CON output to the log file.
-#                                       dos in hma: Report that DOS occupies HMA (equiv. DOS=HIGH)
 #                                     dos sda size: SDA (swappable data area) size, in bytes. Set to 0 to use a reasonable default.
 #                                   hma free space: Controls the amount of free space available in HMA. This setting is not meaningful unless the
 #                                                     DOS kernel occupies HMA and the emulated DOS version is at least 5.0.
@@ -1610,7 +1609,6 @@ drive z is remote                                = auto
 hma minimum allocation                           = 0
 ansi.sys                                         = true
 log console                                      = false
-dos in hma                                       = true
 dos sda size                                     = 0
 hma free space                                   = 34816
 cpm compatibility mode                           = auto
@@ -1885,12 +1883,14 @@ cd-rom insertion delay  = 0
 #              Possible values: on, off.
 #   numlock: Sets the initial state of the NumLock key.
 #              Possible values: on, off, .
+#      dos:  Reports whether DOS occupies HMA and allocates UMB memory (if available).
 #     files: Number of file handles available to DOS programs.
 # lastdrive: The maximum drive letter that can be accessed.
 #              Possible values: a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z.
 rem       = This section is designed to resemble the DOS CONFIG.SYS file, although not all CONFIG.SYS options are currently supported.
 break     = off
 numlock   = 
+dos       = high, umb
 files     = 127
 lastdrive = a
 

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1887,7 +1887,7 @@ cd-rom insertion delay  = 0
 #     files: Number of file handles available to DOS programs.
 # lastdrive: The maximum drive letter that can be accessed.
 #              Possible values: a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z.
-rem       = This section is designed to resemble the DOS CONFIG.SYS file, although not all CONFIG.SYS options are currently supported.
+rem       = This section is designed to resemble the DOS CONFIG.SYS file, although it does not support all CONFIG.SYS options.
 break     = off
 numlock   = 
 dos       = high, umb

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1888,7 +1888,7 @@ cd-rom insertion delay  = 0
 #     files: Number of file handles available to DOS programs (8-255).
 # lastdrive: The maximum drive letter that can be accessed.
 #              Possible values: a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z.
-rem       = This section is designed to resemble the DOS CONFIG.SYS file, although it does not support all CONFIG.SYS options.
+rem       = This section is the DOS CONFIG.SYS file, although not all CONFIG.SYS options are supported.
 break     = off
 numlock   = 
 dos       = high, umb

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -92,6 +92,7 @@ int dos_clipboard_device_access;
 char *dos_clipboard_device_name;
 const char dos_clipboard_device_default[]="CLIP$";
 
+int maxfcb=100;
 int maxdrive=1;
 int enablelfn=-1;
 bool uselfn;
@@ -2540,11 +2541,13 @@ public:
             else
                 ::disk_data_rate = 3500000; /* Probably an average IDE data rate for early 1990s ISA IDE controllers in PIO mode */
         }
-		Bit8u drives=1;
+		maxfcb=100;
 		DOS_FILES=127;
 		Section_prop *config_section = static_cast<Section_prop *>(control->GetSection("config"));
 		if (config_section != NULL && !control->opt_noconfig && !control->opt_securemode && !control->SecureMode()) {
 			DOS_FILES = (unsigned int)config_section->Get_int("files");
+			if (DOS_FILES<8) DOS_FILES=8;
+			else if (DOS_FILES>255) DOS_FILES=255;
 			char *dosopt = (char *)config_section->Get_string("dos"), *r=strchr(dosopt, ',');
 			if (r==NULL) {
 				if (!strcasecmp(trim(dosopt), "high")) dos_in_hma=true;
@@ -2559,6 +2562,9 @@ public:
 				if (!strcasecmp(trim(r+1), "umb")) dos_umb=true;
 				else if (!strcasecmp(trim(r+1), "noumb")) dos_umb=false;
 			}
+			maxfcb = (int)config_section->Get_int("fcbs");
+			if (maxfcb<1) maxfcb=1;
+			else if (maxfcb>255) maxfcb=255;
 			char *lastdrive = (char *)config_section->Get_string("lastdrive");
 			if (strlen(lastdrive)==1&&lastdrive[0]>='a'&&lastdrive[0]<='z')
 				maxdrive=lastdrive[0]-'a'+1;

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -24,7 +24,6 @@
 #include "dos_inc.h"
 #include "support.h"
 #include "drives.h"
-#include "control.h"
 
 Bit8u sattr[260], fattr;
 char sname[260][LFN_NAMELENGTH+1],storect[CTBUF];
@@ -67,8 +66,7 @@ void DOS_ParamBlock::SaveData(void) {
 	sSave(sExec,initcsip,exec.initcsip);
 }
 
-extern bool startup_state_numlock;
-extern void SetNumLock(void);
+extern int maxdrive;
 void DOS_InfoBlock::SetLocation(Bit16u segment) {
 	seg = segment;
 	pt=PhysMake(seg,0);
@@ -76,24 +74,6 @@ void DOS_InfoBlock::SetLocation(Bit16u segment) {
 	for(Bit8u i=0;i<sizeof(sDIB);i++) mem_writeb(pt+i,0xff);
 	for(Bit8u i=0;i<14;i++) mem_writeb(pt+i,0);
 	
-	Bit8u drives=1;
-	DOS_FILES=127;
-	Section_prop *section = static_cast<Section_prop *>(control->GetSection("config"));
-	if (section != NULL && !control->opt_noconfig && !control->opt_securemode && !control->SecureMode()) {
-		char *lastdrive = (char *)section->Get_string("lastdrive");
-		if (strlen(lastdrive)==1&&lastdrive[0]>='a'&&lastdrive[0]<='z')
-			drives=lastdrive[0]-'a'+1;
-		char *dosbreak = (char *)section->Get_string("break");
-		DOS_FILES = (unsigned int)section->Get_int("files");
-		if (!strcasecmp(dosbreak, "on"))
-			dos.breakcheck=true;
-#ifdef WIN32
-		char *numlock = (char *)section->Get_string("numlock");
-		if (!strcasecmp(numlock, "off")&&startup_state_numlock || !strcasecmp(numlock, "on")&&!startup_state_numlock)
-			SetNumLock();
-#endif
-	}
-
 	sSave(sDIB,regCXfrom5e,(Bit16u)0);
 	sSave(sDIB,countLRUcache,(Bit16u)0);
 	sSave(sDIB,countLRUopens,(Bit16u)0);
@@ -101,7 +81,7 @@ void DOS_InfoBlock::SetLocation(Bit16u segment) {
 	sSave(sDIB,protFCBs,(Bit16u)0);
 	sSave(sDIB,specialCodeSeg,(Bit16u)0);
 	sSave(sDIB,joindedDrives,(Bit8u)0);
-	sSave(sDIB,lastdrive,(Bit8u)drives);//increase this if you add drives to cds-chain
+	sSave(sDIB,lastdrive,(Bit8u)maxdrive);//increase this if you add drives to cds-chain
 
 	sSave(sDIB,diskInfoBuffer,RealMake(segment,offsetof(sDIB,diskBufferHeadPt)));
 	sSave(sDIB,setverPtr,(Bit32u)0);

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -421,15 +421,15 @@ bool DOS_Rename(char const * const oldname,char const * const newname) {
 		DOS_SetError(DOSERR_NOT_SAME_DEVICE);
 		return false;
 	}
-	/*Test if target exists => no access */
 	Bit16u attr;
-	if(Drives[drivenew]->GetFileAttr(fullnew,&attr)) {
-		DOS_SetError(DOSERR_ACCESS_DENIED);
-		return false;
-	}
 	/* Source must exist, check for path ? */
 	if (!Drives[driveold]->GetFileAttr( fullold, &attr ) ) {
 		DOS_SetError(DOSERR_FILE_NOT_FOUND);
+		return false;
+	}
+	/*Test if target exists => no access */
+	if(Drives[drivenew]->GetFileAttr(fullnew,&attr)&&!(uselfn&&!force_sfn&&strcmp(fullold, fullnew)&&!strcasecmp(fullold, fullnew))) {
+		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return false;
 	}
 

--- a/src/dos/dos_tables.cpp
+++ b/src/dos/dos_tables.cpp
@@ -24,6 +24,7 @@
 #include "control.h"
 #include <assert.h>
 
+extern int maxfcb;
 extern Bitu DOS_PRIVATE_SEGMENT_Size;
 
 void CALLBACK_DeAllocate(Bitu in);
@@ -306,7 +307,7 @@ void DOS_SetupTables(void) {
 	/* Create a fake FCB SFT */
 	seg=DOS_GetMemory(4,"Fake FCB SFT");
 	real_writed(seg,0,0xffffffff);		//Last File Table
-	real_writew(seg,4,100);				//File Table supports 100 files
+	real_writew(seg,4,maxfcb);			//File Table supports 100 files
 	dos_infoblock.SetFCBTable(RealMake(seg,0));
 
 	/* Create a fake DPB */

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -2844,7 +2844,7 @@ bool fatDrive::Rename(const char * oldname, const char * newname) {
 	dir_lfn_range = lfnRange;
 
 	/* Check if new name (file or directory) already exists, fail if so */
-	if(getFileDirEntry(newname, &fileEntry2, &dirClust2, &subEntry2, /*dirOk*/true)) return false;
+	if(getFileDirEntry(newname, &fileEntry2, &dirClust2, &subEntry2, /*dirOk*/true)&&!(uselfn&&!force_sfn&&strcmp(oldname, newname)&&!strcasecmp(oldname, newname))) return false;
 
 	/* Can we even get the name of the file itself? */
 	if(!getEntryName(newname, &dirName2[0])||!strlen(trim(dirName2))) return false;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3367,7 +3367,7 @@ void DOSBOX_SetupConfigSections(void) {
 	Pstring->Set_help("Sets the initial state of the NumLock key.");
     Pstring->Set_values(numopt);
     Pstring = secprop->Add_string("dos",Property::Changeable::OnlyAtStart,"high, umb");
-	Pstring->Set_help("Specifies where to load DOS.");
+	Pstring->Set_help("Reports whether DOS occupies HMA and allocates UMB memory (if available).");
     Pint = secprop->Add_int("files",Property::Changeable::OnlyAtStart,127);
     Pint->Set_help("Number of file handles available to DOS programs.");
     Pstring = secprop->Add_string("lastdrive",Property::Changeable::OnlyAtStart,"a");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2911,9 +2911,6 @@ void DOSBOX_SetupConfigSections(void) {
     Pbool = secprop->Add_bool("log console",Property::Changeable::WhenIdle,false);
     Pbool->Set_help("If set, log DOS CON output to the log file.");
 
-    Pbool = secprop->Add_bool("dos in hma",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("Report that DOS occupies HMA (equiv. DOS=HIGH)");
-
     Pint = secprop->Add_int("dos sda size",Property::Changeable::WhenIdle,0);
     Pint->Set_help("SDA (swappable data area) size, in bytes. Set to 0 to use a reasonable default.");
 
@@ -3362,13 +3359,15 @@ void DOSBOX_SetupConfigSections(void) {
     /* CONFIG.SYS options (stub) */
     secprop=control->AddSection_prop("config",&Null_Init,false);
 
-    Pstring = secprop->Add_string("rem",Property::Changeable::OnlyAtStart,"This section is designed to resemble the DOS CONFIG.SYS file, although not all CONFIG.SYS options are currently supported.");
+    Pstring = secprop->Add_string("rem",Property::Changeable::OnlyAtStart,"This section is designed to resemble the DOS CONFIG.SYS file, although it does not support all CONFIG.SYS options.");
     Pstring = secprop->Add_string("break",Property::Changeable::OnlyAtStart,"off");
 	Pstring->Set_help("Sets or clears extended CTRL+C checking.");
     Pstring->Set_values(ps1opt);
     Pstring = secprop->Add_string("numlock",Property::Changeable::OnlyAtStart,"");
 	Pstring->Set_help("Sets the initial state of the NumLock key.");
     Pstring->Set_values(numopt);
+    Pstring = secprop->Add_string("dos",Property::Changeable::OnlyAtStart,"high, umb");
+	Pstring->Set_help("Specifies where to load DOS.");
     Pint = secprop->Add_int("files",Property::Changeable::OnlyAtStart,127);
     Pint->Set_help("Number of file handles available to DOS programs.");
     Pstring = secprop->Add_string("lastdrive",Property::Changeable::OnlyAtStart,"a");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3368,6 +3368,8 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring->Set_values(numopt);
     Pstring = secprop->Add_string("dos",Property::Changeable::OnlyAtStart,"high, umb");
 	Pstring->Set_help("Reports whether DOS occupies HMA and allocates UMB memory (if available).");
+    Pint = secprop->Add_int("fcbs",Property::Changeable::OnlyAtStart,100);
+    Pint->Set_help("Number of FCB handles available to DOS programs.");
     Pint = secprop->Add_int("files",Property::Changeable::OnlyAtStart,127);
     Pint->Set_help("Number of file handles available to DOS programs.");
     Pstring = secprop->Add_string("lastdrive",Property::Changeable::OnlyAtStart,"a");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3359,7 +3359,7 @@ void DOSBOX_SetupConfigSections(void) {
     /* CONFIG.SYS options (stub) */
     secprop=control->AddSection_prop("config",&Null_Init,false);
 
-    Pstring = secprop->Add_string("rem",Property::Changeable::OnlyAtStart,"This section is designed to resemble the DOS CONFIG.SYS file, although it does not support all CONFIG.SYS options.");
+    Pstring = secprop->Add_string("rem",Property::Changeable::OnlyAtStart,"This section is the DOS CONFIG.SYS file, although not all CONFIG.SYS options are supported.");
     Pstring = secprop->Add_string("break",Property::Changeable::OnlyAtStart,"off");
 	Pstring->Set_help("Sets or clears extended CTRL+C checking.");
     Pstring->Set_values(ps1opt);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3369,9 +3369,9 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring = secprop->Add_string("dos",Property::Changeable::OnlyAtStart,"high, umb");
 	Pstring->Set_help("Reports whether DOS occupies HMA and allocates UMB memory (if available).");
     Pint = secprop->Add_int("fcbs",Property::Changeable::OnlyAtStart,100);
-    Pint->Set_help("Number of FCB handles available to DOS programs.");
+    Pint->Set_help("Number of FCB handles available to DOS programs (1-255).");
     Pint = secprop->Add_int("files",Property::Changeable::OnlyAtStart,127);
-    Pint->Set_help("Number of file handles available to DOS programs.");
+    Pint->Set_help("Number of file handles available to DOS programs (8-255).");
     Pstring = secprop->Add_string("lastdrive",Property::Changeable::OnlyAtStart,"a");
 	Pstring->Set_help("The maximum drive letter that can be accessed.");
     Pstring->Set_values(driveletters);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8068,7 +8068,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 			char linestr[CROSS_LEN+1], *p;
 			Section_prop * section = static_cast<Section_prop *>(control->GetSection("dosbox"));
 			extra = const_cast<char*>(section->data.c_str());
-			if (extra) {
+			if (extra&&strlen(extra)) {
 				std::istringstream in(extra);
 				if (in)	for (std::string line; std::getline(in, line); ) {
 					if (strncasecmp(line.c_str(), "pc-98 ", 6)) continue;
@@ -8086,7 +8086,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 			}
 			section = static_cast<Section_prop *>(control->GetSection("dos"));
 			extra = const_cast<char*>(section->data.c_str());
-			if (extra) {
+			if (extra&&strlen(extra)) {
 				std::istringstream in(extra);
 				if (in)	for (std::string line; std::getline(in, line); ) {
 					if (strncasecmp(line.c_str(), "pc-98 ", 6)) continue;
@@ -8112,19 +8112,25 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 			char linestr[CROSS_LEN+1], *p;
 			Section_prop * section = static_cast<Section_prop *>(control->GetSection("dos"));
 			extra = const_cast<char*>(section->data.c_str());
-			if (extra) {
+			if (extra&&strlen(extra)) {
 				std::istringstream in(extra);
 				if (in)	for (std::string line; std::getline(in, line); ) {
-					if (strncasecmp(line.c_str(), "files", 5)) continue;
+					if (strncasecmp(line.c_str(), "files", 5)&&strncasecmp(line.c_str(), "dos in hma", 10)) continue;
 					if (line.length()>CROSS_LEN) {
 						strncpy(linestr, line.c_str(), CROSS_LEN);
 						linestr[CROSS_LEN]=0;
 					} else
 						strcpy(linestr, line.c_str());
 					p=strchr(linestr, '=');
-					if (p!=NULL&&config_section->HandleInputline(line)) {
-						*p=0;
-						LOG_MSG("Redirected \"%s\" from [dos] to [config] section\n", trim(linestr));
+					if (p!=NULL) {
+						if (!strncasecmp(line.c_str(), "dos in hma", 10)) {
+							if (!strcasecmp(trim(p+1), "true")) line="dos=high";
+							else if (!strcasecmp(trim(p+1), "false")) line="dos=low";
+						}
+						if (config_section->HandleInputline(line)) {
+							*p=0;
+							LOG_MSG("Redirected \"%s\" from [dos] to [config] section\n", trim(linestr));
+						}
 					}
 				}
 			}

--- a/src/ints/xms.cpp
+++ b/src/ints/xms.cpp
@@ -87,6 +87,7 @@ unsigned int XMS_HANDLES =                  XMS_HANDLES_DEFAULT;
 bool DOS_IS_IN_HMA();
 
 extern Bitu rombios_minimum_location;
+extern bool dos_umb;
 
 Bitu xms_hma_minimum_alloc = 0;
 bool xms_hma_exists = true;
@@ -818,7 +819,7 @@ public:
 			}
 		}
 
-		DOS_BuildUMBChain(umb_available,ems_available);
+		DOS_BuildUMBChain(umb_available&&dos_umb,ems_available);
 		umb_init = true;
 
         /* CP/M compat will break unless a copy of the JMP instruction is mirrored in HMA */
@@ -829,7 +830,7 @@ public:
 		/* Remove upper memory information */
 		dos_infoblock.SetStartOfUMBChain(0xffff);
 		if (umb_available) {
-			dos_infoblock.SetUMBChainState(0);
+			if (dos_umb) dos_infoblock.SetUMBChainState(0);
 			umb_available=false;
 		}
 

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -700,12 +700,7 @@ Hex Section_prop::Get_hex(string const& _propname) const {
     return 0;
 }
 
-static bool configfile=false;
 bool Section_prop::HandleInputline(string const& gegevens) {
-	if (configfile) {
-		if (!data.empty()) data += "\n"; //Add return to previous line in buffer
-		data += gegevens;
-	}
     string str1 = gegevens;
     string::size_type loc = str1.find('=');
     if (loc == string::npos) return false;
@@ -1005,7 +1000,6 @@ bool Config::ParseConfigFile(char const * const configfilename) {
     string gegevens;
     Section* currentsection = NULL;
     Section* testsec = NULL;
-	configfile=true;
     while (getline(in,gegevens)) {
 
         /* strip leading/trailing whitespace */
@@ -1032,7 +1026,17 @@ bool Config::ParseConfigFile(char const * const configfilename) {
             break;
         default:
             try {
-                if (currentsection) currentsection->HandleInputline(gegevens);
+                if (currentsection) {
+					bool savedata=!strcasecmp(currentsection->GetName(), "pc98")||!strcasecmp(currentsection->GetName(), "config");
+					if (!currentsection->HandleInputline(gegevens)&&strcasecmp(currentsection->GetName(), "autoexec")) savedata=true;
+					if (savedata) {
+						Section_prop *section = static_cast<Section_prop *>(currentsection);
+						if (section!=NULL) {
+							if (!section->data.empty()) section->data += "\n";
+							section->data += gegevens;
+						}
+					}
+				}
             } catch(const char* message) {
                 message=0;
                 //EXIT with message
@@ -1040,7 +1044,6 @@ bool Config::ParseConfigFile(char const * const configfilename) {
             break;
         }
     }
-	configfile=false;
     current_config_dir.clear();//So internal changes don't use the path information
     return true;
 }

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -471,62 +471,66 @@ void DOS_Shell::Run(void) {
         if (machine == MCH_PC98) WriteOut(MSG_Get("SHELL_STARTUP_PC98"));
         if (machine == MCH_HERC || machine == MCH_MDA) WriteOut(MSG_Get("SHELL_STARTUP_HERC"));
         WriteOut(MSG_Get("SHELL_STARTUP_END"));
+		strcpy(config_data, "");
+		Section_prop *section = static_cast<Section_prop *>(control->GetSection("config"));
+		if (!control->opt_securemode&&!control->SecureMode()&&!control->opt_noconfig) {
+			const char * extra = const_cast<char*>(section->data.c_str());
+			if (extra) {
+				std::istringstream in(extra);
+				char linestr[CROSS_LEN+1], cmdstr[CROSS_LEN], valstr[CROSS_LEN], tmpstr[CROSS_LEN];
+				char *cmd=cmdstr, *val=valstr, *tmp=tmpstr, *p;
+				if (in)	for (std::string line; std::getline(in, line); ) {
+					if (line.length()>CROSS_LEN) {
+						strncpy(linestr, line.c_str(), CROSS_LEN);
+						linestr[CROSS_LEN]=0;
+					} else
+						strcpy(linestr, line.c_str());
+					p=strchr(linestr, '=');
+					if (p!=NULL) {
+						*p=0;
+						strcpy(cmd, linestr);
+						strcpy(val, p+1);
+						trim(cmd);
+						trim(val);
+						if (strlen(config_data)+strlen(cmd)+strlen(val)+3<CONFIG_SIZE) {
+							strcat(config_data, cmd);
+							strcat(config_data, "=");
+							strcat(config_data, val);
+							strcat(config_data, "\r\n");
+						}
+						if (!strncasecmp(cmd, "set ", 4))
+							DoCommand((char *)(std::string(cmd)+"="+std::string(val)).c_str());
+						else if (!strcasecmp(cmd, "install")||!strcasecmp(cmd, "installhigh")||!strcasecmp(cmd, "device")||!strcasecmp(cmd, "devicehigh")) {
+							strcpy(tmp, val);
+							char *name=StripArg(tmp);
+							if (!*name||!DOS_FileExists(name)) {
+								WriteOut("The following file is missing or corrupted: %s\n", name);
+								continue;
+							}
+							if (!strcasecmp(cmd, "install")) {
+								DoCommand(val);
+							} else if (!strcasecmp(cmd, "installhigh"))
+								DoCommand((char *)("lh "+std::string(val)).c_str());
+							else if (!strcasecmp(cmd, "device")) {
+								DoCommand((char *)("device "+std::string(val)).c_str());
+							} else if (!strcasecmp(cmd, "devicehigh"))
+								DoCommand((char *)("lh device "+std::string(val)).c_str());
+						}
+					} else if (!strncasecmp(line.c_str(), "rem ", 4)) {
+						strcat(config_data, line.c_str());
+						strcat(config_data, "\r\n");
+					}
+				}
+			}
+		} else {
+			strcat(config_data, "rem=");
+			strcat(config_data, (char *)section->Get_string("rem"));
+			strcat(config_data, "\r\n");
+		}
+		VFILE_Register("CONFIG.SYS",(Bit8u *)config_data,(Bit32u)strlen(config_data));
 #if defined(WIN32)
 		if (!control->opt_securemode&&!control->SecureMode())
 		{
-			if (!control->opt_noconfig) {
-				Section_prop *section = static_cast<Section_prop *>(control->GetSection("config"));
-				const char * extra = const_cast<char*>(section->data.c_str());
-				strcpy(config_data, "");
-				if (extra) {
-					std::istringstream in(extra);
-					char linestr[CROSS_LEN+1], cmdstr[CROSS_LEN], valstr[CROSS_LEN], tmpstr[CROSS_LEN];
-					char *cmd=cmdstr, *val=valstr, *tmp=tmpstr, *p;
-					if (in)	for (std::string line; std::getline(in, line); ) {
-						if (line.length()>CROSS_LEN) {
-							strncpy(linestr, line.c_str(), CROSS_LEN);
-							linestr[CROSS_LEN]=0;
-						} else
-							strcpy(linestr, line.c_str());
-						p=strchr(linestr, '=');
-						if (p!=NULL) {
-							*p=0;
-							strcpy(cmd, linestr);
-							strcpy(val, p+1);
-							trim(cmd);
-							trim(val);
-							if (strlen(config_data)+strlen(cmd)+strlen(val)+3<CONFIG_SIZE) {
-								strcat(config_data, cmd);
-								strcat(config_data, "=");
-								strcat(config_data, val);
-								strcat(config_data, "\r\n");
-							}
-							if (!strncasecmp(cmd, "set ", 4))
-								DoCommand((char *)(std::string(cmd)+"="+std::string(val)).c_str());
-							else if (!strcasecmp(cmd, "install")||!strcasecmp(cmd, "installhigh")||!strcasecmp(cmd, "device")||!strcasecmp(cmd, "devicehigh")) {
-								strcpy(tmp, val);
-								char *name=StripArg(tmp);
-								if (!*name||!DOS_FileExists(name)) {
-									WriteOut("The following file is missing or corrupted: %s\n", name);
-									continue;
-								}
-								if (!strcasecmp(cmd, "install")) {
-									DoCommand(val);
-								} else if (!strcasecmp(cmd, "installhigh"))
-									DoCommand((char *)("lh "+std::string(val)).c_str());
-								else if (!strcasecmp(cmd, "device")) {
-									DoCommand((char *)("device "+std::string(val)).c_str());
-								} else if (!strcasecmp(cmd, "devicehigh"))
-									DoCommand((char *)("lh device "+std::string(val)).c_str());
-							}
-						} else if (!strncasecmp(line.c_str(), "rem ", 4)) {
-							strcat(config_data, line.c_str());
-							strcat(config_data, "\r\n");
-						}
-					}
-				}
-				VFILE_Register("CONFIG.SYS",(Bit8u *)config_data,(Bit32u)strlen(config_data));
-			}
 			const Section_prop* sec = 0; sec = static_cast<Section_prop*>(control->GetSection("dos"));
 			if(sec->Get_bool("automountall")) {
 				Bit32u drives = GetLogicalDrives();

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -473,7 +473,7 @@ void DOS_Shell::Run(void) {
         WriteOut(MSG_Get("SHELL_STARTUP_END"));
 		strcpy(config_data, "");
 		Section_prop *section = static_cast<Section_prop *>(control->GetSection("config"));
-		if (!control->opt_securemode&&!control->SecureMode()&&!control->opt_noconfig) {
+		if (section!=NULL&&!control->opt_noconfig&&!control->opt_securemode&&!control->SecureMode()) {
 			const char * extra = const_cast<char*>(section->data.c_str());
 			if (extra) {
 				std::istringstream in(extra);
@@ -522,7 +522,8 @@ void DOS_Shell::Run(void) {
 					}
 				}
 			}
-		} else {
+		}
+		if (!strlen(config_data)) {
 			strcat(config_data, "rem=");
 			strcat(config_data, (char *)section->Get_string("rem"));
 			strcat(config_data, "\r\n");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -519,6 +519,9 @@ void DOS_Shell::Run(void) {
 								} else if (!strcasecmp(cmd, "devicehigh"))
 									DoCommand((char *)("lh device "+std::string(val)).c_str());
 							}
+						} else if (!strncasecmp(line.c_str(), "rem ", 4)) {
+							strcat(config_data, line.c_str());
+							strcat(config_data, "\r\n");
 						}
 					}
 				}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -682,6 +682,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 				removeChar(dir_target, '\"');
 				arg2=dir_target;
 				strcpy(sargs, dir_source);
+				if (uselfn) removeChar(sargs, '\"');
 				strcat(sargs, uselfn?lname:name);
 				if (uselfn&&strchr(arg2,'*')&&!strchr(arg2,'.')) strcat(arg2, ".*");
 				char *dot1=strrchr(uselfn?lname:name,'.'), *dot2=strrchr(arg2,'.'), *star;
@@ -758,6 +759,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 					arg2=tfull;
 				}
 				strcpy(targs, dir_source);
+				if (uselfn) removeChar(targs, '\"');
 				strcat(targs, arg2);
 				sources.push_back(uselfn?((sargs[0]!='"'?"\"":"")+std::string(sargs)+(sargs[strlen(sargs)-1]!='"'?"\"":"")).c_str():sargs);
 				sources.push_back(uselfn?((targs[0]!='"'?"\"":"")+std::string(targs)+(targs[strlen(targs)-1]!='"'?"\"":"")).c_str():targs);


### PR DESCRIPTION
The REN command could rename files when the old name and new name are different, but it did not work if the old name and new name are different only by case, e.g. "REN NAME name". So I updated the code to allow this in LFN mode.

Also, the [config] section now supports the "DOS" option, so "DOS=HIGH/LOW, UMB/NOUMB" as in DOS's config.sys is now supported. The previous "dos in hma=true/false" option in [dos] section will be automatically converted to "DOS=HIGH/LOW" if the [config] section does not exist in the config file.