### PR TITLE
Add COUNTRY command for country-specific date & time formats

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.83.3
+  - Added COUNTRY command to set country code for country-
+    specific date and time formats. (Wengier)
   - DOS 440Dh IOCTL function 67h (get access flag) added to
     allow FDISK.EXE to determine FAT filesystem type.
   - Unknown DOS 440Dh IOCTLs warnings now indicate whether
@@ -6,19 +8,18 @@
   - S3 VESA BIOS mode number for 1024x768 32bpp changed to
     avoid conflict with Windows 95 S3 driver and 800x600
     16bpp mode.
-  - FAT driver no longer mounts FAT32 volumes unless dosver
-    is 7.10 or higher at startup to mimic MS-DOS behavior.
-  - FAT driver no longer mounts FAT16B LBA volumes unless
-    dosver is 7.0 or higher at startup to mimic MS-DOS
-    behavior.
+  - FAT driver no longer mounts FAT32 volumes unless the
+    DOS version is 7.1 or higher, and it no longer mounts
+    FAT16B LBA volumes unless the DOS version is 7.0 or
+    higher. These are to mimic the MS-DOS behavior.
   - Fixed FAT driver not to attempt to mount partitions that
     have nothing to do with the FAT filesystem (such as
-    type 0Dh and extended LBA partition tables).
+    type 0Dh and extended LBA partition tables). Also fixed
+    the FAT driver to not assume partition start sector 63
+    if it cannot identify a partition to use.
   - Added code to FAT driver to identify telltale pattern
     left by Microsoft FDISK when a partition is created (but
     not yet formatted) and reject.
-  - Fixed FAT driver to not assume partition start sector 63
-    if it cannot identify a partition to use.
 0.83.2
   - Added help messages for some supported commands. (Wengier)
   - Added phone book support for the emulated modem. There is

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 **README for DOSBox-X** (official website: [dosbox-x.com](http://dosbox-x.com))
 
-**Introdution**
+**Introduction to DOSBox-X**
 ---------------
 
 DOSBox-X is a cross-platform DOS emulator based on the DOSBox project (www.dosbox.com)
@@ -9,7 +9,7 @@ Like DOSBox, it emulates a PC necessary for running many MS-DOS games and applic
 
 For more information about DOSBox-X, please read the user guide in the [DOSBox-X Wiki](https://github.com/joncampbell123/dosbox-x/wiki).
 
-(Please always use the latest version from the [Releases page](https://github.com/joncampbell123/dosbox-x/releases))
+(Please always use the latest version of DOSBox-X from the [Releases page](https://github.com/joncampbell123/dosbox-x/releases))
 
 This project has a Code of Conduct in [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), please read it.
 

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1550,9 +1550,10 @@ dongle    = false
 #                                                     3.3                              MS-DOS 3.3 emulation (not tested!)
 #                                                     5.0                              MS-DOS 5.0 emulation (recommended for DOS gaming)
 #                                                     6.22                             MS-DOS 6.22 emulation
-#                                                     7.0                              MS-DOS 7.0 (Windows 95 pure DOS mode) emulation
-#                                                     7.1                              MS-DOS 7.1 (Windows 98 pure DOS mode) emulation
-#                                                     LFN (long filename) support will be enabled with a reported DOS version of 7.0 or higher with "lfn=auto" (default).
+#                                                     7.0                              MS-DOS 7.0 (or Windows 95 pure DOS mode) emulation
+#                                                     7.1                              MS-DOS 7.1 (or Windows 98 pure DOS mode) emulation
+#                                                     Long filename (LFN) support will be enabled with a reported DOS version of 7.0 or higher with "lfn=auto" (default).
+#                                                     Similarly, FAT32 disk images will be supported with a reported DOS version of 7.1 or higher.
 #                                                     
 #                                              lfn: Enable long filename support. If set to auto (default), it is enabled if the reported DOS version is at least 7.0.
 #                                                     If set to autostart, the builtin VER command won't activate/disactivate LFN support according to the reported DOS version.
@@ -1889,6 +1890,7 @@ cd-rom insertion delay  = 0
 #       dos: Reports whether DOS occupies HMA and allocates UMB memory (if available).
 #      fcbs: Number of FCB handles available to DOS programs (1-255).
 #     files: Number of file handles available to DOS programs (8-255).
+#   country: Sets the country code for country-specific date/time formats.
 # lastdrive: The maximum drive letter that can be accessed by programs.
 #              Possible values: a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z.
 rem         = This section is DOS's CONFIG.SYS file, not all CONFIG.SYS options supported
@@ -1897,6 +1899,7 @@ numlock     =
 dos         = high, umb
 fcbs        = 100
 files       = 127
+country     = 1
 lastdrive   = a
 set path    = Z:\
 set prompt  = $P$G

--- a/include/shell.h
+++ b/include/shell.h
@@ -279,6 +279,10 @@ public:
     /*! \brief      Change TTY (console) device (CTTY)
      */
 	void CMD_CTTY(char * args);
+
+    /*! \brief      Change country code
+     */
+	void CMD_COUNTRY(char * args);
     void CMD_TRUENAME(char * args);
     void CMD_DXCAPTURE(char * args);
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3071,9 +3071,10 @@ void DOSBOX_SetupConfigSections(void) {
             "3.3                              MS-DOS 3.3 emulation (not tested!)\n"
             "5.0                              MS-DOS 5.0 emulation (recommended for DOS gaming)\n"
             "6.22                             MS-DOS 6.22 emulation\n"
-            "7.0                              MS-DOS 7.0 (Windows 95 pure DOS mode) emulation\n"
-            "7.1                              MS-DOS 7.1 (Windows 98 pure DOS mode) emulation\n"
-            "LFN (long filename) support will be enabled with a reported DOS version of 7.0 or higher with \"lfn=auto\" (default).\n");
+            "7.0                              MS-DOS 7.0 (or Windows 95 pure DOS mode) emulation\n"
+            "7.1                              MS-DOS 7.1 (or Windows 98 pure DOS mode) emulation\n"
+            "Long filename (LFN) support will be enabled with a reported DOS version of 7.0 or higher with \"lfn=auto\" (default).\n"
+			"Similarly, FAT32 disk images will be supported with a reported DOS version of 7.1 or higher.\n");
 
     Pstring = secprop->Add_string("lfn",Property::Changeable::WhenIdle,"auto");
     Pstring->Set_values(lfn_settings);
@@ -3376,6 +3377,8 @@ void DOSBOX_SetupConfigSections(void) {
     Pint->Set_help("Number of FCB handles available to DOS programs (1-255).");
     Pint = secprop->Add_int("files",Property::Changeable::OnlyAtStart,127);
     Pint->Set_help("Number of file handles available to DOS programs (8-255).");
+    Pint = secprop->Add_int("country",Property::Changeable::OnlyAtStart,1);
+    Pint->Set_help("Sets the country code for country-specific date/time formats.");
     Pstring = secprop->Add_string("lastdrive",Property::Changeable::OnlyAtStart,"a");
 	Pstring->Set_help("The maximum drive letter that can be accessed by programs.");
     Pstring->Set_values(driveletters);


### PR DESCRIPTION
I noticed that DOSBox-X did not support the set country code function, and all date & time formats (such as the DIR and DATE/TIME commands) were fixed to the U.S. format. Apparently this is not very flexible for non-US users. So I solved this by adding the COUNTRY command which allows to change the country code within DOSBox-X, and then date and time will be shown according to the formats associated with the specific country code. For example, "COUNTRY 61" will set the country code to 61 (International English) which will use the DD-MM-YYYY date format instead of the U.S. MM-DD-YYYY date format.

I also added comment to the config file that FAT32 disk images will be supported with a reported DOS version of 7.1 or higher to reflect the recent change to the FAT driver. It uses the current reported DOS version, not the DOS version at start though.