### PR TITLE
Save & verify DOSBox-X version/build for save states

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.83.3
+  - Added GUI menu option under "DOS" to change the long
+    filename setting (enable, disable, or auto). (Wengier)
   - Improvements and fixes to the save/load state feature:
     It now supports Sound Blaster Goldplay mode;
     It now saves PC-98 FM interrupt state so that reloading

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,9 @@
     It is also fixed not to crash when used within a guest
     operting system (when the DOS kernel has been shut down
     using the BOOT command);
+    It will save and verify the DOSBox-X version and build.
+    States saved by DOSBox-X in one platform (e.g. 64-bit
+    Windows) may not work in another (e.g. 32-bit Linux). 
     The GUI menu will show if the save slot is empty, and if
     not the program name of save state will be displayed.
   - Re-ported and improved the save state feature for saving

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -3901,6 +3901,11 @@ private:
 		WRITE_POD( &dos.internal_output, dos.internal_output );
 
 		WRITE_POD( &dos.loaded_codepage, dos.loaded_codepage );
+		WRITE_POD( &dos.version.major, dos.version.major );
+		WRITE_POD( &dos.version.minor, dos.version.minor );
+		WRITE_POD( &countryNo, countryNo );
+		WRITE_POD( &uselfn, uselfn );
+		WRITE_POD( &lfn_filefind_handle, lfn_filefind_handle );
 
 		POD_Save_DOS_Devices(stream);
 		POD_Save_DOS_DriveManager(stream);
@@ -3936,6 +3941,11 @@ private:
         READ_POD( &dos.internal_output, dos.internal_output );
 	
 		READ_POD( &dos.loaded_codepage, dos.loaded_codepage );
+		READ_POD( &dos.version.major, dos.version.major );
+		READ_POD( &dos.version.minor, dos.version.minor );
+		READ_POD( &countryNo, countryNo );
+		READ_POD( &uselfn, uselfn );
+		READ_POD( &lfn_filefind_handle, lfn_filefind_handle );
 
 		POD_Load_DOS_Devices(stream);
 		POD_Load_DOS_DriveManager(stream);

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -3043,6 +3043,10 @@ public:
 		else if (!strcmp(section->Get_string("lfn"), "autostart")) enablelfn=-2;
 		else enablelfn=-1;
 
+        mainMenu.get_item("dos_lfn_auto").check(enablelfn==-1).refresh_item(mainMenu);
+        mainMenu.get_item("dos_lfn_enable").check(enablelfn==1).refresh_item(mainMenu);
+        mainMenu.get_item("dos_lfn_disable").check(enablelfn==0).refresh_item(mainMenu);
+
 		std::string ver = section->Get_string("ver");
 		if (!ver.empty()) {
 			const char *s = ver.c_str();

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -4840,7 +4840,7 @@ void SaveState::load(size_t slot) const { //throw (Error)
 			char * const buffer = (char*)alloca( (length+1) * sizeof(char)); // char buffer[length];
 			check_version.read (buffer, length);
 			check_version.close();
-			std::string platform;
+			buffer[length]='\0';
 			char *p=strrchr(buffer, '\n');
 			if (p!=NULL) *p=0;
 			std::string emulatorversion = std::string("DOSBox-X ") + VERSION + std::string(" (") + SDL_STRING + std::string(")\n") + GetPlatform();
@@ -4850,7 +4850,6 @@ void SaveState::load(size_t slot) const { //throw (Error)
 #else
 				if(!force_load_state) {
 #endif
-					buffer[length]='\0';
 					LOG_MSG("Aborted. Check your DOSBox-X version: %s",buffer);
 					load_err=true;
 					goto delete_all;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -4841,8 +4841,10 @@ void SaveState::load(size_t slot) const { //throw (Error)
 			check_version.read (buffer, length);
 			check_version.close();
 			std::string platform;
-			std::string emulatorversion = std::string("DOSBox-X ") + VERSION + std::string(" (") + SDL_STRING + std::string(")\n") + GetPlatform() + std::string("\n") + UPDATED_STR;
-			if (strncmp(buffer,emulatorversion.c_str(),length)) {
+			char *p=strrchr(buffer, '\n');
+			if (p!=NULL) *p=0;
+			std::string emulatorversion = std::string("DOSBox-X ") + VERSION + std::string(" (") + SDL_STRING + std::string(")\n") + GetPlatform();
+			if (p==NULL||strcasecmp(buffer,emulatorversion.c_str())) {
 #if defined(WIN32)
 				if(!force_load_state&&MessageBox(GetHWND(),"DOSBox-X version mismatch. Load the state anyway?","Warning",MB_YESNO|MB_DEFBUTTON2)==IDNO) {
 #else

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1022,13 +1022,13 @@ void DOSBOX_RealInit() {
 	}
 
 	//add support for loading/saving game states
-	MAPPER_AddHandler(SaveGameState, MK_f5, MMOD2,"savestate","SaveState", &item);
+	MAPPER_AddHandler(SaveGameState, MK_f9, MMOD1|MMOD2,"savestate","SaveState", &item);
         item->set_text("Save state");
-	MAPPER_AddHandler(LoadGameState, MK_f9, MMOD2,"loadstate","LoadState", &item);
+	MAPPER_AddHandler(LoadGameState, MK_f10, MMOD1|MMOD2,"loadstate","LoadState", &item);
         item->set_text("Load state");
-	MAPPER_AddHandler(PreviousSaveSlot, MK_f6, MMOD2,"prevslot","PrevSlot", &item);
+	MAPPER_AddHandler(PreviousSaveSlot, MK_f7, MMOD1|MMOD2,"prevslot","PrevSlot", &item);
         item->set_text("Previous slot");
-	MAPPER_AddHandler(NextSaveSlot, MK_f7, MMOD2,"nextslot","NextSlot", &item);
+	MAPPER_AddHandler(NextSaveSlot, MK_f8, MMOD1|MMOD2,"nextslot","NextSlot", &item);
         item->set_text("Next slot");
 
     Section_prop *section = static_cast<Section_prop *>(control->GetSection("dosbox"));

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -77,6 +77,8 @@
 #include "zip.h"
 #include "unzip.h"
 #include "ioapi.h"
+#include "shell.h"
+#include "build_timestamp.h"
 #define MAXU32 0xffffffff
 #include "vs2015/zlib/contrib/minizip/zip.c"
 #include "vs2015/zlib/contrib/minizip/unzip.c"
@@ -816,6 +818,30 @@ void PreviousSaveSlot(bool pressed) {
 }
 }
 
+std::string GetPlatform(void) {
+	char platform[30];
+	strcpy(platform, 
+#if defined(WIN32)
+	"Windows"
+#elif defined(LINUX)
+	"Linux"
+#elif unix
+    "Unix"
+#elif defined(MACOSX)
+    "macOS"
+#else
+    "Other"
+#endif
+);
+#if defined(_M_X64) || defined (_M_AMD64) || defined (_M_ARM64)
+	strcat(platform, " 64");
+#else
+	strcat(platform, " 32");
+#endif
+	strcat(platform, "-bit build");
+	return std::string(platform);
+}
+
 size_t GetGameState_Run(void) { return GetGameState(); }
 void SetGameState_Run(int value) { SetGameState(value); }
 void SaveGameState_Run(void) { SaveGameState(true); }
@@ -965,6 +991,7 @@ void Init_VGABIOS() {
         memset((char*)MemBase+0xC0000,0x00,VGA_BIOS_Size);
 }
 
+void SetCyclesCount_mapper_shortcut(bool pressed);
 void DOSBOX_RealInit() {
     DOSBoxMenu::item *item;
 
@@ -989,6 +1016,10 @@ void DOSBOX_RealInit() {
         MAPPER_AddHandler(DOSBOX_SlowDown, MK_lbracket, MMODHOST,"slowdown","SlowDn", &item);
         item->set_text("Slow down");
     }
+	{
+		MAPPER_AddHandler(&SetCyclesCount_mapper_shortcut, MK_nothing, 0, "editcycles", "EditCycles", &item);
+		item->set_text("Edit cycles");
+	}
 
 	//add support for loading/saving game states
 	MAPPER_AddHandler(SaveGameState, MK_f5, MMOD2,"savestate","SaveState", &item);
@@ -4606,10 +4637,14 @@ void SaveState::save(size_t slot) { //throw (Error)
 	if (slot >= SLOT_COUNT)  return;
 	SDL_PauseAudio(0);
 	bool save_err=false;
-	if((MEM_TotalPages()*4096/1024/1024)>200) {
-		LOG_MSG("Stopped. 200 MB is the maximum memory size for saving/loading states.");
+	if((MEM_TotalPages()*4096/1024/1024)>400) {
+		LOG_MSG("Stopped. 400 MB is the maximum memory size for saving/loading states.");
+#if defined(WIN32)
+		MessageBox(GetHWND(),"Unsupported memory size.","Error",MB_OK);
+#endif
 		return;
 	}
+	bool create_version=false;
 	bool create_title=false;
 	bool create_memorysize=false;
 	extern const char* RunningProgram;
@@ -4647,6 +4682,14 @@ void SaveState::save(size_t slot) { //throw (Error)
 			i->second.rawBytes[slot].set(ss.str());
 			
 			//LOG_MSG("Component is %s",i->first.c_str());
+
+			if(!create_version) {
+				std::string tempname = temp+"DOSBox-X_Version";
+				std::ofstream emulatorversion (tempname.c_str(), std::ofstream::binary);
+				emulatorversion << "DOSBox-X " << VERSION << " (" << SDL_STRING << ")" << std::endl << GetPlatform() << std::endl << UPDATED_STR;
+				create_version=true;
+				emulatorversion.close();
+			}
 
 			if(!create_title) {
 				std::string tempname = temp+"Program_Name";
@@ -4692,6 +4735,8 @@ void SaveState::save(size_t slot) { //throw (Error)
 		save2=temp+i->first;
 		my_minizip((char **)save.c_str(), (char **)save2.c_str());
 	}
+	save2=temp+"DOSBox-X_Version";
+	my_minizip((char **)save.c_str(), (char **)save2.c_str());
 	save2=temp+"Program_Name";
 	my_minizip((char **)save.c_str(), (char **)save2.c_str());
 	save2=temp+"Memory_Size";
@@ -4702,22 +4747,33 @@ delete_all:
 		save2=temp+i->first;
 		remove(save2.c_str());
 	}
+	save2=temp+"DOSBox-X_Version";
+	remove(save2.c_str());
 	save2=temp+"Program_Name";
 	remove(save2.c_str());
 	save2=temp+"Memory_Size";
 	remove(save2.c_str());
-	if (!save_err) LOG_MSG("Saved. (Slot %d)",(int)slot+1);
+	if (save_err) {
+#if defined(WIN32)
+		MessageBox(GetHWND(),"Failed to save the current state.","Error",MB_OK);
+#endif
+	} else
+		LOG_MSG("Saved. (Slot %d)",(int)slot+1);
 }
 
 void SaveState::load(size_t slot) const { //throw (Error)
 //	if (isEmpty(slot)) return;
 	bool load_err=false;
-	if((MEM_TotalPages()*4096/1024/1024)>200) {
-		LOG_MSG("Stopped. 200 MB is the maximum memory size for saving/loading states.");
+	if((MEM_TotalPages()*4096/1024/1024)>400) {
+		LOG_MSG("Stopped. 400 MB is the maximum memory size for saving/loading states.");
+#if defined(WIN32)
+		MessageBox(GetHWND(),"Unsupported memory size.","Error",MB_OK);
+#endif
 		return;
 	}
 	SDL_PauseAudio(0);
 	extern const char* RunningProgram;
+	bool read_version=false;
 	bool read_title=false;
 	bool read_memorysize=false;
 	std::string path;
@@ -4762,6 +4818,45 @@ void SaveState::load(size_t slot) const { //throw (Error)
 
 		my_miniunz((char **)save.c_str(),i->first.c_str(),temp.c_str());
 
+		if(!read_version) {
+			my_miniunz((char **)save.c_str(),"DOSBox-X_Version",temp.c_str());
+			std::ifstream check_version;
+			int length = 8;
+
+			std::string tempname = temp+"DOSBox-X_Version";
+			check_version.open(tempname.c_str(), std::ifstream::in);
+			if(check_version.fail()) {
+				LOG_MSG("Save state corrupted! Program in inconsistent state! - DOSBox-X_Version");
+#if defined(WIN32)
+				MessageBox(GetHWND(),"Save state corrupted!","Error",MB_OK);
+#endif
+				load_err=true;
+				goto delete_all;
+			}
+			check_version.seekg (0, std::ios::end);
+			length = check_version.tellg();
+			check_version.seekg (0, std::ios::beg);
+
+			char * const buffer = (char*)alloca( (length+1) * sizeof(char)); // char buffer[length];
+			check_version.read (buffer, length);
+			check_version.close();
+			std::string platform;
+			std::string emulatorversion = std::string("DOSBox-X ") + VERSION + std::string(" (") + SDL_STRING + std::string(")\n") + GetPlatform() + std::string("\n") + UPDATED_STR;
+			if (strncmp(buffer,emulatorversion.c_str(),length)) {
+#if defined(WIN32)
+				if(!force_load_state&&MessageBox(GetHWND(),"DOSBox-X version mismatch. Load the state anyway?","Warning",MB_YESNO|MB_DEFBUTTON2)==IDNO) {
+#else
+				if(!force_load_state) {
+#endif
+					buffer[length]='\0';
+					LOG_MSG("Aborted. Check your DOSBox-X version: %s",buffer);
+					load_err=true;
+					goto delete_all;
+				}
+			}
+			read_version=true;
+		}
+
 		if(!read_title) {
 			my_miniunz((char **)save.c_str(),"Program_Name",temp.c_str());
 			std::ifstream check_title;
@@ -4784,11 +4879,11 @@ void SaveState::load(size_t slot) const { //throw (Error)
 			char * const buffer = (char*)alloca( (length+1) * sizeof(char)); // char buffer[length];
 			check_title.read (buffer, length);
 			check_title.close();
-			if (strncmp(buffer,RunningProgram,length)) {
+			if (strncmp(buffer,RunningProgram,length)||!length) {
 #if defined(WIN32)
-				if(!force_load_state&&MessageBox(GetHWND(),"Program name mismatch. Load the state anyway?","Warning",MB_YESNO)==IDNO) {
+				if(!force_load_state&&MessageBox(GetHWND(),"Program name mismatch. Load the state anyway?","Warning",MB_YESNO|MB_DEFBUTTON2)==IDNO) {
 #else
-				if(!force_load_state&&strncmp(buffer,RunningProgram,length)) {
+				if(!force_load_state) {
 #endif
 					buffer[length]='\0';
 					LOG_MSG("Aborted. Check your program name: %s",buffer);
@@ -4875,6 +4970,8 @@ delete_all:
 		save2=temp+i->first;
 		remove(save2.c_str());
 	}
+	save2=temp+"DOSBox-X_Version";
+	remove(save2.c_str());
 	save2=temp+"Program_Name";
 	remove(save2.c_str());
 	save2=temp+"Memory_Size";
@@ -4952,5 +5049,6 @@ std::string SaveState::getName(size_t slot) const {
 	check_title.read (buffer, length);
 	check_title.close();
 	remove(tempname.c_str());
+	buffer[length]='\0';
 	return std::string(buffer);
 }

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -373,6 +373,8 @@ static const char *def_menu_dos[] =
 {
     "DOSMouseMenu",
     "--",
+	"DOSLFNMenu",
+    "--",
     "DOSPC98Menu",
     "--",
     "mapper_swapimg",
@@ -391,6 +393,16 @@ static const char *def_menu_dos_mouse[] =
     "dos_mouse_y_axis_reverse",
     "--",
     "dos_mouse_sensitivity",
+    NULL
+};
+
+/* DOS LFN menu ("DOSLFNMenu") */
+static const char *def_menu_dos_lfn[] =
+{
+    "dos_lfn_auto",
+    "--",
+    "dos_lfn_enable",
+    "dos_lfn_disable",
     NULL
 };
 
@@ -1220,6 +1232,9 @@ void ConstructMenu(void) {
 
     /* DOS mouse menu */
     ConstructSubMenu(mainMenu.get_item("DOSMouseMenu").get_master_id(), def_menu_dos_mouse);
+
+    /* DOS LFN menu */
+    ConstructSubMenu(mainMenu.get_item("DOSLFNMenu").get_master_id(), def_menu_dos_lfn);
 
     /* DOS PC-98 menu */
     ConstructSubMenu(mainMenu.get_item("DOSPC98Menu").get_master_id(), def_menu_dos_pc98);

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -324,6 +324,7 @@ static void RENDER_Halt( void ) {
 extern Bitu PIC_Ticks;
 extern bool pause_on_vsync;
 void PauseDOSBox(bool pressed);
+void AspectRatio_mapper_shortcut(bool pressed);
 
 void RENDER_EndUpdate( bool abort ) {
     if (GCC_UNLIKELY(!render.updating))
@@ -1045,6 +1046,17 @@ void RENDER_Init() {
 
     render.frameskip.max=(Bitu)section->Get_int("frameskip");
 
+    MAPPER_AddHandler(DecreaseFrameSkip,MK_nothing,0,"decfskip","Dec Fskip");
+    MAPPER_AddHandler(IncreaseFrameSkip,MK_nothing,0,"incfskip","Inc Fskip");
+
+	DOSBoxMenu::item *item;
+
+	MAPPER_AddHandler(&AspectRatio_mapper_shortcut, MK_nothing, 0, "aspratio", "AspRatio", &item);
+	item->set_text("Fit to aspect ratio");
+
+    // DEBUG option
+    MAPPER_AddHandler(BlankTestRefresh,MK_nothing,0,"blankrefreshtest","RefrshTest");
+
     mainMenu.get_item("vga_9widetext").check(vga.draw.char9_set).refresh_item(mainMenu);
     mainMenu.get_item("doublescan").check(vga.draw.doublescan_set).refresh_item(mainMenu);
     mainMenu.get_item("mapper_aspratio").check(render.aspect).refresh_item(mainMenu);
@@ -1082,12 +1094,6 @@ void RENDER_Init() {
 
     if(!running) render.updating=true;
     running = true;
-
-    MAPPER_AddHandler(DecreaseFrameSkip,MK_nothing,0,"decfskip","Dec Fskip");
-    MAPPER_AddHandler(IncreaseFrameSkip,MK_nothing,0,"incfskip","Inc Fskip");
-
-    // DEBUG option
-    MAPPER_AddHandler(BlankTestRefresh,MK_nothing,0,"blankrefreshtest","RefrshTest");
 
     GFX_SetTitle(-1,(Bits)render.frameskip.max,-1,false);
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8791,10 +8791,6 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         {
             DOSBoxMenu::item *item;
 
-#if defined(__WIN32__) && !defined(C_SDL2)
-			MAPPER_AddHandler(ToggleMenu,MK_return,MMOD1|MMOD2,"togglemenu","TogMenu");
-#endif // WIN32
-
             MAPPER_AddHandler(&HideMenu_mapper_shortcut, MK_escape, MMODHOST, "togmenu", "ToggleMenu", &item);
             item->set_text("Hide/show menu bar");
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -7029,6 +7029,40 @@ bool dos_mouse_sensitivity_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::ite
     return true;
 }
 
+extern int enablelfn;
+bool dos_lfn_auto_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+    enablelfn = -1;
+	uselfn = dos.version.major>6;
+    mainMenu.get_item("dos_lfn_auto").check(true).refresh_item(mainMenu);
+    mainMenu.get_item("dos_lfn_enable").check(false).refresh_item(mainMenu);
+    mainMenu.get_item("dos_lfn_disable").check(false).refresh_item(mainMenu);
+    return true;
+}
+
+bool dos_lfn_enable_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+    enablelfn = 1;
+	uselfn = true;
+    mainMenu.get_item("dos_lfn_auto").check(false).refresh_item(mainMenu);
+    mainMenu.get_item("dos_lfn_enable").check(true).refresh_item(mainMenu);
+    mainMenu.get_item("dos_lfn_disable").check(false).refresh_item(mainMenu);
+    return true;
+}
+
+bool dos_lfn_disable_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+    enablelfn = 0;
+	uselfn = false;
+    mainMenu.get_item("dos_lfn_auto").check(false).refresh_item(mainMenu);
+    mainMenu.get_item("dos_lfn_enable").check(false).refresh_item(mainMenu);
+    mainMenu.get_item("dos_lfn_disable").check(true).refresh_item(mainMenu);
+    return true;
+}
+
 extern bool                         gdc_5mhz_mode_initial;
 
 bool vid_pc98_5mhz_gdc_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
@@ -8652,6 +8686,20 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
             }
 
             {
+                DOSBoxMenu::item &item = mainMenu.alloc_item(DOSBoxMenu::submenu_type_id,"DOSLFNMenu");
+                item.set_text("Long filename support");
+
+                {
+                    mainMenu.alloc_item(DOSBoxMenu::item_type_id,"dos_lfn_auto").set_text("Auto").
+                        set_callback_function(dos_lfn_auto_menu_callback);
+                    mainMenu.alloc_item(DOSBoxMenu::item_type_id,"dos_lfn_enable").set_text("Enable").
+                        set_callback_function(dos_lfn_enable_menu_callback);
+                    mainMenu.alloc_item(DOSBoxMenu::item_type_id,"dos_lfn_disable").set_text("Disable").
+                        set_callback_function(dos_lfn_disable_menu_callback);
+                }
+            }
+
+            {
                 DOSBoxMenu::item &item = mainMenu.alloc_item(DOSBoxMenu::submenu_type_id,"DOSPC98Menu");
                 item.set_text("PC-98 PIT master clock");
 
@@ -8944,8 +8992,6 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         extern bool Mouse_Vertical;
         extern bool Mouse_Drv;
 
-        mainMenu.get_item("dos_mouse_enable_int33").check(Mouse_Drv).refresh_item(mainMenu);
-        mainMenu.get_item("dos_mouse_y_axis_reverse").check(Mouse_Vertical).refresh_item(mainMenu);
 #if !defined(C_EMSCRIPTEN)
         mainMenu.get_item("show_console").check(showconsole_init).refresh_item(mainMenu);
 #endif

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8798,13 +8798,6 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
             item->set_text("Pause with interrupts enabled");
         }
 
-        {
-            DOSBoxMenu::item *item;
-
-            MAPPER_AddHandler(&AspectRatio_mapper_shortcut, MK_nothing, 0, "aspratio", "AspRatio", &item);
-            item->set_text("Fit to aspect ratio");
-        }
-
         RENDER_Init();
         CAPTURE_Init();
         IO_Init();

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8794,9 +8794,6 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         {
             DOSBoxMenu::item *item;
 
-            MAPPER_AddHandler(&SetCyclesCount_mapper_shortcut, MK_nothing, 0, "editcycles", "EditCycles", &item);
-            item->set_text("Edit cycles");
-
             MAPPER_AddHandler(&HideMenu_mapper_shortcut, MK_escape, MMODHOST, "togmenu", "TogMenu", &item);
             item->set_text("Hide/show menu bar");
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3676,9 +3676,6 @@ static void GUI_StartUp() {
     //ShowSplashScreen();   /* I will keep the splash screen alive. But now, the BIOS will do it --J.C. */
 
     /* Get some Event handlers */
-#if defined(__WIN32__) && !defined(C_SDL2)
-    MAPPER_AddHandler(ToggleMenu,MK_return,MMOD1|MMOD2,"togglemenu","ToggleMenu");
-#endif // WIN32
     MAPPER_AddHandler(ResetSystem, MK_r, MMODHOST, "reset", "Reset", &item); /* Host+R (Host+CTRL+R acts funny on my Linux system) */
     item->set_text("Reset guest system");
 
@@ -8794,7 +8791,11 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         {
             DOSBoxMenu::item *item;
 
-            MAPPER_AddHandler(&HideMenu_mapper_shortcut, MK_escape, MMODHOST, "togmenu", "TogMenu", &item);
+#if defined(__WIN32__) && !defined(C_SDL2)
+			MAPPER_AddHandler(ToggleMenu,MK_return,MMOD1|MMOD2,"togglemenu","TogMenu");
+#endif // WIN32
+
+            MAPPER_AddHandler(&HideMenu_mapper_shortcut, MK_escape, MMODHOST, "togmenu", "ToggleMenu", &item);
             item->set_text("Hide/show menu bar");
 
             MAPPER_AddHandler(&PauseWithInterrupts_mapper_shortcut, MK_nothing, 0, "pauseints", "PauseInts", &item);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8992,6 +8992,9 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         extern bool Mouse_Vertical;
         extern bool Mouse_Drv;
 
+        mainMenu.get_item("dos_mouse_enable_int33").check(Mouse_Drv).refresh_item(mainMenu);	
+        mainMenu.get_item("dos_mouse_y_axis_reverse").check(Mouse_Vertical).refresh_item(mainMenu);
+
 #if !defined(C_EMSCRIPTEN)
         mainMenu.get_item("show_console").check(showconsole_init).refresh_item(mainMenu);
 #endif

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -32,6 +32,7 @@
 #include "cross.h"
 #include "control.h"
 #include "shell.h"
+#include "menu.h"
 
 Bitu call_program;
 
@@ -1060,6 +1061,9 @@ void CONFIG::Run(void) {
 								else if (!strcmp(section->Get_string("lfn"), "false")) enablelfn=0;
 								else if (!strcmp(section->Get_string("lfn"), "autostart")) enablelfn=-2;
 								else enablelfn=-1;
+								mainMenu.get_item("dos_lfn_auto").check(enablelfn==-1).refresh_item(mainMenu);
+								mainMenu.get_item("dos_lfn_enable").check(enablelfn==1).refresh_item(mainMenu);
+								mainMenu.get_item("dos_lfn_disable").check(enablelfn==0).refresh_item(mainMenu);
 								uselfn = enablelfn==1 || ((enablelfn == -1 || enablelfn == -2) && dos.version.major>6);
 							} else if (!strcasecmp(inputline.substr(0, 4).c_str(), "ver=")) {
 								std::string ver = section->Get_string("ver");


### PR DESCRIPTION
sAs discussed earlier, states saved by DOSBox-X in one platform may not work in another, so I improved the save states feature to save the DOSBox-X version and build. An example of DOSBox-X_VERSION file to be saved will be:

```
DOSBox-X 0.83.3 (SDL2)
Windows 64-bit build
Jun 3, 2020 10:56:46am
```

When you load a saved state, DOSBox-X will verify if the current environment matches this (everything except the build date/time). If not, it may refuse to load the state. But you can always force load the state by enabling the "Force load state" menu option.