### PR TITLE
FluidSynth: Let's try to find a SoundFont file before bailing

### DIFF
--- a/dosbox-x.desktop
+++ b/dosbox-x.desktop
@@ -2,7 +2,7 @@
 Name=DOSBox-X
 Comment=An enhanced x86/DOS emulator with sound/graphics
 Exec=dosbox-x
-Icon=dosbox-x.png
+Icon=dosbox-x
 Terminal=false
 Type=Application
 Categories=System;Emulator;

--- a/dosbox-x.spec.in
+++ b/dosbox-x.spec.in
@@ -1,5 +1,9 @@
-BuildRequires: libX11 libX11-devel libXext libXext-devel libpng libpng-devel alsa-lib alsa-lib-devel ncurses ncurses-devel zlib zlib-devel mesa-libGL mesa-libGL-devel pulseaudio-libs pulseaudio-libs-devel make, libtool, gcc
+BuildRequires: libX11 libX11-devel libXext libXext-devel libpng libpng-devel
+BuildRequires: alsa-lib alsa-lib-devel ncurses ncurses-devel zlib zlib-devel
+BuildRequires: mesa-libGL mesa-libGL-devel pulseaudio-libs pulseaudio-libs-devel
+BuildRequires: fluidsynth-devel libpcap-devel make libtool gcc
 Requires: libX11 libXext libpng alsa-lib ncurses zlib mesa-libGL pulseaudio-libs
+Requires: fluid-soundfont-gm
 Name: @PACKAGE_NAME@
 Version: @PACKAGE_VERSION@
 Release: 0%{?dist}
@@ -29,7 +33,7 @@ of Windows.
 %autosetup -n dosbox-x
 
 %build
-./build-debug-no-avcodec
+./build-debug
 
 %check
 

--- a/src/gui/midi_synth.h
+++ b/src/gui/midi_synth.h
@@ -282,6 +282,7 @@ public:
 				return false;
 			}
 #else
+			// Default on "other" platforms according to fluidsynth docs
 			// This works on RH and Fedora, if a soundfont is installed
 			if (FILE *file = fopen("/usr/share/soundfonts/default.sf2", "r")) {
 				fclose(file);

--- a/src/gui/midi_synth.h
+++ b/src/gui/midi_synth.h
@@ -270,10 +270,31 @@ public:
 		(void)conf;
 
 		Section_prop *section = static_cast<Section_prop *>(control->GetSection("midi"));
-		const char * sf = section->Get_string("fluid.soundfont");
-		if (!*sf) {
-			LOG_MSG("MIDI:fluidsynth: SoundFont not specified");
-			return false;
+		const char *sf = section->Get_string("fluid.soundfont");
+		if (!*sf) { // Let's try to find a soundfont before bailing
+#if defined (WIN32)
+			// default for windows according to fluidsynth docs
+			if (FILE *file = fopen("C:\soundfonts\default.sf2", "r")) {
+				fclose(file);
+				sf = "C:\soundfonts\default.sf2";
+			} else {
+				LOG_MSG("MIDI:fluidsynth: SoundFont not specified");
+				return false;
+			}
+#else
+			// This works on RH and Fedora, if a soundfont is installed
+			if (FILE *file = fopen("/usr/share/soundfonts/default.sf2", "r")) {
+				fclose(file);
+				sf = "/usr/share/soundfonts/default.sf2";
+			// Ubuntu and Debian don't have a default.sf2...
+			} else if (FILE *file = fopen("/usr/share/sounds/sf2/FluidR3_GM.sf2", "r")) {
+				fclose(file);
+				sf = "/usr/share/sounds/sf2/FluidR3_GM.sf2";
+			} else {
+				LOG_MSG("MIDI:fluidsynth: SoundFont not specified, and no system SoundFont found");
+				return false;
+			}
+#endif
 		}
 		soundfont.assign(sf);
 		settings = new_fluid_settings();


### PR DESCRIPTION
# Description
Try some default soundfont locations, if fluid.soundfont was not set.

Compile tested on Linux only.

p.s. I'm also wondering about the default fluid.driver=jack on Linux. That is all good and well for FluidSynth upstream, but in reality I don't think many people will want to go through the hassle of setting up Jack, and breaking audio for most other applications in the process. I think "pulseaudio" would be a better default, and would work out-of-the-box on most modern Linux desktops.