### PR TITLE
Display program name of the save state etc

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,13 @@
 0.83.3
-  - Save/load state now saves PC-98 FM interrupt state so
-    that reloading state does not cause hung music.
-  - Save/load state now supports Sound Blaster Goldplay mode.
-  - Save/load state fixed not to crash when used within a
-    guest operting system (when the DOS kernel has been
-    shut down using the BOOT command).
+  - Improvements and fixes to the save/load state feature:
+    It now supports Sound Blaster Goldplay mode;
+    It now saves PC-98 FM interrupt state so that reloading
+    state does not cause hung music;
+    It is also fixed not to crash when used within a guest
+    operting system (when the DOS kernel has been shut down
+    using the BOOT command);
+    The GUI menu will show if the save slot is empty, and if
+    not the program name of save state will be displayed.
   - Re-ported and improved the save state feature for saving
     and loading states with support for up to 10 save slots.
     They can be selected from the "Capture" menu. (Wengier)

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -298,6 +298,7 @@ public:
     void save   (size_t slot);       //throw (Error)
     void load   (size_t slot) const; //throw (Error)
     bool isEmpty(size_t slot) const;
+    std::string getName(size_t slot) const;
 
     //initialization: register relevant components on program startup
     struct Component

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -2072,7 +2072,7 @@ void POD_Load_DOS_Files( std::istream& stream )
 			}
 
 			// shutdown old file
-			if( Files[lcv] ) {
+			if( Files[lcv] && Files[lcv]->GetName() != NULL ) {
 				// invalid file state - abort
 				if( strcmp( Files[lcv]->GetName(), "NUL" ) == 0 ) break;
 				if( strcmp( Files[lcv]->GetName(), "CON" ) == 0 ) break;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -7609,11 +7609,11 @@ bool force_loadstate_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * c
 bool refresh_slots_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
     (void)menuitem;//UNUSED
-	for (int i=0; i<10; i++) {
+	for (int i=0; i<SaveState::SLOT_COUNT; i++) {
 		char name[6]="slot0";
 		name[4]='0'+i;
-		std::string str="Slot 1"+std::string(SaveState::instance().isEmpty(i)?" [Empty]":"");
-		str[5]='1'+i;
+		std::string command=SaveState::instance().getName(i);
+		std::string str="Slot "+(i>=9?"10":std::string(1, '1'+i))+(command=="[Empty]"?" [Empty slot]":(command==""?"":" (Program: "+command+")"));
 		mainMenu.get_item(name).set_text(str.c_str()).refresh_item(mainMenu);
 	}
     return true;
@@ -8744,16 +8744,14 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
             item.set_text("Select save slot");
 
             {
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot0").set_text(("Slot 1"+std::string(SaveState::instance().isEmpty(0)?" [Empty]":"")).c_str()).set_callback_function(save_slot_0_callback);
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot1").set_text(("Slot 2"+std::string(SaveState::instance().isEmpty(1)?" [Empty]":"")).c_str()).set_callback_function(save_slot_1_callback);
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot2").set_text(("Slot 3"+std::string(SaveState::instance().isEmpty(2)?" [Empty]":"")).c_str()).set_callback_function(save_slot_2_callback);
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot3").set_text(("Slot 4"+std::string(SaveState::instance().isEmpty(3)?" [Empty]":"")).c_str()).set_callback_function(save_slot_3_callback);
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot4").set_text(("Slot 5"+std::string(SaveState::instance().isEmpty(4)?" [Empty]":"")).c_str()).set_callback_function(save_slot_4_callback);
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot5").set_text(("Slot 6"+std::string(SaveState::instance().isEmpty(5)?" [Empty]":"")).c_str()).set_callback_function(save_slot_5_callback);
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot6").set_text(("Slot 7"+std::string(SaveState::instance().isEmpty(6)?" [Empty]":"")).c_str()).set_callback_function(save_slot_6_callback);
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot7").set_text(("Slot 8"+std::string(SaveState::instance().isEmpty(7)?" [Empty]":"")).c_str()).set_callback_function(save_slot_7_callback);
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot8").set_text(("Slot 9"+std::string(SaveState::instance().isEmpty(8)?" [Empty]":"")).c_str()).set_callback_function(save_slot_8_callback);
-				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"slot9").set_text(("Slot 10"+std::string(SaveState::instance().isEmpty(9)?" [Empty]":"")).c_str()).set_callback_function(save_slot_9_callback);
+				DOSBoxMenu::callback_t callbacks[SaveState::SLOT_COUNT] = {save_slot_0_callback, save_slot_1_callback, save_slot_2_callback, save_slot_3_callback, save_slot_4_callback, save_slot_5_callback, save_slot_6_callback, save_slot_7_callback, save_slot_8_callback, save_slot_9_callback};
+				char name[6]="slot0";
+				for (int i=0; i<SaveState::SLOT_COUNT; i++) {
+					name[4]='0'+i;
+					std::string command=SaveState::instance().getName(i);
+					std::string str="Slot "+(i>=9?"10":std::string(1, '1'+i))+(command=="[Empty]"?" [Empty slot]":(command==""?"":" (Program: "+command+")"));
+					mainMenu.alloc_item(DOSBoxMenu::item_type_id,name).set_text(str.c_str()).set_callback_function(callbacks[i]);
+				}
             }
 			char name[6]="slot0";
 			name[4]='0'+GetGameState_Run();


### PR DESCRIPTION
The new save state feature I ported earlier will display if a save slot is empty in the menu, but it did not display the program name of a save slot. Thus I improved the feature so that the program name will be displayed if it is not empty. With this it becomes very easy to see which program each save slot was saved for. 

I also did some other small cleanups to the feature, such as applying the new program name to DOSBox-X.

