### PR TITLE
New CREDITS page and copyright headers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,10 @@
-DOSBox-X by joncampbell123
+The DOSBox-X project
 
-Based on DOSBox by the DOSBox Team
+Maintainer: joncampbell123 (Jonathan Campbell)
+
+Please see the file CREDITS.md for credits
+
+Originally based on DOSBox by the DOSBox Team
 
 The DOSBox Team
 ---------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,4 @@
 0.83.3
-  - IMGMOUNT command without parameters will show disk
-    names for drive-number only mounts. (Wengier)
   - Improved the HX-DOS build package to make it fully
     automated: all required HX DOS Extender files will
     be included in the package, and dosbox-x.exe can
@@ -20,6 +18,8 @@
     arrows or PageUp/PageDn keys respectively. (Wengier)
   - Support for reloading the keyboard mapper file with
     the config -set command. (Wengier)
+  - IMGMOUNT command without parameters will show disk
+    names for drive-number only mounts. (Wengier)
   - IMGMOUNT can now autodetect DOS <= 3.21 harddisk
     geometry with MFM sector images (rderooy & Wengier)
   - IMGMOUNT -fs none fixed to use same geometry detect

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -5,8 +5,7 @@ Jonathan Campbell, the maintainer of DOSBox-X does not claim to have written all
 
 Some of the code is DOSBox SVN code in which some of the SVN commits made since 2011 were incorporated into DOSBox-X.
 
-Some of the source code also came from DOSBox forks such as DOSBox Daum, DOSBox ECE, DOSBox-staging as well as
-vDosPlus, with major works from contributors like Wengier and rderooy.
+Some of the source code also came from similar projects such as DOSBox Daum, DOSBox ECE, DOSBox-staging and vDosPlus, with major works from contributors like Wengier and rderooy.
 
 A list of features ported from DOSBox Daum:
 
@@ -18,7 +17,7 @@ A list of features ported from DOSBox Daum:
 * MT-32 emulation (MUNT)
 * Internal 3dfx voodoo chip emulation
 * Some support for FluidSynth MIDI synthesizer
-* improved PC Speaker emulation accuracy
+* Improved PC Speaker emulation accuracy
 * CGA with Monochrome Monitor Support
 * Support for CPU types like Pentium MMX
 * Features such as V-Sync, xBRZ scaler, overscan border and stereo-swap
@@ -47,7 +46,7 @@ A list of features ported from vDosPlus by Wengier:
 
 Features such as save and load states are also recently ported from community contributions and have since been improved by the DOSBox-X project.
 
-This is an attempt to properly credit the other code and its sources below. It is not yet complete, and feel free to revise and correct this list if there are errors.
+This is an attempt to properly credit the other code and its sources below. It is not yet a complete list, and please feel free to revise and correct this list if there are errors.
 
 NE2000 network card emulation (Bochs; LGPLv2+) src/hardware/ne2000.cpp
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -5,7 +5,8 @@ Jonathan Campbell, the maintainer of DOSBox-X does not claim to have written all
 
 Some of the code is DOSBox SVN code in which some of the SVN commits made since 2011 were incorporated into DOSBox-X.
 
-Some of the source code also came from similar projects such as DOSBox Daum, DOSBox ECE, DOSBox-staging and vDosPlus, with major works from contributors like Wengier and rderooy.
+Some of the source code also came from similar projects such as [DOSBox Daum](http://ykhwong.x-y.net), [DOSBox ECE](https://dosboxece.yesterplay.net/), [DOSBox-staging](https://dosbox-staging.github.io/) and [vDosPlus](http://www.vdosplus.org/), with major works from contributors like Wengier and rderooy.
+
 
 A list of features ported from DOSBox Daum:
 
@@ -44,7 +45,7 @@ A list of features ported from vDosPlus by Wengier:
 * Support for clipboard copy and paste (Windows)
 * Several shell improvements
 
-Features such as save and load states are also recently ported from community contributions and have since been improved by the DOSBox-X project.
+Features such as save and load states have also been recently ported from community contributions and have since been improved by the DOSBox-X project.
 
 This is an attempt to properly credit the other code and its sources below. It is not yet a complete list, and please feel free to revise and correct this list if there are errors.
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -3,10 +3,9 @@ Credits
 
 Jonathan Campbell, the maintainer of DOSBox-X does not claim to have written all of the code in this project.
 
-Some of the code is DOSBox SVN code in which some of the SVN commits made since 2011 were incorporated into DOSBox-X.
+The original code is from the [DOSBox](https://www.dosbox.com) project in which some of the SVN commits made since 2011 were incorporated into DOSBox-X.
 
-Some of the source code also came from similar projects such as [DOSBox Daum](http://ykhwong.x-y.net), [DOSBox ECE](https://dosboxece.yesterplay.net/), [DOSBox-staging](https://dosbox-staging.github.io/) and [vDosPlus](http://www.vdosplus.org/), with major works from contributors like Wengier and rderooy.
-
+Some of the source code also came from similar projects such as [DOSBox Daum](http://ykhwong.x-y.net), [DOSBox ECE](https://dosboxece.yesterplay.net/), [DOSBox-staging](https://dosbox-staging.github.io/) and [vDosPlus](http://www.vdosplus.org/), with major works from contributors like Wengier, Allofich, and rderooy.
 
 A list of features ported from DOSBox Daum:
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -3,7 +3,7 @@ Credits
 
 Jonathan Campbell, the maintainer of DOSBox-X does not claim to have written all of the code in this project.
 
-The original code is from the [DOSBox](https://www.dosbox.com) project in which some of the SVN commits made since 2011 were incorporated into DOSBox-X.
+The base code is from the [DOSBox](https://www.dosbox.com) project in which some of the SVN commits made since 2011 were incorporated into DOSBox-X. This code had since been heavily modified by the DOSBox-X project.
 
 Some of the source code also came from similar projects such as [DOSBox Daum](http://ykhwong.x-y.net), [DOSBox ECE](https://dosboxece.yesterplay.net/), [DOSBox-staging](https://dosbox-staging.github.io/) and [vDosPlus](http://www.vdosplus.org/), with major works from contributors like Wengier, Allofich, and rderooy.
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,7 +1,7 @@
 Credits
 =======
 
-The developer of DOSBox-X does not claim to have written all of the code in this project.
+Jonathan Campbell, the maintainer of DOSBox-X does not claim to have written all of the code in this project.
 
 Some of the code is DOSBox SVN code in which some of the SVN commits made since 2011 were incorporated into DOSBox-X.
 
@@ -22,7 +22,7 @@ A list of features ported from DOSBox Daum:
 * CGA with Monochrome Monitor Support
 * Support for CPU types like Pentium MMX
 * Features such as V-Sync, xBRZ scaler, overscan border and stereo-swap
-* Patches such as DBCS and font patch
+* Various patches such as DBCS and font patch
 
 A list of features ported from DOSBox ECE:
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -26,12 +26,13 @@ A list of features ported from DOSBox Daum:
 
 A list of features ported from DOSBox ECE:
 
+* Support for FLAC, Opus, Vorbis, and MP3 CD-DA tracks
 * Support for mapping mouse buttons to keyboard
 * Improved support for FluidSynth MIDI synthesizer
+* Updated Nuked OPL3 to 1.8
 
 A list of features ported from DOSBox-staging:
 
-* Support for FLAC, Opus, Vorbis, and MP3 CD-DA tracks
 * AUTOTYPE command for scripted keyboard entry
 * LS command (heavily improved since then by Wengier)
 * Modem phonebook support

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -12,7 +12,7 @@ A list of features ported from DOSBox Daum:
 
 * GUI menu bar (heavily improved since then)
 * Some commands (PROMPT, MOUSE, VOL, DEVICE, etc)
-* Some support for automatic drive mount (Windows)
+* Basic support for automatic drive mount (Windows)
 * Printer output
 * NE2000 Ethernet
 * MT-32 emulation (MUNT)
@@ -33,17 +33,18 @@ A list of features ported from DOSBox-staging:
 
 * Support for FLAC, Opus, Vorbis, and MP3 CD-DA tracks
 * AUTOTYPE command for scripted keyboard entry
-* LS command (heavily improved since then)
+* LS command (heavily improved since then by Wengier)
 * Modem phonebook support
 * Support for changing key bindings in runtime
 
-A list of features ported from vDosPlus:
+A list of features ported from vDosPlus by Wengier:
 
-* Long filename support (improved for FAT drives since then)
-* Clipboard copy & paste (Windows)
+* Long filename support (improved for FAT drives since then by Wengier and joncampbell123)
+* Improved support for automatic drive mount (Windows)
+* Support for clipboard copy and paste (Windows)
 * Several shell improvements
 
-This is an attempt to properly credit the other code and it's sources below. It is not yet complete, and feel free to revise and correct this list if there are errors.
+This is an attempt to properly credit the other code and its sources below. It is not yet complete, and feel free to revise and correct this list if there are errors.
 
 NE2000 network card emulation (Bochs; LGPLv2+) src/hardware/ne2000.cpp
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -26,13 +26,13 @@ A list of features ported from DOSBox Daum:
 
 A list of features ported from DOSBox ECE:
 
-* Support for FLAC, Opus, Vorbis, and MP3 CD-DA tracks
 * Support for mapping mouse buttons to keyboard
 * Improved support for FluidSynth MIDI synthesizer
 * Updated Nuked OPL3 to 1.8
 
 A list of features ported from DOSBox-staging:
 
+* Support for FLAC, Opus, Vorbis, and MP3 CD-DA tracks
 * AUTOTYPE command for scripted keyboard entry
 * LS command (heavily improved since then by Wengier)
 * Modem phonebook support
@@ -44,6 +44,8 @@ A list of features ported from vDosPlus by Wengier:
 * Improved support for automatic drive mount (Windows)
 * Support for clipboard copy and paste (Windows)
 * Several shell improvements
+
+Features such as save and load states are also recently ported from community contributions and have since been improved by the DOSBox-X project.
 
 This is an attempt to properly credit the other code and its sources below. It is not yet complete, and feel free to revise and correct this list if there are errors.
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,72 @@
+Credits
+=======
+
+The developer of DOSBox-X does not claim to have written all of the code in this project.
+
+Some of the code is DOSBox SVN code in which some of the SVN commits made since 2011 were incorporated into DOSBox-X.
+
+Some of the source code also came from DOSBox forks such as DOSBox Daum, DOSBox ECE, DOSBox-staging as well as
+vDosPlus, with major works from contributors like Wengier and rderooy.
+
+A list of features ported from DOSBox Daum:
+
+* GUI menu bar (heavily improved since then)
+* Some commands (PROMPT, MOUSE, VOL, DEVICE, etc)
+* Some support for automatic drive mount (Windows)
+* Printer output
+* NE2000 Ethernet
+* MT-32 emulation (MUNT)
+* Internal 3dfx voodoo chip emulation
+* Some support for FluidSynth MIDI synthesizer
+* improved PC Speaker emulation accuracy
+* CGA with Monochrome Monitor Support
+* Support for CPU types like Pentium MMX
+* Features such as V-Sync, xBRZ scaler, overscan border and stereo-swap
+* Patches such as DBCS and font patch
+
+A list of features ported from DOSBox ECE:
+
+* Support for mapping mouse buttons to keyboard
+* Improved support for FluidSynth MIDI synthesizer
+
+A list of features ported from DOSBox-staging:
+
+* Support for FLAC, Opus, Vorbis, and MP3 CD-DA tracks
+* AUTOTYPE command for scripted keyboard entry
+* LS command (heavily improved since then)
+* Modem phonebook support
+* Support for changing key bindings in runtime
+
+A list of features ported from vDosPlus:
+
+* Long filename support (improved for FAT drives since then)
+* Clipboard copy & paste (Windows)
+* Several shell improvements
+
+This is an attempt to properly credit the other code and it's sources below. It is not yet complete, and feel free to revise and correct this list if there are errors.
+
+NE2000 network card emulation (Bochs; LGPLv2+) src/hardware/ne2000.cpp
+
+MT32 synthesizer (MUNT; LGPLv2.1+) src/mt32/.cpp src/mt32/.h
+
+Framework-agnostic GUI toolkit (Jorg Walter; GPLv3+) src/libs/gui_tk/.cpp src/libs/gui_tk/.h
+
+Porttalk library, to read/write I/O ports directly (Unknown source) src/libs/porttalk/.cpp src/libs/porttalk/.h
+
+FreeDOS utilities as binary blobs (FreeDOS; no license) src/builtin/*.cpp
+
+NukedOPL OPL3 emulation (Alexey Khokholov; GPLv2+) src/hardware/nukedopl.cpp
+
+OPL emulation based on Ken Silverman OPL2 emulation (LGPLv2.1+) src/hardware/opl.cpp
+
+MOS6581 SID emulation (GPLv2+) src/hardware/reSID/.cpp src/hardware/reSID/.h
+
+SN76496 emulation (MAME project; GPLv2+) src/hardware/sn76496.h src/hardware/tandy_sound.cpp
+
+3dfx Voodoo Graphics SST-1/2 emulation (Aaron Giles; BSD 3-clause) src/hardware/voodoo_emu.cpp
+
+PC-98 FM board emulation (Neko Project II; BSD 3-clause) src/hardware/snd_pc98/*
+
+QCOW image support (Michael Greger; GPLv2+) src/ints/qcow2_disk.cpp
+
+HQ2X and HQ3X render scaler (ScummVM, Maxim Stepin; GPLv2+) src/gui/render_templates_hq2x.h

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -44,7 +44,9 @@ A list of features ported from vDosPlus by Wengier:
 * Support for clipboard copy and paste (Windows)
 * Several shell improvements
 
-Features such as save and load states have also been recently ported from community contributions and have since been improved by the DOSBox-X project.
+Features such as save and load states were also ported from community contributions and have since been improved by the DOSBox-X project.
+
+The DOSBox-X Wiki pages were created and updated by Wengier and rderooy. 
 
 This is an attempt to properly credit the other code and its sources below. It is not yet a complete list, and please feel free to revise and correct this list if there are errors.
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ from other projects such as [DOSBox ECE](https://dosboxece.yesterplay.net/), [DO
 [vDosPlus](http://www.vdosplus.org/), with major improvements and works from its contributors
 such as Wengier and rderooy.
 
-See also the [DOSBox-X source code description](README.source-code-description) page for crediting of the source code.
+See also the [CREDITS](CREDITS.md) page for crediting of the source code.
 
 
 Known DOSBox-X forks

--- a/README.source-code-description
+++ b/README.source-code-description
@@ -1380,37 +1380,4 @@ Some of the code in this source tree also came from other forks of
 DOSBox such as DOSBox Daum, DOSBox ECE, DOSBox-staging as well as
 vDosPlus, with major works from contributors like Wengier and rderooy.
 
-This is my attempt to properly credit the code and it's sources below.
-It is not yet complete, and feel free to revise and correct this list
-if there are errors.
-
-NE2000 network card emulation (Bochs; LGPLv2+) src/hardware/ne2000.cpp
-
-MT32 synthesizer (MUNT; LGPLv2.1+) src/mt32/.cpp src/mt32/.h
-
-AVI writer with OpenDML support (written by myself; GPLv2+) src/aviwriter/.cpp src/aviwriter/.h
-
-Framework-agnostic GUI toolkit (Jorg Walter; GPLv3+) src/libs/gui_tk/.cpp src/libs/gui_tk/.h
-
-Porttalk library, to read/write I/O ports directly (Unknown source) src/libs/porttalk/.cpp src/libs/porttalk/.h
-
-FreeDOS utilities as binary blobs (FreeDOS; no license) src/builtin/*.cpp
-
-NukedOPL OPL3 emulation (Alexey Khokholov; GPLv2+) src/hardware/nukedopl.cpp
-
-OPL emulation based on Ken Silverman OPL2 emulation (LGPLv2.1+) src/hardware/opl.cpp
-
-MOS6581 SID emulation (GPLv2+) src/hardware/reSID/.cpp src/hardware/reSID/.h
-
-SN76496 emulation (MAME project; GPLv2+) src/hardware/sn76496.h src/hardware/tandy_sound.cpp
-
-PC-98 video rendering and I/O handling code (written by myself; GPLv2+) src/hardware/vga_pc98*.cpp
-
-3dfx Voodoo Graphics SST-1/2 emulation (Aaron Giles; BSD 3-clause) src/hardware/voodoo_emu.cpp
-
-PC-98 FM board emulation (Neko Project II; BSD 3-clause) src/hardware/snd_pc98/*
-
-QCOW image support (Michael Greger; GPLv2+) src/ints/qcow2_disk.cpp
-
-HQ2X and HQ3X render scaler (ScummVM, Maxim Stepin; GPLv2+) src/gui/render_templates_hq2x.h
-
+For more information please look at the CREDITS.md file.

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -15,8 +15,9 @@
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
  *
- *  Heavy improvements by the DOSBox-X Team - joncampbell123, Wengier, rderooy
- *  AUTOTYPE Copyright (C) 2020 The dosbox-staging team
+ *  Heavy improvements to various commands by the DOSBox-X Team
+ *  With major works from joncampbell123, Wengier, and rderooy
+ *  AUTOTYPE command Copyright (C) 2020 the dosbox-staging team
  */
 
 

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -14,6 +14,9 @@
  *  You should have received a copy of the GNU General Public License
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+ *
+ *  Heavy improvements by the DOSBox-X Team - joncampbell123, Wengier, rderooy
+ *  AUTOTYPE Copyright (C) 2020 The dosbox-staging team
  */
 
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -577,7 +577,7 @@ void DOS_Shell::Run(void) {
 
     }
     else {
-        WriteOut(optK?"\n":"DOSBox-X command shell [Version %s %s]\nBased on DOSBox by the DOSBox Team, 2011-2020\n\n",VERSION,SDL_STRING);
+        WriteOut(optK?"\n":"DOSBox-X command shell [Version %s %s]\nCopyright DOSBox-X Team. All rights reserved\n\n",VERSION,SDL_STRING);
     }
 
 	if (cmd->FindString("/INIT",line,true)) {
@@ -878,8 +878,6 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_HELP","If you want a list of all supported commands type \033[33;1mHELP /ALL\033[0m.\nA short list of the most often used commands:\n");
 	MSG_Add("SHELL_CMD_ECHO_ON","ECHO is on.\n");
 	MSG_Add("SHELL_CMD_ECHO_OFF","ECHO is off.\n");
-        MSG_Add("SHELL_ILLEGAL_CONTROL_CHARACTER",
-	        "Unexpected control character: Dec %03u and Hex %#04x.\n");
 	MSG_Add("SHELL_ILLEGAL_SWITCH","Illegal switch: %s.\n");
 	MSG_Add("SHELL_MISSING_PARAMETER","Required parameter missing.\n");
 	MSG_Add("SHELL_CMD_CHDIR_ERROR","Unable to change to: %s.\n");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -878,6 +878,7 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_HELP","If you want a list of all supported commands type \033[33;1mHELP /ALL\033[0m.\nA short list of the most often used commands:\n");
 	MSG_Add("SHELL_CMD_ECHO_ON","ECHO is on.\n");
 	MSG_Add("SHELL_CMD_ECHO_OFF","ECHO is off.\n");
+	MSG_Add("SHELL_ILLEGAL_CONTROL_CHARACTER","Unexpected control character: Dec %03u and Hex %#04x.\n");
 	MSG_Add("SHELL_ILLEGAL_SWITCH","Illegal switch: %s.\n");
 	MSG_Add("SHELL_MISSING_PARAMETER","Required parameter missing.\n");
 	MSG_Add("SHELL_CMD_CHDIR_ERROR","Unable to change to: %s.\n");

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -14,6 +14,11 @@
  *  You should have received a copy of the GNU General Public License
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+ *
+ *  Heavy improvements by the DOSBox-X Team, 2011-2020
+ *  DXCAPTURE, DEBUGBOX, INT2FDBG by joncampbell123
+ *  ATTRIB, COUNTRY, FOR, LFNFOR, VERIFY, TRUENAME by Wengier
+ *  LS by The dosbox-staging team and Wengier
  */
 
 

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -16,9 +16,9 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
  *
  *  Heavy improvements by the DOSBox-X Team, 2011-2020
- *  DXCAPTURE, DEBUGBOX, INT2FDBG by joncampbell123
- *  ATTRIB, COUNTRY, FOR, LFNFOR, VERIFY, TRUENAME by Wengier
- *  LS by The dosbox-staging team and Wengier
+ *  DXCAPTURE, DEBUGBOX, INT2FDBG commands by joncampbell123
+ *  ATTRIB, COUNTRY, FOR, LFNFOR, VERIFY, TRUENAME commands by Wengier
+ *  LS command by the dosbox-staging team and Wengier
  */
 
 


### PR DESCRIPTION
As discussed recently the current source code credit page is out of date, so I decided to clean it up by making a separate CREDITS.md page, which now has a list of features ported from other projects including DOSBox Daum, DOSBox ECE, DOSBox-staging and vDosPlus. I also added copyright headers for pages for DOS commands as required by the GPL license.