### PR TITLE
Support SHELL= in [config] with built-in 4DOS 8.00 command shell as alternative shell

### DIFF
--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1886,6 +1886,9 @@ cd-rom spinup time      = 0
 cd-rom spindown timeout = 0
 cd-rom insertion delay  = 0
 
+[4dos]
+rem = This section is the 4DOS.INI file, if you use 4DOS as the command shell
+
 [config]
 #       rem: Records comments (remarks).
 #     break: Sets or clears extended CTRL+C checking.

--- a/include/builtin.h
+++ b/include/builtin.h
@@ -1,5 +1,6 @@
 
 #include "dos_inc.h"
+#include "../src/builtin/4DOS_img.h"
 
 extern struct BuiltinFileBlob bfb_DSXMENU_EXE_PC;		// DSXMENU.EXE
 extern struct BuiltinFileBlob bfb_DSXMENU_EXE_PC98;		// DSXMENU.EXE
@@ -29,4 +30,7 @@ extern struct BuiltinFileBlob bfb_50_COM;		// 50.COM
 extern struct BuiltinFileBlob bfb_25_COM;		// 25.COM
 extern struct BuiltinFileBlob bfb_25_COM_ega;	// 25.COM
 extern struct BuiltinFileBlob bfb_25_COM_other;	// 25.COM
+extern struct BuiltinFileBlob bfb_4DOS_COM;     // 4DOS.COM
+extern struct BuiltinFileBlob bfb_4DOS_HLP;     // 4DOS.HLP
+extern struct BuiltinFileBlob bfb_4HELP_EXE;     // 4HELP.EXE
 

--- a/include/shell.h
+++ b/include/shell.h
@@ -318,6 +318,7 @@ public:
 	bool echo;
 	bool exit;
 	bool call;
+    bool perm;
 	bool lfnfor;
     /* Status */
     bool input_eof;                     //! STDIN has hit EOF

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -561,7 +561,7 @@ public:
         WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_1"));
         WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_FORMAT"),"Drive","Type","Label");
         for(int p = 0;p < 8;p++) WriteOut("----------");
-
+        bool none=true;
         for (int d = 0;d < DOS_DRIVES;d++) {
             if (!Drives[d]) continue;
 
@@ -579,8 +579,10 @@ public:
             }
 
             root[1] = 0; //This way, the format string can be reused.
-            WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_FORMAT"),root, Drives[d]->GetInfo(),name);       
+            WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_FORMAT"),root, Drives[d]->GetInfo(),name);
+            none=false;
         }
+        if (none) WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_NONE"));
         dos.dta(save_dta);
     }
 
@@ -3586,7 +3588,7 @@ public:
         WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_1"));
         WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_FORMAT"),"Drive","Type","Label");
         for(int p = 0;p < 8;p++) WriteOut("----------");
-
+        bool none=true;
         for (int d = 0;d < DOS_DRIVES;d++) {
             if (!Drives[d] || (strncmp(Drives[d]->GetInfo(), "fatDrive ", 9) && strncmp(Drives[d]->GetInfo(), "isoDrive ", 9))) continue;
             char root[7] = {(char)('A'+d),':','\\','*','.','*',0};
@@ -3604,13 +3606,20 @@ public:
 
             root[1] = 0; //This way, the format string can be reused.
             WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_FORMAT"),root, Drives[d]->GetInfo(),name);       
+            none=false;
         }
+        if (none) WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_NONE"));
 		WriteOut("\n");
 		WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_2"));
 		WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_NUMBER_FORMAT"),"Drive number","Disk name");
         for(int p = 0;p < 8;p++) WriteOut("----------");
+        none=true;
 		for (int index = 0; index < MAX_DISK_IMAGES; index++)
-			if (imageDiskList[index]) WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_NUMBER_FORMAT"), std::to_string(index).c_str(), imageDiskList[index]->diskname.c_str());
+			if (imageDiskList[index]) {
+                WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_NUMBER_FORMAT"), std::to_string(index).c_str(), imageDiskList[index]->diskname.c_str());
+                none=false;
+            }
+        if (none) WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_NONE"));
         dos.dta(save_dta);
     }
     void Run(void) {
@@ -5651,6 +5660,7 @@ void DOS_SetupPrograms(void) {
     MSG_Add("PROGRAM_MOUNT_STATUS_1","The currently mounted drives are:\n");
     MSG_Add("PROGRAM_IMGMOUNT_STATUS_2","The currently mounted drive numbers are:\n");
     MSG_Add("PROGRAM_IMGMOUNT_STATUS_1","The currently mounted FAT/ISO drives are:\n");
+    MSG_Add("PROGRAM_IMGMOUNT_STATUS_NONE","No drive available\n");
     MSG_Add("PROGRAM_MOUNT_ERROR_1","Directory %s doesn't exist.\n");
     MSG_Add("PROGRAM_MOUNT_ERROR_2","%s is not a directory\n");
     MSG_Add("PROGRAM_MOUNT_ILL_TYPE","Illegal type %s\n");
@@ -5661,12 +5671,12 @@ void DOS_SetupPrograms(void) {
         "For example: MOUNT c %s\n"
         "This makes the directory %s act as the C: drive inside DOSBox-X.\n"
         "The directory has to exist in the host system.\n\n"
-		"Options are accepted. For example:\n"
-		"MOUNT -nocachedir c %s mounts C: without caching the drive.\n"
-		"MOUNT -freesize 128 c %s mounts C: with the specified free disk space.\n"
-		"MOUNT -ro c %s mounts the C: drive in read-only mode.\n"
-		"MOUNT -t cdrom c %s mounts the C: drive as a CD-ROM drive.\n"
-		"MOUNT -u c unmounts the C: drive.\n\n"
+		"Options are accepted. For example:\n\n"
+		"\033[32;1mMOUNT -nocachedir c %s \033[0m  mounts C: without caching the drive.\n"
+		"\033[32;1mMOUNT -freesize 128 c %s \033[0mmounts C: with the specified free disk space.\n"
+		"\033[32;1mMOUNT -ro c %s \033[0m          mounts the C: drive in read-only mode.\n"
+		"\033[32;1mMOUNT -t cdrom c %s \033[0m     mounts the C: drive as a CD-ROM drive.\n"
+		"\033[32;1mMOUNT -u c \033[0m                       unmounts the C: drive.\n\n"
 		"Type MOUNT with no parameters to display a list of mounted drives.\n");
     MSG_Add("PROGRAM_MOUNT_UMOUNT_NOT_MOUNTED","Drive %c is not mounted.\n");
     MSG_Add("PROGRAM_MOUNT_UMOUNT_SUCCESS","Drive %c has successfully been removed.\n");
@@ -5693,10 +5703,10 @@ void DOS_SetupPrograms(void) {
         "  {program}   Runs the specified program\n"
         "  {options}   Program options (if any)\n\n"
         "Examples:\n"
-        "  LOADFIX game.exe     Allocates 64KB of conventional memory and runs game.exe\n"
-        "  LOADFIX -128         Allocates 128KB of conventional memory\n"
-        "  LOADFIX -xms         Allocates 1MB of XMS memory\n"
-        "  LOADFIX -f           Frees allocated conventional memory\n");
+        "  \033[32;1mLOADFIX game.exe\033[34;1m     Allocates 64KB of conventional memory and runs game.exe\n"
+        "  \033[32;1mLOADFIX -128\033[34;1m         Allocates 128KB of conventional memory\n"
+        "  \033[32;1mLOADFIX -xms\033[34;1m         Allocates 1MB of XMS memory\n"
+        "  \033[32;1mLOADFIX -f\033[34;1m           Frees allocated conventional memory\n");
 
     MSG_Add("MSCDEX_SUCCESS","MSCDEX installed.\n");
     MSG_Add("MSCDEX_ERROR_MULTIPLE_CDROMS","MSCDEX: Failure: Drive-letters of multiple CD-ROM drives have to be continuous.\n");
@@ -6032,15 +6042,15 @@ void DOS_SetupPrograms(void) {
         );
     MSG_Add("PROGRAM_IMGMAKE_EXAMPLE",
         "Some usage examples of IMGMAKE:\n\n"
-        "  \033[34;1mimgmake c:\\image.img -t fd_1440\033[0m          - create a 1.44MB floppy image\n"
-        "  \033[34;1mimgmake c:\\image.img -t hd -size 100\033[0m     - create a 100MB hdd image\n"
-        "  \033[34;1mimgmake c:\\image.img -t hd_520 -nofs\033[0m     - create a 520MB blank hdd image\n"
-        "  \033[34;1mimgmake c:\\image.img -t hd_2gig -fat 32\033[0m  - create a 2GB FAT32 hdd image\n"
-        "  \033[34;1mimgmake c:\\image.img -t hd -chs 130,2,17\033[0m - create a special hdd image\n"
+        "  \033[32;1mIMGMAKE c:\\image.img -t fd_1440\033[0m          - create a 1.44MB floppy image\n"
+        "  \033[32;1mIMGMAKE c:\\image.img -t hd -size 100\033[0m     - create a 100MB hdd image\n"
+        "  \033[32;1mIMGMAKE c:\\image.img -t hd_520 -nofs\033[0m     - create a 520MB blank hdd image\n"
+        "  \033[32;1mIMGMAKE c:\\image.img -t hd_2gig -fat 32\033[0m  - create a 2GB FAT32 hdd image\n"
+        "  \033[32;1mIMGMAKE c:\\image.img -t hd -chs 130,2,17\033[0m - create a special hdd image\n"
 #ifdef WIN32
-        "  \033[34;1mimgmake c:\\image.img -source a\033[0m           - read image from physical drive A\n"
+        "  \033[32;1mIMGMAKE c:\\image.img -source a\033[0m           - read image from physical drive A\n"
 #endif
-        "  \033[34;1mimgmake -t fd_2880 -force\033[0m           - force to create a 2.88MB floppy image\n"
+        "  \033[32;1mIMGMAKE -t fd_2880 -force\033[0m           - force to create a 2.88MB floppy image\n"
         );
 
 #ifdef WIN32
@@ -6058,12 +6068,12 @@ void DOS_SetupPrograms(void) {
     MSG_Add("PROGRAM_KEYB_INFO","Codepage %i has been loaded\n");
     MSG_Add("PROGRAM_KEYB_INFO_LAYOUT","Codepage %i has been loaded for layout %s\n");
     MSG_Add("PROGRAM_KEYB_SHOWHELP","Configures a keyboard for a specific language.\n\n"
-        "\033[32;1mKEYB\033[0m [keyboard layout ID[ codepage number[ codepage file]]]\n\n"
+        "KEYB [keyboard layout ID [codepage number [codepage file]]]\n\n"
         "Some examples:\n"
-        "  \033[32;1mKEYB\033[0m: Display currently loaded codepage.\n"
-        "  \033[32;1mKEYB\033[0m sp: Load the spanish (SP) layout, use an appropriate codepage.\n"
-        "  \033[32;1mKEYB\033[0m sp 850: Load the spanish (SP) layout, use codepage 850.\n"
-        "  \033[32;1mKEYB\033[0m sp 850 mycp.cpi: Same as above, but use file mycp.cpi.\n");
+        "  \033[32;1mKEYB\033[0m          Display currently loaded codepage.\n"
+        "  \033[32;1mKEYB sp\033[0m       Load the Spanish (SP) layout, use an appropriate codepage.\n"
+        "  \033[32;1mKEYB sp 850\033[0m   Load the Spanish (SP) layout, use codepage 850.\n"
+        "  \033[32;1mKEYB sp 850 mycp.cpi\033[0m Same as above, but use file mycp.cpi.\n");
     MSG_Add("PROGRAM_KEYB_NOERROR","Keyboard layout %s loaded for codepage %i\n");
     MSG_Add("PROGRAM_KEYB_FILENOTFOUND","Keyboard file %s not found\n\n");
     MSG_Add("PROGRAM_KEYB_INVALIDFILE","Keyboard file %s invalid\n");

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -5459,28 +5459,18 @@ void AUTOTYPE::PrintUsage()
 {
 	constexpr const char *msg =
 	        "Performs scripted keyboard entry into a running DOS program.\n\n"
-			"\033[32;1mAUTOTYPE\033[0m [-list] [-w WAIT] [-p PACE] "
-	        "button_1 [button_2 [...]] \n\n"
+	        "AUTOTYPE [-list] [-w WAIT] [-p PACE] button_1 [button_2 [...]]\n\n"
 	        "Where:\n"
 	        "  -list:   prints all available button names.\n"
-	        "  -w WAIT: seconds before typing begins. Two second default; "
-	        "max of 30.\n"
-	        "  -p PACE: seconds between each keystroke. Half-second "
-	        "default; max of 10.\n"
-	        "\n"
-	        "  The sequence is comprised of one or more space-separated "
-	        "buttons.\n"
-	        "  Autotyping begins after WAIT seconds, and each button is "
-	        "entered \n"
-	        "  every PACE seconds. The , character inserts an extra PACE "
-	        "delay.\n"
-	        "\n"
+	        "  -w WAIT: seconds before typing begins. Two second default; max of 30.\n"
+	        "  -p PACE: seconds between each keystroke. Half-second default; max of 10.\n\n"
+	        "  The sequence is comprised of one or more space-separated buttons.\n"
+	        "  Autotyping begins after WAIT seconds, and each button is entered\n"
+	        "  every PACE seconds. The , character inserts an extra PACE delay.\n\n"
 	        "Some examples:\n"
-	        "  \033[32;1mAUTOTYPE\033[0m -w 1 -p 0.3 up enter , right "
-	        "enter\n"
-	        "  \033[32;1mAUTOTYPE\033[0m -p 0.2 f1 kp_8 , , enter\n"
-	        "  \033[32;1mAUTOTYPE\033[0m -w 1.3 esc enter , p l a y e r "
-	        "enter\n";
+	        "  \033[32;1mAUTOTYPE -w 1 -p 0.3 up enter , right enter\033[0m\n"
+	        "  \033[32;1mAUTOTYPE -p 0.2 f1 kp_8 , , enter\033[0m\n"
+	        "  \033[32;1mAUTOTYPE -w 1.3 esc enter , p l a y e r enter\033[0m\n";
 	WriteOut_NoParsing(msg);
 }
 
@@ -5703,10 +5693,10 @@ void DOS_SetupPrograms(void) {
         "  {program}   Runs the specified program\n"
         "  {options}   Program options (if any)\n\n"
         "Examples:\n"
-        "  \033[32;1mLOADFIX game.exe\033[34;1m     Allocates 64KB of conventional memory and runs game.exe\n"
-        "  \033[32;1mLOADFIX -128\033[34;1m         Allocates 128KB of conventional memory\n"
-        "  \033[32;1mLOADFIX -xms\033[34;1m         Allocates 1MB of XMS memory\n"
-        "  \033[32;1mLOADFIX -f\033[34;1m           Frees allocated conventional memory\n");
+        "  \033[32;1mLOADFIX game.exe\033[0m     Allocates 64KB of conventional memory and runs game.exe\n"
+        "  \033[32;1mLOADFIX -128\033[0m         Allocates 128KB of conventional memory\n"
+        "  \033[32;1mLOADFIX -xms\033[0m         Allocates 1MB of XMS memory\n"
+        "  \033[32;1mLOADFIX -f\033[0m           Frees allocated conventional memory\n");
 
     MSG_Add("MSCDEX_SUCCESS","MSCDEX installed.\n");
     MSG_Add("MSCDEX_ERROR_MULTIPLE_CDROMS","MSCDEX: Failure: Drive-letters of multiple CD-ROM drives have to be continuous.\n");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3545,7 +3545,11 @@ void DOSBOX_SetupConfigSections(void) {
                 "Set to 0 to use controller or CD-ROM drive-specific default.");
     }
 
-    /* CONFIG.SYS options (stub) */
+    /* 4DOS.INI options */
+    secprop=control->AddSection_prop("4dos",&Null_Init,false);
+    Pstring = secprop->Add_string("rem",Property::Changeable::OnlyAtStart,"This section is the 4DOS.INI file, if you use 4DOS as the command shell");
+
+    /* CONFIG.SYS options */
     secprop=control->AddSection_prop("config",&Null_Init,false);
 
     Pstring = secprop->Add_string("rem",Property::Changeable::OnlyAtStart,"This section is DOS's CONFIG.SYS file, not all CONFIG.SYS options supported");
@@ -3556,6 +3560,8 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring = secprop->Add_string("numlock",Property::Changeable::OnlyAtStart,"");
 	Pstring->Set_help("Sets the initial state of the NumLock key.");
     Pstring->Set_values(numopt);
+    Pstring = secprop->Add_string("shell",Property::Changeable::OnlyAtStart,"");
+	Pstring->Set_help("Specifies the command shell (COMMAND.COM or 4DOS.COM).");
     Pstring = secprop->Add_string("dos",Property::Changeable::OnlyAtStart,"high, umb");
 	Pstring->Set_help("Reports whether DOS occupies HMA and allocates UMB memory (if available).");
     Pint = secprop->Add_int("fcbs",Property::Changeable::OnlyAtStart,100);

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1519,6 +1519,7 @@ void SHELL_Run() {
         if (strlen(shell)) {
             tmp=trim(shell);
             name=StripArg(tmp);
+            upcase(name);
             if (*name&&DOS_FileExists(name))
                 altshell=true;
         }
@@ -1529,6 +1530,7 @@ void SHELL_Run() {
         first_shell->perm=false;
         first_shell->exit=true;
         first_shell->Run();
+        first_shell->SetEnv("COMSPEC",name);
         if (!strlen(tmp)) {
             char *p=strrchr(name, '\\');
             if (!strcasecmp(p==NULL?name:p+1, "COMMAND.COM") || !strcasecmp(name, "Z:COMMAND.COM")) {strcpy(tmpstr, init_line);tmp=tmpstr;}

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -461,6 +461,7 @@ void DOS_Shell::Run(void) {
 		return;
 	}
 
+    bool optInit=cmd->FindString("/INIT",line,true);
     if (this == first_shell) {
         /* Start a normal shell and check for a first command init */
         WriteOut(MSG_Get("SHELL_STARTUP_BEGIN"),VERSION,SDL_STRING,UPDATED_STR);
@@ -593,11 +594,11 @@ void DOS_Shell::Run(void) {
 		}
 		VFILE_Register("4DOS.INI",(Bit8u *)i4dos_data,(Bit32u)strlen(i4dos_data));
     }
-    else {
+    else if (!optInit) {
         WriteOut(optK?"\n":"DOSBox-X command shell [Version %s %s]\nCopyright DOSBox-X Team. All rights reserved\n\n",VERSION,SDL_STRING);
     }
 
-	if (cmd->FindString("/INIT",line,true)) {
+	if (optInit) {
 		input_line[CMD_MAXLINE-1u] = 0;
 		strncpy(input_line,line.c_str(),CMD_MAXLINE-1u);
 		line.erase();
@@ -1529,8 +1530,9 @@ void SHELL_Run() {
         first_shell->exit=true;
         first_shell->Run();
         if (!strlen(tmp)) {
-            if (!stricmp(name, "COMMAND.COM") || !stricmp(name, "Z:\\COMMAND.COM")) {strcpy(tmpstr, init_line);tmp=tmpstr;}
-            else if (!stricmp(name, "4DOS.COM") || !stricmp(name, "Z:\\4DOS.COM")) {strcpy(tmpstr, "AUTOEXEC.BAT");tmp=tmpstr;}
+            char *p=strrchr(name, '\\');
+            if (!strcasecmp(p==NULL?name:p+1, "COMMAND.COM") || !strcasecmp(name, "Z:COMMAND.COM")) {strcpy(tmpstr, init_line);tmp=tmpstr;}
+            else if (!strcasecmp(p==NULL?name:p+1, "4DOS.COM") || !strcasecmp(name, "Z:4DOS.COM")) {strcpy(tmpstr, "AUTOEXEC.BAT");tmp=tmpstr;}
         }
 		first_shell->Execute(name, tmp);
 		return;

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -2563,7 +2563,7 @@ void DOS_Shell::CMD_SUBST(char * args) {
 			WriteOut(MSG_Get("SHELL_CMD_SUBST_DRIVE_LIST"));
 			WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_FORMAT"),"Drive","Type","Label");
 			for(int p = 0;p < 8;p++) WriteOut("----------");
-
+			bool none=true;
 			for (int d = 0;d < DOS_DRIVES;d++) {
 				if (!Drives[d]||strncmp(Drives[d]->GetInfo(),"local ",6)) continue;
 
@@ -2581,8 +2581,10 @@ void DOS_Shell::CMD_SUBST(char * args) {
 				}
 
 				root[1] = 0; //This way, the format string can be reused.
-				WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_FORMAT"),root, Drives[d]->GetInfo(),name);       
+				WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_FORMAT"),root, Drives[d]->GetInfo(),name);
+                none=false;
 			}
+            if (none) WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_NONE"));
 			dos.dta(save_dta);
 			return;
 		}


### PR DESCRIPTION
I have now added support for SHELL= option in [config] section of dosbox-x.conf to resemble SHELL= in DOS's config.sys file. With this you can now specify a non-default command shell such as the free but powerful 4DOS 8.00 shell for 4DOS features and capabilities. In order to make this work a slightly modified version of the 4DOS 8.00 (consisting of 4DOS.COM, 4DOS.HLP, 4HELP.EXE) is now added to the Z: drive. For example, you can now specify "SHELL=4DOS.COM" to launch this shell at start. There is now a [4dos] section added in the dosbox-x.conf file to act as the 4DOS.INI file if you use this shell. On the other hand, the current command shell will be used as is if SHELL= is not specified, or if you specify "SHELL=COMMAND.COM".