### PR TITLE
Improvements to IMGMAKE command

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,8 +4,9 @@
     and paste via the right mouse button without any
     key modifier that may have been specified by the
     config option "clip_key_modifier". (Wengier)
-  - Fixed mounting disk images with spaces via the
-    "Drive" menu. (Wengier)
+  - Fixed mounting a directory with command-line like
+    "dosbox-x .", and fixed mounting disk images with
+    spaces via the "Drive" menu on Windows. (Wengier)
   - IMGMAKE warning replaced to indicate a general
     incompatibility between MS-DOS/SCANDISK and
     cluster sizes 64KB or larger.

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -561,7 +561,7 @@ public:
         WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_1"));
         WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_FORMAT"),"Drive","Type","Label");
         for(int p = 0;p < 8;p++) WriteOut("----------");
-
+        bool none=true;
         for (int d = 0;d < DOS_DRIVES;d++) {
             if (!Drives[d]) continue;
 
@@ -579,8 +579,10 @@ public:
             }
 
             root[1] = 0; //This way, the format string can be reused.
-            WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_FORMAT"),root, Drives[d]->GetInfo(),name);       
+            WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_FORMAT"),root, Drives[d]->GetInfo(),name);
+            none=false;
         }
+        if (none) WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_NONE"));
         dos.dta(save_dta);
     }
 
@@ -3586,7 +3588,7 @@ public:
         WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_1"));
         WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_FORMAT"),"Drive","Type","Label");
         for(int p = 0;p < 8;p++) WriteOut("----------");
-
+        bool none=true;
         for (int d = 0;d < DOS_DRIVES;d++) {
             if (!Drives[d] || (strncmp(Drives[d]->GetInfo(), "fatDrive ", 9) && strncmp(Drives[d]->GetInfo(), "isoDrive ", 9))) continue;
             char root[7] = {(char)('A'+d),':','\\','*','.','*',0};
@@ -3604,13 +3606,20 @@ public:
 
             root[1] = 0; //This way, the format string can be reused.
             WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_FORMAT"),root, Drives[d]->GetInfo(),name);       
+            none=false;
         }
+        if (none) WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_NONE"));
 		WriteOut("\n");
 		WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_2"));
 		WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_NUMBER_FORMAT"),"Drive number","Disk name");
         for(int p = 0;p < 8;p++) WriteOut("----------");
+        none=true;
 		for (int index = 0; index < MAX_DISK_IMAGES; index++)
-			if (imageDiskList[index]) WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_NUMBER_FORMAT"), std::to_string(index).c_str(), imageDiskList[index]->diskname.c_str());
+			if (imageDiskList[index]) {
+                WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_NUMBER_FORMAT"), std::to_string(index).c_str(), imageDiskList[index]->diskname.c_str());
+                none=false;
+            }
+        if (none) WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_NONE"));
         dos.dta(save_dta);
     }
     void Run(void) {
@@ -5651,6 +5660,7 @@ void DOS_SetupPrograms(void) {
     MSG_Add("PROGRAM_MOUNT_STATUS_1","The currently mounted drives are:\n");
     MSG_Add("PROGRAM_IMGMOUNT_STATUS_2","The currently mounted drive numbers are:\n");
     MSG_Add("PROGRAM_IMGMOUNT_STATUS_1","The currently mounted FAT/ISO drives are:\n");
+    MSG_Add("PROGRAM_IMGMOUNT_STATUS_NONE","No drive available\n");
     MSG_Add("PROGRAM_MOUNT_ERROR_1","Directory %s doesn't exist.\n");
     MSG_Add("PROGRAM_MOUNT_ERROR_2","%s is not a directory\n");
     MSG_Add("PROGRAM_MOUNT_ILL_TYPE","Illegal type %s\n");
@@ -5661,12 +5671,12 @@ void DOS_SetupPrograms(void) {
         "For example: MOUNT c %s\n"
         "This makes the directory %s act as the C: drive inside DOSBox-X.\n"
         "The directory has to exist in the host system.\n\n"
-		"Options are accepted. For example:\n"
-		"MOUNT -nocachedir c %s mounts C: without caching the drive.\n"
-		"MOUNT -freesize 128 c %s mounts C: with the specified free disk space.\n"
-		"MOUNT -ro c %s mounts the C: drive in read-only mode.\n"
-		"MOUNT -t cdrom c %s mounts the C: drive as a CD-ROM drive.\n"
-		"MOUNT -u c unmounts the C: drive.\n\n"
+		"Options are accepted. For example:\n\n"
+		"\033[32;1mMOUNT -nocachedir c %s \033[0m  mounts C: without caching the drive.\n"
+		"\033[32;1mMOUNT -freesize 128 c %s \033[0mmounts C: with the specified free disk space.\n"
+		"\033[32;1mMOUNT -ro c %s \033[0m          mounts the C: drive in read-only mode.\n"
+		"\033[32;1mMOUNT -t cdrom c %s \033[0m     mounts the C: drive as a CD-ROM drive.\n"
+		"\033[32;1mMOUNT -u c \033[0m                       unmounts the C: drive.\n\n"
 		"Type MOUNT with no parameters to display a list of mounted drives.\n");
     MSG_Add("PROGRAM_MOUNT_UMOUNT_NOT_MOUNTED","Drive %c is not mounted.\n");
     MSG_Add("PROGRAM_MOUNT_UMOUNT_SUCCESS","Drive %c has successfully been removed.\n");
@@ -5693,10 +5703,10 @@ void DOS_SetupPrograms(void) {
         "  {program}   Runs the specified program\n"
         "  {options}   Program options (if any)\n\n"
         "Examples:\n"
-        "  LOADFIX game.exe     Allocates 64KB of conventional memory and runs game.exe\n"
-        "  LOADFIX -128         Allocates 128KB of conventional memory\n"
-        "  LOADFIX -xms         Allocates 1MB of XMS memory\n"
-        "  LOADFIX -f           Frees allocated conventional memory\n");
+        "  \033[32;1mLOADFIX game.exe\033[34;1m     Allocates 64KB of conventional memory and runs game.exe\n"
+        "  \033[32;1mLOADFIX -128\033[34;1m         Allocates 128KB of conventional memory\n"
+        "  \033[32;1mLOADFIX -xms\033[34;1m         Allocates 1MB of XMS memory\n"
+        "  \033[32;1mLOADFIX -f\033[34;1m           Frees allocated conventional memory\n");
 
     MSG_Add("MSCDEX_SUCCESS","MSCDEX installed.\n");
     MSG_Add("MSCDEX_ERROR_MULTIPLE_CDROMS","MSCDEX: Failure: Drive-letters of multiple CD-ROM drives have to be continuous.\n");
@@ -6032,15 +6042,15 @@ void DOS_SetupPrograms(void) {
         );
     MSG_Add("PROGRAM_IMGMAKE_EXAMPLE",
         "Some usage examples of IMGMAKE:\n\n"
-        "  \033[34;1mimgmake c:\\image.img -t fd_1440\033[0m          - create a 1.44MB floppy image\n"
-        "  \033[34;1mimgmake c:\\image.img -t hd -size 100\033[0m     - create a 100MB hdd image\n"
-        "  \033[34;1mimgmake c:\\image.img -t hd_520 -nofs\033[0m     - create a 520MB blank hdd image\n"
-        "  \033[34;1mimgmake c:\\image.img -t hd_2gig -fat 32\033[0m  - create a 2GB FAT32 hdd image\n"
-        "  \033[34;1mimgmake c:\\image.img -t hd -chs 130,2,17\033[0m - create a special hdd image\n"
+        "  \033[32;1mIMGMAKE c:\\image.img -t fd_1440\033[0m          - create a 1.44MB floppy image\n"
+        "  \033[32;1mIMGMAKE c:\\image.img -t hd -size 100\033[0m     - create a 100MB hdd image\n"
+        "  \033[32;1mIMGMAKE c:\\image.img -t hd_520 -nofs\033[0m     - create a 520MB blank hdd image\n"
+        "  \033[32;1mIMGMAKE c:\\image.img -t hd_2gig -fat 32\033[0m  - create a 2GB FAT32 hdd image\n"
+        "  \033[32;1mIMGMAKE c:\\image.img -t hd -chs 130,2,17\033[0m - create a special hdd image\n"
 #ifdef WIN32
-        "  \033[34;1mimgmake c:\\image.img -source a\033[0m           - read image from physical drive A\n"
+        "  \033[32;1mIMGMAKE c:\\image.img -source a\033[0m           - read image from physical drive A\n"
 #endif
-        "  \033[34;1mimgmake -t fd_2880 -force\033[0m           - force to create a 2.88MB floppy image\n"
+        "  \033[32;1mIMGMAKE -t fd_2880 -force\033[0m           - force to create a 2.88MB floppy image\n"
         );
 
 #ifdef WIN32
@@ -6058,12 +6068,12 @@ void DOS_SetupPrograms(void) {
     MSG_Add("PROGRAM_KEYB_INFO","Codepage %i has been loaded\n");
     MSG_Add("PROGRAM_KEYB_INFO_LAYOUT","Codepage %i has been loaded for layout %s\n");
     MSG_Add("PROGRAM_KEYB_SHOWHELP","Configures a keyboard for a specific language.\n\n"
-        "\033[32;1mKEYB\033[0m [keyboard layout ID[ codepage number[ codepage file]]]\n\n"
+        "KEYB [keyboard layout ID [codepage number [codepage file]]]\n\n"
         "Some examples:\n"
-        "  \033[32;1mKEYB\033[0m: Display currently loaded codepage.\n"
-        "  \033[32;1mKEYB\033[0m sp: Load the spanish (SP) layout, use an appropriate codepage.\n"
-        "  \033[32;1mKEYB\033[0m sp 850: Load the spanish (SP) layout, use codepage 850.\n"
-        "  \033[32;1mKEYB\033[0m sp 850 mycp.cpi: Same as above, but use file mycp.cpi.\n");
+        "  \033[32;1mKEYB\033[0m          Display currently loaded codepage.\n"
+        "  \033[32;1mKEYB sp\033[0m       Load the Spanish (SP) layout, use an appropriate codepage.\n"
+        "  \033[32;1mKEYB sp 850\033[0m   Load the Spanish (SP) layout, use codepage 850.\n"
+        "  \033[32;1mKEYB sp 850 mycp.cpi\033[0m Same as above, but use file mycp.cpi.\n");
     MSG_Add("PROGRAM_KEYB_NOERROR","Keyboard layout %s loaded for codepage %i\n");
     MSG_Add("PROGRAM_KEYB_FILENOTFOUND","Keyboard file %s not found\n\n");
     MSG_Add("PROGRAM_KEYB_INVALIDFILE","Keyboard file %s invalid\n");

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -489,7 +489,9 @@ search:
 		temp_str[0]=drive;
 		temp_str[1]=' ';
 		strcat(mountstring,temp_str);
+		strcat(mountstring,"\"");
 		strcat(mountstring,path);
+		strcat(mountstring,"\"");
 		if (boot) strcat(mountstring," -U");
 		strcat(mountstring," >nul");
 		DOS_Shell temp;
@@ -2655,7 +2657,7 @@ restart_int:
             WriteOut(MSG_Get("PROGRAM_IMGMAKE_CANNOT_WRITE"),temp_line.c_str());
             return;
         }
-#if defined (_MSC_VER) and (_MSC_VER >= 1400)
+#if defined (_MSC_VER) && (_MSC_VER >= 1400)
         if(fseeko64(f,(__int64)(size - 1ull),SEEK_SET)) {
 #else
         if(fseeko64(f,static_cast<off_t>(size - 1ull),SEEK_SET)) {

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2467,7 +2467,10 @@ restart_int:
             path.c_str(),filename.c_str(),dpath.c_str());
         return;
 */
-            
+
+        bool ForceOverwrite = false;
+        if (cmd->FindExist("-force",true))
+            ForceOverwrite = true;
 #ifdef WIN32
         // read from real floppy?
         if(cmd->FindString("-source",src,true)) {
@@ -2483,9 +2486,6 @@ restart_int:
                 return;
             }
 
-            bool ForceOverwrite = false;
-            if (cmd->FindExist("-force",true))
-                ForceOverwrite = true;
             /* temp_line is the given filename */
             if (!(cmd->FindCommand(1, temp_line)))
                 temp_line = "IMGMAKE.IMG";
@@ -2633,9 +2633,6 @@ restart_int:
         /* beyond this point clamp c */
         if (c > 1023) c = 1023;
 
-        bool ForceOverwrite = false;
-        if (cmd->FindExist("-force",true))
-            ForceOverwrite = true;
         /* temp_line is the given filename */
         if (!(cmd->FindCommand(1, temp_line)))
             temp_line = "IMGMAKE.IMG";

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2491,13 +2491,13 @@ restart_int:
                 temp_line = "IMGMAKE.IMG";
 
             FILE* f = fopen(temp_line.c_str(),"r");
-            if (f && !ForceOverwrite){
+            if (f){
                 fclose(f);
-                WriteOut(MSG_Get("PROGRAM_IMGMAKE_FILE_EXISTS"),temp_line.c_str());
-                return;
+                if (!ForceOverwrite) {
+                    WriteOut(MSG_Get("PROGRAM_IMGMAKE_FILE_EXISTS"),temp_line.c_str());
+                    return;
+                }
             }
-            if (ForceOverwrite)
-                fclose(f);
             f = fopen(temp_line.c_str(),"wb+");
             if (!f) {
                 WriteOut(MSG_Get("PROGRAM_IMGMAKE_CANNOT_WRITE"),temp_line.c_str());
@@ -2641,10 +2641,12 @@ restart_int:
             temp_line = "IMGMAKE.IMG";
 
         FILE* f = fopen(temp_line.c_str(),"r");
-        if (f && !ForceOverwrite){
+        if (f){
             fclose(f);
-            WriteOut(MSG_Get("PROGRAM_IMGMAKE_FILE_EXISTS"),temp_line.c_str());
-            return;
+            if (!ForceOverwrite) {
+                WriteOut(MSG_Get("PROGRAM_IMGMAKE_FILE_EXISTS"),temp_line.c_str());
+                return;
+            }
         }
 
         WriteOut(MSG_Get("PROGRAM_IMGMAKE_PRINT_CHS"),temp_line.c_str(),c,h,s);
@@ -2654,8 +2656,6 @@ restart_int:
         sectors = (unsigned int)(size / 512);
 
         // create the image file
-        if (ForceOverwrite)
-            fclose(f);
         f = fopen64(temp_line.c_str(),"wb+");
         if (!f) {
             WriteOut(MSG_Get("PROGRAM_IMGMAKE_CANNOT_WRITE"),temp_line.c_str());

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -5459,28 +5459,18 @@ void AUTOTYPE::PrintUsage()
 {
 	constexpr const char *msg =
 	        "Performs scripted keyboard entry into a running DOS program.\n\n"
-			"\033[32;1mAUTOTYPE\033[0m [-list] [-w WAIT] [-p PACE] "
-	        "button_1 [button_2 [...]] \n\n"
+	        "AUTOTYPE [-list] [-w WAIT] [-p PACE] button_1 [button_2 [...]]\n\n"
 	        "Where:\n"
 	        "  -list:   prints all available button names.\n"
-	        "  -w WAIT: seconds before typing begins. Two second default; "
-	        "max of 30.\n"
-	        "  -p PACE: seconds between each keystroke. Half-second "
-	        "default; max of 10.\n"
-	        "\n"
-	        "  The sequence is comprised of one or more space-separated "
-	        "buttons.\n"
-	        "  Autotyping begins after WAIT seconds, and each button is "
-	        "entered \n"
-	        "  every PACE seconds. The , character inserts an extra PACE "
-	        "delay.\n"
-	        "\n"
+	        "  -w WAIT: seconds before typing begins. Two second default; max of 30.\n"
+	        "  -p PACE: seconds between each keystroke. Half-second default; max of 10.\n\n"
+	        "  The sequence is comprised of one or more space-separated buttons.\n"
+	        "  Autotyping begins after WAIT seconds, and each button is entered\n"
+	        "  every PACE seconds. The , character inserts an extra PACE delay.\n\n"
 	        "Some examples:\n"
-	        "  \033[32;1mAUTOTYPE\033[0m -w 1 -p 0.3 up enter , right "
-	        "enter\n"
-	        "  \033[32;1mAUTOTYPE\033[0m -p 0.2 f1 kp_8 , , enter\n"
-	        "  \033[32;1mAUTOTYPE\033[0m -w 1.3 esc enter , p l a y e r "
-	        "enter\n";
+	        "  \033[32;1mAUTOTYPE -w 1 -p 0.3 up enter , right enter\033[0m\n"
+	        "  \033[32;1mAUTOTYPE -p 0.2 f1 kp_8 , , enter\033[0m\n"
+	        "  \033[32;1mAUTOTYPE -w 1.3 esc enter , p l a y e r enter\033[0m\n";
 	WriteOut_NoParsing(msg);
 }
 
@@ -5703,10 +5693,10 @@ void DOS_SetupPrograms(void) {
         "  {program}   Runs the specified program\n"
         "  {options}   Program options (if any)\n\n"
         "Examples:\n"
-        "  \033[32;1mLOADFIX game.exe\033[34;1m     Allocates 64KB of conventional memory and runs game.exe\n"
-        "  \033[32;1mLOADFIX -128\033[34;1m         Allocates 128KB of conventional memory\n"
-        "  \033[32;1mLOADFIX -xms\033[34;1m         Allocates 1MB of XMS memory\n"
-        "  \033[32;1mLOADFIX -f\033[34;1m           Frees allocated conventional memory\n");
+        "  \033[32;1mLOADFIX game.exe\033[0m     Allocates 64KB of conventional memory and runs game.exe\n"
+        "  \033[32;1mLOADFIX -128\033[0m         Allocates 128KB of conventional memory\n"
+        "  \033[32;1mLOADFIX -xms\033[0m         Allocates 1MB of XMS memory\n"
+        "  \033[32;1mLOADFIX -f\033[0m           Frees allocated conventional memory\n");
 
     MSG_Add("MSCDEX_SUCCESS","MSCDEX installed.\n");
     MSG_Add("MSCDEX_ERROR_MULTIPLE_CDROMS","MSCDEX: Failure: Drive-letters of multiple CD-ROM drives have to be continuous.\n");

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -1117,12 +1117,13 @@ private:
 
 		// - pure data
 		WRITE_POD( &render.src, render.src );
-
 		WRITE_POD( &render.pal, render.pal );
 		WRITE_POD( &render.updating, render.updating );
 		WRITE_POD( &render.active, render.active );
 		WRITE_POD( &render.fullFrame, render.fullFrame );
 		WRITE_POD( &render.frameskip, render.frameskip );
+		WRITE_POD( &render.aspect, render.aspect );
+		WRITE_POD( &render.scale, render.scale );
 	}
 
 	virtual void setBytes(std::istream& stream)
@@ -1132,12 +1133,13 @@ private:
 
 		// - pure data
 		READ_POD( &render.src, render.src );
-
 		READ_POD( &render.pal, render.pal );
 		READ_POD( &render.updating, render.updating );
 		READ_POD( &render.active, render.active );
 		READ_POD( &render.fullFrame, render.fullFrame );
 		READ_POD( &render.frameskip, render.frameskip );
+		READ_POD( &render.aspect, render.aspect );
+		READ_POD( &render.scale, render.scale );
 
 		//***************************************
 		//***************************************
@@ -1145,11 +1147,12 @@ private:
 		// reset screen
 		//memset( &render.frameskip, 0, sizeof(render.frameskip) );
 
-		render.scale.clearCache = true;
-		if( render.scale.outWrite ) { GFX_EndUpdate(NULL); }
-
-		RENDER_SetSize( render.src.width, render.src.height, render.src.bpp, render.src.fps, render.src.ratio );
-
+		if (render.aspect==ASPECT_FALSE) {
+			render.scale.clearCache = true;
+			if( render.scale.outWrite ) { GFX_EndUpdate(NULL); }
+			RENDER_SetSize( render.src.width, render.src.height, render.src.bpp, render.src.fps, render.src.ratio );
+		} else
+			GFX_ResetScreen();
 	}
 } dummy;
 }

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -2563,7 +2563,7 @@ void DOS_Shell::CMD_SUBST(char * args) {
 			WriteOut(MSG_Get("SHELL_CMD_SUBST_DRIVE_LIST"));
 			WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_FORMAT"),"Drive","Type","Label");
 			for(int p = 0;p < 8;p++) WriteOut("----------");
-
+			bool none=true;
 			for (int d = 0;d < DOS_DRIVES;d++) {
 				if (!Drives[d]||strncmp(Drives[d]->GetInfo(),"local ",6)) continue;
 
@@ -2581,8 +2581,10 @@ void DOS_Shell::CMD_SUBST(char * args) {
 				}
 
 				root[1] = 0; //This way, the format string can be reused.
-				WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_FORMAT"),root, Drives[d]->GetInfo(),name);       
+				WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_FORMAT"),root, Drives[d]->GetInfo(),name);
+                none=false;
 			}
+            if (none) WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_NONE"));
 			dos.dta(save_dta);
 			return;
 		}


### PR DESCRIPTION
The IMGMAKE command will show an error if you try to create a disk image file which already exists. I noticed that there is a -force option in DOSBox Optionals to overwrite the existing disk image file even if it already exists. I believe this is a useful addition so I added this to DOSBox-X too. Also, IMGMAKE will now use the default image file name "IMGMAKE.IMG" if no image file name is specified. In addition, I made some improvements to the help message for this command.