### PR TITLE
4DOS fixes and -helpdebug option to list debug-related options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,5 @@
 0.83.2
   - Fixed issues with the "config -wcd -all" command (Wengier)
-  - Added DTASEG, DTAOFF, and PSPSEG as hex value constants to
-    the debugger interface to aid in debugging DOS programs.
   - Added [config] section in dosbox-x.conf to resemble DOS's
     CONFIG.SYS file. It currently supports REM, BREAK, NUMLOCK,
     FCBS, FILES, DOS, DEVICE/DEVICEHIGH, INSTALL/INSTALLHIGH,
@@ -22,6 +20,11 @@
     to auto-decide on the best setting for the platform. This
     fixes very small window issue on high DPI devices such as
     Microsoft Surface tablets. (Wengier)
+  - Added DTASEG, DTAOFF, and PSPSEG as hex value constants to
+    the debugger interface to aid in debugging DOS programs.
+  - New command-line option -helpdebug added to list debug-
+    related command-line options. The standard -? / -h / -help
+    command-line option will no longer list them (Wengier)
   - Implemented LFN support for FAT driver, so that it is now
     possible to view directory list, create or open files and
     directories etc with long filenames on FAT12/16/32 drives
@@ -70,7 +73,9 @@
   - Several improvements to DEL command, such as a new /F option to
     force delete of read-only files, and improved handling when the
     argument is a directory (Wengier)
-  - DIR /O & /OG supported in addition to /ON|/OE|/OS|/OD (Wengier)
+  - DIR /O & /OG supported in addition to /ON|/OE|/OS|/OD options.
+    Options such as /-O & /-A can be used to override /O, /A etc if
+    they are specified in the DIRCMD environment varaible (Wengier)
   - DIR and VOL commands now display real serial numbers for mounted
     local drives (Windows only) and FAT drives (Wengier)
   - Fixed SYS command not working properly (Wengier)

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1855,7 +1855,7 @@ public:
             }
 
 			char msg[30];
-			const Bit8u page(0);
+			const Bit8u page=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);;
 			BIOS_NCOLS;
 			strcpy(msg, CURSOR_POS_COL(page)>0?"\r\n":""); 
 			strcat(msg, "Booting from drive ");
@@ -5393,7 +5393,7 @@ void DOS_SetupPrograms(void) {
         "Syntax: IMGMAKE file [-t type] [[-size size] | [-chs geometry]] [-nofs]\n"
         "  [-source source] [-r retries] [-bat]\n"
         "  file: The image file that is to be created - !path on the host!\n"
-        "  -type: Type of image.\n"
+        "  -t: Type of image.\n"
         "    Floppy templates (names resolve to floppy sizes in kilobytes):\n"
         "     fd_160 fd_180 fd_200 fd_320 fd_360 fd_400 fd_720 fd_1200 fd_1440 fd_2880\n"
         "    Harddisk templates:\n"

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -903,10 +903,10 @@ bool fatDrive::getDirClustNum(const char *dir, Bit32u *clustNum, bool parDir) {
 				lfn_filefind_handle=fbak;
 				return false;
 			} else {
-				lfn_filefind_handle=fbak;
                 char find_name[DOS_NAMELENGTH_ASCII],lfind_name[LFN_NAMELENGTH];
                 Bit16u find_date,find_time;Bit32u find_size;Bit8u find_attr;
 				imgDTA->GetResult(find_name,lfind_name,find_size,find_date,find_time,find_attr);
+				lfn_filefind_handle=fbak;
 				if(!(find_attr &DOS_ATTR_DIRECTORY)) return false;
 			}
 			if (BPB.is_fat32())

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -6449,7 +6449,6 @@ bool DOSBOX_parse_argv() {
             fprintf(stderr,"  -erasemapper                            Erase mapper file\n");
             fprintf(stderr,"  -resetmapper                            Erase mapper file\n");
             fprintf(stderr,"  -console                                Show console (win32)\n");
-            fprintf(stderr,"  -noconsole                              Don't show console (debug+win32 only)\n");
             fprintf(stderr,"  -nogui                                  Don't show gui (win32 only)\n");
             fprintf(stderr,"  -nomenu                                 Don't show menu (win32 only)\n");
             fprintf(stderr,"  -userconf                               Create user level config file\n");
@@ -6462,9 +6461,6 @@ bool DOSBOX_parse_argv() {
             fprintf(stderr,"  -savedir <path>                         Save path\n");
             fprintf(stderr,"  -disable-numlock-check                  Disable numlock check (win32 only)\n");
             fprintf(stderr,"  -date-host-forced                       Force synchronization of date with host\n");
-            fprintf(stderr,"  -debug                                  Set all logging levels to debug\n");
-            fprintf(stderr,"  -early-debug                            Log early initialization messages in DOSBox (implies -console)\n");
-            fprintf(stderr,"  -keydbg                                 Log all SDL key events (debugging)\n");
             fprintf(stderr,"  -lang <message file>                    Use specific message file instead of language= setting\n");
             fprintf(stderr,"  -nodpiaware                             Ignore (don't signal) Windows DPI awareness\n");
             fprintf(stderr,"  -securemode                             Enable secure mode\n");
@@ -6473,14 +6469,32 @@ bool DOSBOX_parse_argv() {
             fprintf(stderr,"  -exit                                   Exit after executing AUTOEXEC.BAT\n");
             fprintf(stderr,"  -c <command string>                     Execute this command in addition to AUTOEXEC.BAT.\n");
             fprintf(stderr,"                                          Make sure to surround the command in quotes to cover spaces.\n");
-            fprintf(stderr,"  -set <section property=value>           Sets the config option (overriding the config file).\n");
+            fprintf(stderr,"  -set <section property=value>           Set the config option (overriding the config file).\n");
             fprintf(stderr,"                                          Make sure to surround the string in quotes to cover spaces.\n");
-            fprintf(stderr,"  -break-start                            Break into debugger at startup\n");
             fprintf(stderr,"  -time-limit <n>                         Kill the emulator after 'n' seconds\n");
             fprintf(stderr,"  -fastbioslogo                           Fast BIOS logo (skip 1-second pause)\n");
+            fprintf(stderr,"  -helpdebug                              Show debug-related options\n\n");
+
+#if defined(WIN32)
+            DOSBox_ConsolePauseWait();
+#endif
+
+            return 0;
+        } else if (optname == "helpdebug") {
+            DOSBox_ShowConsole();
+
+            fprintf(stderr,"\ndosbox-x [options]\n");
+            fprintf(stderr,"\nDOSBox-X version %s %s, copyright 2011-2020 joncampbell123.\n",VERSION,SDL_STRING);
+            fprintf(stderr,"Based on DOSBox by the DOSBox Team (See AUTHORS file)\n\n");
+            fprintf(stderr,"Debugging options:\n\n");
+            fprintf(stderr,"  -debug                                  Set all logging levels to debug\n");
+            fprintf(stderr,"  -early-debug                            Log early initialization messages in DOSBox (implies -console)\n");
+            fprintf(stderr,"  -keydbg                                 Log all SDL key events\n");
+            fprintf(stderr,"  -break-start                            Break into debugger at startup\n");
+            fprintf(stderr,"  -noconsole                              Don't show console (debug+win32 only)\n");
             fprintf(stderr,"  -log-con                                Log CON output to a log file\n");
             fprintf(stderr,"  -log-int21                              Log calls to INT 21h (debug level)\n");
-            fprintf(stderr,"  -log-fileio                             Log file I/O through INT 21h (debug level)\n");
+            fprintf(stderr,"  -log-fileio                             Log file I/O through INT 21h (debug level)\n\n");
 
 #if defined(WIN32)
             DOSBox_ConsolePauseWait();
@@ -8050,14 +8064,10 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 			//Due to parsing there can be a = at the start of value.
 			while (value.size() && (value.at(0) ==' ' ||value.at(0) =='=') ) value.erase(0,1);
 			for(Bitu i = 3; i < pvars.size(); i++) value += (std::string(" ") + pvars[i]);
-			if (value.empty() ) {
-				LOG_MSG(MSG_Get("PROGRAM_CONFIG_SET_SYNTAX"));
-				continue;
-			}
 			std::string inputline = pvars[1] + "=" + value;
 			
 			bool change_success = tsec->HandleInputline(inputline.c_str());
-			if (!change_success) LOG_MSG("Cannot set \"%s\"\n", inputline.c_str());
+			if (!change_success&&!value.empty()) LOG_MSG("Cannot set \"%s\"\n", inputline.c_str());
 		}
 		
 		// Redirect existing PC-98 related settings from other sections to the [pc98] section if the latter is empty

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -6402,7 +6402,7 @@ void DOSBox_ShowConsole() {
 void DOSBox_ConsolePauseWait() {
     char c;
 
-    printf("Hit ENTER to continue\n");
+    printf("Press ENTER key to continue\n");
     do {
         if (fread(&c, 1, 1, stdin) != 1) break;
     } while (!(c == 13 || c == 10)); /* wait for Enter key */
@@ -6448,9 +6448,8 @@ bool DOSBOX_parse_argv() {
             fprintf(stderr,"  -printconf                              Print config file location\n");
             fprintf(stderr,"  -erasemapper                            Erase mapper file\n");
             fprintf(stderr,"  -resetmapper                            Erase mapper file\n");
-            fprintf(stderr,"  -console                                Show console (win32)\n");
-            fprintf(stderr,"  -nogui                                  Don't show gui (win32 only)\n");
-            fprintf(stderr,"  -nomenu                                 Don't show menu (win32 only)\n");
+            fprintf(stderr,"  -nogui                                  Don't show GUI (Windows version only)\n");
+            fprintf(stderr,"  -nomenu                                 Don't show menu (Windows version only)\n");
             fprintf(stderr,"  -userconf                               Create user level config file\n");
             fprintf(stderr,"  -conf <param>                           Use config file <param>\n");
             fprintf(stderr,"  -startui -startgui                      Start DOSBox-X with UI\n");
@@ -6458,8 +6457,8 @@ bool DOSBOX_parse_argv() {
             fprintf(stderr,"  -showcycles                             Show cycles count\n");
             fprintf(stderr,"  -showrt                                 Show emulation speed relative to realtime\n");
             fprintf(stderr,"  -fullscreen                             Start in fullscreen\n");
-            fprintf(stderr,"  -savedir <path>                         Save path\n");
-            fprintf(stderr,"  -disable-numlock-check                  Disable numlock check (win32 only)\n");
+            fprintf(stderr,"  -savedir <path>                         Set save path\n");
+            fprintf(stderr,"  -disable-numlock-check                  Disable NumLock check (Windows version only)\n");
             fprintf(stderr,"  -date-host-forced                       Force synchronization of date with host\n");
             fprintf(stderr,"  -lang <message file>                    Use specific message file instead of language= setting\n");
             fprintf(stderr,"  -nodpiaware                             Ignore (don't signal) Windows DPI awareness\n");
@@ -6488,10 +6487,11 @@ bool DOSBOX_parse_argv() {
             fprintf(stderr,"Based on DOSBox by the DOSBox Team (See AUTHORS file)\n\n");
             fprintf(stderr,"Debugging options:\n\n");
             fprintf(stderr,"  -debug                                  Set all logging levels to debug\n");
-            fprintf(stderr,"  -early-debug                            Log early initialization messages in DOSBox (implies -console)\n");
+            fprintf(stderr,"  -early-debug                            Log early initialization messages in DOSBox-X (implies -console)\n");
             fprintf(stderr,"  -keydbg                                 Log all SDL key events\n");
             fprintf(stderr,"  -break-start                            Break into debugger at startup\n");
-            fprintf(stderr,"  -noconsole                              Don't show console (debug+win32 only)\n");
+            fprintf(stderr,"  -console                                Show console (Windows builds only)\n");
+            fprintf(stderr,"  -noconsole                              Don't show console (Windows debug builds only)\n");
             fprintf(stderr,"  -log-con                                Log CON output to a log file\n");
             fprintf(stderr,"  -log-int21                              Log calls to INT 21h (debug level)\n");
             fprintf(stderr,"  -log-fileio                             Log file I/O through INT 21h (debug level)\n\n");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -860,7 +860,7 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_VOL_SERIAL_NOLABEL","has no label\n");
 	MSG_Add("SHELL_CMD_VOL_SERIAL_LABEL","is %s\n");
 	MSG_Add("SHELL_ILLEGAL_PATH","Illegal Path.\n");
-	MSG_Add("SHELL_CMD_HELP","If you want a list of all supported commands type \033[33;1mhelp /all\033[0m .\nA short list of the most often used commands:\n");
+	MSG_Add("SHELL_CMD_HELP","If you want a list of all supported commands type \033[33;1mHELP /ALL\033[0m.\nA short list of the most often used commands:\n");
 	MSG_Add("SHELL_CMD_ECHO_ON","ECHO is on.\n");
 	MSG_Add("SHELL_CMD_ECHO_OFF","ECHO is off.\n");
 	MSG_Add("SHELL_ILLEGAL_SWITCH","Illegal switch: %s.\n");
@@ -1098,7 +1098,7 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_EXIT_HELP","Exits from the command shell.\n");
 	MSG_Add("SHELL_CMD_EXIT_HELP_LONG","EXIT\n");
 	MSG_Add("SHELL_CMD_HELP_HELP","Shows command help.\n");
-	MSG_Add("SHELL_CMD_HELP_HELP_LONG","HELP\n");
+	MSG_Add("SHELL_CMD_HELP_HELP_LONG","HELP [/ALL]\n");
 	MSG_Add("SHELL_CMD_MKDIR_HELP","Creates a directory.\n");
 	MSG_Add("SHELL_CMD_MKDIR_HELP_LONG","MKDIR [drive:][path]\n"
 	        "MD [drive:][path]\n");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -508,13 +508,13 @@ void DOS_Shell::Run(void) {
 								WriteOut("The following file is missing or corrupted: %s\n", name);
 								continue;
 							}
-							if (!strcasecmp(cmd, "install")) {
+							if (!strcasecmp(cmd, "install"))
 								DoCommand(val);
-							} else if (!strcasecmp(cmd, "installhigh"))
+							else if (!strcasecmp(cmd, "installhigh"))
 								DoCommand((char *)("lh "+std::string(val)).c_str());
-							else if (!strcasecmp(cmd, "device")) {
+							else if (!strcasecmp(cmd, "device"))
 								DoCommand((char *)("device "+std::string(val)).c_str());
-							} else if (!strcasecmp(cmd, "devicehigh"))
+							else if (!strcasecmp(cmd, "devicehigh"))
 								DoCommand((char *)("lh device "+std::string(val)).c_str());
 						}
 					} else if (!strncasecmp(line.c_str(), "rem ", 4)) {
@@ -1072,7 +1072,7 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_DIR_HELP","Displays a list of files and subdirectories in a directory.\n");
 	MSG_Add("SHELL_CMD_DIR_HELP_LONG","DIR [drive:][path][filename] [/[W|B]] [/S] [/P] [/A[D|S|H|R|A]] [/O[N|E|S|D|G]]\n\n"
 		   "   [drive:][path][filename]\n"
-		   "       Specifies drive, directory, and/or files to list.\n"
+		   "   \tSpecifies drive, directory, and/or files to list.\n"
 		   "   /W\tUses wide list format.\n"
 		   "   /B\tUses bare format (no heading information or summary).\n"
 		   "   /S\tDisplays files in specified directory and all subdirectories.\n"

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -529,6 +529,7 @@ continue_1:
 	char * lend=strrchr(sfull,'\\')+1;*lend=0;
 	dta=dos.dta();
 	bool exist=false;
+	lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
 	while (res) {
 		dta.GetResult(name,lname,size,date,time,attr);
 		if (!optF && (attr & DOS_ATTR_READ_ONLY)) {
@@ -548,14 +549,13 @@ continue_1:
 				if (c==3) {WriteOut("^C\r\n");break;}
 				c = c=='y'||c=='Y' ? 'Y':'N';
 				WriteOut("%c\r\n", c);
-				if (c=='N') {lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;res = DOS_FindNext();lfn_filefind_handle=fbak;continue;}
+				if (c=='N') {lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;res = DOS_FindNext();continue;}
 			}
 			if (!strlen(full)||!DOS_UnlinkFile(((uselfn||strchr(full, ' ')?(full[0]!='"'?"\"":""):"")+std::string(full)+(uselfn||strchr(full, ' ')?(full[strlen(full)-1]!='"'?"\"":""):"")).c_str())) WriteOut(MSG_Get("SHELL_CMD_DEL_ERROR"),uselfn?sfull:full);
 		}
-		lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
 		res=DOS_FindNext();
-		lfn_filefind_handle=fbak;
 	}
+	lfn_filefind_handle=fbak;
 	if (!exist) WriteOut(MSG_Get("SHELL_CMD_FILE_NOT_FOUND"),args);
 	dos.dta(save_dta);
 }
@@ -1212,12 +1212,14 @@ void DOS_Shell::CMD_DIR(char * args) {
 
 	ScanCMDBool(args,"4"); /* /4 ignored (default) */
 	bool optW=ScanCMDBool(args,"W");
-	bool optS=ScanCMDBool(args,"S");
 	bool optP=ScanCMDBool(args,"P");
-	if (ScanCMDBool(args,"WP") || ScanCMDBool(args,"PW")) {
-		optW=optP=true;
-	}
+	if (ScanCMDBool(args,"WP") || ScanCMDBool(args,"PW")) optW=optP=true;
+	if (ScanCMDBool(args,"-W")) optW=false;
+	if (ScanCMDBool(args,"-P")) optP=false;
+	bool optS=ScanCMDBool(args,"S");
+	if (ScanCMDBool(args,"-S")) optS=false;
 	bool optB=ScanCMDBool(args,"B");
+	if (ScanCMDBool(args,"-B")) optB=false;
 	bool optA=ScanCMDBool(args,"A");
 	bool optAD=ScanCMDBool(args,"AD");
 	bool optAminusD=ScanCMDBool(args,"A-D");
@@ -1229,6 +1231,19 @@ void DOS_Shell::CMD_DIR(char * args) {
 	bool optAminusR=ScanCMDBool(args,"A-R");
 	bool optAA=ScanCMDBool(args,"AA");
 	bool optAminusA=ScanCMDBool(args,"A-A");
+	if (ScanCMDBool(args,"-A")) {
+		optA = false;
+		optAD = false;
+		optAminusD = false;
+		optAS = false;
+		optAminusS = false;
+		optAH = false;
+		optAminusH = false;
+		optAR = false;
+		optAminusR = false;
+		optAA = false;
+		optAminusA = false;
+	}
 	// Sorting flags
 	bool reverseSort = false;
 	bool optON=ScanCMDBool(args,"ON");
@@ -1257,6 +1272,7 @@ void DOS_Shell::CMD_DIR(char * args) {
 		reverseSort = true;
 	}
 	bool optO=ScanCMDBool(args,"O");
+	if (ScanCMDBool(args,"OGN")) optO=true;
 	if (ScanCMDBool(args,"-O")) {
 		optO = false;
 		optOG = false;

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -90,10 +90,10 @@ static SHELL_Cmd cmd_list[]={
 {	"LFNFOR",		1,		&DOS_Shell::CMD_LFNFOR,		"SHELL_CMD_LFNFOR_HELP"},
 {	"TRUENAME",		1,		&DOS_Shell::CMD_TRUENAME,	"SHELL_CMD_TRUENAME_HELP"},
 // The following are additional commands for debugging purposes in DOSBox-X
-{	"INT2FDBG",		1,		&DOS_Shell::CMD_INT2FDBG,	"Hooks INT 2Fh for debugging purposes.\n"},
 {	"DX-CAPTURE",	1,		&DOS_Shell::CMD_DXCAPTURE,  "Runs program with video or audio capture.\n"},
 #if C_DEBUG
 {	"DEBUGBOX",		1,		&DOS_Shell::CMD_DEBUGBOX,	"Runs program and breaks into debugger at entry point.\n"},
+{	"INT2FDBG",		1,		&DOS_Shell::CMD_INT2FDBG,	"Hooks INT 2Fh for debugging purposes.\n"},
 #endif
 {0,0,0,0}
 }; 
@@ -237,6 +237,7 @@ __do_command_begin:
 		return; \
 	}
 
+#if C_DEBUG
 Bitu int2fdbg_hook_callback = 0;
 
 static Bitu INT2FDBG_Handler(void) {
@@ -364,6 +365,7 @@ void DOS_Shell::CMD_INT2FDBG(char * args) {
 		WriteOut("  /I      Installs hook\n");
 	}
 }
+#endif
 
 void DOS_Shell::CMD_BREAK(char * args) {
 	HELP("BREAK");

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -107,7 +107,7 @@ static void outc(Bit8u c) {
 
 static void backone() {
 	BIOS_NCOLS;
-	const Bit8u page(0);
+	Bit8u page=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
 	if (CURSOR_POS_COL(page)>0)
 		outc(8);
 	else if (CURSOR_POS_ROW(page)>0)
@@ -602,6 +602,8 @@ void DOS_Shell::InputCommand(char * line) {
 									r++;
 							}
 						}
+						int fbak=lfn_filefind_handle;
+						lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
                         while (res) {
 							dta.GetResult(name,lname,sz,date,time,att);
 							if ((strchr(uselfn?lname:name,' ')!=NULL&&q/2*2==q)||r)
@@ -622,11 +624,9 @@ void DOS_Shell::InputCommand(char * line) {
 										l_completion.push_back(qlname);
                                 }
                             }
-							int fbak=lfn_filefind_handle;
-							lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
                             res=DOS_FindNext();
-							lfn_filefind_handle=fbak;
                         }
+						lfn_filefind_handle=fbak;
                         /* Add executable list to front of completion list. */
                         std::copy(executable.begin(),executable.end(),std::front_inserter(l_completion));
                         it_completion = l_completion.begin();


### PR DESCRIPTION
I noticed that in certain situations 4DOS DIR command may not list all files in the directory properly when LFN is enabled because of issue related to the filefind handle, so I fixed it. As a result, 4DOS DIR should now work correctly in these situations.

I also added the -helpdebug command-line option to list all debug-related command-line options such as -early-debug, -keydbg, -log-con and -log-fileio (these options are only useful for developers and very technical users, but not normal users). The standard -? or -help option will no longer list them, but the new -helpdebug command-line option will be listed by -? or -help for these who indeed want to use the debugging feature.

Finally, some small cleanups are made to the options of the built-in DIR command: options such as /-A and /-P can be used to override /A and /P etc if the latter are specified in the %DIRCMD% environment variable.

Tested to ensure the build works properly.