### PR TITLE
Improvements to overlay drives

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,8 +5,9 @@
     function that FAT filesystem mounting uses.
   - Added suppprt for mounting overlay drives using MOUNT
     command with "-t overlay" option. Ported from DOSBox
-    SVN and adopted for DOSBox-X, this feature allows the
-    user to redirect new and changed files to a different
+    SVN and adopted for DOSBox-X with additional features
+    such as long filename support, this allows the users
+    to redirect new and changed file(s) to a different
     location transparently. (Wengier)
   - Cleaned up the DPI awareness auto detection code to
     allow Visual Studio builds to again run on Windows 7.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,9 +6,9 @@
   - Added suppprt for mounting overlay drives using MOUNT
     command with "-t overlay" option. Ported from DOSBox
     SVN and adopted for DOSBox-X with additional features
-    such as long filename support, this allows the users
-    to redirect new and changed file(s) to a different
-    location transparently. (Wengier)
+    such as long filename and PC-98 support, this allows
+    the users to redirect new and changed file(s) to a
+    different location transparently. (Wengier)
   - Cleaned up the DPI awareness auto detection code to
     allow Visual Studio builds to again run on Windows 7.
     Meanwhile, MinGW builds (either SDL1 or SDL2 version)

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -941,9 +941,9 @@ public:
                   //Erase old drive on succes
                   if (newdrive) {
                       if (o_error) { 
-                          if (o_error == 1) WriteOut("No mixing of relative and absolute paths. Overlay failed.");
-                          else if (o_error == 2) WriteOut("overlay directory can not be the same as underlying filesystem.");
-                          else WriteOut("An error occurred when trying to create an overlay drive.");
+                          if (o_error == 1) WriteOut("No mixing of relative and absolute paths. Overlay failed.\n");
+                          else if (o_error == 2) WriteOut("Overlay directory cannot be the same as underlying filesystem.\n");
+                          else WriteOut("An error occurred when trying to create an overlay drive.\n");
                           delete newdrive;
                           return;
                       } else
@@ -951,7 +951,7 @@ public:
                       delete Drives[drive-'A'];
                       Drives[drive-'A'] = 0;
                   } else { 
-                      WriteOut("overlay drive construction failed.");
+                      WriteOut("Overlay drive construction failed.\n");
                       return;
                   }
               } else {
@@ -2948,7 +2948,8 @@ void RESCAN::Run(void)
         if (drive < DOS_DRIVES && Drives[drive]) {
             Drives[drive]->EmptyCache();
             WriteOut(MSG_Get("PROGRAM_RESCAN_SUCCESS"));
-        }
+        } else
+            WriteOut("Invalid drive specification\n");
     }
 }
 

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -4109,8 +4109,14 @@ private:
                     newDrive = new fatDrive(paths[i].c_str(), (Bit32u)sizes[0], (Bit32u)sizes[1], (Bit32u)sizes[2], (Bit32u)sizes[3], options);
                 }
                 imgDisks.push_back(newDrive);
-                if (!(dynamic_cast<fatDrive*>(newDrive))->created_successfully) {
+				fatDrive* fdrive=dynamic_cast<fatDrive*>(newDrive);
+                if (!fdrive->created_successfully) {
                     errorMessage = (char*)MSG_Get("PROGRAM_IMGMOUNT_CANT_CREATE");
+					if (fdrive->req_ver>0) {
+						char ver_msg[60];
+						sprintf(ver_msg, "This operation requires DOS version %.1f or higher.\n", fdrive->req_ver);
+						errorMessage=(std::string(ver_msg)+std::string(errorMessage)).c_str();
+					}
                 }
             }
             if (errorMessage) {

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -946,8 +946,13 @@ public:
                           else WriteOut("An error occurred when trying to create an overlay drive.\n");
                           delete newdrive;
                           return;
-                      } else
-						dynamic_cast<Overlay_Drive*>(newdrive)->ovlreadonly = readonly;  
+                      } else {
+						  Overlay_Drive* odrive=dynamic_cast<Overlay_Drive*>(newdrive);
+						  if (odrive!=NULL) {
+							odrive->ovlnocachedir = nocachedir;
+							odrive->ovlreadonly = readonly;
+						  }
+					  }
                       delete Drives[drive-'A'];
                       Drives[drive-'A'] = 0;
                   } else { 

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -283,7 +283,7 @@ void DOS_Drive_Cache::AddEntryDirOverlay(const char* path, char *sfile, bool che
           }
       }
 
-      sname[0]=0;
+      if (filename_not_strict_8x3(sname)) sname[0]=0;
       char* genname=CreateEntry(dir,file,sname,true);
       Bits index = GetLongName(dir,(char *)(!strlen(sname)||filename_not_strict_8x3(sname)?file:sname));
 	  if (strlen(genname)) {
@@ -528,20 +528,14 @@ Bits DOS_Drive_Cache::GetLongName(CFileInfo* curDir, char* shortName) {
     Bits low    = 0;
     Bits high   = (Bits)(filelist_size-1);
     Bits res;
-    while (low<=high) {
-        Bits mid = (low+high)/2;
-		if (uselfn&&!strcasecmp(shortName,curDir->fileList[(size_t)mid]->orgname)) {
-            strcpy(shortName,curDir->fileList[(size_t)mid]->orgname);
-			return mid;
+	if (strlen(shortName))
+		for (Bitu i=0; i<filelist_size; i++) {
+			if (!strcasecmp(shortName,curDir->fileList[i]->orgname) || !strcasecmp(shortName,curDir->fileList[i]->shortname)) {
+				strcpy(shortName,curDir->fileList[i]->orgname);
+				return (Bits)i;
+			}
 		}
-        res = uselfn?strcmp(shortName,curDir->fileList[(size_t)mid]->shortname):strcasecmp(shortName,curDir->fileList[(size_t)mid]->shortname);
-        if (res>0)  low  = mid+1; else
-        if (res<0)  high = mid-1; else
-        {   // Found
-            strcpy(shortName,curDir->fileList[(size_t)mid]->orgname);
-            return mid;
-        }
-    }
+
 #ifdef WINE_DRIVE_SUPPORT
     if (strlen(shortName) < 8 || shortName[4] != '~' || shortName[5] == '.' || shortName[6] == '.' || shortName[7] == '.') return -1; // not available
     // else it's most likely a Wine style short name ABCD~###, # = not dot  (length at least 8) 

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1366,6 +1366,7 @@ void fatDrive::fatDriveInit(const char *sysFilename, Bit32u bytesector, Bit32u c
     int opt_partition_index = -1;
 	bool is_hdd = (filesize > 2880);
 	struct partTable mbrData;
+	req_ver = 0.0;
 
 	if(!loadedDisk) {
 		created_successfully = false;
@@ -1541,17 +1542,22 @@ void fatDrive::fatDriveInit(const char *sysFilename, Bit32u bytesector, Bit32u c
                             countSector = mbrData.pentry[m].partSize;
                             break;
                         }
-                        else if (dos.version.major >= 7 && mbrData.pentry[m].parttype == 0x0E/*FAT16B LBA*/) { /* MS-DOS 7.0 or higher */
-                            LOG_MSG("Using partition %d on drive (type 0x%02x); skipping %d sectors", m, mbrData.pentry[m].parttype, mbrData.pentry[m].absSectStart);
-                            startSector = mbrData.pentry[m].absSectStart;
-                            countSector = mbrData.pentry[m].partSize;
+                        else if (mbrData.pentry[m].parttype == 0x0E/*FAT16B LBA*/) {
+							if (dos.version.major >= 7) { /* MS-DOS 7.0 or higher */
+								LOG_MSG("Using partition %d on drive (type 0x%02x); skipping %d sectors", m, mbrData.pentry[m].parttype, mbrData.pentry[m].absSectStart);
+								startSector = mbrData.pentry[m].absSectStart;
+								countSector = mbrData.pentry[m].partSize;
+							} else
+								req_ver = 7.0;
                             break;
                         }
-                        else if ((dos.version.major > 7 || (dos.version.major == 7 && dos.version.minor >= 10)) && /* MS-DOS 7.10 or higher */
-                                (mbrData.pentry[m].parttype == 0x0B || mbrData.pentry[m].parttype == 0x0C)) { /* FAT32 types */
-                            LOG_MSG("Using partition %d on drive (type 0x%02x); skipping %d sectors", m, mbrData.pentry[m].parttype, mbrData.pentry[m].absSectStart);
-                            startSector = mbrData.pentry[m].absSectStart;
-                            countSector = mbrData.pentry[m].partSize;
+                        else if (mbrData.pentry[m].parttype == 0x0B || mbrData.pentry[m].parttype == 0x0C) { /* FAT32 types */
+							if (dos.version.major > 7 || (dos.version.major == 7 && dos.version.minor >= 10)) { /* MS-DOS 7.10 or higher */
+								LOG_MSG("Using partition %d on drive (type 0x%02x); skipping %d sectors", m, mbrData.pentry[m].parttype, mbrData.pentry[m].absSectStart);
+								startSector = mbrData.pentry[m].absSectStart;
+								countSector = mbrData.pentry[m].partSize;
+							} else
+								req_ver = 7.1;
                             break;
                         }
                     }

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -1731,14 +1731,10 @@ char* GetCrossedName(const char *basedir, const char *dir) {
 }
 
 /* 
- * design principles/limitations/requirements:
- * 1) All filenames inside the overlay directories are UPPERCASE and conform to the 8.3 standard except for the special DBOVERLAY files.
- * 2) Renaming directories is currently not supported.
+ * Wengier: Long filenames are supported in all including overlay drives.
+ * Shift-JIS characters (Kana, Kanji, etc) are also supported in PC-98 mode.
  *
- * Point 2 is still being worked on.
- */
-
-/* New rename for base directories:
+ * New rename for base directories (not yet supported):
  * Alter shortname in the drive_cache: take care of order and long names. 
  * update stored deleted files list in overlay. 
  */

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -3113,8 +3113,10 @@ bool Overlay_Drive::is_dir_only_in_overlay(const char* name) {
 	char fname[CROSS_LEN];
 	char* temp_name = dirCache.GetExpandName(GetCrossedName(basedir,name));
 	strcpy(fname, "");
-	if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir)))
+	if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir))) {
 		strcpy(fname,temp_name+strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0));
+		CROSS_DOSFILENAME(fname);
+	}
 	for(std::vector<std::string>::iterator it = DOSdirs_cache.begin(); it != DOSdirs_cache.end(); it+=2) {
 		if (!strcasecmp((*it).c_str(), name)||strlen(fname)&&!strcasecmp((*it).c_str(), fname)||(*(it+1)).length()&&!strcasecmp((*(it+1)).c_str(), name)) return true;
 	}
@@ -3139,8 +3141,10 @@ bool Overlay_Drive::is_deleted_file(const char* name) {
 	else
 		strcat(tname,temp_name);
 	strcpy(fname, "");
-	if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir)))
+	if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir))) {
 		strcpy(fname,temp_name+strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0));
+		CROSS_DOSFILENAME(fname);
+	}
 	for(std::vector<std::string>::iterator it = deleted_files_in_base.begin(); it != deleted_files_in_base.end(); it++) {
 		if (!strcasecmp((*it).c_str(), name)||!strcasecmp((*it).c_str(), tname)||(strlen(fname)&&!strcasecmp((*it).c_str(), fname))) return true;
 	}
@@ -3159,8 +3163,10 @@ void Overlay_Drive::remove_DOSdir_from_cache(const char* name) {
 	char fname[CROSS_LEN];
 	char* temp_name = dirCache.GetExpandName(GetCrossedName(basedir,name));
 	strcpy(fname, "");
-	if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir)))
+	if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir))) {
 		strcpy(fname,temp_name+strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0));
+		CROSS_DOSFILENAME(fname);
+	}
 	for(std::vector<std::string>::iterator it = DOSdirs_cache.begin(); it != DOSdirs_cache.end(); it+=2) {
 		if (!strcasecmp((*it).c_str(), name)||(strlen(fname)&&!strcasecmp((*it).c_str(), fname))||((*(it+1)).length()&&!strcasecmp((*(it+1)).c_str(), name))) {
 			DOSdirs_cache.erase(it+1);
@@ -3186,8 +3192,10 @@ void Overlay_Drive::remove_deleted_file(const char* name,bool create_on_disk) {
 	else
 		strcat(tname,temp_name);
 	strcpy(fname, "");
-	if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir)))
+	if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir))) {
 		strcpy(fname,temp_name+strlen(basedir)+(*(temp_name+strlen(basedir))=='\\'?1:0));
+		CROSS_DOSFILENAME(fname);
+	}
 	for(std::vector<std::string>::iterator it = deleted_files_in_base.begin(); it != deleted_files_in_base.end(); ++it) {
 		if (!strcasecmp((*it).c_str(), name)||!strcasecmp((*it).c_str(), tname)||(strlen(fname)&&!strcasecmp((*it).c_str(), fname))) {
 			deleted_files_in_base.erase(it);

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -1762,6 +1762,11 @@ char* GetCrossedName(const char *basedir, const char *dir) {
 //Or create an empty directory in local drive base. 
 
 bool Overlay_Drive::RemoveDir(const char * dir) {
+	if (ovlnocachedir) {
+		dirCache.EmptyCache();
+		update_cache(true);
+	}
+	
     if (ovlreadonly) {
         DOS_SetError(DOSERR_WRITE_PROTECTED);
         return false;
@@ -1848,6 +1853,11 @@ bool Overlay_Drive::RemoveDir(const char * dir) {
 }
 
 bool Overlay_Drive::MakeDir(const char * dir) {
+	if (ovlnocachedir) {
+		dirCache.EmptyCache();
+		update_cache(true);
+	}
+
     if (ovlreadonly) {
         DOS_SetError(DOSERR_WRITE_PROTECTED);
         return false;
@@ -1925,6 +1935,11 @@ bool Overlay_Drive::MakeDir(const char * dir) {
 }
 
 bool Overlay_Drive::TestDir(const char * dir) {
+	if (ovlnocachedir) {
+		dirCache.EmptyCache();
+		update_cache(true);
+	}
+
 	//First check if directory exist exclusively in the overlay. 
 	//Currently using the update_cache cache, alternatively access the directory itself.
 
@@ -2159,6 +2174,11 @@ void Overlay_Drive::convert_overlay_to_DOSname_in_base(char* dirname )
 }
 
 bool Overlay_Drive::FileOpen(DOS_File * * file,const char * name,Bit32u flags) {
+	if (ovlnocachedir) {
+		dirCache.EmptyCache();
+		update_cache(true);
+	}
+
     if (ovlreadonly) {
         if ((flags&0xf) == OPEN_WRITE || (flags&0xf) == OPEN_READWRITE) {
             DOS_SetError(DOSERR_WRITE_PROTECTED);
@@ -2252,6 +2272,11 @@ bool Overlay_Drive::FileOpen(DOS_File * * file,const char * name,Bit32u flags) {
 }
 
 bool Overlay_Drive::FileCreate(DOS_File * * file,const char * name,Bit16u /*attributes*/) {
+	if (ovlnocachedir) {
+		dirCache.EmptyCache();
+		update_cache(true);
+	}
+	
     if (ovlreadonly) {
 		DOS_SetError(DOSERR_WRITE_PROTECTED);
         return false;
@@ -2915,6 +2940,11 @@ bool Overlay_Drive::SetFileAttr(const char * name,Bit16u attr) {
 }
 
 bool Overlay_Drive::GetFileAttr(const char * name,Bit16u * attr) {
+	if (ovlnocachedir) {
+		dirCache.EmptyCache();
+		update_cache(true);
+	}
+
 	char overlayname[CROSS_LEN], tmp[CROSS_LEN], overtmpname[CROSS_LEN];
 	strcpy(overlayname,overlaydir);
 	strcat(overlayname,name);
@@ -3172,6 +3202,11 @@ bool Overlay_Drive::check_if_leading_is_deleted(const char* name){
 }
 
 bool Overlay_Drive::FileExists(const char* name) {
+	if (ovlnocachedir) {
+		dirCache.EmptyCache();
+		update_cache(true);
+	}
+
 	char overlayname[CROSS_LEN];
 	strcpy(overlayname,overlaydir);
 	strcat(overlayname,name);
@@ -3343,6 +3378,11 @@ bool Overlay_Drive::FindFirst(const char * _dir,DOS_DTA & dta,bool fcb_findfirst
 		DOS_SetError(DOSERR_PATH_NOT_FOUND);
 		return false;
 	}
+	
+	if (ovlnocachedir) {
+		dirCache.EmptyCache();
+		update_cache(true);
+	}
 
 	if (*_dir) {
 		char newname[CROSS_LEN], tmp[CROSS_LEN];
@@ -3374,6 +3414,11 @@ bool Overlay_Drive::FindFirst(const char * _dir,DOS_DTA & dta,bool fcb_findfirst
 }
 
 bool Overlay_Drive::FileStat(const char* name, FileStat_Block * const stat_block) {
+	if (ovlnocachedir) {
+		dirCache.EmptyCache();
+		update_cache(true);
+	}
+
 	char overlayname[CROSS_LEN], tmp[CROSS_LEN], overtmpname[CROSS_LEN];
 	strcpy(overlayname,overlaydir);
 	strcat(overlayname,name);

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -2709,15 +2709,6 @@ again:
 	strcpy(ovname,overlaydir);
 	char* prel = lfull_name + strlen(basedir);
 
-#if 0
-	//Check hidden/deleted directories first. TODO is this really needed. If the directory exist in the overlay things are weird anyway.
-	//the deleted paths are added to the deleted_files list.
-	if (is_deleted_dir(prel)) {
-		LOG_MSG("skipping early out deleted dir %s",prel);
-		goto again;
-	}
-#endif
-
 	char preldos[CROSS_LEN];
 	strcpy(preldos,prel);
 	CROSS_DOSFILENAME(preldos);
@@ -3350,8 +3341,8 @@ bool Overlay_Drive::Rename(const char * oldname,const char * newname) {
 
 	//TODO with cache function!
 	//Tricky function.
-	//Renaming directories is currently not supported, due the drive_cache not handling that smoothly.
-	//So oldname is directory => Exit!
+	//Renaming directories is currently not fully supported, due the drive_cache not handling that smoothly.
+	//So oldname is directory => exit unless it is only in overlay.
 	//If oldname is on overlay => simple rename.
 	//if oldname is on base => copy file to overlay with new name and mark old file as deleted. 
 	//More advanced version. keep track of the file being renamed in order to detect that the file is being renamed back. 

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -409,6 +409,7 @@ public:
 	const FAT_BootSector::bpb_union_t &GetBPB(void);
 	void SetBPB(const FAT_BootSector::bpb_union_t &bpb);
 	imageDisk *loadedDisk = NULL;
+	float req_ver = 0.0;
 	bool created_successfully = true;
 private:
 	char* Generate_SFN(const char *path, const char *name);

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -746,6 +746,7 @@ public:
 	virtual bool TestDir(const char * dir);
 	virtual bool RemoveDir(const char * dir);
 	virtual bool MakeDir(const char * dir);
+	bool ovlnocachedir = false;
 	bool ovlreadonly = false;
 private:
 	char overlaydir[CROSS_LEN];

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -2283,11 +2283,19 @@ static char PAUSED(void) {
 void DOS_Shell::CMD_MORE(char * args) {
 	HELP("MORE");
 	//ScanCMDBool(args,">");
-	int nchars = 0, nlines = 0, linecount = 0, LINES = (Bit16u)mem_readb(BIOS_ROWS_ON_SCREEN_MINUS_1), COLS = mem_readw(BIOS_SCREEN_COLUMNS), TABSIZE = 8;
+	int nchars = 0, nlines = 0, linecount = 0, LINES = 25, COLS = 80, TABSIZE = 8;
 	char * word;
 	Bit8u c, last=0;
 	Bit16u n=1;
 	StripSpaces(args);
+	if (IS_PC98_ARCH) {
+		LINES=real_readb(0x60,0x113) & 0x01 ? 25 : 20;
+		COLS=80;
+	} else {
+		LINES=real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
+		COLS=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
+	}
+	LINES--;
 	if(!*args||!strcasecmp(args, "con")) {
 		while (true) {
 			DOS_ReadFile (STDIN,&c,&n);

--- a/vs2015/sdl2/src/stdlib/SDL_stdlib.c
+++ b/vs2015/sdl2/src/stdlib/SDL_stdlib.c
@@ -549,11 +549,13 @@ localexit:
     /* *INDENT-ON* */
 }
 
+#ifndef _MSC_VER
 void
 _ftol2_sse()
 {
     _ftol();
 }
+#endif
 
 /* 64-bit math operators for 32-bit systems */
 void


### PR DESCRIPTION
I have made further improvements to the recently supported overlay drives. For example, long filename support should now work more reliably on such drives than before, also fixed some other issues I found.