### PR TITLE
Correct inclusion of sys/endian.h on NetBSD

### DIFF
--- a/include/byteorder.h
+++ b/include/byteorder.h
@@ -115,11 +115,11 @@
 #define _BSD_SOURCE
 #include <endian.h>
 
-#elif defined(__OpenBSD__)
+#elif defined(__NetBSD__) || defined(__OpenBSD__)
 
 #include <sys/endian.h>
 
-#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
 
 #include <sys/endian.h>
 


### PR DESCRIPTION
Avoid redefining `be16toh`, etc. Use the system definitions instead.

Avoids horrible build errors:

~~~
../../include/mem.h: In function ‘Bit32u host_readd(ConstHostPt)’:
../../include/byteorder.h:130:20: error: ‘letoh32’ was not declared in this scope
 #define le32toh(x) letoh32(x)
                    ^
../../include/mem.h:109:12: note: in expansion of macro ‘le32toh’
     return le32toh((*(const Bit32u *)off)); // BSD endian.h
            ^~~~~~~
../../include/mem.h: In function ‘Bit64u host_readq(ConstHostPt)’:
../../include/byteorder.h:133:20: error: ‘letoh64’ was not declared in this scope
 #define le64toh(x) letoh64(x)
~~~