### PR TITLE
Support for "usescancodes=auto" to fix issues with non-US keyboards on SDL1 builds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,12 @@
 0.83.4
+  - Add and enable the setting "usescancodes=auto"
+    by default to fix issues with non-US keyboards
+    on SDL1 builds. (Wengier)
   - Fixed possible DPMI error when running Windows
     98 installation from the DOSBox-X shell without
     using a batch file. (Wengier)
+  - Fixed possible corruption with program group
+    files when running Windows for Workgroups 3.11.
   - Unknown INT 2Fh calls are now debug output, not
     an error.
   - Added VESA BIOS mode 68h alias as indicated on

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -41,6 +41,8 @@
 #        mapperfile: File used to load/save the key/event mappings from. Resetmapper only works with the default value.
 #   mapperfile_sdl2: File used to load/save the key/event mappings from (SDL2 builds). Resetmapper only works with the default value.
 #      usescancodes: Avoid usage of symkeys, might not work on all operating systems.
+#                      If set to "auto" (default), it is enabled for SDL1 and non-US keyboards.
+#                      Possible values: true, false, auto.
 #          overscan: Width of overscan border (0 to 10). (works only if output=surface)
 #          titlebar: Change the string displayed in the DOSBox-X title bar.
 #          showmenu: Whether to show the menu bar (if supported). Default true.
@@ -60,7 +62,7 @@ waitonerror       = true
 priority          = higher,normal
 mapperfile        = mapper-0.83.4.map
 mapperfile_sdl2   = mapper-0.83.4.sdl2.map
-usescancodes      = false
+usescancodes      = auto
 overscan          = 0
 titlebar          = 
 showmenu          = true

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -415,7 +415,7 @@ bool fatFile::Write(const Bit8u * data, Bit16u *size) {
 			if(loadedSector) myDrive->writeSector(currentSector, sectorBuffer);
 			loadedSector = false;
 
-			if (sizedec == 0) goto finalizeWrite;
+			if (sizedec == 0) { curSectOff = 0; goto finalizeWrite; }
 
 			currentSector = myDrive->getAbsoluteSectFromBytePos(firstCluster, seekpos);
 			if(currentSector == 0) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3762,7 +3762,7 @@ static void GUI_StartUp() {
     MAPPER_AddHandler(SwitchFullScreen,MK_f,MMODHOST,"fullscr","Fullscreen", &item);
     item->set_text("Toggle fullscreen");
 
-    MAPPER_AddHandler(PasteClipboard, MK_nothing, 0, "paste", "Paste Clipboard"); //end emendelson
+    MAPPER_AddHandler(PasteClipboard, MK_nothing, 0, "paste", "ClipPaste"); //end emendelson
 #if C_DEBUG
     /* Pause binds with activate-debugger */
     MAPPER_AddHandler(&PauseDOSBox, MK_pause, MMOD1, "pause", "Pause");
@@ -6279,8 +6279,11 @@ void SDL_SetupConfigSection() {
     Pstring = Pmulti->GetSection()->Add_string("force",Property::Changeable::Always,"");
 #endif
 
-    Pbool = sdl_sec->Add_bool("usescancodes",Property::Changeable::Always,false);
-    Pbool->Set_help("Avoid usage of symkeys, might not work on all operating systems.");
+	const char* truefalseautoopt[] = { "true", "false", "auto", 0};
+    Pstring = sdl_sec->Add_string("usescancodes",Property::Changeable::OnlyAtStart,"auto");
+    Pstring->Set_values(truefalseautoopt);
+    Pstring->Set_help("Avoid usage of symkeys, might not work on all operating systems.\n"
+        "If set to \"auto\" (default), it is enabled for SDL1 and non-US keyboards.");
 
     Pint = sdl_sec->Add_int("overscan",Property::Changeable::Always, 0);
     Pint->SetMinMax(0,10);


### PR DESCRIPTION
As mentioned in Issue #1762, international keyboard layout issues seem to be a common problem (particularly with the SDL1 build). So I added support for "usescancodes=auto" which will automatically enable this if the keyboard layout is non-US on SDL1 builds.