### PR TITLE
Add AUTOTYPE command to perform scripted keyboard entry into a running DOS program

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 0.83.3
-  - Added code page 866 (Cyrillic Russian) to supported
+  - Added AUTOTYPE command to perform scripted keyboard
+    entry into a running DOS program or game. Ported from
+    DOSBox-staging, it can be used to reliably skip intro,
+    provide input to answer initial startup or config
+    questions, or conduct a simple demo. (Wengier)
+  - Added code page 866 (Cyrillic Russian) to support
     host to guest code page mapping (tuffnatty)
   - Mouse buttons (left, middle, right) can now be mapped
     to keys in the keyboard mapper. (Wengier)

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,6 @@
-Please see the file CHANGLOG for the most recent changes to DOSBox-X.
+For the latest version of DOSBox-X please go to the Releases page.
+
+Also look at the file CHANGELOG for latest changes to the DOSBox-X source code.
 
 Below are changes to DOSBox.
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+Please see the file CHANGLOG for the most recent changes to DOSBox-X.
+
+Below are changes to DOSBox.
+
 0.74
   - Several small game specific fixes/hacks/support. (Offensive,
     Roadhog, GTA installer, Kingdom O' Magic soundcard detection, 

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2795,7 +2795,7 @@ void LOADFIX::Run(void)
         kb = 1024;
     }
 
-    if (cmd->FindExist("-?", false) || cmd->FindExist("/?", false)) {
+    if (cmd->GetCount()==1 && (cmd->FindExist("-?", false) || cmd->FindExist("/?", false))) {
         WriteOut(MSG_Get("PROGRAM_LOADFIX_HELP"));
         return;
     }
@@ -5044,6 +5044,209 @@ void LABEL_ProgramStart(Program** make)
 	*make = new LABEL;
 }
 
+std::vector<std::string> MAPPER_GetEventNames(const std::string &prefix);
+void MAPPER_AutoType(std::vector<std::string> &sequence,
+                     const uint32_t wait_ms,
+                     const uint32_t pacing_ms);
+
+class AUTOTYPE : public Program {
+public:
+	void Run();
+
+private:
+	void PrintUsage();
+	void PrintKeys();
+	bool ReadDoubleArg(const std::string &name,
+	                   const char *flag,
+	                   const double &def_value,
+	                   const double &min_value,
+	                   const double &max_value,
+	                   double &value);
+};
+
+void AUTOTYPE_ProgramStart(Program **make);
+
+void AUTOTYPE::PrintUsage()
+{
+	constexpr const char *msg =
+	        "\033[32;1mAUTOTYPE\033[0m [-list] [-w WAIT] [-p PACE] "
+	        "button_1 [button_2 [...]] \n\n"
+	        "Where:\n"
+	        "  -list:   prints all available button names.\n"
+	        "  -w WAIT: seconds before typing begins. Two second default; "
+	        "max of 30.\n"
+	        "  -p PACE: seconds between each keystroke. Half-second "
+	        "default; max of 10.\n"
+	        "\n"
+	        "  The sequence is comprised of one or more space-separated "
+	        "buttons.\n"
+	        "  Autotyping begins after WAIT seconds, and each button is "
+	        "entered \n"
+	        "  every PACE seconds. The , character inserts an extra PACE "
+	        "delay.\n"
+	        "\n"
+	        "Some examples:\n"
+	        "  \033[32;1mAUTOTYPE\033[0m -w 1 -p 0.3 up enter , right "
+	        "enter\n"
+	        "  \033[32;1mAUTOTYPE\033[0m -p 0.2 f1 kp_8 , , enter\n"
+	        "  \033[32;1mAUTOTYPE\033[0m -w 1.3 esc enter , p l a y e r "
+	        "enter\n";
+	WriteOut_NoParsing(msg);
+}
+
+// Prints the key-names for the mapper's currently-bound events.
+void AUTOTYPE::PrintKeys()
+{
+	const std::vector<std::string> names = MAPPER_GetEventNames("key_");
+
+	// Keep track of the longest key name
+	size_t max_length = 0;
+	for (const auto &name : names)
+		max_length = (std::max)(name.length(), max_length);
+
+	// Sanity check to avoid dividing by 0
+	if (!max_length) {
+		WriteOut_NoParsing(
+		        "AUTOTYPE: The mapper has no key bindings\n");
+		return;
+	}
+
+	// Setup our rows and columns
+	const size_t wrap_width = 72; // confortable columns not pushed to the edge
+	const size_t columns = wrap_width / max_length;
+	const size_t rows = ceil_udivide(names.size(), columns);
+
+	// Build the string output by rows and columns
+	auto name = names.begin();
+	for (size_t row = 0; row < rows; ++row) {
+		for (size_t i = row; i < names.size(); i += rows)
+			WriteOut("  %-*s", static_cast<int>(max_length), name[i].c_str());
+		WriteOut_NoParsing("\n");
+	}
+}
+
+/*
+ *  Converts a string to a finite number (such as float or double).
+ *  Returns the number or quiet_NaN, if it could not be parsed.
+ *  This function does not attemp to capture exceptions that may
+ *  be thrown from std::stod(...)
+ */
+template<typename T>
+T to_finite(const std::string& input) {
+	// Defensively set NaN from the get-go
+	T result = std::numeric_limits<T>::quiet_NaN();
+	size_t bytes_read = 0;
+	try {
+		const double interim = std::stod(input, &bytes_read);
+		if (!input.empty() && bytes_read == input.size())
+			result = static_cast<T>(interim);
+	}
+	// Capture expected exceptions stod may throw
+	catch (std::invalid_argument &e) {}
+	catch (std::out_of_range &e) {}
+	return result;
+}
+
+/*
+ *  Reads a floating point argument from command line, where:
+ *  - name is a human description for the flag, ie: DELAY
+ *  - flag is the command-line flag, ie: -d or -delay
+ *  - default is the default value if the flag doesn't exist
+ *  - value will be populated with the default or provided value
+ *
+ *  Returns:
+ *    true if 'value' is set to the default or read from the arg.
+ *    false if the argument was used but could not be parsed.
+ */
+bool AUTOTYPE::ReadDoubleArg(const std::string &name,
+                             const char *flag,
+                             const double &def_value,
+                             const double &min_value,
+                             const double &max_value,
+                             double &value)
+{
+	bool result = false;
+	std::string str_value;
+
+	// Is the user trying to set this flag?
+	if (cmd->FindString(flag, str_value, true)) {
+		// Can the user's value be parsed?
+		const double user_value = to_finite<double>(str_value);
+		if (std::isfinite(user_value)) {
+			result = true;
+
+			// Clamp the user's value if needed
+			value = clamp(user_value, min_value, max_value);
+
+			// Inform them if we had to clamp their value
+			if (std::fabs(user_value - value) >
+			    std::numeric_limits<double>::epsilon())
+				WriteOut("AUTOTYPE: bounding %s value of %.2f "
+				         "to %.2f\n",
+				         name.c_str(), user_value, value);
+
+		} else { // Otherwise we couldn't parse their value
+			WriteOut("AUTOTYPE: %s value '%s' is not a valid "
+			         "floating point number\n",
+			         name.c_str(), str_value.c_str());
+		}
+	} else { // Otherwise thay haven't passed this flag
+		value = def_value;
+		result = true;
+	}
+	return result;
+}
+
+void AUTOTYPE::Run()
+{
+	// Hack To allow long commandlines
+	ChangeToLongCmd();
+
+	// Usage
+	if (!cmd->GetCount()||(cmd->GetCount()==1 && (cmd->FindExist("-?", false) || cmd->FindExist("/?", false)))) {
+		PrintUsage();
+		return;
+	}
+
+	// Print available keys
+	if (cmd->FindExist("-list", false)) {
+		PrintKeys();
+		return;
+	}
+
+	// Get the wait delay in milliseconds
+	double wait_s;
+	constexpr double def_wait_s = 2.0;
+	constexpr double min_wait_s = 0.0;
+	constexpr double max_wait_s = 30.0;
+	if (!ReadDoubleArg("WAIT", "-w", def_wait_s, min_wait_s, max_wait_s, wait_s))
+		return;
+	const auto wait_ms = static_cast<uint32_t>(wait_s * 1000);
+
+	// Get the inter-key pacing in milliseconds
+	double pace_s;
+	constexpr double def_pace_s = 0.5;
+	constexpr double min_pace_s = 0.0;
+	constexpr double max_pace_s = 10.0;
+	if (!ReadDoubleArg("PACE", "-p", def_pace_s, min_pace_s, max_pace_s, pace_s))
+		return;
+	const auto pace_ms = static_cast<uint32_t>(pace_s * 1000);
+
+	// Get the button sequence
+	std::vector<std::string> sequence;
+	cmd->FillVector(sequence);
+	if (sequence.empty()) {
+		WriteOut_NoParsing("AUTOTYPE: button sequence is empty\n");
+		return;
+	}
+	MAPPER_AutoType(sequence, wait_ms, pace_ms);
+}
+
+void AUTOTYPE_ProgramStart(Program **make)
+{
+	*make = new AUTOTYPE;
+}
+
 void DOS_SetupPrograms(void) {
     /*Add Messages */
 
@@ -5510,4 +5713,5 @@ void DOS_SetupPrograms(void) {
 
     PROGRAMS_MakeFile("CAPMOUSE.COM", CAPMOUSE_ProgramStart);
     PROGRAMS_MakeFile("LABEL.COM", LABEL_ProgramStart);
+    PROGRAMS_MakeFile("AUTOTYPE.COM", AUTOTYPE_ProgramStart);
 }

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -5069,7 +5069,8 @@ void AUTOTYPE_ProgramStart(Program **make);
 void AUTOTYPE::PrintUsage()
 {
 	constexpr const char *msg =
-	        "\033[32;1mAUTOTYPE\033[0m [-list] [-w WAIT] [-p PACE] "
+	        "Performs scripted keyboard entry into a running DOS program.\n\n"
+			"\033[32;1mAUTOTYPE\033[0m [-list] [-w WAIT] [-p PACE] "
 	        "button_1 [button_2 [...]] \n\n"
 	        "Where:\n"
 	        "  -list:   prints all available button names.\n"

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -5672,39 +5672,32 @@ void DOS_SetupPrograms(void) {
             "\033[1mCO80\033[0m, \033[1mBW80\033[0m, \033[1mCO40\033[0m, \033[1mBW40\033[0m, or \033[1mMONO\033[0m\n"
             "\033[34;1mMODE CON RATE=\033[0mr \033[34;1mDELAY=\033[0md :typematic rates, r=1-32 (32=fastest), d=1-4 (1=lowest)\n");
     MSG_Add("PROGRAM_MODE_INVALID_PARAMETERS","Invalid parameter(s).\n");
-    //MSG_Add("PROGRAM_MORE_USAGE","Usage: \033[34;1mMORE <\033[0m text-file\n");
-    //MSG_Add("PROGRAM_MORE_MORE","-- More --");
 
     /*regular setup*/
-    PROGRAMS_MakeFile("MOUNT.COM",MOUNT_ProgramStart);
-    PROGRAMS_MakeFile("LOADFIX.COM",LOADFIX_ProgramStart);
-    PROGRAMS_MakeFile("RESCAN.COM",RESCAN_ProgramStart);
     PROGRAMS_MakeFile("INTRO.COM",INTRO_ProgramStart);
-    PROGRAMS_MakeFile("BOOT.COM",BOOT_ProgramStart);
 
     if (!IS_PC98_ARCH)
         PROGRAMS_MakeFile("LOADROM.COM", LOADROM_ProgramStart);
 
     PROGRAMS_MakeFile("IMGMAKE.COM", IMGMAKE_ProgramStart);
     PROGRAMS_MakeFile("IMGMOUNT.COM", IMGMOUNT_ProgramStart);
+    PROGRAMS_MakeFile("MOUNT.COM",MOUNT_ProgramStart);
+    PROGRAMS_MakeFile("BOOT.COM",BOOT_ProgramStart);
 
-    if (!IS_PC98_ARCH)
-        PROGRAMS_MakeFile("MODE.COM", MODE_ProgramStart);
-
-    //PROGRAMS_MakeFile("MORE.COM", MORE_ProgramStart);
-
-    if (!IS_PC98_ARCH)
+    if (!IS_PC98_ARCH) {
         PROGRAMS_MakeFile("KEYB.COM", KEYB_ProgramStart);
-
-    if (!IS_PC98_ARCH)
+        PROGRAMS_MakeFile("MODE.COM", MODE_ProgramStart);
         PROGRAMS_MakeFile("MOUSE.COM", MOUSE_ProgramStart);
+	}
 
+    PROGRAMS_MakeFile("LOADFIX.COM",LOADFIX_ProgramStart);
     PROGRAMS_MakeFile("A20GATE.COM",A20GATE_ProgramStart);
     PROGRAMS_MakeFile("SHOWGUI.COM",SHOWGUI_ProgramStart);
 #if defined C_DEBUG
     PROGRAMS_MakeFile("NMITEST.COM",NMITEST_ProgramStart);
 #endif
     PROGRAMS_MakeFile("RE-DOS.COM",REDOS_ProgramStart);
+    PROGRAMS_MakeFile("RESCAN.COM",RESCAN_ProgramStart);
 
     if (IS_VGA_ARCH && svgaCard != SVGA_None)
         PROGRAMS_MakeFile("VESAMOED.COM",VESAMOED_ProgramStart);

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1410,6 +1410,15 @@ void SHELL_Init() {
             VFILE_RegisterBuiltinFileBlob(bfb_25_COM_other);
     }
 
+    /* don't register 28.com unless EGA/VGA */
+    if (IS_VGA_ARCH)
+        VFILE_RegisterBuiltinFileBlob(bfb_28_COM);
+    else if (IS_EGA_ARCH)
+        VFILE_RegisterBuiltinFileBlob(bfb_28_COM_ega);
+
+    /* don't register 50 unless VGA */
+    if (IS_VGA_ARCH) VFILE_RegisterBuiltinFileBlob(bfb_50_COM);
+
     /* MEM.COM is not compatible with PC-98 and/or 8086 emulation */
     if (!IS_PC98_ARCH && CPU_ArchitectureType >= CPU_ARCHTYPE_80186)
         VFILE_RegisterBuiltinFileBlob(bfb_MEM_COM);
@@ -1419,15 +1428,6 @@ void SHELL_Init() {
         VFILE_RegisterBuiltinFileBlob(bfb_DSXMENU_EXE_PC98);
     else
         VFILE_RegisterBuiltinFileBlob(bfb_DSXMENU_EXE_PC);
-
-    /* don't register 28.com unless EGA/VGA */
-    if (IS_VGA_ARCH)
-        VFILE_RegisterBuiltinFileBlob(bfb_28_COM);
-    else if (IS_EGA_ARCH)
-        VFILE_RegisterBuiltinFileBlob(bfb_28_COM_ega);
-
-    /* don't register 50 unless VGA */
-    if (IS_VGA_ARCH) VFILE_RegisterBuiltinFileBlob(bfb_50_COM);
 
 	DOS_PSP psp(psp_seg);
 	psp.MakeNew(0);

--- a/windows-installer/readme.txt
+++ b/windows-installer/readme.txt
@@ -9,9 +9,9 @@ As a general-purpose DOS emulator, DOSBox-X has many useful and unique features 
 
 Quick Start
 ===========
-Type INTRO in DOSBox-X for a quick tour. It is essential that you get familiar with the idea of mounting, since DOSBox-X does not automatically make any drive (or a part of it) accessible to the emulation, unless you change the option automountall=false to automountall=true in the dosbox-x.conf file.
+Type INTRO in DOSBox-X for a quick tour. It is essential that you get familiar with the idea of mounting, since DOSBox-X does not automatically make any drive (or a part of it) accessible to the emulation, unless you turn on automatic mounting of available Windows drives at start by changing the option automountall=false to automountall=true in the dosbox-x.conf file.
 
-At the beginning you've got a Z:\> instead of a C:\> at the prompt. Since no drives are mounted yet, you need to make your directories available as drives in DOSBox-X by using the "mount" command. For example, the command line "mount C D:\GAMES" will give you a C drive in DOSBox-X which points to your Windows D:\GAMES directory (that was created before). To change to the drive mounted like above, type "C:". If everything went fine, DOSBox-X will display the prompt "C:\>".
+At the beginning you've got a Z:\> instead of a C:\> at the DOSBox-X prompt. Since no drives are mounted yet, you need to make your directories available as drives in DOSBox-X by using the "mount" command. For example, the command line "mount C D:\GAMES" will give you a C drive in DOSBox-X which points to your Windows D:\GAMES directory (that was created before). To change to the drive mounted like above, type "C:". If everything went fine, DOSBox-X will display the prompt "C:\>".
 
 You don't have to always type these commands. There is an [autoexec] section in the dosbox-x.conf file. The commands present there are run when DOSBox-X starts, so you can use this section for the mounting and other purposes.
 


### PR DESCRIPTION
This is originally a command from DOSBox-staging to perform scripted keyboard entry into running DOS programs or games. According to the description, it can be used to reliably skip intros, provide input to answer initial startup or configuration questions, or conduct a simple demo. I ported it to DOSBox-X since it may be useful for DOSBox-X too.