### PR TITLE
Convert mouse wheel movements to (arrow) keys + mapper file reloadable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 0.83.3
+  - Added the "Boot from disk image" menu item (A:, C:
+    and D: drives only) in the "Drive" menu for the
+    Windows platform. (Wengier)
   - Support for converting mouse wheel movements into
     keyboard presses like arrow keys, configurable by
     the option "mouse_wheel_key" (default is 0 which

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,11 @@
 0.83.3
   - Support for converting mouse wheel movements into
-    keyboard presses in Windows, configurable by the
-    option "mouse_wheel_key" (default is 0 which disables
-    this feature). When set to 1, mouse wheel movements
-    will be converted to up/down arrows. Setting to 2 or
-    3 will convert such movements to left/right arrows
-    or PageUp/PageDown keys respectively. (Wengier)
+    keyboard presses like arrow keys, configurable by
+    the option "mouse_wheel_key" (default is 0 which
+    disables this feature). When set to 1, mouse wheel
+    movements are converted to up/down arrows. Setting
+    it to 2 or 3 converts such movements to left/right
+    arrows or PageUp/PageDn keys respectively. (Wengier)
   - Support for reloading the keyboard mapper file with
     the config -set command. (Wengier)
   - IMGMOUNT can now autodetect DOS <= 3.21 harddisk

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,13 @@
 0.83.3
+  - Support for converting mouse wheel movements into
+    keyboard presses in Windows, configurable by the
+    option "mouse_wheel_key" (default is 0 which disables
+    this feature). When set to 1, mouse wheel movements
+    will be converted to up/down arrows. Setting to 2 or
+    3 will convert such movements to left/right arrows
+    or PageUp/PageDown keys respectively. (Wengier)
+  - Support for reloading the keyboard mapper file with
+    the config -set command. (Wengier)
   - IMGMOUNT can now autodetect DOS <= 3.21 harddisk
     geometry with MFM sector images (rderooy)
   - IMGMOUNT -fs none fixed to use same geometry detect

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 0.83.3
-  - Added the "Boot from disk image" menu item (A:, C:
-    and D: drives only) in the "Drive" menu for the
-    Windows platform. (Wengier)
+  - Added the "Boot from disk image" menu item (A:, C:,
+    and D: drives only) in the "Drive" menu to boot the
+    specified disk image directly in Windows (Wengier)
   - Support for converting mouse wheel movements into
     keyboard presses like arrow keys, configurable by
     the option "mouse_wheel_key" (default is 0 which

--- a/PLANS/General TODO.txt
+++ b/PLANS/General TODO.txt
@@ -53,8 +53,8 @@
 
 * Support for loading BIOS images and mapping them into adapter ROM
 
-  - We could test various VGA BIOSes in DOSBox that way
-  - We could also run old motherboard BIOSes in DOSBox that way
+  - We could test various VGA BIOSes in DOSBox-X that way
+  - We could also run old motherboard BIOSes in DOSBox-X that way
 
 * Convert I/O and memory handler callback system to on-demand bus mapping and
   tracing design
@@ -89,7 +89,7 @@
     changes, the emulator has to invalidate all I/O and memory callbacks
     to allow the "slow" path to do it's work again.
   - The reason we don't do bus lookup every time is one of performance.
-    DOSBox already has an array of IO handlers and memory page handlers,
+    DOSBox-X already has an array of IO handlers and memory page handlers,
     so why not make use of it as a cache for callbacks once the slow path
     has been taken? Doing it this way should have almost no impact on
     emulator performance.
@@ -137,12 +137,14 @@
 
 * Multiple DOS kernel emulation
 
-  - Instead of only emulating a general mishmash of MS-DOS 5.0 to 7.1 syscalls,
+  - Instead of only emulating a general mishmash of MS-DOS 5.0 to 6.x syscalls,
     allow dosbox-x.conf setting (and command line at runtime) to choose that
     a particular brand and version is emulated. For example, if you say that
     you want DOSBox-X to emulate MS-DOS 3.3, then it will return values and act
     like MS-DOS 3.3 (including the shorter form of the disk parameter table
-    prior to MS-DOS 4.0.
+    prior to MS-DOS 4.0). On the ther hand, if you say that you want DOSBox-X
+    to emulate MS-DOS 7.1, then it will return values and act like MS-DOS 7.1
+    (including support for FAT32 drives and long filenames).
 
 * Misc
 

--- a/PLANS/General TODO.txt
+++ b/PLANS/General TODO.txt
@@ -137,10 +137,10 @@
 
 * Multiple DOS kernel emulation
 
-  - Instead of only emulating a general mishmash of MS-DOS 5.0 to 6.22 syscalls,
-    allow dosbox.conf setting (and command line at runtime) to choose that
+  - Instead of only emulating a general mishmash of MS-DOS 5.0 to 7.1 syscalls,
+    allow dosbox-x.conf setting (and command line at runtime) to choose that
     a particular brand and version is emulated. For example, if you say that
-    you want DOSBox to emulate MS-DOS 3.3, then it will return values and act
+    you want DOSBox-X to emulate MS-DOS 3.3, then it will return values and act
     like MS-DOS 3.3 (including the shorter form of the disk parameter table
     prior to MS-DOS 4.0.
 

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -32,6 +32,8 @@
 #                      When using a high DPI mouse, the emulation of mouse movement can noticeably reduce the
 #                      sensitiveness of your device, i.e. the mouse is slower but more precise.
 #                      Possible values: integration, locked, always, never.
+#   mouse_wheel_key: Convert mouse wheel movements into keyboard presses in Windows.
+#                      0: disabled; 1: up/down arrows; 2: left/right arrows; 3: PgUp/PgDn keys.
 #       waitonerror: Wait before closing the console if DOSBox-X has an error.
 #          priority: Priority levels for DOSBox-X. Second entry behind the comma is for when DOSBox-X is not focused/minimized.
 #                        pause is only valid for the second entry.
@@ -53,6 +55,7 @@ clip_key_modifier = disabled
 clip_paste_speed  = 20
 sensitivity       = 100
 mouse_emulation   = locked
+mouse_wheel_key   = 0
 waitonerror       = true
 priority          = higher,normal
 mapperfile        = mapper-0.83.3.map

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -32,7 +32,7 @@
 #                      When using a high DPI mouse, the emulation of mouse movement can noticeably reduce the
 #                      sensitiveness of your device, i.e. the mouse is slower but more precise.
 #                      Possible values: integration, locked, always, never.
-#   mouse_wheel_key: Convert mouse wheel movements into keyboard presses in Windows.
+#   mouse_wheel_key: Convert mouse wheel movements into keyboard presses such as arrow keys.
 #                      0: disabled; 1: up/down arrows; 2: left/right arrows; 3: PgUp/PgDn keys.
 #       waitonerror: Wait before closing the console if DOSBox-X has an error.
 #          priority: Priority levels for DOSBox-X. Second entry behind the comma is for when DOSBox-X is not focused/minimized.

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -3152,6 +3152,10 @@ void DOS_EnableDriveMenu(char drv) {
 		if (drv == 'A' || drv == 'C' || drv == 'D') {
 			name = std::string("drive_") + drv + "_boot";
 			mainMenu.get_item(name).enable(!dos_kernel_disabled).refresh_item(mainMenu);
+#if defined (WIN32)
+			name = std::string("drive_") + drv + "_bootimg";
+			mainMenu.get_item(name).enable(!dos_kernel_disabled).refresh_item(mainMenu);
+#endif
 		}
     }
 }

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -4113,9 +4113,9 @@ private:
                 if (!fdrive->created_successfully) {
                     errorMessage = (char*)MSG_Get("PROGRAM_IMGMOUNT_CANT_CREATE");
 					if (fdrive->req_ver>0) {
-						char ver_msg[60];
-						sprintf(ver_msg, "This operation requires DOS version %.1f or higher.\n", fdrive->req_ver);
-						errorMessage=(std::string(ver_msg)+std::string(errorMessage)).c_str();
+						static char ver_msg[150];
+						sprintf(ver_msg, "This operation requires DOS version %.1f or higher.\n%s", fdrive->req_ver, errorMessage);
+						errorMessage = ver_msg;
 					}
                 }
             }

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -4516,9 +4516,10 @@ private:
         Bit8u ptype = 0;    // Partition Type
         Bit8u heads = 0;
         Bit8u sectors = 0;
-        Bit16u pe1_size = host_readd(&buf[0x1fa]);
+        Bitu pe1_size = host_readd(&buf[0x1ca]);
         (void)ptype;//unused
-        if (pe1_size != 0) {                     // DOS 2.0-3.21 partition table
+        if ((Bit16u)host_readd(&buf[0x1fa]) != 0) {		// DOS 2.0-3.21 partition table
+			pe1_size = host_readd(&buf[0x1fa]);
             starthead = buf[0x1ef];
             startsect = (buf[0x1f0] & 0x3fu) - 1u;
             startcyl = (unsigned char)buf[0x1f1] | (unsigned int)((buf[0x1f0] & 0xc0) << 2u);
@@ -4526,17 +4527,14 @@ private:
             ptype = buf[0x1f2];
             heads = buf[0x1f3] + 1u;
             sectors = buf[0x1f4] & 0x3fu;
-        } else {                                // DOS 3.3+ partition table
-            pe1_size = host_readd(&buf[0x1ca]);
-            if (pe1_size != 0) {
-                starthead = buf[0x1bf];
-                startsect = (buf[0x1c0] & 0x3fu) - 1u;
-                startcyl = (unsigned char)buf[0x1c1] | (unsigned int)((buf[0x1c0] & 0xc0) << 2u);
-                endcyl = (unsigned char)buf[0x1c5] | (unsigned int)((buf[0x1c4] & 0xc0) << 2u);
-                ptype = buf[0x1c2];
-                heads = buf[0x1c3] + 1u;
-                sectors = buf[0x1c4] & 0x3fu;
-            }
+        } else if (pe1_size != 0) {						// DOS 3.3+ partition table
+			starthead = buf[0x1bf];
+			startsect = (buf[0x1c0] & 0x3fu) - 1u;
+			startcyl = (unsigned char)buf[0x1c1] | (unsigned int)((buf[0x1c0] & 0xc0) << 2u);
+			endcyl = (unsigned char)buf[0x1c5] | (unsigned int)((buf[0x1c4] & 0xc0) << 2u);
+			ptype = buf[0x1c2];
+			heads = buf[0x1c3] + 1u;
+			sectors = buf[0x1c4] & 0x3fu;
         }
         if (pe1_size != 0) {
             Bit32u part_start = startsect + sectors * starthead +

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -417,10 +417,10 @@ void MenuBrowseFolder(char drive, std::string drive_type) {
 #endif
 }
 
-void MenuBrowseImageFile(char drive) {
+void MenuBrowseImageFile(char drive, bool boot) {
 	std::string str(1, drive);
 	std::string drive_warn;
-	if (Drives[drive-'A']) {
+	if (Drives[drive-'A']&&!boot) {
 		drive_warn="Drive "+str+": is already mounted. Unmount it first, and then try again.";
 		MessageBox(GetHWND(),drive_warn.c_str(),"Error",MB_OK);
 		return;
@@ -486,13 +486,23 @@ search:
 		temp_str[1]=' ';
 		strcat(mountstring,temp_str);
 		strcat(mountstring,path);
+		if (boot) strcat(mountstring," -U");
 		strcat(mountstring," >nul");
 		DOS_Shell temp;
 		temp.ParseLine(mountstring);
 		if (!Drives[drive-'A']) {
-			drive_warn="Drive "+str+": failed to mounted.";
+			drive_warn="Drive "+str+": failed to mount.";
 			MessageBox(GetHWND(),drive_warn.c_str(),"Error",MB_OK);
 			return;
+		} else if (boot) {
+			char bootstring[DOS_PATHLENGTH+CROSS_LEN+20];
+			strcpy(bootstring,"BOOT -L ");
+			strcat(bootstring,str.c_str());
+			strcat(bootstring," >nul");
+			DOS_Shell temp;
+			temp.ParseLine(bootstring);
+			std::string drive_warn="Drive "+str+": failed to boot.";
+			MessageBox(GetHWND(),drive_warn.c_str(),"Error",MB_OK);
 		}
 	}
 	SetCurrentDirectory( Temp_CurrentDir );
@@ -5128,9 +5138,7 @@ void LABEL_ProgramStart(Program** make)
 }
 
 std::vector<std::string> MAPPER_GetEventNames(const std::string &prefix);
-void MAPPER_AutoType(std::vector<std::string> &sequence,
-                     const uint32_t wait_ms,
-                     const uint32_t pacing_ms);
+void MAPPER_AutoType(std::vector<std::string> &sequence, const uint32_t wait_ms, const uint32_t pacing_ms);
 
 class AUTOTYPE : public Program {
 public:

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -1844,7 +1844,7 @@ bool Overlay_Drive::RemoveDir(const char * dir) {
 
 		if (!empty) return false;
 		if (logoverlay) LOG_MSG("directory empty! Hide it.");
-		//Directory is empty, mark it as deleted and create DBOVERLAY file.
+		//Directory is empty, mark it as deleted and create $DBOVERLAY file.
 		//Ensure that overlap folder can not be created.
 		char odir[CROSS_LEN];
 		strcpy(odir,overlaydir);
@@ -2032,11 +2032,18 @@ FILE* Overlay_Drive::create_file_in_overlay(const char* dos_filename, char const
 	strcat(newname,dos_filename); //HERE we need to convert it to Linux TODO
 	CROSS_FILENAME(newname);
 
+#ifdef host_cnv_use_wchar
+    wchar_t wmode[8];
+    unsigned int tis;
+    for (tis=0;tis < 7 && mode[tis] != 0;tis++) wmode[tis] = (wchar_t)mode[tis];
+    assert(tis < 7); // guard
+    wmode[tis] = 0;
+#endif
 	FILE* f;
 	const host_cnv_char_t* host_name = CodePageGuestToHost(newname);
 	if (host_name!=NULL) {
 #ifdef host_cnv_use_wchar
-		f = _wfopen(host_name,_HT("wb+"));
+		f = _wfopen(host_name,wmode);
 #else
 		f = fopen_wrap(host_name,mode);
 #endif
@@ -2071,7 +2078,7 @@ FILE* Overlay_Drive::create_file_in_overlay(const char* dos_filename, char const
 			const host_cnv_char_t* host_name = CodePageGuestToHost(temp_name);
 			if (host_name!=NULL) {
 #ifdef host_cnv_use_wchar
-				f = _wfopen(host_name,_HT("wb+"));
+				f = _wfopen(host_name,wmode);
 #else
 				f = fopen_wrap(host_name,mode);
 #endif
@@ -2090,7 +2097,7 @@ FILE* Overlay_Drive::create_file_in_overlay(const char* dos_filename, char const
 			const host_cnv_char_t* host_name = CodePageGuestToHost(newname);
 			if (host_name!=NULL) {
 #ifdef host_cnv_use_wchar
-				f = _wfopen(host_name,_HT("wb+"));
+				f = _wfopen(host_name,wmode);
 #else
 				f = fopen_wrap(host_name,mode);
 #endif
@@ -2151,7 +2158,7 @@ static OverlayFile* ccc(DOS_File* file) {
 }
 
 Overlay_Drive::Overlay_Drive(const char * startdir,const char* overlay, Bit16u _bytes_sector,Bit8u _sectors_cluster,Bit16u _total_clusters,Bit16u _free_clusters,Bit8u _mediaid,Bit8u &error,std::vector<std::string> &options)
-:localDrive(startdir,_bytes_sector,_sectors_cluster,_total_clusters,_free_clusters,_mediaid,options),special_prefix("DBOVERLAY") {
+:localDrive(startdir,_bytes_sector,_sectors_cluster,_total_clusters,_free_clusters,_mediaid,options),special_prefix("$DBOVERLAY") {
 	optimize_cache_v1 = true; //Try to not reread overlay files on deletes. Ideally drive_cache should be improved to handle deletes properly.
 	//Currently this flag does nothing, as the current behavior is to not reread due to caching everything.
 #if defined (WIN32)	
@@ -2632,7 +2639,7 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 
 	if (read_directory_contents) {
 		for (i = specials.begin(); i != specials.end(); ++i) {
-			//Specials look like this DBOVERLAY_YYY_FILENAME.EXT or DIRNAME[\/]DBOVERLAY_YYY_FILENAME.EXT where 
+			//Specials look like this $DBOVERLAY_YYY_FILENAME.EXT or DIRNAME[\/]$DBOVERLAY_YYY_FILENAME.EXT where 
 			//YYY is the operation involved. Currently only DEL is supported.
 			//DEL = file marked as deleted, (but exists in localDrive!)
 			std::string name(*i);
@@ -2645,7 +2652,7 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 				special_dir = name.substr(0,s);
 				name.erase(0,s);
 			}
-			name.erase(0,special_prefix.length()+1); //Erase DBOVERLAY_
+			name.erase(0,special_prefix.length()+1); //Erase $DBOVERLAY_
 			s = name.find('_');
 			if (s == std::string::npos || s == 0) continue;
 			special_operation = name.substr(0,s);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2019  The DOSBox Team
+ *  Copyright (C) 2002-2020  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -445,7 +445,7 @@ void increaseticks() { //Make it return ticksRemain and set it in the function a
         }
         else {
             /* Certain configurations always give an exact sleepingtime of 1, this causes problems due to the fact that
-               dosbox keeps track of full blocks.
+               DOSBox-X keeps track of full blocks.
                This code introduces some randomness to the time slept, which improves stability on those configurations
              */
             static const Bit32u sleeppattern[] = { 2, 2, 3, 2, 2, 4, 2 };
@@ -1070,7 +1070,7 @@ void DOSBOX_RealInit() {
 
     // TODO: should be parsed by...? perhaps at some point we support machine= for backwards compat
     //       but translate it into two separate params that specify what machine vs what video hardware.
-    //       or better yet as envisioned, a possible dosbox.conf schema that allows a machine with no
+    //       or better yet as envisioned, a possible dosbox-x.conf schema that allows a machine with no
     //       base video of it's own, and then to specify an ISA or PCI card attached to the bus that
     //       provides video.
     std::string mtype(section->Get_string("machine"));
@@ -1251,7 +1251,7 @@ void DOSBOX_SetupConfigSections(void) {
     const char* irqhandler[] = {
         "", "simple", "cooperative_2nd", 0 };
 
-    /* Setup all the different modules making up DOSBox */
+    /* Setup all the different modules making up DOSBox-X */
     const char* machines[] = {
         "hercules", "cga", "cga_mono", "cga_rgb", "cga_composite", "cga_composite2", "tandy", "pcjr", "ega",
         "vgaonly", "svga_s3", "svga_et3000", "svga_et4000",
@@ -1714,7 +1714,7 @@ void DOSBOX_SetupConfigSections(void) {
     // TODO: "Special mode" which apparently triggers this alternate behavior and used by default on PC-98, is configurable
     //       by software through the PIC control words, and should control this setting if this is "auto".
     //       It's time for "auto" default setting to end once and for all the running gag that PC-98 games will not run
-    //       properly without having to add "cascade interrupt ignore in service=true" to your dosbox.conf all the time.
+    //       properly without having to add "cascade interrupt ignore in service=true" to your dosbox-x.conf all the time.
     Pstring = secprop->Add_string("cascade interrupt ignore in service",Property::Changeable::WhenIdle,"auto");
     Pstring->Set_values(truefalseautoopt);
     Pstring->Set_help("If true, PIC emulation will allow slave pic interrupts even if the cascade interrupt is still \"in service\" (common PC-98 behavior)\n"

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -4389,8 +4389,7 @@ void MAPPER_Init(void) {
     }
 }
 
-void ReloadMapper(Section_prop *sec, bool init) {
-	Section_prop const *const section=static_cast<Section_prop *>(control->GetSection("sdl"));
+void ReloadMapper(Section_prop *section, bool init) {
     Prop_path* pp;
 #if defined(C_SDL2)
 	pp = section->Get_path("mapperfile_sdl2");

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -343,6 +343,7 @@ public:
 
     //! \brief Add binding to the bindlist
     void AddBind(CBind * bind);
+	void ClearBinds();
 
     virtual ~CEvent();
 
@@ -622,6 +623,12 @@ CEvent::~CEvent() {
 void CEvent::AddBind(CBind * bind) {
     bindlist.push_front(bind);
     bind->event=this;
+}
+void CEvent::ClearBinds() {
+	for (CBind *bind : bindlist) {
+		delete bind;
+	}
+	bindlist.clear();
 }
 void CEvent::DeActivateAll(void) {
     for (CBindList_it bit=bindlist.begin();bit!=bindlist.end();++bit) {
@@ -3543,7 +3550,13 @@ static struct {
 
 #endif
 
+static void ClearAllBinds(void) {
+	for (CEvent *event : events)
+		event->ClearBinds();
+}
+
 static void CreateDefaultBinds(void) {
+	ClearAllBinds();
     char buffer[512];
     Bitu i=0;
     while (DefaultKeys[i].eventend) {
@@ -3716,6 +3729,7 @@ static void MAPPER_SaveBinds(void) {
 static bool MAPPER_LoadBinds(void) {
     FILE * loadfile=fopen(mapper.filename.c_str(),"rt");
     if (!loadfile) return false;
+	ClearAllBinds();
     char linein[512];
     while (fgets(linein,512,loadfile)) {
         CreateStringBind(linein,/*loading*/true);
@@ -4336,14 +4350,14 @@ void MAPPER_AutoType(std::vector<std::string> &sequence,
 }
 
 void MAPPER_Init(void) {
-    LOG(LOG_MISC,LOG_DEBUG)("Initializing DOSBox mapper");
+    LOG(LOG_MISC,LOG_DEBUG)("Initializing DOSBox-X mapper");
 
     mapper.exit=true;
 
     MAPPER_CheckKeyboardLayout();
     InitializeJoysticks();
-    CreateLayout();
-    CreateBindGroups();
+    if (buttons.empty()) CreateLayout();
+    if (bindgroups.empty()) CreateBindGroups();
     if (!MAPPER_LoadBinds()) CreateDefaultBinds();
     for (CButton_it but_it = buttons.begin(); but_it != buttons.end(); ++but_it) {
         (*but_it)->BindColor();
@@ -4374,6 +4388,24 @@ void MAPPER_Init(void) {
         if (ev != NULL) ev->update_menu_shortcut();
     }
 }
+
+void ReloadMapper(Section_prop *sec, bool init) {
+	Section_prop const *const section=static_cast<Section_prop *>(control->GetSection("sdl"));
+    Prop_path* pp;
+#if defined(C_SDL2)
+	pp = section->Get_path("mapperfile_sdl2");
+    mapper.filename = pp->realpath;
+	if (mapper.filename=="") pp = section->Get_path("mapperfile");
+#else
+    pp = section->Get_path("mapperfile");
+#endif
+    mapper.filename = pp->realpath;
+	if (init) {
+		GFX_LosingFocus(); //Release any keys pressed, or else they'll get stuck.
+		MAPPER_Init();
+	}
+}
+
 //Somehow including them at the top conflicts with something in setup.h
 #ifdef C_X11_XKB
 #include "SDL_syswm.h"
@@ -4555,15 +4587,7 @@ void MAPPER_StartUp() {
         }
     }
 #endif
-    Prop_path* pp;
-#if defined(C_SDL2)
-	pp = section->Get_path("mapperfile_sdl2");
-    mapper.filename = pp->realpath;
-	if (mapper.filename=="") pp = section->Get_path("mapperfile");
-#else
-    pp = section->Get_path("mapperfile");
-#endif
-    mapper.filename = pp->realpath;
+	ReloadMapper(section, false);
 
     {
         DOSBoxMenu::item *itemp = NULL;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3675,7 +3675,7 @@ static void GUI_StartUp() {
     SDL_WM_SetCaption("DOSBox-X",VERSION);
 #endif
 
-    /* Please leave the Splash screen stuff in working order in DOSBox. We spend a lot of time making DOSBox. */
+    /* Please leave the Splash screen stuff in working order in DOSBox-X. We spend a lot of time making DOSBox-X. */
     //ShowSplashScreen();   /* I will keep the splash screen alive. But now, the BIOS will do it --J.C. */
 
     /* Get some Event handlers */
@@ -5279,7 +5279,7 @@ void GFX_Events() {
 
                                 /* Now poke a "release ALT" command into the keyboard buffer
                                  * we have to do this, otherwise ALT will 'stick' and cause
-                                 * problems with the app running in the DOSBox.
+                                 * problems with the app running in the DOSBox-X.
                                  */
                                 KEYBOARD_AddKey(KBD_leftalt, false);
                                 KEYBOARD_AddKey(KBD_rightalt, false);
@@ -5581,7 +5581,7 @@ void GFX_Events() {
 
                                 /* Now poke a "release ALT" command into the keyboard buffer
                                  * we have to do this, otherwise ALT will 'stick' and cause
-                                 * problems with the app running in the DOSBox.
+                                 * problems with the app running in the DOSBox-X.
                                  */
                                 KEYBOARD_AddKey(KBD_leftalt, false);
                                 KEYBOARD_AddKey(KBD_rightalt, false);
@@ -6131,12 +6131,6 @@ void SDL_SetupConfigSection() {
         "If the default setting of 20 causes lost keystrokes, increase the number.\n"
         "Or experiment with decreasing the number for applications that accept keystrokes quickly.");
 
-    const char* wheelkeys[] = { "0", "1", "2", "3", 0 };
-    Pint = sdl_sec->Add_int("mouse_wheel_key", Property::Changeable::WhenIdle, 0);
-	Pstring->Set_values(wheelkeys);
-    Pint->Set_help("Convert mouse wheel movements into keyboard presses in Windows.\n"
-		"0: disabled; 1: up/down arrows; 2: left/right arrows; 3: PgUp/PgDn keys.");
-
     Pmulti = sdl_sec->Add_multi("sensitivity",Property::Changeable::Always, ",");
     Pmulti->Set_help("Mouse sensitivity. The optional second parameter specifies vertical sensitivity (e.g. 100,-50).");
     Pmulti->SetValue("100");
@@ -6157,6 +6151,12 @@ void SDL_SetupConfigSection() {
         "When using a high DPI mouse, the emulation of mouse movement can noticeably reduce the\n"
         "sensitiveness of your device, i.e. the mouse is slower but more precise.");
     Pstring->Set_values(emulation);
+
+    const char* wheelkeys[] = { "0", "1", "2", "3", 0 };
+    Pint = sdl_sec->Add_int("mouse_wheel_key", Property::Changeable::WhenIdle, 0);
+    Pstring->Set_values(wheelkeys);
+    Pint->Set_help("Convert mouse wheel movements into keyboard presses in Windows.\n"
+		"0: disabled; 1: up/down arrows; 2: left/right arrows; 3: PgUp/PgDn keys.");
 
     Pbool = sdl_sec->Add_bool("waitonerror",Property::Changeable::Always, true);
     Pbool->Set_help("Wait before closing the console if DOSBox-X has an error.");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -256,7 +256,7 @@ bool save_slot_9_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menui
 #if defined(WIN32)
 void MenuMountDrive(char drive, const char drive2[DOS_PATHLENGTH]);
 void MenuBrowseFolder(char drive, std::string drive_type);
-void MenuBrowseImageFile(char drive);
+void MenuBrowseImageFile(char drive, bool boot);
 
 bool drive_mountauto_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
@@ -365,7 +365,28 @@ bool drive_mountimg_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * con
 
     if (dos_kernel_disabled) return true;
 
-    MenuBrowseImageFile(drive+'A');
+    MenuBrowseImageFile(drive+'A', false);
+
+    return true;
+}
+
+bool drive_bootimg_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+
+    int drive;
+    const char *mname = menuitem->get_name().c_str();
+    if (!strncmp(mname,"drive_",6)) {
+        drive = mname[6] - 'A';
+        if (drive != 0 && drive != 2 && drive != 3) return false;
+    }
+    else {
+        return false;
+    }
+
+    if (dos_kernel_disabled) return true;
+
+    MenuBrowseImageFile(drive+'A', true);
 
     return true;
 }
@@ -451,6 +472,9 @@ const DOSBoxMenu::callback_t drive_callbacks[] = {
     drive_unmount_menu_callback,
     drive_rescan_menu_callback,
     drive_boot_menu_callback,
+#if defined(WIN32)
+    drive_bootimg_menu_callback,
+#endif
     NULL
 };
 
@@ -464,7 +488,8 @@ const char *drive_opts[][2] = {
 #endif
     { "unmount",                "Unmount" },
     { "rescan",                 "Rescan" },
-	{ "boot",                   "Boot from drive" },
+    { "boot",                   "Boot from drive" },
+    { "bootimg",                "Boot from disk image" },
     { NULL, NULL }
 };
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -169,6 +169,7 @@ void osx_init_touchbar(void);
 #endif
 
 void ShutDownMemHandles(Section * sec);
+void MAPPER_AutoType(std::vector<std::string> &sequence, const uint32_t wait_ms, const uint32_t pacing_ms);
 
 SDL_Block sdl;
 Bitu frames = 0;
@@ -4827,6 +4828,10 @@ static void HandleMouseButton(SDL_MouseButtonEvent * button, SDL_MouseMotionEven
 				SendInput(1, &ip, sizeof(INPUT));
 				ip.ki.dwFlags = KEYEVENTF_SCANCODE | KEYEVENTF_KEYUP | KEYEVENTF_EXTENDEDKEY;
 				SendInput(1, &ip, sizeof(INPUT));
+#else
+				std::vector<std::string> sequence;
+				sequence.push_back(std::string(wheel_key==2?"left":(wheel_key==3?"pageup":"up")));
+				MAPPER_AutoType(sequence, 0.5, 0);
 #endif
 			} else
 				Mouse_ButtonPressed(100-1);
@@ -4843,6 +4848,10 @@ static void HandleMouseButton(SDL_MouseButtonEvent * button, SDL_MouseMotionEven
 				SendInput(1, &ip, sizeof(INPUT));
 				ip.ki.dwFlags = KEYEVENTF_SCANCODE | KEYEVENTF_KEYUP | KEYEVENTF_EXTENDEDKEY;
 				SendInput(1, &ip, sizeof(INPUT));
+#else
+				std::vector<std::string> sequence;
+				sequence.push_back(std::string(wheel_key==2?"right":(wheel_key==3?"pagedown":"down")));
+				MAPPER_AutoType(sequence, 0.5, 0);
 #endif
 			} else
 				Mouse_ButtonPressed(100+1);
@@ -5327,10 +5336,10 @@ void GFX_Events() {
         case SDL_QUIT:
             throw(0);
             break;
-#if defined (WIN32)
 		case SDL_MOUSEWHEEL:
 			if (wheel_key) {
 				if(event.wheel.y > 0) {
+#if defined (WIN32)
 					INPUT ip = {0};
 					ip.type = INPUT_KEYBOARD;
 					ip.ki.wScan = wheel_key==2?75:(wheel_key==3?73:72);
@@ -5340,7 +5349,13 @@ void GFX_Events() {
 					SendInput(1, &ip, sizeof(INPUT));
 					ip.ki.dwFlags = KEYEVENTF_SCANCODE | KEYEVENTF_KEYUP | KEYEVENTF_EXTENDEDKEY;
 					SendInput(1, &ip, sizeof(INPUT));
+#else
+					std::vector<std::string> sequence;
+					sequence.push_back(std::string(wheel_key==2?"left":(wheel_key==3?"pageup":"up")));
+					MAPPER_AutoType(sequence, 0.5, 0);
+#endif
 				} else if(event.wheel.y < 0) {
+#if defined (WIN32)
 					INPUT ip = {0};
 					ip.type = INPUT_KEYBOARD;
 					ip.ki.wScan = wheel_key==2?77:(wheel_key==3?81:80);
@@ -5350,9 +5365,15 @@ void GFX_Events() {
 					SendInput(1, &ip, sizeof(INPUT));
 					ip.ki.dwFlags = KEYEVENTF_SCANCODE | KEYEVENTF_KEYUP | KEYEVENTF_EXTENDEDKEY;
 					SendInput(1, &ip, sizeof(INPUT));
+#else
+					std::vector<std::string> sequence;
+					sequence.push_back(std::string(wheel_key==2?"right":(wheel_key==3?"pagedown":"down")));
+					MAPPER_AutoType(sequence, 0.5, 0);
+#endif
 				}
 			}
 			break;
+#if defined (WIN32)
         case SDL_KEYDOWN:
         case SDL_KEYUP:
             if (event.key.keysym.sym==SDLK_LALT) sdl.laltstate = event.key.type;
@@ -6155,7 +6176,7 @@ void SDL_SetupConfigSection() {
     const char* wheelkeys[] = { "0", "1", "2", "3", 0 };
     Pint = sdl_sec->Add_int("mouse_wheel_key", Property::Changeable::WhenIdle, 0);
     Pstring->Set_values(wheelkeys);
-    Pint->Set_help("Convert mouse wheel movements into keyboard presses in Windows.\n"
+    Pint->Set_help("Convert mouse wheel movements into keyboard presses such as arrow keys.\n"
 		"0: disabled; 1: up/down arrows; 2: left/right arrows; 3: PgUp/PgDn keys.");
 
     Pbool = sdl_sec->Add_bool("waitonerror",Property::Changeable::Always, true);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -489,7 +489,9 @@ const char *drive_opts[][2] = {
     { "unmount",                "Unmount" },
     { "rescan",                 "Rescan" },
     { "boot",                   "Boot from drive" },
+#if defined(WIN32)
     { "bootimg",                "Boot from disk image" },
+#endif
     { NULL, NULL }
 };
 
@@ -3524,7 +3526,7 @@ static void GUI_StartUp() {
   #ifdef WIN32
     /* NTS: This should not print any warning whatsoever because Windows builds by default will use
      *      the Windows API to disable DPI scaling of the main window, unless the user modifies the
-     *      setting through dosbox.conf or the command line. */
+     *      setting through dosbox-x.conf or the command line. */
     /* NTS: Mac OS X has high DPI scaling too, though Apple is wise to enable it by default only for
      *      Macbooks with "Retina" displays. On Mac OS X, unless otherwise wanted by the user, it is
      *      wise to let Mac OS X scale up the DOSBox-X window by 2x so that the DOS prompt is not
@@ -6879,7 +6881,7 @@ void AUTOEXEC_Init();
 // NTS: I intend to add code that not only indicates High DPI awareness but also queries the monitor DPI
 //      and then factor the DPI into DOSBox's scaler and UI decisions.
 void Windows_DPI_Awareness_Init() {
-    // if the user says not to from the command line, or disables it from dosbox.conf, then don't enable DPI awareness.
+    // if the user says not to from the command line, or disables it from dosbox-x.conf, then don't enable DPI awareness.
     if (!dpi_aware_enable || control->opt_disable_dpi_awareness)
         return;
 

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -36,7 +36,7 @@
 
 Bitu call_program;
 
-extern int enablelfn, paste_speed;
+extern int enablelfn, paste_speed, wheel_key;
 extern const char *modifier;
 extern bool dos_kernel_disabled, force_nocachedir, freesizecap, wpcolon;
 
@@ -550,6 +550,7 @@ private:
 	}
 };
 
+void ReloadMapper(Section_prop *sec);
 void CONFIG::Run(void) {
 	static const char* const params[] = {
 		"-r", "-wcp", "-wcd", "-wc", "-writeconf", "-l", "-rmconf",
@@ -1037,10 +1038,6 @@ void CONFIG::Run(void) {
 			//Due to parsing there can be a = at the start of value.
 			while (value.size() && (value.at(0) ==' ' ||value.at(0) =='=') ) value.erase(0,1);
 			for(Bitu i = 3; i < pvars.size(); i++) value += (std::string(" ") + pvars[i]);
-			if (value.empty() ) {
-				WriteOut(MSG_Get("PROGRAM_CONFIG_SET_SYNTAX"));
-				return;
-			}
 			std::string inputline = pvars[1] + "=" + value;
 			
 			bool change_success = tsec->HandleInputline(inputline.c_str());
@@ -1055,6 +1052,12 @@ void CONFIG::Run(void) {
 						} else if (!strcasecmp(pvars[0].c_str(), "sdl")) {
 							modifier = section->Get_string("clip_key_modifier");
 							paste_speed = section->Get_int("clip_paste_speed");
+							wheel_key = section->Get_int("mouse_wheel_key");
+#if defined(C_SDL2)
+							if (!strcasecmp(inputline.substr(0, 16).c_str(), "mapperfile_sdl2=")) ReloadMapper(section);
+#else
+							if (!strcasecmp(inputline.substr(0, 11).c_str(), "mapperfile=")) ReloadMapper(section);
+#endif
 						} else if (!strcasecmp(pvars[0].c_str(), "dos")) {
 							if (!strcasecmp(inputline.substr(0, 4).c_str(), "lfn=")) {
 								if (!strcmp(section->Get_string("lfn"), "true")) enablelfn=1;

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -550,7 +550,7 @@ private:
 	}
 };
 
-void ReloadMapper(Section_prop *sec);
+void ReloadMapper(Section_prop *sec, bool init);
 void CONFIG::Run(void) {
 	static const char* const params[] = {
 		"-r", "-wcp", "-wcd", "-wc", "-writeconf", "-l", "-rmconf",
@@ -1054,9 +1054,9 @@ void CONFIG::Run(void) {
 							paste_speed = section->Get_int("clip_paste_speed");
 							wheel_key = section->Get_int("mouse_wheel_key");
 #if defined(C_SDL2)
-							if (!strcasecmp(inputline.substr(0, 16).c_str(), "mapperfile_sdl2=")) ReloadMapper(section);
+							if (!strcasecmp(inputline.substr(0, 16).c_str(), "mapperfile_sdl2=")) ReloadMapper(section,true);
 #else
-							if (!strcasecmp(inputline.substr(0, 11).c_str(), "mapperfile=")) ReloadMapper(section);
+							if (!strcasecmp(inputline.substr(0, 11).c_str(), "mapperfile=")) ReloadMapper(section,true);
 #endif
 						} else if (!strcasecmp(pvars[0].c_str(), "dos")) {
 							if (!strcasecmp(inputline.substr(0, 4).c_str(), "lfn=")) {


### PR DESCRIPTION
I have added two new features to DOSBox-X as follows:

1. Mouse wheel movements can now be automatically converted to key presses, configurable by a new option "mouse_wheel_key", which is disabled by default. When set to 1, mouse wheel movements will be converted to up/down arrows. Setting to 2 or 3 will convert such movements to left/right arrows or PageUp/PageDown keys respectively. For now this feature is only available in Windows.

2. Reloading the keyboard mapper file is now possible with the config -set command. Originally a feature of DOSBox-staging, it is now ported to work in DOSBox-X too.

There are some other small cleanups including fixing the error message for Linux when mounting FAT32 drives as mentioned in the discussion of pull request #1656.