### PR TITLE
Fix Glide reset VM and allow quick launch to not auto-unmount drives

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,4 @@
 0.83.5
-  - The save state feature now saves and restore the
-    mounted path for mounted local or overlay drives.
-    This fixes error while loading states when the
-    local drives are not yet mounted. (Wengier)
   - Worked around the mounting issue with LaunchBox,
     by allowing a mounting command-line with single
     quotes like MOUNT C 'X:\DOS' on Windows. (Wengier)
@@ -11,6 +7,10 @@
   - Added "Quick launch program..." menu (under "DOS")
     to quickly run the specified program as selected
     by the Windows file browser in DOSBox-X. (Wengier)
+  - The save state feature now saves and restores the
+    mounted paths for mounted local or overlay drives.
+    This fixes the error when trying to load states
+    but the local drives aren't yet mounted. (Wengier)
   - Increased save slots from 10 to 100. Each page in
     the save slot menu (under "Capture") still shows
     10 slots, but you can now go to previous or next

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
 0.83.5
+  - The save state feature now saves and restore the
+    mounted path for mounted local or overlay drives.
+    This fixes error while loading states when the
+    local drives are not yet mounted. (Wengier)
   - Worked around the mounting issue with LaunchBox,
     by allowing a mounting command-line with single
     quotes like MOUNT C 'X:\DOS' on Windows. (Wengier)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 0.83.5
   - Worked around the mounting issue with LaunchBox,
-    allowing MOUNT C 'C:\DOS' for Windows. (Wengier)
+    by allowing a mounting command-line with single
+    quotes like MOUNT C 'X:\DOS' on Windows. (Wengier)
   - Updated xxHash library by Yann Collet from 0.7.4
     to the stable version 0.8.0. (Wengier)
   - Added "Quick launch program..." menu (under "DOS")

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ Pick a RPM package for your Linux platform and install. On CentOS, RHEL or Fedor
 
 ``sudo rpm -i <filename>.rpm``
 
-While ``<filename>`` is the main file name of the RPM package you wish to install. You may want to use the debug builds (the last three packages mentioned above) if you desire to do some debugging work when running DOSBox-X. If there are missing dependencies for the rpm command, such as libpng and fluid-soundfont, then you will need to install them first.
+Where ``<filename>`` is the main file name of the RPM package you wish to install. You may want to use the debug builds (the last three packages in the above example) if you desire to do some debugging work when running DOSBox-X. If there are missing dependencies for the rpm command, such as libpng and fluid-soundfont, then you will need to install them first.
 
 Note: You may not see all such packages for some DOSBox-X versions. For example, there are no CentOS 8 builds for DOSBox-X version 0.83.4. Only CentOS 7 builds are available for this version, namely the following:
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The full source code is officially provided with each DOSBox-X release, which ma
 Compatibility with DOS programs and games
 -----------------------------------------
 
-With the eventual goal of being a complete emulation package that covers all pre-2000 DOS and Windows 3.x/9x based hardware scenarios, we are making efforts to ensure that the vast majority of DOS games and applications will run in DOSBox-X, and these include both text-mode and graphical-mode DOS programs. Microsoft Windows versions that are largely DOS-based (such as Windows 3.x and 9x) are officially supported by DOSBox-X as well. Note that certain config settings may need to be changed from the default ones for some of these programs to work smoothly.
+With the eventual goal of being a complete emulation package that covers all pre-2000 DOS and Windows 3.x/9x based hardware scenarios, we are making efforts to ensure that the vast majority of DOS games and applications will run in DOSBox-X, and these include both text-mode and graphical-mode DOS programs. Microsoft Windows versions that are largely DOS-based (such as Windows 3.x and 9x) are officially supported by DOSBox-X as well. Note that certain config settings may need to be changed from the default ones for some of these programs to work smoothly. Take a look at the [DOSBox-X Wiki](https://github.com/joncampbell123/dosbox-x/wiki) for more information.
 
 Efforts are also made to aid retro DOS developments by attempting to accurately emulate the hardware, which is why DOSBox-X used to focus on the demoscene software (especially anything prior to 1996) because that era of the MS-DOS scene tends to have all manner of weird hardware tricks, bugs, and speed-sensitive issues that make them the perfect kind of stuff to test emulation accuracy against, even more so than old DOS games. But without a doubt we are also making a lot of efforts to test DOSBox-X against other DOS games and applications, as well as PC-98 programs (most of them are games).
 
@@ -116,7 +116,7 @@ greatly appreciated:
   - Bug fixes, patches, improvements, refinements
   - Suggestions, ideas, general conversation
   - Platform support (primarily Linux and Windows, but others are welcome)
-  - Documentation, language file transition
+  - Documentation, language file translation
   - Notes regarding games, applications, hacks, weird MS-DOS tricks, etc.
 
 If you want to tweak or write some code and you don't know what to work

--- a/include/builtin.h
+++ b/include/builtin.h
@@ -1,5 +1,6 @@
 
 #include "dos_inc.h"
+#include "../src/builtin/glide2x.h"
 #include "../src/builtin/4DOS_img.h"
 
 extern struct BuiltinFileBlob bfb_DSXMENU_EXE_PC;		// DSXMENU.EXE
@@ -30,7 +31,8 @@ extern struct BuiltinFileBlob bfb_50_COM;		// 50.COM
 extern struct BuiltinFileBlob bfb_25_COM;		// 25.COM
 extern struct BuiltinFileBlob bfb_25_COM_ega;	// 25.COM
 extern struct BuiltinFileBlob bfb_25_COM_other;	// 25.COM
-extern struct BuiltinFileBlob bfb_4DOS_COM;     // 4DOS.COM
-extern struct BuiltinFileBlob bfb_4DOS_HLP;     // 4DOS.HLP
-extern struct BuiltinFileBlob bfb_4HELP_EXE;     // 4HELP.EXE
+extern struct BuiltinFileBlob bfb_4DOS_COM;		// 4DOS.COM
+extern struct BuiltinFileBlob bfb_4DOS_HLP;		// 4DOS.HLP
+extern struct BuiltinFileBlob bfb_4HELP_EXE;	// 4HELP.EXE
+extern struct BuiltinFileBlob bfb_GLIDE2X_OVL;	// GLIDE2X.OVL
 

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -367,7 +367,6 @@ public:
 private:
 	static struct imagePlayer {
 		// Objects, pointers, and then scalars; in descending size-order.
-		MixerObject              mixerChannel       = {};
 		std::weak_ptr<TrackFile> trackFile          = {};
 		SDL_mutex                *mutex             = nullptr;
 		MixerChannel             *channel           = nullptr;

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -440,7 +440,7 @@ CDROM_Interface_Image::CDROM_Interface_Image(Bit8u subUnit)
 			player.mutex = SDL_CreateMutex();
 
 		if (!player.channel) {
-			player.channel = player.mixerChannel.Install(&CDAudioCallBack, 0, "CDAUDIO");
+			player.channel = MIXER_AddChannel(&CDAudioCallBack, 0, "CDAUDIO");
 			player.channel->Enable(false); // only enabled during playback periods
 		}
 	}

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -426,6 +426,7 @@ void MenuBrowseFolder(char drive, std::string drive_type) {
 #endif
 }
 
+extern bool dos_kernel_disabled, clearline;
 void MenuBrowseImageFile(char drive, bool boot) {
 	std::string str(1, drive);
 	std::string drive_warn;
@@ -438,6 +439,8 @@ void MenuBrowseImageFile(char drive, bool boot) {
 		MessageBox(GetHWND(),MSG_Get("PROGRAM_CONFIG_SECURE_DISALLOW"),"Error",MB_OK);
 		return;
 	}
+	if (dos_kernel_disabled)
+		return;
 #if !defined(HX_DOS)
 	OPENFILENAME OpenFileName;
 	char szFile[MAX_PATH];
@@ -520,7 +523,6 @@ search:
 #endif
 }
 
-extern bool dos_kernel_disabled;
 void MenuBrowseProgramFile() {
 	if(control->SecureMode()) {
 		MessageBox(GetHWND(),MSG_Get("PROGRAM_CONFIG_SECURE_DISALLOW"),"Error",MB_OK);
@@ -528,11 +530,12 @@ void MenuBrowseProgramFile() {
 	}
 	if (dos_kernel_disabled)
 		return;
+    std::string drive_warn;
 	DOS_MCB mcb(dos.psp()-1);
 	static char psp_name[9];
 	mcb.GetFileName(psp_name);
 	if(strlen(psp_name)&&strcmp(psp_name, "COMMAND")) {
-        std::string drive_warn=strcmp(psp_name, "4DOS")?"Another program is already running.":"Another shell is currently running.";
+        drive_warn=strcmp(psp_name, "4DOS")?"Another program is already running.":"Another shell is currently running.";
         MessageBox(GetHWND(),drive_warn.c_str(),"Error",MB_OK);
         return;
     }
@@ -542,7 +545,6 @@ void MenuBrowseProgramFile() {
 	char szFile[MAX_PATH];
 	char CurrentDir[MAX_PATH];
 	const char * Temp_CurrentDir = CurrentDir;
-
     char drv=' ';
     for (int i=2; i<DOS_DRIVES-1; i++) {
         if (!Drives[i]) {
@@ -550,10 +552,12 @@ void MenuBrowseProgramFile() {
             break;
         }
     }
-    if (drv==' ') {
-        if (MessageBox(GetHWND(), "Quick launch automatically mounts drive C in DOSBox-X.\nDrive C has already been mounted. Do you want to continue?","Warning",MB_YESNO)==IDNO) return;
+    if (drv==' ') { // Fallback to C: if no free drive found
+        drive_warn="Quick launch automatically mounts drive C in DOSBox-X.\nDrive C has already been mounted. Do you want to continue?";
+        if (MessageBox(GetHWND(),drive_warn.c_str(),"Warning",MB_YESNO)==IDNO) {return;}
         drv='C';
     }
+    mainMenu.get_item("quick_launch").enable(false).refresh_item(mainMenu);
 
 	szFile[0] = 0;
 
@@ -618,6 +622,7 @@ search:
 			}
 		}
 
+        clearline=true;
         bool exist=Drives[drv-'A'];
 		char pathname[DOS_PATHLENGTH];
 		sprintf(pathname,"%s%s",drive,dir);
@@ -634,10 +639,12 @@ search:
 		DOS_Shell shell;
 		shell.ParseLine(mountstring);
 		if (!Drives[drv-'A']) {
-			std::string drive_warn="Drive "+std::string(1, drv)+": failed to mount.";
+			drive_warn="Drive "+std::string(1, drv)+": failed to mount.";
 			MessageBox(GetHWND(),drive_warn.c_str(),"Error",MB_OK);
+            if (!dos_kernel_disabled) mainMenu.get_item("quick_launch").enable(true).refresh_item(mainMenu);
 			return;
         }
+        Bit8u olddrv=DOS_GetDefaultDrive();
 		DOS_SetDefaultDrive(drv-'A');
 
 		char name1[DOS_PATHLENGTH+2], name2[DOS_PATHLENGTH+4], name3[DOS_PATHLENGTH+4];
@@ -661,32 +668,38 @@ search:
 
 		SetCurrentDirectory( Temp_CurrentDir );
         shell.Execute(name1," ");
-        if(!strcasecmp(ext,".bat")) {
+        if (!strcasecmp(ext,".bat")) {
             bool echo=shell.echo;
             shell.echo=false;
             shell.RunInternal();
             shell.echo=echo;
-        } else {
+        }
+        if (!exist) {
+            for (int i=0; i<1000; i++) CALLBACK_Idle();
+            drive_warn="Program has finished execution. Do you want to unmount Drive "+std::string(1, drv)+" now?";
+            if (MessageBox(GetHWND(),drive_warn.c_str(),"Warning",MB_YESNO|MB_DEFBUTTON1)==IDYES) {
+                if (Drives[olddrv]) DOS_SetDefaultDrive(olddrv);
+                strcpy(mountstring,"MOUNT ");
+                char temp_str[3] = { 0,0,0 };
+                temp_str[0]=drv;
+                temp_str[1]=' ';
+                strcat(mountstring,temp_str);
+                strcat(mountstring," -u >nul");
+                shell.ParseLine(mountstring);
+            }
+        }
+        if (strcasecmp(ext,".bat")) {
             n=1;
             Bit8u c='\r';
             DOS_WriteFile(STDOUT,&c,&n);
             c='\n';
             DOS_WriteFile(STDOUT,&c,&n);
         }
-        if (!exist) {
-            strcpy(mountstring,"MOUNT ");
-            char temp_str[3] = { 0,0,0 };
-            temp_str[0]=drv;
-            temp_str[1]=' ';
-            strcat(mountstring,temp_str);
-            strcat(mountstring," -u >nul");
-            shell.ParseLine(mountstring);
-        }
 		shell.ShowPrompt();
 	}
 
 	SetCurrentDirectory( Temp_CurrentDir );
-	return;
+    if (!dos_kernel_disabled) mainMenu.get_item("quick_launch").enable(true).refresh_item(mainMenu);
 #endif
 }
 #endif

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -96,7 +96,13 @@ public:
 	virtual void EmptyCache(void) { dirCache.EmptyCache(); };
 	virtual void MediaChange() {};
 	const char* getBasedir() {return basedir;};
-
+	struct {
+		Bit16u bytes_sector;
+		Bit8u sectors_cluster;
+		Bit16u total_clusters;
+		Bit16u free_clusters;
+		Bit8u mediaid;
+	} allocation;
 	int remote = -1;
 
 protected:
@@ -106,14 +112,6 @@ protected:
 	struct {
 		char srch_dir[CROSS_LEN];
     } srchInfo[MAX_OPENDIRS] = {};
-
-	struct {
-		Bit16u bytes_sector;
-		Bit8u sectors_cluster;
-		Bit16u total_clusters;
-		Bit16u free_clusters;
-		Bit8u mediaid;
-	} allocation;
 };
 
 #if 0 // nothing uses this

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8145,6 +8145,7 @@ bool custom_bios = false;
 #endif
 
 //extern void UI_Init(void);
+void grGlideShutdown(void);
 int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
     CommandLine com_line(argc,argv);
     Config myconf(&com_line);
@@ -9634,6 +9635,7 @@ fresh_boot:
                 real_writed(0,0x03*4,(Bit32u)BIOS_DEFAULT_HANDLER_LOCATION);
             }
 
+            grGlideShutdown();
             /* shutdown DOSBox-X's virtual drive Z */
             VFILE_Shutdown();
 

--- a/src/hardware/glide.cpp
+++ b/src/hardware/glide.cpp
@@ -485,7 +485,7 @@ void GLIDE_ResetScreen(bool update)
 #else
         SDL_Surface* SDL_SetVideoMode(int width,int height,int bpp,Bit32u flags);
         sdl.surface = SDL_SetVideoMode(glide.width,glide.height,0,(glide.fullscreen[0]?SDL_FULLSCREEN:0)|SDL_ANYFORMAT);
-#endif      
+#endif
 	}
 }
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -84,7 +84,7 @@ static struct {
     Bitu            pos,done;
     float           mastervol[2];
     float           recordvol[2];
-    MixerChannel*       channels;
+    MixerChannel*   channels;
     Bit32u          freq;
     Bit32u          blocksize;
     struct mixedFraction samples_per_ms;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -41,7 +41,7 @@ static bool first_run=true;
 extern bool use_quick_reboot, mountwarning;
 extern bool startcmd, startwait, winautorun;
 extern bool enable_config_as_shell_commands;
-extern bool dos_shell_running_program;
+extern bool dos_shell_running_program, addovl;
 extern const char* RunningProgram;
 extern Bit16u countryNo;
 bool usecon = true;
@@ -1423,6 +1423,7 @@ void SHELL_Init() {
 	VFILE_RegisterBuiltinFileBlob(bfb_APPEND_EXE);
 	VFILE_RegisterBuiltinFileBlob(bfb_DEVICE_COM);
 	VFILE_RegisterBuiltinFileBlob(bfb_BUFFERS_COM);
+    if (addovl) VFILE_RegisterBuiltinFileBlob(bfb_GLIDE2X_OVL);
 
 	/* These are IBM PC/XT/AT ONLY. They will not work in PC-98 mode. */
 	if (!IS_PC98_ARCH) {

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -46,6 +46,7 @@
 # define MAX(a,b) std::max(a,b)
 #endif
 
+bool clearline=false;
 extern int lfn_filefind_handle;
 
 void DOS_Shell::ShowPrompt(void) {
@@ -157,6 +158,13 @@ void DOS_Shell::InputCommand(char * line) {
 			size=0;			//Kill the while loop
 			continue;
 		}
+        if (clearline) {
+            clearline = false;
+            *line=0;
+            if (l_completion.size()) l_completion.clear(); //reset the completion list.
+            str_index = 0;
+            str_len = 0;
+        }
 
         if (input_handle != STDIN) { /* FIXME: Need DOS_IsATTY() or somesuch */
             cr = (Bit16u)c; /* we're not reading from the console */


### PR DESCRIPTION
I noticed that resetting virtual machine will probably not work when the Glide feature is currently active. So I fixed this in the code. Also, I improved the new quick launch feature to ask the user whether to auto-unmount the drive after the program has finished execution.