### PR TITLE
Fixed "config -wc(d)" not writing certain [config] options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 0.83.2
+  - Fixed issues with the "config -wcd -all" command (Wengier)
   - Added DTASEG, DTAOFF, and PSPSEG as hex value constants to
     the debugger interface to aid in debugging DOS programs.
   - Added [config] section in dosbox-x.conf to resemble DOS's

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -1075,14 +1075,14 @@ void PROGRAMS_Init() {
 	
 	// writeconf
 	MSG_Add("PROGRAM_CONFIG_FILE_ERROR","\nCan't open file %s\n");
-	MSG_Add("PROGRAM_CONFIG_FILE_WHICH","Writing config file %s");
+	MSG_Add("PROGRAM_CONFIG_FILE_WHICH","Writing config file %s\n");
 	
 	// help
 	MSG_Add("PROGRAM_CONFIG_USAGE","Config tool:\n"\
 		"-writeconf or -wc without parameter: write to primary loaded config file.\n"\
 		"-writeconf or -wc with filename: write file to config directory.\n"\
 		"Use -writelang or -wl filename to write the current language strings.\n"\
-		"-all  Use -all with -wc and -writeconf to write ALL options to the file.\n"\
+		"-all Use this option with -wc and -writeconf to write ALL options to the file.\n"\
 		"-wcp [filename]\n Write config file to the program directory, dosbox-x.conf or the specified \n filename.\n"\
 		"-wcd\n Write to the default config file in the config directory.\n"\
 		"-l lists configuration parameters.\n"\

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -858,6 +858,32 @@ bool Config::PrintConfig(char const * const configfilename,bool everything) cons
         }
 
         (*tel)->PrintData(outfile,everything);
+		if (!strcmp(temp, "config")) {
+			const char * extra = const_cast<char*>(sec->data.c_str());
+			if (extra&&strlen(extra)) {
+				std::istringstream in(extra);
+				char linestr[CROSS_LEN+1], cmdstr[CROSS_LEN], valstr[CROSS_LEN];
+				char *cmd=cmdstr, *val=valstr, *p;
+				if (in)	for (std::string line; std::getline(in, line); ) {
+					if (line.length()>CROSS_LEN) {
+						strncpy(linestr, line.c_str(), CROSS_LEN);
+						linestr[CROSS_LEN]=0;
+					} else
+						strcpy(linestr, line.c_str());
+					p=strchr(linestr, '=');
+					if (p!=NULL) {
+						*p=0;
+						strcpy(cmd, linestr);
+						cmd=trim(cmd);
+						strcpy(val, p+1);
+						val=trim(val);
+						lowcase(cmd);
+						if (!strncmp(cmd, "set ", 4)||!strcmp(cmd, "install")||!strcmp(cmd, "installhigh")||!strcmp(cmd, "device")||!strcmp(cmd, "devicehigh"))
+							fprintf(outfile, "%-9s = %s\n", cmd, val);
+					}
+				}
+			}
+		}
         fprintf(outfile,"\n");      /* Always an empty line between sections */
     }
     fclose(outfile);

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -863,7 +863,7 @@ bool Config::PrintConfig(char const * const configfilename,bool everything) cons
 			if (extra&&strlen(extra)) {
 				std::istringstream in(extra);
 				char linestr[CROSS_LEN+1], cmdstr[CROSS_LEN], valstr[CROSS_LEN];
-				char *cmd=cmdstr, *val=valstr, *p;
+				char *cmd=cmdstr, *val=valstr, *lin=linestr, *p;
 				if (in)	for (std::string line; std::getline(in, line); ) {
 					if (line.length()>CROSS_LEN) {
 						strncpy(linestr, line.c_str(), CROSS_LEN);
@@ -881,6 +881,16 @@ bool Config::PrintConfig(char const * const configfilename,bool everything) cons
 						if (!strncmp(cmd, "set ", 4)||!strcmp(cmd, "install")||!strcmp(cmd, "installhigh")||!strcmp(cmd, "device")||!strcmp(cmd, "devicehigh"))
 							fprintf(outfile, "%-9s = %s\n", cmd, val);
 					}
+				}
+				std::istringstream rem(extra);
+				if (everything&&rem) for (std::string line; std::getline(rem, line); ) {
+					if (line.length()>CROSS_LEN) {
+						strncpy(linestr, line.c_str(), CROSS_LEN);
+						linestr[CROSS_LEN]=0;
+					} else
+						strcpy(linestr, line.c_str());
+					if (!strncasecmp(trim(lin), "rem ", 4)&&*trim(trim(lin)+4)!='=')
+						fprintf(outfile, "%s\n", trim(lin));
 				}
 			}
 		}


### PR DESCRIPTION
I noticed an issue with the "config -wc(d)" command when writing the [config] section, i.e. it did not write commands like set/device/devicehigh/install/installhigh (because they are handled slightly differently), so I fixed this issue in this pull request. As a result,  "config -wc(d)" should now write all supported commands to the [config] section.