### PR TITLE
Fixed "config -wcd -all" (Issue #1596) etc

### DIFF
--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1888,7 +1888,7 @@ cd-rom insertion delay  = 0
 #     files: Number of file handles available to DOS programs (8-255).
 # lastdrive: The maximum drive letter that can be accessed.
 #              Possible values: a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z.
-rem       = This section is the DOS CONFIG.SYS file, although not all CONFIG.SYS options are supported.
+rem       = This section is DOS's CONFIG.SYS file, not all CONFIG.SYS options supported
 break     = off
 numlock   = 
 dos       = high, umb

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2447,6 +2447,7 @@ restart_int:
             printHelp();
             return;
         }
+		std::transform(disktype.begin(), disktype.end(), disktype.begin(), ::tolower);
 
         Bit8u mediadesc = 0xF8; // media descriptor byte; also used to differ fd and hd
         Bit16u root_ent = 512; // FAT root directory entries: 512 is for harddisks
@@ -3346,9 +3347,9 @@ public:
             if (!PrepElTorito(type, el_torito_cd_drive, el_torito_floppy_base, el_torito_floppy_type)) return;
         }
 
-		if (temp_line.size() == 1 && isdigit(temp_line[0]) && temp_line[0]>='0' && temp_line[0]<MAX_DISK_IMAGES+'0' && cmd->FindExist("-u",false)) {
+		if (temp_line.size() == 1 && isdigit(temp_line[0]) && temp_line[0]>='0' && temp_line[0]<MAX_DISK_IMAGES+'0' && cmd->FindExist("-u",true)) {
 			Unmount(temp_line[0]);
-			return;
+			if (!cmd->FindCommand(2,temp_line)||!temp_line.size()) return;
 		}
 
         //default fstype is fat

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3359,7 +3359,7 @@ void DOSBOX_SetupConfigSections(void) {
     /* CONFIG.SYS options (stub) */
     secprop=control->AddSection_prop("config",&Null_Init,false);
 
-    Pstring = secprop->Add_string("rem",Property::Changeable::OnlyAtStart,"This section is the DOS CONFIG.SYS file, although not all CONFIG.SYS options are supported.");
+    Pstring = secprop->Add_string("rem",Property::Changeable::OnlyAtStart,"This section is DOS's CONFIG.SYS file, not all CONFIG.SYS options supported");
     Pstring = secprop->Add_string("break",Property::Changeable::OnlyAtStart,"off");
 	Pstring->Set_help("Sets or clears extended CTRL+C checking.");
     Pstring->Set_values(ps1opt);

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -518,15 +518,13 @@ private:
 	void restart(const char* useconfig);
 	
 	void writeconf(std::string name, bool configdir,bool everything) {
-        (void)configdir;//UNUSED
-#if 0 /* I'd rather have an option stating the user wants to write to user homedir */
+		// "config -wcd" should write to the config directory
 		if (configdir) {
 			// write file to the default config directory
 			std::string config_path;
 			Cross::GetPlatformConfigDir(config_path);
 			name = config_path + name;
 		}
-#endif
 		WriteOut(MSG_Get("PROGRAM_CONFIG_FILE_WHICH"),name.c_str());
 		if (!control->PrintConfig(name.c_str(),everything)) {
 			WriteOut(MSG_Get("PROGRAM_CONFIG_FILE_ERROR"),name.c_str());
@@ -563,6 +561,7 @@ void CONFIG::Run(void) {
 	bool all = false;
 	bool first = true;
 	std::vector<std::string> pvars;
+	if (cmd->FindExist("-all", true)) all = true;
 	// Loop through the passed parameters
 	while(presult != P_NOPARAMS) {
 		presult = (enum prs)cmd->GetParameterFromList(params, pvars);

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -490,8 +490,8 @@ void DOS_Shell::Run(void) {
 						*p=0;
 						strcpy(cmd, linestr);
 						strcpy(val, p+1);
-						trim(cmd);
-						trim(val);
+						cmd=trim(cmd);
+						val=trim(val);
 						if (strlen(config_data)+strlen(cmd)+strlen(val)+3<CONFIG_SIZE) {
 							strcat(config_data, cmd);
 							strcat(config_data, "=");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1192,10 +1192,11 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_VERIFY_HELP_LONG","VERIFY [ON | OFF]\n\nType VERIFY without a parameter to display the current VERIFY setting.\n");
 	MSG_Add("SHELL_CMD_VER_HELP","Displays or sets DOSBox-X's reported DOS version.\n");
 	MSG_Add("SHELL_CMD_VER_HELP_LONG","VER\n" 
-		   "VER SET [major minor] or VER SET [major.minor]\n\n" 
-		   "  [major minor] or [major.minor]  Set the reported DOS version.\n"
-		   "  e.g. \"VER SET 5 0\" or \"VER SET 7.1\" for DOS 5.0 or 7.1 resp.\n\n" 
-		   "Type VER without parameters to display the current DOS version.\n");
+		   "VER SET [major.minor] or VER SET [major minor]\n\n" 
+		   "  [major.minor] or [major minor]  Set the reported DOS version.\n\n"
+		   "  Example: \"VER SET 6.0\" or \"VER SET 7.1\" for DOS 6.0 or 7.1 respectively.\n"
+		   "  The command \"VER SET 7 1\" however sets the reported DOS version as 7.01.\n\n" 
+		   "Type VER without parameters to display DOSBox-X and the reported DOS version.\n");
 	MSG_Add("SHELL_CMD_VER_VER","DOSBox-X version %s (%s). Reported DOS version %d.%02d.\n");
 	MSG_Add("SHELL_CMD_ADDKEY_HELP","Generates artificial keypresses.\n");
 	MSG_Add("SHELL_CMD_ADDKEY_HELP_LONG","ADDKEY [key]\n");


### PR DESCRIPTION
As mentioned in Issue #1596, there are two problems with the "config -wcd -all" command, one is that it no longer writes to the config directory (in contrary to what is sstated by "config /?"), and the other is that "config -wcd -all" does not work the same way as "config -all -wcd". So I fixed both issues in this pull request.

It also fixed that "IMGMAKE FDD.IMG -T HD_2GIG" not working. The command required the lowercase string of "hd_2gig", which is not always expected. Also, the command "IMGMOUNT 2 HDD.IMG -FS NONE -U" should work too.