### PR TITLE
Make it appear FAT32 volumes where formatted by Win98

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2823,7 +2823,11 @@ restart_int:
                 sbuf[0]=0xEB; sbuf[1]=0x3c; sbuf[2]=0x90;
             }
             // OEM
-            sprintf((char*)&sbuf[0x03],"MSDOS5.0");
+            if (FAT >= 32) {
+                sprintf((char*)&sbuf[0x03],"MSWIN4.1");
+            } else {
+                sprintf((char*)&sbuf[0x03],"MSDOS5.0");
+            }
             // bytes per sector: always 512
             host_writew(&sbuf[0x0b],512);
             // sectors per cluster: 1,2,4,8,16,...


### PR DESCRIPTION
which makes more sense than MSDOS5.0

This also seems to be recommended by MS:
https://www.win.tue.nl/~aeb/linux/fs/fat/fat-1.html

**Does this PR address some issue(s) ?**
https://github.com/joncampbell123/dosbox-x/issues/1553
