### PR TITLE
Allow key mapping to mouse buttons

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 0.83.3
-  - Support for mounting cues files with MP3/OGG/WAV/FLAC
+  - Mouse buttons (left, middle, right) can now be mapped
+    to keys in the keyboard mapper. (Wengier)
+  - Support for mounting .cue files with MP3/OGG/WAV/FLAC
     compressed audio tracks. (Wengier) 
   - Rewrote the Windows installer for DOSBox-X, as well as
     the building script for the installer. All required

--- a/src/gui/midi_synth.h
+++ b/src/gui/midi_synth.h
@@ -274,9 +274,9 @@ public:
 		if (!*sf) { // Let's try to find a soundfont before bailing
 #if defined (WIN32)
 			// default for windows according to fluidsynth docs
-			if (FILE *file = fopen("C:\soundfonts\default.sf2", "r")) {
+			if (FILE *file = fopen("C:\\soundfonts\\default.sf2", "r")) {
 				fclose(file);
-				sf = "C:\soundfonts\default.sf2";
+				sf = "C:\\soundfonts\\default.sf2";
 			} else {
 				LOG_MSG("MIDI:fluidsynth: SoundFont not specified");
 				return false;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8524,7 +8524,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
             item.set_text("Main");
             {
                 DOSBoxMenu::item &item = mainMenu.alloc_item(DOSBoxMenu::submenu_type_id,"MainSendKey");
-                item.set_text("Send Key");
+                item.set_text("Send special key");
             }
         }
         {


### PR DESCRIPTION
DOSBox-X ECE has this feature, but DOSBox-X did not, so I decided to add this feature to DOSBox-X too. As a result, the events for mouse buttons (left, middle, right) will now appear in the mapper and the users can map them to keys if they wish.

Also fixed the path to the default FluidSynth font file in Windows platform.