### PR TITLE
RENDER_SetSize() takes FPS as parameter, not frame time.

### DIFF
--- a/src/hardware/voodoo_interface.cpp
+++ b/src/hardware/voodoo_interface.cpp
@@ -225,7 +225,7 @@ static void Voodoo_UpdateScreen(void) {
 		if (v->ogl) {
 			v->ogl_dimchange = false;
 		} else {
-			RENDER_SetSize(v->fbi.width, v->fbi.height, 16, vdraw.vfreq, 4.0/3.0);
+			RENDER_SetSize(v->fbi.width, v->fbi.height, 16, 1000.0f / vdraw.vfreq, 4.0/3.0);
 		}
 
 		Voodoo_VerticalTimer(0);


### PR DESCRIPTION
As mentioned on vogons by user realnc
https://www.vogons.org/viewtopic.php?p=850281#p850281
