### PR TITLE
Fix for Issue #1761 and CHKDSK

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -549,7 +549,6 @@ static Bitu DOS_21Handler(void) {
         LOG(LOG_CPU, LOG_DEBUG)("Executing interrupt 21, ah=%x, al=%x", reg_ah, reg_al);
     }
 
-
     /* Real MS-DOS behavior:
      *   If HIMEM.SYS is loaded and CONFIG.SYS says DOS=HIGH, DOS will load itself into the HMA area.
      *   To prevent crashes, the INT 21h handler down below will enable the A20 gate before executing
@@ -1194,6 +1193,11 @@ static Bitu DOS_21Handler(void) {
                     reg_al = 0x00;
                     SegSet16(ds,dos.tables.dpb);
                     reg_bx = drive*dos.tables.dpb_size;
+                    if (mem_readw(SegPhys(ds)+reg_bx+0x1F)==0xFFFF) {
+                        Bit32u bytes_per_sector,sectors_per_cluster,total_clusters,free_clusters;
+                        if (DOS_GetFreeDiskSpace32(reg_dl,&bytes_per_sector,&sectors_per_cluster,&total_clusters,&free_clusters))
+                            mem_writew(SegPhys(ds)+reg_bx+0x1F,free_clusters);
+                    }
                     LOG(LOG_DOSMISC,LOG_NORMAL)("Get drive parameter block.");
                 } else {
                     reg_al=0xff;

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -486,6 +486,14 @@ bool DOS_FindFirst(char * search,Bit16u attr,bool fcb_findfirst) {
 		strcpy(dir,fullsearch);
 	}
 
+	// Silence CHKDSK "Invalid sub-directory entry"
+	if (fcb_findfirst && !strcmp(search+1, ":????????.???") && attr==30) {
+		char psp_name[9];
+		DOS_MCB psp_mcb(dos.psp()-1);
+		psp_mcb.GetFileName(psp_name);
+		if (!strcmp(psp_name, "CHKDSK")) attr&=~DOS_ATTR_DIRECTORY;
+	}
+
 	sdrive=drive;
 	dta.SetupSearch(drive,(Bit8u)attr,pattern);
 

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -1239,8 +1239,8 @@ bool localDrive::isRemote(void) {
 	char psp_name[9];
 	DOS_MCB psp_mcb(dos.psp()-1);
 	psp_mcb.GetFileName(psp_name);
-	if (strcmp(psp_name, "SCANDISK") == 0) {
-		/* Check for SCANDISK.EXE and return true (Wengier) */
+	if (!strcmp(psp_name, "SCANDISK") || !strcmp(psp_name, "CHKDSK")) {
+		/* Check for SCANDISK.EXE (or CHKDSK.EXE) and return true (Wengier) */
 		return true;
 	}
 	/* Automatically detect if called by SCANDISK.EXE even if it is renamed (tested with the program from MS-DOS 6.20 to Windows ME) */

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -349,8 +349,8 @@ bool Virtual_Drive::isRemote(void) {
 	char psp_name[9];
 	DOS_MCB psp_mcb(dos.psp()-1);
 	psp_mcb.GetFileName(psp_name);
-	if (strcmp(psp_name, "SCANDISK") == 0) {
-		/* Check for SCANDISK.EXE and return true (Wengier) */
+	if (!strcmp(psp_name, "SCANDISK") || !strcmp(psp_name, "CHKDSK")) {
+		/* Check for SCANDISK.EXE (or CHKDSK.EXE) and return true (Wengier) */
 		return true;
 	}
 	/* Automatically detect if called by SCANDISK.EXE even if it is renamed (tested with the program from MS-DOS 6.20 to Windows ME) */

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -93,8 +93,10 @@ void pc98_update_cpu_page_ptr(void);
 bool KEYBOARD_Report_BIOS_PS2Mouse();
 bool gdc_5mhz_according_to_bios(void);
 void pc98_update_display_page_ptr(void);
-bool MEM_map_ROM_alias_physmem(Bitu start,Bitu end);
 void pc98_update_palette(void);
+bool MEM_map_ROM_alias_physmem(Bitu start,Bitu end);
+void MOUSE_Startup(Section *sec);
+void runBoot();
 
 bool bochs_port_e9 = false;
 bool isa_memory_hole_512kb = false;
@@ -281,7 +283,6 @@ extern bool bootguest, use_quick_reboot;
 bool bootvm = false;
 static std::string dosbox_int_debug_out;
 
-void runBoot();
 void VGA_SetCaptureStride(uint32_t v);
 void VGA_SetCaptureAddress(uint32_t v);
 void VGA_SetCaptureState(uint32_t v);
@@ -8568,7 +8569,10 @@ private:
 
         for (Bitu i=0;i < 0x400;i++) mem_writeb(0x7C00+i,0);
 
-		if ((bootguest||(!bootvm&&use_quick_reboot))&&bootdrive>=0&&imageDiskList[bootdrive]) runBoot();
+		if ((bootguest||(!bootvm&&use_quick_reboot))&&bootdrive>=0&&imageDiskList[bootdrive]) {
+			MOUSE_Startup(NULL);
+			runBoot();
+		}
 		if (use_quick_reboot&&!bootvm&&bootdrive<0&&first_shell != NULL) throw int(6);
 		bootvm=false;
 		bootguest=false;


### PR DESCRIPTION
As mentioned in Issue #1761, the mouse did not move when you enable the quick reboot for Windows guests, so I fixed this in this pull request.

Furthermore, I silenced the CHKDSK "invalid sub-directory entry" error message, which is in fact not an error, as mentioned in Issue #1760. and also fixed the crash ("Corrupt MCB chain") when using CHKDSK for a mounted local or virtual drive.