### PR TITLE
Implement IOCTL functions "set device parameters" and "set serial number"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,13 @@
 0.83.3
   - Added COUNTRY command to set country code for country-
-    specific date and time formats. (Wengier)
+    specific date and time formats. For example, the command
+    "COUNTRY 61" sets the country code to 61 (International
+    English) which use the DD-MM-YYYY date format instead of
+    the default (U.S.) MM-DD-YYYY date format. (Wengier)
   - DOS 440Dh IOCTL function 67h (get access flag) added to
-    allow FDISK.EXE to determine FAT filesystem type.
+    allow FDISK.EXE to determine FAT filesystem type. Also
+    implemented function 40h (set device parameters) and
+    function 46h (set volume serial number). (Wengier)
   - Unknown DOS 440Dh IOCTLs warnings now indicate whether
     triggered by call or query.
   - S3 VESA BIOS mode number for 1024x768 32bpp changed to

--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -580,7 +580,7 @@ bool DOS_IOCTL_AX440D_CH48(Bit8u drive,bool query) {
         case 0x4B:
         case 0x61:
         case 0x62:
-		case 0x66:
+        case 0x66:
         case 0x6A:
         case 0x6B:
             return DOS_IOCTL_AX440D_CH08(drive,query);

--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -29,7 +29,7 @@
 bool DOS_IOCTL_AX440D_CH08(Bit8u drive,bool query) {
     PhysPt ptr	= SegPhys(ds)+reg_dx;
     switch (reg_cl) {
-        case 0x40:		/* Set Device parameters */
+        case 0x40:		/* Set device parameters */
 			{
 				if (strncmp(Drives[drive]->GetInfo(),"fatDrive ",9)) {
 					DOS_SetError(DOSERR_ACCESS_DENIED);
@@ -77,7 +77,7 @@ bool DOS_IOCTL_AX440D_CH08(Bit8u drive,bool query) {
 				fdp->SetBPB(bpb);
 				break;
 			}
-        case 0x60:		/* Get Device parameters */
+        case 0x60:		/* Get device parameters */
 			if (query) break;
 			{
                 //mem_writeb(ptr+0,0);					// special functions (call value)
@@ -476,7 +476,7 @@ bool DOS_IOCTL_AX440D_CH08(Bit8u drive,bool query) {
 bool DOS_IOCTL_AX440D_CH48(Bit8u drive,bool query) {
     PhysPt ptr	= SegPhys(ds)+reg_dx;
     switch (reg_cl) {
-        case 0x40:
+        case 0x40:		/* Set device parameters */
 			{
 				if (strncmp(Drives[drive]->GetInfo(),"fatDrive ",9)) {
 					DOS_SetError(DOSERR_ACCESS_DENIED);
@@ -509,7 +509,7 @@ bool DOS_IOCTL_AX440D_CH48(Bit8u drive,bool query) {
 					bpb.v.BPB_TotSec32 = (uint32_t)mem_readd(ptr+0x1c);          // number of big sectors
 					bpb.v32.BPB_FATSz32 = (uint32_t)mem_readd(ptr+0x20);         // sectors per FAT
 					bpb.v32.BPB_ExtFlags = (uint16_t)mem_readw(ptr+0x24);
-					bpb.v32.BPB_FSVer = (uint32_t)mem_readw(ptr+0x26);
+					bpb.v32.BPB_FSVer = (uint16_t)mem_readw(ptr+0x26);
 					bpb.v32.BPB_RootClus = (uint32_t)mem_readd(ptr+0x28);
 					bpb.v32.BPB_FSInfo = (uint16_t)mem_readw(ptr+0x2C);
 					bpb.v32.BPB_BkBootSec = (uint16_t)mem_readw(ptr+0x2E);
@@ -520,7 +520,7 @@ bool DOS_IOCTL_AX440D_CH48(Bit8u drive,bool query) {
 				}
 				break;
 			}
-        case 0x60:		/* Get Device parameters */
+        case 0x60:		/* Get device parameters */
 			if (query) break;
 			{
                 //mem_writeb(ptr+0,0);					// special functions (call value)
@@ -559,7 +559,7 @@ bool DOS_IOCTL_AX440D_CH48(Bit8u drive,bool query) {
                         mem_writed(ptr+0x1c,(uint32_t)bpb.v.BPB_TotSec32);          // number of big sectors
                         mem_writed(ptr+0x20,(uint32_t)bpb.v32.BPB_FATSz32);         // sectors per FAT
                         mem_writew(ptr+0x24,(uint16_t)bpb.v32.BPB_ExtFlags);
-                        mem_writew(ptr+0x26,(uint32_t)bpb.v32.BPB_FSVer);
+                        mem_writew(ptr+0x26,(uint16_t)bpb.v32.BPB_FSVer);
                         mem_writed(ptr+0x28,(uint32_t)bpb.v32.BPB_RootClus);
                         mem_writew(ptr+0x2C,(uint16_t)bpb.v32.BPB_FSInfo);
                         mem_writew(ptr+0x2E,(uint16_t)bpb.v32.BPB_BkBootSec);

--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -29,6 +29,54 @@
 bool DOS_IOCTL_AX440D_CH08(Bit8u drive,bool query) {
     PhysPt ptr	= SegPhys(ds)+reg_dx;
     switch (reg_cl) {
+        case 0x40:		/* Set Device parameters */
+			{
+				if (strncmp(Drives[drive]->GetInfo(),"fatDrive ",9)) {
+					DOS_SetError(DOSERR_ACCESS_DENIED);
+					return false;
+				}				
+				fatDrive *fdp = dynamic_cast<fatDrive*>(Drives[drive]);
+				if (fdp == NULL || fdp->readonly) {
+					DOS_SetError(DOSERR_ACCESS_DENIED);
+					return false;
+				}
+
+				if (query) break;
+				
+				FAT_BootSector::bpb_union_t bpb=fdp->GetBPB();
+				if (fdp->loadedDisk != NULL)
+					fdp->loadedDisk->cylinders = mem_readw(ptr+4);				 // number of cylinders
+
+				if (mem_readw(ptr+0xd) == 0 && mem_readw(ptr+0xf) == 0 && mem_readw(ptr+0x12) == 0) { // FAT32 BPB?
+					bpb.v32.BPB_BytsPerSec = mem_readw(ptr+7);                   // bytes per sector (Win3 File Mgr. uses it)
+					bpb.v32.BPB_SecPerClus = mem_readw(ptr+9);                   // sectors per cluster
+					bpb.v32.BPB_RsvdSecCnt = mem_readw(ptr+0xa);                 // number of reserved sectors
+					bpb.v32.BPB_NumFATs = mem_readw(ptr+0xc);                    // number of FATs
+					bpb.v32.BPB_RootEntCnt = mem_readw(ptr+0xd);                 // number of root entries (Fake, the real BPB value is zero)
+					bpb.v32.BPB_TotSec16 = mem_readw(ptr+0xf);                   // number of small sectors (always zero on BPB and returned by Win98)
+					bpb.v32.BPB_Media = mem_readw(ptr+0x11);                     // media type
+					bpb.v32.BPB_FATSz32 = (uint16_t)mem_readw(ptr+0x12);         // sectors per FAT (FIXME: What does Win98 do if this value > 0xFFFF?)
+					bpb.v32.BPB_SecPerTrk = (uint16_t)mem_readw(ptr+0x14);       // sectors per track
+					bpb.v32.BPB_NumHeads = (uint16_t)mem_readw(ptr+0x16);	     // number of heads
+					bpb.v32.BPB_HiddSec = (uint32_t)mem_readd(ptr+0x18);         // number of hidden sectors
+					bpb.v32.BPB_TotSec32 = (uint32_t)mem_readd(ptr+0x1c);        // number of big sectors
+				} else {
+					bpb.v.BPB_BytsPerSec = mem_readw(ptr+7);                     // bytes per sector (Win3 File Mgr. uses it)
+					bpb.v.BPB_SecPerClus = mem_readw(ptr+9);                     // sectors per cluster
+					bpb.v.BPB_RsvdSecCnt = mem_readw(ptr+0xa);                   // number of reserved sectors
+					bpb.v.BPB_NumFATs = mem_readw(ptr+0xc);                      // number of FATs
+					bpb.v.BPB_RootEntCnt = mem_readw(ptr+0xd);			         // number of root entries
+					bpb.v.BPB_TotSec16 = mem_readw(ptr+0xf);                     // number of small sectors
+					bpb.v.BPB_Media = mem_readw(ptr+0x11);                       // media type
+					bpb.v.BPB_FATSz16 = (uint16_t)mem_readw(ptr+0x12);           // sectors per FAT
+					bpb.v.BPB_SecPerTrk = (uint16_t)mem_readw(ptr+0x14);         // sectors per track
+					bpb.v.BPB_NumHeads = (uint16_t)mem_readw(ptr+0x16);          // number of heads
+					bpb.v.BPB_HiddSec = (uint32_t)mem_readd(ptr+0x18);           // number of hidden sectors
+					bpb.v.BPB_TotSec32 = (uint32_t)mem_readd(ptr+0x1c);          // number of big sectors
+				}
+				fdp->SetBPB(bpb);
+				break;
+			}
         case 0x60:		/* Get Device parameters */
 			if (query) break;
 			{
@@ -113,7 +161,7 @@ bool DOS_IOCTL_AX440D_CH08(Bit8u drive,bool query) {
                 Bit16u sect = 0;
 
                 fatDrive *fdp = dynamic_cast<fatDrive*>(Drives[drive]);
-                if (fdp == NULL) {
+                if (fdp == NULL || fdp->readonly) {
                     DOS_SetError(DOSERR_ACCESS_DENIED);
                     return false;
                 }
@@ -194,10 +242,23 @@ bool DOS_IOCTL_AX440D_CH08(Bit8u drive,bool query) {
                 LOG(LOG_IOCTL,LOG_DEBUG)("DOS:IOCTL Call 0D:62 Drive %2X pretending to verify device track C/H/S=%u/%u/%u ntracks=%u",drive,cyl,head,sect,ntracks);
             }
             break;
-        case 0x40:	/* Set Device parameters */
-            LOG(LOG_IOCTL,LOG_WARN)("DOS:IOCTL Call 0D:40 Drive %2X Set Device Parameters ignored, which may mean a mismatch between FAT filesystem BPBs",drive);
-            break;
         case 0x46:	/* Set volume serial number */
+			if (query) break;
+			{
+				fatDrive* fdp = dynamic_cast<fatDrive*>(Drives[drive]);
+				if (fdp == NULL || fdp->readonly) {
+					DOS_SetError(DOSERR_ACCESS_DENIED);
+					return false;
+				}
+
+				FAT_BootSector::bpb_union_t bpb=fdp->GetBPB();
+				unsigned long serial_number=mem_readd(ptr+2)?mem_readd(ptr+2):0x1234;
+				if (bpb.is_fat32())
+					bpb.v32.BS_VolID=serial_number;
+				else
+					bpb.v.BPB_VolID=serial_number;
+				fdp->SetBPB(bpb);
+			}
             break;
         case 0x66:	/* Get volume serial number */
 			if (query) break;
@@ -239,7 +300,7 @@ bool DOS_IOCTL_AX440D_CH08(Bit8u drive,bool query) {
         case 0x41:  /* Write logical device track */
 			{
                 fatDrive *fdp = dynamic_cast<fatDrive*>(Drives[drive]);
-                if (fdp == NULL) {
+                if (fdp == NULL || fdp->readonly) {
                     DOS_SetError(DOSERR_ACCESS_DENIED);
                     return false;
                 }
@@ -415,6 +476,50 @@ bool DOS_IOCTL_AX440D_CH08(Bit8u drive,bool query) {
 bool DOS_IOCTL_AX440D_CH48(Bit8u drive,bool query) {
     PhysPt ptr	= SegPhys(ds)+reg_dx;
     switch (reg_cl) {
+        case 0x40:
+			{
+				if (strncmp(Drives[drive]->GetInfo(),"fatDrive ",9)) {
+					DOS_SetError(DOSERR_ACCESS_DENIED);
+					return false;
+				}
+				fatDrive *fdp = dynamic_cast<fatDrive*>(Drives[drive]);
+				if (fdp == NULL || fdp->readonly) {
+					DOS_SetError(DOSERR_ACCESS_DENIED);
+					return false;
+				}
+
+				if (query) break;
+				
+				FAT_BootSector::bpb_union_t bpb=fdp->GetBPB();				
+				if (fdp->loadedDisk != NULL)
+					fdp->loadedDisk->cylinders = mem_readw(ptr+4);	             // number of cylinders
+
+				if (mem_readw(ptr+0xd) == 0 && mem_readw(ptr+0xf) == 0 && mem_readw(ptr+0x12) == 0) { // FAT32 BPB?
+					bpb.v.BPB_BytsPerSec = mem_readw(ptr+7);                     // bytes per sector (Win3 File Mgr. uses it)
+					bpb.v.BPB_SecPerClus = mem_readw(ptr+9);                     // sectors per cluster
+					bpb.v.BPB_RsvdSecCnt = mem_readw(ptr+0xa);                   // number of reserved sectors
+					bpb.v.BPB_NumFATs = mem_readw(ptr+0xc);                      // number of FATs
+					bpb.v.BPB_RootEntCnt = mem_readw(ptr+0xd);			         // number of root entries
+					bpb.v.BPB_TotSec16 = mem_readw(ptr+0xf);                     // number of small sectors
+					bpb.v.BPB_Media = mem_readw(ptr+0x11);                       // media type
+					bpb.v.BPB_FATSz16 = (uint16_t)mem_readw(ptr+0x12);           // sectors per FAT
+					bpb.v.BPB_SecPerTrk = (uint16_t)mem_readw(ptr+0x14);         // sectors per track
+					bpb.v.BPB_NumHeads = (uint16_t)mem_readw(ptr+0x16);          // number of heads
+					bpb.v.BPB_HiddSec = (uint32_t)mem_readd(ptr+0x18);           // number of hidden sectors
+					bpb.v.BPB_TotSec32 = (uint32_t)mem_readd(ptr+0x1c);          // number of big sectors
+					bpb.v32.BPB_FATSz32 = (uint32_t)mem_readd(ptr+0x20);         // sectors per FAT
+					bpb.v32.BPB_ExtFlags = (uint16_t)mem_readw(ptr+0x24);
+					bpb.v32.BPB_FSVer = (uint32_t)mem_readw(ptr+0x26);
+					bpb.v32.BPB_RootClus = (uint32_t)mem_readd(ptr+0x28);
+					bpb.v32.BPB_FSInfo = (uint16_t)mem_readw(ptr+0x2C);
+					bpb.v32.BPB_BkBootSec = (uint16_t)mem_readw(ptr+0x2E);
+					fdp->SetBPB(bpb);
+				} else {
+					DOS_SetError(DOSERR_ACCESS_DENIED);
+					return false;
+				}
+				break;
+			}
         case 0x60:		/* Get Device parameters */
 			if (query) break;
 			{
@@ -469,13 +574,13 @@ bool DOS_IOCTL_AX440D_CH48(Bit8u drive,bool query) {
                 }
                 break;
             }
-        case 0x40:
         case 0x42:
         case 0x46:
         case 0x4A:
         case 0x4B:
         case 0x61:
         case 0x62:
+		case 0x66:
         case 0x6A:
         case 0x6B:
             return DOS_IOCTL_AX440D_CH08(drive,query);
@@ -503,7 +608,9 @@ bool DOS_IOCTL(void) {
 		}
 	} else if (reg_al<0x12) { 				/* those use a diskdrive except 0x0b */
 		if (reg_al!=0x0b) {
-			drive=reg_bl;if (!drive) drive = DOS_GetDefaultDrive();else drive--;
+			drive=reg_bl;
+			if ((reg_al==0x0D||reg_al==0x11) && (reg_cl==0x4B||reg_cl==0x6B)) drive=reg_bh;
+			if (!drive) drive = DOS_GetDefaultDrive();else drive--;
 			if( (drive >= 2) && !(( drive < DOS_DRIVES ) && Drives[drive]) ) {
 				DOS_SetError(DOSERR_INVALID_DRIVE);
 				return false;

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2857,8 +2857,8 @@ void LOADFIX::Run(void)
                 char args[256];
                 args[0] = 0;
                 do {
-                    ok = cmd->FindCommand(commandNr++,temp_line);
-                    if(sizeof(args)-strlen(args)-1 < temp_line.length()+1)
+                    ok = cmd->FindCommand(commandNr,temp_line);
+                    if(commandNr++>cmd->GetCount() || sizeof(args)-strlen(args)-1 < temp_line.length()+1)
                         break;
                     strcat(args,temp_line.c_str());
                     strcat(args," ");

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -5092,13 +5092,14 @@ void DOS_SetupPrograms(void) {
     MSG_Add("PROGRAM_LOADFIX_ERROR","Memory allocation error.\n");
     MSG_Add("PROGRAM_LOADFIX_HELP",
         "Reduces the amount of available conventional or XMS memory.\n\n"
-        "LOADFIX [-xms] [-{ram}] [{program}]\n"
+        "LOADFIX [-xms] [-{ram}] [{program}] [{options}]\n"
         "LOADFIX -f [-xms]\n\n"
         "  -xms        Allocates memory from XMS rather than conventional memory\n"
         "  -{ram}      Specifies the amount of memory to allocate in KB\n"
         "                 Defaults to 64kb for conventional memory; 1MB for XMS memory\n"
         "  -f          Frees previously allocated memory\n"
-        "  {program}   Runs the specified program\n\n"
+        "  {program}   Runs the specified program\n"
+        "  {options}   Program options (if any)\n\n"
         "Examples:\n"
         "  LOADFIX game.exe     Allocates 64KB of conventional memory and runs game.exe\n"
         "  LOADFIX -128         Allocates 128KB of conventional memory\n"

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -406,6 +406,7 @@ public:
 	bool directoryBrowse(Bit32u dirClustNumber, direntry *useEntry, Bit32s entNum, Bit32s start=0);
 	bool directoryChange(Bit32u dirClustNumber, const direntry *useEntry, Bit32s entNum);
 	const FAT_BootSector::bpb_union_t &GetBPB(void);
+	const void SetBPB(FAT_BootSector::bpb_union_t);
 	imageDisk *loadedDisk = NULL;
 	bool created_successfully = true;
 private:

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1026,7 +1026,7 @@ char *FormatTime(Bitu hour, Bitu min, Bitu sec, Bitu msec)	{
 		strcpy(ampm, hour != 12 && hour == fhour ? "am" : "pm");
 	}
 	char sep = dos.tables.country[13];
-	if (sec==0&&msec==0)
+	if (sec>=100&&msec>=100)
 		sprintf(retBuf, "%2u%c%02u%c", (unsigned int)hour, sep, (unsigned int)min, *ampm);
 	else
 		sprintf(retBuf, "%u%c%02u%c%02u%c%02u%s", (unsigned int)hour, sep, (unsigned int)min, sep, (unsigned int)sec, dos.tables.country[9], (unsigned int)msec, ampm);
@@ -1210,7 +1210,7 @@ static bool doDir(DOS_Shell * shell, char * args, DOS_DTA dta, char * numformat,
 							for (size_t i=14-namelen;i>0;i--) shell->WriteOut(" ");
 						}
 					} else {
-						shell->WriteOut("%-8s %-3s   %-16s %s %s %s\n",name,ext,"<DIR>",FormatDate(year,month,day),FormatTime(hour,minute,0,0),uselfn&&!optZ?lname:"");
+						shell->WriteOut("%-8s %-3s   %-16s %s %s %s\n",name,ext,"<DIR>",FormatDate(year,month,day),FormatTime(hour,minute,100,100),uselfn&&!optZ?lname:"");
 					}
 					dir_count++;
 				} else {
@@ -1218,7 +1218,7 @@ static bool doDir(DOS_Shell * shell, char * args, DOS_DTA dta, char * numformat,
 						shell->WriteOut("%-16s",name);
 					} else {
 						FormatNumber(size,numformat);
-						shell->WriteOut("%-8s %-3s   %16s %s %s %s\n",name,ext,numformat,FormatDate(year,month,day),FormatTime(hour,minute,0,0),uselfn&&!optZ?lname:"");
+						shell->WriteOut("%-8s %-3s   %16s %s %s %s\n",name,ext,numformat,FormatDate(year,month,day),FormatTime(hour,minute,100,100),uselfn&&!optZ?lname:"");
 					}
 					if (optS) {
 						cfile_count++;


### PR DESCRIPTION
I noticed that IOCTL functions "set device parameters" and "set volume serial number" were not implemented in the code, so I made efforts to implement them. The function "set volume serial number" is tested to work on all FAT drives. And the function "set device parameters" seems to work so far during my limited testing.

Also fixed an issue with the built-in LOADFIX command.