### PR TITLE
Implement phone book to remap phone numbers to addresses for modem

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -80,4 +80,33 @@ static inline bool is_power_of_2(Bitu val) {
 	 * For more info see https://graphics.stanford.edu/~seander/bithacks.html#DetermineIfPowerOf2*/
 }
 
+/// Copy a string into C array
+///
+/// This function copies string pointed by src to fixed-size buffer dst.
+/// At most N bytes from src are copied, where N is size of dst.
+/// If exactly N bytes are copied, then terminating null byte is put
+/// into buffer, thus buffer overrun is prevented.
+///
+/// Function returns pointer to buffer to be compatible with std::strcpy.
+///
+/// Usage:
+///
+///     char buffer[2];
+///     safe_strcpy(buffer, "abc");
+///     // buffer is filled with "a"
+
+template<size_t N>
+char * safe_strcpy(char (& dst)[N], const char * src) noexcept {
+        snprintf(dst, N, "%s", src);
+        return & dst[0];
+}
+
+template<size_t N>
+char * safe_strcat(char (& dst)[N], const char * src) noexcept {
+        strncat(dst, src, N - strnlen(dst, N) - 1);
+        return & dst[0];
+}
+
+#define safe_strncpy(a,b,n) do { strncpy((a),(b),(n)-1); (a)[(n)-1] = 0; } while (0)
+
 #endif

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2796,6 +2796,9 @@ void DOSBOX_SetupConfigSections(void) {
     Pmulti_remain->GetSection()->Add_string("parameters",Property::Changeable::WhenIdle,"");
     Pmulti_remain->Set_help("see serial1");
 
+    Pstring = secprop->Add_path("phonebookfile", Property::Changeable::OnlyAtStart, "phonebook-" VERSION ".txt");
+    Pstring->Set_help("File used to map fake phone numbers to addresses.");
+
     // printer redirection parameters
     secprop = control->AddSection_prop("printer", &Null_Init);
     Pbool = secprop->Add_bool("printer", Property::Changeable::WhenIdle, true);

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -1337,6 +1337,11 @@ public:
         //       COM1 is a 8251 UART, while COM2 and higher if they exist are 8250/16xxx UARTs
         if (IS_PC98_ARCH) return;
 
+#if C_MODEM
+                const Prop_path *pbFilename = section->Get_path("phonebookfile");
+		MODEM_ReadPhonebook(pbFilename->realpath);
+#endif
+                
 		char s_property[] = "serialx"; 
 		for(Bit8u i = 0; i < 4; i++) {
 			// get the configuration property

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -763,11 +763,16 @@ void CSerialModem::Timer2(void) {
 				rqueue->addb(txval);
 				//LOG_MSG("Echo back to queue: %x",txval);
 			}
-			if (txval==0xa) continue;		//Real modem doesn't seem to skip this?
-			else if (txval==0x8 && (cmdpos > 0)) --cmdpos;	// backspace
-			else if (txval==0xd) DoCommand();				// return
-			else if (txval != '+') {
-				if(cmdpos<99) {
+			if (txval == '\n')
+                            continue; // Real modem doesn't seem to skip this?
+                        
+                        if (txval == '\b') {
+                            if (cmdpos > 0)
+                                cmdpos--;
+                        } else if (txval == '\r') {
+                            DoCommand();
+                        } else if (txval != '+') {
+                            if (cmdpos < 99) {
 					cmdbuf[cmdpos] = (char)txval;
 					cmdpos++;
 				}

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -24,6 +24,8 @@
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <fstream>
+#include <sstream>
 
 #include "support.h"
 #include "serialport.h"
@@ -32,6 +34,76 @@
 
 //#include "mixer.h"
 
+class PhonebookEntry {
+public:
+	PhonebookEntry(const std::string &_phone, const std::string &_address) :
+		phone(_phone),
+		address(_address) {
+	}
+
+	bool IsMatchingPhone(const std::string &input) const {
+		return (input == phone);
+	}
+
+	const std::string &GetAddress() const {
+		return address;
+	}
+
+private:
+	std::string phone;
+	std::string address;
+};
+
+static std::vector<PhonebookEntry *> phones;
+static const char phoneValidChars[] = "01234567890*=,;#+>";
+
+static bool MODEM_IsPhoneValid(const std::string &input) {
+	size_t found = input.find_first_not_of(phoneValidChars);
+	if (found != std::string::npos) {
+		LOG_MSG("SERIAL: Phone %s contains invalid character %c", input.c_str(), input[found]);
+		return false;
+	}
+
+	return true;
+}
+
+bool MODEM_ReadPhonebook(const std::string &filename) {
+	std::ifstream loadfile(filename);
+	if (!loadfile)
+		return false;
+
+	LOG_MSG("SERIAL: Loading phonebook from %s", filename.c_str());
+
+	std::string linein;
+	while (std::getline(loadfile, linein)) {
+		std::istringstream iss(linein);
+		std::string phone, address;
+
+		if (!(iss >> phone >> address)) {
+			LOG_MSG("SERIAL: Skipped a bad line in %s", filename.c_str());
+			continue;
+		}
+
+		// Check phone number for characters ignored by Hayes modems.
+		if (!MODEM_IsPhoneValid(phone))
+			continue;
+
+		LOG_MSG("SERIAL: Mapped phone %s to address %s", phone.c_str(), address.c_str());
+		PhonebookEntry *pbEntry = new PhonebookEntry(phone, address);
+		phones.push_back(pbEntry);
+	}
+
+	return true;
+}
+
+static const char *MODEM_GetAddressFromPhone(const char *input) {
+	for (const auto entry : phones) {
+		if (entry->IsMatchingPhone(input))
+			return entry->GetAddress().c_str();
+	}
+
+	return nullptr;
+}
 
 CSerialModem::CSerialModem(Bitu id, CommandLine* cmd):CSerial(id, cmd) {
 	InstallationSuccessful=false;
@@ -174,19 +246,24 @@ void CSerialModem::SendRes(ResTypes response) {
 	}
 }
 
-bool CSerialModem::Dial(char * host) {
+bool CSerialModem::Dial(const char *host) {
+        char buf[128] = "";
+	safe_strcpy(buf, host);
+
+	const char *destination = buf;
 
 	// Scan host for port
 	Bit16u port;
-	char * hasport=strrchr(host,':');
+	char *hasport=strrchr(buf, ':');
 	if (hasport) {
-		*hasport++=0;
-		port=(Bit16u)atoi(hasport);
+		*hasport++ = 0;
+		port = (Bit16u)atoi(hasport);
 	}
 	else port=MODEM_DEFAULT_PORT;
-	// Resolve host we're gonna dial
-	LOG_MSG("Connecting to host %s port %d",host,port);
-	clientsocket = new TCPClientSocket(host, port);
+	
+        // Resolve host we're gonna dial
+	LOG_MSG("Connecting to host %s port %d", destination, port);
+	clientsocket = new TCPClientSocket(destination, port);
 	if(!clientsocket->isopen) {
 		delete clientsocket;
 		clientsocket=0;
@@ -314,7 +391,7 @@ void CSerialModem::DoCommand() {
 	LOG_MSG("Command sent to modem: ->%s<-\n", cmdbuf);
 	/* Check for empty line, stops dialing and autoanswer */
 	if (!cmdbuf[0]) {
-		reg[0]=0;	// autoanswer off
+		reg[0] = 0;	// autoanswer off
 		return;
 	}
 	//else {
@@ -346,25 +423,29 @@ void CSerialModem::DoCommand() {
 		char chr = GetChar(scanbuf);
 		switch (chr) {
 		case 'D': { // Dial
-			char * foundstr=&scanbuf[0];
+			char *foundstr = &scanbuf[0];
 			if (*foundstr=='T' || *foundstr=='P') foundstr++;
-			// Small protection against empty line and long string
-			if ((!foundstr[0]) || (strlen(foundstr)>100)) {
+			
+                        // Small protection against empty line and long string
+			if ((!foundstr[0]) || (strlen(foundstr) > 100)) {
 				SendRes(ResERROR);
 				return;
 			}
-			char* helper;
 			// scan for and remove spaces; weird bug: with leading spaces in the string,
 			// SDLNet_ResolveHost will return no error but not work anyway (win)
-			while(foundstr[0]==' ') foundstr++;
-			helper=foundstr;
+			while(foundstr[0] == ' ') foundstr++;
+			char* helper = foundstr;
 			helper+=strlen(foundstr);
-			while(helper[0]==' ') {
-				helper[0]=0;
+			while(helper[0] == ' ') {
+				helper[0] = 0;
 				helper--;
 			}
-
-			//Large enough scope, so the buffers are still valid when reaching Dail.
+                        const char *mappedaddr = MODEM_GetAddressFromPhone(foundstr);
+			if (mappedaddr) {
+				Dial(mappedaddr);
+				return;
+			}
+			//Large enough scope, so the buffers are still valid when reaching Dial.
 			char buffer[128];
 			char obuffer[128];
 			if (strlen(foundstr) >= 12) {
@@ -386,7 +467,7 @@ void CSerialModem::DoCommand() {
 							buffer[j++] = '.';
 						// If the string is longer than 12 digits,
 						// interpret the rest as port
-						if (i == 11 && strlen(foundstr)>12)
+						if (i == 11 && strlen(foundstr) > 12)
 							buffer[j++] = ':';
 					}
 					buffer[j] = 0;

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -50,6 +50,8 @@ enum ResTypes {
 #define TEL_CLIENT 0
 #define TEL_SERVER 1
 
+bool MODEM_ReadPhonebook(const std::string &filename);
+
 class CFifo {
 public:
 	CFifo(Bitu _size) {
@@ -166,9 +168,9 @@ public:
 
 	void EnterIdleState();
 	void EnterConnectedState();
-
+        
 	void openConnection(void);
-	bool Dial(char * host);
+	bool Dial(const char *host);
 	void AcceptIncomingCall(void);
 	Bitu ScanNumber(char * & scan);
 	char GetChar(char * & scan);


### PR DESCRIPTION
# Description
Ported phonebook feature from dosbox-staging
https://github.com/dosbox-staging/dosbox-staging/commit/e905a6bd5d2f0d0d0fa07d904f9dab75a929ecbf

Authored by @NicknineTheEagle

Also port a fix for backspace handling
https://github.com/dosbox-staging/dosbox-staging/commit/9cb13f6158e223ec0757b6546add37d5f2de3115

**Does this PR address some issue(s) ?**
Some DOS programs or games allow only limited input when typing a phone number, not allowing letters, periods or columns, or simply have a limit length entry field.

This gets around it. You can specify a dummy phonenumber, and when you dial that number it instead connects to the address you specified in the phonebook.

The phonebook file should have the layout
 ```<dummy number> <host:port>```

**Does this PR introduce new feature(s) ?**
Yes, support for a phonebook for the emulated modem, and a new config setting in the [serial] section named phonebookfile=


**Are there any breaking changes ?**
none known

**Additional information**

_Add any additional information that may be useful._
I have tested the new feature with Kermit for DOS.