### PR TITLE
Add support for autodetecting DOS <= 3.21 partition geometry

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.83.3
+  - IMGMOUNT can now autodetect DOS <= 3.21 harddisk
+    geometry with MFM sector images (rderooy)
   - IMGMOUNT -fs none fixed to use same geometry detect
     function that FAT filesystem mounting uses.
   - Added suppprt for mounting overlay drives using MOUNT

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -4422,16 +4422,33 @@ private:
             return false;
         }
         // check MBR partition entry 1
-        Bitu starthead = buf[0x1bf];
-        Bitu startsect = (buf[0x1c0] & 0x3fu) - 1u;
-        Bitu startcyl = (unsigned char)buf[0x1c1] | (unsigned int)((buf[0x1c0] & 0xc0) << 2u);
-        Bitu endcyl = (unsigned char)buf[0x1c5] | (unsigned int)((buf[0x1c4] & 0xc0) << 2u);
-
-        Bitu ptype = buf[0x1c2];
-        Bitu heads = buf[0x1c3] + 1u;
-        Bitu sectors = buf[0x1c4] & 0x3fu;
-
-        Bitu pe1_size = host_readd(&buf[0x1ca]);
+        // This is used for plain MFM sector format as created by IMGMAKE
+        Bit8u starthead = 0;
+        Bit8u startsect = 0;
+        Bit16u startcyl = 0;
+        Bit16u endcyl = 0;
+        Bit8u ptype = 0;
+        Bit8u heads = 0;
+        Bit8u sectors = 0;
+        Bit16u pe1_size = host_readd(&buf[0x1fa]);
+        if (pe1_size != 0) { // DOS 2.0-3.21 partition table
+            starthead = buf[0x1ef];
+            startsect = (buf[0x1f0] & 0x3fu) - 1u;
+            startcyl = (unsigned char)buf[0x1f1] | (unsigned int)((buf[0x1f0] & 0xc0) << 2u);
+            endcyl = (unsigned char)buf[0x1f5] | (unsigned int)((buf[0x1f4] & 0xc0) << 2u);
+            ptype = buf[0x1f2];
+            heads = buf[0x1f3] + 1u;
+            sectors = buf[0x1f4] & 0x3fu;
+        } else {             // DOS 3.3+ partition table
+            pe1_size = host_readd(&buf[0x1ca]);
+            starthead = buf[0x1bf];
+            startsect = (buf[0x1c0] & 0x3fu) - 1u;
+            startcyl = (unsigned char)buf[0x1c1] | (unsigned int)((buf[0x1c0] & 0xc0) << 2u);
+            endcyl = (unsigned char)buf[0x1c5] | (unsigned int)((buf[0x1c4] & 0xc0) << 2u);
+            ptype = buf[0x1c2];
+            heads = buf[0x1c3] + 1u;
+            sectors = buf[0x1c4] & 0x3fu;
+        }
         if (pe1_size != 0) {
             Bitu part_start = startsect + sectors * starthead +
                 startcyl * sectors*heads;


### PR DESCRIPTION
with MFM sector images as created by IMGMAKE.

Tested with;
- PC DOS 2.10 with 20MB FAT12 disk
- PC DOS 3.20 with 20MB FAT16 disk
- MS DOS 3.21 with 20MB FAT16 disk
- PC DOS 4.01 with 1GB FAT16 disk
- MS DOS 6.21 with 2GB FAT16 disk
- MS DOS 7.10 with 8GB FAT32 disk

**Does this PR address some issue(s) ?**
https://github.com/joncampbell123/dosbox-x/issues/1623
