### PR TITLE
Fixed long directory names in %PATH% not working

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,12 +3,12 @@
   - Added DTASEG, DTAOFF, and PSPSEG as hex value constants to
     the debugger interface to aid in debugging DOS programs.
   - Added [config] section in dosbox-x.conf to resemble DOS's
-    CONFIG.SYS file. It currently supports REM, BREAK, FILES,
-    FCBS, SET, DOS, DEVICE/DEVICEHIGH, INSTALL/INSTALLHIGH and
-    LASTDRIVE commands. The file CONFIG.SYS will appear on the
-    Z: drive, similar to the AUTOEXEC.BAT file. It is possible
-    to bypass the [config] section with the -noconfig command-
-    line option or with the secure mode enabled (Wengier)
+    CONFIG.SYS file. It currently supports REM, BREAK, NUMLOCK,
+    FCBS, FILES, DOS, DEVICE/DEVICEHIGH, INSTALL/INSTALLHIGH,
+    SET and LASTDRIVE commands. The file CONFIG.SYS will appear
+    on the Z: drive, similar to AUTOEXEC.BAT file. The [config]
+    section can be bypassed with the -noconfig command-line
+    option or with the secure mode enabled (Wengier)
   - Moved PC-98 related config options (starting with "pc-98 ")
     from [dosbox] and [dos] sections to its own [pc98] section.
     These options in existing dosbox-x.conf/dosbox.conf files

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -222,17 +222,15 @@ static bool DOS_MultiplexFunctions(void) {
 				/* Hack for Windows 98 SETUP.EXE (Wengier) */
 				return false;
 			}
-			else {
-				strcpy(name,"COMMAND.COM");
-				MEM_BlockWrite(SegPhys(ds)+reg_dx,name,(Bitu)(strlen(name)+1));
-				strcpy(name+1,"/P /D");
-				name[0]=(char)strlen(name);
-				MEM_BlockWrite(SegPhys(ds)+reg_si,name,(Bitu)(strlen(name+1)+2));
-				reg_ax=0;
-				reg_bx=0;
-				return true;
-			}
-		} /* all cases "return", no break needed */
+			strcpy(name,"COMMAND.COM");
+			MEM_BlockWrite(SegPhys(ds)+reg_dx,name,(Bitu)(strlen(name)+1));
+			strcpy(name+1,"/P /D /K AUTOEXEC");
+			name[0]=(char)strlen(name+1);
+			MEM_BlockWrite(SegPhys(ds)+reg_si,name,(Bitu)(strlen(name+1)+2));
+			reg_ax=0;
+			reg_bx=0;
+			return true;
+		}
     case 0x1612:
 		if (dos.version.major < 7) return false;
         reg_ax=0;

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -1082,9 +1082,9 @@ void PROGRAMS_Init() {
 		"-writeconf or -wc without parameter: write to primary loaded config file.\n"\
 		"-writeconf or -wc with filename: write file to config directory.\n"\
 		"Use -writelang or -wl filename to write the current language strings.\n"\
-		"-all Use this option with -wc and -writeconf to write ALL options to the file.\n"\
 		"-wcp [filename]\n Write config file to the program directory, dosbox-x.conf or the specified \n filename.\n"\
 		"-wcd\n Write to the default config file in the config directory.\n"\
+		"-all Use this with -wc, -wcp, or -wcd to write ALL options to the file.\n"\
 		"-l lists configuration parameters.\n"\
 		"-h, -help, -? sections / sectionname / propertyname\n"\
 		" Without parameters, displays this help screen. Add \"sections\" for a list of\n sections."\

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -1148,7 +1148,7 @@ char * DOS_Shell::Which(char * name) {
 
 
 	/* No Path in filename look through path environment string */
-	char path[DOS_PATHLENGTH];std::string temp;
+	char path[DOS_PATHLENGTH],spath[DOS_PATHLENGTH];std::string temp;
 	if (!GetEnvStr("PATH",temp)) return 0;
 	const char * pathenv=temp.c_str();
 	if (!pathenv) return 0;
@@ -1172,10 +1172,22 @@ char * DOS_Shell::Which(char * name) {
 			path[DOS_PATHLENGTH - 1] = 0;
 		} else path[i_path] = 0;
 
+		int k=0;
+		for (int i=0;i<(int)strlen(path);i++)
+			if (path[i]!='\"')
+				path[k++]=path[i];
+		path[k]=0;
 
 		/* check entry */
 		if(size_t len = strlen(path)){
 			if(len >= (DOS_PATHLENGTH - 2)) continue;
+
+			if (uselfn&&len>3) {
+				if (path[len - 1]=='\\') path[len - 1]=0;
+				if (DOS_GetSFNPath(("\""+std::string(path)+"\"").c_str(), spath, false))
+					strcpy(path, spath);
+				len = strlen(path);
+			}
 
 			if(path[len - 1] != '\\') {
 				strcat(path,"\\"); 


### PR DESCRIPTION
The PATH environment variable sets the search paths of executable programs, but I noticed that long directory names in %PATH% did not work properly, so I fixed this issue. I also did minor fixups to the Get Shell Parameter function.

Tested to ensure the code works.