### PR TITLE
Fixes for DIR/LS commands

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,8 @@
     phone book file entries need to be in the format of:
     "<dummy number> <hostname/ip:port>" e.g.
     5551234 cavebbs.homeip.net:23
-  - Fixed issues with the "config -wcd -all" command (Wengier)
+  - Fixed issues with the "config -wcd -all" command and other
+    updates to the CONFIG command (Wengier)
   - Added [config] section in dosbox-x.conf to resemble DOS's
     CONFIG.SYS file. It currently supports REM, BREAK, NUMLOCK,
     FCBS, FILES, DOS, DEVICE/DEVICEHIGH, INSTALL/INSTALLHIGH,
@@ -78,10 +79,11 @@
   - Several improvements to DEL command, such as a new /F option to
     force delete of read-only files, and improved handling when the
     argument is a directory (Wengier)
+  - LS command added to list directory contents. It does not support
+    all options as in Unix/Linux platform (Wengier)
   - DIR /O & /OG supported in addition to /ON|/OE|/OS|/OD options.
     Options such as /-O & /-A can be used to override /O, /A etc if
     they are specified in the DIRCMD environment varaible (Wengier)
-  - LS command added to list directory contents (Wengier)
   - DIR and VOL commands now display real serial numbers for mounted
     local drives (Windows only) and FAT drives (Wengier)
   - Fixed SYS command not working properly (Wengier)

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -4932,7 +4932,7 @@ class LABEL : public Program
 {
 public:
     void Help() {
-        WriteOut("LABEL [drive:][label]\n");
+        WriteOut("Creates, changes, or deletes the volume label of a drive.\n\nLABEL [drive:][label]\n");
     }
 	void Run() override
     {
@@ -5060,7 +5060,8 @@ void DOS_SetupPrograms(void) {
 		"MOUNT -freesize 128 c %s mounts C: with the specified free disk space.\n"
 		"MOUNT -ro c %s mounts the C: drive in read-only mode.\n"
 		"MOUNT -t cdrom c %s mounts the C: drive as a CD-ROM drive.\n"
-		"MOUNT -u c unmounts the C: drive.\n");
+		"MOUNT -u c unmounts the C: drive.\n\n"
+		"Type MOUNT with no parameters to display a list of mounted drives.\n");
     MSG_Add("PROGRAM_MOUNT_UMOUNT_NOT_MOUNTED","Drive %c is not mounted.\n");
     MSG_Add("PROGRAM_MOUNT_UMOUNT_SUCCESS","Drive %c has successfully been removed.\n");
     MSG_Add("PROGRAM_MOUNT_UMOUNT_NUMBER_SUCCESS","Drive number %c has successfully been removed.\n");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1069,28 +1069,23 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_CLS_HELP","Clears screen.\n");
 	MSG_Add("SHELL_CMD_CLS_HELP_LONG","CLS\n");
 	MSG_Add("SHELL_CMD_DIR_HELP","Displays a list of files and subdirectories in a directory.\n");
-	MSG_Add("SHELL_CMD_DIR_HELP_LONG","DIR [drive:][path][filename] [/[W|B]] [/S] [/P] [/A[D|S|H|R|A]] [/O[N|E|S|D|G]]\n\n"
-		   "   [drive:][path][filename]\n"
-		   "   \tSpecifies drive, directory, and/or files to list.\n"
-		   "   /W\tUses wide list format.\n"
-		   "   /B\tUses bare format (no heading information or summary).\n"
-		   "   /S\tDisplays files in specified directory and all subdirectories.\n"
-		   "   /P\tPauses after each screenful of information.\n"
-		   "   /A\tDisplays all files and directories.\n"
-		   "   /AD\tDisplays all directories.\n"
-		   "   /AS\tDisplays files with system attributes.\n"
-		   "   /AH\tDisplays files with hidden attributes.\n"
-		   "   /AR\tDisplays files with read-only attributes.\n"
-		   "   /AA\tDisplays files with archive attributes.\n"
-		   "   /O\tList by files in sorted order.\n"
-		   "   /ON\tList files sorted by name (alphabetic).\n"
-		   "   /OE\tList files sorted by extension (alphabetic).\n"
-		   "   /OS\tList files sorted by size (smallest first).\n"
-		   "   /OD\tList files sorted by date (oldest first).\n"
-		   "   /OG\tList directories first, then files.\n"
-		   "   The \"-\" sign can be used in /A[D|S|H|R|A] and /O[N|E|S|D|G] commands,\n"
-		   "   meaning \"not\". For example, /A-D displays all files (not directories),\n"
-		   "   and /O-S lists files reversely sorted by size (biggest first).\n"
+	MSG_Add("SHELL_CMD_DIR_HELP_LONG","DIR [drive:][path][filename] [/[W|B]] [/S] [/P] [/A[D|H|S|R|A]] [/O[N|E|G|S|D]]\n\n"
+		   "  [drive:][path][filename]\n"
+		   "              Specifies drive, directory, and/or files to list.\n"
+		   "  /W          Uses wide list format.\n"
+		   "  /B          Uses bare format (no heading information or summary).\n"
+		   "  /S          Displays files in specified directory and all subdirectories.\n"
+		   "  /P          Pauses after each screenful of information.\n"
+		   "  /A          Displays files with specified attributes.\n"
+		   "  attributes   D  Directories                R  Read-only files\n"
+		   "               H  Hidden files               A  Files ready for archiving\n"
+		   "               S  System files               -  Prefix meaning not\n"
+		   "  /O          List by files in sorted order.\n"
+		   "  sortorder    N  By name (alphabetic)       S  By size (smallest first)\n"
+		   "               E  By extension (alphabetic)  D  By date & time (earlist first)\n"
+		   "               G  Group directories first    -  Prefix to reverse order\n\n"
+		   "Switches may be preset in the DIRCMD environment variable.  Override\n"
+		   "preset switches by prefixing any switch with - (hyphen)--for example, /-W.\n"
 		   );
 	MSG_Add("SHELL_CMD_ECHO_HELP","Displays messages, or turns command-echoing on or off.\n");
 	MSG_Add("SHELL_CMD_ECHO_HELP_LONG","  ECHO [ON | OFF]\n  ECHO [message]\n\nType ECHO without parameters to display the current echo setting.\n");
@@ -1175,8 +1170,8 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_LS_HELP_LONG", "LS [drive:][path][filename] [/A] [/L] [/P]\n\n"
 	        "  /A\tLists hidden and system files also.\n"
 	        "  /L\tLists names one per line.\n"
-		    "  /P\tPauses after each screenful of information.\n");
-	MSG_Add("SHELL_CMD_LS_PATH_ERR", "Cannot access: %s (no such file or directory)\n");
+		    "  /P\tPauses after each screenful of information.\n"
+			"  /Z\tDisplays short names even if LFN support is available.\n");
 	MSG_Add("SHELL_CMD_CHOICE_HELP","Waits for a keypress and sets ERRORLEVEL.\n");
 	MSG_Add("SHELL_CMD_CHOICE_HELP_LONG","CHOICE [/C:choices] [/N] [/S] text\n"
 	        "  /C[:]choices  -  Specifies allowable keys.  Default is: yn.\n"

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1157,7 +1157,11 @@ void SHELL_Init() {
 		   "  source\tSpecifies the file or files to be copied.\n"
 		   "  destination\tSpecifies the directory and/or filename for the new file(s).\n"
 		   "  /Y\t\tSuppresses prompting to confirm you want to overwrite an\n\t\texisting destination file.\n"
-		   "  /-Y\t\tCauses prompting to confirm you want to overwrite an\n\t\texisting destination file.\n");
+		   "  /-Y\t\tCauses prompting to confirm you want to overwrite an\n\t\texisting destination file.\n\n"
+		   "The switch /Y may be preset in the COPYCMD environment variable.\n"
+		   "This may be overridden with /-Y on the command line.\n\n"
+		   "To append files, specify a single file for destination, but multiple files\n"
+		   "for source (using wildcards or file1+file2+file3 format.\n");
 	MSG_Add("SHELL_CMD_CALL_HELP","Starts a batch file from within another batch file.\n");
 	MSG_Add("SHELL_CMD_CALL_HELP_LONG","CALL [drive:][path]filename [batch-parameters]\n\n"
 		   "batch-parameters   Specifies any command-line information required by\n"
@@ -1167,7 +1171,7 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_LOADHIGH_HELP","Loads a program into upper memory (requires XMS and UMB memory).\n");
 	MSG_Add("SHELL_CMD_LOADHIGH_HELP_LONG","LH\t\t[drive1:][path]filename [parameters]\nLOADHIGH\t[drive1:][path]filename [parameters]\n");
 	MSG_Add("SHELL_CMD_LS_HELP", "Lists directory contents.\n");
-	MSG_Add("SHELL_CMD_LS_HELP_LONG", "LS [drive:][path][filename] [/A] [/L] [/P]\n\n"
+	MSG_Add("SHELL_CMD_LS_HELP_LONG", "LS [drive:][path][filename] [/A] [/L] [/P] [/Z]\n\n"
 	        "  /A\tLists hidden and system files also.\n"
 	        "  /L\tLists names one per line.\n"
 		    "  /P\tPauses after each screenful of information.\n"

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1138,10 +1138,10 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_TYPE_HELP_LONG","TYPE [drive:][path][filename]\n");
 	MSG_Add("SHELL_CMD_REM_HELP","Adds comments in a batch file.\n");
 	MSG_Add("SHELL_CMD_REM_HELP_LONG","REM [comment]\n");
-	MSG_Add("SHELL_CMD_RENAME_HELP","Renames one or more files.\n");
-	MSG_Add("SHELL_CMD_RENAME_HELP_LONG","RENAME [drive:][path]filename1 filename2.\n"
-	        "REN [drive:][path]filename1 filename2.\n\n"
-	        "Note that you can not specify a new drive or path for your destination file.\n");
+	MSG_Add("SHELL_CMD_RENAME_HELP","Renames a file/directory or files.\n");
+	MSG_Add("SHELL_CMD_RENAME_HELP_LONG","RENAME [drive:][path][directoryname1 | filename1] [directoryname2 | filename2]\n"
+	        "REN [drive:][path][directoryname1 | filename1] [directoryname2 | filename2]\n\n"
+	        "Note that you can not specify a new drive or path for your destination.\n");
 	MSG_Add("SHELL_CMD_DELETE_HELP","Removes one or more files.\n");
 	MSG_Add("SHELL_CMD_DELETE_HELP_LONG","DEL [/P] [/F] [/Q] names\n"
 		   "ERASE [/P] [/F] [/Q] names\n\n"
@@ -1161,13 +1161,17 @@ void SHELL_Init() {
 		   "The switch /Y may be preset in the COPYCMD environment variable.\n"
 		   "This may be overridden with /-Y on the command line.\n\n"
 		   "To append files, specify a single file for destination, but multiple files\n"
-		   "for source (using wildcards or file1+file2+file3 format.\n");
+		   "for source (using wildcards or file1+file2+file3 format).\n");
 	MSG_Add("SHELL_CMD_CALL_HELP","Starts a batch file from within another batch file.\n");
 	MSG_Add("SHELL_CMD_CALL_HELP_LONG","CALL [drive:][path]filename [batch-parameters]\n\n"
 		   "batch-parameters   Specifies any command-line information required by\n"
 		   "                   the batch program.\n");
 	MSG_Add("SHELL_CMD_SUBST_HELP","Assigns an internal directory to a drive.\n");
-	MSG_Add("SHELL_CMD_SUBST_HELP_LONG","SUBST [drive1: [drive2:]path]\nSUBST drive1: /D\n");
+	MSG_Add("SHELL_CMD_SUBST_HELP_LONG","SUBST [drive1: [drive2:]path]\nSUBST drive1: /D\n\n"
+		   "  drive1:\tSpecifies a drive to which you want to assign a path.\n"
+		   "  [drive2:]path\tSpecifies a mounted local drive and path you want to assign to.\n"
+		   "  /D\t\tDeletes a mounted or substituted drive.\n\n"
+		   "Type SUBST with no parameters to display a list of mounted local drives.\n");
 	MSG_Add("SHELL_CMD_LOADHIGH_HELP","Loads a program into upper memory (requires XMS and UMB memory).\n");
 	MSG_Add("SHELL_CMD_LOADHIGH_HELP_LONG","LH\t\t[drive1:][path]filename [parameters]\nLOADHIGH\t[drive1:][path]filename [parameters]\n");
 	MSG_Add("SHELL_CMD_LS_HELP", "Lists directory contents.\n");


### PR DESCRIPTION
The "DIR /?" command will show the help message for DIR, but I noticed that it does not match the way that its help message is displayed in a real DOS system, so I fixed this. Now "DIR /?" will show the help message for DIR in a way much more similar to the real DOS counterpart.

Also, I was aware that the LS command as ported from dosbox-staging earlier did not support LFNs by default because that project does not support LFNs at this time. I did add limited LFN support earlier when porting it, but it was not complete. For the sake of completeness I decided to make further fix for this so that the LS command is now fully compatible with LFNs if it is enabled just like the other internal commands (but you can still use the /Z option to display 8.3 names instead even if LFN is available).

Tested to ensure it works.