### PR TITLE
Windows installer: default DOSBox-X build to install according to Windows version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
 0.83.3
+  - Cleaned up the DPI awareness auto detection code to
+    allow Visual Studio builds to again run on Windows 7.
+    Meanwhile, MinGW builds (either SDL1 or SDL2 version)
+    are still required for Windows XP systems. (Wengier)
   - IMGMOUNT -fs none fixed to use same geometry detect
     function that FAT filesystem mounting uses.
   - Added suppprt for mounting overlay drives using MOUNT

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,14 +1,15 @@
 0.83.3
+  - IMGMOUNT -fs none fixed to use same geometry detect
+    function that FAT filesystem mounting uses.
+  - Added suppprt for mounting overlay drives using MOUNT
+    command with "-t overlay" option. Ported from DOSBox
+    SVN and adopted for DOSBox-X, this feature allows the
+    user to redirect new and changed files to a different
+    location transparently. (Wengier)
   - Cleaned up the DPI awareness auto detection code to
     allow Visual Studio builds to again run on Windows 7.
     Meanwhile, MinGW builds (either SDL1 or SDL2 version)
     are still required for Windows XP systems. (Wengier)
-  - IMGMOUNT -fs none fixed to use same geometry detect
-    function that FAT filesystem mounting uses.
-  - Added suppprt for mounting overlay drives using MOUNT
-    command with "-t overlay" option. This feature allows
-    the user to redirect new and changed file(s) to a
-    different location transparently. (Wengier)
   - Updated Nuked OPL3 to latest version 1.8 for accurate
     OPL3 emulation (Wengier)
   - Added AUTOTYPE command to perform scripted keyboard

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -422,6 +422,10 @@ void DOS_Shell::CMD_DELETE(char * args) {
 		WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"),rem);
 		return;
 	}
+	if (!*args) {
+		WriteOut(MSG_Get("SHELL_MISSING_PARAMETER"));
+		return;
+	}
 
 	StripSpaces(args);
 	args=trim(args);
@@ -947,6 +951,10 @@ void DOS_Shell::CMD_MKDIR(char * args) {
 		WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"),rem);
 		return;
 	}
+	if (!*args) {
+		WriteOut(MSG_Get("SHELL_MISSING_PARAMETER"));
+		return;
+	}
 	if (!DOS_MakeDir(args)) {
 		WriteOut(MSG_Get("SHELL_CMD_MKDIR_ERROR"),args);
 	}
@@ -961,6 +969,10 @@ void DOS_Shell::CMD_RMDIR(char * args) {
 	char * rem=ScanCMDRemain(args);
 	if (rem) {
 		WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"),rem);
+		return;
+	}
+	if (!*args) {
+		WriteOut(MSG_Get("SHELL_MISSING_PARAMETER"));
 		return;
 	}
 	if (!DOS_RemoveDir(args)) {
@@ -1544,7 +1556,7 @@ void DOS_Shell::CMD_LS(char *args) {
 	if (!strrchr(pattern.c_str(), '.'))
 		pattern += ".*";
 
-	char spattern[CROSS_LEN]; 
+	char spattern[CROSS_LEN];
 	if (!DOS_GetSFNPath(pattern.c_str(),spattern,false)) {
 		WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));
 		return;
@@ -1554,7 +1566,10 @@ void DOS_Shell::CMD_LS(char *args) {
 	bool ret = DOS_FindFirst((char *)((uselfn?"\"":"")+std::string(spattern)+(uselfn?"\"":"")).c_str(), 0xffff & ~DOS_ATTR_VOLUME);
 	if (!ret) {
 		lfn_filefind_handle=fbak;
-		WriteOut(MSG_Get("SHELL_CMD_FILE_NOT_FOUND"), trim(args));
+		if (trim(args))
+			WriteOut(MSG_Get("SHELL_CMD_FILE_NOT_FOUND"), trim(args));
+		else
+			WriteOut(MSG_Get("SHELL_ILLEGAL_PATH"));
 		dos.dta(save_dta);
 		return;
 	}

--- a/windows-installer/DOSBox-X-setup.iss
+++ b/windows-installer/DOSBox-X-setup.iss
@@ -1,5 +1,5 @@
 #define MyAppName "DOSBox-X"
-#define MyAppVersion "0.83.2"
+#define MyAppVersion "0.83.3"
 #define MyAppPublisher "joncampbell123"
 #define MyAppURL "http://dosbox-x.com/"
 #define MyAppExeName "dosbox-x.exe"
@@ -48,7 +48,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
-Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked; OnlyBelowVersion: 0,6.1
+Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Types]
 Name: "full"; Description: "Full installation"
@@ -105,6 +105,15 @@ var
   msg: string;
   build64: Boolean;    
   Page: TInputOptionWizardPage;
+function IsWindowsVersionOrNewer(Major, Minor: Integer): Boolean;
+var
+  Version: TWindowsVersion;
+begin
+  GetWindowsVersionEx(Version);
+  Result :=
+    (Version.Major > Major) or
+    ((Version.Major = Major) and (Version.Minor >= Minor));
+end;
 procedure InitializeWizard();
 begin
     msg:='The selected build will be the default build when you run DOSBox-X from the Windows Start Menu or the desktop. ';
@@ -117,12 +126,21 @@ begin
     Page.Add('MinGW build for lowend systems');
     Page.Add('MinGW build SDL2');
     Page.Add('MinGW build with custom drawn menu');
-    Page.Values[0] := True;
     if IsX86 or IsX64 then
     begin
       Page.CheckListBox.ItemEnabled[2] := False;
       Page.CheckListBox.ItemEnabled[3] := False;
     end
+    if IsARM64 then
+      begin
+        Page.Values[2] := True;
+      end
+    else if IsWindowsVersionOrNewer(6, 0) then
+      begin
+        Page.Values[0] := True;
+      end
+    else
+      Page.Values[4] := True;
 end;
 function NextButtonClick(CurPageID: Integer): Boolean;
 begin


### PR DESCRIPTION
Since Visual Studio builds of DOSBox-X won't run on Windows XP, and ARM builds should be preferred for Windows ARM version, I updated the Windows installer to pre-select a default DOSBox-X build according to the Windows version. If a Windows version earlier than Windows Vista is detected, then the default build to install will be the MinGW build, and if ARM64 is detected, then the default build to install will be the ARM(64) build, and in all other cases the default build to install will be the Visual Studio build. Of course the user can always change the default build to install from the list of options during installation if they want.