### PR TITLE
Fixed ^G unexpected behavior in the shell and added help messages for commands

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,12 +1,16 @@
+DOSBox-X by joncampbell123
+
+Based on DOSBox by the DOSBox Team
+
 The DOSBox Team
 ---------------
 
 Sjoerd v.d. Berg <harekiet>
 Peter Veenstra <qbix79>
 Ulf Wohlers <finsterr>
-Tommy Frössman <fanskapet>
+Tommy FrÃ¶ssman <fanskapet>
 Dean Beeler <canadacow>
-Sebastian Strohhäcker <c2woody>
+Sebastian StrohhÃ¤cker <c2woody>
 Ralf Grillenberger <h-a-l-9000>
 
 nick_without_<> @ users.sourceforge.net

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 0.83.2
+  - Added help messages for some supported commands. (Wengier)
   - Added phone book support for the emulated modem. There is
     a new phonebookfile= option in the [serial] section. The
     phone book file entries need to be in the format of:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@
     phone book file entries need to be in the format of:
     "<dummy number> <hostname/ip:port>" e.g.
     5551234 cavebbs.homeip.net:23
+  - Implemented the missing EMS subfunctions 52h and 59h by
+    porting the patch that adds them (Wengier)
   - Fixed issues with the "config -wcd -all" command and other
     updates to the CONFIG command (Wengier)
   - Added [config] section in dosbox-x.conf to resemble DOS's

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
-DOSBox-X Manual (always use the latest version from [dosbox-x.com](http://dosbox-x.com))
+**README for DOSBox-X** (official website: [dosbox-x.com](http://dosbox-x.com))
+
+**Introdution**
+---------------
 
 DOSBox-X is a cross-platform DOS emulator based on the DOSBox project (www.dosbox.com)
 
+Like DOSBox, it emulates a PC necessary for running many MS-DOS games and applications that simply cannot be run on modern PCs and operating systems. However, while the main focus of DOSBox is for running DOS games, DOSBox-X goes much further than this. Started as a fork of the DOSBox project, it retains compatibility with the wide base of DOS games and DOS gaming DOSBox was designed for. But it is also a platform for running DOS applications, including emulating the environments to run Windows 3.x, 9x and ME and software written for those versions of Windows.
+
 For more information about DOSBox-X, please read the user guide in the [DOSBox-X Wiki](https://github.com/joncampbell123/dosbox-x/wiki).
+
+(Please always use the latest version from the [Releases page](https://github.com/joncampbell123/dosbox-x/releases))
 
 This project has a Code of Conduct in [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), please read it.
 
 I am rewriting this README, and new information will be added over time --J.C.
-
-
 
 How to compile DOSBox-X in Ubuntu (kapper1224)
 ----------------------------------------------

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -883,7 +883,7 @@ bool DOS_UnlinkFile(char const * const name) {
 		std::vector<std::string> cdirs;
 		cdirs.clear();
 		strcpy(spath, dir);
-		if (strchr(dir,'\"')) DOS_GetSFNPath(dir, spath, false);
+		if (!DOS_GetSFNPath(dir, spath, false)) strcpy(spath, dir);
 		if (!strlen(spath)||spath[strlen(spath)-1]!='\\') strcat(spath, "\\");
 		std::string pfull=std::string(spath)+std::string(pattern);
 		int fbak=lfn_filefind_handle;

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -989,6 +989,10 @@ void GUI_Run(bool pressed);
 class SHOWGUI : public Program {
 public:
     void Run(void) {
+        if (cmd->FindExist("-?", false) || cmd->FindExist("/?", false)) {
+			WriteOut("Starts DOSBox-X's configuration GUI.\n\nSHOWGUI\n");
+            return;
+		}
         GUI_Run(false); /* So that I don't have to run the keymapper on every setup of mine just to get the GUI --J.C */
     }
 };
@@ -2884,6 +2888,10 @@ public:
 
 void RESCAN::Run(void) 
 {
+	if (cmd->FindExist("-?", false) || cmd->FindExist("/?", false)) {
+		WriteOut("Clears the caches of a mounted drive.\n\nRESCAN [/A]\nRESCAN [drive:]\n");
+		return;
+	}
     bool all = false;
     
     Bit8u drive = DOS_GetDefaultDrive();
@@ -2986,6 +2994,10 @@ public:
     }
 
     void Run(void) {
+		if (cmd->FindExist("-?", false) || cmd->FindExist("/?", false)) {
+			WriteOut("A full-screen introduction to DOSBox-X.\n\nINTRO [CDROM|MOUNT|USAGE]\n");
+			return;
+		}
         std::string menuname = "BASIC"; // default
         /* Only run if called from the first shell (Xcom TFTD runs any intro file in the path) */
         if(DOS_PSP(dos.psp()).GetParent() != DOS_PSP(DOS_PSP(dos.psp()).GetParent()).GetParent()) return;
@@ -4745,7 +4757,7 @@ void KEYB::Run(void) {
                     WriteOut(MSG_Get("PROGRAM_KEYB_NOERROR"),temp_line.c_str(),dos.loaded_codepage);
                     break;
                 case KEYB_FILENOTFOUND:
-                    WriteOut(MSG_Get("PROGRAM_KEYB_FILENOTFOUND"),temp_line.c_str());
+                    if (temp_line!="/?"&&temp_line!="-?") WriteOut(MSG_Get("PROGRAM_KEYB_FILENOTFOUND"),temp_line.c_str());
                     WriteOut(MSG_Get("PROGRAM_KEYB_SHOWHELP"));
                     break;
                 case KEYB_INVALIDFILE:
@@ -4869,9 +4881,14 @@ void A20GATE_ProgramStart(Program * * make);
 void PC98UTIL_ProgramStart(Program * * make);
 void VESAMOED_ProgramStart(Program * * make);
 
+#if defined C_DEBUG
 class NMITEST : public Program {
 public:
     void Run(void) {
+        if (cmd->FindExist("-?", false) || cmd->FindExist("/?", false)) {
+			WriteOut("Generates a non-maskable interrupt (NMI).\n\nNMITEST\n\nNote: This is a debugging tool to test if the interrupt handler works properly.\n");
+            return;
+		}
         CPU_Raise_NMI();
     }
 };
@@ -4879,6 +4896,7 @@ public:
 static void NMITEST_ProgramStart(Program * * make) {
     *make=new NMITEST;
 }
+#endif
 
 class CAPMOUSE : public Program
 {
@@ -4905,11 +4923,10 @@ public:
             break;
         case 0:
         default:
-            WriteOut("Mouse capture/release.\n\n");
-            WriteOut("CAPMOUSE /[?|C|R]\n");
-            WriteOut("  /? help\n");
-            WriteOut("  /C capture mouse\n");
-            WriteOut("  /R release mouse\n");
+            WriteOut("Captures or releases the mouse inside DOSBox-X.\n\n");
+            WriteOut("CAPMOUSE [/C|/R]\n");
+            WriteOut("  /C Capture the mouse\n");
+            WriteOut("  /R Release the mouse\n");
             return;
         }
 
@@ -5319,7 +5336,7 @@ void DOS_SetupPrograms(void) {
     MSG_Add("PROGRAM_BOOT_CART_LIST_CMDS","Available PCjr cartridge commandos:%s");
     MSG_Add("PROGRAM_BOOT_CART_NO_CMDS","No PCjr cartridge commandos found");
 
-    MSG_Add("PROGRAM_LOADROM_HELP","LOADROM ROM_file\n");
+    MSG_Add("PROGRAM_LOADROM_HELP","Loads the specified ROM image file.\n\nLOADROM ROM_file\n");
     MSG_Add("PROGRAM_LOADROM_HELP","Must specify ROM file to load.\n");
     MSG_Add("PROGRAM_LOADROM_SPECIFY_FILE","Must specify ROM file to load.\n");
     MSG_Add("PROGRAM_LOADROM_CANT_OPEN","ROM file not accessible.\n");
@@ -5380,7 +5397,7 @@ void DOS_SetupPrograms(void) {
         " -t hdd              Image type is hard disk; VHD and HDI files are supported\n"
         " -t ram              Image type is RAM drive\n"
         " -fs iso             File system is ISO 9660\n"
-        " -fs fat             File system is FAT; FAT12 and FAT16 are supported\n"
+        " -fs fat             File system is FAT; FAT12, FAT16 and FAT32 are supported\n"
         " -fs none            Do not detect file system\n"
         " -reservecyl #       Report # number of cylinders less than actual in BIOS\n"
         " -ide 1m|1s|2m|2s    Specifies the controller to mount drive\n"
@@ -5433,7 +5450,7 @@ void DOS_SetupPrograms(void) {
 
     MSG_Add("PROGRAM_KEYB_INFO","Codepage %i has been loaded\n");
     MSG_Add("PROGRAM_KEYB_INFO_LAYOUT","Codepage %i has been loaded for layout %s\n");
-    MSG_Add("PROGRAM_KEYB_SHOWHELP",
+    MSG_Add("PROGRAM_KEYB_SHOWHELP","Configures a keyboard for a specific language.\n\n"
         "\033[32;1mKEYB\033[0m [keyboard layout ID[ codepage number[ codepage file]]]\n\n"
         "Some examples:\n"
         "  \033[32;1mKEYB\033[0m: Display currently loaded codepage.\n"
@@ -5445,7 +5462,7 @@ void DOS_SetupPrograms(void) {
     MSG_Add("PROGRAM_KEYB_INVALIDFILE","Keyboard file %s invalid\n");
     MSG_Add("PROGRAM_KEYB_LAYOUTNOTFOUND","No layout in %s for codepage %i\n");
     MSG_Add("PROGRAM_KEYB_INVCPFILE","None or invalid codepage file for layout %s\n\n");
-    MSG_Add("PROGRAM_MODE_USAGE",
+    MSG_Add("PROGRAM_MODE_USAGE","Configures system devices.\n\n"
             "\033[34;1mMODE\033[0m display-type       :display-type codes are "
             "\033[1mCO80\033[0m, \033[1mBW80\033[0m, \033[1mCO40\033[0m, \033[1mBW40\033[0m, or \033[1mMONO\033[0m\n"
             "\033[34;1mMODE CON RATE=\033[0mr \033[34;1mDELAY=\033[0md :typematic rates, r=1-32 (32=fastest), d=1-4 (1=lowest)\n");
@@ -5479,7 +5496,9 @@ void DOS_SetupPrograms(void) {
 
     PROGRAMS_MakeFile("A20GATE.COM",A20GATE_ProgramStart);
     PROGRAMS_MakeFile("SHOWGUI.COM",SHOWGUI_ProgramStart);
+#if defined C_DEBUG
     PROGRAMS_MakeFile("NMITEST.COM",NMITEST_ProgramStart);
+#endif
     PROGRAMS_MakeFile("RE-DOS.COM",REDOS_ProgramStart);
 
     if (IS_VGA_ARCH && svgaCard != SVGA_None)

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2889,7 +2889,7 @@ public:
 void RESCAN::Run(void) 
 {
 	if (cmd->FindExist("-?", false) || cmd->FindExist("/?", false)) {
-		WriteOut("Clears the caches of a mounted drive.\n\nRESCAN [/A]\nRESCAN [drive:]\n");
+		WriteOut("Clears the caches of a mounted drive.\n\nRESCAN [/A]\nRESCAN [drive:]\n\n  [/A]\t\tRescan all drives\n  [drive:]\tThe drive to rescan\n\nType RESCAN with no parameters to rescan the current drive.\n");
 		return;
 	}
     bool all = false;
@@ -4949,7 +4949,7 @@ class LABEL : public Program
 {
 public:
     void Help() {
-        WriteOut("Creates, changes, or deletes the volume label of a drive.\n\nLABEL [drive:][label]\n");
+        WriteOut("Creates, changes, or deletes the volume label of a drive.\n\nLABEL [drive:][label]\n\n  [drive:]\tSpecifies the drive letter\n  [label]\tSpecifies the volume label\n");
     }
 	void Run() override
     {

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -1669,6 +1669,7 @@ public:
             WriteOut("Disabling A20 gate\n");
         }
         else {
+			WriteOut("Turns on/off or changes the A20 gate mode.\n\n");
             WriteOut("A20GATE SET [off | off_fake | on | on_fake | mask | fast]\n");
             WriteOut("A20GATE [ON | OFF]\n");
         }

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -969,6 +969,10 @@ public:
     }
 
     void Run(void) {
+        if (cmd->FindExist("-?", false) || cmd->FindExist("/?", false)) {
+			WriteOut("Displays or changes the current sound levels.\n\nMIXER [option]\n");
+            return;
+		}
         if(cmd->FindExist("/LISTMIDI")) {
             ListMidi();
             return;

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -486,15 +486,15 @@ void VGA_SetCGA4Table(Bit8u val0,Bit8u val1,Bit8u val2,Bit8u val3) {
 class VFRCRATE : public Program {
 public:
     void Run(void) {
-        WriteOut("Video refresh rate.\n\n");
+        WriteOut("Locks or unlocks the video refresh rate.\n\n");
         if (cmd->FindExist("/?", false)) {
 			WriteOut("VFRCRATE [SET [OFF|PAL|NTSC|rate]\n");
-			WriteOut("  SET OFF   unlock\n");
-			WriteOut("  SET PAL   lock to PAL frame rate\n");
-			WriteOut("  SET NTSC  lock to NTSC frame rate\n");
-			WriteOut("  SET rate  lock to integer frame rate, e.g. 15\n");
-			WriteOut("  SET rate  lock to decimal frame rate, e.g. 29.97\n");
-			WriteOut("  SET rate  lock to fractional frame rate, e.g. 60000/1001\n");
+			WriteOut("  SET OFF   Unlock the refresh rate\n");
+			WriteOut("  SET PAL   Lock to PAL frame rate\n");
+			WriteOut("  SET NTSC  Lock to NTSC frame rate\n");
+			WriteOut("  SET rate  Lock to integer frame rate, e.g. 15\n");
+			WriteOut("  SET rate  Lock to decimal frame rate, e.g. 29.97\n");
+			WriteOut("  SET rate  Lock to fractional frame rate, e.g. 60000/1001\n");
 			return;
 		}
         if (cmd->FindString("SET",temp_line,false)) {

--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -774,6 +774,16 @@ static void INT10_TeletypeOutputAttr(Bit8u chr,Bit8u attr,bool useattr,Bit8u pag
     Bit8u cur_row=CURSOR_POS_ROW(page);
     Bit8u cur_col=CURSOR_POS_COL(page);
     switch (chr) {
+    case 8:
+        if(cur_col>0) cur_col--;
+        break;
+    case '\r':
+        cur_col=0;
+        break;
+    case '\n':
+//      cur_col=0; //Seems to break an old chess game
+        cur_row++;
+        break;
     case 7: /* Beep */
         // Prepare PIT counter 2 for ~900 Hz square wave
         IO_Write(0x43, 0xb6);
@@ -787,18 +797,7 @@ static void INT10_TeletypeOutputAttr(Bit8u chr,Bit8u attr,bool useattr,Bit8u pag
         while ((PIC_FullIndex() - start) < 333.0) CALLBACK_Idle();
         // Speaker off
         IO_Write(0x61, IO_Read(0x61) & ~0x3);
-        // No change in position
-        return;
-    case 8:
-        if(cur_col>0) cur_col--;
-        break;
-    case '\r':
-        cur_col=0;
-        break;
-    case '\n':
-//      cur_col=0; //Seems to break an old chess game
-        cur_row++;
-        break;
+        chr=' ';
     default:
         /* Draw the actual Character */
         WriteChar(cur_col,cur_row,page,chr,attr,useattr);

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -2097,7 +2097,7 @@ public:
 			got_opt=true;
             if (arg == "?" || arg == "help") {
                 doHelp();
-                break;
+                return;
             }
             else if (arg == "mode") {
                 cmd->NextOptArgv(/*&*/tmp);

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -561,7 +561,7 @@ void DOS_Shell::Run(void) {
 
     }
     else {
-        WriteOut(optK?"\n":"DOSBox-X command shell %s %s\n\n",VERSION,UPDATED_STR);
+        WriteOut(optK?"\n":"DOSBox-X version %s command shell\nBuild date: %s\n\n",VERSION,UPDATED_STR);
     }
 
 	if (cmd->FindString("/INIT",line,true)) {
@@ -1091,7 +1091,7 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_ECHO_HELP_LONG","  ECHO [ON | OFF]\n  ECHO [message]\n\nType ECHO without parameters to display the current echo setting.\n");
 	MSG_Add("SHELL_CMD_EXIT_HELP","Exits from the command shell.\n");
 	MSG_Add("SHELL_CMD_EXIT_HELP_LONG","EXIT\n");
-	MSG_Add("SHELL_CMD_HELP_HELP","Shows command help.\n");
+	MSG_Add("SHELL_CMD_HELP_HELP","Shows DOSBox-X command help.\n");
 	MSG_Add("SHELL_CMD_HELP_HELP_LONG","HELP [/A or /ALL]\nHELP [command]\n\n"
 		    "   /A or /ALL\tLists all supported internal commands.\n\n"
 			"Note: HELP will not list external commands such as MOUNT and IMGMOUNT.\n");
@@ -1236,8 +1236,6 @@ void SHELL_Init() {
 		   "  $V   DOS version number\n"
 		   "  $_   Carriage return and linefeed\n"
 		   "  $$   $ (dollar sign)\n");
-	MSG_Add("SHELL_CMD_LABEL_HELP","Creates or changes the volume label of a disk.\n");
-	MSG_Add("SHELL_CMD_LABEL_HELP_LONG","LABEL [volume]\n\n\tvolume\t\tSpecifies the drive letter.\n");
     MSG_Add("SHELL_CMD_ALIAS_HELP", "Defines or displays aliases.\n");
     MSG_Add("SHELL_CMD_ALIAS_HELP_LONG", "ALIAS [name[=value] ... ]\n\nType ALIAS without parameters to display the list of aliases in the form:\n`ALIAS NAME = VALUE'\n");
     MSG_Add("SHELL_CMD_CTTY_HELP","Changes the terminal device used to control the system.\n");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -561,7 +561,7 @@ void DOS_Shell::Run(void) {
 
     }
     else {
-        WriteOut(optK?"\n":"DOSBox-X Version %s (%s) Command Shell\nBased on DOSBox by the DOSBox Team, 2011-2020\n\n",VERSION,SDL_STRING);
+        WriteOut(optK?"\n":"DOSBox-X command shell [Version %s %s]\nBased on DOSBox by the DOSBox Team, 2011-2020\n\n",VERSION,SDL_STRING);
     }
 
 	if (cmd->FindString("/INIT",line,true)) {

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -561,7 +561,7 @@ void DOS_Shell::Run(void) {
 
     }
     else {
-        WriteOut(optK?"\n":"DOSBox-X version %s command shell\nBuild date: %s\n\n",VERSION,UPDATED_STR);
+        WriteOut(optK?"\n":"DOSBox-X Version %s (%s) Command Shell\nBased on DOSBox by the DOSBox Team, 2011-2020\n\n",VERSION,SDL_STRING);
     }
 
 	if (cmd->FindString("/INIT",line,true)) {
@@ -1204,7 +1204,7 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_VERIFY_HELP","Controls whether to verify files are written correctly to a disk.\n");
 	MSG_Add("SHELL_CMD_VERIFY_HELP_LONG","VERIFY [ON | OFF]\n\nType VERIFY without a parameter to display the current VERIFY setting.\n");
 	MSG_Add("SHELL_CMD_VER_HELP","Displays or sets DOSBox-X's reported DOS version.\n");
-	MSG_Add("SHELL_CMD_VER_HELP_LONG","VER\n" 
+	MSG_Add("SHELL_CMD_VER_HELP_LONG","VER [/R]\n" 
 		   "VER SET [major.minor] or VER SET [major minor]\n\n" 
 		   "  [major.minor] or [major minor]  Set the reported DOS version.\n\n"
 		   "  Example: \"VER SET 6.0\" or \"VER SET 7.1\" for DOS 6.0 or 7.1 respectively.\n"

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -38,6 +38,7 @@
 #include <cstdlib>
 #include <vector>
 #include <string>
+#include "build_timestamp.h"
 
 #if defined(_MSC_VER)
 # pragma warning(disable:4244) /* const fmath::local::uint64_t to double possible loss of data */
@@ -2842,7 +2843,10 @@ void DOS_Shell::CMD_VER(char *args) {
 			dos.version.minor = (Bit8u)(atoi(args));
 		}
 		if (enablelfn != -2) uselfn = enablelfn==1 || (enablelfn == -1 && dos.version.major>6);
-	} else WriteOut(MSG_Get("SHELL_CMD_VER_VER"),VERSION,SDL_STRING,dos.version.major,dos.version.minor);
+	} else {
+		WriteOut(MSG_Get("SHELL_CMD_VER_VER"),VERSION,SDL_STRING,dos.version.major,dos.version.minor);
+		if (optR) WriteOut("DOSBox-X build date and time: %s\n",UPDATED_STR);
+	}
 }
 
 void DOS_Shell::CMD_VOL(char *args){

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -613,8 +613,8 @@ void DOS_Shell::CMD_HELP(char * args){
 		cmd_index++;
 	}
 	if (*args&&!show) {
-		char * arg1=StripArg(args);
-		DoCommand((char *)(std::string(arg1)+" /?").c_str());
+		std::string argc=std::string(StripArg(args));
+		if (argc!="") DoCommand((char *)(argc+(argc=="DOS4GW"||argc=="DOS32A"?"":" /?")).c_str());
 	}
 }
 
@@ -1557,9 +1557,7 @@ void DOS_Shell::CMD_LS(char *args) {
 				WriteOut("\033[34;1m%-*s\033[0m", max[w_count % col], name.c_str());
 		} else {
 			if (!uselfn||optZ) lowcase(name);
-			const bool is_executable = !strcasecmp(name.substr(name.length()-4).c_str(), ".exe") ||
-			                           !strcasecmp(name.substr(name.length()-4).c_str(), ".com") ||
-			                           !strcasecmp(name.substr(name.length()-4).c_str(), ".bat");
+			const bool is_executable = name.length()>4 && (!strcasecmp(name.substr(name.length()-4).c_str(), ".exe") || !strcasecmp(name.substr(name.length()-4).c_str(), ".com") || !strcasecmp(name.substr(name.length()-4).c_str(), ".bat"));
 			if (col==1) {
 				WriteOut(is_executable?"\033[32;1m%s\033[0m\n":"%s\n", name.c_str());
 				p_count++;

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -3334,6 +3334,7 @@ void DOS_Shell::CMD_DXCAPTURE(char * args) {
 		return;
 	}
 
+    args=(char *)argv.c_str();
     if (ScanCMDBool(args,"V"))
         cap_video = true;
     if (ScanCMDBool(args,"-V"))
@@ -3359,7 +3360,7 @@ void DOS_Shell::CMD_DXCAPTURE(char * args) {
     if (cap_mtaudio)
         CAPTURE_StartMTWave();
 
-    DoCommand((char *)argv.c_str());
+    DoCommand(args);
 
     if (post_exit_delay_ms > 0) {
         LOG_MSG("Pausing for post exit delay (%.3f seconds)",(double)post_exit_delay_ms / 1000);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -3327,7 +3327,6 @@ void DOS_Shell::CMD_DXCAPTURE(char * args) {
     bool cap_mtaudio = false;
     unsigned long post_exit_delay_ms = 3000; /* 3 sec */
 
-
     if (!strcmp(args,"-?")) {
 		args[0]='/';
 		HELP("DXCAPTURE");
@@ -3335,20 +3334,27 @@ void DOS_Shell::CMD_DXCAPTURE(char * args) {
 	}
 
     args=(char *)argv.c_str();
-    if (ScanCMDBool(args,"V"))
-        cap_video = true;
-    if (ScanCMDBool(args,"-V"))
-        cap_video = false;
-
-    if (ScanCMDBool(args,"A"))
-        cap_audio = true;
-    if (ScanCMDBool(args,"-A"))
-        cap_audio = false;
-
-    if (ScanCMDBool(args,"M"))
-        cap_mtaudio = true;
-    if (ScanCMDBool(args,"-M"))
-        cap_mtaudio = false;
+    char *arg1;
+    while (strlen(args)&&args[0]=='/') {
+		arg1=StripArg(args);
+		upcase(arg1);
+		if (!(strcmp(arg1,"/V")))
+			cap_video = true;
+		else if (!(strcmp(arg1,"/-V")))
+			cap_video = false;
+		else if (!(strcmp(arg1,"/A")))
+			cap_audio = true;
+		else if (!(strcmp(arg1,"/-A")))
+			cap_audio = false;
+		else if (!(strcmp(arg1,"/M")))
+			cap_mtaudio = true;
+		else if (!(strcmp(arg1,"/-M")))
+			cap_mtaudio = false;
+		else {
+			WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"),arg1);
+			return;
+		}
+    }
 
     if (!cap_video && !cap_audio && !cap_mtaudio)
         cap_video = true;

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -564,7 +564,15 @@ continue_1:
 				WriteOut("%c\r\n", c);
 				if (c=='N') {lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;res = DOS_FindNext();continue;}
 			}
-			if (!strlen(full)||!DOS_UnlinkFile(((uselfn||strchr(full, ' ')?(full[0]!='"'?"\"":""):"")+std::string(full)+(uselfn||strchr(full, ' ')?(full[strlen(full)-1]!='"'?"\"":""):"")).c_str())) WriteOut(MSG_Get("SHELL_CMD_DEL_ERROR"),uselfn?sfull:full);
+			if (strlen(full)) {
+				std::string pfull=(uselfn||strchr(full, ' ')?(full[0]!='"'?"\"":""):"")+std::string(full)+(uselfn||strchr(full, ' ')?(full[strlen(full)-1]!='"'?"\"":""):"");
+				bool reset=false;
+				if (optF && (attr & DOS_ATTR_READ_ONLY)&&DOS_SetFileAttr(pfull.c_str(), attr & ~DOS_ATTR_READ_ONLY)) reset=true;
+				if (!DOS_UnlinkFile(pfull.c_str())) {
+					if (optF&&reset) DOS_SetFileAttr(pfull.c_str(), attr);
+					WriteOut(MSG_Get("SHELL_CMD_DEL_ERROR"),uselfn?sfull:full);
+				}
+			} else WriteOut(MSG_Get("SHELL_CMD_DEL_ERROR"),uselfn?sfull:full);
 		}
 		res=DOS_FindNext();
 	}

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -515,7 +515,6 @@ continue_1:
 		strcpy(path, "");
 		strcpy(pattern, full);
 	}
-	LOG_MSG("args %s full %s\n", args, full);
 	int k=0;
 	for (int i=0;i<(int)strlen(pattern);i++)
 		if (pattern[i]!='\"')
@@ -1264,15 +1263,15 @@ void DOS_Shell::CMD_DIR(char * args) {
 	bool optB=ScanCMDBool(args,"B");
 	if (ScanCMDBool(args,"-B")) optB=false;
 	bool optA=ScanCMDBool(args,"A");
-	bool optAD=ScanCMDBool(args,"AD");
+	bool optAD=ScanCMDBool(args,"AD")||ScanCMDBool(args,"A:D");
 	bool optAminusD=ScanCMDBool(args,"A-D");
-	bool optAS=ScanCMDBool(args,"AS");
+	bool optAS=ScanCMDBool(args,"AS")||ScanCMDBool(args,"A:S");
 	bool optAminusS=ScanCMDBool(args,"A-S");
-	bool optAH=ScanCMDBool(args,"AH");
+	bool optAH=ScanCMDBool(args,"AH")||ScanCMDBool(args,"A:H");
 	bool optAminusH=ScanCMDBool(args,"A-H");
-	bool optAR=ScanCMDBool(args,"AR");
+	bool optAR=ScanCMDBool(args,"AR")||ScanCMDBool(args,"A:R");
 	bool optAminusR=ScanCMDBool(args,"A-R");
-	bool optAA=ScanCMDBool(args,"AA");
+	bool optAA=ScanCMDBool(args,"AA")||ScanCMDBool(args,"A:A");
 	bool optAminusA=ScanCMDBool(args,"A-A");
 	if (ScanCMDBool(args,"-A")) {
 		optA = false;
@@ -1289,27 +1288,27 @@ void DOS_Shell::CMD_DIR(char * args) {
 	}
 	// Sorting flags
 	bool reverseSort = false;
-	bool optON=ScanCMDBool(args,"ON");
+	bool optON=ScanCMDBool(args,"ON")||ScanCMDBool(args,"O:N");
 	if (ScanCMDBool(args,"O-N")) {
 		optON = true;
 		reverseSort = true;
 	}
-	bool optOD=ScanCMDBool(args,"OD");
+	bool optOD=ScanCMDBool(args,"OD")||ScanCMDBool(args,"O:D");
 	if (ScanCMDBool(args,"O-D")) {
 		optOD = true;
 		reverseSort = true;
 	}
-	bool optOE=ScanCMDBool(args,"OE");
+	bool optOE=ScanCMDBool(args,"OE")||ScanCMDBool(args,"O:E");
 	if (ScanCMDBool(args,"O-E")) {
 		optOE = true;
 		reverseSort = true;
 	}
-	bool optOS=ScanCMDBool(args,"OS");
+	bool optOS=ScanCMDBool(args,"OS")||ScanCMDBool(args,"O:S");
 	if (ScanCMDBool(args,"O-S")) {
 		optOS = true;
 		reverseSort = true;
 	}
-	bool optOG=ScanCMDBool(args,"OG");
+	bool optOG=ScanCMDBool(args,"OG")||ScanCMDBool(args,"O:G");
 	if (ScanCMDBool(args,"O-G")) {
 		optOG = true;
 		reverseSort = true;

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -3117,16 +3117,18 @@ void DOS_Shell::CMD_ADDKEY(char * args){
 bool debugger_break_on_exec = false;
 
 void DOS_Shell::CMD_DEBUGBOX(char * args) {
+    while (*args == ' ') args++;
+	std::string argv=std::string(args);
+	args=StripArg(args);
 	HELP("DEBUGBOX");
     /* TODO: The command as originally taken from DOSBox SVN supported a /NOMOUSE option to remove the INT 33h vector */
     debugger_break_on_exec = true;
-    while (*args == ' ') args++;
     if (!strcmp(args,"-?")) {
 		args[0]='/';
 		HELP("DEBUGBOX");
 		return;
 	}
-    DoCommand(args);
+    DoCommand((char *)argv.c_str());
     debugger_break_on_exec = false;
 }
 #endif
@@ -3316,13 +3318,15 @@ void CAPTURE_StopMTWave(void);
 //              The command name is chosen not to conform to the 8.3 pattern
 //              on purpose to avoid conflicts with any existing DOS applications.
 void DOS_Shell::CMD_DXCAPTURE(char * args) {
+    while (*args == ' ') args++;
+	std::string argv=std::string(args);
+	args=StripArg(args);
 	HELP("DXCAPTURE");
     bool cap_video = false;
     bool cap_audio = false;
     bool cap_mtaudio = false;
     unsigned long post_exit_delay_ms = 3000; /* 3 sec */
 
-    while (*args == ' ') args++;
 
     if (!strcmp(args,"-?")) {
 		args[0]='/';
@@ -3355,7 +3359,7 @@ void DOS_Shell::CMD_DXCAPTURE(char * args) {
     if (cap_mtaudio)
         CAPTURE_StartMTWave();
 
-    DoCommand(args);
+    DoCommand((char *)argv.c_str());
 
     if (post_exit_delay_ms > 0) {
         LOG_MSG("Pausing for post exit delay (%.3f seconds)",(double)post_exit_delay_ms / 1000);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -522,7 +522,7 @@ continue_1:
 	pattern[k]=0;
 	strcpy(spath, path);
 	if (strchr(args,'\"')||uselfn) {
-		DOS_GetSFNPath(("\""+std::string(path)+"\\").c_str(), spath, false);
+		if (!DOS_GetSFNPath(("\""+std::string(path)+"\\").c_str(), spath, false)) strcpy(spath, path);
 		if (!strlen(spath)||spath[strlen(spath)-1]!='\\') strcat(spath, "\\");
 	}
 	std::string pfull=std::string(spath)+std::string(pattern);
@@ -709,7 +709,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 	pattern[k]=0;
 	strcpy(spath, path);
 	if (strchr(arg1,'\"')||uselfn) {
-		DOS_GetSFNPath(("\""+std::string(path)+"\\").c_str(), spath, false);
+		if (!DOS_GetSFNPath(("\""+std::string(path)+"\\").c_str(), spath, false)) strcpy(spath, path);
 		if (!strlen(spath)||spath[strlen(spath)-1]!='\\') strcat(spath, "\\");
 	}
 	RealPt save_dta=dos.dta();
@@ -2092,7 +2092,7 @@ void DOS_Shell::CMD_IF(char * args) {
 			pattern[k]=0;
 			strcpy(spath, path);
 			if (strchr(word,'\"')||uselfn) {
-				DOS_GetSFNPath(("\""+std::string(path)+"\\").c_str(), spath, false);
+				if (!DOS_GetSFNPath(("\""+std::string(path)+"\\").c_str(), spath, false)) strcpy(spath, path);
 				if (!strlen(spath)||spath[strlen(spath)-1]!='\\') strcat(spath, "\\");
 			}
 			RealPt save_dta=dos.dta();
@@ -3227,7 +3227,7 @@ void DOS_Shell::CMD_FOR(char *args) {
 			}
 			strcpy(spath, path);
 			if (strchr(fp,'\"')||uselfn) {
-				DOS_GetSFNPath(("\""+std::string(path)+"\\").c_str(), spath, false);
+				if (!DOS_GetSFNPath(("\""+std::string(path)+"\\").c_str(), spath, false)) strcpy(spath, path);
 				if (!strlen(spath)||spath[strlen(spath)-1]!='\\') strcat(spath, "\\");
 				int k=0;
 				for (int i=0;i<(int)strlen(path);i++)

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -2845,7 +2845,7 @@ void DOS_Shell::CMD_VER(char *args) {
 		if (enablelfn != -2) uselfn = enablelfn==1 || (enablelfn == -1 && dos.version.major>6);
 	} else {
 		WriteOut(MSG_Get("SHELL_CMD_VER_VER"),VERSION,SDL_STRING,dos.version.major,dos.version.minor);
-		if (optR) WriteOut("DOSBox-X build date and time: %s\n",UPDATED_STR);
+		if (optR) WriteOut("DOSBox-X's build date and time: %s\n",UPDATED_STR);
 	}
 }
 

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -545,7 +545,7 @@ continue_1:
 	lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
 	while (res) {
 		dta.GetResult(name,lname,size,date,time,attr);
-		if (!optF && (attr & DOS_ATTR_READ_ONLY)) {
+		if (!optF && (attr & DOS_ATTR_READ_ONLY) && !(attr & DOS_ATTR_DIRECTORY)) {
 			exist=true;
 			strcpy(end,name);
 			strcpy(lend,lname);

--- a/windows-installer/setup_preamble.txt
+++ b/windows-installer/setup_preamble.txt
@@ -1,5 +1,7 @@
 Welcome to DOSBox-X, a cross-platform DOS emulater based on the DOSBox project.
 
+Like DOSBox, it emulates a PC necessary for running many MS-DOS games and applications that simply cannot be run on modern PCs and operating systems. However, while the main focus of DOSBox is for running DOS games, DOSBox-X goes much further than this. Started as a fork of the DOSBox project, it retains compatibility with the wide base of DOS games and DOS gaming DOSBox was designed for. But it is also a platform for running DOS applications, including emulating the environments to run Windows 3.x, 9x and ME and software written for those versions of Windows.
+
 Note:
 
 Due to the way of how Windows works, access to the 'Program Files' folder requires administrative permissions. Unless you have specific reasons, we recommend that you install DOSBox-X in a different folder that does not require administrative permissions.


### PR DESCRIPTION
I noticed that the ^G character (beep) can cause unexpected behavior in the command shell: it will not move the cursor by itself, but if you later press keys such as ESC and BackSpace to delete the entire input line, then the command prompt (e.g. Z:\\>) can be deleted as well. So I fixed this by moving the cursor filled with a white space when the ^G is pressed. As a result, keys such as ESC and BackSpace will no longer delete the command prompt in such case, and ^G will still function properly.

Also, I added help messages for some commands in the Z: drive (such as MIXER and RESCAN). So "command /?" will show the help messages for these commands.