### PR TITLE
Warning fixes

### DIFF
--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -35,13 +35,13 @@
 #endif
 #include <ctype.h>
 
-#define DOS_NAMELENGTH 12
+#define DOS_NAMELENGTH 12u
 #define DOS_NAMELENGTH_ASCII (DOS_NAMELENGTH+1)
-#define LFN_NAMELENGTH 255
-#define DOS_FCBNAME 15
-#define DOS_DIRDEPTH 8
-#define DOS_PATHLENGTH 255
-#define DOS_TEMPSIZE 1024
+#define LFN_NAMELENGTH 255u
+#define DOS_FCBNAME 15u
+#define DOS_DIRDEPTH 8u
+#define DOS_PATHLENGTH 255u
+#define DOS_TEMPSIZE 1024u
 
 enum {
     CPM_COMPAT_OFF=0,

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -397,7 +397,7 @@ void DOS_DTA::SetupSearch(Bit8u _sdrive,Bit8u _sattr,char * pattern) {
 	sSave(sDTA,sdrive,_sdrive);
 	sSave(sDTA,sattr,_sattr);
 
-	int i;
+	unsigned int i;
 	if (lfn_filefind_handle<LFN_FILEFIND_NONE) {
 		sattr[lfn_filefind_handle]=_sattr;
 		for (i=0;i<LFN_NAMELENGTH;i++) {

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -888,7 +888,7 @@ bool DOS_UnlinkFile(char const * const name) {
 				cdirs.push_back(std::string(temp));
 			}
 			lfn_filefind_handle=LFN_FILEFIND_INTERNAL;
-		} while (ret=DOS_FindNext());
+		} while ((ret=DOS_FindNext())==true);
 		lfn_filefind_handle=fbak;
 		bool removed=false;
 		while (!cdirs.empty()) {

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -3242,8 +3242,7 @@ public:
         for(int p = 0;p < 8;p++) WriteOut("----------");
 
         for (int d = 0;d < DOS_DRIVES;d++) {
-            if (!Drives[d]||strncmp(Drives[d]->GetInfo(),"fatDrive ",9)&&strncmp(Drives[d]->GetInfo(),"isoDrive ",9)) continue;
-			
+            if (!Drives[d] || (strncmp(Drives[d]->GetInfo(), "fatDrive ", 9) && strncmp(Drives[d]->GetInfo(), "isoDrive ", 9))) continue;
             char root[7] = {(char)('A'+d),':','\\','*','.','*',0};
             bool ret = DOS_FindFirst(root,DOS_ATTR_VOLUME);
             if (ret) {

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1857,6 +1857,7 @@ public:
 			char msg[30];
 			const Bit8u page(0);
 			BIOS_NCOLS;
+            (void)ncols;
 			strcpy(msg, CURSOR_POS_COL(page)>0?"\r\n":""); 
 			strcat(msg, "Booting from drive ");
 			strcat(msg, std::string(1, drive).c_str());

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -79,7 +79,7 @@ bool filename_not_8x3(const char *n) {
  * If the name is strict 8.3 uppercase like "FILENAME.TXT" there is no point making an LFN because it is a waste of space */
 bool filename_not_strict_8x3(const char *n) {
 	if (filename_not_8x3(n)) return true;
-	for (int i=0; i<strlen(n); i++)
+	for (unsigned int i=0; i<strlen(n); i++)
 		if (n[i]>='a' && n[i]<='z')
 			return true;
 	return false; /* it is strict 8.3 upper case */
@@ -103,7 +103,7 @@ char* fatDrive::Generate_SFN(const char *path, const char *name) {
 	if (!strlen(lfn)) return NULL;
 	direntry fileEntry = {};
 	Bit32u dirClust, subEntry;
-	int k=1, i, t=10000;
+	unsigned int k=1, i, t=10000;
 	while (k<10000) {
 		n=lfn;
 		if (t>strlen(n)||k==1||k==10||k==100||k==1000) {

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -111,7 +111,7 @@ char* fatDrive::Generate_SFN(const char *path, const char *name) {
 			*sfn=0;
 			while (*n == '.'||*n == ' ') n++;
 			while (strlen(n)&&(*(n+strlen(n)-1)=='.'||*(n+strlen(n)-1)==' ')) *(n+strlen(n)-1)=0;
-			while (*n != 0 && *n != '.' && i<(k<10?6:(k<100?5:(k<1000?4:3)))) {
+			while (*n != 0 && *n != '.' && i<(k<10?6u:(k<100?5u:(k<1000?4:3u)))) {
 				if (*n == ' ') {
 					n++;
 					continue;
@@ -2287,7 +2287,7 @@ nextfile:
 			lfnRange.dirPos_start = dirPos - 1; /* NTS: The code above has already incremented dirPos */
 		}
 
-		if (lfn_max_ord != 0 && (dlfn->LDIR_Ord & 0x3F) > 0 && (dlfn->LDIR_Ord & 0x3F) <= lfn_max_ord && dlfn->LDIR_Chksum == lfn_checksum) {
+		if (lfn_max_ord != 0 && (dlfn->LDIR_Ord & 0x3F) > 0 && (dlfn->LDIR_Ord & 0x3Fu) <= lfn_max_ord && dlfn->LDIR_Chksum == lfn_checksum) {
 			unsigned int oidx = (dlfn->LDIR_Ord & 0x3Fu) - 1u;
 			unsigned int stridx = oidx * 13u;
 
@@ -2523,7 +2523,7 @@ bool fatDrive::addDirectoryEntry(Bit32u dirClustNumber, const direntry& useEntry
 		/* 13 characters per LFN entry.
 		 * FIXME: When we convert the LFN to wchar using code page, strlen() prior to conversion will not work,
 		 *        convert first then count wchar_t characters. */
-		need = 1 + ((strlen(lfn) + 12) / 13)/*round up*/;
+		need = (unsigned int)(1 + ((strlen(lfn) + 12) / 13))/*round up*/;
 	}
 
 	size_t dirent_per_sector = getSectSize() / sizeof(direntry);

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -300,7 +300,7 @@ bool isoDrive::FindNext(DOS_DTA &dta) {
 	char pattern[CROSS_LEN], findName[DOS_NAMELENGTH_ASCII], lfindName[ISO_MAXPATHNAME];
     dta.GetSearchParams(attr, pattern, uselfn);
 	
-	int dirIterator = lfn_filefind_handle>=LFN_FILEFIND_MAX?dta.GetDirID():(sdid?sdid[lfn_filefind_handle]:0);
+	int dirIterator = lfn_filefind_handle>=LFN_FILEFIND_MAX?dta.GetDirID():sdid[lfn_filefind_handle];
 	bool isRoot = dirIterators[dirIterator].root;
 	
     isoDirEntry de = {};

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4237,6 +4237,9 @@ void MenuFreeScreen(void) {
 #endif
 
 static void HandleMouseButton(SDL_MouseButtonEvent * button, SDL_MouseMotionEvent * motion) {
+#if !defined(WIN32)
+    (void)motion;
+#endif
     bool inputToScreen = false;
     bool inMenu = false;
 

--- a/src/hardware/mame/emu.h
+++ b/src/hardware/mame/emu.h
@@ -56,6 +56,9 @@ public:
 	sound_stream temp;
 
 	sound_stream* stream_alloc(int whatever, int channels, int size) {
+        (void)whatever;
+        (void)channels;
+        (void)size;
 		return &temp;
 	};
 	
@@ -63,6 +66,8 @@ public:
 	virtual void sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples) = 0;
 
 	device_sound_interface(const machine_config &mconfig, device_t& _device) {
+        (void)mconfig;
+        (void)_device;
 	}
 
 };
@@ -71,6 +76,7 @@ struct attotime {
 	int whatever;
 
 	static attotime from_hz(int hz) {
+        (void)hz;
 		return attotime();
 	}
 };
@@ -118,9 +124,15 @@ public:
 	}
 
 	void save_item(int wtf, int blah= 0) {
+        (void)wtf;
+        (void)blah;
 	}
 
 	device_t(const machine_config &mconfig, device_type type, const char *tag, device_t *owner, u32 _clock) : clockRate( _clock ) {
+        (void)mconfig;
+        (void)type;
+        (void)tag;
+        (void)owner;
 	}
 
 	virtual ~device_t() {
@@ -130,6 +142,7 @@ public:
 
 
 static void auto_free(const device_t::machine_t& machine, void * buffer) {
+    (void)machine;
 	free(buffer);
 }
 

--- a/src/hardware/mame/emu.h
+++ b/src/hardware/mame/emu.h
@@ -141,11 +141,6 @@ public:
 
 
 
-static void auto_free(const device_t::machine_t& machine, void * buffer) {
-    (void)machine;
-	free(buffer);
-}
-
 #define auto_alloc_array_clear(m, t, c) calloc(c, sizeof(t) )
 #define auto_alloc_clear(m, t) static_cast<t*>( calloc(1, sizeof(t) ) )
 

--- a/src/hardware/mame/fmopl.cpp
+++ b/src/hardware/mame/fmopl.cpp
@@ -1698,7 +1698,7 @@ void FM_OPL::WriteReg(int r, int v)
 			}
 		}
 		/* update */
-		if(CH->block_fnum != block_fnum)
+		if(CH->block_fnum != (unsigned int)block_fnum)
 		{
 			uint8_t block  = block_fnum >> 10;
 
@@ -1768,11 +1768,11 @@ void FM_OPL::ResetChip()
 
 	/* reset operator parameters */
 //	for(OPL_CH &CH : P_CH)
-	for(int ch = 0; ch < sizeof( P_CH )/ sizeof(P_CH[0]); ch++)
+	for(unsigned int ch = 0; ch < sizeof( P_CH )/ sizeof(P_CH[0]); ch++)
 	{
 		OPL_CH &CH = P_CH[ch];
 //		for(OPL_SLOT &SLOT : CH.SLOT)
-		for(int slot = 0; slot < sizeof( CH.SLOT ) / sizeof( CH.SLOT[0]); slot++)
+		for(unsigned int slot = 0; slot < sizeof( CH.SLOT ) / sizeof( CH.SLOT[0]); slot++)
 		{
 		    
 			OPL_SLOT &SLOT = CH.SLOT[slot];
@@ -1799,7 +1799,7 @@ void FM_OPL::ResetChip()
 
 void FM_OPL::postload()
 {
-	for(int ch = 0; ch < sizeof( P_CH )/ sizeof(P_CH[0]); ch++)
+	for(unsigned int ch = 0; ch < sizeof( P_CH )/ sizeof(P_CH[0]); ch++)
 	{
 		OPL_CH &CH = P_CH[ch];
 		/* Look up key scale level */
@@ -1807,7 +1807,7 @@ void FM_OPL::postload()
 		CH.ksl_base = static_cast<uint32_t>(ksl_tab[block_fnum >> 6]);
 		CH.fc       = fn_tab[block_fnum & 0x03ff] >> (7 - (block_fnum >> 10));
 
-		for(int slot = 0; slot < sizeof( CH.SLOT ) / sizeof( CH.SLOT[0]); slot++)
+		for(unsigned int slot = 0; slot < sizeof( CH.SLOT ) / sizeof( CH.SLOT[0]); slot++)
 		{
 			OPL_SLOT &SLOT = CH.SLOT[slot];
 			/* Calculate key scale rate */

--- a/src/hardware/mame/fmopl.cpp
+++ b/src/hardware/mame/fmopl.cpp
@@ -928,6 +928,7 @@ struct FM_OPL
 	/* lock/unlock for common table */
 	static int LockTable(device_t *device)
 	{
+        (void)device;
 		num_lock++;
 		if(num_lock>1) return 0;
 

--- a/src/hardware/mame/fmopl.cpp
+++ b/src/hardware/mame/fmopl.cpp
@@ -1998,7 +1998,7 @@ static FM_OPL *OPLCreate(device_t *device, uint32_t clock, uint32_t rate, int ty
 static void OPLDestroy(FM_OPL *OPL)
 {
 	FM_OPL::UnLockTable();
-	auto_free(OPL->device->machine(), OPL);
+    free(OPL);
 }
 
 /* Optional handlers */

--- a/src/hardware/mame/saa1099.cpp
+++ b/src/hardware/mame/saa1099.cpp
@@ -219,6 +219,8 @@ void saa1099_device::device_start()
 
 void saa1099_device::sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples)
 {
+    (void)stream;
+    (void)inputs;
 	int j, ch;
 	/* if the channels are disabled we're done */
 	if (!m_all_ch_enable)
@@ -360,6 +362,8 @@ void saa1099_device::envelope_w(int ch)
 
 WRITE8_MEMBER( saa1099_device::control_w )
 {
+    (void)offset;
+    (void)space;
 	if ((data & 0xff) > 0x1c)
 	{
 		/* Error! */
@@ -380,6 +384,8 @@ WRITE8_MEMBER( saa1099_device::control_w )
 
 WRITE8_MEMBER( saa1099_device::data_w )
 {
+    (void)offset;
+    (void)space;
 	int reg = m_selected_reg;
 	int ch;
 

--- a/src/hardware/mame/sn76496.cpp
+++ b/src/hardware/mame/sn76496.cpp
@@ -297,6 +297,9 @@ void sn76496_base_device::device_clock_changed()
 
 WRITE8_MEMBER( sn76496_base_device::stereo_w )
 {
+    (void)offset;
+    (void)space;
+    (void)data;
 //	m_sound->update();
 //	if (m_stereo) m_stereo_mask = data;
 //	else fatalerror("sn76496_base_device: Call to stereo write with mono chip!\n");
@@ -364,6 +367,8 @@ void sn76496_base_device::write(uint8_t data)
 
 WRITE8_MEMBER( sn76496_base_device::write )
 {
+    (void)offset;
+    (void)space;
 	write(data);
 }
 
@@ -389,6 +394,8 @@ void sn76496_base_device::countdown_cycles()
 
 void sn76496_base_device::sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples)
 {
+    (void)stream;
+    (void)inputs;
 	int i;
 	stream_sample_t *lbuffer = outputs[0];
 	stream_sample_t *rbuffer = (m_stereo)? outputs[1] : 0;//nullptr;

--- a/src/hardware/mame/sn76496.cpp
+++ b/src/hardware/mame/sn76496.cpp
@@ -434,7 +434,7 @@ void sn76496_base_device::sound_stream_update(sound_stream &stream, stream_sampl
 				// if noisemode is 1, both taps are enabled
 				// if noisemode is 0, the lower tap, whitenoisetap2, is held at 0
 				// The != was a bit-XOR (^) before
-				if (((m_RNG & m_whitenoise_tap1)!=0) != (((m_RNG & m_whitenoise_tap2)!=(m_ncr_style_psg?m_whitenoise_tap2:0)) && in_noise_mode()))
+				if (((m_RNG & m_whitenoise_tap1)!=0) != (((m_RNG & m_whitenoise_tap2)!=(m_ncr_style_psg?(uint32_t)m_whitenoise_tap2:0)) && in_noise_mode()))
 				{
 					m_RNG >>= 1;
 					m_RNG |= m_feedback_mask;

--- a/src/hardware/mame/ymdeltat.cpp
+++ b/src/hardware/mame/ymdeltat.cpp
@@ -465,6 +465,8 @@ void YM_DELTAT::savestate(device_t *device)
 	device->save_item(NAME(DELTAT->prev_acc));
 	device->save_item(NAME(DELTAT->adpcmd));
 	device->save_item(NAME(DELTAT->adpcml));
+#else
+    (void)device;
 #endif
 }
 

--- a/src/hardware/mame/ymf262.cpp
+++ b/src/hardware/mame/ymf262.cpp
@@ -2379,7 +2379,7 @@ static OPL3 *OPL3Create(device_t *device, int clock, int rate, int type)
 static void OPL3Destroy(OPL3 *chip)
 {
 	OPL3_UnLockTable();
-	auto_free(chip->device->machine(), chip);
+    free(chip);
 }
 
 

--- a/src/hardware/mame/ymf262.cpp
+++ b/src/hardware/mame/ymf262.cpp
@@ -1637,6 +1637,7 @@ static inline void set_sl_rr(OPL3 *chip,int slot,int v)
 
 static void update_channels(OPL3 *chip, OPL3_CH *CH)
 {
+    (void)chip;
 	/* update channel passed as a parameter and a channel at CH+=3; */
 	if (CH->extended)
 	{   /* we've just switched to combined 4 operator mode */
@@ -2283,6 +2284,7 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 /* lock/unlock for common table */
 static int OPL3_LockTable(device_t *device)
 {
+    (void)device;
 	num_lock++;
 	if(num_lock>1) return 0;
 
@@ -2524,6 +2526,9 @@ static void OPL3_save_state(OPL3 *chip, device_t *device) {
 	device->save_item(NAME(chip->address));
 	device->save_item(NAME(chip->status));
 	device->save_item(NAME(chip->statusmask));
+#else
+    (void)chip;
+    (void)device;
 #endif
 }
 

--- a/src/hardware/mame/ymf262.cpp
+++ b/src/hardware/mame/ymf262.cpp
@@ -1975,7 +1975,7 @@ static void OPL3WriteReg(OPL3 *chip, int r, int v)
 			}
 		}
 		/* update */
-		if(CH->block_fnum != block_fnum)
+		if(CH->block_fnum != (unsigned int)block_fnum)
 		{
 			uint8_t block  = block_fnum >> 10;
 

--- a/src/hardware/parport/printer.cpp
+++ b/src/hardware/parport/printer.cpp
@@ -1986,17 +1986,23 @@ static Bit8u dataregister; // contents of the parallel port data register
 
 Bitu PRINTER_readdata(Bitu port,Bitu iolen)
 {
+    (void)port;
+    (void)iolen;
 	return dataregister;
 }
 
 void PRINTER_writedata(Bitu port,Bitu val,Bitu iolen)
 {
+    (void)port;
+    (void)iolen;
 	dataregister = (Bit8u)val;
 }
 Bit8u controlreg = 0x04;
 
 Bitu PRINTER_readstatus(Bitu port,Bitu iolen)
 {
+    (void)port;
+    (void)iolen;
 	//LOG_MSG("PRINTER_readstatus CS:IP %8x:%8x",SegValue(cs),reg_eip);
 	// Don't create a CPrinter unless the program really wants to print
 	// Return standard: No error, printer online, no ack and not busy
@@ -2033,6 +2039,7 @@ static void FormFeed(bool pressed)
 
 static void PRINTER_EventHandler(Bitu param)
 {
+    (void)param;
 	//LOG_MSG("printerevent");
 	if (timeout_dirty)
     {
@@ -2048,8 +2055,10 @@ static void PRINTER_EventHandler(Bitu param)
 	}
 }
 
-void PRINTER_writecontrol(Bitu port,Bitu val, Bitu iolen)
+void PRINTER_writecontrol(Bitu port,Bitu val,Bitu iolen)
 {
+    (void)port;
+    (void)iolen;
 	//LOG_MSG("PRINTER_writecontrol CS:IP %8x:%8x",SegValue(cs),reg_eip);
 	// init printer if bit 4 is switched on
 	if ((val & 0x04) && defaultPrinter && (!(controlreg & 0x04)))
@@ -2074,6 +2083,8 @@ void PRINTER_writecontrol(Bitu port,Bitu val, Bitu iolen)
 
 Bitu PRINTER_readcontrol(Bitu port,Bitu iolen)
 {
+    (void)port;
+    (void)iolen;
 	//LOG_MSG("PRINTER_readcontrol CS:IP %8x:%8x",SegValue(cs),reg_eip);
 	// Don't create a CPrinter unless the program really wants to print
 	if (!defaultPrinter)

--- a/src/hardware/parport/printer.cpp
+++ b/src/hardware/parport/printer.cpp
@@ -154,7 +154,7 @@ CPrinter::CPrinter(Bit16u dpi, Bit16u width, Bit16u height, char* output, bool m
 		}
 		LOG(LOG_MISC,LOG_NORMAL)("PRINTER: Enabled");
 	}
-};
+}
 
 void CPrinter::resetPrinterHard()
 {
@@ -221,7 +221,7 @@ CPrinter::~CPrinter(void)
 #if defined (WIN32)
 	DeleteDC(printerDC);
 #endif
-};
+}
 
 void CPrinter::selectCodepage(Bit16u cp)
 {
@@ -1569,7 +1569,7 @@ void CPrinter::formFeed()
 	finishMultipage();
 }
 
-static void findNextName(char* front, char* ext, char* fname)
+static void findNextName(const char* front, const char* ext, char* fname)
 {
 	int i = 1;
 	Bitu slen = (Bitu)strlen(document_path);

--- a/src/hardware/parport/printer_redir.cpp
+++ b/src/hardware/parport/printer_redir.cpp
@@ -66,7 +66,10 @@ void CPrinterRedir::Write_CON(Bitu val) {
 	PRINTER_writecontrol(0,val,1);
 }
 void CPrinterRedir::Write_IOSEL(Bitu val) {
+    (void)val; // UNUSED
 	// nothing
 }
-void CPrinterRedir::handleUpperEvent(Bit16u type) {}
+void CPrinterRedir::handleUpperEvent(Bit16u type) {
+    (void)type; // UNUSED
+}
 #endif // C_PRINTER

--- a/src/hardware/ps1_sound.cpp
+++ b/src/hardware/ps1_sound.cpp
@@ -331,7 +331,7 @@ static void PS1SN76496Update(Bitu length)
 		ps1.chanSN->Enable(false);
 	}
 
-	Bit16s * buffer=(Bit16s *)MixTemp;
+	//Bit16s * buffer=(Bit16s *)MixTemp;
 #if 0
 	SN76496Update(&ps1.sn,buffer,length);
 #endif

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -233,7 +233,7 @@ static Bitu TandyDACRead(Bitu port,Bitu /*iolen*/) {
 	case 0xc7:
 		return (Bit8u)(((tandy.dac.frequency>>8)&0xf) | (tandy.dac.amplitude<<5));
 	}
-	LOG_MSG("Tandy DAC: Read from unknown %X",port);
+	LOG_MSG("Tandy DAC: Read from unknown %X", (unsigned int)port);
 	return 0xff;
 }
 

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -481,7 +481,7 @@ static Bitu IRQ1_Handler(void) {
     case 0x51:
     case 0x52:
     case 0x53: /* del . Not entirely correct, but works fine */
-        if(!(flags3&0x01) && !(flags1&0x03) && (flags1&0x0c)==0x0c && (!(flags3&0x10) && (flags3&0x0c)==0x0c || (flags3&0x10) && (flags2&0x03)==0x03)) { /* Ctrl-Alt-Del? */
+        if (!(flags3 & 0x01) && !(flags1 & 0x03) && (flags1 & 0x0c) == 0x0c && ((!(flags3 & 0x10) && (flags3 & 0x0c) == 0x0c) || ((flags3 & 0x10) && (flags2 & 0x03) == 0x03))) { /* Ctrl-Alt-Del? */
 			throw int(3);
             break;
 		}

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -846,7 +846,7 @@ void CONFIG::Run(void) {
 						if (extra&&strlen(extra)) {
 							std::istringstream in(extra);
 							char linestr[CROSS_LEN+1], cmdstr[CROSS_LEN], valstr[CROSS_LEN];
-							char *cmd=cmdstr, *val=valstr, *lin=linestr, *p;
+							char *cmd=cmdstr, *val=valstr, /**lin=linestr,*/ *p;
 							if (in)	for (std::string line; std::getline(in, line); ) {
 								if (line.length()>CROSS_LEN) {
 									strncpy(linestr, line.c_str(), CROSS_LEN);
@@ -896,7 +896,7 @@ void CONFIG::Run(void) {
 						if (extra&&strlen(extra)) {
 							std::istringstream in(extra);
 							char linestr[CROSS_LEN+1], cmdstr[CROSS_LEN], valstr[CROSS_LEN];
-							char *cmd=cmdstr, *val=valstr, *lin=linestr, *p;
+							char *cmd=cmdstr, *val=valstr, /**lin=linestr,*/ *p;
 							if (in)	for (std::string line; std::getline(in, line); ) {
 								if (line.length()>CROSS_LEN) {
 									strncpy(linestr, line.c_str(), CROSS_LEN);

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -287,12 +287,11 @@ void DOS_Shell::ParseLine(char * line) {
 
 	Bit16u dummy,dummy2;
 	Bit32u bigdummy = 0;
-	Bitu num = 0;		/* Number of commands in this line */
 	bool append;
 	bool normalstdin  = false;	/* wether stdin/out are open on start. */
 	bool normalstdout = false;	/* Bug: Assumed is they are "con"      */
 	
-	num = GetRedirection(line,&in, &out, &toc, &append);
+    GetRedirection(line, &in, &out, &toc, &append);
 	if (in || out || toc) {
 		normalstdin  = (psp->GetFileHandle(0) != 0xff); 
 		normalstdout = (psp->GetFileHandle(1) != 0xff); 

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -701,7 +701,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 				if (dot2==NULL) {
 					star=strchr(arg2,'*');
 					if (strchr(arg2,'?')) {
-						for (int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-arg2:strlen(arg2)); i++) {
+						for (unsigned int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-arg2:strlen(arg2)); i++) {
 							if (*(arg2+i)=='?'&&i<strlen(name))
 								*(arg2+i)=name[i];
 						}
@@ -725,7 +725,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 					*dot2='.';
 					star=strchr(tname2,'*');
 					if (strchr(tname2,'?')) {
-						for (int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-tname2:strlen(tname2)); i++) {
+						for (unsigned int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-tname2:strlen(tname2)); i++) {
 							if (*(tname2+i)=='?'&&i<strlen(tname1))
 								*(tname2+i)=tname1[i];
 						}
@@ -742,7 +742,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 						strcpy(text2, dot2+1);
 						star=strchr(text2,'*');
 						if (strchr(text2,'?')) {
-							for (int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-text2:strlen(text2)); i++) {
+							for (unsigned int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-text2:strlen(text2)); i++) {
 								if (*(text2+i)=='?'&&i<strlen(text1))
 									*(text2+i)=text1[i];
 							}
@@ -756,7 +756,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 					} else {
 						strcpy(text2, dot2+1);
 						if (strchr(text2,'?')||strchr(text2,'*')) {
-							for (int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-text2:strlen(text2)); i++) {
+							for (unsigned int i=0; i<(uselfn?LFN_NAMELENGTH:DOS_NAMELENGTH) && i<(star?star-text2:strlen(text2)); i++) {
 								if (*(text2+i)=='*') {
 									*(text2+i)=0;
 									break;
@@ -3085,7 +3085,7 @@ void DOS_Shell::CMD_ALIAS(char* args) {
     } else {
         char alias_name[256] = { 0 };
         char* cmd = 0;
-        for (int offset = 0; *args && offset < sizeof(alias_name)-1; ++offset, ++args) {
+        for (unsigned int offset = 0; *args && offset < sizeof(alias_name)-1; ++offset, ++args) {
             if (*args == '=') {
                 cmd = trim(alias_name);
                 ++args;

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -171,7 +171,7 @@ __do_command_begin:
 	char * cmd_write=cmd_buffer;
 	int q=0;
 	while (*line) {
-		if (strchr("/\t", *line) || q/2*2==q && strchr(" =", *line))
+        if (strchr("/\t", *line) || (q / 2 * 2 == q && strchr(" =", *line)))
 			break;
 		if (*line == '"') q++;
 //		if (*line == ':') break; //This breaks drive switching as that is handled at a later stage. 
@@ -955,7 +955,7 @@ struct DtaResult {
 	Bit16u time;
 	Bit8u attr;
 
-	static bool groupDef(const DtaResult &lhs, const DtaResult &rhs) { return (lhs.attr & DOS_ATTR_DIRECTORY) && !(rhs.attr & DOS_ATTR_DIRECTORY)?true:(((lhs.attr & DOS_ATTR_DIRECTORY) && (rhs.attr & DOS_ATTR_DIRECTORY) || !(lhs.attr & DOS_ATTR_DIRECTORY) && !(rhs.attr & DOS_ATTR_DIRECTORY)) && strcmp(lhs.name, rhs.name) < 0); }
+	static bool groupDef(const DtaResult &lhs, const DtaResult &rhs) { return (lhs.attr & DOS_ATTR_DIRECTORY) && !(rhs.attr & DOS_ATTR_DIRECTORY)?true:((((lhs.attr & DOS_ATTR_DIRECTORY) && (rhs.attr & DOS_ATTR_DIRECTORY)) || (!(lhs.attr & DOS_ATTR_DIRECTORY) && !(rhs.attr & DOS_ATTR_DIRECTORY))) && strcmp(lhs.name, rhs.name) < 0); }
 	static bool groupDirs(const DtaResult &lhs, const DtaResult &rhs) { return (lhs.attr & DOS_ATTR_DIRECTORY) && !(rhs.attr & DOS_ATTR_DIRECTORY); }
 	static bool compareName(const DtaResult &lhs, const DtaResult &rhs) { return strcmp(lhs.name, rhs.name) < 0; }
 	static bool compareExt(const DtaResult &lhs, const DtaResult &rhs) { return strcmp(lhs.getExtension(), rhs.getExtension()) < 0; }
@@ -1367,7 +1367,7 @@ void DOS_Shell::CMD_DIR(char * args) {
 		Bitu free_space=1024u*1024u*100u;
 		if (Drives[drive]) {
 			Bit32u bytes_sector32;Bit32u sectors_cluster32;Bit32u total_clusters32;Bit32u free_clusters32;
-			if (dos.version.major > 7 || (dos.version.major == 7 && dos.version.minor >= 10) &&
+			if ((dos.version.major > 7 || (dos.version.major == 7 && dos.version.minor >= 10)) &&
 				Drives[drive]->AllocationInfo32(&bytes_sector32,&sectors_cluster32,&total_clusters32,&free_clusters32)) { /* FAT32 aware extended API */
 				rsize=true;
 				freec=0;
@@ -1691,7 +1691,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 							if (c=='n'||c=='N') {DOS_CloseFile(sourceHandle);ret = DOS_FindNext();continue;}
 						}
 						if (!exist&&size) {
-							int drive=strlen(nameTarget)>1&&nameTarget[1]==':'||nameTarget[2]==':'?(toupper(nameTarget[nameTarget[0]=='"'?1:0])-'A'):-1;
+							int drive=strlen(nameTarget)>1&&(nameTarget[1]==':'||nameTarget[2]==':')?(toupper(nameTarget[nameTarget[0]=='"'?1:0])-'A'):-1;
 							if (drive>=0&&Drives[drive]) {
 								Bit16u bytes_sector;Bit8u sectors_cluster;Bit16u total_clusters;Bit16u free_clusters;
 								rsize=true;
@@ -2949,7 +2949,7 @@ static char *str_replace(char *orig, char *rep, char *with) {
     len_with = with?strlen(with):0;
 
     ins = orig;
-    for (count = 0; tmp = strstr(ins, rep); ++count)
+    for (count = 0; (tmp = strstr(ins, rep)) != NULL; ++count)
         ins = tmp + len_rep;
 
     tmp = result = (char *)malloc(strlen(orig) + (len_with - len_rep) * count + 1);


### PR DESCRIPTION
Compiler warning fixes for GCC and Visual Studio.

While fixing the parentheses warnings I fixed what seemed to be 2 minor logic bugs.

In one case, if you set the DOS version to > 7 and used the "dir" command, you would not get the correct remaining free space.

In the other, `nameTarget[2]` might have been referenced without confirming that `nameTarget` was at least that long.

Builds on Visual Studio. I think it should build with GCC but I can't confirm that right now.
