### PR TITLE
Fix two compile warnings

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -4517,7 +4517,7 @@ int my_minizip(char ** savefile, char ** savefile2) {
             //printf("creating %s\n",savefile);
 
             {
-                FILE * fin;
+                FILE *fin = NULL;
                 int size_read;
                 char* filenameinzip = (char *)savefile2;
                 const char *savefilenameinzip;

--- a/vs2015/zlib/contrib/minizip/zip.c
+++ b/vs2015/zlib/contrib/minizip/zip.c
@@ -518,15 +518,15 @@ local ZPOS64_T zip64local_SearchCentralDir(const zlib_filefunc64_32_def* pzlib_f
     if (ZREAD64(*pzlib_filefunc_def,filestream,buf,uReadSize)!=uReadSize)
       break;
 
-    for (i=(int)uReadSize-3; (i--)>0;)
+    for (i=(int)uReadSize-3; (i--)>0;) {
       if (((*(buf+i))==0x50) && ((*(buf+i+1))==0x4b) &&
         ((*(buf+i+2))==0x05) && ((*(buf+i+3))==0x06))
       {
         uPosFound = uReadPos+i;
         break;
       }
-
-      if (uPosFound!=0)
+    }
+    if (uPosFound!=0)
         break;
   }
   TRYFREE(buf);


### PR DESCRIPTION
# Description
Fix a compile warning in zip.c and dosbox.cpp

They stood out because the where part of the last messages on the screen when building :-)
