### PR TITLE
Fix make install on Mac and BSD

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -69,17 +69,17 @@ compat-site-update:
 	(cd ../dosbox-x-gh-pages && git commit -m 'more' {msdos,demoscene}-compat.html)
 
 install: src/dosbox-x
-	install -d $(DESTDIR)$(bindir)
+	mkdir -p $(DESTDIR)$(bindir)
 	install -m 755 src/dosbox-x $(DESTDIR)$(bindir)
-	install -d $(DESTDIR)$(prefix)/share/dosbox-x
+	mkdir -p $(DESTDIR)$(prefix)/share/dosbox-x
 	install -m 644 CHANGELOG $(DESTDIR)$(prefix)/share/dosbox-x
 	install -m 644 font/FREECG98.BMP $(DESTDIR)$(prefix)/share/dosbox-x
 	install -m 644 dosbox-x.reference.conf $(DESTDIR)$(prefix)/share/dosbox-x
-	install -d $(DESTDIR)$(prefix)/share/icons/hicolor/48x48/apps
+	mkdir -p $(DESTDIR)$(prefix)/share/icons/hicolor/48x48/apps
 	install -m 644 src/dosbox.png $(DESTDIR)$(prefix)/share/icons/hicolor/48x48/apps/dosbox-x.png
-	install -d $(DESTDIR)$(prefix)/share/applications
+	mkdir -p $(DESTDIR)$(prefix)/share/applications
 	install -m 644 dosbox-x.desktop $(DESTDIR)$(prefix)/share/applications
-	install -d $(DESTDIR)$(prefix)/share/metainfo
+	mkdir -p $(DESTDIR)$(prefix)/share/metainfo
 	install -m 644 dosbox-x.appdata.xml $(DESTDIR)$(prefix)/share/metainfo
 	-test -x /usr/sbin/setcap && setcap cap_net_raw=ep $(DESTDIR)$(bindir)/dosbox-x
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -69,13 +69,13 @@ compat-site-update:
 	(cd ../dosbox-x-gh-pages && git commit -m 'more' {msdos,demoscene}-compat.html)
 
 install: src/dosbox-x
-	install -D -d $(DESTDIR)$(bindir)
+	install -d $(DESTDIR)$(bindir)
 	install -m 755 src/dosbox-x $(DESTDIR)$(bindir)
-	install -D -d $(DESTDIR)$(prefix)/share/dosbox-x
+	install -d $(DESTDIR)$(prefix)/share/dosbox-x
 	install -m 644 CHANGELOG $(DESTDIR)$(prefix)/share/dosbox-x
 	install -m 644 font/FREECG98.BMP $(DESTDIR)$(prefix)/share/dosbox-x
 	install -m 644 dosbox-x.reference.conf $(DESTDIR)$(prefix)/share/dosbox-x
-	install -D -d $(DESTDIR)$(prefix)/share/icons/hicolor/48x48/apps
+	install -d $(DESTDIR)$(prefix)/share/icons/hicolor/48x48/apps
 	install -m 644 src/dosbox.png $(DESTDIR)$(prefix)/share/icons/hicolor/48x48/apps/dosbox-x.png
 	install -d $(DESTDIR)$(prefix)/share/applications
 	install -m 644 dosbox-x.desktop $(DESTDIR)$(prefix)/share/applications


### PR DESCRIPTION
# Description

Replaced `install -D -d` and `install -d` with `mkdir -p`

`-D` flag is not portable to non-GNU systems

**Does this PR address some issue(s) ?**

N/A


**Does this PR introduce new feature(s) ?**

N/A


**Are there any breaking changes ?**

N/A


**Additional information**

`-p` flag is to recursively create parent directories if they do not exist
