### PR TITLE
Re-port the improved save state feature with save slot support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,12 @@
 0.83.3
+  - Re-ported the save state feature for saving and loading
+    states with support for up to 10 save slots. They can be
+    selected from the "Capture" menu. (Wengier)
   - Added COUNTRY command to set country code for country-
     specific date and time formats. For example, the command
     "COUNTRY 61" sets the country code to 61 (International
-    English) which use the DD-MM-YYYY date format instead of
-    the default (U.S.) MM-DD-YYYY date format. (Wengier)
+    English) which uses the DD-MM-YYYY date format instead
+    of the default (U.S.) MM-DD-YYYY date format. (Wengier)
   - DOS 440Dh IOCTL function 67h (get access flag) added to
     allow FDISK.EXE to determine FAT filesystem type. Also
     implemented function 40h (set device parameters) and

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 0.83.3
-  - Re-ported the save state feature for saving and loading
-    states with support for up to 10 save slots. They can be
-    selected from the "Capture" menu. (Wengier)
+  - Re-ported and improved the save state feature for saving
+    and loading states with support for up to 10 save slots.
+    They can be selected from the "Capture" menu. (Wengier)
   - Added COUNTRY command to set country code for country-
     specific date and time formats. For example, the command
     "COUNTRY 61" sets the country code to 61 (International

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -438,6 +438,10 @@ public:
         desc.Load((PhysPt)(table_base+selector));
         return true;
     }
+	
+	virtual void SaveState( std::ostream& stream );
+	virtual void LoadState( std::istream& stream );
+
 
 protected:
     PhysPt table_base;
@@ -489,6 +493,9 @@ public:
 		ldt_value=value;
 		return true;
 	}
+
+	virtual void SaveState( std::ostream& stream );
+	virtual void LoadState( std::istream& stream );
 
 private:
 	PhysPt ldt_base;

--- a/include/dma.h
+++ b/include/dma.h
@@ -131,6 +131,9 @@ public:
 	}
 	Bitu Read(Bitu want, Bit8u * buffer);
 	Bitu Write(Bitu want, Bit8u * buffer);
+
+	void SaveState( std::ostream& stream );
+	void LoadState( std::istream& stream );
 };
 
 class DmaController {
@@ -159,6 +162,9 @@ public:
 	}
 	void WriteControllerReg(Bitu reg,Bitu val,Bitu len);
 	Bitu ReadControllerReg(Bitu reg,Bitu len);
+
+	void SaveState( std::ostream& stream );
+	void LoadState( std::istream& stream );
 };
 
 DmaChannel * GetDMAChannel(Bit8u chan);

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -96,6 +96,8 @@ public:
 	virtual Bit32u	GetSeekPos()	{ return 0xffffffff; }
 	void SetDrive(Bit8u drv) { hdrive=drv;}
 	Bit8u GetDrive(void) { return hdrive;}
+	virtual void 	SaveState( std::ostream& stream );
+	virtual void 	LoadState( std::istream& stream, bool pop );
     virtual void    Flush(void) { }
 
 	char* name = NULL;
@@ -141,6 +143,7 @@ private:
 
 class localFile : public DOS_File {
 public:
+	localFile();
 	localFile(const char* _name, FILE * handle);
 	bool Read(Bit8u * data,Bit16u * size);
 	bool Write(const Bit8u * data,Bit16u * size);
@@ -310,6 +313,8 @@ public:
 	virtual void MediaChange() {};
 	// disk cycling functionality (request resources)
 	virtual void Activate(void) {};
+	virtual void SaveState( std::ostream& stream );
+	virtual void LoadState( std::istream& stream );
 	virtual void UpdateDPB(unsigned char dos_drive) { (void)dos_drive; };
 
     // INT 25h/INT 26h

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -262,3 +262,180 @@ static inline constexpr bytecount_t _tebibytes(const bytecount_t x) {
 }
 
 #endif /* DOSBOX_DOSBOX_H */
+
+#ifndef SAVE_STATE_H_INCLUDED
+#define SAVE_STATE_H_INCLUDED
+
+#include <sstream>
+#include <map>
+#include <algorithm>
+#include <functional>
+#include <vector>
+
+
+#define WRITE_POD(x,y) \
+	stream.write(reinterpret_cast<const char*>( (x) ), sizeof( (y) ) );
+
+#define WRITE_POD_SIZE(x,y) \
+	stream.write(reinterpret_cast<const char*>( (x) ), (y) );
+
+#define READ_POD(x,y) \
+	stream.read(reinterpret_cast<char*>( (x) ), sizeof( (y) ) );
+
+#define READ_POD_SIZE(x,y) \
+	stream.read(reinterpret_cast<char*>( (x) ), (y) );
+
+
+
+class SaveState
+{
+public:
+    static SaveState& instance();
+
+   typedef std::string Error;
+    static const size_t SLOT_COUNT = 10; //slot: [0,...,SLOT_COUNT - 1]
+
+    void save   (size_t slot);       //throw (Error)
+    void load   (size_t slot) const; //throw (Error)
+    bool isEmpty(size_t slot) const;
+
+    //initialization: register relevant components on program startup
+    struct Component
+    {
+        virtual void getBytes(std::ostream& stream) = 0;
+        virtual void setBytes(std::istream& stream) = 0;
+    };
+
+    void registerComponent(const std::string& uniqueName, Component& comp); //comp must have global lifetime!
+
+private:
+    SaveState() {}
+    SaveState(const SaveState&);
+    SaveState& operator=(const SaveState&);
+
+    class RawBytes
+    {
+    public:
+        RawBytes() : dataExists(false), isCompressed(false) {}
+        void set(const std::string& stream);
+        std::string get() const; //throw (Error)
+        void compress() const;   //throw (Error)
+        bool dataAvailable() const;
+    private:
+        bool dataExists; //determine whether set method (even with empty string) was called
+        mutable bool isCompressed; //design for logical not binary const
+        mutable std::string bytes; //
+    };
+
+    struct CompData
+    {
+        CompData(Component& cmp) : comp(cmp), rawBytes(SLOT_COUNT) {}
+        Component& comp;
+        std::vector<RawBytes> rawBytes;
+    };
+
+    typedef std::map<std::string, CompData> CompEntry;
+    CompEntry components;
+};
+
+
+//some helper functions
+template <class T>
+void writePOD(std::ostream& stream, const T& data);
+
+template <class T>
+void readPOD(std::istream& stream, T& data);
+
+void writeString(std::ostream& stream, const std::string& data);
+void readString(std::istream& stream, std::string& data);
+
+
+//Implementation of SaveState::Component for saving POD types only
+class SerializeGlobalPOD : public SaveState::Component
+{
+public:
+    SerializeGlobalPOD(const std::string& compName)
+    {
+        SaveState::instance().registerComponent(compName, *this);
+    }
+
+    template <class T>
+    void registerPOD(T& pod) //register POD for serializatioin
+    {
+        podRef.push_back(POD(pod));
+    }
+
+protected:
+    virtual void getBytes(std::ostream& stream)
+    {
+        std::for_each(podRef.begin(), podRef.end(), std::bind1st(WriteGlobalPOD(), &stream));
+    }
+
+    virtual void setBytes(std::istream& stream)
+    {
+        std::for_each(podRef.begin(), podRef.end(), std::bind1st(ReadGlobalPOD(), &stream));
+    }
+
+private:
+    struct POD
+    {
+        template <class T>
+        POD(T& pod) : address(&pod), size(sizeof(T)) {}
+        void* address;
+        size_t size;
+    };
+
+    struct WriteGlobalPOD : public std::binary_function<std::ostream*, POD, void>
+    {
+        void operator()(std::ostream* stream, const POD& data) const
+        {
+            stream->write(static_cast<const char*>(data.address), data.size);
+        }
+    };
+
+    struct ReadGlobalPOD : public std::binary_function<std::istream*, POD, void>
+    {
+        void operator()(std::istream* stream, const POD& data) const
+        {
+            stream->read(static_cast<char*>(data.address), data.size);
+        }
+    };
+
+    std::vector<POD> podRef;
+};
+
+//---------------- inline implementation -------------------------
+template <class T>
+inline
+void writePOD(std::ostream& stream, const T& data)
+{
+    stream.write(reinterpret_cast<const char*>(&data), sizeof(T));
+}
+
+
+template <class T>
+inline
+void readPOD(std::istream& stream, T& data)
+{
+    stream.read(reinterpret_cast<char*>(&data), sizeof(T));
+}
+
+
+inline
+void writeString(std::ostream& stream, const std::string& data)
+{
+    const size_t stringSize = data.size();
+    writePOD(stream, stringSize);
+    stream.write(data.c_str(), stringSize * sizeof(std::string::value_type));
+}
+
+
+inline
+void readString(std::istream& stream, std::string& data)
+{
+    size_t stringSize = 0;
+    readPOD(stream, stringSize);
+    data.resize(stringSize);
+    stream.read(&data[0], stringSize * sizeof(std::string::value_type));
+}
+#endif //SAVE_STATE_H_INCLUDED

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -85,6 +85,8 @@ public:
 
 	void FillUp(void);
 	void Enable(bool _yesno);
+	void SaveState( std::ostream& stream );
+	void LoadState( std::istream& stream );
 
 	MIXER_Handler handler;
 	float volmain[2];

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -426,4 +426,7 @@ void CPU_Core_Dynrec_Cache_Close(void) {
 	cache_close();
 }
 
+void CPU_Core_Dynrec_Cache_Reset(void) {
+	cache_reset();
+}
 #endif

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -172,12 +172,14 @@ void CPU_Core_Full_Init(void);
 void CPU_Core_Dyn_X86_Init(void);
 void CPU_Core_Dyn_X86_Cache_Init(bool enable_cache);
 void CPU_Core_Dyn_X86_Cache_Close(void);
+void CPU_Core_Dyn_X86_Cache_Reset(void);
 void CPU_Core_Dyn_X86_SetFPUMode(bool dh_fpu);
 void CPU_Core_Dyn_X86_Cache_Reset(void);
 #elif (C_DYNREC)
 void CPU_Core_Dynrec_Init(void);
 void CPU_Core_Dynrec_Cache_Init(bool enable_cache);
 void CPU_Core_Dynrec_Cache_Close(void);
+void CPU_Core_Dynrec_Cache_Reset(void);
 #endif
 
 bool CPU_IsDynamicCore(void);
@@ -705,6 +707,9 @@ public:
 		is386=desc.Is386();
 		return true;
 	}
+
+	void SaveState( std::ostream& stream );
+	void LoadState( std::istream& stream );
 
 	TSS_Descriptor desc;
 	Bitu selector = 0;
@@ -3597,6 +3602,8 @@ public:
 
 		if (CPU_CycleAutoAdjust) GFX_SetTitle((Bit32s)CPU_CyclePercUsed,-1,-1,false);
 		else GFX_SetTitle((Bit32s)CPU_CycleMax,-1,-1,false);
+		// savestate support
+		cpu.hlt.old_decoder=cpudecoder;
 		return true;
 	}
 	~CPU(){ /* empty */};
@@ -3770,6 +3777,63 @@ void CPU_Init() {
 //initialize static members
 bool CPU::inited=false;
 
+//save state support
+void DescriptorTable::SaveState( std::ostream& stream )
+{
+	WRITE_POD( &table_base, table_base );
+	WRITE_POD( &table_limit, table_limit );
+}
+ 
+ 
+void DescriptorTable::LoadState( std::istream& stream )
+{
+	READ_POD( &table_base, table_base );
+	READ_POD( &table_limit, table_limit );
+}
+
+
+void GDTDescriptorTable::SaveState(std::ostream& stream)
+{
+	this->DescriptorTable::SaveState(stream);
+
+
+	WRITE_POD( &ldt_base, ldt_base );
+	WRITE_POD( &ldt_limit, ldt_limit );
+	WRITE_POD( &ldt_value, ldt_value );
+}
+
+
+void GDTDescriptorTable::LoadState(std::istream& stream)
+{
+	this->DescriptorTable::LoadState(stream);
+
+
+	READ_POD( &ldt_base, ldt_base );
+	READ_POD( &ldt_limit, ldt_limit );
+	READ_POD( &ldt_value, ldt_value );
+}
+
+
+void TaskStateSegment::SaveState( std::ostream& stream )
+{
+	WRITE_POD( &desc.saved, desc.saved );
+	WRITE_POD( &selector, selector );
+	WRITE_POD( &base, base );
+	WRITE_POD( &limit, limit );
+	WRITE_POD( &is386, is386 );
+	WRITE_POD( &valid, valid );
+}
+
+
+void TaskStateSegment::LoadState( std::istream& stream )
+{
+	READ_POD( &desc.saved, desc.saved );
+	READ_POD( &selector, selector );
+	READ_POD( &base, base );
+	READ_POD( &limit, limit );
+	READ_POD( &is386, is386 );
+	READ_POD( &valid, valid );
+}
 
 // TODO: This looks to be unused
 Bit16u CPU_FindDecoderType( CPU_Decoder *decoder )
@@ -3787,13 +3851,20 @@ Bit16u CPU_FindDecoderType( CPU_Decoder *decoder )
 #if !defined(C_EMSCRIPTEN)
 	else if( cpudecoder == &CPU_Core_Simple_Run ) decoder_idx = 2;
 	else if( cpudecoder == &CPU_Core_Full_Run ) decoder_idx = 3;
+	else if( cpudecoder == &CPU_Core_Normal_Trap_Run ) decoder_idx = 100;
 #endif
 #if C_DYNAMIC_X86
 	else if( cpudecoder == &CPU_Core_Dyn_X86_Run ) decoder_idx = 4;
 #endif
+#if (C_DYNREC)
+else if( cpudecoder == &CPU_Core_Dynrec_Run ) decoder_idx = 5;
+#endif
 	else if( cpudecoder == &CPU_Core_Normal_Trap_Run ) decoder_idx = 100;
 #if C_DYNAMIC_X86
 	else if( cpudecoder == &CPU_Core_Dyn_X86_Trap_Run ) decoder_idx = 101;
+#endif
+#if(C_DYNREC)
+else if( cpudecoder == &CPU_Core_Dynrec_Trap_Run ) decoder_idx = 102;
 #endif
 	else if( cpudecoder == &HLT_Decode ) decoder_idx = 200;
 
@@ -3814,14 +3885,29 @@ CPU_Decoder* CPU_IndexDecoderType(Bit16u decoder_idx)
 #if C_DYNAMIC_X86
     case 4: return &CPU_Core_Dyn_X86_Run;
 #endif
+#if (C_DYNREC)
+    case 5: return &CPU_Core_Dynrec_Run;
+#endif
     case 100: return &CPU_Core_Normal_Trap_Run;
 #if C_DYNAMIC_X86
     case 101: return &CPU_Core_Dyn_X86_Trap_Run;
+#endif
+#if(C_DYNREC)
+	case 102: return &CPU_Core_Dynrec_Trap_Run;
 #endif
     case 200: return &HLT_Decode;
     default: return 0;
     }
 }
+
+extern void POD_Save_CPU_Flags( std::ostream& stream );
+extern void POD_Save_CPU_Paging( std::ostream& stream );
+extern void POD_Load_CPU_Flags( std::istream& stream );
+extern void POD_Load_CPU_Paging( std::istream& stream );
+
+#if (C_DYNAMIC_X86)
+extern void CPU_Core_Dyn_X86_Cache_Reset(void);
+#endif
 
 Bitu vm86_fake_io_seg = 0xF000;	/* unused area in BIOS for IO instruction */
 Bitu vm86_fake_io_off = 0x0700;
@@ -3980,3 +4066,181 @@ void CPU_Core_Dyn_X86_SaveDHFPUState(void) {
 void CPU_Core_Dyn_X86_RestoreDHFPUState(void) {
 }
 
+namespace
+{
+class SerializeCPU : public SerializeGlobalPOD
+{
+public:
+SerializeCPU() : SerializeGlobalPOD("CPU")
+{}
+
+private:
+virtual void getBytes(std::ostream& stream)
+{
+    Bit16u decoder_idx;
+
+    extern Bits PageFaultCore(void);
+    extern Bits IOFaultCore(void);
+
+
+
+    decoder_idx = CPU_FindDecoderType( cpudecoder );
+
+    //********************************************
+    //********************************************
+    //********************************************
+
+    SerializeGlobalPOD::getBytes(stream);
+
+
+    // - pure data
+    WRITE_POD( &cpu_regs, cpu_regs );
+
+    WRITE_POD( &cpu.cpl, cpu.cpl );
+    WRITE_POD( &cpu.mpl, cpu.mpl );
+    WRITE_POD( &cpu.cr0, cpu.cr0 );
+    WRITE_POD( &cpu.pmode, cpu.pmode );
+    cpu.gdt.SaveState(stream);
+    cpu.idt.SaveState(stream);
+    WRITE_POD( &cpu.stack, cpu.stack );
+    WRITE_POD( &cpu.code, cpu.code );
+    WRITE_POD( &cpu.hlt.cs, cpu.hlt.cs );
+    WRITE_POD( &cpu.hlt.eip, cpu.hlt.eip );
+    WRITE_POD( &cpu.exception, cpu.exception );
+    WRITE_POD( &cpu.direction, cpu.direction );
+    WRITE_POD( &cpu.trap_skip, cpu.trap_skip );
+    WRITE_POD( &cpu.drx, cpu.drx );
+    WRITE_POD( &cpu.trx, cpu.trx );
+
+    WRITE_POD( &Segs, Segs );
+    WRITE_POD( &CPU_Cycles, CPU_Cycles );
+    WRITE_POD( &CPU_CycleLeft, CPU_CycleLeft );
+    WRITE_POD( &CPU_IODelayRemoved, CPU_IODelayRemoved );
+    cpu_tss.SaveState(stream);
+    WRITE_POD( &lastint, lastint );
+
+    //********************************************
+    //********************************************
+    //********************************************
+
+    // - reloc func ptr
+    WRITE_POD( &decoder_idx, decoder_idx );
+
+    POD_Save_CPU_Flags(stream);
+	POD_Save_CPU_Paging(stream);
+}
+
+virtual void setBytes(std::istream& stream)
+{
+    Bit16u decoder_idx;
+    Bit16u decoder_old;
+
+
+
+
+
+    decoder_old = CPU_FindDecoderType( cpudecoder );
+
+    //********************************************
+    //********************************************
+    //********************************************
+
+    SerializeGlobalPOD::setBytes(stream);
+
+
+    // - pure data
+    READ_POD( &cpu_regs, cpu_regs );
+
+    READ_POD( &cpu.cpl, cpu.cpl );
+    READ_POD( &cpu.mpl, cpu.mpl );
+    READ_POD( &cpu.cr0, cpu.cr0 );
+    READ_POD( &cpu.pmode, cpu.pmode );
+    cpu.gdt.LoadState(stream);
+    cpu.idt.LoadState(stream);
+    READ_POD( &cpu.stack, cpu.stack );
+    READ_POD( &cpu.code, cpu.code );
+    READ_POD( &cpu.hlt.cs, cpu.hlt.cs );
+    READ_POD( &cpu.hlt.eip, cpu.hlt.eip );
+    READ_POD( &cpu.exception, cpu.exception );
+    READ_POD( &cpu.direction, cpu.direction );
+    READ_POD( &cpu.trap_skip, cpu.trap_skip );
+    READ_POD( &cpu.drx, cpu.drx );
+    READ_POD( &cpu.trx, cpu.trx );
+
+    READ_POD( &Segs, Segs );
+    READ_POD( &CPU_Cycles, CPU_Cycles );
+    READ_POD( &CPU_CycleLeft, CPU_CycleLeft );
+    READ_POD( &CPU_IODelayRemoved, CPU_IODelayRemoved );
+    cpu_tss.LoadState(stream);
+    READ_POD( &lastint, lastint );
+
+    //********************************************
+    //********************************************
+    //********************************************
+
+    // - reloc func ptr
+    READ_POD( &decoder_idx, decoder_idx );
+
+
+
+    POD_Load_CPU_Flags(stream);
+	POD_Load_CPU_Paging(stream);
+
+    //*******************************************
+    //*******************************************
+    //*******************************************
+
+    // switch to running core
+    if( decoder_idx < 100 ) {
+        switch( decoder_old ) {
+            // run -> run (0-99)
+
+            // trap -> run
+            case 100: cpudecoder = CPU_IndexDecoderType(0); break;
+            case 101: cpudecoder = CPU_IndexDecoderType(4); break;
+            case 102: cpudecoder = CPU_IndexDecoderType(5); break;
+
+            // hlt -> run
+            case 200: cpudecoder = cpu.hlt.old_decoder; break;
+        }
+    }
+
+    // switch to trap core
+    else if( decoder_idx < 200 ) {
+        switch( decoder_old ) {
+            // run -> trap
+            case 0:
+            case 1:
+            case 2:
+            case 3: cpudecoder = CPU_IndexDecoderType(100); break;
+            case 4: cpudecoder = CPU_IndexDecoderType(101); break;
+            case 5: cpudecoder = CPU_IndexDecoderType(102); break;
+
+            // trap -> trap (100-199)
+
+            // hlt -> trap
+            case 200: {
+                switch( CPU_FindDecoderType(cpu.hlt.old_decoder) ) {
+                    case 0:
+                    case 1:
+                    case 2:
+                    case 3: cpudecoder = CPU_IndexDecoderType(100); break;
+                    case 4: cpudecoder = CPU_IndexDecoderType(101); break;
+                    case 5: cpudecoder = CPU_IndexDecoderType(102); break;
+                }
+            }
+        }
+    }
+
+    // switch to hlt core
+    else if( decoder_idx < 300 ) {
+        cpudecoder = CPU_IndexDecoderType(200);
+    }
+#if (C_DYNAMIC_X86)
+    CPU_Core_Dyn_X86_Cache_Reset();
+#elif (C_DYNREC)
+    CPU_Core_Dynrec_Cache_Reset();
+#endif
+}
+} dummy;
+}

--- a/src/cpu/flags.cpp
+++ b/src/cpu/flags.cpp
@@ -1210,3 +1210,15 @@ void DestroyConditionFlags(void) {
 
 #endif
 
+// save state support
+void POD_Save_CPU_Flags( std::ostream& stream )
+{
+	// - pure data
+	WRITE_POD( &lflags, lflags );
+}
+
+void POD_Load_CPU_Flags( std::istream& stream )
+{
+	// - pure data
+	READ_POD( &lflags, lflags );
+}

--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -1197,3 +1197,58 @@ void PAGING_Init() {
 	pf_queue.used=0;
 }
 
+// save state support
+void POD_Save_CPU_Paging( std::ostream& stream )
+{
+	WRITE_POD( &paging.cr3, paging.cr3 );
+	WRITE_POD( &paging.cr2, paging.cr2 );
+//	WRITE_POD( &paging.wp, paging.wp );
+	WRITE_POD( &paging.base, paging.base );
+
+	WRITE_POD( &paging.tlb.read, paging.tlb.read );
+	WRITE_POD( &paging.tlb.write, paging.tlb.write );
+	WRITE_POD( &paging.tlb.phys_page, paging.tlb.phys_page );
+
+	WRITE_POD( &paging.links, paging.links );
+//	WRITE_POD( &paging.ur_links, paging.ur_links );
+//	WRITE_POD( &paging.krw_links, paging.krw_links );
+//	WRITE_POD( &paging.kr_links, paging.kr_links );
+
+	WRITE_POD( &paging.firstmb, paging.firstmb );
+	WRITE_POD( &paging.enabled, paging.enabled );
+
+	WRITE_POD( &pf_queue, pf_queue );
+}
+
+void POD_Load_CPU_Paging( std::istream& stream )
+{
+	READ_POD( &paging.cr3, paging.cr3 );
+	READ_POD( &paging.cr2, paging.cr2 );
+//	READ_POD( &paging.wp, paging.wp );
+	READ_POD( &paging.base, paging.base );
+
+	READ_POD( &paging.tlb.read, paging.tlb.read );
+	READ_POD( &paging.tlb.write, paging.tlb.write );
+	READ_POD( &paging.tlb.phys_page, paging.tlb.phys_page );
+
+	READ_POD( &paging.links, paging.links );
+//	READ_POD( &paging.ur_links, paging.ur_links );
+//	READ_POD( &paging.krw_links, paging.krw_links );
+//	READ_POD( &paging.kr_links, paging.kr_links );
+
+	READ_POD( &paging.firstmb, paging.firstmb );
+	READ_POD( &paging.enabled, paging.enabled );
+
+	READ_POD( &pf_queue, pf_queue );
+
+	// reset all information
+	paging.links.used = PAGING_LINKS;
+	PAGING_ClearTLB();
+
+	for( int lcv=0; lcv<TLB_SIZE; lcv++ ) {
+		paging.tlb.read[lcv] = 0;
+		paging.tlb.write[lcv] = 0;
+		paging.tlb.readhandler[lcv] = &init_page_handler;
+		paging.tlb.writehandler[lcv] = &init_page_handler;
+	}
+}

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -3850,3 +3850,99 @@ void DOS_Int21_71aa(char* name1, const char* name2) {
 			E_Exit("DOS:Illegal LFN Subst call %2X",reg_bh);
 	}
 }
+
+//save state support
+extern void POD_Save_DOS_Devices( std::ostream& stream );
+extern void POD_Save_DOS_DriveManager( std::ostream& stream );
+extern void POD_Save_DOS_Files( std::ostream& stream );
+extern void POD_Save_DOS_Memory( std::ostream& stream);
+extern void POD_Save_DOS_Mscdex( std::ostream& stream );
+extern void POD_Save_DOS_Tables( std::ostream& stream );
+
+extern void POD_Load_DOS_Devices( std::istream& stream );
+extern void POD_Load_DOS_DriveManager( std::istream& stream );
+extern void POD_Load_DOS_Files( std::istream& stream );
+extern void POD_Load_DOS_Memory( std::istream& stream );
+extern void POD_Load_DOS_Mscdex( std::istream& stream );
+extern void POD_Load_DOS_Tables( std::istream& stream );
+
+namespace
+{
+class SerializeDos : public SerializeGlobalPOD
+{
+public:
+	SerializeDos() : SerializeGlobalPOD("Dos") 
+	{}
+
+private:
+	virtual void getBytes(std::ostream& stream)
+	{
+		SerializeGlobalPOD::getBytes(stream);
+
+		//***********************************************
+		//***********************************************
+		//***********************************************
+		// - pure data
+		WRITE_POD( &dos_copybuf, dos_copybuf );
+
+		// - pure data
+		WRITE_POD( &dos.firstMCB, dos.firstMCB );
+		WRITE_POD( &dos.errorcode, dos.errorcode );
+		//WRITE_POD( &dos.env, dos.env );
+		//WRITE_POD( &dos.cpmentry, dos.cpmentry );
+		WRITE_POD( &dos.return_code, dos.return_code );
+		WRITE_POD( &dos.return_mode, dos.return_mode );
+
+		WRITE_POD( &dos.current_drive, dos.current_drive );
+		WRITE_POD( &dos.verify, dos.verify );
+		WRITE_POD( &dos.breakcheck, dos.breakcheck );
+		WRITE_POD( &dos.echo, dos.echo );
+		WRITE_POD( &dos.direct_output, dos.direct_output );
+		WRITE_POD( &dos.internal_output, dos.internal_output );
+
+		WRITE_POD( &dos.loaded_codepage, dos.loaded_codepage );
+
+		POD_Save_DOS_Devices(stream);
+		POD_Save_DOS_DriveManager(stream);
+		POD_Save_DOS_Files(stream);
+		POD_Save_DOS_Memory(stream);
+		POD_Save_DOS_Mscdex(stream);
+		POD_Save_DOS_Tables(stream);
+	}
+
+	virtual void setBytes(std::istream& stream)
+	{
+		SerializeGlobalPOD::setBytes(stream);
+
+		//***********************************************
+		//***********************************************
+		//***********************************************
+		// - pure data
+		READ_POD( &dos_copybuf, dos_copybuf );
+
+		// - pure data
+		READ_POD( &dos.firstMCB, dos.firstMCB );
+		READ_POD( &dos.errorcode, dos.errorcode );
+		//READ_POD( &dos.env, dos.env );
+		//READ_POD( &dos.cpmentry, dos.cpmentry );
+		READ_POD( &dos.return_code, dos.return_code );
+		READ_POD( &dos.return_mode, dos.return_mode );
+
+		READ_POD( &dos.current_drive, dos.current_drive );
+		READ_POD( &dos.verify, dos.verify );
+		READ_POD( &dos.breakcheck, dos.breakcheck );
+		READ_POD( &dos.echo, dos.echo );
+		READ_POD( &dos.direct_output, dos.direct_output );
+        READ_POD( &dos.internal_output, dos.internal_output );
+	
+		READ_POD( &dos.loaded_codepage, dos.loaded_codepage );
+
+		POD_Load_DOS_Devices(stream);
+		POD_Load_DOS_DriveManager(stream);
+		POD_Load_DOS_Files(stream);
+		POD_Load_DOS_Memory(stream);
+		POD_Load_DOS_Mscdex(stream);
+		POD_Load_DOS_Tables(stream);
+	}
+} dummy;
+}

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -590,3 +590,15 @@ Bitu INT29_HANDLER(void) {
     return CBRET_NONE;
 }
 
+// save state support
+void POD_Save_DOS_Devices( std::ostream& stream )
+{
+	if( strcmp( Devices[2]->GetName(), "CON" ) == 0 )
+		Devices[2]->SaveState(stream);
+}
+
+void POD_Load_DOS_Devices( std::istream& stream )
+{
+	if( strcmp( Devices[2]->GetName(), "CON" ) == 0 )
+		Devices[2]->LoadState(stream, false);
+}

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -1888,3 +1888,235 @@ void DOS_SetupFiles (void) {
 	Drives[25]=new Virtual_Drive();
 }
 
+// save state support
+void DOS_File::SaveState( std::ostream& stream )
+{
+	Bit32u file_namelen, seek_pos;
+
+
+	file_namelen = strlen( name );
+	seek_pos = GetSeekPos();
+
+	//******************************************
+	//******************************************
+	//******************************************
+
+	// - pure data
+	WRITE_POD( &file_namelen, file_namelen );
+	WRITE_POD_SIZE( name, file_namelen );
+
+	WRITE_POD( &flags, flags );
+	WRITE_POD( &open, open );
+
+	WRITE_POD( &attr, attr );
+	WRITE_POD( &time, time );
+	WRITE_POD( &date, date );
+	WRITE_POD( &refCtr, refCtr );
+	WRITE_POD( &hdrive, hdrive );
+
+	//******************************************
+	//******************************************
+	//******************************************
+
+	// - reloc ptr
+	WRITE_POD( &seek_pos, seek_pos );
+}
+
+
+void DOS_File::LoadState( std::istream& stream, bool pop )
+{
+	Bit32u file_namelen, seek_pos;
+	char *file_name;
+
+	//******************************************
+	//******************************************
+	//******************************************
+
+	// - pure data
+	READ_POD( &file_namelen, file_namelen );
+	file_name = (char*)alloca( file_namelen * sizeof(char) );
+	READ_POD_SIZE( file_name, file_namelen );
+
+	READ_POD( &flags, flags );
+	READ_POD( &open, open );
+
+	READ_POD( &attr, attr );
+	READ_POD( &time, time );
+	READ_POD( &date, date );
+	READ_POD( &refCtr, refCtr );
+	READ_POD( &hdrive, hdrive );
+
+	//******************************************
+	//******************************************
+	//******************************************
+
+	// - reloc ptr
+	READ_POD( &seek_pos, seek_pos );
+
+	if (pop)
+		return;
+
+	if( open ) Seek( &seek_pos, DOS_SEEK_SET );
+	else Close();
+}
+
+
+void POD_Save_DOS_Files( std::ostream& stream )
+{
+	// 1. Do drives first (directories -> files)
+	// 2. Then files next
+
+	for( int lcv=0; lcv<DOS_DRIVES; lcv++ ) {
+		Bit8u drive_valid;
+
+		drive_valid = 0;
+		if( Drives[lcv] == 0 ) drive_valid = 0xff;
+
+		//**********************************************
+		//**********************************************
+		//**********************************************
+
+		// - reloc ptr
+		WRITE_POD( &drive_valid, drive_valid );
+
+		if( drive_valid == 0xff ) continue;
+		Drives[lcv]->SaveState(stream);
+	}
+
+	for( int lcv=0; lcv<DOS_FILES; lcv++ ) {
+		Bit8u file_valid;
+		char *file_name;
+		Bit8u file_namelen, file_drive, file_flags;
+
+		file_valid = 0;
+		if( !Files[lcv] || Files[lcv]->GetName() == NULL ) file_valid = 0xff;
+		else {
+			if( strcmp( Files[lcv]->GetName(), "NUL" ) == 0 ) file_valid = 0xfe;//earth 2140 needs this
+			if( strcmp( Files[lcv]->GetName(), "CON" ) == 0 ) file_valid = 0xfe;
+			if( strcmp( Files[lcv]->GetName(), "LPT1" ) == 0 ) file_valid = 0xfe;
+			if( strcmp( Files[lcv]->GetName(), "PRN" ) == 0 ) file_valid = 0xfe;
+			if( strcmp( Files[lcv]->GetName(), "AUX" ) == 0 ) file_valid = 0xfe;
+			if( strcmp( Files[lcv]->GetName(), "EMMXXXX0" ) == 0 ) file_valid = 0xfe;//raiden needs this
+		}
+
+		// - reloc ptr
+		WRITE_POD( &file_valid, file_valid );
+		// system files
+		if( file_valid == 0xff ) continue;
+		if( file_valid == 0xfe ) {
+			WRITE_POD( &Files[lcv]->refCtr, Files[lcv]->refCtr );
+			continue;
+		}
+
+		//**********************************************
+		//**********************************************
+		//**********************************************
+
+		file_namelen = strlen( Files[lcv]->name );
+		file_name = (char *) alloca( file_namelen );
+		strcpy( file_name, Files[lcv]->name );
+
+		file_drive = Files[lcv]->GetDrive();
+		file_flags = Files[lcv]->flags;
+
+		// - Drives->FileOpen vars (repeat copy)
+		WRITE_POD( &file_namelen, file_namelen );
+		WRITE_POD_SIZE( file_name, file_namelen );
+
+		WRITE_POD( &file_drive, file_drive );
+		WRITE_POD( &file_flags, file_flags );
+
+
+		Files[lcv]->SaveState(stream);
+	}
+}
+
+
+void POD_Load_DOS_Files( std::istream& stream )
+{
+	// 1. Do drives first (directories -> files)
+	// 2. Then files next
+
+	for( int lcv=0; lcv<DOS_DRIVES; lcv++ ) {
+		Bit8u drive_valid;
+
+		// - reloc ptr
+		READ_POD( &drive_valid, drive_valid );
+		if( drive_valid == 0xff ) continue;
+
+		if( Drives[lcv] ) Drives[lcv]->LoadState(stream);
+	}
+
+	//Alien Carnage - game creates and unlinks temp files
+	//Here are two situations
+	//1. Game already unlinked temp file, but information about file is still in Files[] and we saved it. In this case we must only pop old data from stream by loading. This is fixed.
+	//2. Game still did not unlink file, We saved this information. Then was game restarted and temp files were removed. Then we try load save state, but we don't have temp file. This is not fixed
+	DOS_File *dummy = NULL;
+
+	for( int lcv=0; lcv<DOS_FILES; lcv++ ) {
+		Bit8u file_valid;
+		char *file_name;
+		Bit8u file_namelen, file_drive, file_flags;
+
+		// - reloc ptr
+		READ_POD( &file_valid, file_valid );
+
+		// ignore system files
+		if( file_valid == 0xfe ) {
+			READ_POD( &Files[lcv]->refCtr, Files[lcv]->refCtr );
+			continue;
+		}
+
+		// shutdown old file
+		if( Files[lcv] ) {
+			// invalid file state - abort
+			if( strcmp( Files[lcv]->GetName(), "NUL" ) == 0 ) break;
+			if( strcmp( Files[lcv]->GetName(), "CON" ) == 0 ) break;
+			if( strcmp( Files[lcv]->GetName(), "LPT1" ) == 0 ) break;
+			if( strcmp( Files[lcv]->GetName(), "PRN" ) == 0 ) break;
+			if( strcmp( Files[lcv]->GetName(), "AUX" ) == 0 ) break;
+			if( strcmp( Files[lcv]->GetName(), "EMMXXXX0" ) == 0 ) break;//raiden needs this
+
+
+			if( Files[lcv]->IsOpen() ) Files[lcv]->Close();
+			if (Files[lcv]->RemoveRef()<=0) {
+				delete Files[lcv];
+			}
+			Files[lcv]=0;
+		}
+
+		// ignore NULL file
+		if( file_valid == 0xff ) continue;
+
+		//**********************************************
+		//**********************************************
+		//**********************************************
+
+		// - Drives->FileOpen vars (repeat copy)
+
+		READ_POD( &file_namelen, file_namelen );
+		file_name = (char *) alloca( file_namelen );
+		READ_POD_SIZE( file_name, file_namelen );
+
+		READ_POD( &file_drive, file_drive );
+		READ_POD( &file_flags, file_flags );
+
+
+		// NOTE: Must open regardless to get 'new' DOS_File class
+		Drives[file_drive]->FileOpen( &Files[lcv], file_name, file_flags );
+
+		if( Files[lcv] ) {
+			Files[lcv]->LoadState(stream, false);
+		} else {
+			//Alien carnage ->pop data for invalid file from stream
+			if (dummy == NULL) {
+				dummy = new localFile();
+			}
+			dummy->LoadState(stream, true);
+		};
+	}
+
+	if (dummy != NULL) {
+		delete dummy;
+	}
+}

--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -49,12 +49,12 @@ bool DOS_IOCTL_AX440D_CH08(Bit8u drive,bool query) {
 
 				if (mem_readw(ptr+0xd) == 0 && mem_readw(ptr+0xf) == 0 && mem_readw(ptr+0x12) == 0) { // FAT32 BPB?
 					bpb.v32.BPB_BytsPerSec = mem_readw(ptr+7);                   // bytes per sector (Win3 File Mgr. uses it)
-					bpb.v32.BPB_SecPerClus = mem_readw(ptr+9);                   // sectors per cluster
+					bpb.v32.BPB_SecPerClus = mem_readb(ptr+9);                   // sectors per cluster
 					bpb.v32.BPB_RsvdSecCnt = mem_readw(ptr+0xa);                 // number of reserved sectors
-					bpb.v32.BPB_NumFATs = mem_readw(ptr+0xc);                    // number of FATs
+					bpb.v32.BPB_NumFATs = mem_readb(ptr+0xc);                    // number of FATs
 					bpb.v32.BPB_RootEntCnt = mem_readw(ptr+0xd);                 // number of root entries (Fake, the real BPB value is zero)
 					bpb.v32.BPB_TotSec16 = mem_readw(ptr+0xf);                   // number of small sectors (always zero on BPB and returned by Win98)
-					bpb.v32.BPB_Media = mem_readw(ptr+0x11);                     // media type
+					bpb.v32.BPB_Media = mem_readb(ptr+0x11);                     // media type
 					bpb.v32.BPB_FATSz32 = (uint16_t)mem_readw(ptr+0x12);         // sectors per FAT (FIXME: What does Win98 do if this value > 0xFFFF?)
 					bpb.v32.BPB_SecPerTrk = (uint16_t)mem_readw(ptr+0x14);       // sectors per track
 					bpb.v32.BPB_NumHeads = (uint16_t)mem_readw(ptr+0x16);	     // number of heads
@@ -62,12 +62,12 @@ bool DOS_IOCTL_AX440D_CH08(Bit8u drive,bool query) {
 					bpb.v32.BPB_TotSec32 = (uint32_t)mem_readd(ptr+0x1c);        // number of big sectors
 				} else {
 					bpb.v.BPB_BytsPerSec = mem_readw(ptr+7);                     // bytes per sector (Win3 File Mgr. uses it)
-					bpb.v.BPB_SecPerClus = mem_readw(ptr+9);                     // sectors per cluster
+					bpb.v.BPB_SecPerClus = mem_readb(ptr+9);                     // sectors per cluster
 					bpb.v.BPB_RsvdSecCnt = mem_readw(ptr+0xa);                   // number of reserved sectors
-					bpb.v.BPB_NumFATs = mem_readw(ptr+0xc);                      // number of FATs
+					bpb.v.BPB_NumFATs = mem_readb(ptr+0xc);                      // number of FATs
 					bpb.v.BPB_RootEntCnt = mem_readw(ptr+0xd);			         // number of root entries
 					bpb.v.BPB_TotSec16 = mem_readw(ptr+0xf);                     // number of small sectors
-					bpb.v.BPB_Media = mem_readw(ptr+0x11);                       // media type
+					bpb.v.BPB_Media = mem_readb(ptr+0x11);                       // media type
 					bpb.v.BPB_FATSz16 = (uint16_t)mem_readw(ptr+0x12);           // sectors per FAT
 					bpb.v.BPB_SecPerTrk = (uint16_t)mem_readw(ptr+0x14);         // sectors per track
 					bpb.v.BPB_NumHeads = (uint16_t)mem_readw(ptr+0x16);          // number of heads
@@ -104,12 +104,12 @@ bool DOS_IOCTL_AX440D_CH08(Bit8u drive,bool query) {
                     if (bpb.is_fat32()) {
                         /* Windows 98 behavior: Some of the FAT32 BPB fields are translated into FAT16 BPB fields even though those fields are zero in the actual BPB */
                         mem_writew(ptr+7,bpb.v32.BPB_BytsPerSec);                   // bytes per sector (Win3 File Mgr. uses it)
-                        mem_writew(ptr+9,bpb.v32.BPB_SecPerClus);                   // sectors per cluster
+                        mem_writeb(ptr+9,bpb.v32.BPB_SecPerClus);                   // sectors per cluster
                         mem_writew(ptr+0xa,bpb.v32.BPB_RsvdSecCnt);                 // number of reserved sectors
-                        mem_writew(ptr+0xc,bpb.v32.BPB_NumFATs);                    // number of FATs
+                        mem_writeb(ptr+0xc,bpb.v32.BPB_NumFATs);                    // number of FATs
                         mem_writew(ptr+0xd,0x200);                                  // number of root entries (Fake, the real BPB value is zero)
                         mem_writew(ptr+0xf,0);                                      // number of small sectors (always zero on BPB and returned by Win98)
-                        mem_writew(ptr+0x11,bpb.v32.BPB_Media);                     // media type
+                        mem_writeb(ptr+0x11,bpb.v32.BPB_Media);                     // media type
                         mem_writew(ptr+0x12,(uint16_t)bpb.v32.BPB_FATSz32);         // sectors per FAT (FIXME: What does Win98 do if this value > 0xFFFF?)
                         mem_writew(ptr+0x14,(uint16_t)bpb.v32.BPB_SecPerTrk);       // sectors per track
                         mem_writew(ptr+0x16,(uint16_t)bpb.v32.BPB_NumHeads);	    // number of heads
@@ -118,12 +118,12 @@ bool DOS_IOCTL_AX440D_CH08(Bit8u drive,bool query) {
                     }
                     else {
                         mem_writew(ptr+7,bpb.v.BPB_BytsPerSec);                     // bytes per sector (Win3 File Mgr. uses it)
-                        mem_writew(ptr+9,bpb.v.BPB_SecPerClus);                     // sectors per cluster
+                        mem_writeb(ptr+9,bpb.v.BPB_SecPerClus);                     // sectors per cluster
                         mem_writew(ptr+0xa,bpb.v.BPB_RsvdSecCnt);                   // number of reserved sectors
-                        mem_writew(ptr+0xc,bpb.v.BPB_NumFATs);                      // number of FATs
+                        mem_writeb(ptr+0xc,bpb.v.BPB_NumFATs);                      // number of FATs
                         mem_writew(ptr+0xd,bpb.v.BPB_RootEntCnt);			        // number of root entries
                         mem_writew(ptr+0xf,bpb.v.BPB_TotSec16);                     // number of small sectors
-                        mem_writew(ptr+0x11,bpb.v.BPB_Media);                       // media type
+                        mem_writeb(ptr+0x11,bpb.v.BPB_Media);                       // media type
                         mem_writew(ptr+0x12,(uint16_t)bpb.v.BPB_FATSz16);           // sectors per FAT
                         mem_writew(ptr+0x14,(uint16_t)bpb.v.BPB_SecPerTrk);         // sectors per track
                         mem_writew(ptr+0x16,(uint16_t)bpb.v.BPB_NumHeads);          // number of heads
@@ -496,12 +496,12 @@ bool DOS_IOCTL_AX440D_CH48(Bit8u drive,bool query) {
 
 				if (mem_readw(ptr+0xd) == 0 && mem_readw(ptr+0xf) == 0 && mem_readw(ptr+0x12) == 0) { // FAT32 BPB?
 					bpb.v.BPB_BytsPerSec = mem_readw(ptr+7);                     // bytes per sector (Win3 File Mgr. uses it)
-					bpb.v.BPB_SecPerClus = mem_readw(ptr+9);                     // sectors per cluster
+					bpb.v.BPB_SecPerClus = mem_readb(ptr+9);                     // sectors per cluster
 					bpb.v.BPB_RsvdSecCnt = mem_readw(ptr+0xa);                   // number of reserved sectors
-					bpb.v.BPB_NumFATs = mem_readw(ptr+0xc);                      // number of FATs
+					bpb.v.BPB_NumFATs = mem_readb(ptr+0xc);                      // number of FATs
 					bpb.v.BPB_RootEntCnt = mem_readw(ptr+0xd);			         // number of root entries
 					bpb.v.BPB_TotSec16 = mem_readw(ptr+0xf);                     // number of small sectors
-					bpb.v.BPB_Media = mem_readw(ptr+0x11);                       // media type
+					bpb.v.BPB_Media = mem_readb(ptr+0x11);                       // media type
 					bpb.v.BPB_FATSz16 = (uint16_t)mem_readw(ptr+0x12);           // sectors per FAT
 					bpb.v.BPB_SecPerTrk = (uint16_t)mem_readw(ptr+0x14);         // sectors per track
 					bpb.v.BPB_NumHeads = (uint16_t)mem_readw(ptr+0x16);          // number of heads
@@ -546,12 +546,12 @@ bool DOS_IOCTL_AX440D_CH48(Bit8u drive,bool query) {
 
                     if (bpb.is_fat32()) {
                         mem_writew(ptr+7,bpb.v.BPB_BytsPerSec);                     // bytes per sector (Win3 File Mgr. uses it)
-                        mem_writew(ptr+9,bpb.v.BPB_SecPerClus);                     // sectors per cluster
+                        mem_writeb(ptr+9,bpb.v.BPB_SecPerClus);                     // sectors per cluster
                         mem_writew(ptr+0xa,bpb.v.BPB_RsvdSecCnt);                   // number of reserved sectors
-                        mem_writew(ptr+0xc,bpb.v.BPB_NumFATs);                      // number of FATs
+                        mem_writeb(ptr+0xc,bpb.v.BPB_NumFATs);                      // number of FATs
                         mem_writew(ptr+0xd,bpb.v.BPB_RootEntCnt);			        // number of root entries
                         mem_writew(ptr+0xf,bpb.v.BPB_TotSec16);                     // number of small sectors
-                        mem_writew(ptr+0x11,bpb.v.BPB_Media);                       // media type
+                        mem_writeb(ptr+0x11,bpb.v.BPB_Media);                       // media type
                         mem_writew(ptr+0x12,(uint16_t)bpb.v.BPB_FATSz16);           // sectors per FAT
                         mem_writew(ptr+0x14,(uint16_t)bpb.v.BPB_SecPerTrk);         // sectors per track
                         mem_writew(ptr+0x16,(uint16_t)bpb.v.BPB_NumHeads);          // number of heads

--- a/src/dos/dos_memory.cpp
+++ b/src/dos/dos_memory.cpp
@@ -607,3 +607,16 @@ void DOS_SetupMemory(void) {
 	dos.firstMCB=DOS_MEM_START;
 	dos_infoblock.SetFirstMCB(DOS_MEM_START);
 }
+
+// save state support
+void POD_Save_DOS_Memory( std::ostream& stream )
+{
+	// - pure data
+	WRITE_POD( &memAllocStrategy, memAllocStrategy );
+}
+
+void POD_Load_DOS_Memory( std::istream& stream )
+{
+	// - pure data
+	READ_POD( &memAllocStrategy, memAllocStrategy );
+}

--- a/src/dos/dos_tables.cpp
+++ b/src/dos/dos_tables.cpp
@@ -386,3 +386,21 @@ void DOS_SetupTables(void) {
     mem_writew(Real2Phys(DOS_DriveDataListHead)+0x04,0x0000);
 }
 
+// save state support
+void POD_Save_DOS_Tables( std::ostream& stream )
+{
+	// - pure data
+	WRITE_POD( &DOS_TableUpCase, DOS_TableUpCase );
+	WRITE_POD( &DOS_TableLowCase, DOS_TableLowCase );
+
+	WRITE_POD( &dos_memseg, dos_memseg );
+}
+
+void POD_Load_DOS_Tables( std::istream& stream )
+{
+	// - pure data
+	READ_POD( &DOS_TableUpCase, DOS_TableUpCase );
+	READ_POD( &DOS_TableLowCase, DOS_TableLowCase );
+
+	READ_POD( &dos_memseg, dos_memseg );
+}

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1956,11 +1956,11 @@ void fatDrive::SetBPB(const FAT_BootSector::bpb_union_t &bpb) {
 	BPB.v.BPB_NumHeads = bpb.v.BPB_NumHeads;
 	BPB.v.BPB_HiddSec = bpb.v.BPB_HiddSec;
 	BPB.v.BPB_TotSec32 = bpb.v.BPB_TotSec32;
-	if (!BPB.is_fat32() && (BPB.v.BPB_BootSig == 0x28 || BPB.v.BPB_BootSig == 0x29))
+	if (!bpb.is_fat32() && (bpb.v.BPB_BootSig == 0x28 || bpb.v.BPB_BootSig == 0x29))
 		BPB.v.BPB_VolID = bpb.v.BPB_VolID;
-	if (BPB.is_fat32() && (BPB.v32.BS_BootSig == 0x28 || BPB.v32.BS_BootSig == 0x29))
+	if (bpb.is_fat32() && (bpb.v32.BS_BootSig == 0x28 || bpb.v32.BS_BootSig == 0x29))
 		BPB.v32.BS_VolID = bpb.v32.BS_VolID;
-	if (BPB.is_fat32()) {
+	if (bpb.is_fat32()) {
 		BPB.v32.BPB_BytsPerSec = bpb.v32.BPB_BytsPerSec;
 		BPB.v32.BPB_SecPerClus = bpb.v32.BPB_SecPerClus;
 		BPB.v32.BPB_RsvdSecCnt = bpb.v32.BPB_RsvdSecCnt;

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -1540,6 +1540,7 @@ Bit32u localFile::GetSeekPos() {
 	return (Bit32u)ftell( fhandle );
 }
 
+localFile::localFile() {}
 
 localFile::localFile(const char* _name, FILE * handle) {
 	fhandle=handle;

--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -420,3 +420,39 @@ char * DOS_Drive::GetBaseDir(void) {
 	return info + 16;
 }
 
+// save state support
+void DOS_Drive::SaveState( std::ostream& stream )
+{
+	// - pure data
+	WRITE_POD( &curdir, curdir );
+	WRITE_POD( &info, info );
+}
+
+void DOS_Drive::LoadState( std::istream& stream )
+{
+	// - pure data
+	READ_POD( &curdir, curdir );
+	READ_POD( &info, info );
+}
+
+void DriveManager::SaveState( std::ostream& stream )
+{
+	// - pure data
+	WRITE_POD( &currentDrive, currentDrive );
+}
+
+void DriveManager::LoadState( std::istream& stream )
+{
+	// - pure data
+	READ_POD( &currentDrive, currentDrive );
+}
+
+void POD_Save_DOS_DriveManager( std::ostream& stream )
+{
+	DriveManager::SaveState(stream);
+}
+
+void POD_Load_DOS_DriveManager( std::istream& stream )
+{
+	DriveManager::LoadState(stream);
+}

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -751,6 +751,11 @@ void SaveGameState(bool pressed) {
     {
         SaveState::instance().save(currentSlot);
         LOG_MSG("[%s]: State %d saved!", getTime().c_str(), currentSlot + 1);
+		char name[6]="slot0";
+		name[4]='0'+currentSlot;
+		std::string str="Slot 1"+std::string(SaveState::instance().isEmpty(currentSlot)?" [Empty]":"");
+		str[5]='1'+currentSlot;
+		mainMenu.get_item(name).set_text(str.c_str()).refresh_item(mainMenu);
     }
     catch (const SaveState::Error& err)
     {
@@ -4858,5 +4863,28 @@ delete_all:
 
 bool SaveState::isEmpty(size_t slot) const {
 	if (slot >= SLOT_COUNT) return true;
-	return (components.empty() || !components.begin()->second.rawBytes[slot].dataAvailable());
+	std::string path;
+	bool Get_Custom_SaveDir(std::string& savedir);
+	if(Get_Custom_SaveDir(path)) {
+		path+=CROSS_FILESPLIT;
+	} else {
+		extern std::string capturedir;
+		const size_t last_slash_idx = capturedir.find_last_of("\\/");
+		if (std::string::npos != last_slash_idx) {
+			path = capturedir.substr(0, last_slash_idx);
+		} else {
+			path = ".";
+		}
+		path += CROSS_FILESPLIT;
+		path +="save";
+		path += CROSS_FILESPLIT;
+	}
+	std::string temp;
+	temp = path;
+	std::stringstream slotname;
+	slotname << slot+1;
+	std::string save=temp+slotname.str()+".sav";
+	std::ifstream check_slot;
+	check_slot.open(save.c_str(), std::ifstream::in);
+	return check_slot.fail();
 }

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -4731,6 +4731,9 @@ void SaveState::load(size_t slot) const { //throw (Error)
 	check_slot.open(save.c_str(), std::ifstream::in);
 	if(check_slot.fail()) {
 		LOG_MSG("No saved slot - %d (%s)",slot+1,save.c_str());
+#if defined(WIN32)
+		MessageBox(GetHWND(),"The selected save slot is empty.","Error",MB_OK);
+#endif
 		load_err=true;
 		return;
 	}
@@ -4754,6 +4757,9 @@ void SaveState::load(size_t slot) const { //throw (Error)
 			check_title.open(tempname.c_str(), std::ifstream::in);
 			if(check_title.fail()) {
 				LOG_MSG("Save state corrupted! Program in inconsistent state! - Program_Name");
+#if defined(WIN32)
+				MessageBox(GetHWND(),"Save state corrupted!","Error",MB_OK);
+#endif
 				load_err=true;
 				goto delete_all;
 			}
@@ -4765,7 +4771,7 @@ void SaveState::load(size_t slot) const { //throw (Error)
 			check_title.read (buffer, length);
 			check_title.close();
 #if defined(WIN32)
-			if(!force_load_state&&strncmp(buffer,RunningProgram,length)&&MessageBox(GetHWND(),"Program name mismatch. Continue anyway?","Warning",MB_YESNO)==IDNO) {
+			if(!force_load_state&&strncmp(buffer,RunningProgram,length)&&MessageBox(GetHWND(),"Program name mismatch. Load the state anyway?","Warning",MB_YESNO)==IDNO) {
 #else
 			if(!force_load_state&&strncmp(buffer,RunningProgram,length)) {
 #endif
@@ -4810,6 +4816,9 @@ void SaveState::load(size_t slot) const { //throw (Error)
 		check_file.close();
 		if(check_file.fail()) {
 			LOG_MSG("Save state corrupted! Program in inconsistent state! - %s",i->first.c_str());
+#if defined(WIN32)
+			MessageBox(GetHWND(),"Save state corrupted!","Error",MB_OK);
+#endif
 			load_err=true;
 			goto delete_all;
 		}
@@ -4821,6 +4830,9 @@ void SaveState::load(size_t slot) const { //throw (Error)
 		i->second.comp.setBytes(mystream);
 		if (mystream.rdbuf()->in_avail() != 0 || mystream.eof()) { //basic consistency check
 			LOG_MSG("Save state corrupted! Program in inconsistent state! - %s",i->first.c_str());
+#if defined(WIN32)
+			MessageBox(GetHWND(),"Save state corrupted!","Error",MB_OK);
+#endif
 			load_err=true;
 			goto delete_all;
 		}

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -1040,3 +1040,15 @@ void FPU_Init() {
 
 #endif
 
+//save state support
+namespace
+{
+class SerializeFpu : public SerializeGlobalPOD
+{
+public:
+    SerializeFpu() : SerializeGlobalPOD("FPU")
+    {
+        registerPOD(fpu);
+    }
+} dummy;
+}

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -477,6 +477,8 @@ static const char *def_save_slots[] =
     "slot7",
     "slot8",
     "slot9",
+	"--",
+    "refreshslot",
 	NULL
 };
 

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -438,7 +438,12 @@ static const char *def_menu_capture[] =
     "mapper_recmtwave",
     "mapper_caprawopl",
     "mapper_caprawmidi",
+    "--",
 #endif
+    "force_loadstate",
+    "mapper_savestate",
+    "mapper_loadstate",
+	"saveslotmenu",
     NULL
 };
 
@@ -455,6 +460,25 @@ static const char *def_menu_capture_format[] =
 };
 # endif
 #endif
+
+/* Save slots */
+static const char *def_save_slots[] =
+{
+	"mapper_prevslot",
+	"mapper_nextslot",
+	"--",
+    "slot0",
+    "slot1",
+    "slot2",
+    "slot3",
+    "slot4",
+    "slot5",
+    "slot6",
+    "slot7",
+    "slot8",
+    "slot9",
+	NULL
+};
 
 /* Drive menu ("DriveMenu") */
 static const char *def_menu_drive[] =
@@ -1212,6 +1236,7 @@ void ConstructMenu(void) {
     ConstructSubMenu(mainMenu.get_item("CaptureFormatMenu").get_master_id(), def_menu_capture_format);
 # endif
 #endif
+    ConstructSubMenu(mainMenu.get_item("saveslotmenu").get_master_id(), def_save_slots);
 
     /* Drive menu */
     ConstructSubMenu(mainMenu.get_item("DriveMenu").get_master_id(), def_menu_drive);

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -1094,3 +1094,56 @@ void RENDER_Init() {
     RENDER_UpdateScalerMenu();
 }
 
+//save state support
+namespace
+{
+class SerializeRender : public SerializeGlobalPOD
+{
+public:
+	SerializeRender() : SerializeGlobalPOD("Render")
+	{}
+
+private:
+	virtual void getBytes(std::ostream& stream)
+	{
+		SerializeGlobalPOD::getBytes(stream);
+
+
+		// - pure data
+		WRITE_POD( &render.src, render.src );
+
+		WRITE_POD( &render.pal, render.pal );
+		WRITE_POD( &render.updating, render.updating );
+		WRITE_POD( &render.active, render.active );
+		WRITE_POD( &render.fullFrame, render.fullFrame );
+		WRITE_POD( &render.frameskip, render.frameskip );
+	}
+
+	virtual void setBytes(std::istream& stream)
+	{
+		SerializeGlobalPOD::setBytes(stream);
+
+
+		// - pure data
+		READ_POD( &render.src, render.src );
+
+		READ_POD( &render.pal, render.pal );
+		READ_POD( &render.updating, render.updating );
+		READ_POD( &render.active, render.active );
+		READ_POD( &render.fullFrame, render.fullFrame );
+		READ_POD( &render.frameskip, render.frameskip );
+
+		//***************************************
+		//***************************************
+
+		// reset screen
+		//memset( &render.frameskip, 0, sizeof(render.frameskip) );
+
+		render.scale.clearCache = true;
+		if( render.scale.outWrite ) { GFX_EndUpdate(NULL); }
+
+		RENDER_SetSize( render.src.width, render.src.height, render.src.bpp, render.src.fps, render.src.ratio );
+
+	}
+} dummy;
+}

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -7598,12 +7598,23 @@ bool doublebuf_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const m
 }
 
 bool force_loadstate_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
-#if !defined(C_EMSCRIPTEN)
     (void)menu;//UNUSED
     (void)menuitem;//UNUSED
     force_load_state = !force_load_state;
     mainMenu.get_item("force_loadstate").check(force_load_state).refresh_item(mainMenu);
-#endif
+    return true;
+}
+
+bool refresh_slots_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+	for (int i=0; i<10; i++) {
+		char name[6]="slot0";
+		name[4]='0'+i;
+		std::string str="Slot 1"+std::string(SaveState::instance().isEmpty(i)?" [Empty]":"");
+		str[5]='1'+i;
+		mainMenu.get_item(name).set_text(str.c_str()).refresh_item(mainMenu);
+	}
     return true;
 }
 
@@ -8954,6 +8965,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"showdetails").set_text("Show details").set_callback_function(showdetails_menu_callback).check(!menu.hidecycles && !menu.showrt);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"highdpienable").set_text("High DPI enable").set_callback_function(highdpienable_menu_callback).check(dpi_aware_enable);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"force_loadstate").set_text("Force load state").set_callback_function(force_loadstate_menu_callback).check(force_load_state);
+        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"refreshslot").set_text("Refresh status").set_callback_function(refresh_slots_menu_callback);
 
         mainMenu.get_item("mapper_blankrefreshtest").set_text("Refresh test (blank display)").set_callback_function(refreshtest_menu_callback).refresh_item(mainMenu);
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8732,16 +8732,16 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
             item.set_text("Select save slot");
 
             {
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot0").set_text("Slot 1").set_callback_function(save_slot_0_callback);
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot1").set_text("Slot 2").set_callback_function(save_slot_1_callback);
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot2").set_text("Slot 3").set_callback_function(save_slot_2_callback);
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot3").set_text("Slot 4").set_callback_function(save_slot_3_callback);
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot4").set_text("Slot 5").set_callback_function(save_slot_4_callback);
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot5").set_text("Slot 6").set_callback_function(save_slot_5_callback);
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot6").set_text("Slot 7").set_callback_function(save_slot_6_callback);
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot7").set_text("Slot 8").set_callback_function(save_slot_7_callback);
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot8").set_text("Slot 9").set_callback_function(save_slot_8_callback);
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot9").set_text("Slot 10").set_callback_function(save_slot_9_callback);
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot0").set_text(("Slot 1"+std::string(SaveState::instance().isEmpty(0)?" [Empty]":"")).c_str()).set_callback_function(save_slot_0_callback);
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot1").set_text(("Slot 2"+std::string(SaveState::instance().isEmpty(1)?" [Empty]":"")).c_str()).set_callback_function(save_slot_1_callback);
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot2").set_text(("Slot 3"+std::string(SaveState::instance().isEmpty(2)?" [Empty]":"")).c_str()).set_callback_function(save_slot_2_callback);
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot3").set_text(("Slot 4"+std::string(SaveState::instance().isEmpty(3)?" [Empty]":"")).c_str()).set_callback_function(save_slot_3_callback);
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot4").set_text(("Slot 5"+std::string(SaveState::instance().isEmpty(4)?" [Empty]":"")).c_str()).set_callback_function(save_slot_4_callback);
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot5").set_text(("Slot 6"+std::string(SaveState::instance().isEmpty(5)?" [Empty]":"")).c_str()).set_callback_function(save_slot_5_callback);
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot6").set_text(("Slot 7"+std::string(SaveState::instance().isEmpty(6)?" [Empty]":"")).c_str()).set_callback_function(save_slot_6_callback);
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot7").set_text(("Slot 8"+std::string(SaveState::instance().isEmpty(7)?" [Empty]":"")).c_str()).set_callback_function(save_slot_7_callback);
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot8").set_text(("Slot 9"+std::string(SaveState::instance().isEmpty(8)?" [Empty]":"")).c_str()).set_callback_function(save_slot_8_callback);
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot9").set_text(("Slot 10"+std::string(SaveState::instance().isEmpty(9)?" [Empty]":"")).c_str()).set_callback_function(save_slot_9_callback);
             }
 			char name[6]="slot0";
 			name[4]='0'+GetGameState_Run();

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -40,6 +40,7 @@
 extern bool dpi_aware_enable;
 extern bool log_int21;
 extern bool log_fileio;
+extern bool force_load_state;
 
 bool OpenGL_using(void);
 void GFX_OpenGLRedrawScreen(void);
@@ -182,6 +183,78 @@ void MenuUnmountDrive(char drive);
 void MenuMountDrive(char drive, const char drive2[DOS_PATHLENGTH]);
 void MenuBrowseFolder(char drive, std::string drive_type);
 void MenuBrowseImageFile(char drive);
+void SetGameState_Run(int value);
+size_t GetGameState_Run(void);
+
+bool save_slot_0_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+	SetGameState_Run(0);
+	return true;
+}
+
+bool save_slot_1_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+	SetGameState_Run(1);
+	return true;
+}
+
+bool save_slot_2_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+	SetGameState_Run(2);
+	return true;
+}
+
+bool save_slot_3_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+	SetGameState_Run(3);
+	return true;
+}
+
+bool save_slot_4_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+	SetGameState_Run(4);
+	return true;
+}
+
+bool save_slot_5_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+	SetGameState_Run(5);
+	return true;
+}
+
+bool save_slot_6_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+	SetGameState_Run(6);
+	return true;
+}
+
+bool save_slot_7_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+	SetGameState_Run(7);
+	return true;
+}
+
+bool save_slot_8_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+	SetGameState_Run(8);
+	return true;
+}
+
+bool save_slot_9_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+	SetGameState_Run(9);
+	return true;
+}
 
 bool drive_mountauto_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
@@ -364,7 +437,6 @@ bool drive_boot_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const m
 
     return true;
 }
-
 
 const DOSBoxMenu::callback_t drive_callbacks[] = {
 #if defined(WIN32)
@@ -7525,6 +7597,16 @@ bool doublebuf_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const m
     return true;
 }
 
+bool force_loadstate_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
+#if !defined(C_EMSCRIPTEN)
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+    force_load_state = !force_load_state;
+    mainMenu.get_item("force_loadstate").check(force_load_state).refresh_item(mainMenu);
+#endif
+    return true;
+}
+
 #if defined(LINUX)
 bool x11_on_top = false;
 #endif
@@ -8645,6 +8727,26 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
             }
         }
 # endif
+		{
+            DOSBoxMenu::item &item = mainMenu.alloc_item(DOSBoxMenu::submenu_type_id,"saveslotmenu");
+            item.set_text("Select save slot");
+
+            {
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot0").set_text("Slot 1").set_callback_function(save_slot_0_callback);
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot1").set_text("Slot 2").set_callback_function(save_slot_1_callback);
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot2").set_text("Slot 3").set_callback_function(save_slot_2_callback);
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot3").set_text("Slot 4").set_callback_function(save_slot_3_callback);
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot4").set_text("Slot 5").set_callback_function(save_slot_4_callback);
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot5").set_text("Slot 6").set_callback_function(save_slot_5_callback);
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot6").set_text("Slot 7").set_callback_function(save_slot_6_callback);
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot7").set_text("Slot 8").set_callback_function(save_slot_7_callback);
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot8").set_text("Slot 9").set_callback_function(save_slot_8_callback);
+				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot9").set_text("Slot 10").set_callback_function(save_slot_9_callback);
+            }
+			char name[6]="slot0";
+			name[4]='0'+GetGameState_Run();
+			mainMenu.get_item(name).check(true).refresh_item(mainMenu);
+		}
 #endif
         {
             DOSBoxMenu::item &item = mainMenu.alloc_item(DOSBoxMenu::submenu_type_id,"DriveMenu");
@@ -8851,6 +8953,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"alwaysontop").set_text("Always on top").set_callback_function(alwaysontop_menu_callback).check(is_always_on_top());
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"showdetails").set_text("Show details").set_callback_function(showdetails_menu_callback).check(!menu.hidecycles && !menu.showrt);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"highdpienable").set_text("High DPI enable").set_callback_function(highdpienable_menu_callback).check(dpi_aware_enable);
+        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"force_loadstate").set_text("Force load state").set_callback_function(force_loadstate_menu_callback).check(force_load_state);
 
         mainMenu.get_item("mapper_blankrefreshtest").set_text("Refresh test (blank display)").set_callback_function(refreshtest_menu_callback).refresh_item(mainMenu);
 
@@ -9430,3 +9533,18 @@ void SDL_GL_SwapBuffers(void) {
     SDL_GL_SwapWindow(sdl.window);
 }
 #endif
+
+// save state support
+void POD_Save_Sdlmain( std::ostream& stream )
+{
+	// - pure data
+	WRITE_POD( &sdl.mouse.autolock, sdl.mouse.autolock );
+	WRITE_POD( &sdl.mouse.requestlock, sdl.mouse.requestlock );
+}
+
+void POD_Load_Sdlmain( std::istream& stream )
+{
+	// - pure data
+	READ_POD( &sdl.mouse.autolock, sdl.mouse.autolock );
+	READ_POD( &sdl.mouse.requestlock, sdl.mouse.requestlock );
+}

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -64,6 +64,41 @@ namespace OPL2 {
 			adlib_init((Bit32u)rate);
 		}
 
+		virtual void SaveState( std::ostream& stream ) {
+			const char pod_name[32] = "OPL2";
+
+			if( stream.fail() ) return;
+
+
+			WRITE_POD( &pod_name, pod_name );
+
+			//************************************************
+			//************************************************
+			//************************************************
+
+			adlib_savestate(stream);
+		}
+
+		virtual void LoadState( std::istream& stream ) {
+			char pod_name[32] = {0};
+
+			if( stream.fail() ) return;
+
+
+			// error checking
+			READ_POD( &pod_name, pod_name );
+			if( strcmp( pod_name, "OPL2" ) ) {
+				stream.clear( std::istream::failbit | std::istream::badbit );
+				return;
+			}
+
+			//************************************************
+			//************************************************
+			//************************************************
+
+			adlib_loadstate(stream);
+		}
+
 		~Handler() {
 		}
 	};
@@ -93,6 +128,41 @@ namespace OPL3 {
 
 		virtual void Init( Bitu rate ) {
 			adlib_init((Bit32u)rate);
+		}
+
+		virtual void SaveState( std::ostream& stream ) {
+			const char pod_name[32] = "OPL3";
+
+			if( stream.fail() ) return;
+
+
+			WRITE_POD( &pod_name, pod_name );
+
+			//************************************************
+			//************************************************
+			//************************************************
+
+			adlib_savestate(stream);
+		}
+
+		virtual void LoadState( std::istream& stream ) {
+			char pod_name[32] = {0};
+
+			if( stream.fail() ) return;
+
+
+			// error checking
+			READ_POD( &pod_name, pod_name );
+			if( strcmp( pod_name, "OPL3" ) ) {
+				stream.clear( std::istream::failbit | std::istream::badbit );
+				return;
+			}
+
+			//************************************************
+			//************************************************
+			//************************************************
+
+			adlib_loadstate(stream);
 		}
 
 		~Handler() {
@@ -155,6 +225,40 @@ struct Handler : public Adlib::Handler {
 	virtual void Init(Bitu rate) {
 		chip = ym3812_init(0, OPL2_INTERNAL_FREQ, (uint32_t)rate);
 	}
+	virtual void SaveState( std::ostream& stream ) {
+    	const char pod_name[32] = "MAMEOPL2";
+
+    	if( stream.fail() ) return;
+
+
+    	WRITE_POD( &pod_name, pod_name );
+
+    	//************************************************
+    	//************************************************
+    	//************************************************
+
+    	FMOPL_SaveState(chip, stream);
+    }
+
+    virtual void LoadState( std::istream& stream ) {
+    	char pod_name[32] = {0};
+
+    	if( stream.fail() ) return;
+
+
+    	// error checking
+    	READ_POD( &pod_name, pod_name );
+    	if( strcmp( pod_name, "MAMEOPL2" ) ) {
+    		stream.clear( std::istream::failbit | std::istream::badbit );
+    		return;
+    	}
+
+    	//************************************************
+    	//************************************************
+    	//************************************************
+
+    	FMOPL_LoadState(chip, stream);
+    }
 	~Handler() {
 		ym3812_shutdown(chip);
 	}
@@ -195,6 +299,39 @@ struct Handler : public Adlib::Handler {
 	}
 	virtual void Init(Bitu rate) {
 		chip = ymf262_init(0, OPL3_INTERNAL_FREQ, (int)rate);
+	}
+	virtual void SaveState( std::ostream& stream ) {
+    	const char pod_name[32] = "MAMEOPL3";
+
+    	if( stream.fail() ) return;
+
+
+    	WRITE_POD( &pod_name, pod_name );
+
+    	//************************************************
+    	//************************************************
+    	//************************************************
+
+    	YMF_SaveState(chip, stream);
+ 	}
+    virtual void LoadState( std::istream& stream ) {
+    	char pod_name[32] = {0};
+
+    	if( stream.fail() ) return;
+
+
+    	// error checking
+    	READ_POD( &pod_name, pod_name );
+    	if( strcmp( pod_name, "MAMEOPL3" ) ) {
+    		stream.clear( std::istream::failbit | std::istream::badbit );
+    		return;
+    	}
+
+    	//************************************************
+    	//************************************************
+    	//************************************************
+
+    	YMF_LoadState(chip, stream);
 	}
 	~Handler() {
 		ymf262_shutdown(chip);
@@ -1008,3 +1145,76 @@ void OPL_ShutDown(Section* sec){
 	module = 0;
 }
 
+// savestate support
+void Adlib::Module::SaveState( std::ostream& stream )
+{
+	// - pure data
+	WRITE_POD( &mode, mode );
+	WRITE_POD( &reg, reg );
+	WRITE_POD( &ctrl, ctrl );
+	WRITE_POD( &oplmode, oplmode );
+	WRITE_POD( &lastUsed, lastUsed );
+
+	handler->SaveState(stream);
+
+	WRITE_POD( &cache, cache );
+	WRITE_POD( &chip, chip );
+}
+
+void Adlib::Module::LoadState( std::istream& stream )
+{
+	// - pure data
+	READ_POD( &mode, mode );
+	READ_POD( &reg, reg );
+	READ_POD( &ctrl, ctrl );
+	READ_POD( &oplmode, oplmode );
+	READ_POD( &lastUsed, lastUsed );
+
+	handler->LoadState(stream);
+
+	READ_POD( &cache, cache );
+	READ_POD( &chip, chip );
+}
+
+void POD_Save_Adlib(std::ostream& stream)
+{
+	const char pod_name[32] = "Adlib";
+
+	if( stream.fail() ) return;
+	if( !module ) return;
+	if( !module->mixerChan ) return;
+
+
+	WRITE_POD( &pod_name, pod_name );
+
+	//************************************************
+	//************************************************
+	//************************************************
+
+	module->SaveState(stream);
+	module->mixerChan->SaveState(stream);
+}
+
+void POD_Load_Adlib(std::istream& stream)
+{
+	char pod_name[32] = {0};
+
+	if( stream.fail() ) return;
+	if( !module ) return;
+	if( !module->mixerChan ) return;
+
+
+	// error checking
+	READ_POD( &pod_name, pod_name );
+	if( strcmp( pod_name, "Adlib" ) ) {
+		stream.clear( std::istream::failbit | std::istream::badbit );
+		return;
+	}
+
+	//************************************************
+	//************************************************
+	//************************************************
+
+	module->LoadState(stream);
+	module->mixerChan->LoadState(stream);
+}

--- a/src/hardware/adlib.h
+++ b/src/hardware/adlib.h
@@ -112,6 +112,8 @@ public:
 	virtual void Generate( MixerChannel* chan, Bitu samples ) = 0;
 	//Initialize at a specific sample rate and mode
 	virtual void Init( Bitu rate ) = 0;
+	virtual void SaveState( std::ostream& stream ) {}
+	virtual void LoadState( std::istream& stream ) {}
 
 	virtual ~Handler() {
 	}
@@ -160,6 +162,10 @@ public:
 	void PortWrite( Bitu port, Bitu val, Bitu iolen );
 	Bitu PortRead( Bitu port, Bitu iolen );
 	void Init( Mode m );
+
+	// savestate support
+	virtual void SaveState( std::ostream& stream );
+	virtual void LoadState( std::istream& stream );
 
 	Module( Section* configuration); 
 	~Module();

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -616,3 +616,27 @@ void CMOS_Init() {
     AddVMEventFunction(VM_EVENT_RESET,AddVMEventFunctionFuncPair(CMOS_Reset));
 }
 
+// save state support
+void *cmos_timerevent_PIC_Event = (void*)cmos_timerevent;
+
+namespace
+{
+class SerializeCmos : public SerializeGlobalPOD
+{
+public:
+    SerializeCmos() : SerializeGlobalPOD("CMOS")
+    {
+        registerPOD(cmos.regs);
+        registerPOD(cmos.nmi);
+        registerPOD(cmos.reg);
+        registerPOD(cmos.timer.enabled);
+        registerPOD(cmos.timer.div);
+        registerPOD(cmos.timer.delay);
+        registerPOD(cmos.timer.acknowledged);
+        registerPOD(cmos.last.timer);
+        registerPOD(cmos.last.ended);
+        registerPOD(cmos.last.alarm);
+        registerPOD(cmos.update_ended);
+    }
+} dummy;
+}

--- a/src/hardware/dbopl.h
+++ b/src/hardware/dbopl.h
@@ -253,6 +253,9 @@ struct Handler : public Adlib::Handler {
 	virtual void WriteReg( Bit32u addr, Bit8u val );
 	virtual void Generate( MixerChannel* chan, Bitu samples );
 	virtual void Init( Bitu rate );
+	virtual void SaveState( std::ostream& stream );
+	virtual void LoadState( std::istream& stream );
+
 };
 
 

--- a/src/hardware/gameblaster.cpp
+++ b/src/hardware/gameblaster.cpp
@@ -178,3 +178,71 @@ void CMS_ShutDown(Section* sec) {
         test = NULL;
     }
 }
+
+// save state support
+void POD_Save_Gameblaster( std::ostream& stream )
+{
+	const char pod_name[32] = "CMS";
+
+    if( stream.fail() ) return;
+    if( !test ) return;
+    if( !cms_chan ) return;
+
+    WRITE_POD( &pod_name, pod_name );
+
+    //*******************************************
+    //*******************************************
+    //*******************************************
+
+    // - pure data
+    WRITE_POD( &lastWriteTicks, lastWriteTicks );
+    WRITE_POD( &cmsBase, cmsBase );
+    WRITE_POD( &cms_detect_register, cms_detect_register );
+
+    //************************************************
+    //************************************************
+    //************************************************
+
+    for (int i=0; i<2; i++) {
+        device[i]->SaveState(stream);
+    }
+
+    cms_chan->SaveState(stream);
+}
+
+
+void POD_Load_Gameblaster( std::istream& stream )
+{
+	char pod_name[32] = {0};
+
+	if( stream.fail() ) return;
+	if( !test ) return;
+	if( !cms_chan ) return;
+
+
+	// error checking
+	READ_POD( &pod_name, pod_name );
+	if( strcmp( pod_name, "CMS" ) ) {
+		stream.clear( std::istream::failbit | std::istream::badbit );
+		return;
+	}
+
+	//*******************************************
+	//*******************************************
+	//*******************************************
+
+    // - pure data
+    READ_POD( &lastWriteTicks, lastWriteTicks );
+    READ_POD( &cmsBase, cmsBase );
+    READ_POD( &cms_detect_register, cms_detect_register );
+
+	//************************************************
+	//************************************************
+	//************************************************
+
+    for (int i=0; i<2; i++) {
+        device[i]->LoadState(stream);
+   }
+
+	cms_chan->LoadState(stream);
+}

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -829,3 +829,18 @@ void IO_PutCallout(IO_CalloutObject *obj) {
     obj->getcounter--;
 }
 
+//save state support
+namespace
+{
+class SerializeIO : public SerializeGlobalPOD
+{
+public:
+    SerializeIO() : SerializeGlobalPOD("IO handler")
+    {
+        //io_writehandlers -> quasi constant
+        //io_readhandlers  -> quasi constant
+
+        //registerPOD(iof_queue.used); registerPOD(iof_queue.entries);
+    }
+} dummy;
+}

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -289,3 +289,21 @@ void JOYSTICK_Init() {
         AddVMEventFunction(VM_EVENT_POWERON,AddVMEventFunctionFuncPair(JOYSTICK_OnPowerOn));
 }
 
+//save state support
+namespace
+{
+class SerializeStick : public SerializeGlobalPOD
+{
+public:
+    SerializeStick() : SerializeGlobalPOD("Joystick")
+    {
+        registerPOD(joytype);
+        registerPOD(stick);
+        registerPOD(last_write);
+        registerPOD(write_active);
+        registerPOD(swap34);
+        registerPOD(button_wrapping_enabled);
+        registerPOD(autofire);
+    }
+} dummy;
+}

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -2657,3 +2657,31 @@ void KEYBOARD_Reset() {
     KEYBOARD_SetLEDs(0);
 }
 
+//save state support
+void *KEYBOARD_TransferBuffer_PIC_Event = (void*)KEYBOARD_TransferBuffer;
+void *KEYBOARD_TickHandler_PIC_Timer = (void*)KEYBOARD_TickHandler;
+
+namespace
+{
+class SerializeKeyboard : public SerializeGlobalPOD
+{
+public:
+    SerializeKeyboard() : SerializeGlobalPOD("Keyboard")
+    {
+        registerPOD(keyb.buffer);
+        registerPOD(keyb.used); 
+        registerPOD(keyb.pos); 
+        registerPOD(keyb.repeat.key); 
+        registerPOD(keyb.repeat.wait); 
+        registerPOD(keyb.repeat.pause); 
+        registerPOD(keyb.repeat.rate); 
+        registerPOD(keyb.command); 
+        registerPOD(keyb.p60data); 
+        registerPOD(keyb.p60changed); 
+        registerPOD(keyb.active); 
+        registerPOD(keyb.scanning); 
+        registerPOD(keyb.scheduled);
+        registerPOD(port_61_data);
+    }
+} dummy;
+}

--- a/src/hardware/mame/emu.h
+++ b/src/hardware/mame/emu.h
@@ -135,6 +135,13 @@ public:
         (void)owner;
 	}
 
+	void SaveState( std::ostream& stream ) {
+	    WRITE_POD( &clockRate, clockRate );
+	}
+	void LoadState( std::istream& stream ) {
+	    READ_POD( &clockRate, clockRate );
+	}
+
 	virtual ~device_t() {
 	}
 };

--- a/src/hardware/mame/fmopl.cpp
+++ b/src/hardware/mame/fmopl.cpp
@@ -2266,6 +2266,160 @@ void ym3812_update_one(void *chip, OPLSAMPLE *buffer, int length)
 	}
 
 }
+
+// save state support
+void SaveState_Channel(OPL_CH *CH, std::ostream& stream) {
+	int slot, ch;
+
+	for( ch=0 ; ch < 9 ; ch++, CH++ ) {
+		/* channel */
+		WRITE_POD( &CH->block_fnum, CH->block_fnum );
+	    WRITE_POD( &CH->kcode, CH->kcode );
+	    /* slots */
+  		for( slot=0 ; slot < 2 ; slot++ ) {
+        	OPL_SLOT *SLOT = &CH->SLOT[slot];
+
+        	WRITE_POD( &SLOT->ar, SLOT->ar );
+        	WRITE_POD( &SLOT->dr, SLOT->dr );
+        	WRITE_POD( &SLOT->rr, SLOT->rr );
+        	WRITE_POD( &SLOT->KSR, SLOT->KSR );
+       	    WRITE_POD( &SLOT->ksl, SLOT->ksl );
+        	WRITE_POD( &SLOT->mul, SLOT->mul );
+
+        	WRITE_POD( &SLOT->Cnt, SLOT->Cnt );
+        	WRITE_POD( &SLOT->FB, SLOT->FB );
+        	WRITE_POD( &SLOT->op1_out, SLOT->op1_out );
+        	WRITE_POD( &SLOT->CON, SLOT->CON );
+
+        	WRITE_POD( &SLOT->eg_type, SLOT->eg_type );
+            WRITE_POD( &SLOT->state, SLOT->state );
+            WRITE_POD( &SLOT->TL, SLOT->TL );
+            WRITE_POD( &SLOT->volume, SLOT->volume );
+            WRITE_POD( &SLOT->sl, SLOT->sl );
+            WRITE_POD( &SLOT->key, SLOT->key );
+
+            WRITE_POD( &SLOT->AMmask, SLOT->AMmask );
+            WRITE_POD( &SLOT->vib, SLOT->vib );
+
+            WRITE_POD( &SLOT->wavetable, SLOT->wavetable );
+    	}
+	}
+}
+
+void LoadState_Channel(OPL_CH *CH, std::istream& stream) {
+	int slot, ch;
+
+	for( ch=0 ; ch < 9 ; ch++, CH++ ) {
+		/* channel */
+	    READ_POD( &CH->block_fnum, CH->block_fnum );
+	    READ_POD( &CH->kcode, CH->kcode );
+	    /* slots */
+   		for( slot=0 ; slot < 2 ; slot++ ) {
+        	OPL_SLOT *SLOT = &CH->SLOT[slot];
+
+        	READ_POD( &SLOT->ar, SLOT->ar );
+        	READ_POD( &SLOT->dr, SLOT->dr );
+        	READ_POD( &SLOT->rr, SLOT->rr );
+        	READ_POD( &SLOT->KSR, SLOT->KSR );
+        	READ_POD( &SLOT->ksl, SLOT->ksl );
+        	READ_POD( &SLOT->mul, SLOT->mul );
+
+        	READ_POD( &SLOT->Cnt, SLOT->Cnt );
+        	READ_POD( &SLOT->FB, SLOT->FB );
+        	READ_POD( &SLOT->op1_out, SLOT->op1_out );
+        	READ_POD( &SLOT->CON, SLOT->CON );
+
+        	READ_POD( &SLOT->eg_type, SLOT->eg_type );
+            READ_POD( &SLOT->state, SLOT->state );
+            READ_POD( &SLOT->TL, SLOT->TL );
+            READ_POD( &SLOT->volume, SLOT->volume );
+            READ_POD( &SLOT->sl, SLOT->sl );
+            READ_POD( &SLOT->key, SLOT->key );
+
+            READ_POD( &SLOT->AMmask, SLOT->AMmask );
+            READ_POD( &SLOT->vib, SLOT->vib );
+
+            READ_POD( &SLOT->wavetable, SLOT->wavetable );
+    	}
+	}
+}
+
+void FMOPL_SaveState(void *chip, std::ostream& stream ) {
+    FM_OPL *OPL = (FM_OPL *)chip;
+
+    SaveState_Channel(OPL->P_CH, stream);
+
+    WRITE_POD(&OPL->eg_cnt, OPL->eg_cnt);
+    WRITE_POD(&OPL->eg_timer, OPL->eg_timer);
+    WRITE_POD(&OPL->rhythm, OPL->rhythm);
+
+    WRITE_POD(&OPL->lfo_am_depth, OPL->lfo_am_depth);
+    WRITE_POD(&OPL->lfo_pm_depth_range, OPL->lfo_pm_depth_range);
+    WRITE_POD(&OPL->lfo_am_cnt, OPL->lfo_am_cnt);
+    WRITE_POD(&OPL->lfo_pm_cnt, OPL->lfo_pm_cnt);
+
+    WRITE_POD(&OPL->noise_rng, OPL->noise_rng);
+    WRITE_POD(&OPL->noise_p, OPL->noise_p);
+
+   	if( OPL->type & OPL_TYPE_WAVESEL ) {
+    	WRITE_POD(&OPL->wavesel, OPL->wavesel);
+  	}
+
+    WRITE_POD(&OPL->T, OPL->T);
+    WRITE_POD(&OPL->st, OPL->st);
+
+#if BUILD_Y8950
+    //ToDo - Bruenor
+	/*if ( (OPL->type & OPL_TYPE_ADPCM) && (OPL->deltat) ) {
+		// OPL->deltat->savestate(device);
+	}
+
+	if ( OPL->type & OPL_TYPE_IO ) {
+		// device->save_item(NAME(OPL->portDirection));
+		// device->save_item(NAME(OPL->portLatch));
+	}*/
+#endif
+
+    WRITE_POD(&OPL->address, OPL->address);
+    WRITE_POD(&OPL->status, OPL->status);
+    WRITE_POD(&OPL->statusmask, OPL->statusmask);
+    WRITE_POD(&OPL->mode, OPL->mode);
+}
+
+void FMOPL_LoadState(void *chip, std::istream& stream ) {
+    FM_OPL *OPL = (FM_OPL *)chip;
+
+    LoadState_Channel(OPL->P_CH, stream);
+
+    READ_POD(&OPL->eg_cnt, OPL->eg_cnt);
+    READ_POD(&OPL->eg_timer, OPL->eg_timer);
+
+    READ_POD(&OPL->rhythm, OPL->rhythm);
+
+    READ_POD(&OPL->lfo_am_depth, OPL->lfo_am_depth);
+    READ_POD(&OPL->lfo_pm_depth_range, OPL->lfo_pm_depth_range);
+    READ_POD(&OPL->lfo_am_cnt, OPL->lfo_am_cnt);
+    READ_POD(&OPL->lfo_pm_cnt, OPL->lfo_pm_cnt);
+
+    READ_POD(&OPL->noise_rng, OPL->noise_rng);
+    READ_POD(&OPL->noise_p, OPL->noise_p);
+
+   	if( OPL->type & OPL_TYPE_WAVESEL ) {
+    	READ_POD(&OPL->wavesel, OPL->wavesel);
+  	}
+
+    READ_POD(&OPL->T, OPL->T);
+    READ_POD(&OPL->st, OPL->st);
+
+#if BUILD_Y8950
+    //ToDo - Bruenor
+#endif
+
+    READ_POD(&OPL->address, OPL->address);
+    READ_POD(&OPL->status, OPL->status);
+    READ_POD(&OPL->statusmask, OPL->statusmask);
+    READ_POD(&OPL->mode, OPL->mode);
+}
 #endif /* BUILD_YM3812 */
 
 

--- a/src/hardware/mame/fmopl.h
+++ b/src/hardware/mame/fmopl.h
@@ -51,6 +51,8 @@ void ym3812_update_one(void *chip, OPLSAMPLE *buffer, int length);
 void ym3812_set_timer_handler(void *chip, OPL_TIMERHANDLER TimerHandler, device_t *device);
 void ym3812_set_irq_handler(void *chip, OPL_IRQHANDLER IRQHandler, device_t *device);
 void ym3812_set_update_handler(void *chip, OPL_UPDATEHANDLER UpdateHandler, device_t *device);
+void FMOPL_SaveState( void *chip, std::ostream& stream );
+void FMOPL_LoadState( void *chip, std::istream& stream );
 
 #endif /* BUILD_YM3812 */
 

--- a/src/hardware/mame/saa1099.cpp
+++ b/src/hardware/mame/saa1099.cpp
@@ -475,3 +475,46 @@ WRITE8_MEMBER(saa1099_device::write)
 	else
 		data_w(space, 0, data);
 }
+
+void saa1099_device::SaveState( std::ostream& stream )
+{
+	// - pure data
+	device_t::SaveState(stream);
+ 
+	WRITE_POD( &m_noise_params, m_noise_params );
+	WRITE_POD( &m_env_enable, m_env_enable );
+	WRITE_POD( &m_env_reverse_right, m_env_reverse_right );
+	WRITE_POD( &m_env_mode, m_env_mode );
+	WRITE_POD( &m_env_bits, m_env_bits );
+	WRITE_POD( &m_env_clock, m_env_clock );
+	WRITE_POD( &m_env_step, m_env_step );
+	WRITE_POD( &m_all_ch_enable, m_all_ch_enable );
+	WRITE_POD( &m_sync_state, m_sync_state );
+	WRITE_POD( &m_selected_reg, m_selected_reg );
+	WRITE_POD( &m_channels, m_channels );
+	WRITE_POD( &m_noise, m_noise );
+	WRITE_POD( &m_sample_rate, m_sample_rate );
+	WRITE_POD( &m_master_clock, m_master_clock );
+}
+
+
+void saa1099_device::LoadState( std::istream& stream )
+{
+	// - pure data
+	device_t::LoadState(stream);
+
+	READ_POD( &m_noise_params, m_noise_params );
+	READ_POD( &m_env_enable, m_env_enable );
+	READ_POD( &m_env_reverse_right, m_env_reverse_right );
+	READ_POD( &m_env_mode, m_env_mode );
+	READ_POD( &m_env_bits, m_env_bits );
+	READ_POD( &m_env_clock, m_env_clock );
+	READ_POD( &m_env_step, m_env_step );
+	READ_POD( &m_all_ch_enable, m_all_ch_enable );
+	READ_POD( &m_sync_state, m_sync_state );
+	READ_POD( &m_selected_reg, m_selected_reg );
+	READ_POD( &m_channels, m_channels );
+	READ_POD( &m_noise, m_noise );
+	READ_POD( &m_sample_rate, m_sample_rate );
+	READ_POD( &m_master_clock, m_master_clock );
+}

--- a/src/hardware/mame/saa1099.h
+++ b/src/hardware/mame/saa1099.h
@@ -60,6 +60,9 @@ public:
 	// sound stream update overrides
 	virtual void sound_stream_update(sound_stream &stream, stream_sample_t **inputs, stream_sample_t **outputs, int samples);
 
+	void SaveState( std::ostream& stream );
+	void LoadState( std::istream& stream );
+
 private:
 	struct saa1099_channel
 	{

--- a/src/hardware/mame/sn76496.cpp
+++ b/src/hardware/mame/sn76496.cpp
@@ -489,6 +489,47 @@ void sn76496_base_device::convert_samplerate(int32_t target_rate) {
 	rate_counter = 0;
 }
 
+void sn76496_base_device::SaveState( std::ostream& stream ) {
+    WRITE_POD(&m_vol_table, m_vol_table);
+    WRITE_POD(&m_register, m_register);
+    WRITE_POD(&m_last_register, m_last_register);
+    WRITE_POD(&m_volume, m_volume);
+    WRITE_POD(&m_RNG, m_RNG);
+    //WRITE_POD(&m_clock_divider, m_clock_divider);
+    WRITE_POD(&m_current_clock, m_current_clock);
+    //WRITE_POD(&m_feedback_mask, m_feedback_mask);
+    //WRITE_POD(&m_whitenoise_tap1, m_whitenoise_tap1);
+    //WRITE_POD(&m_whitenoise_tap2, m_whitenoise_tap2);
+    //WRITE_POD(&m_negate, m_negate);
+    //WRITE_POD(&m_stereo, m_stereo);
+    WRITE_POD(&m_stereo_mask, m_stereo_mask);
+    WRITE_POD(&m_period, m_period);
+    WRITE_POD(&m_count, m_count);
+    WRITE_POD(&m_output, m_output);
+    WRITE_POD(&m_cycles_to_ready, m_cycles_to_ready);
+    //WRITE_POD(&m_sega_style_psg, m_sega_style_psg);
+}
+void sn76496_base_device::LoadState( std::istream& stream ) {
+    READ_POD(&m_vol_table, m_vol_table);
+    READ_POD(&m_register, m_register);
+    READ_POD(&m_last_register, m_last_register);
+    READ_POD(&m_volume, m_volume);
+    READ_POD(&m_RNG, m_RNG);
+    //READ_POD(&m_clock_divider, m_clock_divider);
+    READ_POD(&m_current_clock, m_current_clock);
+    //READ_POD(&m_feedback_mask, m_feedback_mask);
+    //READ_POD(&m_whitenoise_tap1, m_whitenoise_tap1);
+    //READ_POD(&m_whitenoise_tap2, m_whitenoise_tap2);
+    //READ_POD(&m_negate, m_negate);
+    //READ_POD(&m_stereo, m_stereo);
+    READ_POD(&m_stereo_mask, m_stereo_mask);
+    READ_POD(&m_period, m_period);
+    READ_POD(&m_count, m_count);
+    READ_POD(&m_output, m_output);
+    READ_POD(&m_cycles_to_ready, m_cycles_to_ready);
+    //READ_POD(&m_sega_style_psg, m_sega_style_psg);
+}
+
 void sn76496_base_device::register_for_save_states()
 {
 	save_item(NAME(m_vol_table));

--- a/src/hardware/mame/sn76496.h
+++ b/src/hardware/mame/sn76496.h
@@ -39,6 +39,8 @@ public:
 //	auto ready_cb() { return m_ready_handler.bind(); }
 
 	void convert_samplerate(int32_t target_rate);
+	void SaveState( std::ostream& stream );
+    void LoadState( std::istream& stream );
 protected:
 	sn76496_base_device(
 			const machine_config &mconfig,

--- a/src/hardware/mame/ymf262.cpp
+++ b/src/hardware/mame/ymf262.cpp
@@ -2594,6 +2594,129 @@ void ymf262_set_update_handler(void *chip, OPL3_UPDATEHANDLER UpdateHandler, dev
 	reinterpret_cast<OPL3 *>(chip)->SetUpdateHandler(UpdateHandler, device);
 }
 
+void SaveState_Channel(OPL3_CH *channel, std::ostream& stream) {
+    WRITE_POD( &channel->block_fnum, channel->block_fnum );
+    WRITE_POD( &channel->fc, channel->fc );
+    WRITE_POD( &channel->ksl_base, channel->ksl_base );
+    WRITE_POD( &channel->kcode, channel->kcode );
+    WRITE_POD( &channel->extended, channel->extended );
+}
+
+void LoadState_Channel(OPL3_CH *channel, std::istream& stream) {
+    READ_POD( &channel->block_fnum, channel->block_fnum );
+    READ_POD( &channel->fc, channel->fc );
+    READ_POD( &channel->ksl_base, channel->ksl_base );
+    READ_POD( &channel->kcode, channel->kcode );
+    READ_POD( &channel->extended, channel->extended );
+}
+
+void SaveState_Slot(OPL3_SLOT *slot, std::ostream& stream) {
+    WRITE_POD( &slot->ar, slot->ar );
+    WRITE_POD( &slot->dr, slot->dr );
+    WRITE_POD( &slot->rr, slot->rr );
+    WRITE_POD( &slot->KSR, slot->KSR );
+    WRITE_POD( &slot->ksl, slot->ksl );
+    WRITE_POD( &slot->ksr, slot->ksr );
+    WRITE_POD( &slot->mul, slot->mul );
+
+    WRITE_POD( &slot->Cnt, slot->Cnt );
+    WRITE_POD( &slot->Incr, slot->Incr );
+    WRITE_POD( &slot->FB, slot->FB );
+    WRITE_POD( &slot->conn_enum, slot->conn_enum );
+    WRITE_POD( &slot->op1_out, slot->op1_out );
+    WRITE_POD( &slot->CON, slot->CON );
+
+    WRITE_POD( &slot->eg_type, slot->eg_type );
+    WRITE_POD( &slot->state, slot->state );
+    WRITE_POD( &slot->TL, slot->TL );
+    WRITE_POD( &slot->TLL, slot->TLL );
+    WRITE_POD( &slot->volume, slot->volume );
+    WRITE_POD( &slot->sl, slot->sl );
+
+    WRITE_POD( &slot->eg_m_ar, slot->eg_m_ar );
+    WRITE_POD( &slot->eg_sh_ar, slot->eg_sh_ar );
+    WRITE_POD( &slot->eg_sel_ar, slot->eg_sel_ar );
+    WRITE_POD( &slot->eg_m_dr, slot->eg_m_dr );
+    WRITE_POD( &slot->eg_sh_dr, slot->eg_sh_dr );
+    WRITE_POD( &slot->eg_sel_dr, slot->eg_sel_dr );
+    WRITE_POD( &slot->eg_m_rr, slot->eg_m_rr );
+    WRITE_POD( &slot->eg_sh_rr, slot->eg_sh_rr );
+    WRITE_POD( &slot->eg_sel_rr, slot->eg_sel_rr );
+
+    WRITE_POD( &slot->key, slot->key );
+
+    WRITE_POD( &slot->AMmask, slot->AMmask );
+    WRITE_POD( &slot->vib, slot->vib );
+
+    WRITE_POD( &slot->waveform_number, slot->waveform_number );
+    WRITE_POD( &slot->wavetable, slot->wavetable );
+}
+
+void LoadState_Slot(OPL3_SLOT *slot, std::istream& stream) {
+    READ_POD( &slot->ar, slot->ar );
+    READ_POD( &slot->dr, slot->dr );
+    READ_POD( &slot->rr, slot->rr );
+    READ_POD( &slot->KSR, slot->KSR );
+    READ_POD( &slot->ksl, slot->ksl );
+    READ_POD( &slot->ksr, slot->ksr );
+    READ_POD( &slot->mul, slot->mul );
+
+    READ_POD( &slot->Cnt, slot->Cnt );
+    READ_POD( &slot->Incr, slot->Incr );
+    READ_POD( &slot->FB, slot->FB );
+    READ_POD( &slot->conn_enum, slot->conn_enum );
+    READ_POD( &slot->op1_out, slot->op1_out );
+    READ_POD( &slot->CON, slot->CON );
+
+    READ_POD( &slot->eg_type, slot->eg_type );
+    READ_POD( &slot->state, slot->state );
+    READ_POD( &slot->TL, slot->TL );
+    READ_POD( &slot->TLL, slot->TLL );
+    READ_POD( &slot->volume, slot->volume );
+    READ_POD( &slot->sl, slot->sl );
+
+    READ_POD( &slot->eg_m_ar, slot->eg_m_ar );
+    READ_POD( &slot->eg_sh_ar, slot->eg_sh_ar );
+    READ_POD( &slot->eg_sel_ar, slot->eg_sel_ar );
+    READ_POD( &slot->eg_m_dr, slot->eg_m_dr );
+    READ_POD( &slot->eg_sh_dr, slot->eg_sh_dr );
+    READ_POD( &slot->eg_sel_dr, slot->eg_sel_dr );
+    READ_POD( &slot->eg_m_rr, slot->eg_m_rr );
+    READ_POD( &slot->eg_sh_rr, slot->eg_sh_rr );
+    READ_POD( &slot->eg_sel_rr, slot->eg_sel_rr );
+
+    READ_POD( &slot->key, slot->key );
+
+    READ_POD( &slot->AMmask, slot->AMmask );
+    READ_POD( &slot->vib, slot->vib );
+
+    READ_POD( &slot->waveform_number, slot->waveform_number );
+    READ_POD( &slot->wavetable, slot->wavetable );
+}
+
+void YMF_SaveState( void *chip, std::ostream& stream ) {
+    for (int ch=0; ch<18; ch++) {
+        OPL3_CH *channel = &((OPL3 *)chip)->P_CH[ch];
+
+        SaveState_Channel(channel, stream);
+
+        for (int sl=0; sl<2; sl++) {
+            SaveState_Slot(&channel->SLOT[sl], stream);
+        }
+    }
+}
+
+void YMF_LoadState( void *chip, std::istream& stream ) {
+    for (int ch=0; ch<18; ch++) {
+        OPL3_CH *channel = &((OPL3 *)chip)->P_CH[ch];
+
+        LoadState_Channel(channel, stream);
+
+        for (int sl=0; sl<2; sl++) {
+            LoadState_Slot(&channel->SLOT[sl], stream);
+        }
+    }
+}
 
 /*
 ** Generate samples for one of the YMF262's

--- a/src/hardware/mame/ymf262.h
+++ b/src/hardware/mame/ymf262.h
@@ -30,6 +30,8 @@ void ymf262_reset_chip(void *chip);
 int  ymf262_write(void *chip, int a, int v);
 unsigned char ymf262_read(void *chip, int a);
 int  ymf262_timer_over(void *chip, int c);
+void YMF_SaveState( void *chip, std::ostream& stream );
+void YMF_LoadState( void *chip, std::istream& stream );
 void ymf262_update_one(void *chip, OPL3SAMPLE **buffers, int length);
 
 void ymf262_set_timer_handler(void *chip, OPL3_TIMERHANDLER TimerHandler, device_t *device);

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1221,3 +1221,107 @@ void MIXER_Init() {
     MIXER_Controls_Init();
 }
 
+// save state support
+//void *MIXER_Mix_NoSound_PIC_Timer = (void*)MIXER_Mix_NoSound;
+void *MIXER_Mix_PIC_Timer = (void*)MIXER_Mix;
+
+
+void MixerChannel::SaveState( std::ostream& stream )
+{
+	// - pure data
+	WRITE_POD( &volmain, volmain );
+	WRITE_POD( &scale, scale );
+	WRITE_POD( &volmul, volmul );
+	//WRITE_POD( &freq_add, freq_add );
+	WRITE_POD( &enabled, enabled );
+}
+
+
+void MixerChannel::LoadState( std::istream& stream )
+{
+	// - pure data
+	READ_POD( &volmain, volmain );
+	READ_POD( &scale, scale );
+	READ_POD( &volmul, volmul );
+	//READ_POD( &freq_add, freq_add );
+	READ_POD( &enabled, enabled );
+
+	//********************************************
+	//********************************************
+	//********************************************
+
+	// reset mixer channel (system data)
+	mixer.pos = 0;
+	mixer.done = 0;
+}
+
+extern void POD_Save_Adlib(std::ostream& stream);
+extern void POD_Save_Disney(std::ostream& stream);
+extern void POD_Save_Gameblaster(std::ostream& stream);
+extern void POD_Save_GUS(std::ostream& stream);
+extern void POD_Save_MPU401(std::ostream& stream);
+extern void POD_Save_PCSpeaker(std::ostream& stream);
+extern void POD_Save_Sblaster(std::ostream& stream);
+extern void POD_Save_Tandy_Sound(std::ostream& stream);
+extern void POD_Load_Adlib(std::istream& stream);
+extern void POD_Load_Disney(std::istream& stream);
+extern void POD_Load_Gameblaster(std::istream& stream);
+extern void POD_Load_GUS(std::istream& stream);
+extern void POD_Load_MPU401(std::istream& stream);
+extern void POD_Load_PCSpeaker(std::istream& stream);
+extern void POD_Load_Sblaster(std::istream& stream);
+extern void POD_Load_Tandy_Sound(std::istream& stream);
+
+namespace
+{
+class SerializeMixer : public SerializeGlobalPOD
+{
+public:
+	SerializeMixer() : SerializeGlobalPOD("Mixer")
+	{}
+
+private:
+	virtual void getBytes(std::ostream& stream)
+	{
+
+		//*************************************************
+		//*************************************************
+
+		SerializeGlobalPOD::getBytes(stream);
+
+
+		POD_Save_Adlib(stream);
+		POD_Save_Disney(stream);
+		POD_Save_Gameblaster(stream);
+		POD_Save_GUS(stream);
+		POD_Save_MPU401(stream);
+		POD_Save_PCSpeaker(stream);
+		POD_Save_Sblaster(stream);
+		POD_Save_Tandy_Sound(stream);
+	}
+
+	virtual void setBytes(std::istream& stream)
+	{
+
+		//*************************************************
+		//*************************************************
+
+		SerializeGlobalPOD::setBytes(stream);
+
+
+		POD_Load_Adlib(stream);
+		POD_Load_Disney(stream);
+		POD_Load_Gameblaster(stream);
+		POD_Load_GUS(stream);
+		POD_Load_MPU401(stream);
+		POD_Load_PCSpeaker(stream);
+		POD_Load_Sblaster(stream);
+		POD_Load_Tandy_Sound(stream);
+
+		// reset mixer channel (system data)
+		mixer.pos = 0;
+		mixer.done = 0;
+	}
+
+} dummy;
+}

--- a/src/hardware/mpu401.cpp
+++ b/src/hardware/mpu401.cpp
@@ -850,3 +850,47 @@ void MPU401_Init() {
 	control->GetSection("midi")->onpropchange.push_back(&MIDI_OnSectionPropChange);
 }
 
+// save state support
+void *MPU401_Event_PIC_Event = (void*)MPU401_Event;
+
+void POD_Save_MPU401( std::ostream& stream )
+{
+	const char pod_name[32] = "MPU401";
+
+	if( stream.fail() ) return;
+	if( !test ) return;
+
+
+	WRITE_POD( &pod_name, pod_name );
+
+	//*******************************************
+	//*******************************************
+	//*******************************************
+
+	// - pure data
+	WRITE_POD( &mpu, mpu );
+}
+
+
+void POD_Load_MPU401( std::istream& stream )
+{
+	char pod_name[32] = {0};
+
+	if( stream.fail() ) return;
+	if( !test ) return;
+
+
+	// error checking
+	READ_POD( &pod_name, pod_name );
+	if( strcmp( pod_name, "MPU401" ) ) {
+		stream.clear( std::istream::failbit | std::istream::badbit );
+		return;
+	}
+
+	//************************************************
+	//************************************************
+	//************************************************
+
+	// - pure data
+	READ_POD( &mpu, mpu );
+}

--- a/src/hardware/opl.cpp
+++ b/src/hardware/opl.cpp
@@ -1465,3 +1465,115 @@ void adlib_getsample(Bit16s* sndptr, Bits numsamples) {
 	}
 }
 
+// save state support
+void adlib_savestate( std::ostream& stream )
+{
+	Bit32u cur_wform_idx[MAXOPERATORS];
+
+
+	for( int lcv=0; lcv<MAXOPERATORS; lcv++ ) {
+		cur_wform_idx[lcv] = ((Bitu) (op[lcv].cur_wform)) - ((Bitu) &wavtable);
+	}
+
+	//****************************************************
+	//****************************************************
+	//****************************************************
+
+	// opl.cpp
+
+	// - pure data
+	WRITE_POD( &recipsamp, recipsamp );
+	WRITE_POD( &wavtable, wavtable );
+
+	WRITE_POD( &vibval_var1, vibval_var1 );
+	WRITE_POD( &vibval_var2, vibval_var2 );
+
+	//****************************************************
+	//****************************************************
+	//****************************************************
+
+	// opl.h
+
+	// - pure data
+	WRITE_POD( &chip_num, chip_num );
+
+	// - near-pure data
+	WRITE_POD( &op, op );
+
+	// - pure data
+	WRITE_POD( &int_samplerate, int_samplerate );
+	WRITE_POD( &status, status );
+	WRITE_POD( &opl_index, opl_index );
+	WRITE_POD( &adlibreg, adlibreg );
+	WRITE_POD( &wave_sel, wave_sel );
+
+	WRITE_POD( &vibtab_pos, vibtab_pos );
+	WRITE_POD( &vibtab_add, vibtab_add );
+	WRITE_POD( &tremtab_pos, tremtab_pos );
+	WRITE_POD( &tremtab_add, tremtab_add );
+	WRITE_POD( &generator_add, generator_add );
+
+
+
+
+	// - reloc ptr (!!!)
+	WRITE_POD( &cur_wform_idx, cur_wform_idx );
+}
+
+
+void adlib_loadstate( std::istream& stream )
+{
+	Bit32u cur_wform_idx[MAXOPERATORS];
+
+	//****************************************************
+	//****************************************************
+	//****************************************************
+
+	// opl.cpp
+
+	// - pure data
+	READ_POD( &recipsamp, recipsamp );
+	READ_POD( &wavtable, wavtable );
+
+	READ_POD( &vibval_var1, vibval_var1 );
+	READ_POD( &vibval_var2, vibval_var2 );
+
+	//****************************************************
+	//****************************************************
+	//****************************************************
+
+	// opl.h
+
+	// - pure data
+	READ_POD( &chip_num, chip_num );
+
+	// - near-pure data
+	READ_POD( &op, op );
+
+	// - pure data
+	READ_POD( &int_samplerate, int_samplerate );
+	READ_POD( &status, status );
+	READ_POD( &opl_index, opl_index );
+	READ_POD( &adlibreg, adlibreg );
+	READ_POD( &wave_sel, wave_sel );
+
+	READ_POD( &vibtab_pos, vibtab_pos );
+	READ_POD( &vibtab_add, vibtab_add );
+	READ_POD( &tremtab_pos, tremtab_pos );
+	READ_POD( &tremtab_add, tremtab_add );
+	READ_POD( &generator_add, generator_add );
+
+
+
+
+	// - reloc ptr (!!!)
+	READ_POD( &cur_wform_idx, cur_wform_idx );
+
+	//****************************************************
+	//****************************************************
+	//****************************************************
+
+	for( int lcv=0; lcv<MAXOPERATORS; lcv++ ) {
+		op[lcv].cur_wform = (Bit16s *) ((Bitu) &wavtable + cur_wform_idx[lcv]);
+	}
+}

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -780,3 +780,73 @@ void PCSPEAKER_Init() {
 	AddVMEventFunction(VM_EVENT_RESET,AddVMEventFunctionFuncPair(PCSPEAKER_OnReset));
 }
 
+// save state support
+void POD_Save_PCSpeaker( std::ostream& stream )
+{
+	const char pod_name[32] = "PCSpeaker";
+
+	if( stream.fail() ) return;
+	if( !test ) return;
+	if( !spkr.chan ) return;
+
+
+	WRITE_POD( &pod_name, pod_name );
+
+	//*******************************************
+	//*******************************************
+	//*******************************************
+
+	// - near-pure data
+	WRITE_POD( &spkr, spkr );
+
+	//*******************************************
+	//*******************************************
+	//*******************************************
+
+	spkr.chan->SaveState(stream);
+}
+
+
+void POD_Load_PCSpeaker( std::istream& stream )
+{
+	char pod_name[32] = {0};
+
+	if( stream.fail() ) return;
+	if( !test ) return;
+	if( !spkr.chan ) return;
+
+
+	// error checking
+	READ_POD( &pod_name, pod_name );
+	if( strcmp( pod_name, "PCSpeaker" ) ) {
+		stream.clear( std::istream::failbit | std::istream::badbit );
+		return;
+	}
+
+	//************************************************
+	//************************************************
+	//************************************************
+
+	MixerChannel *chan_old;
+
+
+	// - save static ptrs
+	chan_old = spkr.chan;
+
+	//*******************************************
+	//*******************************************
+	//*******************************************
+
+	// - near-pure data
+	READ_POD( &spkr, spkr );
+
+	//*******************************************
+	//*******************************************
+	//*******************************************
+
+	// - restore static ptrs
+	spkr.chan = chan_old;
+
+
+	spkr.chan->LoadState(stream);
+}

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -1472,3 +1472,5 @@ void SERIAL_Init () {
     }
 }
 
+// save state support
+void *Serial_EventHandler_PIC_Event = (void*)Serial_EventHandler;

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -400,3 +400,104 @@ void TANDYSOUND_Init() {
 	AddVMEventFunction(VM_EVENT_RESET,AddVMEventFunctionFuncPair(TANDYSOUND_OnReset));
 }
 
+// save state support
+void *TandyDAC_DMA_CallBack_Func = (void*)TandyDAC_DMA_CallBack;
+
+void POD_Save_Tandy_Sound( std::ostream& stream )
+{
+	const char pod_name[32] = "Tandy";
+
+	if( stream.fail() ) return;
+	if( !test ) return;
+	if( !tandy.chan ) return;
+
+
+	WRITE_POD( &pod_name, pod_name );
+
+	//*******************************************
+	//*******************************************
+	//*******************************************
+
+	Bit8u dma_idx;
+
+
+	dma_idx = 0xff;
+	for( int lcv=0; lcv<8; lcv++ ) {
+		if( tandy.dac.dma.chan == GetDMAChannel(lcv) ) { dma_idx = lcv; break; }
+	}
+
+	// *******************************************
+	// *******************************************
+	// *******************************************
+
+	// - near-pure data
+	WRITE_POD( &tandy, tandy );
+
+	// - reloc ptr
+	WRITE_POD( &dma_idx, dma_idx );
+
+	// *******************************************
+	// *******************************************
+	// *******************************************
+
+    activeDevice->SaveState(stream);
+
+	tandy.chan->SaveState(stream);
+	tandy.dac.chan->SaveState(stream);
+}
+
+void POD_Load_Tandy_Sound( std::istream& stream )
+{
+	char pod_name[32] = {0};
+
+	if( stream.fail() ) return;
+	if( !test ) return;
+	if( !tandy.chan ) return;
+
+
+	// error checking
+	READ_POD( &pod_name, pod_name );
+	if( strcmp( pod_name, "Tandy" ) ) {
+		stream.clear( std::istream::failbit | std::istream::badbit );
+		return;
+	}
+
+	//************************************************
+	//************************************************
+	//************************************************
+
+	Bit8u dma_idx;
+	MixerChannel *chan_old, *dac_chan_old;
+
+	// - save static ptrs
+	chan_old = tandy.chan;
+	dac_chan_old = tandy.dac.chan;
+
+	// *******************************************
+	// *******************************************
+	// *******************************************
+
+	// - near-pure data
+	READ_POD( &tandy, tandy );
+
+	// - reloc ptr
+	READ_POD( &dma_idx, dma_idx );
+
+	// *******************************************
+	// *******************************************
+	// *******************************************
+	tandy.dac.dma.chan = NULL;
+	if( dma_idx != 0xff ) tandy.dac.dma.chan = GetDMAChannel(dma_idx);
+
+	// *******************************************
+	// *******************************************
+	// *******************************************
+
+	// - restore static ptrs
+	tandy.chan = chan_old;
+	tandy.dac.chan = dac_chan_old;
+    activeDevice->LoadState(stream);
+
+	tandy.chan->LoadState(stream);
+	tandy.dac.chan->LoadState(stream);
+}

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -1036,3 +1036,20 @@ void TIMER_Init() {
 	AddVMEventFunction(VM_EVENT_POWERON, AddVMEventFunctionFuncPair(TIMER_OnPowerOn));
 }
 
+//save state support
+void *PIT0_Event_PIC_Event = (void*)PIT0_Event;
+
+namespace
+{
+class SerializeTimer : public SerializeGlobalPOD
+{
+public:
+    SerializeTimer() : SerializeGlobalPOD("IntTimer10")
+    {
+        registerPOD(pit);
+        //registerPOD(gate2);
+        registerPOD(latched_timerstatus);
+		registerPOD(latched_timerstatus_locked);
+    }
+} dummy;
+}

--- a/src/hardware/vga_attr.cpp
+++ b/src/hardware/vga_attr.cpp
@@ -362,3 +362,22 @@ void VGA_UnsetupAttr(void) {
     IO_FreeReadHandler(0x3c1,IO_MB);
 }
 
+// save state support
+void POD_Save_VGA_Attr( std::ostream& stream )
+{
+	// - pure struct data
+	WRITE_POD( &vga.attr, vga.attr );
+
+
+	// no static globals found
+}
+
+
+void POD_Load_VGA_Attr( std::istream& stream )
+{
+	// - pure struct data
+	READ_POD( &vga.attr, vga.attr );
+
+
+	// no static globals found
+}

--- a/src/hardware/vga_crtc.cpp
+++ b/src/hardware/vga_crtc.cpp
@@ -463,3 +463,22 @@ Bitu vga_read_p3d5x(Bitu port,Bitu iolen) {
 	}
 }
 
+// save state support 
+void POD_Save_VGA_Crtc( std::ostream& stream )
+{
+	// - pure struct data
+	WRITE_POD( &vga.crtc, vga.crtc );
+ 
+ 
+	// no static globals found
+}
+
+
+void POD_Load_VGA_Crtc( std::istream& stream )
+{
+	// - pure struct data
+	READ_POD( &vga.crtc, vga.crtc );
+
+
+	// no static globals found
+}

--- a/src/hardware/vga_dac.cpp
+++ b/src/hardware/vga_dac.cpp
@@ -386,3 +386,22 @@ void VGA_UnsetupDAC(void) {
     IO_FreeReadHandler(0x3c9,IO_MB);
 }
 
+// save state support
+void POD_Save_VGA_Dac( std::ostream& stream )
+{
+	// - pure struct data
+	WRITE_POD( &vga.dac, vga.dac );
+
+
+	// no static globals found
+}
+
+
+void POD_Load_VGA_Dac( std::istream& stream )
+{
+	// - pure struct data
+	READ_POD( &vga.dac, vga.dac );
+
+
+	// no static globals found
+}

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -4434,3 +4434,171 @@ uint32_t VGA_QuerySizeIG(void) {
              (uint32_t)vga.draw.width;
 }
 
+// save state support
+void *VGA_DisplayStartLatch_PIC_Event = (void*)VGA_DisplayStartLatch;
+void *VGA_DrawEGASingleLine_PIC_Event = (void*)VGA_DrawEGASingleLine;
+//void *VGA_DrawPart_PIC_Event = (void*)VGA_DrawPart;
+void *VGA_DrawSingleLine_PIC_Event = (void*)VGA_DrawSingleLine;
+void *VGA_Other_VertInterrupt_PIC_Event = (void*)VGA_Other_VertInterrupt;
+void *VGA_PanningLatch_PIC_Event = (void*)VGA_PanningLatch;
+void *VGA_VertInterrupt_PIC_Event = (void*)VGA_VertInterrupt;
+void *VGA_VerticalTimer_PIC_Event = (void*)VGA_VerticalTimer;
+
+
+void POD_Save_VGA_Draw( std::ostream& stream )
+{
+	Bit8u linear_base_idx;
+	Bit8u font_tables_idx[2];
+	Bit8u drawline_idx;
+
+
+	if(0) {}
+	else if( vga.draw.linear_base == vga.mem.linear ) linear_base_idx = 0;
+	//else if( vga.draw.linear_base == vga.fastmem ) linear_base_idx = 1;
+
+
+	for( int lcv=0; lcv<2; lcv++ ) {
+		if(0) {}
+		else if( vga.draw.font_tables[lcv] == &(vga.draw.font[0*1024]) ) font_tables_idx[lcv] = 0;
+		else if( vga.draw.font_tables[lcv] == &(vga.draw.font[8*1024]) ) font_tables_idx[lcv] = 1;
+		else if( vga.draw.font_tables[lcv] == &(vga.draw.font[16*1024]) ) font_tables_idx[lcv] = 2;
+		else if( vga.draw.font_tables[lcv] == &(vga.draw.font[24*1024]) ) font_tables_idx[lcv] = 3;
+		else if( vga.draw.font_tables[lcv] == &(vga.draw.font[32*1024]) ) font_tables_idx[lcv] = 4;
+		else if( vga.draw.font_tables[lcv] == &(vga.draw.font[40*1024]) ) font_tables_idx[lcv] = 5;
+		else if( vga.draw.font_tables[lcv] == &(vga.draw.font[48*1024]) ) font_tables_idx[lcv] = 6;
+		else if( vga.draw.font_tables[lcv] == &(vga.draw.font[56*1024]) ) font_tables_idx[lcv] = 7;
+	}
+
+
+	if(0) {}
+	else if( VGA_DrawLine == VGA_Draw_1BPP_Line ) drawline_idx = 1;
+	else if( VGA_DrawLine == VGA_Draw_2BPP_Line ) drawline_idx = 3;
+	else if( VGA_DrawLine == VGA_Draw_2BPPHiRes_Line ) drawline_idx = 4;
+	else if( VGA_DrawLine == VGA_Draw_CGA16_Line ) drawline_idx = 5;
+	else if( VGA_DrawLine == VGA_Draw_4BPP_Line ) drawline_idx = 6;
+	else if( VGA_DrawLine == VGA_Draw_4BPP_Line_Double ) drawline_idx = 7;
+	else if( VGA_DrawLine == VGA_Draw_Linear_Line ) drawline_idx = 8;
+	else if( VGA_DrawLine == VGA_Draw_Xlat32_Linear_Line ) drawline_idx = 9;
+	else if( VGA_DrawLine == VGA_Draw_VGA_Line_HWMouse ) drawline_idx = 11;
+	else if( VGA_DrawLine == VGA_Draw_LIN16_Line_HWMouse ) drawline_idx = 12;
+	else if( VGA_DrawLine == VGA_Draw_LIN32_Line_HWMouse ) drawline_idx = 13;
+	else if( VGA_DrawLine == VGA_TEXT_Draw_Line ) drawline_idx = 14;
+	else if( VGA_DrawLine == VGA_TEXT_Herc_Draw_Line ) drawline_idx = 15;
+	else if( VGA_DrawLine == VGA_TEXT_Xlat32_Draw_Line ) drawline_idx = 17;
+
+	//**********************************************
+	//**********************************************
+
+	// - near-pure (struct) data
+	WRITE_POD( &vga.draw, vga.draw );
+
+
+	// - reloc ptr
+	WRITE_POD( &linear_base_idx, linear_base_idx );
+	WRITE_POD( &font_tables_idx, font_tables_idx );
+
+	//**********************************************
+	//**********************************************
+
+	// static globals
+
+	// - reloc function ptr
+	WRITE_POD( &drawline_idx, drawline_idx );
+
+
+	// - pure data
+	WRITE_POD( &TempLine, TempLine );
+
+
+	// - system data
+	//WRITE_POD( &vsync, vsync );
+	//WRITE_POD( &uservsyncjolt, uservsyncjolt );
+
+
+	// - pure data
+	WRITE_POD( &temp, temp );
+	WRITE_POD( &FontMask, FontMask );
+	WRITE_POD( &bg_color_index, bg_color_index );
+}
+
+
+void POD_Load_VGA_Draw( std::istream& stream )
+{
+	Bit8u linear_base_idx;
+	Bit8u font_tables_idx[2];
+	Bit8u drawline_idx;
+
+	//**********************************************
+	//**********************************************
+
+	// - near-pure (struct) data
+	READ_POD( &vga.draw, vga.draw );
+
+
+	// - reloc ptr
+	READ_POD( &linear_base_idx, linear_base_idx );
+	READ_POD( &font_tables_idx, font_tables_idx );
+
+	//**********************************************
+	//**********************************************
+
+	// static globals
+
+	// - reloc function ptr
+	READ_POD( &drawline_idx, drawline_idx );
+
+
+	// - pure data
+	READ_POD( &TempLine, TempLine );
+
+
+	// - system data
+	//READ_POD( &vsync, vsync );
+	//READ_POD( &uservsyncjolt, uservsyncjolt );
+
+
+	// - pure data
+	READ_POD( &temp, temp );
+	READ_POD( &FontMask, FontMask );
+	READ_POD( &bg_color_index, bg_color_index );
+
+	//**********************************************
+	//**********************************************
+
+	switch( linear_base_idx ) {
+		case 0: vga.draw.linear_base = vga.mem.linear; break;
+		//case 1: vga.draw.linear_base = vga.fastmem; break;
+	}
+
+
+	for( int lcv=0; lcv<2; lcv++ ) {
+		switch( font_tables_idx[lcv] ) {
+			case 0: vga.draw.font_tables[lcv] = &(vga.draw.font[0*1024]); break;
+			case 1: vga.draw.font_tables[lcv] = &(vga.draw.font[8*1024]); break;
+			case 2: vga.draw.font_tables[lcv] = &(vga.draw.font[16*1024]); break;
+			case 3: vga.draw.font_tables[lcv] = &(vga.draw.font[24*1024]); break;
+			case 4: vga.draw.font_tables[lcv] = &(vga.draw.font[32*1024]); break;
+			case 5: vga.draw.font_tables[lcv] = &(vga.draw.font[40*1024]); break;
+			case 6: vga.draw.font_tables[lcv] = &(vga.draw.font[48*1024]); break;
+			case 7: vga.draw.font_tables[lcv] = &(vga.draw.font[56*1024]); break;
+		}
+	}
+
+
+	switch( drawline_idx ) {
+		case 1: VGA_DrawLine = VGA_Draw_1BPP_Line; break;
+		case 3: VGA_DrawLine = VGA_Draw_2BPP_Line; break;
+		case 4: VGA_DrawLine = VGA_Draw_2BPPHiRes_Line; break;
+		case 5: VGA_DrawLine = VGA_Draw_CGA16_Line; break;
+		case 6: VGA_DrawLine = VGA_Draw_4BPP_Line; break;
+		case 7: VGA_DrawLine = VGA_Draw_4BPP_Line_Double; break;
+		case 8: VGA_DrawLine = VGA_Draw_Linear_Line; break;
+		case 9: VGA_DrawLine = VGA_Draw_Xlat32_Linear_Line; break;
+		case 11: VGA_DrawLine = VGA_Draw_VGA_Line_HWMouse; break;
+		case 12: VGA_DrawLine = VGA_Draw_LIN16_Line_HWMouse; break;
+		case 13: VGA_DrawLine = VGA_Draw_LIN32_Line_HWMouse; break;
+		case 14: VGA_DrawLine = VGA_TEXT_Draw_Line; break;
+		case 15: VGA_DrawLine = VGA_TEXT_Herc_Draw_Line; break;
+		case 17: VGA_DrawLine = VGA_TEXT_Xlat32_Draw_Line; break;
+	}
+}

--- a/src/hardware/vga_gfx.cpp
+++ b/src/hardware/vga_gfx.cpp
@@ -250,3 +250,29 @@ void VGA_UnsetupGFX(void) {
     IO_FreeReadHandler(0x3cf,IO_MB);
 }
 
+// save state support
+ 
+void POD_Save_VGA_Gfx( std::ostream& stream )
+{
+	// - pure struct data
+	WRITE_POD( &vga.gfx, vga.gfx );
+
+	//*******************************************
+	//*******************************************
+
+	// - system data
+	//WRITE_POD( &index9warned, index9warned );
+}
+
+
+void POD_Load_VGA_Gfx( std::istream& stream )
+{
+	// - pure struct data
+	READ_POD( &vga.gfx, vga.gfx );
+
+	//*******************************************
+	//*******************************************
+
+	// - system data
+	//READ_POD( &index9warned, index9warned );
+}

--- a/src/hardware/vga_memory.cpp
+++ b/src/hardware/vga_memory.cpp
@@ -2531,3 +2531,67 @@ void VGA_SetupMemory() {
 	}
 }
 
+// save state support
+void *VGA_PageHandler_Func[16] =
+{
+	(void *) &vgaph.map,
+	//(void *) &vgaph.changes,
+	//(void *) &vgaph.text,
+	(void *) &vgaph.tandy,
+	//(void *) &vgaph.cega,
+	//(void *) &vgaph.cvga,
+	//(void *) &vgaph.uega,
+	(void *) &vgaph.uvga,
+	(void *) &vgaph.pcjr,
+	(void *) &vgaph.herc,
+	//(void *) &vgaph.lin4,
+	(void *) &vgaph.lfb,
+	//(void *) &vgaph.lfbchanges,
+	(void *) &vgaph.mmio,
+	(void *) &vgaph.empty,
+};
+
+void POD_Save_VGA_Memory( std::ostream& stream )
+{
+	// - static ptrs
+	//Bit8u* linear;
+	//Bit8u* linear_orgptr;
+
+
+	// - pure data
+	WRITE_POD_SIZE( vga.mem.linear_orgptr, sizeof(Bit8u) * (std::max<Bit32u>(vga.mem.memsize, 512 * 1024U) + 2048 + 16) );
+
+	//***************************************************
+	//***************************************************
+
+	// static globals
+
+	// - pure struct data
+	WRITE_POD( &vgapages, vgapages );
+
+	// - static classes
+	//WRITE_POD( &vgaph, vgaph );
+}
+
+
+void POD_Load_VGA_Memory( std::istream& stream )
+{
+	// - static ptrs
+	//Bit8u* linear;
+	//Bit8u* linear_orgptr;
+
+
+	// - pure data
+	READ_POD_SIZE( vga.mem.linear_orgptr, sizeof(Bit8u) * (std::max<Bit32u>(vga.mem.memsize, 512 * 1024U) + 2048 + 16) );
+
+	//***************************************************
+	//***************************************************
+
+	// static globals
+
+	// - pure struct data
+	READ_POD( &vgapages, vgapages );
+
+	// - static classes
+	//READ_POD( &vgaph, vgaph );
+}

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1167,3 +1167,36 @@ void VGA_SetupOther(void) {
 	}
 }
 
+// save state support
+void POD_Save_VGA_Other( std::ostream& stream )
+{
+	// - pure struct data
+	WRITE_POD( &vga.other, vga.other );
+
+	//****************************************
+	//****************************************
+
+	// static globals
+
+	// - system + user data
+	WRITE_POD( &hue_offset, hue_offset );
+	WRITE_POD( &cga16_val, cga16_val );
+	WRITE_POD( &herc_pal, herc_pal );
+}
+
+
+void POD_Load_VGA_Other( std::istream& stream )
+{
+	// - pure struct data
+	READ_POD( &vga.other, vga.other );
+
+	//****************************************
+	//****************************************
+
+	// static globals
+
+	// - system + user data
+	READ_POD( &hue_offset, hue_offset );
+	READ_POD( &cga16_val, cga16_val );
+	READ_POD( &herc_pal, herc_pal );
+}

--- a/src/hardware/vga_paradise.cpp
+++ b/src/hardware/vga_paradise.cpp
@@ -242,3 +242,22 @@ void SVGA_Setup_ParadisePVGA1A(void) {
 	IO_Write(0x3cf, 0x05); // Enable!
 }
 
+// save state support
+void POD_Save_VGA_Paradise( std::ostream& stream )
+{
+	// static globals
+
+
+	// - pure struct data
+	WRITE_POD( &pvga1a, pvga1a );
+}
+
+
+void POD_Load_VGA_Paradise( std::istream& stream )
+{
+	// static globals
+
+
+	// - pure struct data
+	READ_POD( &pvga1a, pvga1a );
+}

--- a/src/hardware/vga_s3.cpp
+++ b/src/hardware/vga_s3.cpp
@@ -592,3 +592,25 @@ void SVGA_Setup_S3Trio(void) {
     PCI_AddSVGAS3_Device();
 }
 
+// save state support
+void POD_Save_VGA_S3( std::ostream& stream )
+{
+	// - pure struct data
+	WRITE_POD( &vga.s3, vga.s3 );
+
+	//*****************************************
+	//*****************************************
+
+	// static globals
+}
+
+void POD_Load_VGA_S3( std::istream& stream )
+{
+	// - pure struct data
+	READ_POD( &vga.s3, vga.s3 );
+
+	//*****************************************
+	//*****************************************
+
+	// static globals
+}

--- a/src/hardware/vga_seq.cpp
+++ b/src/hardware/vga_seq.cpp
@@ -218,3 +218,22 @@ void VGA_UnsetupSEQ(void) {
     IO_FreeReadHandler(0x3c5,IO_MB);
 }
 
+// save state support
+void POD_Save_VGA_Seq( std::ostream& stream )
+{
+	// - pure struct data
+	WRITE_POD( &vga.seq, vga.seq );
+
+
+	// no static globals found
+}
+
+
+void POD_Load_VGA_Seq( std::istream& stream )
+{
+	// - pure struct data
+	READ_POD( &vga.seq, vga.seq );
+
+
+	// no static globals found
+}

--- a/src/hardware/vga_tseng.cpp
+++ b/src/hardware/vga_tseng.cpp
@@ -990,3 +990,24 @@ void SVGA_Setup_TsengET3K(void) {
     phys_writeb(rom_base+0x007b,' ');
 }
 
+// save state support
+void POD_Save_VGA_Tseng( std::ostream& stream )
+{
+	// static globals
+
+
+	// - pure struct data
+	WRITE_POD( &et4k, et4k );
+	WRITE_POD( &et3k, et3k );
+}
+
+
+void POD_Load_VGA_Tseng( std::istream& stream )
+{
+	// static globals
+
+
+	// - pure struct data
+	READ_POD( &et4k, et4k );
+	READ_POD( &et3k, et3k );
+}

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -1332,3 +1332,22 @@ void VGA_SetupXGA(void) {
 	IO_RegisterReadHandler(0xe2ea,&XGA_Read,IO_MB | IO_MW | IO_MD);
 }
 
+// save state support
+void POD_Save_VGA_XGA( std::ostream& stream )
+{
+	// static globals
+
+
+	// - pure struct data
+	WRITE_POD( &xga, xga );
+}
+
+
+void POD_Load_VGA_XGA( std::istream& stream )
+{
+	// static globals
+
+
+	// - pure struct data
+	READ_POD( &xga, xga );
+}

--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -1918,3 +1918,24 @@ void EMS_Init() {
 	AddVMEventFunction(VM_EVENT_DOS_EXIT_BEGIN,AddVMEventFunctionFuncPair(EMS_ShutDown));
 }
 
+//save state support
+namespace
+{
+class SerializeEMS : public SerializeGlobalPOD
+{
+public:
+    SerializeEMS() : SerializeGlobalPOD("EMS")
+    {
+        registerPOD(emm_handles);
+        registerPOD(emm_mappings);
+        registerPOD(emm_segmentmappings);
+        registerPOD(GEMMIS_seg);
+		registerPOD(vcpi.enabled);
+        registerPOD(vcpi.ems_handle);
+        registerPOD(vcpi.pm_interface);
+        registerPOD(vcpi.private_area);
+        registerPOD(vcpi.pic1_remapping);
+        registerPOD(vcpi.pic2_remapping);
+    }
+} dummy;
+}

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -1203,3 +1203,23 @@ void INT10_Startup(Section *sec) {
 void INT10_Init() {
 }
 
+//save state support
+namespace
+{
+class SerializeInt10 : public SerializeGlobalPOD
+{
+public:
+    SerializeInt10() : SerializeGlobalPOD("Int10")
+    {
+        registerPOD(int10);
+        //registerPOD(CurMode);
+        //registerPOD(call_10);
+        //registerPOD(warned_ff);
+    }
+
+	 //   virtual void setBytes(std::istream& stream)
+    //{
+      //  SerializeGlobalPOD::setBytes(stream);
+		//}
+} dummy;
+}

--- a/src/ints/xms.cpp
+++ b/src/ints/xms.cpp
@@ -886,3 +886,15 @@ void XMS_Init() {
 	AddVMEventFunction(VM_EVENT_DOS_EXIT_BEGIN,AddVMEventFunctionFuncPair(XMS_ShutDown));
 }
 
+//save state support
+namespace
+{
+class SerializeXMS : public SerializeGlobalPOD
+{
+public:
+    SerializeXMS() : SerializeGlobalPOD("XMS")
+    {
+        registerPOD(xms_handles);
+    }
+} dummy;
+}


### PR DESCRIPTION
As we already know the current save state feature in DOSBox-X is extremely experimental. It only supports save and load states with no additional features, and even that does not work most of the time. So I decided to port the more recent save state feature to DOSBox-X instead. While it is still not perfect, it is certainly more developed, and it supports up to 10 save slots to select from, which is apparently very useful.

The unmodified patch only supports using the shortcuts to save state, load state, and switch to the previous or the next save slot (no GUI menu support because it was for original DOSBox), but I improved it by adding GUI menus so that you can use the menu to save and load states as well as selecting a save slot (from 1 to 10) via the menu.

While the new save state feature does change a lot of files, changes in most of the files are simply added to the end, without touching the original contents. As a result, I don't think the new code will affect the existing code for the most part.

Also, the code used by the old save state and the new save state feature are very different, so they can in fact work independently from each other. For this reason I have kept the old save state feature as is for now, but I can remove it if it is deemed no longer necessary.
