### PR TITLE
SVN 4352, 4353 (Adlib)

### DIFF
--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -645,7 +645,7 @@ bool Chip::Write( Bit32u reg, Bit8u val ) {
 			timer1.Reset( time );
 		} else {
 			//timer 0 not masked
-			if (!(val & 0x40)) {
+			if (val&0x20) {
 				if (val & 0x1) {
 					timer0.Start(time);
 				}
@@ -654,7 +654,7 @@ bool Chip::Write( Bit32u reg, Bit8u val ) {
 				}
 			}
 			//Timer 1 not masked
-			if (!(val & 0x20)) {
+			if (val&0x40) {
 				if (val & 0x2) {
 					timer1.Start(time);
 				}

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -619,6 +619,9 @@ skipWrite:
 Chip
 */
 
+Chip::Chip() : timer0(80), timer1(320) {
+}
+
 bool Chip::Write( Bit32u reg, Bit8u val ) {
 	if (adlib_force_timer_overflow_on_polling) {
 		/* detect end of polling loop by whether it writes */
@@ -628,37 +631,37 @@ bool Chip::Write( Bit32u reg, Bit8u val ) {
 
 	switch ( reg ) {
 	case 0x02:
-		timer[0].counter = val;
+		timer0.SetCounter(val);
 		return true;
 	case 0x03:
-		timer[1].counter = val;
+		timer1.SetCounter(val);
 		return true;
 	case 0x04:
 		double time;
 		time = PIC_FullIndex();
+		//Reset overflow in both timers
 		if ( val & 0x80 ) {
-			timer[0].Reset( time );
-			timer[1].Reset( time );
+			timer0.Reset( time );
+			timer1.Reset( time );
 		} else {
-			timer[0].Update( time );
-			timer[1].Update( time );
-			if ( val & 0x1 ) {
-				timer[0].Start( time, 80 );
-			} else {
-				timer[0].Stop( );
+			//timer 0 not masked
+			if (!(val & 0x40)) {
+				if (val & 0x1) {
+					timer0.Start(time);
+				}
+				else {
+					timer0.Stop();
+				}
 			}
-			timer[0].masked = (val & 0x40) > 0;
-			if ( timer[0].masked )
-				timer[0].overflow = false;
-			if ( val & 0x2 ) {
-				timer[1].Start( time, 320 );
-			} else {
-				timer[1].Stop( );
+			//Timer 1 not masked
+			if (!(val & 0x20)) {
+				if (val & 0x2) {
+					timer1.Start(time);
+				}
+				else {
+					timer1.Stop();
+				}
 			}
-			timer[1].masked = (val & 0x20) > 0;
-			if ( timer[1].masked )
-				timer[1].overflow = false;
-
 		}
 		return true;
 	}
@@ -667,9 +670,7 @@ bool Chip::Write( Bit32u reg, Bit8u val ) {
 
 
 Bit8u Chip::Read( ) {
-	double time( PIC_FullIndex() );
-	timer[0].Update( time );
-	timer[1].Update( time );
+	const double time( PIC_FullIndex() );
 
 	if (adlib_force_timer_overflow_on_polling) {
 		static const double poll_timeout = 0.1; /* if polling more than 100us per second, do timeout */
@@ -681,13 +682,13 @@ Bit8u Chip::Read( ) {
 //			LOG_MSG("Adlib polling hack triggered. Forcing timers to reset. Hope this helps your DOS game to detect Adlib.");
 
 			poll_counter = 0;
-			if (!timer[0].overflow && timer[0].enabled) {
-				timer[0].Stop();
-				timer[0].overflow = true;
+			if (!timer0.overflow && timer0.enabled) {
+				timer0.Stop();
+				timer0.overflow = true;
 			}
-			if (!timer[1].overflow && timer[1].enabled) {
-				timer[1].Stop();
-				timer[1].overflow = true;
+			if (!timer1.overflow && timer1.enabled) {
+				timer1.Stop();
+				timer1.overflow = true;
 			}
 		}
 
@@ -696,16 +697,15 @@ Bit8u Chip::Read( ) {
 
 	Bit8u ret = 0;
 	//Overflow won't be set if a channel is masked
-	if ( timer[0].overflow ) {
+	if (timer0.Update(time)) {
 		ret |= 0x40;
 		ret |= 0x80;
 	}
-	if ( timer[1].overflow ) {
+	if (timer1.Update(time)) {
 		ret |= 0x20;
 		ret |= 0x80;
 	}
 	return ret;
-
 }
 
 void Module::CacheWrite( Bit32u reg, Bit8u val ) {

--- a/src/hardware/adlib.h
+++ b/src/hardware/adlib.h
@@ -30,68 +30,91 @@
 
 namespace Adlib {
 
-struct Timer {
+class Timer {
+	//Rounded down start time
 	double start;
+	//Clock interval
+	double interval;
+	//Delay before you overflow
 	double delay;
-	bool enabled, overflow, masked;
 	Bit8u counter;
-	Timer() {
-		masked = false;
+public:
+	bool enabled;
+	bool overflow;
+
+	Timer( Bit16s micros ) {
 		overflow = false;
 		enabled = false;
 		counter = 0;
+		start = 0;
 		delay = 0;
-        start = 0;
-	}
-	//Call update before making any further changes
-	void Update( double time ) {
-		if ( !enabled || !delay ) 
-			return;
-		double deltaStart = time - start;
-		//Only set the overflow flag when not masked
-		if ( deltaStart >= 0 && !masked ) {
-			overflow = 1;
-		}
-	}
-	//On a reset make sure the start is in sync with the next cycle
-	void Reset(const double& time ) {
-		overflow = false;
-		if ( !delay || !enabled )
-			return;
-		double delta = (time - start);
-		double rem = fmod( delta, delay );
-		double next = delay - rem;
-		start = time + next;		
-	}
-	void Stop( ) {
-		enabled = false;
-	}
-	void Start( const double& time, Bits scale ) {
-		//Don't enable again
-		if ( enabled ) {
-			return;
-		}
-		enabled = true;
-		delay = 0.001 * (256 - counter ) * scale;
-		start = time + delay;
+		//Interval in milliseconds
+		interval = micros * 0.001;
 	}
 
+	//Update returns with true if overflow
+	bool Update( double time ) {
+		if ( !enabled ) 
+			return false;
+		const double deltaTime = time - start;
+		//Only set the overflow flag when not masked
+		if (deltaTime >= delay  ) {
+			overflow = true;
+			return true;
+		}
+		return false;
+	}
+	
+	//On a reset make sure the start is in sync with the next cycle
+	void Reset(const double time ) {
+		overflow = false;
+		if ( !enabled )
+			return;
+		//Sync start to the last delay interval
+		const double deltaTime = time - start;
+		const double rem = fmod(deltaTime, delay);
+		start = time - rem;
+	}
+
+	void SetCounter(Bit8u val) {
+		counter = val;
+	}
+	
+	//Stopping always clears the overflow as well
+	void Stop( ) {
+		enabled = false;
+		overflow = false;
+	}
+	
+	//Starting clears overflow
+	void Start( const double time ) {
+		enabled = true;
+		overflow = false;
+		//The counter is basically copied on start so calculate delay now
+		delay = (256 - counter) * interval;
+		//Sync start to the last clock interval
+		double rem = fmod(time, interval);
+		start = time - rem;
+	}
+	
+	//Does this clock need an update, you could save a pic_fullindex on read?
+	bool NeedUpdate() const {
+		return enabled && !overflow;
+	}
 };
 
 struct Chip {
-	Chip() {
-		last_poll = 0;
-		poll_counter = 0;
-	}
 	//Last selected register
-	Timer timer[2];
+	Timer timer0, timer1;
 	//Check for it being a write to the timer
 	bool Write( Bit32u reg, Bit8u val );
 	//Read the current timer state, will use current double
 	Bit8u Read( );
+	
+	Chip();
 	//poll counter
-	double last_poll;
-	unsigned int poll_counter;
+	double last_poll = 0;
+	unsigned int poll_counter = 0;
 };
 
 //The type of handler this is


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/4352/
https://sourceforge.net/p/dosbox/code-0/4353/

Note that for 4352, there is some code in adlib.cpp in DOSBox-X not present in SVN that might interfere/might no longer be necessary, etc. (It necessitated a few minor changes to r4352 to get compilation working). 

```
	if (adlib_force_timer_overflow_on_polling) {
		static const double poll_timeout = 0.1; /* if polling more than 100us per second, do timeout */

		if ((time-last_poll) > poll_timeout) {
			poll_counter = 0;
		}
		else if (++poll_counter >= 50) {
//			LOG_MSG("Adlib polling hack triggered. Forcing timers to reset. Hope this helps your DOS game to detect Adlib.");

			poll_counter = 0;
			if (!timer0.overflow && timer0.enabled) {
				timer0.Stop();
				timer0.overflow = true;
			}
			if (!timer1.overflow && timer1.enabled) {
				timer1.Stop();
				timer1.overflow = true;
			}
		}

		last_poll = time;
	}
```

