### PR TITLE
Various cleanups to dos_programs.cpp

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -5689,7 +5689,9 @@ void DOS_SetupPrograms(void) {
     MSG_Add("PROGRAM_IMGMAKE_SYNTAX",
         "Creates floppy or harddisk images.\n"
         "Syntax: IMGMAKE file [-t type] [[-size size] | [-chs geometry]] [-nofs]\n"
+#ifdef WIN32
         "  [-source source] [-r retries] [-bat]\n"
+#endif
         "  file: The image file that is to be created - !path on the host!\n"
         "  -t: Type of image.\n"
         "    Floppy templates (names resolve to floppy sizes in kilobytes):\n"

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -4426,10 +4426,13 @@ private:
             yet_detected = DetectMFMsectorPartition(buf, fcsize, sizes);
 
         // Try bximage disk geometry
+        // bximage flat images should already be detected by
+        // DetectMFMSectorPartition(), not sure what this adds...
         if (!yet_detected) {
             yet_detected = DetectBximagePartition(fcsize, sizes);
         }
-        Bit8u ptype = buf[0x1c2]; // DOS 3.3+ partition type
+        
+        Bit8u ptype = buf[0x1c2]; // Location of DOS 3.3+ partition type
 	bool assume_lba = false;
 
 	/* If the first partition is a Windows 95 FAT32 (LBA) type partition, and we failed to detect,

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -4422,59 +4422,13 @@ private:
             return false;
         }
         // check MBR partition entry 1
-        // This is used for plain MFM sector format as created by IMGMAKE
-        Bit8u starthead = 0;
-        Bit8u startsect = 0;
-        Bit16u startcyl = 0;
-        Bit16u endcyl = 0;
-        Bit8u ptype = 0;
-        Bit8u heads = 0;
-        Bit8u sectors = 0;
-        Bit16u pe1_size = host_readd(&buf[0x1fa]);
-        if (pe1_size != 0) { // DOS 2.0-3.21 partition table
-            starthead = buf[0x1ef];
-            startsect = (buf[0x1f0] & 0x3fu) - 1u;
-            startcyl = (unsigned char)buf[0x1f1] | (unsigned int)((buf[0x1f0] & 0xc0) << 2u);
-            endcyl = (unsigned char)buf[0x1f5] | (unsigned int)((buf[0x1f4] & 0xc0) << 2u);
-            ptype = buf[0x1f2];
-            heads = buf[0x1f3] + 1u;
-            sectors = buf[0x1f4] & 0x3fu;
-        } else {             // DOS 3.3+ partition table
-            pe1_size = host_readd(&buf[0x1ca]);
-            starthead = buf[0x1bf];
-            startsect = (buf[0x1c0] & 0x3fu) - 1u;
-            startcyl = (unsigned char)buf[0x1c1] | (unsigned int)((buf[0x1c0] & 0xc0) << 2u);
-            endcyl = (unsigned char)buf[0x1c5] | (unsigned int)((buf[0x1c4] & 0xc0) << 2u);
-            ptype = buf[0x1c2];
-            heads = buf[0x1c3] + 1u;
-            sectors = buf[0x1c4] & 0x3fu;
-        }
-        if (pe1_size != 0) {
-            Bitu part_start = startsect + sectors * starthead +
-                startcyl * sectors*heads;
-            Bitu part_end = heads * sectors*endcyl;
-            Bits part_len = (Bits)(part_end - part_start);
-            // partition start/end sanity check
-            // partition length should not exceed file length
-            // real partition size can be a few cylinders less than pe1_size
-            // if more than 1023 cylinders see if first partition fits
-            // into 1023, else bail.
-            if ((part_len<0) || ((Bitu)part_len > pe1_size) || (pe1_size > fcsize) ||
-                ((pe1_size - (Bitu)part_len) / (sectors*heads)>2u) ||
-                ((pe1_size / (heads*sectors))>1023u)) {
-                //LOG_MSG("start(c,h,s) %u,%u,%u",startcyl,starthead,startsect);
-                //LOG_MSG("endcyl %u heads %u sectors %u",endcyl,heads,sectors);
-                //LOG_MSG("psize %u start %u end %u",pe1_size,part_start,part_end);
-            }
-            else if (!yet_detected) {
-                sizes[0] = 512; sizes[1] = sectors;
-                sizes[2] = heads; sizes[3] = (Bit16u)(fcsize / (heads*sectors));
-                if (sizes[3]>1023) sizes[3] = 1023;
-                yet_detected = true;
-            }
-        }
+        if (!yet_detected)
+            yet_detected = DetectMFMsectorPartition(buf, fcsize, sizes);
+
+        Bit8u ptype = buf[0x1c2]; // DOS 3.3+ partition type
         if (!yet_detected) {
             // Try bximage disk geometry
+            //Bit8u ptype = buf[0x1c2]; // DOS 3.3+ partition type
             Bitu cylinders = (Bitu)(fcsize / (16 * 63));
             // Int13 only supports up to 1023 cylinders
             // For mounting unknown images we could go up with the heads to 255
@@ -4545,6 +4499,62 @@ private:
             WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_GEOMETRY"));
             return false;
         }
+    }
+
+    bool DetectMFMsectorPartition(Bit8u buf[], Bit32u fcsize, Bitu sizes[]) {
+        // This is used for plain MFM sector format as created by IMGMAKE
+        Bit8u starthead = 0;
+        Bit8u startsect = 0;
+        Bit16u startcyl = 0;
+        Bit16u endcyl = 0;
+        Bit8u ptype = 0;    // Partition Type
+        Bit8u heads = 0;
+        Bit8u sectors = 0;
+        Bit16u pe1_size = host_readd(&buf[0x1fa]);
+        if (pe1_size != 0) {                     // DOS 2.0-3.21 partition table
+            starthead = buf[0x1ef];
+            startsect = (buf[0x1f0] & 0x3fu) - 1u;
+            startcyl = (unsigned char)buf[0x1f1] | (unsigned int)((buf[0x1f0] & 0xc0) << 2u);
+            endcyl = (unsigned char)buf[0x1f5] | (unsigned int)((buf[0x1f4] & 0xc0) << 2u);
+            ptype = buf[0x1f2];
+            heads = buf[0x1f3] + 1u;
+            sectors = buf[0x1f4] & 0x3fu;
+        } else {                                // DOS 3.3+ partition table
+            pe1_size = host_readd(&buf[0x1ca]);
+            if (pe1_size != 0) {
+                starthead = buf[0x1bf];
+                startsect = (buf[0x1c0] & 0x3fu) - 1u;
+                startcyl = (unsigned char)buf[0x1c1] | (unsigned int)((buf[0x1c0] & 0xc0) << 2u);
+                endcyl = (unsigned char)buf[0x1c5] | (unsigned int)((buf[0x1c4] & 0xc0) << 2u);
+                ptype = buf[0x1c2];
+                heads = buf[0x1c3] + 1u;
+                sectors = buf[0x1c4] & 0x3fu;
+            }
+        }
+        if (pe1_size != 0) {
+            Bit32u part_start = startsect + sectors * starthead +
+                startcyl * sectors * heads;
+            Bit32u part_end = heads * sectors * endcyl;
+            Bit32u part_len = part_end - part_start;
+            // partition start/end sanity check
+            // partition length should not exceed file length
+            // real partition size can be a few cylinders less than pe1_size
+            // if more than 1023 cylinders see if first partition fits
+            // into 1023, else bail.
+            if ((part_len<0) || (part_len > pe1_size) || (pe1_size > fcsize) ||
+                ((pe1_size - part_len) / (sectors*heads)>2u) ||
+                ((pe1_size / (heads*sectors))>1023u)) {
+                //LOG_MSG("start(c,h,s) %u,%u,%u",startcyl,starthead,startsect);
+                //LOG_MSG("endcyl %u heads %u sectors %u",endcyl,heads,sectors);
+                //LOG_MSG("psize %u start %u end %u",pe1_size,part_start,part_end);
+            } else {
+                sizes[0] = 512; sizes[1] = sectors;
+                sizes[2] = heads; sizes[3] = (Bit16u)(fcsize / (heads*sectors));
+                if (sizes[3]>1023) sizes[3] = 1023;
+                return true;
+            }
+        }
+        return false;
     }
 
     bool MountIso(const char drive, const std::vector<std::string> &paths, const signed char ide_index, const bool ide_slave) {

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -2117,7 +2117,7 @@ void IDEATADevice::update_from_biosdisk() {
         cyls = (tmp + ((63 * 16) - 1)) / (63 * 16);
         LOG_MSG("WARNING: Unable to reduce heads to 16 and below\n");
         LOG_MSG("If at all possible, please consider using INT 13h geometry with a head\n");
-        LOG_MSG("cound that is easier to map to the BIOS, like 240 heads or 128 heads/track.\n");
+        LOG_MSG("count that is easier to map to the BIOS, like 240 heads or 128 heads/track.\n");
         LOG_MSG("Some OSes, such as Windows 95, will not enable their 32-bit IDE driver if\n");
         LOG_MSG("a clean mapping does not exist between IDE and BIOS geometry.\n");
         LOG_MSG("Mapping BIOS DISK C/H/S %u/%u/%u as IDE %u/%u/%u (non-straightforward mapping)\n",


### PR DESCRIPTION
# Description
This moves the Plain MFM image detection into a separate method to clean the code a bit.

I'm not sure what the purpose is of the bximage code. I also moved that into a separate method, but it is compile tested only. I did try a bximage flat file, but it seems to be identical to a plain MFM image, and indeed the plain MFM code handled the detection. And I don't see any code to handle the other bximage formats (sparse, growing or vpc), so I don't think it is for that either.

I'm wondering if this code should be removed...

The code underneath that was strangely indented, causing me to first assume it was part of an IF block, which it turned out was false.
