### PR TITLE
Euro= option to display Euro symbol instead of the specified ASCII character in any codepage

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 0.83.4
+  - Added "euro" config option (in [render] section)
+    to display Euro symbol instead of the specified
+    ASCII character in any codepage. (Wengier)
   - PC-98 CG MMIO writes fixed to limit writes only
     to the user-defined areas, same as the IO writes.
     This fixes "Niko Niko" that appears to write a

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -672,6 +672,8 @@ pc-98 show graphics layer on initialize  = true
 #                                      When using xBRZ scaler with 'surface' output, aspect ratio correction is done by the scaler itself, so none of the above apply
 #                            Possible values: false, true, 0, 1, yes, no, nearest, bilinear.
 #                   char9: Allow 9-pixel wide text mode fonts.
+#                    euro: Display Euro symbol instead of the specified ASCII character (33-255).
+#                            For example, setting it to 128 allows Euro symbol to be displayed instead of C-cedilla.
 #              doublescan: If set, doublescanned output emits two scanlines for each source line, in the
 #                            same manner as the actual VGA output (320x200 is rendered as 640x400 for example).
 #                            If clear, doublescanned output is rendered at the native source resolution (320x200 as 320x200).
@@ -695,6 +697,7 @@ frameskip               = 0
 alt render              = false
 aspect                  = false
 char9                   = true
+euro                    = -1
 doublescan              = true
 scaler                  = normal2x
 xbrz slice              = 16

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -707,6 +707,8 @@ Bit16u keyboard_layout::extract_codepage(const char* keyboard_file_name) {
 	return (IS_PC98_ARCH ? 932 : 437);
 }
 
+extern int eurAscii;
+extern Bit8u euro_08[8], euro_14[14], euro_16[16];
 Bitu keyboard_layout::read_codepage_file(const char* codepage_file_name, Bit32s codepage_id) {
 	char cp_filename[512];
 	strcpy(cp_filename, codepage_file_name);
@@ -938,7 +940,7 @@ Bitu keyboard_layout::read_codepage_file(const char* codepage_file_name, Bit32s 
                     if (int10.rom.font_16 != 0) {
                         PhysPt font16pt=Real2Phys(int10.rom.font_16);
                         for (Bit16u i=0;i<256*16;i++) {
-                            phys_writeb(font16pt+i,cpi_buf[font_data_start+i]);
+                            phys_writeb(font16pt+i,eurAscii>32&&i/16==eurAscii?euro_16[i%16]:cpi_buf[font_data_start+i]);
                         }
                         // terminate alternate list to prevent loading
                         phys_writeb(Real2Phys(int10.rom.font_16_alternate),0);
@@ -949,7 +951,7 @@ Bitu keyboard_layout::read_codepage_file(const char* codepage_file_name, Bit32s 
                     if (int10.rom.font_14 != 0) {
                         PhysPt font14pt=Real2Phys(int10.rom.font_14);
                         for (Bit16u i=0;i<256*14;i++) {
-                            phys_writeb(font14pt+i,cpi_buf[font_data_start+i]);
+                            phys_writeb(font14pt+i,eurAscii>32&&i/14==eurAscii?euro_14[i%14]:cpi_buf[font_data_start+i]);
                         }
                         // terminate alternate list to prevent loading
                         phys_writeb(Real2Phys(int10.rom.font_14_alternate),0);
@@ -960,14 +962,14 @@ Bitu keyboard_layout::read_codepage_file(const char* codepage_file_name, Bit32s 
                     if (int10.rom.font_8_first != 0) {
                         PhysPt font8pt=Real2Phys(int10.rom.font_8_first);
                         for (Bit16u i=0;i<128*8;i++) {
-                            phys_writeb(font8pt+i,cpi_buf[font_data_start+i]);
+                            phys_writeb(font8pt+i,eurAscii>32&&i/8==eurAscii?euro_08[i%8]:cpi_buf[font_data_start+i]);
                         }
                         font_changed=true;
                     }
                     if (int10.rom.font_8_second != 0) {
                         PhysPt font8pt=Real2Phys(int10.rom.font_8_second);
                         for (Bit16u i=0;i<128*8;i++) {
-                            phys_writeb(font8pt+i,cpi_buf[font_data_start+i+128*8]);
+                            phys_writeb(font8pt+i,eurAscii>127&&(i+128)/8==eurAscii?euro_08[i%8]:cpi_buf[font_data_start+i+128*8]);
                         }
                         font_changed=true;
                     }

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -5755,9 +5755,8 @@ public:
         } else {
             lpExecInfo.lpFile = cmd;
             lpExecInfo.lpParameters = cmdstr;
-            //ShellExecute(NULL, "open", cmd, cmdstr, NULL, sw);
         }
-        WriteOut("Running %s..", cmd);
+        WriteOut("Running %s..\n", cmd);
         ShellExecuteEx(&lpExecInfo);
         int ErrorCode = GetLastError();
         if(lpExecInfo.hProcess!=NULL) {
@@ -5770,7 +5769,7 @@ public:
                 if (ctrlbrk) {
                     Bit8u c;Bit16u n=1;
                     DOS_ReadFile (STDIN,&c,&n);
-                    if (c == 3) WriteOut("^C");
+                    if (c == 3) WriteOut("^C\n");
                     EndStartProcess();
                     break;
                 }
@@ -5778,7 +5777,6 @@ public:
             ErrorCode = GetLastError();
             CloseHandle(lpExecInfo.hProcess);
         }
-        WriteOut("\n");
         DOS_SetError(ErrorCode);
     }
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2063,6 +2063,10 @@ void DOSBOX_SetupConfigSections(void) {
     Pbool = secprop->Add_bool("char9",Property::Changeable::Always,true);
     Pbool->Set_help("Allow 9-pixel wide text mode fonts.");
 
+    Pint = secprop->Add_int("euro",Property::Changeable::Always,-1);
+    Pint->Set_help("Display Euro symbol instead of the specified ASCII character (33-255).\n"
+            "For example, setting it to 128 allows Euro symbol to be displayed instead of C-cedilla.");
+
     /* NTS: In the original code borrowed from yhkong, this was named "multiscan". All it really does is disable
      *      the doublescan down-rezzing DOSBox normally does with 320x240 graphics so that you get the full rendition of what a VGA output would emit. */
     Pbool = secprop->Add_bool("doublescan",Property::Changeable::Always,true);

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -39,6 +39,7 @@
 #endif
 
 Render_t                                render;
+int                                     eurAscii = -1;
 Bitu                                    last_gfx_flags = 0;
 ScalerLineHandler_t                     RENDER_DrawLine;
 
@@ -1002,6 +1003,11 @@ void RENDER_Init() {
 
     vga.draw.doublescan_set=section->Get_bool("doublescan");
     vga.draw.char9_set=section->Get_bool("char9");
+	eurAscii = section->Get_int("euro");
+	if (eurAscii != -1 && (eurAscii < 33 || eurAscii > 255)) {
+		LOG_MSG("Euro ASCII value has to be between 33 and 255\n");
+		eurAscii = -1;
+	}
 
 	//Set monochrome mode color and brightness
 	vga.draw.monochrome_pal=0;

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -1028,8 +1028,30 @@ Bitu read_herc_status(Bitu /*port*/,Bitu /*iolen*/) {
 	return retval;
 }
 
+extern int eurAscii;
+extern Bit8u int10_font_08[256 * 8], int10_font_14[256 * 14], int10_font_16[256 * 16];
+Bit8u euro_08[8] = {
+  0x3c, 0x66, 0xfc, 0x60,
+  0xf8, 0x66, 0x3c, 0x00,
+};
+Bit8u euro_14[14] = {
+  0x00, 0x00, 0x3c, 0x66, 0x60, 0xfc, 0x60,
+  0xf8, 0x60, 0x66, 0x3c, 0x00, 0x00, 0x00,
+};
+Bit8u euro_16[16] = {
+  0x00, 0x00, 0x00, 0x3c, 0x66, 0x60, 0xfc, 0x60,
+  0xf8, 0x60, 0x66, 0x3c, 0x00, 0x00, 0x00, 0x00,
+};
 
 void VGA_SetupOther(void) {
+    if (eurAscii>32 && eurAscii<256) {
+        for (unsigned int i=eurAscii*8;i<(eurAscii+1)*8;i++)
+            int10_font_08[i]=euro_08[i%8];
+        for (unsigned int i=eurAscii*14;i<(eurAscii+1)*14;i++)
+            int10_font_14[i]=euro_14[i%14];
+        for (unsigned int i=eurAscii*16;i<(eurAscii+1)*16;i++)
+            int10_font_16[i]=euro_16[i%16];
+    }
 	memset( &vga.tandy, 0, sizeof( vga.tandy ));
 	vga.attr.disabled = 0;
 	vga.config.bytes_skip=0;
@@ -1046,12 +1068,10 @@ void VGA_SetupOther(void) {
 	vga.tandy.line_shift = 13;
 
 	if (machine==MCH_CGA || machine==MCH_AMSTRAD || IS_TANDY_ARCH) {
-		extern Bit8u int10_font_08[256 * 8];
 		for (Bitu i=0;i<256;i++)	memcpy(&vga.draw.font[i*32],&int10_font_08[i*8],8);
 		vga.draw.font_tables[0]=vga.draw.font_tables[1]=vga.draw.font;
 	}
     if (machine==MCH_MCGA) { // MCGA uses a 8x16 font, through double-scanning as if 8x8 CGA text mode
-        extern Bit8u int10_font_16[256 * 16];
         for (Bitu i=0;i<256;i++)	memcpy(&vga.draw.font[i*32],&int10_font_16[i*16],16);
         vga.draw.font_tables[0]=vga.draw.font_tables[1]=vga.draw.font;
     }
@@ -1060,7 +1080,6 @@ void VGA_SetupOther(void) {
 		IO_RegisterWriteHandler(0x3dc,write_lightpen,IO_MB);
 	}
 	if (machine==MCH_HERC || machine==MCH_MDA) {
-		extern Bit8u int10_font_14[256 * 14];
 		for (Bitu i=0;i<256;i++)	memcpy(&vga.draw.font[i*32],&int10_font_14[i*14],14);
 		vga.draw.font_tables[0]=vga.draw.font_tables[1]=vga.draw.font;
 		MAPPER_AddHandler(HercBlend,MK_nothing,0,"hercblend","Herc Blend");


### PR DESCRIPTION
The current DOSBox-X version only allows the Euro symbol to be displayed in codepage 858, but not in the default font or any other codepages, as mentioned in Issue #1655. Meanwhile, vDos/vDosPlus does support the Euro symbol to be displayed instead of the specified ASCII character (between 33 and 255) in any codepage, so I decided to add this to DOSBox-X too via the euro config option (in [render] section]. It is disabled by default, but can be enabled by e.g.:

``euro=128``

which will allow the Euro symbol to be displayed instead of C-cedilla (ASCII 128). Tested in CGA (font_08), EGA (font_14) and MCGA/VGA (font_16) modes and confirmed to work.