### PR TITLE
Change mkdir permissions to 775

### DIFF
--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -955,7 +955,7 @@ bool localDrive::MakeDir(const char * dir) {
 #if defined (WIN32)						/* MS Visual C++ */
 	int temp=_wmkdir(host_name);
 #else
-	int temp=mkdir(host_name,0700);
+	int temp=mkdir(host_name,0775);
 #endif
 	if (temp==0) dirCache.CacheOut(newdir,true);
 
@@ -1924,7 +1924,7 @@ bool Overlay_Drive::MakeDir(const char * dir) {
 #if defined (WIN32)
 					temp=_wmkdir(host_name);
 #else
-					temp=mkdir(host_name,0700);
+					temp=mkdir(host_name,0775);
 #endif
 					if (temp==0) madepdir=true;
 				}
@@ -1937,7 +1937,7 @@ bool Overlay_Drive::MakeDir(const char * dir) {
 #if defined (WIN32)
 		temp=_wmkdir(host_name);
 #else
-		temp=mkdir(host_name,0700);
+		temp=mkdir(host_name,0775);
 #endif
 	}
 	if (temp==0) {
@@ -2428,7 +2428,7 @@ bool Overlay_Drive::Sync_leading_dirs(const char* dos_filename){
 #if defined (WIN32)						/* MS Visual C++ */
 				int temp = mkdir(dirnameoverlay);
 #else
-				int temp = mkdir(dirnameoverlay,0700);
+				int temp = mkdir(dirnameoverlay,0775);
 #endif
 				if (temp != 0) return false;
 			}
@@ -2956,7 +2956,7 @@ bool Overlay_Drive::SetFileAttr(const char * name,Bit16u attr) {
 #if defined (WIN32)
 			temp=_wmkdir(host_name);
 #else
-			temp=mkdir(host_name,0700);
+			temp=mkdir(host_name,0775);
 #endif
 		}
 		if (temp==0) created=true;


### PR DESCRIPTION
By default on Linux, if you create a directory, it is created with
permissions 775 (rwxrwxr-x). But for some reason if you use
DOSBox to create a directory using folder mounts it creates it
with 700 (rwx------)

On the other hand, if you create a file, it creates with the same
permissions as Linux does (664, or rw-rw-r--).

With this patch, DOSBox-X creates dirctories with the same
permissions as Linux does.
