### PR TITLE
Fixed command-line program handling (Issue #1675)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.83.3
+  - Fixed command-line like "./dosbox-x /dir/app.bat"
+    not able to launch the specified program (Wengier)
   - Pentium MMX instructions now only available for
     Pentium MMX or higher. Fixed the bug that allowed
     MMX instructions for Pentium and lower if programs

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 0.83.3
   - Fixed command-line like "./dosbox-x /dir/app.bat"
     not able to launch the specified program (Wengier)
+  - The default key modifier for the Windows clipboard
+    copy & paste via the right mouse button feature is
+    now "shift" instead of "disabled" (Wengier)
   - Pentium MMX instructions now only available for
     Pentium MMX or higher. Fixed the bug that allowed
     MMX instructions for Pentium and lower if programs

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,13 +1,13 @@
 0.83.3
   - Pentium MMX instructions now only available for
-    Pentium MMX or higher. A bug was fixed that allowed
+    Pentium MMX or higher. Fixed the bug that allowed
     MMX instructions for Pentium and lower if programs
-    ignored the CPUID feature bits.
-  - Fixed Pentium MMX instructions so that they work
-    in both 16-bit real mode and 32-bit protected mode
-    to match real hardware (joncampbell123)
-  - Updated the code for Pentium MMX instructions to
-    the latest version by kekko (Wengier)
+    ignored the CPUID feature bits. Also fixed Pentium
+    MMX instructions so that they work in both 16-bit
+    real mode and 32-bit protected mode to match how
+    they work in real hardware (joncampbell123)
+  - Updated DOSBox-X's implementation for Pentium MMX
+    instructions to latest version by kekko (Wengier)
   - DOSBox-X will try to automatically run the program
     with LOADFIX if the error message "Packed file is
     corrupt" is detected. (Wengier)

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -3,6 +3,8 @@ Credits
 
 Jonathan Campbell, the maintainer of DOSBox-X does not claim to have written all of the code in this project.
 
+The purpose of this document is to try and build a comprehensive list of source code in this repository that was borrowed from other projects.
+
 The base code is from the [DOSBox](https://www.dosbox.com) project in which some of the SVN commits made since 2011 were incorporated into DOSBox-X. This code had since been heavily modified by the DOSBox-X project.
 
 Some of the source code also came from similar projects such as [DOSBox Daum](http://ykhwong.x-y.net), [DOSBox ECE](https://dosboxece.yesterplay.net/), [DOSBox-staging](https://dosbox-staging.github.io/) and [vDosPlus](http://www.vdosplus.org/), with major works from contributors like Wengier, Allofich, and rderooy.
@@ -19,7 +21,7 @@ A list of features ported from DOSBox Daum:
 * Some support for FluidSynth MIDI synthesizer
 * Improved PC Speaker emulation accuracy
 * CGA with Monochrome Monitor Support
-* Support for CPU types like Pentium MMX
+* Support for CPU types like Pentium Pro
 * Features such as V-Sync, xBRZ scaler, overscan border and stereo-swap
 * Various patches such as DBCS and font patch
 
@@ -44,11 +46,11 @@ A list of features ported from vDosPlus by Wengier:
 * Support for clipboard copy and paste (Windows)
 * Several shell improvements
 
-Features such as save and load states were also ported from community contributions and have since been improved by the DOSBox-X project.
+Features such as save & load states and Pentium MMX instructions were also ported from community contributions and have since been improved by the DOSBox-X project.
 
 The DOSBox-X Wiki pages were created and updated by Wengier and rderooy. 
 
-This is an attempt to properly credit the other code and its sources below. It is not yet a complete list, and please feel free to revise and correct this list if there are errors.
+This is an attempt to properly credit the other code and its sources below. It is **not** a complete list yet, and please feel free to revise and correct this list if there are errors.
 
 NE2000 network card emulation (Bochs; LGPLv2+) src/hardware/ne2000.cpp
 

--- a/README.source-code-description
+++ b/README.source-code-description
@@ -124,8 +124,8 @@ Once vcpkg is installed and bootstrapped, open Command Prompt or PowerShell, and
 .\vcpkg integrate install
 .\vcpkg install --triplet x64-windows fluidsynth
 
-The above assumes 64-bit build. For 32-bit build please use "--triplet x86-windows"
-instead of "--triplet x64-windows".
+The above assumes Windows x64 build. For x86 build use "--triplet x86-windows" instead of
+"--triplet x64-windows". For ARM64 build please use "--triplet arm64-windows" instead.
 
 Then open ./vs2015/config.h and change "#undef C_FLUIDSYNTH" to "#define C_FLUIDSYNTH 1".
 

--- a/README.source-code-description
+++ b/README.source-code-description
@@ -112,11 +112,12 @@ For building the source code in Visual Studio 2015 or 2017,
 you may change the platform toolset to v140 or v141 respectively.
 
 Libraries such as SDL, freetype, libpdcurses, libpng and zlib are already included,
-but the FluidSynth support is not included by default for Visual Studio builds.
+but support for FluidSynth MIDI Synthesizer is not included or enabled by default
+for Visual Studio builds.
 
 You can enable FluidSynth support by setting up vcpkg to install the build dependency.
 vcpkg is a command-line package manager for C/C++ by Microsoft, and it is freely
-available from: https://github.com/microsoft/vcpkg
+available from (with install instructions): https://github.com/microsoft/vcpkg
 
 Once vcpkg is installed and bootstrapped, open Command Prompt or PowerShell, and run:
 
@@ -129,6 +130,8 @@ instead of "--triplet x64-windows".
 Then open ./vs2015/config.h and change "#undef C_FLUIDSYNTH" to "#define C_FLUIDSYNTH 1".
 
 Build the source code. FluidSynth support should now be enabled for DOSBox-X.
+Set "mididevice=fluidsynth" in the [midi] section of DOSBox-X's configuration file
+(dosbox-x.conf) along with required soundfont file (e.g. FluidR3_GM.sf2) to use it.
 
 As of 2018/06/06, VS2017 builds (32-bit and 64-bit) explicitly require
 a processor that supports the SSE instruction set.

--- a/README.source-code-description
+++ b/README.source-code-description
@@ -50,8 +50,8 @@ In Windows, the modifications also permit the emulation to run independent
 of the main window so that moving, resizing, or using menus does not cause
 emulation to pause.
 
-In Mac OS X, the modifications provide an interface to allow DOSBox-X to
-replace and manage the OS X menu bar.
+In Mac OS X (macOS), the modifications provide an interface to allow DOSBox-X
+to replace and manage the macOS menu bar.
 
 How to compile the source code (cross-platform)
 -----------------------------------------------
@@ -98,11 +98,11 @@ To create a DOSBox-X RPM for use in RHEL, CentOS or Fedora
 
 ./make-rpm.sh
 
-Compiling the source code using Visual Studio
----------------------------------------------
+Compiling the source code using Visual Studio (Windows)
+-------------------------------------------------------
 
 You can build the source code with Visual Studio (2015, 2017, 2019).
-The executables will work on 32/64-bit Windows Vista or higher.
+The executables will work on 32-bit and 64-bit Windows Vista or higher.
 
 Use the ./vs2015/dosbox-x.sln "solution" file and build the source code.
 You will need the DirectX 2010 SDK for Direct3D9 support.
@@ -115,6 +115,9 @@ Libraries such as SDL, freetype, libpdcurses, libpng and zlib are already includ
 but the FluidSynth support is not included by default for Visual Studio builds.
 
 You can enable FluidSynth support by setting up vcpkg to install the build dependency.
+vcpkg is a command-line package manager for C/C++ by Microsoft, and it is freely
+available from: https://github.com/microsoft/vcpkg
+
 Once vcpkg is installed and bootstrapped, open Command Prompt or PowerShell, and run:
 
 .\vcpkg integrate install

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -17,7 +17,7 @@
 # autolock_feedback: Autolock status feedback type, i.e. visual, auditive, none.
 #                      Possible values: none, beep, flash.
 # clip_key_modifier: Change the keyboard modifier for the Windows clipboard copy/paste function using the right mouse button.
-#                      Set to "none" if no modifier is desired. Set to "disabled" will disable this feature (default).
+#                      The default modifier is "shift". Set to "none" if no modifier is desired, or "disabled" to disable this feature.
 #                      Possible values: none, alt, lalt, ralt, ctrl, lctrl, rctrl, shift, lshift, rshift, disabled.
 #  clip_paste_speed: Set keyboard speed for pasting from the Windows clipboard.
 #                      If the default setting of 20 causes lost keystrokes, increase the number.

--- a/include/programs.h
+++ b/include/programs.h
@@ -43,7 +43,8 @@ public:
 		dos=0,		// MS-DOS style /switches
 		gnu,		// GNU style --switches or -switches, switch parsing stops at --
 		gnu_getopt,	// GNU style --long or -a -b -c -d or -abcd (short as single char), switch parsing stops at --
-		either		// both dos and gnu, switch parsing stops at --
+		either,		// Both DOS and GNU styles, switch parsing stops at --
+		either_except	// Both DOS and GNU styles, except for paths to executables
 	};
 public:
 	CommandLine(int argc,char const * const argv[],enum opt_style opt=CommandLine::either);

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -3580,7 +3580,7 @@ void DOS_Int21_7160(char *name1, char *name2) {
 									CALLBACK_SCF(false);
 								} else {
 									reg_ax=2;
-									CALLBACK_SCF(true);								
+									CALLBACK_SCF(true);
 								}
 								break;
 						case 2:         // LFN path name
@@ -3590,7 +3590,7 @@ void DOS_Int21_7160(char *name1, char *name2) {
 									CALLBACK_SCF(false);
 								} else {
 									reg_ax=2;
-									CALLBACK_SCF(true);								
+									CALLBACK_SCF(true);
 								}
 								break;
 						default:
@@ -3855,7 +3855,7 @@ void DOS_Int21_71aa(char* name1, const char* name2) {
 				CALLBACK_SCF(false);
 			} else {
 				reg_ax=3;
-				CALLBACK_SCF(true);						
+				CALLBACK_SCF(true);
 			}
 			break;
 		}

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -358,14 +358,19 @@ static bool DOS_MultiplexFunctions(void) {
 		}
 		else return false;
 	case 0x160A:
+	{
+		char psp_name[9];
+		DOS_MCB psp_mcb(dos.psp()-1);
+		psp_mcb.GetFileName(psp_name);
 		// Report Windows version 4.0 (95) to NESTICLE x.xx so that it uses LFN when available
-		if (uselfn && reg_sp == 0x220A && mem_readw(SegPhys(ss)+reg_sp) == 0x1FBB) {
+		if (uselfn && (!strcmp(psp_name, "NESTICLE") || reg_sp == 0x220A && mem_readw(SegPhys(ss)+reg_sp)/0x100 == 0x1F)) {
 			reg_ax = 0;
 			reg_bx = 0x400;
 			reg_cx = 2;
 			return true;
 		}
 		return false;
+	}
 	case 0x1680:	/*  RELEASE CURRENT VIRTUAL MACHINE TIME-SLICE */
 		//TODO Maybe do some idling but could screw up other systems :)
 		return true; //So no warning in the debugger anymore

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -525,10 +525,6 @@ Bits DOS_Drive_Cache::GetLongName(CFileInfo* curDir, char* shortName) {
     // Remove dot, if no extension...
     RemoveTrailingDot(shortName);
     // Search long name and return array number of element
-    Bits low    = 0;
-    Bits high   = (Bits)(filelist_size-1);
-    (void)low;//unused
-    (void)high;//unused
     Bits res;
 	if (strlen(shortName))
 		for (Bitu i=0; i<filelist_size; i++) {

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -2816,7 +2816,6 @@ bool Overlay_Drive::FileUnlink(const char * name) {
 	strcat(basename,name);
 	CROSS_FILENAME(basename);
 
-
 	char overlayname[CROSS_LEN];
 	strcpy(overlayname,overlaydir);
 	strcat(overlayname,name);
@@ -2838,6 +2837,7 @@ bool Overlay_Drive::FileUnlink(const char * name) {
 		}
 	}
 //	char *fullname = dirCache.GetExpandName(newname);
+
 	if (!removed&&unlink(overlayname)) {
 		//Unlink failed for some reason try finding it.
 		ht_stat_t status;
@@ -3482,8 +3482,6 @@ bool Overlay_Drive::Rename(const char * oldname,const char * newname) {
 	strcpy
 #endif
 	(host_namenew, CodePageGuestToHost(overlaynamenew));
-	bool success=false;
-	(void)success;//unused
 	if (ht_stat(host_nameold,&temp_stat)) {
 		char* temp_name = dirCache.GetExpandName(GetCrossedName(basedir,oldname));
 		if (strlen(temp_name)>strlen(basedir)&&!strncasecmp(temp_name, basedir, strlen(basedir))) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1120,13 +1120,13 @@ void CPU_Snap_Back_To_Real_Mode();
 static void KillSwitch(bool pressed) {
     if (!pressed) return;
     if (sdl.desktop.fullscreen) GFX_SwitchFullScreen();
-#if 0 /* Re-enable this hack IF DOSBox continues to have problems page-faulting on kill switch */
+#if 0 /* Re-enable this hack IF DOSBox-X continues to have problems page-faulting on kill switch */
     CPU_Snap_Back_To_Real_Mode(); /* TEMPORARY HACK. There are portions of DOSBox that write to memory as if still running DOS. */
     /* ^ Without this hack, when running Windows NT 3.1 this Kill Switch effectively becomes the Instant Page Fault BSOD switch
-     * because the DOSBox code attempting to write to real mode memory causes a page fault (though hitting the kill switch a
-     * second time shuts DOSBox down properly). It's sort of the same issue behind the INT 33h emulation causing instant BSOD
-     * in Windows NT the instant you moved or clicked the mouse. The purpose of this hack is that, before any of that DOSBox
-     * code has a chance, we force the CPU back into real mode so that the code doesn't trigger funny page faults and DOSBox
+     * because the DOSBox-X code attempting to write to real mode memory causes a page fault (though hitting the kill switch a
+     * second time shuts DOSBox-X down properly). It's sort of the same issue behind the INT 33h emulation causing instant BSOD
+     * in Windows NT the instant you moved or clicked the mouse. The purpose of this hack is that, before any of that DOSBox-X
+     * code has a chance, we force the CPU back into real mode so that the code doesn't trigger funny page faults and DOSBox-X
      * shuts down properly. */
 #endif
     warn_on_mem_write = true;
@@ -2272,7 +2272,7 @@ static bool enable_hook_everything = false;
 // Whether or not to hook the keyboard and block special keys.
 // Setting this is recommended so that your keyboard is fully usable in the guest OS when you
 // enable the mouse+keyboard capture. But hooking EVERYTHING is not recommended because there is a
-// danger you become trapped in the DOSBox emulator!
+// danger you become trapped in the DOSBox-X emulator!
 static bool enable_hook_special_keys = true;
 
 #if defined(WIN32) && !defined(HX_DOS)
@@ -2347,7 +2347,7 @@ static LRESULT CALLBACK WinExtHookKeyboardHookProc(int nCode,WPARAM wParam,LPARA
                         case VK_TAB:    // try to catch ALT+TAB too (not blocking VK_TAB will allow host OS to switch tasks)
                         case VK_ESCAPE: // try to catch CTRL+ESC as well (so Windows 95 Start Menu is accessible)
                         case VK_SPACE:  // and space (catching VK_ZOOM isn't enough to prevent Windows 10 from changing res)
-                        // these keys have no meaning to DOSBox and so we hook them by default to allow the guest OS to use them
+                        // these keys have no meaning to DOSBox-X and so we hook them by default to allow the guest OS to use them
                         case VK_BROWSER_BACK: // Browser Back key
                         case VK_BROWSER_FORWARD: // Browser Forward key
                         case VK_BROWSER_REFRESH: // Browser Refresh key
@@ -3311,7 +3311,7 @@ static void SetPriority(PRIORITY_LEVELS level) {
 #endif
     switch (level) {
 #ifdef WIN32
-    case PRIORITY_LEVEL_PAUSE:  // if DOSBox is paused, assume idle priority
+    case PRIORITY_LEVEL_PAUSE:  // if DOSBox-X is paused, assume idle priority
     case PRIORITY_LEVEL_LOWEST:
         SetPriorityClass(GetCurrentProcess(),IDLE_PRIORITY_CLASS);
         break;
@@ -3328,8 +3328,8 @@ static void SetPriority(PRIORITY_LEVELS level) {
         SetPriorityClass(GetCurrentProcess(),HIGH_PRIORITY_CLASS);
         break;
 #elif C_SET_PRIORITY
-/* Linux use group as dosbox has mulitple threads under linux */
-    case PRIORITY_LEVEL_PAUSE:  // if DOSBox is paused, assume idle priority
+/* Linux use group as dosbox-x has mulitple threads under linux */
+    case PRIORITY_LEVEL_PAUSE:  // if DOSBox-X is paused, assume idle priority
     case PRIORITY_LEVEL_LOWEST:
         setpriority (PRIO_PGRP, 0,PRIO_MAX);
         break;
@@ -3455,7 +3455,7 @@ static void GUI_StartUp() {
     else if (notfocus == "highest") { sdl.priority.nofocus=PRIORITY_LEVEL_HIGHEST; }
     else if (notfocus == "pause")   {
         /* we only check for pause here, because it makes no sense
-         * for DOSBox to be paused while it has focus
+         * for DOSBox-X to be paused while it has focus
          */
         sdl.priority.nofocus=PRIORITY_LEVEL_PAUSE;
     }
@@ -3539,7 +3539,7 @@ static void GUI_StartUp() {
         int win_h = GetSystemMetrics(SM_CYSCREEN);
         if (sdl_w != win_w && sdl_h != win_h) 
             LOG_MSG("Windows DPI/blurry apps scaling detected as it might be a large screen.\n"
-			"Please see the DOSBox-X documentation for more details.\n");
+				"Please see the DOSBox-X documentation for more details.\n");
         }
   #else
     if (!sdl.desktop.full.width || !sdl.desktop.full.height){
@@ -6522,7 +6522,7 @@ void DOSBox_ShowConsole() {
         return;
 
     /* Microsoft Windows: Allocate a console and begin spewing to it.
-       DOSBox is compiled on Windows platforms as a Win32 application, and therefore, no console. */
+       DOSBox-X is compiled on Windows platforms as a Win32 application, and therefore, no console. */
     /* FIXME: What about "file handles" 0/1/2 emulated by C library, for use with _open/_close/_lseek/etc? */
     AllocConsole();
 
@@ -9231,7 +9231,7 @@ fresh_boot:
         guest_msdos_mcb_chain = (Bit16u)(~0u);
 
         /* NTS: CPU reset handler, and BIOS init, has the instruction pointer poised to run through BIOS initialization,
-         *      which will then "boot" into the DOSBox kernel, and then the shell, by calling VM_Boot_DOSBox_Kernel() */
+         *      which will then "boot" into the DOSBox-X kernel, and then the shell, by calling VM_Boot_DOSBox_Kernel() */
         /* FIXME: throwing int() is a stupid and nondescriptive way to signal shutdown/reset. */
         try {
 #if C_DEBUG
@@ -9267,14 +9267,14 @@ fresh_boot:
                 wait_debugger = true;
                 dos_kernel_shutdown = !dos_kernel_disabled; /* only if DOS kernel enabled */
             }
-            else if (x == 8) { /* Booting to a BIOS, shutting down DOSBox BIOS */
+            else if (x == 8) { /* Booting to a BIOS, shutting down DOSBox-X BIOS */
                 LOG(LOG_MISC,LOG_DEBUG)("Emulation threw a signal to boot into BIOS image");
 
                 reboot_machine = true;
                 dos_kernel_shutdown = !dos_kernel_disabled; /* only if DOS kernel enabled */
             }
             else {
-                LOG(LOG_MISC,LOG_DEBUG)("Emulation threw DOSBox kill switch signal");
+                LOG(LOG_MISC,LOG_DEBUG)("Emulation threw DOSBox-X kill switch signal");
 
                 // kill switch (see instances of throw(0) and throw(1) elsewhere in DOSBox)
                 run_machine = false;
@@ -9320,7 +9320,7 @@ fresh_boot:
             /* disable INT 33h mouse services. it can interfere with guest OS paging and control of the mouse */
             DisableINT33();
 
-            /* unmap the DOSBox kernel private segment. if the user told us not to,
+            /* unmap the DOSBox-X kernel private segment. if the user told us not to,
              * but the segment exists below 640KB, then we must, because the guest OS
              * will trample it and assume control of that region of RAM. */
             if (!keep_private_area_on_boot || reboot_machine)
@@ -9334,7 +9334,7 @@ fresh_boot:
                 real_writed(0,0x03*4,(Bit32u)BIOS_DEFAULT_HANDLER_LOCATION);
             }
 
-            /* shutdown DOSBox's virtual drive Z */
+            /* shutdown DOSBox-X's virtual drive Z */
             VFILE_Shutdown();
 
             /* shutdown the programs */

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -6557,6 +6557,7 @@ bool DOSBOX_parse_argv() {
     assert(control != NULL);
     assert(control->cmdline != NULL);
 
+	control->cmdline->ChangeOptStyle(CommandLine::either_except);
     control->cmdline->BeginOpt(true/*eat argv*/);
     while (control->cmdline->GetOpt(optname)) {
         std::transform(optname.begin(), optname.end(), optname.begin(), ::tolower);
@@ -6582,6 +6583,7 @@ bool DOSBOX_parse_argv() {
             fprintf(stderr,"\ndosbox-x [options]\n");
             fprintf(stderr,"\nDOSBox-X version %s %s, copyright 2011-2020 joncampbell123.\n",VERSION,SDL_STRING);
             fprintf(stderr,"Based on DOSBox by the DOSBox Team (See AUTHORS file)\n\n");
+            fprintf(stderr,"Options can be started with either \"-\" or \"/\" (e.g. \"-help\" or \"/help\"):\n\n");
             fprintf(stderr,"  -?, -h, -help                           Show this help\n");
             fprintf(stderr,"  -editconf                               Launch editor\n");
             fprintf(stderr,"  -opencaptures <param>                   Launch captures\n");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -6169,10 +6169,10 @@ void SDL_SetupConfigSection() {
     Pstring->Set_values(feeds);
 
 	const char* clipboardmodifier[] = { "none", "alt", "lalt", "ralt", "ctrl", "lctrl", "rctrl", "shift", "lshift", "rshift", "disabled", 0};
-	Pstring = sdl_sec->Add_string("clip_key_modifier",Property::Changeable::Always, "disabled");
+	Pstring = sdl_sec->Add_string("clip_key_modifier",Property::Changeable::Always, "shift");
 	Pstring->Set_values(clipboardmodifier);
 	Pstring->Set_help("Change the keyboard modifier for the Windows clipboard copy/paste function using the right mouse button.\n"
-		"Set to \"none\" if no modifier is desired. Set to \"disabled\" will disable this feature (default).");
+		"The default modifier is \"shift\". Set to \"none\" if no modifier is desired, or \"disabled\" to disable this feature.");
 
     Pint = sdl_sec->Add_int("clip_paste_speed", Property::Changeable::WhenIdle, 20);
     Pint->Set_help("Set keyboard speed for pasting from the Windows clipboard.\n"

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3538,8 +3538,8 @@ static void GUI_StartUp() {
         int win_w = GetSystemMetrics(SM_CXSCREEN);
         int win_h = GetSystemMetrics(SM_CYSCREEN);
         if (sdl_w != win_w && sdl_h != win_h) 
-            LOG_MSG("Windows dpi/blurry apps scaling detected! The screen might be too large or not show properly,\n"
-                "please see the DOSBox Manual/README for details.\n");
+            LOG_MSG("Windows DPI/blurry apps scaling detected as it might be a large screen.\n"
+			"Please see the DOSBox-X documentation for more details.\n");
         }
   #else
     if (!sdl.desktop.full.width || !sdl.desktop.full.height){

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1320,14 +1320,21 @@ bool CommandLine::GetOpt(std::string &name) {
         std::string &argv = *opt_scan;
         const char *str = argv.c_str();
 
-        if ((opt_style == CommandLine::either || opt_style == CommandLine::dos) && *str == '/') {
+        if (opt_style == CommandLine::either_except && *str == '/' && (strlen(str)<6 || (strlen(str)>5 && strcasecmp(str+strlen(str)-4, ".bat") && strcasecmp(str+strlen(str)-4, ".com") && strcasecmp(str+strlen(str)-4, ".exe")))) {
+            /* MS-DOS style /option, with the exception of ending with .BAT, .COM, .EXE */
+            name = str+1; /* copy to caller minus leaking slash, then erase/skip */
+            if (opt_eat_argv) opt_scan = cmds.erase(opt_scan);
+            else ++opt_scan;
+            return true;
+        }
+        else if ((opt_style == CommandLine::either || opt_style == CommandLine::dos) && *str == '/') {
             /* MS-DOS style /option. Example: /A /OPT /HAX /BLAH */
             name = str+1; /* copy to caller minus leaking slash, then erase/skip */
             if (opt_eat_argv) opt_scan = cmds.erase(opt_scan);
             else ++opt_scan;
             return true;
         }
-        else if ((opt_style == CommandLine::either || opt_style == CommandLine::gnu || opt_style == CommandLine::gnu_getopt) && *str == '-') {
+        else if ((opt_style == CommandLine::either || opt_style == CommandLine::either_except || opt_style == CommandLine::gnu || opt_style == CommandLine::gnu_getopt) && *str == '-') {
             str++; /* step past '-' */
             if (str[0] == '-' && str[1] == 0) { /* '--' means to stop parsing */
                 opt_scan = cmds.end();

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -652,15 +652,13 @@ public:
 					if (batpath==".\\") batpath=".";
 					else if (batpath=="..\\") batpath="..";
 					batname = control->auto_bat_additional[i].substr(pos+1);
-					cmd += "@mount c: " + batpath + " -q\n";
+					cmd += "@mount c: \"" + batpath + "\" -q\n";
 				}
 				cmd += "@c:\n";
 				cmd += "@cd \\\n";
-                /* NTS: "CALL" does not support quoting the filename.
-                 *      This will break if the batch file name has spaces in it. */
-                cmd += "@CALL ";
+                cmd += "@CALL \"";
                 cmd += batname;
-                cmd += "\n";
+                cmd += "\"\n";
 				cmd += "@mount -u c: -q\n";
             }
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -641,12 +641,16 @@ public:
             for (unsigned int i=0;i<control->auto_bat_additional.size();i++) {
 				std::string batname;
 				/* NTS: this code might have problems with DBCS filenames - yksoft1 */
-				size_t pos = control->auto_bat_additional[i].find_last_of(CROSS_FILESPLIT);
+
+				std::replace(control->auto_bat_additional[i].begin(),control->auto_bat_additional[i].end(),'/','\\');
+				size_t pos = control->auto_bat_additional[i].find_last_of('\\');
 				if(pos == std::string::npos) {  //Only a filename, mount current directory
 					batname = control->auto_bat_additional[i];
 					cmd += "@mount c: . -q\n";
 				} else { //Parse the path of .BAT file
 					std::string batpath = control->auto_bat_additional[i].substr(0,pos+1);
+					if (batpath==".\\") batpath=".";
+					else if (batpath=="..\\") batpath="..";
 					batname = control->auto_bat_additional[i].substr(pos+1);
 					cmd += "@mount c: " + batpath + " -q\n";
 				}


### PR DESCRIPTION
As noticed in Issue #1675, there are some bugs in DOSBox-X's command-line parameter handling which cause command-line like "./dosbox-x /dir/app.bat" to not work as expected. Thus I fixed the issues so that such an argument should now work in both Windows and Linux.

Also slightly updated the documentation to mention the parameter "--triplet arm64-windows" when using vcpkg to install library for ARM64 build.