### PR TITLE
Support quick reboot mode for DOS restart calls (including Ctrl+Alt+Del) with a toggle menu

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,9 @@
 0.83.4
+  - Add "quick reboot" config option and "use quick
+    reboot" toggle menu (under "DOS") so that when
+    set or selected the DOS restart call reboots the
+    emulated DOS (integrated or guest DOS) instead
+    of the virtual machine in DOSBox-X. (Wengier)
   - Added new "Reboot guest system" menu item (under
     "Main") to reboot the kernel of the integrated
     DOS or the guest DOS directly. The previous menu
@@ -29,7 +34,7 @@
     or overlay drives to run on the host. (Wengier)
   - Added START command to run commands on Windows
     host system. The /MAX, /MIN, /HID options can
-    be used to run the specified program maxmized,
+    be used to run the specified program maximized,
     minimized, or hidden (they can be shortened to
     +, -, _ respectively). This command is disabled
     by default, but can be enabled by either the
@@ -41,7 +46,7 @@
     in the Windows Command Prompt and wait for a key
     press before exiting. (Wengier)
   - Added SHELL= option to the [config] section in
-    dosbox-x.conf to specifiy an alternative shell,
+    dosbox-x.conf to specify an alternative shell,
     e.g. "SHELL=4DOS.COM". (Wengier)
   - Added built-in 4DOS 8.00 shell for 4DOS features
     and capabilities. There is now a [4dos] section

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,11 @@
 0.83.4
-  - Add "quick reboot" config option and "use quick
-    reboot" toggle menu (under "DOS") so that when
-    set or selected the DOS restart call reboots the
-    emulated DOS (integrated or guest DOS) instead
-    of the virtual machine in DOSBox-X. (Wengier)
+  - Added "use quick reboot" toggle menu (under
+    "DOS") so that when enabled, DOS restart calls
+    will reboot the emulated DOS (integrated or
+    guest DOS) instead of the virtual machine in
+    DOSBox-X. Also, you could change the default
+    setting for this by setting the new "quick
+    reboot" config option in "dos" section (Wengier)
   - Added new "Reboot guest system" menu item (under
     "Main") to reboot the kernel of the integrated
     DOS or the guest DOS directly. The previous menu
@@ -63,7 +65,8 @@
   - IMGMOUNT now assumes "-fs none" automatically if
     a drive number is specified instead of a drive
     letter. Also improved this command's handling of
-    El Torito floppy drives. (Wengier)
+    El Torito floppy drives, e.g. you can use option
+    "-bootcd d" instead of "-el-torito d". (Wengier)
   - IMGMAKE warning replaced to indicate a general
     incompatibility between MS-DOS/SCANDISK and
     cluster sizes 64KB or larger.

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1553,6 +1553,7 @@ dongle    = false
 #                        keep private area on boot: If set, keep the DOSBox-X private area around after boot (Mainline DOSBox behavior). If clear, unmap and discard the private area when you boot an operating system.
 #                              private area in umb: If set, keep private DOS segment in upper memory block, usually segment 0xC800 (Mainline DOSBox behavior)
 #                                                     If clear, place private DOS segment at the base of system memory (just below the MCB)
+#                                     quick reboot: If set, the DOS restart call will reboot the emulated DOS (integrated DOS or guest DOS) instead of the virtual machine
 #                                              ver: Set DOS version. Specify as major.minor format. A single number is treated as the major version (compatible with LFN support). Common settings are:
 #                                                     auto (or unset)                  Pick a DOS kernel version automatically
 #                                                     3.3                              MS-DOS 3.3 emulation (not tested!)
@@ -1651,6 +1652,7 @@ kernel allocation in umb                         = false
 keep umb on boot                                 = false
 keep private area on boot                        = false
 private area in umb                              = true
+quick reboot                                     = false
 ver                                              = 
 lfn                                              = auto
 automount                                        = true

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -301,6 +301,11 @@ static INLINE Bit16u DOS_PackDate(Bit16u year,Bit16u mon,Bit16u day) {
   #define fseeko64 fseek
   #define fseek_ofs_t long
  #endif
+#elif defined (__MINGW64_VERSION_MAJOR)
+ #define fopen64 fopen
+ #define ftello64 _ftelli64
+ #define fseeko64 _fseeki64
+ #define fseek_ofs_t __int64
 #else
  #define fopen64 fopen
  #define ftello64 ftell

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -39,7 +39,7 @@
 #include "serialport.h"
 #include "dos_network.h"
 
-extern bool log_int21, log_fileio;
+extern bool log_int21, log_fileio, use_quick_reboot;
 extern int lfn_filefind_handle;
 unsigned long totalc, freec;
 Bit16u countryNo = 0;
@@ -3058,6 +3058,9 @@ public:
 		dos.version.minor=0;
 		dos.direct_output=false;
 		dos.internal_output=false;
+
+		use_quick_reboot = section->Get_bool("quick reboot");
+		mainMenu.get_item("quick_reboot").check(use_quick_reboot).refresh_item(mainMenu);
 
 		std::string lfn = section->Get_string("lfn");
 		if (lfn=="true") enablelfn=1;

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -50,7 +50,8 @@
 // Use cdrom Interface
 int useCdromInterface	= CDROM_USE_SDL;
 int forceCD				= -1;
-extern bool dos_kernel_disabled, bootguest;
+extern int bootdrive;
+extern bool dos_kernel_disabled, bootguest, bootvm, use_quick_reboot;
 
 static Bitu MSCDEX_Strategy_Handler(void); 
 static Bitu MSCDEX_Interrupt_Handler(void);
@@ -168,7 +169,7 @@ CMscdex::CMscdex(void) {
 }
 
 CMscdex::~CMscdex(void) {
-	if (bootguest) return;
+	if ((bootguest||(use_quick_reboot&&!bootvm))&&bootdrive>=0) return;
 	defaultBufSeg = 0;
 	for (Bit16u i=0; i<GetNumDrives(); i++) {
 		delete cdrom[i];
@@ -1348,7 +1349,7 @@ void MSCDEX_SetCDInterface(int intNr, int numCD) {
 }
 
 void MSCDEX_ShutDown(Section* /*sec*/) {
-	if (bootguest) return;
+	if ((bootguest||(use_quick_reboot&&!bootvm))&&bootdrive>=0) return;
 	if (mscdex != NULL) {
 		delete mscdex;
 		mscdex = NULL;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3254,6 +3254,9 @@ void DOSBOX_SetupConfigSections(void) {
     Pbool->Set_help("If set, keep private DOS segment in upper memory block, usually segment 0xC800 (Mainline DOSBox behavior)\n"
             "If clear, place private DOS segment at the base of system memory (just below the MCB)");
 
+    Pbool = secprop->Add_bool("quick reboot",Property::Changeable::WhenIdle,false);
+    Pbool->Set_help("If set, the DOS restart call will reboot the emulated DOS (integrated DOS or guest DOS) instead of the virtual machine\n");
+
     Pstring = secprop->Add_string("ver",Property::Changeable::WhenIdle,"");
     Pstring->Set_help("Set DOS version. Specify as major.minor format. A single number is treated as the major version (compatible with LFN support). Common settings are:\n"
             "auto (or unset)                  Pick a DOS kernel version automatically\n"

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -383,6 +383,8 @@ static const char *def_menu_dos[] =
     "--",
     "DOSPC98Menu",
     "--",
+    "quick_reboot",
+    "--",
     "mapper_swapimg",
     "mapper_swapcd",
     "--",

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -42,6 +42,7 @@ extern bool dpi_aware_enable;
 extern bool log_int21;
 extern bool log_fileio;
 extern bool force_load_state;
+extern bool use_quick_reboot;
 #if defined(WIN32)
 bool direct_mouse_clipboard=false;
 bool winrun=false;
@@ -184,7 +185,7 @@ Bitu frames = 0;
 ScreenSizeInfo          screen_size_info;
 
 extern bool dos_kernel_disabled;
-extern bool bootguest;
+extern bool bootguest, bootvm;
 extern int bootdrive;
 
 void runBoot(void);
@@ -3392,7 +3393,7 @@ void ResetSystem(bool pressed) {
         pausewithinterrupts_enable = false;
 		mainMenu.get_item("mapper_pauseints").check(false).refresh_item(mainMenu);
 	}
-
+	bootvm=true;
     throw int(3);
 }
 
@@ -3407,7 +3408,6 @@ void RebootGuest(bool pressed) {
         pausewithinterrupts_enable = false;
 		mainMenu.get_item("mapper_pauseints").check(false).refresh_item(mainMenu);
 	}
-
 	if (!dos_kernel_disabled) {
 	    if (CurMode->type==M_TEXT || IS_PC98_ARCH) {
 			char msg[]="[2J";
@@ -7773,6 +7773,14 @@ bool force_loadstate_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * c
     return true;
 }
 
+bool quick_reboot_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+    use_quick_reboot = !use_quick_reboot;
+    mainMenu.get_item("quick_reboot").check(use_quick_reboot).refresh_item(mainMenu);
+    return true;
+}
+
 bool refresh_slots_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
     (void)menuitem;//UNUSED
@@ -9133,6 +9141,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"alwaysontop").set_text("Always on top").set_callback_function(alwaysontop_menu_callback).check(is_always_on_top());
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"showdetails").set_text("Show details").set_callback_function(showdetails_menu_callback).check(!menu.hidecycles && !menu.showrt);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"highdpienable").set_text("High DPI enable").set_callback_function(highdpienable_menu_callback).check(dpi_aware_enable);
+        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"quick_reboot").set_text("Use quick reboot").set_callback_function(quick_reboot_menu_callback).check(use_quick_reboot);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"force_loadstate").set_text("Force load state").set_callback_function(force_loadstate_menu_callback).check(force_load_state);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"refreshslot").set_text("Refresh status").set_callback_function(refresh_slots_menu_callback);
 

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -31,7 +31,8 @@
 # pragma warning(disable:4244) /* const fmath::local::uint64_t to double possible loss of data */
 #endif
 
-extern bool int13_extensions_enable, bootguest;
+extern int bootdrive;
+extern bool int13_extensions_enable, bootguest, bootvm, use_quick_reboot;
 
 diskGeo DiskGeometryList[] = {
     { 160,  8, 1, 40, 0, 512,  64, 1, 0xFE},      // IBM PC double density 5.25" single-sided 160KB
@@ -1200,7 +1201,7 @@ void BIOS_SetupDisks(void) {
     RealSetVec(0x13,CALLBACK_RealPointer(call_int13));
 
     //release the drives after a soft reset
-    if (!bootguest) FreeBIOSDiskList();
+    if (!bootguest&&(bootvm||!use_quick_reboot)||bootdrive<0) FreeBIOSDiskList();
 
     /* FIXME: Um... these aren't callbacks. Why are they allocated as callbacks? We have ROM general allocation now. */
     diskparm0 = CALLBACK_Allocate();


### PR DESCRIPTION
The "Reboot guest system" menu item was recently added to reboot the emulated DOS (guest DOS or integrated DOS) directly, but I noticed that when a DOS program (or guest Windows 9x system) issues a restart call, or you press Ctrl+Alt+Del within a guest system, the whole VM will be reset and will boot into the integrated DOS instead of just rebooting the guest system. To solve this I have added a "use quick reboot" toggle menu (under "DOS") so that when selected the restart call reboots the emulated DOS (either guest DOS or integrated DOS) instead of resetting the virtual machine. If it is not selected then things remain the same as before.  Note that the "Reset virtual machine" menu item is not affected by this. The same result can also be achieved by setting the new "quick reboot" config option (in "dos" section) to "true".

The IMGMOUNT command now supports the "-bootcd" option as an alias to the "-el-torito" option which is harder to type and remember.