### PR TITLE
More softmodem patches ported from dosbox-staging

### DIFF
--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -11,9 +11,9 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 
@@ -225,7 +225,7 @@ void CSerialModem::SendRes(ResTypes response) {
 		case ResNOCARRIER:  code = 3; string = "NO CARRIER"; break;
 		case ResERROR:      code = 4; string = "ERROR"; break;
 		case ResNODIALTONE: code = 6; string = "NO DIALTONE"; break;
-                case ResBUSY:       code = 7; string = "BUSY"; break;
+		case ResBUSY:       code = 7; string = "BUSY"; break;
 		case ResNOANSWER:   code = 8; string = "NO ANSWER"; break;
 		case ResNONE:       return;
 		default:            return;
@@ -290,9 +290,9 @@ void CSerialModem::AcceptIncomingCall(void) {
 }
 
 Bitu CSerialModem::ScanNumber(char * & scan) {
-	Bitu ret=0;
-	while (char c=*scan) {
-		if (c>='0' && c<='9') {
+	Bitu ret = 0;
+	while (char c = *scan) {
+		if (c >= '0' && c <= '9') {
 			ret*=10;
 			ret+=(Bitu)(c-'0');
 			scan++;
@@ -317,7 +317,7 @@ void CSerialModem::Reset(){
 	dtrmode = 2;
 	if(clientsocket) {
 		delete clientsocket;
-		clientsocket=0;
+		clientsocket = 0;
 	}
 	memset(&reg,0,sizeof(reg));
 	reg[MREG_AUTOANSWER_COUNT] = 0;	// no autoanswer
@@ -350,7 +350,7 @@ void CSerialModem::EnterIdleState(void){
 
 	if(waitingclientsocket) {	// clear current incoming socket
 		delete waitingclientsocket;
-		waitingclientsocket=0;
+		waitingclientsocket = 0;
 	}
 	// get rid of everything
 	if(serversocket) {
@@ -362,10 +362,10 @@ void CSerialModem::EnterIdleState(void){
 		if(!serversocket->isopen) {
 			LOG_MSG("Serial%d: Modem could not open TCP port %d.",(int)COMNUMBER,(int)listenport);
 			delete serversocket;
-			serversocket=0;
+			serversocket = 0;
 		} else LOG_MSG("Serial%d: Modem listening on port %d...",(int)COMNUMBER,(int)listenport);
 	}
-	waitingclientsocket=0;
+	waitingclientsocket = 0;
 	
 	commandmode = true;
 	CSerial::setCD(false);
@@ -379,7 +379,7 @@ void CSerialModem::EnterConnectedState(void) {
 	if(serversocket) {
 		// we don't accept further calls
 		delete serversocket;
-		serversocket=0;
+		serversocket = 0;
 	}
 	SendRes(ResCONNECT);
 	commandmode = false;
@@ -499,8 +499,8 @@ void CSerialModem::DoCommand() {
 		}
 		case 'I': // Some strings about firmware
 			switch (ScanNumber(scanbuf)) {
-			case 3: SendLine("DOSBox Emulated Modem Firmware V1.00"); break;
-			case 4: SendLine("Modem compiled for DOSBox version " VERSION); break;
+			case 3: SendLine("DOSBox-X Emulated Modem Firmware V1.00"); break;
+			case 4: SendLine("Modem compiled for DOSBox-X version " VERSION); break;
 			}
 			break;
 		case 'E': // Echo on/off

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -205,11 +205,11 @@ void CSerialModem::SendNumber(Bitu val) {
 	rqueue->addb(0xd);
 	rqueue->addb(0xa);
 	
-	rqueue->addb((Bit8u)(val/100+'0'));
+	rqueue->addb((Bit8u)(val / 100+'0'));
 	val = val%100;
-	rqueue->addb((Bit8u)(val/10+'0'));
+	rqueue->addb((Bit8u)(val / 10+'0'));
 	val = val%10;
-	rqueue->addb((Bit8u)(val+'0'));
+	rqueue->addb((Bit8u)(val + '0'));
 
 	rqueue->addb(0xd);
 	rqueue->addb(0xa);
@@ -219,17 +219,19 @@ void CSerialModem::SendRes(ResTypes response) {
 	char const * string;Bitu code;
 	switch (response)
 	{
-		case ResNONE:		return;
-		case ResOK:			string="OK"; code=0; break;
-		case ResERROR:		string="ERROR"; code=4; break;
-		case ResRING:		string="RING"; code=2; break;
-		case ResNODIALTONE: string="NO DIALTONE"; code=6; break;
-		case ResNOCARRIER:	string="NO CARRIER" ;code=3; break;
-		case ResCONNECT:	string="CONNECT 57600"; code=1; break;
-		default:		return;
+		case ResOK:         code = 0; string = "OK"; break;
+		case ResCONNECT:    code = 1; string = "CONNECT 57600"; break;
+		case ResRING:       code = 2; string = "RING"; break;
+		case ResNOCARRIER:  code = 3; string = "NO CARRIER"; break;
+		case ResERROR:      code = 4; string = "ERROR"; break;
+		case ResNODIALTONE: code = 6; string = "NO DIALTONE"; break;
+                case ResBUSY:       code = 7; string = "BUSY"; break;
+		case ResNOANSWER:   code = 8; string = "NO ANSWER"; break;
+		case ResNONE:       return;
+		default:            return;
 	}
 	
-	if(doresponse!=1) {
+	if(doresponse != 1) {
 		if(doresponse==2 && (response==ResRING || 
 			response == ResCONNECT || response==ResNOCARRIER)) return;
 		if(numericresponse) SendNumber(code);
@@ -312,7 +314,7 @@ void CSerialModem::Reset(){
 	oldDTRstate = getDTR();
 	flowcontrol = 0;
 	plusinc = 0;
-        dtrmode = 2;
+	dtrmode = 2;
 	if(clientsocket) {
 		delete clientsocket;
 		clientsocket=0;
@@ -324,7 +326,7 @@ void CSerialModem::Reset(){
 	reg[MREG_CR_CHAR]          = '\r';
 	reg[MREG_LF_CHAR]          = '\n';
 	reg[MREG_BACKSPACE_CHAR]   = '\b';
-        reg[MREG_GUARD_TIME]       = 50;
+	reg[MREG_GUARD_TIME]       = 50;
 	reg[MREG_DTR_DELAY]        = 5;
 
 	cmdpause = 0;	

--- a/src/hardware/serialport/softmodem.cpp
+++ b/src/hardware/serialport/softmodem.cpp
@@ -60,7 +60,8 @@ static const char phoneValidChars[] = "01234567890*=,;#+>";
 static bool MODEM_IsPhoneValid(const std::string &input) {
 	size_t found = input.find_first_not_of(phoneValidChars);
 	if (found != std::string::npos) {
-		LOG_MSG("SERIAL: Phone %s contains invalid character %c", input.c_str(), input[found]);
+		LOG_MSG("SERIAL: Phonebook %s contains invalid character %c.",
+		        input.c_str(), input[found]);
 		return false;
 	}
 
@@ -264,7 +265,7 @@ bool CSerialModem::Dial(const char *host) {
 	else port=MODEM_DEFAULT_PORT;
 	
         // Resolve host we're gonna dial
-	LOG_MSG("Connecting to host %s port %d", destination, port);
+	LOG_MSG("Connecting to host %s port %u", destination, port);
 	clientsocket = new TCPClientSocket(destination, port);
 	if(!clientsocket->isopen) {
 		delete clientsocket;
@@ -341,8 +342,8 @@ void CSerialModem::Reset(){
 void CSerialModem::EnterIdleState(void){
 	connected = false;
 	ringing = false;
-        dtrofftimer = -1;
-	
+	dtrofftimer = -1;
+
 	if(clientsocket) {
 		delete clientsocket;
 		clientsocket=0;
@@ -357,16 +358,21 @@ void CSerialModem::EnterIdleState(void){
 		while ((waitingclientsocket=serversocket->Accept()))
 			delete waitingclientsocket;
 	} else if (listenport) {
-		
-		serversocket=new TCPServerSocket((Bit16u)listenport);	
+
+		serversocket=new TCPServerSocket((Bit16u)listenport);
 		if(!serversocket->isopen) {
-			LOG_MSG("Serial%d: Modem could not open TCP port %d.",(int)COMNUMBER,(int)listenport);
+			LOG_MSG("Serial%d: Modem could not open TCP port %u.",
+                                static_cast<uint32_t>(COMNUMBER),
+                                static_cast<uint32_t>(listenport));
 			delete serversocket;
 			serversocket = 0;
-		} else LOG_MSG("Serial%d: Modem listening on port %d...",(int)COMNUMBER,(int)listenport);
+		} else
+                    LOG_MSG("Serial%u: Modem listening on port %u...",
+		            static_cast<uint32_t>(COMNUMBER),
+			        static_cast<uint32_t>(listenport));
 	}
 	waitingclientsocket = 0;
-	
+
 	commandmode = true;
 	CSerial::setCD(false);
 	CSerial::setRI(false);
@@ -625,7 +631,9 @@ void CSerialModem::DoCommand() {
 					SendRes(ResERROR);
 					return;
 				default:
-					LOG_MSG("Modem: Unhandled command: &%c%d",cmdchar,(int)ScanNumber(scanbuf));
+					LOG_MSG("Modem: Unhandled command: &%c%u",
+                                                cmdchar,
+                                                static_cast<uint32_t>(ScanNumber(scanbuf)));
 					break;
 			}
 			break;
@@ -645,7 +653,9 @@ void CSerialModem::DoCommand() {
 					SendRes(ResERROR);
 					return;
 				default:
-					LOG_MSG("Modem: Unhandled command: \\%c%d",cmdchar, (int)ScanNumber(scanbuf));
+					LOG_MSG("Modem: Unhandled command: \\%c%u",
+                                                cmdchar,
+                                                static_cast<uint32_t>(ScanNumber(scanbuf)));
 					break;
 			}
 			break;
@@ -654,7 +664,9 @@ void CSerialModem::DoCommand() {
 			SendRes(ResOK);
 			return;
 		default:
-			LOG_MSG("Modem: Unhandled command: %c%d",chr,(int)ScanNumber(scanbuf));
+			LOG_MSG("Modem: Unhandled command: %c%u",
+                                chr,
+                                static_cast<uint32_t>(ScanNumber(scanbuf)));
 			break;
 		}
 	}
@@ -668,7 +680,7 @@ void CSerialModem::TelnetEmulation(Bit8u * data, Bitu size) {
 		if(telClient.inIAC) {
 			if(telClient.recCommand) {
 				if((c != 0) && (c != 1) && (c != 3)) {
-					LOG_MSG("MODEM: Unrecognized option %d", c);
+					LOG_MSG("MODEM: Unrecognized option %u", c);
 					if(telClient.command>250) {
 						/* Reject anything we don't recognize */
 						tqueue->addb(0xff);
@@ -928,8 +940,8 @@ void CSerialModem::transmitByte(Bit8u val, bool first) {
 	//LOG_MSG("MODEM: Byte %x to be transmitted",val);
 }
 
-void CSerialModem::updatePortConfig(Bit16u, Bit8u) { 
-// nothing to do here right?
+void CSerialModem::updatePortConfig(Bit16u, Bit8u lcr) {
+    (void) lcr; // deliberately unused by needed to meet the API
 }
 
 void CSerialModem::updateMSR() {
@@ -941,11 +953,11 @@ void CSerialModem::setBreak(bool) {
 }
 
 void CSerialModem::setRTSDTR(bool rts, bool dtr) {
-    (void)rts;
-	setDTR(dtr);
+    (void) rts; // deliberately unused but needed to meet the API
+    setDTR(dtr);
 }
 void CSerialModem::setRTS(bool val) {
-	(void)val;
+    (void) val; // deliberately unused but needed to meet the API
 }
 void CSerialModem::setDTR(bool val) {
 	if (val != oldDTRstate) {

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -98,7 +98,8 @@ public:
 			static Bits lcount=0;
 			if (lcount < 1000) {
 				lcount++;
-				LOG_MSG("MODEM: FIFO Overflow! (adds len %u)", (int)_len);
+				LOG_MSG("MODEM: FIFO Overflow! (adds len %u)",
+					static_cast<uint32_t>(_len));
 			}
 			return;
 		}
@@ -132,7 +133,8 @@ public:
 			static Bits lcount=0;
 			if (lcount < 1000) {
 				lcount++;
-				LOG_MSG("MODEM: FIFO UNDERFLOW! (gets len %d)",(int)_len);
+				LOG_MSG("MODEM: FIFO UNDERFLOW! (gets len %u)",
+					static_cast<uint32_t>(_len));
 			}
 			return;
 		}

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -149,7 +149,7 @@ private:
 #define MREG_CR_CHAR 3
 #define MREG_LF_CHAR 4
 #define MREG_BACKSPACE_CHAR 5
-
+#define MREG_DTR_DELAY 25
 
 class CSerialModem : public CSerial {
 public:
@@ -168,7 +168,7 @@ public:
 
 	void EnterIdleState();
 	void EnterConnectedState();
-        
+
 	void openConnection(void);
 	bool Dial(const char *host);
 	void AcceptIncomingCall(void);
@@ -220,7 +220,8 @@ protected:
 	Bitu plusinc;
 	Bitu cmdpos;
 	Bitu flowcontrol;
-
+        Bitu dtrmode;
+        Bitu dtrofftimer;
 	Bit8u tmpbuf[MODEM_BUFFER_QUEUE_SIZE];
 
 	Bitu listenport;

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -149,6 +149,7 @@ private:
 #define MREG_CR_CHAR 3
 #define MREG_LF_CHAR 4
 #define MREG_BACKSPACE_CHAR 5
+#define MREG_GUARD_TIME 12
 #define MREG_DTR_DELAY 25
 
 class CSerialModem : public CSerial {

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -11,9 +11,9 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 
@@ -60,9 +60,9 @@ bool MODEM_ReadPhonebook(const std::string &filename);
 class CFifo {
 public:
 	CFifo(Bitu _size) {
-		size=_size;
-		pos=used=0;
-		data=new Bit8u[size];
+		size = _size;
+		pos = used = 0;
+		data = new Bit8u[size];
 	}
 	~CFifo() {
 		delete[] data;
@@ -74,31 +74,31 @@ public:
 		return used;
 	}
 	void clear(void) {
-		used=pos=0;
+		used = pos = 0;
 	}
 
 	void addb(Bit8u _val) {
 		if(used>=size) {
 			static Bits lcount=0;
-			if (lcount<1000) {
+			if (lcount < 1000) {
 				lcount++;
 				LOG_MSG("MODEM: FIFO Overflow! (addb)");
 			}
 			return;
 		}
-		//assert(used<size);
-		Bitu where=pos+used;
-		if (where>=size) where-=size;
-		data[where]=_val;
-		//LOG_MSG("+%x",_val);
+		//assert(used < size);
+		Bitu where = pos + used;
+		if (where >= size) where -= size;
+		data[where] = _val;
+		//LOG_MSG("+%x", _val);
 		used++;
 	}
-	void adds(Bit8u * _str,Bitu _len) {
-		if((used+_len)>size) {
+	void adds(Bit8u * _str, Bitu _len) {
+		if((used+_len) > size) {
 			static Bits lcount=0;
-			if (lcount<1000) {
+			if (lcount < 1000) {
 				lcount++;
-				LOG_MSG("MODEM: FIFO Overflow! (adds len %u)",(int)_len);
+				LOG_MSG("MODEM: FIFO Overflow! (adds len %u)", (int)_len);
 			}
 			return;
 		}
@@ -107,30 +107,30 @@ public:
 		Bitu where=pos+used;
 		used+=_len;
 		while (_len--) {
-			if (where>=size) where-=size;
-			//LOG_MSG("+'%x'",*_str);
-			data[where++]=*_str++;
+			if (where >= size) where -= size;
+			//LOG_MSG("+'%x'", *_str);
+			data[where++] = *_str++;
 		}
 	}
 	Bit8u getb(void) {
 		if (!used) {
 			static Bits lcount=0;
-			if (lcount<1000) {
+			if (lcount < 1000) {
 				lcount++;
 				LOG_MSG("MODEM: FIFO UNDERFLOW! (getb)");
 			}
 			return data[pos];
 		}
 			Bitu where=pos;
-		if (++pos>=size) pos-=size;
+		if (++pos >= size) pos -= size;
 		used--;
-		//LOG_MSG("-%x",data[where]);
+		//LOG_MSG("-%x", data[where]);
 		return data[where];
 	}
 	void gets(Bit8u * _str,Bitu _len) {
 		if (!used) {
 			static Bits lcount=0;
-			if (lcount<1000) {
+			if (lcount < 1000) {
 				lcount++;
 				LOG_MSG("MODEM: FIFO UNDERFLOW! (gets len %d)",(int)_len);
 			}
@@ -139,23 +139,23 @@ public:
 			//assert(used>=_len);
 		used-=_len;
 		while (_len--) {
-			//LOG_MSG("-%x",data[pos]);
-			*_str++=data[pos];
+			//LOG_MSG("-%x", data[pos]);
+			*_str++ = data[pos];
 			if (++pos>=size) pos-=size;
 		}
 	}
 private:
-	Bit8u * data;
-	Bitu size,pos,used;
+	Bit8u *data;
+	Bitu size, pos, used;
 };
 #define MREG_AUTOANSWER_COUNT 0
-#define MREG_RING_COUNT 1
-#define MREG_ESCAPE_CHAR 2
-#define MREG_CR_CHAR 3
-#define MREG_LF_CHAR 4
-#define MREG_BACKSPACE_CHAR 5
-#define MREG_GUARD_TIME 12
-#define MREG_DTR_DELAY 25
+#define MREG_RING_COUNT       1
+#define MREG_ESCAPE_CHAR      2
+#define MREG_CR_CHAR          3
+#define MREG_LF_CHAR          4
+#define MREG_BACKSPACE_CHAR   5
+#define MREG_GUARD_TIME       12
+#define MREG_DTR_DELAY        25
 
 class CSerialModem : public CSerial {
 public:
@@ -178,8 +178,8 @@ public:
 	void openConnection(void);
 	bool Dial(const char *host);
 	void AcceptIncomingCall(void);
-	Bitu ScanNumber(char * & scan);
-	char GetChar(char * & scan);
+	Bitu ScanNumber(char *&scan);
+	char GetChar(char *&scan);
 
 	void DoCommand();
 	
@@ -226,8 +226,8 @@ protected:
 	Bitu plusinc;
 	Bitu cmdpos;
 	Bitu flowcontrol;
-        Bitu dtrmode;
-        Bitu dtrofftimer;
+	Bitu dtrmode;
+	Bitu dtrofftimer;
 	Bit8u tmpbuf[MODEM_BUFFER_QUEUE_SIZE];
 
 	Bitu listenport;

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -42,9 +42,14 @@
 
 enum ResTypes {
 	ResNONE,
-	ResOK,ResERROR,
-	ResCONNECT,ResRING,
-	ResBUSY,ResNODIALTONE,ResNOCARRIER
+	ResOK,
+	ResERROR,
+	ResCONNECT,
+	ResRING,
+	ResBUSY,
+	ResNODIALTONE,
+	ResNOCARRIER,
+	ResNOANSWER
 };
 
 #define TEL_CLIENT 0


### PR DESCRIPTION
# Description
Ported a few more fixes to the softmodem from dosbox-staging.

_Summary of changes brought by this PR._
**Implement DTR drop actions (&Dn) and DTR drop delay (S25) in modem**

&D0 may be needed for old apps which don't set DTR or set it to garbage.
DTR drop delay is required for Quake otherwise it doesn't disconnect
properly.
* https://github.com/dosbox-staging/dosbox-staging/commit/de45c413ae804a4a2e4e47ad5cacaa51d3796995
Authored by @NicknineTheEagle

**Fix auto-answer (S0) behavior in modem**
* https://github.com/dosbox-staging/dosbox-staging/commit/880d2d2ceb6bcc27c3c5103fa79d04314f4280c8
Authored by @NicknineTheEagle

**Fix handling of escape characters in softmodem**
* https://github.com/dosbox-staging/dosbox-staging/commit/4aee47a770dddcf74f4564fc25b48adcd7cfe943#diff-0a3cd723bfb0a49d7200a2be97d5c2da
Authored by @Marco Maccaferri