### PR TITLE
CONFIG command fixups

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,8 +36,11 @@
     the MBR lacks executable code, or the first partition
     is Windows 98-style LBA FAT16 or FAT32.
   - IMGMOUNT now assumes ISO type by default if the image file
-    extension is ".iso". No need for "-t iso" in this case, but
-    it can be overridden by e.g. "-t hdd". (Wengier)
+    extension is .iso/.cue/.bin/.mdf. No need for "-t iso" in
+    this case; it can be overridden by e.g. "-t hdd". (Wengier)
+  - IMGMOUNT command (no parameters) now lists mounted FAT/ISO
+    drives and mounted drive numbers, also SUBST command (no
+    parameters) now lists mounted local drives (Wengier)
   - INT AH=36h fixed to convert free space but maintain a
     cluster size (bytes/sector * sectors/cluster) that is less
     than 64KB to avoid divide by 0 crashes with FORMAT.COM /S
@@ -68,9 +71,6 @@
     argument is a directory (Wengier)
   - DIR and VOL commands now display real serial numbers for mounted
     local drives (Windows only) and FAT drives (Wengier)
-  - IMGMOUNT command (without parameters) now lists mounted FAT/ISO
-    drives and mounted drive numbers, also SUBST command (without
-    parameters) now lists mounted local drives (Wengier)
   - Fixed SYS command not working properly (Wengier)
   - DOS kernel INT 21h function Set File Attribute no longer
     allows changing volume label attributes and fixes directory

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,9 @@
     and fake C/H/S geometry if the disk is 4GB or larger,
     the MBR lacks executable code, or the first partition
     is Windows 98-style LBA FAT16 or FAT32.
+  - IMGMOUNT now assumes ISO type by default if the image file
+    extension is ".iso". No need for "-t iso" in this case, but
+    it can be overridden by e.g. "-t hdd". (Wengier)
   - INT AH=36h fixed to convert free space but maintain a
     cluster size (bytes/sector * sectors/cluster) that is less
     than 64KB to avoid divide by 0 crashes with FORMAT.COM /S

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,9 +14,10 @@
     These options in existing dosbox-x.conf/dosbox.conf files
     will be automatically redirected to the [pc98] section from
     the other sections when DOSBox-X starts (Wengier)
-  - The user directory DOSBox-X uses has been changed from e.g.
-    ~/.dosbox to ~/.config/dosbox-x. It will be read *after*
-    the dosbox-x.conf file in the current directory (Wengier)
+  - The user directory DOSBox-X uses has been changed to use the
+    DOSBox-X directory (e.g. from ~/.dosbox to ~/.config/dosbox-x
+    on Linux platform). It will be read *after* the dosbox-x.conf
+    file in the current directory (Wengier)
   - Config option "dpi aware" now supports the "auto" setting
     to auto-decide on the best setting for the platform. This
     fixes very small window issue on high DPI devices such as
@@ -73,11 +74,10 @@
     attributes in order to prevent filesystem corruption.
     This prevents Windows 95 Setup from creating WINBOOT.INI
     and then changing it into a directory with the call.
-  - FAT driver bugs fixed where a newly created zero length
-    file combined with a lseek() can corrupt filesytem
-    structures (root directory and/or the second FAT table).
-    This fixes filesystem corruption when running Windows
-    95 install.
+  - FAT driver bugs fixed where a newly created zero length file
+    combined with a lseek() can corrupt filesytem structures
+    (root directory and/or the second FAT table). This fixes
+    filesystem corruption when running Windows 95 install.
   - Enabled printer emulation for non-Windows OSes (Linux,
     Mac OS X, etc.). FreeType2 is required to enable
     printer emulation at compile time.
@@ -108,7 +108,7 @@
   - Re-added full drive menu items for the Windows platform.
     The "Boot from drive" item (A:, C: and D: drives only)
     should work in other platforms too. The BOOT command is
-    also slightly improved. (Wengier)
+    also improved to allow e.g. "BOOT A:" to work. (Wengier)
   - INT 10h vector now points into VGA BIOS as a workaround
     for DOS programs that use vector location as part of
     their EGA/VGA detection. This fixes blink attribute

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,7 +37,8 @@
     is Windows 98-style LBA FAT16 or FAT32.
   - IMGMOUNT now assumes ISO type by default if the image file
     extension is .iso/.cue/.bin/.mdf. No need for "-t iso" in
-    this case; it can be overridden by e.g. "-t hdd". (Wengier)
+    this case; but (if appliable) it can be overridden by for
+    example "-t hdd". (Wengier)
   - IMGMOUNT command (no parameters) now lists mounted FAT/ISO
     drives and mounted drive numbers, also SUBST command (no
     parameters) now lists mounted local drives (Wengier)
@@ -69,6 +70,7 @@
   - Several improvements to DEL command, such as a new /F option to
     force delete of read-only files, and improved handling when the
     argument is a directory (Wengier)
+  - DIR /O & /OG supported in addition to /ON|/OE|/OS|/OD (Wengier)
   - DIR and VOL commands now display real serial numbers for mounted
     local drives (Windows only) and FAT drives (Wengier)
   - Fixed SYS command not working properly (Wengier)

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1879,6 +1879,7 @@ cd-rom spindown timeout = 0
 cd-rom insertion delay  = 0
 
 [config]
+#       rem: Records comments (remarks).
 #     break: Sets or clears extended CTRL+C checking.
 #              Possible values: on, off.
 #   numlock: Sets the initial state of the NumLock key.
@@ -1886,7 +1887,7 @@ cd-rom insertion delay  = 0
 #       dos: Reports whether DOS occupies HMA and allocates UMB memory (if available).
 #      fcbs: Number of FCB handles available to DOS programs (1-255).
 #     files: Number of file handles available to DOS programs (8-255).
-# lastdrive: The maximum drive letter that can be accessed.
+# lastdrive: The maximum drive letter that can be accessed by programs.
 #              Possible values: a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z.
 rem         = This section is DOS's CONFIG.SYS file, not all CONFIG.SYS options supported
 break       = off

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1888,13 +1888,19 @@ cd-rom insertion delay  = 0
 #     files: Number of file handles available to DOS programs (8-255).
 # lastdrive: The maximum drive letter that can be accessed.
 #              Possible values: a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z.
-rem       = This section is DOS's CONFIG.SYS file, not all CONFIG.SYS options supported
-break     = off
-numlock   = 
-dos       = high, umb
-fcbs      = 100
-files     = 127
-lastdrive = a
+rem         = This section is DOS's CONFIG.SYS file, not all CONFIG.SYS options supported
+break       = off
+numlock     = 
+dos         = high, umb
+fcbs        = 100
+files       = 127
+lastdrive   = a
+set path    = Z:\
+set prompt  = $P$G
+install     = 
+installhigh = 
+device      = 
+devicehigh  = 
 
 [autoexec]
 # Lines in this section will be run at startup.

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -551,7 +551,7 @@ class DOS_DTA:public MemStruct{
 public:
 	DOS_DTA(RealPt addr) { SetPt(addr); }
 
-    int GetFindData(int fmt,char * finddata);
+    int GetFindData(int fmt,char * finddata,int *c);
 	
 	void SetupSearch(Bit8u _sdrive,Bit8u _sattr,char * pattern);
 	void SetResult(const char * _name,const char * _lname,Bit32u _size,Bit16u _date,Bit16u _time,Bit8u _attr);

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -3396,7 +3396,9 @@ void DOS_Int21_714e(char *name1, char *name2) {
 				reg_ax=handle;
 				DOS_DTA dta(dos.dta());
 				char finddata[CROSS_LEN];
-				MEM_BlockWrite(SegPhys(es)+reg_di,finddata,dta.GetFindData((int)reg_si,finddata));
+				int c=0;
+				MEM_BlockWrite(SegPhys(es)+reg_di,finddata,dta.GetFindData((int)reg_si,finddata,&c));
+				reg_cx=c;
 				CALLBACK_SCF(false);
 		} else {
 				dos.errorcode=error;
@@ -3418,7 +3420,9 @@ void DOS_Int21_714f(const char *name1, const char *name2) {
 		if (DOS_FindNext()) {
 				DOS_DTA dta(dos.dta());
 				char finddata[CROSS_LEN];
-				MEM_BlockWrite(SegPhys(es)+reg_di,finddata,dta.GetFindData((int)reg_si,finddata));
+				int c=0;
+				MEM_BlockWrite(SegPhys(es)+reg_di,finddata,dta.GetFindData((int)reg_si,finddata,&c));
+				reg_cx=c;
 				CALLBACK_SCF(false);
 				reg_ax=0x4f00+handle;
 		} else {

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -447,7 +447,7 @@ void DOS_DTA::GetResult(char * _name, char * _lname,Bit32u & _size,Bit16u & _dat
 	_attr=(Bit8u)sGet(sDTA,attr);
 }
 
-int DOS_DTA::GetFindData(int fmt, char * fdstr) {
+int DOS_DTA::GetFindData(int fmt, char * fdstr, int *c) {
 	if (fmt==1)
 		sprintf(fdstr,"%-1s%-19s%-2s%-2s%-4s%-4s%-4s%-8s%-260s%-14s",(char*)&fd.attr,(char*)&fd.fres1,(char*)&fd.mtime,(char*)&fd.mdate,(char*)&fd.mtime,(char*)&fd.hsize,(char*)&fd.size,(char*)&fd.fres2,(char*)&fd.lname,(char*)&fd.sname);
 	else
@@ -459,6 +459,10 @@ int DOS_DTA::GetFindData(int fmt, char * fdstr) {
     fdstr[35]=(char)(fd.size/16777216);
     fdstr[44+strlen(fd.lname)]=0;
     fdstr[304+strlen(fd.sname)]=0;
+	if (!strcmp(fd.sname,"?")&&strlen(fd.lname))
+		*c=2;
+	else
+		*c=!strchr(fd.sname,'?')&&strchr(fd.lname,'?')?1:0;
     return (sizeof(fd));
 }
 

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -3319,8 +3319,9 @@ public:
             Bit8u tdr = toupper(temp_line[0]);
             if(tdr=='A'||tdr=='B'||tdr=='0'||tdr=='1') type="floppy";
         }
+
         //get the type
-        cmd->FindString("-t", type, true);
+        bool rtype=cmd->FindString("-t", type, true);
 		std::transform(type.begin(), type.end(), type.begin(), ::tolower);
 
         if (type == "cdrom") type = "iso"; //Tiny hack for people who like to type -t cdrom
@@ -3354,7 +3355,7 @@ public:
 
         //default fstype is fat
         std::string fstype="fat";
-        cmd->FindString("-fs",fstype,true);
+        bool rfstype=cmd->FindString("-fs",fstype,true);
 		std::transform(fstype.begin(), fstype.end(), fstype.begin(), ::tolower);
         
         Bitu sizes[4] = { 0,0,0,0 };
@@ -3444,7 +3445,7 @@ public:
         }
         else if (type == "ram") {
             if (paths.size() != 0) {
-                WriteOut("Do not specify files when mounting ramdrives\n");
+                WriteOut("Do not specify files when mounting RAM drives\n");
                 return;
             }
         }
@@ -3453,6 +3454,10 @@ public:
                 if (strcasecmp(temp_line.c_str(), "-u")) WriteOut(MSG_Get("PROGRAM_IMGMOUNT_SPECIFY_FILE"));
                 return; 
             }
+			if (!rtype&&!rfstype&&paths[0].length()>4&&!strcasecmp(paths[0].substr(paths[0].length()-4).c_str(), ".iso")) {
+				type="iso";
+				fstype="iso";
+			}
         }
 
         //====== call the proper subroutine ======
@@ -4147,7 +4152,7 @@ private:
         //formatting might fail; just log the failure and continue
         Bit8u ret = dsk->Format();
         if (ret != 0x00) {
-            LOG_MSG("Warning: could not format ramdrive - error code %u\n", (unsigned int)ret);
+            LOG_MSG("Warning: could not format RAM drive - error code %u\n", (unsigned int)ret);
         }
         return dsk;
     }
@@ -5367,7 +5372,7 @@ void DOS_SetupPrograms(void) {
         " -t iso              Image type is optical disc iso or cue / bin image\n"
         " -t floppy           Image type is floppy\n"
         " -t hdd              Image type is hard disk; VHD and HDI files are supported\n"
-        " -t ram              Image type is ramdrive\n"
+        " -t ram              Image type is RAM drive\n"
         " -fs iso             File system is ISO 9660\n"
         " -fs fat             File system is FAT; FAT12 and FAT16 are supported\n"
         " -fs none            Do not detect file system\n"

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -3454,9 +3454,14 @@ public:
                 if (strcasecmp(temp_line.c_str(), "-u")) WriteOut(MSG_Get("PROGRAM_IMGMOUNT_SPECIFY_FILE"));
                 return; 
             }
-			if (!rtype&&!rfstype&&paths[0].length()>4&&!strcasecmp(paths[0].substr(paths[0].length()-4).c_str(), ".iso")) {
-				type="iso";
-				fstype="iso";
+			if (!rtype&&!rfstype&&paths[0].length()>4) {
+				char ext[5];
+				strncpy(ext, paths[0].substr(paths[0].length()-4).c_str(), 4);
+				ext[4]=0;
+				if (!strcasecmp(ext, ".iso")||!strcasecmp(ext, ".cue")||!strcasecmp(ext, ".bin")||!strcasecmp(ext, ".mdf")) {
+					type="iso";
+					fstype="iso";
+				}
 			}
         }
 
@@ -5362,7 +5367,7 @@ void DOS_SetupPrograms(void) {
         "IMGMOUNT drive filename [-t floppy] [-fs fat] [-size ss,s,h,c]\n"
         "IMGMOUNT drive filename [-t hdd] [-fs fat] [-size ss,s,h,c] [-ide 1m|1s|2m|2s]\n"
         "IMGMOUNT driveLoc filename -fs none [-size ss,s,h,c] [-reservecyl #]\n"
-        "IMGMOUNT drive filename -t iso [-fs iso]\n"
+        "IMGMOUNT drive filename [-t iso] [-fs iso]\n"
         "IMGMOUNT drive -t floppy -el-torito cdDrive\n"
         "IMGMOUNT drive -t ram -size driveSize\n"
         "IMGMOUNT -u drive|driveLocation (or drive|driveLocation filename [options] -u)\n"

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -5263,7 +5263,7 @@ void DOS_SetupPrograms(void) {
             );
         MSG_Add("PROGRAM_INTRO_MOUNT_END",
             "When the mount has successfully completed you can type \033[34;1mc:\033[0m to go to your freshly\n"
-            "mounted C-drive. Typing \033[34;1mdir\033[0m there will show its contents."
+            "mounted C: drive. Typing \033[34;1mdir\033[0m there will show its contents."
             " \033[34;1mcd\033[0m will allow you to\n"
             "enter a directory (recognised by the \033[33;1m[]\033[0m in a directory listing).\n"
             "You can run programs/files which end with \033[31m.exe .bat\033[0m and \033[31m.com\033[0m.\n"
@@ -5305,11 +5305,11 @@ void DOS_SetupPrograms(void) {
         "drive (C or D), the image should have already been mounted using the\n"
         "\033[34;1mIMGMOUNT\033[0m command.\n\n"
         "The syntax of this command is:\n\n"
-        "\033[34;1mBOOT [diskimg1.img diskimg2.img] [-l driveletter]\033[0m\n\n"
+        "\033[34;1mBOOT diskimg1.img [diskimg2.img ...] [-L driveletter]\033[0m\n\n"
 		"Or:\n\n"
-        "\033[34;1mBOOT [driveletter:]\033[0m\n\n"
-        "An image file with a leading colon (:) will be booted in write-protected mode\n"
-		"if the \"leading colon write protect image\" option is enabled.\n"
+        "\033[34;1mBOOT driveletter:\033[0m\n\n"
+        "Note: An image file with a leading colon (:) will be booted in write-protected\n"
+		"mode if the \"leading colon write protect image\" option is enabled.\n"
         );
     MSG_Add("PROGRAM_BOOT_UNABLE","Unable to boot off of drive %c.\n");
     MSG_Add("PROGRAM_BOOT_IMAGE_OPEN","Opening image file: %s\n");

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -5296,6 +5296,8 @@ void DOS_SetupPrograms(void) {
         "\033[34;1mIMGMOUNT\033[0m command.\n\n"
         "The syntax of this command is:\n\n"
         "\033[34;1mBOOT [diskimg1.img diskimg2.img] [-l driveletter]\033[0m\n\n"
+		"Or:\n\n"
+        "\033[34;1mBOOT [driveletter:]\033[0m\n\n"
         "An image file with a leading colon (:) will be booted in write-protected mode\n"
 		"if the \"leading colon write protect image\" option is enabled.\n"
         );
@@ -5358,7 +5360,7 @@ void DOS_SetupPrograms(void) {
         "IMGMOUNT drive filename -t iso [-fs iso]\n"
         "IMGMOUNT drive -t floppy -el-torito cdDrive\n"
         "IMGMOUNT drive -t ram -size driveSize\n"
-        "IMGMOUNT -u drive|driveLocation\n"
+        "IMGMOUNT -u drive|driveLocation (or drive|driveLocation filename [options] -u)\n"
         " drive               Drive letter to mount the image at\n"
         " driveLoc            Location to mount drive, where 0-1 are FDDs, 2-5 are HDDs\n"
         " filename            Filename of the image to mount (leading ':' for read-only)\n"

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3360,6 +3360,7 @@ void DOSBOX_SetupConfigSections(void) {
     secprop=control->AddSection_prop("config",&Null_Init,false);
 
     Pstring = secprop->Add_string("rem",Property::Changeable::OnlyAtStart,"This section is DOS's CONFIG.SYS file, not all CONFIG.SYS options supported");
+ 	Pstring->Set_help("Records comments (remarks).");
     Pstring = secprop->Add_string("break",Property::Changeable::OnlyAtStart,"off");
 	Pstring->Set_help("Sets or clears extended CTRL+C checking.");
     Pstring->Set_values(ps1opt);
@@ -3373,7 +3374,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pint = secprop->Add_int("files",Property::Changeable::OnlyAtStart,127);
     Pint->Set_help("Number of file handles available to DOS programs (8-255).");
     Pstring = secprop->Add_string("lastdrive",Property::Changeable::OnlyAtStart,"a");
-	Pstring->Set_help("The maximum drive letter that can be accessed.");
+	Pstring->Set_help("The maximum drive letter that can be accessed by programs.");
     Pstring->Set_values(driveletters);
 
     //TODO ?

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -722,6 +722,8 @@ void CONFIG::Run(void) {
 					if (p==NULL) break;
 					WriteOut("%s\n", p->propname.c_str());
 				}
+				if (!strcasecmp(pvars[0].c_str(), "config"))
+					WriteOut("set\ninstall\ninstallhigh\ndevice\ndevicehigh\n");
 			} else {
 				// find the property by it's name
 				size_t i = 0;
@@ -1141,7 +1143,7 @@ void PROGRAMS_Init() {
 	MSG_Add("PROGRAM_CONFIG_FILE_WHICH","Writing config file %s\n");
 	
 	// help
-	MSG_Add("PROGRAM_CONFIG_USAGE","The DOSBox-X config tool:\n"\
+	MSG_Add("PROGRAM_CONFIG_USAGE","The DOSBox-X config tool. Supported options:\n\n"\
 		"-wc (or -writeconf) without parameter: Writes to primary loaded config file.\n"\
 		"-wc (or -writeconf) with filename: Writes file to the config directory.\n"\
 		"-wl (or -writelang) with filename: Writes the current language strings.\n"\
@@ -1152,14 +1154,14 @@ void PROGRAMS_Init() {
 		"-h, -help, -? sections / sectionname / propertyname\n"\
 		" Without parameters, displays this help screen. Add \"sections\" for a list of\n sections."\
 		" For info about a specific section or property add its name behind.\n"\
-		"-axclear Clears the autoexec section.\n"\
-		"-axadd [line] Adds a line to the autoexec section.\n"\
-		"-axtype Prints the content of the autoexec section.\n"\
+		"-axclear Clears the [autoexec] section.\n"\
+		"-axadd [line] Adds a line to the [autoexec] section.\n"\
+		"-axtype Prints the content of the [autoexec] section.\n"\
 		"-securemode\n"\
         " Switches to secure mode where MOUNT, IMGMOUNT and BOOT will be disabled\n"\
         " as well as the ability to create config and language files.\n"\
 		"-get \"section property\" returns the value of the property.\n"\
-		"-set \"section property=value\" sets the value.\n" );
+		"-set \"section property=value\" sets the value of the property.\n" );
 	MSG_Add("PROGRAM_CONFIG_HLP_PROPHLP","Purpose of property \"%s\" (contained in section \"%s\"):\n%s\n\nPossible Values: %s\nDefault value: %s\nCurrent value: %s\n");
 	MSG_Add("PROGRAM_CONFIG_HLP_LINEHLP","Purpose of section \"%s\":\n%s\nCurrent value:\n%s\n");
 	MSG_Add("PROGRAM_CONFIG_HLP_NOCHANGE","This property cannot be changed at runtime.\n");

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -684,8 +684,9 @@ void CONFIG::Run(void) {
 				// sanity check
 				Section* sec = control->GetSection(pvars[0].c_str());
 				Section* sec2 = control->GetSectionFromProperty(pvars[1].c_str());
+				
 				if (sec != sec2) {
-					WriteOut(MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"));
+					WriteOut(MSG_Get("PROGRAM_CONFIG_PROPERTY_DUPLICATE"));
 				}
 				break;
 			}
@@ -1143,7 +1144,7 @@ void PROGRAMS_Init() {
 	MSG_Add("PROGRAM_CONFIG_FILE_WHICH","Writing config file %s\n");
 	
 	// help
-	MSG_Add("PROGRAM_CONFIG_USAGE","The DOSBox-X config tool. Supported options:\n\n"\
+	MSG_Add("PROGRAM_CONFIG_USAGE","The DOSBox-X configuration tool. Supported options:\n\n"\
 		"-wc (or -writeconf) without parameter: Writes to primary loaded config file.\n"\
 		"-wc (or -writeconf) with filename: Writes file to the config directory.\n"\
 		"-wl (or -writelang) with filename: Writes the current language strings.\n"\
@@ -1157,9 +1158,8 @@ void PROGRAMS_Init() {
 		"-axclear Clears the [autoexec] section.\n"\
 		"-axadd [line] Adds a line to the [autoexec] section.\n"\
 		"-axtype Prints the content of the [autoexec] section.\n"\
-		"-securemode\n"\
-        " Switches to secure mode where MOUNT, IMGMOUNT and BOOT will be disabled\n"\
-        " as well as the ability to create config and language files.\n"\
+		"-securemode Switches to secure mode where MOUNT, IMGMOUNT and BOOT will be\n"\
+        " disabled as well as the ability to create config and language files.\n"\
 		"-get \"section property\" returns the value of the property.\n"\
 		"-set \"section property=value\" sets the value of the property.\n" );
 	MSG_Add("PROGRAM_CONFIG_HLP_PROPHLP","Purpose of property \"%s\" (contained in section \"%s\"):\n%s\n\nPossible Values: %s\nDefault value: %s\nCurrent value: %s\n");
@@ -1174,6 +1174,7 @@ void PROGRAMS_Init() {
 	MSG_Add("PROGRAM_CONFIG_SECTION_ERROR","Section %s doesn't exist.\n");
 	MSG_Add("PROGRAM_CONFIG_VALUE_ERROR","\"%s\" is not a valid value for property %s.\n");
 	MSG_Add("PROGRAM_CONFIG_PROPERTY_ERROR","No such section or property.\n");
+	MSG_Add("PROGRAM_CONFIG_PROPERTY_DUPLICATE","There may be other sections with the same property name.\n");
 	MSG_Add("PROGRAM_CONFIG_NO_PROPERTY","There is no property %s in section %s.\n");
 	MSG_Add("PROGRAM_CONFIG_SET_SYNTAX","Correct syntax: config -set \"section property=value\".\n");
 	MSG_Add("PROGRAM_CONFIG_GET_SYNTAX","Correct syntax: config -get \"section property\".\n");

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -1141,20 +1141,20 @@ void PROGRAMS_Init() {
 	MSG_Add("PROGRAM_CONFIG_FILE_WHICH","Writing config file %s\n");
 	
 	// help
-	MSG_Add("PROGRAM_CONFIG_USAGE","Config tool:\n"\
-		"-wc (or -writeconf) without parameter: write to primary loaded config file.\n"\
-		"-wc (or -writeconf) with filename: write file to config directory.\n"\
-		"Use -writelang or -wl filename to write the current language strings.\n"\
-		"-wcp [filename]\n Write config file to the program directory, dosbox-x.conf or the specified \n filename.\n"\
-		"-wcd\n Write to the default config file in the config directory.\n"\
+	MSG_Add("PROGRAM_CONFIG_USAGE","The DOSBox-X config tool:\n"\
+		"-wc (or -writeconf) without parameter: Writes to primary loaded config file.\n"\
+		"-wc (or -writeconf) with filename: Writes file to the config directory.\n"\
+		"-wl (or -writelang) with filename: Writes the current language strings.\n"\
+		"-wcp [filename] Writes config file to the program directory (dosbox-x.conf\n or the specified filename).\n"\
+		"-wcd Writes to the default config file in the config directory.\n"\
 		"-all Use this with -wc, -wcp, or -wcd to write ALL options to the config file.\n"\
-		"-l lists configuration parameters.\n"\
+		"-l Lists DOSBox-X configuration parameters.\n"\
 		"-h, -help, -? sections / sectionname / propertyname\n"\
 		" Without parameters, displays this help screen. Add \"sections\" for a list of\n sections."\
 		" For info about a specific section or property add its name behind.\n"\
-		"-axclear clears the autoexec section.\n"\
-		"-axadd [line] adds a line to the autoexec section.\n"\
-		"-axtype prints the content of the autoexec section.\n"\
+		"-axclear Clears the autoexec section.\n"\
+		"-axadd [line] Adds a line to the autoexec section.\n"\
+		"-axtype Prints the content of the autoexec section.\n"\
 		"-securemode\n"\
         " Switches to secure mode where MOUNT, IMGMOUNT and BOOT will be disabled\n"\
         " as well as the ability to create config and language files.\n"\

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -737,6 +737,7 @@ void Section_prop::PrintData(FILE* outfile,bool everything) {
         if ((*tel)->propname.length() > len)
             len = (*tel)->propname.length();
     }
+	if (!strcasecmp(GetName(), "config")&&len<11) len=11;
 
     for(const_it tel = properties.begin();tel != properties.end();++tel) {
         if (!everything && !(*tel)->modified()) continue;
@@ -860,10 +861,11 @@ bool Config::PrintConfig(char const * const configfilename,bool everything) cons
         (*tel)->PrintData(outfile,everything);
 		if (!strcmp(temp, "config")) {
 			const char * extra = const_cast<char*>(sec->data.c_str());
+			bool used1=false, used2=false;
+			char linestr[CROSS_LEN+1], *lin=linestr;
 			if (extra&&strlen(extra)) {
 				std::istringstream in(extra);
-				char linestr[CROSS_LEN+1], cmdstr[CROSS_LEN], valstr[CROSS_LEN];
-				char *cmd=cmdstr, *val=valstr, *lin=linestr, *p;
+				char cmdstr[CROSS_LEN], valstr[CROSS_LEN], *cmd=cmdstr, *val=valstr, *p;
 				if (in)	for (std::string line; std::getline(in, line); ) {
 					if (line.length()>CROSS_LEN) {
 						strncpy(linestr, line.c_str(), CROSS_LEN);
@@ -878,10 +880,24 @@ bool Config::PrintConfig(char const * const configfilename,bool everything) cons
 						strcpy(val, p+1);
 						val=trim(val);
 						lowcase(cmd);
-						if (!strncmp(cmd, "set ", 4)||!strcmp(cmd, "install")||!strcmp(cmd, "installhigh")||!strcmp(cmd, "device")||!strcmp(cmd, "devicehigh"))
-							fprintf(outfile, "%-9s = %s\n", cmd, val);
+						if (!strncmp(cmd, "set ", 4)||!strcmp(cmd, "install")||!strcmp(cmd, "installhigh")||!strcmp(cmd, "device")||!strcmp(cmd, "devicehigh")) {
+							(!strncmp(cmd, "set ", 4)?used1:used2)=true;
+							fprintf(outfile, "%-11s = %s\n", cmd, val);
+						}
 					}
 				}
+			}
+			if (everything&&!used1) {
+				fprintf(outfile, "%-11s = %s\n", "set path", "Z:\\");
+				fprintf(outfile, "%-11s = %s\n", "set prompt", "$P$G");
+			}
+			if (everything&&!used2) {
+				fprintf(outfile, "%-11s = %s\n", "install", "");
+				fprintf(outfile, "%-11s = %s\n", "installhigh", "");
+				fprintf(outfile, "%-11s = %s\n", "device", "");
+				fprintf(outfile, "%-11s = %s\n", "devicehigh", "");
+			}
+			if (extra&&strlen(extra)) {
 				std::istringstream rem(extra);
 				if (everything&&rem) for (std::string line; std::getline(rem, line); ) {
 					if (line.length()>CROSS_LEN) {

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -503,7 +503,8 @@ void DOS_Shell::Run(void) {
 						else if (!strcasecmp(cmd, "install")||!strcasecmp(cmd, "installhigh")||!strcasecmp(cmd, "device")||!strcasecmp(cmd, "devicehigh")) {
 							strcpy(tmp, val);
 							char *name=StripArg(tmp);
-							if (!*name||!DOS_FileExists(name)) {
+							if (!*name) continue;
+							if (!DOS_FileExists(name)) {
 								WriteOut("The following file is missing or corrupted: %s\n", name);
 								continue;
 							}

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1070,9 +1070,9 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_CLS_HELP","Clears screen.\n");
 	MSG_Add("SHELL_CMD_CLS_HELP_LONG","CLS\n");
 	MSG_Add("SHELL_CMD_DIR_HELP","Displays a list of files and subdirectories in a directory.\n");
-	MSG_Add("SHELL_CMD_DIR_HELP_LONG","DIR [drive:][path][filename] [/[W|B]] [/S] [/P] [/A[D|S|H|R|A]] [/O[N|E|S|D]]\n\n"
+	MSG_Add("SHELL_CMD_DIR_HELP_LONG","DIR [drive:][path][filename] [/[W|B]] [/S] [/P] [/A[D|S|H|R|A]] [/O[N|E|S|D|G]]\n\n"
 		   "   [drive:][path][filename]\n"
-		   "       Specifies drive, directory, and/or files to list.\n\n"
+		   "       Specifies drive, directory, and/or files to list.\n"
 		   "   /W\tUses wide list format.\n"
 		   "   /B\tUses bare format (no heading information or summary).\n"
 		   "   /S\tDisplays files in specified directory and all subdirectories.\n"
@@ -1083,11 +1083,13 @@ void SHELL_Init() {
 		   "   /AH\tDisplays files with hidden attributes.\n"
 		   "   /AR\tDisplays files with read-only attributes.\n"
 		   "   /AA\tDisplays files with archive attributes.\n"
+		   "   /O\tList by files in sorted order.\n"
 		   "   /ON\tList files sorted by name (alphabetic).\n"
 		   "   /OE\tList files sorted by extension (alphabetic).\n"
 		   "   /OS\tList files sorted by size (smallest first).\n"
-		   "   /OD\tList files sorted by date (oldest first).\n\n"
-		   "   The \"-\" sign can be used in /A[D|S|H|R|A] and /O[N|E|S|D] commands,\n"
+		   "   /OD\tList files sorted by date (oldest first).\n"
+		   "   /OG\tList directories first, then files.\n"
+		   "   The \"-\" sign can be used in /A[D|S|H|R|A] and /O[N|E|S|D|G] commands,\n"
 		   "   meaning \"not\". For example, /A-D displays all files (not directories),\n"
 		   "   and /O-S lists files reversely sorted by size (biggest first).\n"
 		   );

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -209,10 +209,17 @@ __do_command_begin:
 		cmd_index++;
 	}
 /* This isn't an internal command execute it */
-	char ldir[DOS_PATHLENGTH], *p=ldir;
+	char ldir[CROSS_LEN], *p=ldir;
 	if (strchr(cmd_buffer,'\"')&&DOS_GetSFNPath(cmd_buffer,ldir,false)) {
 		if (!strchr(cmd_buffer, '\\') && strrchr(ldir, '\\'))
 			p=strrchr(ldir, '\\')+1;
+		if (uselfn&&strchr(p, ' ')&&!DOS_FileExists(("\""+std::string(p)+"\"").c_str())) {
+			bool append=false;
+			if (DOS_FileExists(("\""+std::string(p)+".COM\"").c_str())) {append=true;strcat(p, ".COM");}
+			else if (DOS_FileExists(("\""+std::string(p)+".EXE\"").c_str())) {append=true;strcat(p, ".EXE");}
+			else if (DOS_FileExists(("\""+std::string(p)+".BAT\"").c_str())) {append=true;strcat(p, ".BAT");}
+			if (append&&DOS_GetSFNPath(("\""+std::string(p)+"\"").c_str(), cmd_buffer,false)) if(Execute(cmd_buffer,line)) return;
+		}
 		if(Execute(p,line)) return;
 	} else
 		if(Execute(cmd_buffer,line)) return;

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -211,8 +211,8 @@ __do_command_begin:
 /* This isn't an internal command execute it */
 	char ldir[DOS_PATHLENGTH], *p=ldir;
 	if (strchr(cmd_buffer,'\"')&&DOS_GetSFNPath(cmd_buffer,ldir,false)) {
-		if (!strchr(cmd_buffer, '\\') && strchr(ldir, '\\'))
-			p=strchr(ldir, '\\')+1;
+		if (!strchr(cmd_buffer, '\\') && strrchr(ldir, '\\'))
+			p=strrchr(ldir, '\\')+1;
 		if(Execute(p,line)) return;
 	} else
 		if(Execute(cmd_buffer,line)) return;

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -209,8 +209,13 @@ __do_command_begin:
 		cmd_index++;
 	}
 /* This isn't an internal command execute it */
-	char ldir[DOS_PATHLENGTH];
-	if(Execute(strchr(cmd_buffer,'\"')&&DOS_GetSFNPath(cmd_buffer,ldir,false)?ldir:cmd_buffer,line)) return;
+	char ldir[DOS_PATHLENGTH], *p=ldir;
+	if (strchr(cmd_buffer,'\"')&&DOS_GetSFNPath(cmd_buffer,ldir,false)) {
+		if (!strchr(cmd_buffer, '\\') && strchr(ldir, '\\'))
+			p=strchr(ldir, '\\')+1;
+		if(Execute(p,line)) return;
+	} else
+		if(Execute(cmd_buffer,line)) return;
 	if(enable_config_as_shell_commands && CheckConfig(cmd_buffer,line)) return;
 	WriteOut(MSG_Get("SHELL_EXECUTE_ILLEGAL_COMMAND"),cmd_buffer);
 }

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1878,7 +1878,7 @@ void DOS_Shell::CMD_IF(char * args) {
 		}
 
 		{	/* DOS_FindFirst uses dta so set it to our internal dta */
-			char name[DOS_NAMELENGTH_ASCII], lname[LFN_NAMELENGTH], spath[DOS_PATHLENGTH], path[DOS_PATHLENGTH], pattern[DOS_PATHLENGTH], *r=strrchr(word, '\\');
+			char spath[DOS_PATHLENGTH], path[DOS_PATHLENGTH], pattern[DOS_PATHLENGTH], *r=strrchr(word, '\\');
 			if (r!=NULL) {
 				*r=0;
 				strcpy(path, word);
@@ -1901,7 +1901,6 @@ void DOS_Shell::CMD_IF(char * args) {
 			}
 			RealPt save_dta=dos.dta();
 			dos.dta(dos.tables.tempdta);
-			char sword[DOS_PATHLENGTH];
 			int fbak=lfn_filefind_handle;
 			lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
 			std::string full=std::string(spath)+std::string(pattern);

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -1196,19 +1196,19 @@ char * DOS_Shell::Which(char * name) {
 
 			//If name too long =>next
 			if((name_len + len + 1) >= DOS_PATHLENGTH) continue;
-			strcat(path,name);
+			strcat(path,strchr(name, ' ')?("\""+std::string(name)+"\"").c_str():name);
 
 			strcpy(which_ret,path);
-			if (DOS_FileExists(which_ret)) return which_ret;
+			if (DOS_FileExists(which_ret)) return strchr(which_ret, '\"')&&DOS_GetSFNPath(which_ret, spath, false)?spath:which_ret;
 			strcpy(which_ret,path);
 			strcat(which_ret,com_ext);
-			if (DOS_FileExists(which_ret)) return which_ret;
+			if (DOS_FileExists(which_ret)) return strchr(which_ret, '\"')&&DOS_GetSFNPath(which_ret, spath, false)?spath:which_ret;
 			strcpy(which_ret,path);
 			strcat(which_ret,exe_ext);
-			if (DOS_FileExists(which_ret)) return which_ret;
+			if (DOS_FileExists(which_ret)) return strchr(which_ret, '\"')&&DOS_GetSFNPath(which_ret, spath, false)?spath:which_ret;
 			strcpy(which_ret,path);
 			strcat(which_ret,bat_ext);
-			if (DOS_FileExists(which_ret)) return which_ret;
+			if (DOS_FileExists(which_ret)) return strchr(which_ret, '\"')&&DOS_GetSFNPath(which_ret, spath, false)?spath:which_ret;
 		}
 	}
 	return 0;


### PR DESCRIPTION
As mentioned by @rderooy in Issue #1596 and the discussion of pull request #1602, the "config -wcd -all" command may fail if the directory does not yet exist, and it does not add config.sys options like SET/INSTALL(HIGH)/DEVICE(HIGH) to the config file template if they don't exist yet, so I fixed them. It also allows "config -get config" to show SET/INSTALL(HIGH)/DEVICE(HIGH) commands in addition to the other options, just like the command "type config.sys". But it is impossible to change these commands with "config -set" because they can appear multiple times thus they are not regular options like the others.