### PR TITLE
Change default FluidSynth driver on Linux to PulseAudio

### DIFF
--- a/dosbox-x.spec.in
+++ b/dosbox-x.spec.in
@@ -41,9 +41,6 @@ of Windows.
 %make_install DESTDIR=%{buildroot}
 
 desktop-file-install \
-%if 0%{?fedora} && 0%{?fedora} < 19
-  --vendor fedora            \
-%endif
   --dir=%{buildroot}%{_datadir}/applications \
   %{SOURCE1}
 
@@ -59,4 +56,9 @@ install -p -m 0644 %SOURCE3 %{buildroot}%{_datadir}/metainfo
 %{_datadir}/metainfo/*
 %{_datadir}/dosbox-x
 
+# Required for NE2000 networking support
+%post
+if [ -x /usr/sbin/setcap ]; then
+    setcap cap_net_raw+ep %{_bindir}/dosbox-x
+fi
 

--- a/src/gui/midi_synth.h
+++ b/src/gui/midi_synth.h
@@ -302,6 +302,10 @@ public:
 		if (strcmp(section->Get_string("fluid.driver"), "default") != 0) {
 			fluid_settings_setstr(settings, "audio.driver", section->Get_string("fluid.driver"));
 		}
+#if defined (__linux__) // Let's use pulseaudio as default on Linux, and not the FluidSynth default of Jack
+		else
+		    fluid_settings_setstr(settings, "audio.driver", "pulseaudio");
+#endif
 		fluid_settings_setnum(settings, "synth.sample-rate", atof(section->Get_string("fluid.samplerate")));
 		fluid_settings_setnum(settings, "synth.gain", atof(section->Get_string("fluid.gain")));
 		fluid_settings_setint(settings, "synth.polyphony", section->Get_int("fluid.polyphony"));


### PR DESCRIPTION
# Description
FluidSynth defaults to the Jack audio server. This is all good and well for upstream, but all the common Linux desktops use PulseAudio.

Also for a user to install Jack, they will break almost all other audio applications, as almost everything defaults to PulseAudio, including web browsers.

Jack has a lower latency, and is therefore better suited for MIDI, but I think the common use case here is PulseAudio. In the next year or so this may all change, as PipeWire is meant to replace both PulseAudio and Jack.

**Are there any breaking changes ?**

If there are any users that depended on "default" meaning "jack", they will now have to update their config file.
