### PR TITLE
Only use fopen64/etc on Linux and Windows

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -288,16 +288,8 @@ static INLINE Bit16u DOS_PackDate(Bit16u year,Bit16u mon,Bit16u day) {
 }
 
 /* fopen64, ftello64, fseeko64 */
-#if defined(__APPLE__)
- #define fopen64 fopen
- #define ftello64 ftell
- #define fseeko64 fseek
- #define fseek_ofs_t off_t
-#elif defined (__HAIKU__)
- #define fopen64 fopen
- #define ftello64 ftello
- #define fseeko64 fseeko
- #define fseek_ofs_t off_t
+#if defined(__linux__)
+ #define fseek_ofs_t long
 #elif defined (_MSC_VER)
  #define fopen64 fopen
  #if (_MSC_VER >= 1400)
@@ -310,7 +302,10 @@ static INLINE Bit16u DOS_PackDate(Bit16u year,Bit16u mon,Bit16u day) {
   #define fseek_ofs_t long
  #endif
 #else
- #define fseek_ofs_t long
+ #define fopen64 fopen
+ #define ftello64 ftell
+ #define fseeko64 fseek
+ #define fseek_ofs_t off_t
 #endif
 
 /* Dos Error Codes */


### PR DESCRIPTION
Use the standard variants of these functions on every other OS, since everyone else generally implemented large file support on top of the standard functions and lacks these extensions (including macOS, Haiku, and all the BSDs).

There are other exceptions: Solaris and QNX are the only others I could find with Google that hint that they have fopen64 et al, but Solaris at least has deprecated 32-bit support. Unfortunately I can't test on QNX because my QNX hardware is broken. I could be useful with fixing dosbox-x on Solaris but I'm not sure how to get endian definitions out of it (maybe SDL could be used for this, though).

This helps me with building on NetBSD.