### PR TITLE
Improve save state feature's handling of drive assignments and fix Issue #1789

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,10 +21,13 @@
     This fixes the "save state corrupted" error while
     trying to load saved states but the drives are not
     yet mounted in DOSBox-X. (Wengier)
-  - Increased save slots from 10 to 100. Each page in
-    the save slot menu (under "Capture") still shows
-    10 slots, but you can now go to previous or next
-    page (up to 10) for more save slots. (Wengier).
+  - The confirm dialogs for loading saved states now
+    appear on non-Windows platforms as well. (Wengier) 
+  - Increased the number of save slots from 10 to 100.
+    Each page in the save slot menu (under "Capture")
+    still shows 10 slots as before, but you can now go
+    to the previous or next page (up to 10 pages) for
+    more save slots (100 in total). (Wengier).
   - Added support for Glide wrapper. The library file
     glide2x.dll/libglide2x.so/libglide2x.dylib will be
     required for Glide to work. Be sure to use 32-bit

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,9 @@
   - Fixed that joystick may not work with the setting
     "usescancodes=auto" when a non-US keyboard layout
     is activated on the SDL1 build. (Wengier)
+  - Fixed possible failure when mounting .VHD images,
+    and the issue that leading : (read-only marker)
+    may not work for such images. (Wengier)
   - MOUNT command's -Q (quiet) option now silences
     virtually all output of this command. (Wengier)
   - Worked around the mounting issue with LaunchBox,

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,9 @@
 0.83.5
+  - Fixed that joystick may not work with the setting
+    "usescancodes=auto" when a non-US keyboard layout
+    is activated on the SDL1 build. (Wengier)
+  - MOUNT command's -Q (quiet) option now silences
+    virtually all output of this command. (Wengier)
   - Worked around the mounting issue with LaunchBox,
     by allowing a mounting command-line with single
     quotes like MOUNT C 'X:\DOS' on Windows. (Wengier)
@@ -8,9 +13,10 @@
     to quickly run the specified program as selected
     by the Windows file browser in DOSBox-X. (Wengier)
   - The save state feature now saves and restores the
-    mounted paths for mounted local or overlay drives.
-    This fixes the error when trying to load states
-    but the local drives aren't yet mounted. (Wengier)
+    mounted paths for most mounted drives (if the path
+    still exist on the host system). This fixes the
+    error while trying to load saved states but the
+    drives are not yet mounted in DOSBox-X. (Wengier)
   - Increased save slots from 10 to 100. Each page in
     the save slot menu (under "Capture") still shows
     10 slots, but you can now go to previous or next

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,8 +21,9 @@
     This fixes the "save state corrupted" error while
     trying to load saved states but the drives are not
     yet mounted in DOSBox-X. (Wengier)
-  - The confirm dialogs for loading saved states now
-    appear on non-Windows platforms as well. (Wengier) 
+  - All confirm and error dialog boxes for saving or
+    loading states appear in a cross-platform manner
+    now, instead of only on Windows systems. (Wengier) 
   - Increased the number of save slots from 10 to 100.
     Each page in the save slot menu (under "Capture")
     still shows 10 slots as before, but you can now go

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,11 +12,12 @@
   - Added "Quick launch program..." menu (under "DOS")
     to quickly run the specified program as selected
     by the Windows file browser in DOSBox-X. (Wengier)
-  - The save state feature now saves and restores the
-    mounted paths for most mounted drives (if the path
-    still exist on the host system). This fixes the
-    error while trying to load saved states but the
-    drives are not yet mounted in DOSBox-X. (Wengier)
+  - The save state feature now tries to save and then
+    restore the mounted drives of all types (if the
+    paths or image files still exist on host system).
+    This fixes the "save state corrupted" error while
+    trying to load saved states but the drives are not
+    yet mounted in DOSBox-X. (Wengier)
   - Increased save slots from 10 to 100. Each page in
     the save slot menu (under "Capture") still shows
     10 slots, but you can now go to previous or next

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,7 +29,12 @@ If you prefer to use the zip packages as previously mentioned, please select one
 Linux Packages (RPM)
 --------------------
 
-RPM packages are officially released for the Linux operating system (64-bit, with X11), specifically for CentOS 7 / RHEL 7 ("el7") and CentOS 8 / RHEL 8 ("el8") platforms. In the case of DOSBox-X version 0.83.2 for example, the following are the Linux PRM packages:
+RPM packages are officially released for the Linux operating system (64-bit, with X11), specifically for CentOS 7 / RHEL 7 ("el7") and CentOS 8 / RHEL 8 ("el8") platforms. There are usually packages for both CentOS 7 and CentOS 8 platforms, but for the current DOSBox-X version 0.83.4 only CentOS 7 RPM packages are available (no CentOS 8 RPM packages), namely the following files:
+
+* [dosbox-x-0.83.4-0.el7.x86_64.rpm](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.4/dosbox-x-0.83.4-0.el7.x86_64.rpm)
+* [dosbox-x-debuginfo-0.83.4-0.el7.x86_64.rpm](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.4/dosbox-x-debuginfo-0.83.4-0.el7.x86_64.rpm)
+
+The previous DOSBox-X version that provided official packages for both CentOS 7 and CentOS 8 platforms was version 0.83.2, which included the following Linux RPM packages:
 
 * [dosbox-x-0.83.2-0.el7.x86_64.rpm](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.2/dosbox-x-0.83.2-0.el7.x86_64.rpm)
 * [dosbox-x-0.83.2-0.el8.x86_64.rpm](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.2/dosbox-x-0.83.2-0.el8.x86_64.rpm)
@@ -42,11 +47,6 @@ Pick a RPM package of the version you want to use for your Linux platform and in
 ``sudo rpm -i <filename>.rpm``
 
 Where ``<filename>`` is the main file name of the RPM package you wish to install. You may want to use the debug builds (the last three packages in the above example) if you desire to do some debugging work when running DOSBox-X. If there are missing dependencies for the rpm command, such as libpng and fluid-soundfont, then you will need to install them first.
-
-Note: You may not see all such packages for some DOSBox-X versions. For example, there are no CentOS 8 builds for the current DOSBox-X version 0.83.4. Only CentOS 7 builds are available for this version, namely the following:
-
-* [dosbox-x-0.83.4-0.el7.x86_64.rpm](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.4/dosbox-x-0.83.4-0.el7.x86_64.rpm)
-* [dosbox-x-debuginfo-0.83.4-0.el7.x86_64.rpm](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.4/dosbox-x-debuginfo-0.83.4-0.el7.x86_64.rpm)
 
 macOS and DOS Packages (Portable)
 ---------------------------------

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,47 +12,49 @@ Windows Packages (Portable or Installer)
 
 **Note:** For users who wish to use the automatic installation package, the all-in-one Windows installer for the latest official DOSBox-X version is always available from: [DOSBox-X-Setup-Windows-latest.exe](https://github.com/Wengier/dosbox-x-wiki/raw/master/DOSBox-X-Setup-Windows-latest.exe)
 
-You can usually find three zip packages for each DOSBox-X version for the Windows platform in the Releases page. These are portable packages containing binaries built with Visual Studio 2019, MinGW 32-bit and MinGW 64-bit (or mingw-w64). In the case of DOSBox-X version 0.83.4, they correspond to the following respectively:
+You can usually find three zip packages for each DOSBox-X version for the Windows platform in the Releases page, apart from all-in-one Windows installer packages mentioned in this section. These zip files are portable packages containing binaries built with Visual Studio 2019, MinGW 32-bit and MinGW 64-bit (or mingw-w64). For the current DOSBox-X version 0.83.4, they are the following respectively:
 
-* dosbox-x-windows-20200803-055400-windows.zip
-* dosbox-x-mingw-win32-20200803060752.zip
-* dosbox-x-mingw-win64-20200803073328.zip
+* [dosbox-x-windows-20200803-055400-windows.zip](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.4/dosbox-x-windows-20200803-055400-windows.zip)
+* [dosbox-x-mingw-win32-20200803060752.zip](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.4/dosbox-x-mingw-win32-20200803060752.zip)
+* [dosbox-x-mingw-win64-20200803073328.zip](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.4/dosbox-x-mingw-win64-20200803073328.zip)
 
 The Visual Studio builds are the default Windows builds to use, but they only run on Windows Vista and later (Windows 7, 8, and 10). The MinGW builds will be required if you are running Windows XP. You may also want to use one of the MinGW builds (plain, lowend, etc) if you encounter specific problem(s) with the Visual Studio builds. In addition, while the SDL1 version is the default version, the SDL2 version may be prefered over the SDL1 version for certain features (particularly related to input handling) such as touchscreen input support.
 
-You may want to use the all-in-one Windows installation packages instead to ease the installation. The Windows installers are especially recommended for new or non-expert users. With the installer the installation process will be automated while allowing you to change the install folder and the default build to run if you prefer (and the option to install all builds to subdirectories), so that you will be able to start DOSBox-X as soon as the installation ends. A quick start guide is also included in the package. The Windows installer for DOSBox-X version 0.83.4 is available from: [DOSBox-X-Setup-Windows-latest.exe](https://github.com/Wengier/dosbox-x-wiki/raw/master/DOSBox-X-Setup-Windows-latest.exe)
+You may want to use the all-in-one Windows installation packages instead to ease the installation. The Windows installers are especially recommended for new or non-expert users. With the installer the installation process will be automated while allowing you to change the install folder and the default build to run if you prefer (and the option to install all builds to subdirectories), so that you will be able to start DOSBox-X as soon as the installation ends. A quick start guide is also included in the package. The Windows installer for DOSBox-X version 0.83.4 is available from:
+
+* [DOSBox-X-Setup-Windows-latest.exe](https://github.com/Wengier/dosbox-x-wiki/raw/master/DOSBox-X-Setup-Windows-latest.exe)
 
 If you prefer to use the zip packages as previously mentioned, please select one of the zip packages to download for your platform and unzip, then you will find various folders or subdirectories, which are some supported targets. For Visual Studio builds, these correspond to Win32, x64, ARM and ARM64 (either SDL1 or SDL2 version), which are the build platforms. For MinGW builds, the targets are plain MinGW SDL1 build (mingw), MinGW build for lower-end systems (mingw-lowend), MinGW SDL2 build (mingw-sdl2) and MinGW build with custom drawn menu (mingw-sdldraw). Go to a target folder for your platform and run dosbox-x.exe inside it, then DOSBox-X will be launched and ready to be used. Unlike the Windows installer version however, there is no documentation included in these packages, and you may not see all such packages for some DOSBox-X versions.
 
 Linux Packages (RPM)
 --------------------
 
-RPM packages are officially released for the Linux operating system (64-bit, with X11), specifically for CentOS 7 / RHEL 7 ("el7") and CentOS 8 / RHEL 8 ("el8") platforms. In the case of DOSBox-X version 0.83.2 for example, they correspond to the following:
+RPM packages are officially released for the Linux operating system (64-bit, with X11), specifically for CentOS 7 / RHEL 7 ("el7") and CentOS 8 / RHEL 8 ("el8") platforms. In the case of DOSBox-X version 0.83.2 for example, the following are the Linux PRM packages:
 
-* dosbox-x-0.83.2-0.el7.x86_64.rpm
-* dosbox-x-0.83.2-0.el8.x86_64.rpm
-* dosbox-x-debuginfo-0.83.2-0.el7.x86_64.rpm
-* dosbox-x-debuginfo-0.83.2-0.el8.x86_64.rpm
-* dosbox-x-debugsource-0.83.2-0.el8.x86_64.rpm
+* [dosbox-x-0.83.2-0.el7.x86_64.rpm](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.2/dosbox-x-0.83.2-0.el7.x86_64.rpm)
+* [dosbox-x-0.83.2-0.el8.x86_64.rpm](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.2/dosbox-x-0.83.2-0.el8.x86_64.rpm)
+* [dosbox-x-debuginfo-0.83.2-0.el7.x86_64.rpm](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.2/dosbox-x-debuginfo-0.83.2-0.el7.x86_64.rpm)
+* [dosbox-x-debuginfo-0.83.2-0.el8.x86_64.rpm](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.2/dosbox-x-debuginfo-0.83.2-0.el8.x86_64.rpm)
+* [dosbox-x-debugsource-0.83.2-0.el8.x86_64.rpm](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.2/dosbox-x-debugsource-0.83.2-0.el8.x86_64.rpm)
 
-Pick a RPM package for your Linux platform and install. On CentOS, RHEL or Fedora platforms, you can install a RPM package with a command line like this:
+Pick a RPM package of the version you want to use for your Linux platform and install. On CentOS, RHEL or Fedora platforms, you can install a RPM package with a command line like this:
 
 ``sudo rpm -i <filename>.rpm``
 
 Where ``<filename>`` is the main file name of the RPM package you wish to install. You may want to use the debug builds (the last three packages in the above example) if you desire to do some debugging work when running DOSBox-X. If there are missing dependencies for the rpm command, such as libpng and fluid-soundfont, then you will need to install them first.
 
-Note: You may not see all such packages for some DOSBox-X versions. For example, there are no CentOS 8 builds for DOSBox-X version 0.83.4. Only CentOS 7 builds are available for this version, namely the following:
+Note: You may not see all such packages for some DOSBox-X versions. For example, there are no CentOS 8 builds for the current DOSBox-X version 0.83.4. Only CentOS 7 builds are available for this version, namely the following:
 
-* dosbox-x-0.83.4-0.el7.x86_64.rpm
-* dosbox-x-debuginfo-0.83.4-0.el7.x86_64.rpm
+* [dosbox-x-0.83.4-0.el7.x86_64.rpm](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.4/dosbox-x-0.83.4-0.el7.x86_64.rpm)
+* [dosbox-x-debuginfo-0.83.4-0.el7.x86_64.rpm](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.4/dosbox-x-debuginfo-0.83.4-0.el7.x86_64.rpm)
 
 macOS and DOS Packages (Portable)
 ---------------------------------
 
-Besides Windows and Linux packages, there are also packages for the macOS (64-bit) and DOS platforms. In the case of DOSBox-X version 0.83.4, the macOS package and the special HX-DOS package correspond to the following zip packages respectively:
+Besides Windows and Linux packages, there are also packages for the macOS (64-bit) and DOS platforms. For the current DOSBox-X version 0.83.4, the macOS package and the special HX-DOS package are the following zip packages respectively:
 
-* dosbox-x-macosx-x64-20200802220401.zip
-* dosbox-x-mingw-hx-dos-20200803055533.zip
+* [dosbox-x-macosx-x64-20200802220401.zip](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.4/dosbox-x-macosx-x64-20200802220401.zip)
+* [dosbox-x-mingw-hx-dos-20200803055533.zip](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.4/dosbox-x-mingw-hx-dos-20200803055533.zip)
 
 The macOS package requires macOS Sierra 10.12 or higher. Both SDL1 and SDL2 binaries (in .app format) are provided in the macOS package, in the directories named "dosbox-x" and "dosbox-x-sdl2" inside the zip file.
 
@@ -63,9 +65,9 @@ Note: You may not see such packages for some DOSBox-X versions. For example, the
 Source Code Packages (zip or tar.gz)
 ------------------------------------
 
-Full source code packages of DOSBox-X are also available in both zip and tar.gz formats. Both contain the full source code, but you probably want to download the source code in zip format if you are using Windows, and the source code in tar.gz format if you are using Linux. They correspond the following files in the case of DOSBox-X version 0.83.4:
+Full source code packages of DOSBox-X are also available in both zip and tar.gz formats. Both contain the full source code, but you probably want to download the source code in zip format if you are using Windows, and the source code in tar.gz format if you are using Linux. For the current DOSBox-X version 0.83.4, the source code packages are:
 
-* dosbox-x-v0.83.4.zip
-* dosbox-x-v0.83.4.tar.gz
+* [dosbox-x-v0.83.4.zip](https://github.com/joncampbell123/dosbox-x/archive/dosbox-x-v0.83.4.zip)
+* [dosbox-x-v0.83.4.tar.gz](https://github.com/joncampbell123/dosbox-x/archive/dosbox-x-v0.83.4.tar.gz)
 
 If you prefer you can compile DOSBox-X from the source code by yourself. The source code packages as listed in the Releases page contain the source code for that released version, and in this example the DOSBox-X 0.83.4 version. On the other hand, if you are looking for the latest source code of DOSBox-X (including the most recent development changes in the source code), you may want to use the source code in the repository instead. You can use either of them according to your needs, and the source code may be compiled to run on the above-mentioned platforms (Windows, Linux, macOS and DOS) and possibly other operating systems too. Please see the [DOSBox-X source code description](README.source-code-description) file for detailed instructions on building the DOSBox-X source code and further information of the source code.

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -397,6 +397,7 @@ void DOS_Int21_71a7(const char *name1, const char *name2);
 void DOS_Int21_71a8(char* name1, const char* name2);
 void DOS_Int21_71aa(char* name1, const char* name2);
 Bitu DEBUG_EnableDebugger(void);
+void runMount(const char *str);
 void CALLBACK_RunRealInt_retcsip(Bit8u intnum,Bitu &cs,Bitu &ip);
 
 bool DOS_BreakINT23InProgress = false;
@@ -3864,15 +3865,13 @@ void DOS_Int21_71aa(char* name1, const char* name2) {
 			} else {
 				MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
 				char mountstring[DOS_PATHLENGTH+CROSS_LEN+20];
-				strcpy(mountstring,"MOUNT ");
 				char temp_str[3] = { 0,0,0 };
 				temp_str[0]=(char)('A'+reg_bl-1);
 				temp_str[1]=' ';
-				strcat(mountstring,temp_str);
+				strcpy(mountstring,temp_str);
 				strcat(mountstring,name1);
-				strcat(mountstring," >nul");
-				DOS_Shell temp;
-				temp.ParseLine(mountstring);
+				strcat(mountstring," -Q");
+				runMount(mountstring);
 				if (Drives[drive]) {
 					reg_ax=0;
 					CALLBACK_SCF(false);
@@ -3891,13 +3890,11 @@ void DOS_Int21_71aa(char* name1, const char* name2) {
 				CALLBACK_SCF(true);
 			} else {
 				char mountstring[DOS_PATHLENGTH+CROSS_LEN+20];
-				strcpy(mountstring,"MOUNT -u ");
 				char temp_str[2] = { 0,0 };
 				temp_str[0]=(char)('A'+reg_bl-1);
-				strcat(mountstring,temp_str);
-				strcat(mountstring," >nul");
-				DOS_Shell temp;
-				temp.ParseLine(mountstring);
+				strcpy(mountstring,temp_str);
+				strcat(mountstring," -Q -U");
+				runMount(mountstring);
 				if (!Drives[drive]) {
 					reg_ax =0;
 					CALLBACK_SCF(false);

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -2117,7 +2117,15 @@ void POD_Load_DOS_Files( std::istream& stream )
 
 			// - reloc ptr
 			READ_POD( &drive_valid, drive_valid );
-			if( drive_valid == 0xff ) continue;
+			if( drive_valid == 0xff ) {
+                if (Drives[lcv] && lcv<DOS_DRIVES-1) {
+                    DriveManager::UnmountDrive(lcv);
+                    Drives[lcv]=0;
+                    DOS_EnableDriveMenu('A'+lcv);
+                    mem_writeb(Real2Phys(dos.tables.mediaid)+(unsigned int)'A'+lcv*dos.tables.dpb_size,0);
+                }
+                continue;
+            }
 
             char dinfo[256];
             READ_POD( &dinfo, dinfo);

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -2000,6 +2000,7 @@ char overlaydir[CROSS_LEN];
 void MSCDEX_SetCDInterface(int intNr, int forceCD);
 void POD_Save_DOS_Files( std::ostream& stream )
 {
+	WRITE_POD( &dos_kernel_disabled, dos_kernel_disabled );
 	if (!dos_kernel_disabled) {
 		// 1. Do drives first (directories -> files)
 		// 2. Then files next
@@ -2117,6 +2118,7 @@ void DOS_EnableDriveMenu(char drv);
 imageDiskMemory* CreateRamDrive(Bitu sizes[], const int reserved_cylinders, const bool forceFloppy, Program* obj);
 void POD_Load_DOS_Files( std::istream& stream )
 {
+	READ_POD( &dos_kernel_disabled, dos_kernel_disabled );
 	if (!dos_kernel_disabled) {
 		// 1. Do drives first (directories -> files)
 		// 2. Then files next

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -1407,8 +1407,11 @@ void CMscdex::LoadState( std::istream& stream )
 
 void POD_Save_DOS_Mscdex( std::ostream& stream )
 {
+	WRITE_POD( &dos_kernel_disabled, dos_kernel_disabled );
 	if (!dos_kernel_disabled) {
-		for (Bit8u drive_unit=0; drive_unit<mscdex->GetNumDrives(); drive_unit++) {
+		Bit16u dnum=mscdex->GetNumDrives();
+		WRITE_POD( &dnum, dnum);
+		for (Bit8u drive_unit=0; drive_unit<dnum; drive_unit++) {
 			TMSF pos, start, end;
 			bool playing, pause;
 
@@ -1430,8 +1433,18 @@ void POD_Save_DOS_Mscdex( std::ostream& stream )
 
 void POD_Load_DOS_Mscdex( std::istream& stream )
 {
+	READ_POD( &dos_kernel_disabled, dos_kernel_disabled );
 	if (!dos_kernel_disabled) {
-		for (Bit8u drive_unit=0; drive_unit<mscdex->GetNumDrives(); drive_unit++) {
+		Bit16u dnum;
+		READ_POD( &dnum, dnum);
+        if (mscdex->GetNumDrives()>dnum) {
+            mscdex->numDrives=dnum;
+            for (Bit16u i=dnum; i<mscdex->GetNumDrives(); i++) {
+                delete mscdex->cdrom[i];
+                mscdex->cdrom[i] = 0;
+            }
+        }
+		for (Bit8u drive_unit=0; drive_unit<dnum; drive_unit++) {
 			TMSF pos, start, end;
 			Bit32u msf_time, play_len;
 			bool playing, pause;

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -505,6 +505,7 @@ search:
 		qmount=true;
 		runImgmount(mountstring);
 		qmount=false;
+		SetCurrentDirectory( Temp_CurrentDir );
 		if (!Drives[drive-'A']) {
 			drive_warn="Drive "+str+": failed to mount.";
 			MessageBox(GetHWND(),drive_warn.c_str(),"Error",MB_OK);
@@ -548,6 +549,14 @@ void MenuBrowseProgramFile() {
         if (!Drives[i]) {
             drv='A'+i;
             break;
+        }
+    }
+    if (drv==' ') {
+        for (int i=0; i<2; i++) {
+            if (!Drives[i]) {
+                drv='A'+i;
+                break;
+            }
         }
     }
     if (drv==' ') { // Fallback to C: if no free drive found

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -453,7 +453,7 @@ void MenuBrowseImageFile(char drive, bool boot) {
 	GetCurrentDirectory( MAX_PATH, CurrentDir );
 	OpenFileName.lStructSize = sizeof( OPENFILENAME );
 	OpenFileName.hwndOwner = NULL;
-	OpenFileName.lpstrFilter = "Image/Zip files(*.ima, *.img, *.iso, *.cue, *.bin, *.mdf, *.zip, *.7z)\0*.ima;*.img;*.iso;*.mdf;*.zip;*.cue;*.bin;*.7z\0All files(*.*)\0*.*\0";
+	OpenFileName.lpstrFilter = "Image/Zip files(*.ima, *.img, *.vhd, *.hdi, *.iso, *.cue, *.bin, *.mdf, *.zip, *.7z)\0*.ima;*.img;*.vhd;*.hdi;*.iso;*.cue;*.bin;*.mdf;*.zip;*.7z\0All files(*.*)\0*.*\0";
 	OpenFileName.lpstrCustomFilter = NULL;
 	OpenFileName.nMaxCustFilter = 0;
 	OpenFileName.nFilterIndex = 0;
@@ -1060,14 +1060,31 @@ public:
                     OPEN_FLAGS_DASD | OPEN_SHARE_DENYNONE | OPEN_ACCESS_READONLY, 0L);
                 DosClose(cdrom_fd);
                 if (rc != NO_ERROR && rc != ERROR_NOT_READY) {
-                if (!quiet) WriteOut(MSG_Get("PROGRAM_MOUNT_ERROR_2"),temp_line.c_str());
-                return;
-            }
+                    if (!quiet) {
+                        WriteOut(MSG_Get("PROGRAM_MOUNT_ERROR_2"),temp_line.c_str());
+                        if (temp_line.length()>4) {
+                            char ext[5];
+                            strncpy(ext, temp_line.substr(temp_line.length()-4).c_str(), 4);
+                            ext[4]=0;
+                            if (!strcasecmp(ext, ".iso")||!strcasecmp(ext, ".cue")||!strcasecmp(ext, ".bin")||!strcasecmp(ext, ".mdf")||!strcasecmp(ext, ".ima")||!strcasecmp(ext, ".img")||!strcasecmp(ext, ".vhd")||!strcasecmp(ext, ".hdi"))
+                                WriteOut(MSG_Get("PROGRAM_MOUNT_IMGMOUNT"),temp_line.c_str());
+                        }
+                    }
+                    return;
+                }
 #else
-                if (!quiet) WriteOut(MSG_Get("PROGRAM_MOUNT_ERROR_2"),temp_line.c_str());
+                if (!quiet) {
+                    WriteOut(MSG_Get("PROGRAM_MOUNT_ERROR_2"),temp_line.c_str());
+                    if (temp_line.length()>4) {
+                        char ext[5];
+                        strncpy(ext, temp_line.substr(temp_line.length()-4).c_str(), 4);
+                        ext[4]=0;
+                        if (!strcasecmp(ext, ".iso")||!strcasecmp(ext, ".cue")||!strcasecmp(ext, ".bin")||!strcasecmp(ext, ".mdf")||!strcasecmp(ext, ".ima")||!strcasecmp(ext, ".img")||!strcasecmp(ext, ".vhd")||!strcasecmp(ext, ".hdi"))
+                            WriteOut(MSG_Get("PROGRAM_MOUNT_IMGMOUNT"),temp_line.c_str());
+                    }
+                }
                 return;
 #endif
-
             }
 
             if (temp_line[temp_line.size()-1]!=CROSS_FILESPLIT) temp_line+=CROSS_FILESPLIT;
@@ -4038,12 +4055,12 @@ public:
         } else if (fstype=="none") {
             cmd->FindCommand(1,temp_line);
             if ((temp_line.size() > 1) || (!isdigit(temp_line[0]))) {
-                WriteOut_NoParsing(MSG_Get("PROGRAM_IMGMOUNT_SPECIFY2"));
+                WriteOut(MSG_Get("PROGRAM_IMGMOUNT_SPECIFY2"), MAX_DISK_IMAGES-1);
                 return;
             }
             drive=temp_line[0];
             if ((drive<'0') || (drive>=MAX_DISK_IMAGES+'0')) {
-                WriteOut_NoParsing(MSG_Get("PROGRAM_IMGMOUNT_SPECIFY2"));
+                WriteOut(MSG_Get("PROGRAM_IMGMOUNT_SPECIFY2"), MAX_DISK_IMAGES-1);
                 return;
             }
 			int index = drive - '0';
@@ -6101,6 +6118,7 @@ void DOS_SetupPrograms(void) {
     MSG_Add("PROGRAM_IMGMOUNT_STATUS_NONE","No drive available\n");
     MSG_Add("PROGRAM_MOUNT_ERROR_1","Directory %s doesn't exist.\n");
     MSG_Add("PROGRAM_MOUNT_ERROR_2","%s is not a directory\n");
+    MSG_Add("PROGRAM_MOUNT_IMGMOUNT","To mount image files, use the \033[34;1mIMGMOUNT\033[0m command, not the \033[34;1mMOUNT\033[0m command.\n");
     MSG_Add("PROGRAM_MOUNT_ILL_TYPE","Illegal type %s\n");
     MSG_Add("PROGRAM_MOUNT_ALREADY_MOUNTED","Drive %c already mounted with %s\n");
     MSG_Add("PROGRAM_MOUNT_USAGE",
@@ -6396,7 +6414,7 @@ void DOS_SetupPrograms(void) {
     MSG_Add("VHD_PARENT_INVALID_DATE", "The parent of the specified VHD file has been changed and cannot be loaded.\n");
 
     MSG_Add("PROGRAM_IMGMOUNT_SPECIFY_DRIVE","Must specify drive letter to mount image at.\n");
-    MSG_Add("PROGRAM_IMGMOUNT_SPECIFY2","Must specify drive number (0 or 3) to mount image at (0,1=fda,fdb;2,3=hda,hdb).\n");
+    MSG_Add("PROGRAM_IMGMOUNT_SPECIFY2","Must specify drive number (0 to %d) to mount image at (0,1=fda,fdb;2,3=hda,hdb).\n");
     MSG_Add("PROGRAM_IMGMOUNT_SPECIFY_GEOMETRY",
         "For \033[33mCD-ROM\033[0m images:   \033[34;1mIMGMOUNT drive-letter location-of-image -t iso\033[0m\n"
         "\n"

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -67,6 +67,7 @@ bool wpcolon = true;
 bool startcmd = false;
 bool startwait = true;
 bool mountwarning = true;
+bool qmount = false;
 
 void DOS_EnableDriveMenu(char drv);
 
@@ -427,6 +428,7 @@ void MenuBrowseFolder(char drive, std::string drive_type) {
 }
 
 extern bool dos_kernel_disabled, clearline;
+void runBoot(const char *str), runMount(const char *str), runImgmount(const char *str);
 void MenuBrowseImageFile(char drive, bool boot) {
 	std::string str(1, drive);
 	std::string drive_warn;
@@ -491,8 +493,7 @@ search:
 		else
 			strcpy(type,"");
 		char mountstring[DOS_PATHLENGTH+CROSS_LEN+20];
-		strcpy(mountstring,"IMGMOUNT ");
-		strcat(mountstring,type);
+		strcpy(mountstring,type);
 		char temp_str[3] = { 0,0,0 };
 		temp_str[0]=drive;
 		temp_str[1]=' ';
@@ -501,21 +502,18 @@ search:
 		strcat(mountstring,path);
 		strcat(mountstring,"\"");
 		if (boot) strcat(mountstring," -U");
-		strcat(mountstring," >nul");
-		DOS_Shell temp;
-		temp.ParseLine(mountstring);
+		qmount=true;
+		runImgmount(mountstring);
+		qmount=false;
 		if (!Drives[drive-'A']) {
 			drive_warn="Drive "+str+": failed to mount.";
 			MessageBox(GetHWND(),drive_warn.c_str(),"Error",MB_OK);
 			return;
 		} else if (boot) {
-			char bootstring[DOS_PATHLENGTH+CROSS_LEN+20];
-			strcpy(bootstring,"Z:\\BOOT -L ");
-			strcat(bootstring,str.c_str());
-			strcat(bootstring," >nul");
-			DOS_Shell temp;
-			temp.ParseLine(bootstring);
-			std::string drive_warn="Drive "+str+": failed to boot.";
+			char str[] = "A:";
+			str[0]=drive;
+			runBoot(str);
+			std::string drive_warn="Drive "+std::string(1, drive)+": failed to boot.";
 			MessageBox(GetHWND(),drive_warn.c_str(),"Error",MB_OK);
 		}
 	}
@@ -627,17 +625,15 @@ search:
 		char pathname[DOS_PATHLENGTH];
 		sprintf(pathname,"%s%s",drive,dir);
 		char mountstring[DOS_PATHLENGTH+CROSS_LEN+20];
-		strcpy(mountstring,"MOUNT ");
 		char temp_str[3] = { 0,0,0 };
 		temp_str[0]=drv;
 		temp_str[1]=' ';
-		strcat(mountstring,temp_str);
+		strcpy(mountstring,temp_str);
 		strcat(mountstring,"\"");
 		strcat(mountstring,pathname);
 		strcat(mountstring,"\"");
-		strcat(mountstring," -u >nul");
-		DOS_Shell shell;
-		shell.ParseLine(mountstring);
+		strcat(mountstring," -Q -U");
+		runMount(mountstring);
 		if (!Drives[drv-'A']) {
 			drive_warn="Drive "+std::string(1, drv)+": failed to mount.";
 			MessageBox(GetHWND(),drive_warn.c_str(),"Error",MB_OK);
@@ -667,6 +663,7 @@ search:
         DOS_WriteFile(STDERR,(Bit8u*)msg.c_str(),&n);
 
 		SetCurrentDirectory( Temp_CurrentDir );
+        DOS_Shell shell;
         shell.Execute(name1," ");
         if (!strcasecmp(ext,".bat")) {
             bool echo=shell.echo;
@@ -679,13 +676,12 @@ search:
             drive_warn="Program has finished execution. Do you want to unmount Drive "+std::string(1, drv)+" now?";
             if (MessageBox(GetHWND(),drive_warn.c_str(),"Warning",MB_YESNO|MB_DEFBUTTON1)==IDYES) {
                 if (Drives[olddrv]) DOS_SetDefaultDrive(olddrv);
-                strcpy(mountstring,"MOUNT ");
                 char temp_str[3] = { 0,0,0 };
                 temp_str[0]=drv;
                 temp_str[1]=' ';
-                strcat(mountstring,temp_str);
-                strcat(mountstring," -u >nul");
-                shell.ParseLine(mountstring);
+                strcpy(mountstring,temp_str);
+                strcat(mountstring," -Q -U");
+                runMount(mountstring);
             }
         }
         if (strcasecmp(ext,".bat")) {
@@ -802,12 +798,13 @@ public:
         bool path_relative_to_last_config = false;
         if (cmd->FindExist("-pr",true)) path_relative_to_last_config = true;
 
-        if (cmd->FindExist("-q",false))
+        if (cmd->FindExist("-q",true))
             quiet = true;
 
         /* Check for unmounting */
         if (cmd->FindString("-u",umount,false)) {
-            WriteOut(UnmountHelper(umount[0]), toupper(umount[0]));
+            const char *msg=UnmountHelper(umount[0]);
+            if (!quiet) WriteOut(msg, toupper(umount[0]));
             return;
         }
 
@@ -863,9 +860,9 @@ public:
         if (cmd->FindExist("-cd",false)) {
 #if !defined(C_SDL2)
             int num = SDL_CDNumDrives();
-            WriteOut(MSG_Get("PROGRAM_MOUNT_CDROMS_FOUND"),num);
+            if (!quiet) WriteOut(MSG_Get("PROGRAM_MOUNT_CDROMS_FOUND"),num);
             for (int i=0; i<num; i++) {
-                WriteOut("%2d. %s\n",i,SDL_CDName(i));
+                if (!quiet) WriteOut("%2d. %s\n",i,SDL_CDName(i));
             }
 #endif
             return;
@@ -905,7 +902,7 @@ public:
                 str_size="2048,1,65535,0";
                 mediaid=0xF8;       /* Hard Disk */
             } else {
-                WriteOut(MSG_Get("PROGAM_MOUNT_ILL_TYPE"),type.c_str());
+                if (!quiet) WriteOut(MSG_Get("PROGAM_MOUNT_ILL_TYPE"),type.c_str());
                 return;
             }
             /* Parse the free space in mb's (kb's for floppies) */
@@ -959,7 +956,8 @@ public:
             if (!cmd->FindCommand(2,temp_line)) goto showusage;
             if (!temp_line.size()) goto showusage;
 			if (cmd->FindExist("-u",true)) {
-				WriteOut(UnmountHelper(i_drive), toupper(i_drive));
+                const char *msg=UnmountHelper(i_drive);
+				if (!quiet) WriteOut(msg, toupper(i_drive));
 				if (!cmd->FindCommand(2,temp_line)||!temp_line.size()) return;
 			}
             if(path_relative_to_last_config && control->configfiles.size() && !Cross::IsPathAbsolute(temp_line)) {
@@ -1040,7 +1038,7 @@ public:
             }
             if(failed) {
 #endif
-                WriteOut(MSG_Get("PROGRAM_MOUNT_ERROR_1"),temp_line.c_str());
+                if (!quiet) WriteOut(MSG_Get("PROGRAM_MOUNT_ERROR_1"),temp_line.c_str());
                 return;
             }
             /* Not a switch so a normal directory/file */
@@ -1053,11 +1051,11 @@ public:
                     OPEN_FLAGS_DASD | OPEN_SHARE_DENYNONE | OPEN_ACCESS_READONLY, 0L);
                 DosClose(cdrom_fd);
                 if (rc != NO_ERROR && rc != ERROR_NOT_READY) {
-                WriteOut(MSG_Get("PROGRAM_MOUNT_ERROR_2"),temp_line.c_str());
+                if (!quiet) WriteOut(MSG_Get("PROGRAM_MOUNT_ERROR_2"),temp_line.c_str());
                 return;
             }
 #else
-                WriteOut(MSG_Get("PROGRAM_MOUNT_ERROR_2"),temp_line.c_str());
+                if (!quiet) WriteOut(MSG_Get("PROGRAM_MOUNT_ERROR_2"),temp_line.c_str());
                 return;
 #endif
 
@@ -1098,17 +1096,18 @@ public:
 #endif
                 }
                 if (is_physfs) {
-					WriteOut(MSG_Get("PROGRAM_IMGMOUNT_CANT_CREATE_PHYSFS"));
+					if (!quiet) WriteOut(MSG_Get("PROGRAM_IMGMOUNT_CANT_CREATE_PHYSFS"));
                     LOG_MSG("ERROR:This build does not support physfs");
 					return;
                 } else {
 					if (Drives[drive-'A']) {
-						WriteOut(MSG_Get("PROGRAM_MOUNT_ALREADY_MOUNTED"),drive,Drives[drive-'A']->GetInfo());
+						if (!quiet) WriteOut(MSG_Get("PROGRAM_MOUNT_ALREADY_MOUNTED"),drive,Drives[drive-'A']->GetInfo());
 						return;
 					}
                     newdrive  = new cdromDrive(drive,temp_line.c_str(),sizes[0],bit8size,sizes[2],sizes[3],mediaid,error,options);
                 }
                 // Check Mscdex, if it worked out...
+                if (!quiet)
                 switch (error) {
                     case 0  :   WriteOut(MSG_Get("MSCDEX_SUCCESS"));                break;
                     case 1  :   WriteOut(MSG_Get("MSCDEX_ERROR_MULTIPLE_CDROMS"));  break;
@@ -1124,7 +1123,7 @@ public:
                 }
             } else {
                 /* Give a warning when mount c:\ or the / */
-                if (mountwarning) {
+                if (mountwarning && !quiet) {
 #if defined (WIN32) || defined(OS2)
                     if( (temp_line == "c:\\") || (temp_line == "C:\\") ||
                         (temp_line == "c:/") || (temp_line == "C:/")    )
@@ -1134,19 +1133,19 @@ public:
 #endif
                 }
                 if (is_physfs) {
-					WriteOut(MSG_Get("PROGRAM_IMGMOUNT_CANT_CREATE_PHYSFS"));
+					if (!quiet) WriteOut(MSG_Get("PROGRAM_IMGMOUNT_CANT_CREATE_PHYSFS"));
                     LOG_MSG("ERROR:This build does not support physfs");
 					return;
                 } else if(type == "overlay") {
                   //Ensure that the base drive exists:
                   if (!Drives[drive-'A']) { 
-                      WriteOut(MSG_Get("PROGRAM_MOUNT_OVERLAY_NO_BASE"));
+                      if (!quiet) WriteOut(MSG_Get("PROGRAM_MOUNT_OVERLAY_NO_BASE"));
                       return;
                   }
                   localDrive* ldp = dynamic_cast<localDrive*>(Drives[drive-'A']);
                   cdromDrive* cdp = dynamic_cast<cdromDrive*>(Drives[drive-'A']);
                   if (!ldp || cdp) {
-					  WriteOut(MSG_Get("PROGRAM_MOUNT_OVERLAY_INCOMPAT_BASE"));
+					  if (!quiet) WriteOut(MSG_Get("PROGRAM_MOUNT_OVERLAY_INCOMPAT_BASE"));
                       return;
                   }
                   std::string base = ldp->getBasedir();
@@ -1154,7 +1153,8 @@ public:
                   newdrive = new Overlay_Drive(base.c_str(),temp_line.c_str(),sizes[0],bit8size,sizes[2],sizes[3],mediaid,o_error,options);
                   //Erase old drive on succes
                   if (newdrive) {
-                      if (o_error) { 
+                      if (o_error) {
+                          if (quiet) {delete newdrive;return;}
                           if (o_error == 1) WriteOut("No mixing of relative and absolute paths. Overlay failed.\n");
                           else if (o_error == 2) WriteOut("Overlay directory cannot be the same as underlying filesystem.\n");
                           else WriteOut("An error occurred when trying to create an overlay drive.\n");
@@ -1170,7 +1170,7 @@ public:
                       delete Drives[drive-'A'];
                       Drives[drive-'A'] = 0;
                   } else { 
-                      WriteOut("Overlay drive construction failed.\n");
+                      if (!quiet) WriteOut("Overlay drive construction failed.\n");
                       return;
                   }
               } else {
@@ -1180,11 +1180,11 @@ public:
                 }
             }
         } else {
-            WriteOut(MSG_Get("PROGRAM_MOUNT_ILL_TYPE"),type.c_str());
+            if (!quiet) WriteOut(MSG_Get("PROGRAM_MOUNT_ILL_TYPE"),type.c_str());
             return;
         }
         if (Drives[drive-'A']) {
-            WriteOut(MSG_Get("PROGRAM_MOUNT_ALREADY_MOUNTED"),drive,Drives[drive-'A']->GetInfo());
+            if (!quiet) WriteOut(MSG_Get("PROGRAM_MOUNT_ALREADY_MOUNTED"),drive,Drives[drive-'A']->GetInfo());
             if (newdrive) delete newdrive;
             return;
         }
@@ -1235,6 +1235,12 @@ showusage:
 
 static void MOUNT_ProgramStart(Program * * make) {
     *make=new MOUNT;
+}
+
+void runMount(const char *str) {
+	MOUNT mount;
+	mount.cmd=new CommandLine("MOUNT", str);
+	mount.Run();
 }
 
 void GUI_Run(bool pressed);
@@ -2336,11 +2342,9 @@ static void BOOT_ProgramStart(Program * * make) {
     *make=new BOOT;
 }
 
-void runBoot() {
+void runBoot(const char *str) {
 	BOOT boot;
-	char drive[] = "-Q A:";
-	drive[3]='A'+bootdrive;
-	boot.cmd=new CommandLine("BOOT", drive);
+	boot.cmd=new CommandLine("BOOT", str);
 	boot.Run();
 }
 
@@ -4366,21 +4370,21 @@ private:
                     DOS_EnableDriveMenu(i_drive+'A');
                     if (i_drive == DOS_GetDefaultDrive())
                         DOS_SetDrive(toupper('Z') - 'A');
-                    WriteOut(MSG_Get("PROGRAM_MOUNT_UMOUNT_SUCCESS"), letter);
+                    if (!qmount) WriteOut(MSG_Get("PROGRAM_MOUNT_UMOUNT_SUCCESS"), letter);
                     return true;
                 }
                 case 1:
-                    WriteOut(MSG_Get("PROGRAM_MOUNT_UMOUNT_NO_VIRTUAL"));
+                    if (!qmount) WriteOut(MSG_Get("PROGRAM_MOUNT_UMOUNT_NO_VIRTUAL"));
                     return false;
                 case 2:
-                    WriteOut(MSG_Get("MSCDEX_ERROR_MULTIPLE_CDROMS"));
+                    if (!qmount) WriteOut(MSG_Get("MSCDEX_ERROR_MULTIPLE_CDROMS"));
                     return false;
                 default:
                     return false;
                 }
             }
             else {
-                WriteOut(MSG_Get("PROGRAM_MOUNT_UMOUNT_NOT_MOUNTED"), letter);
+                if (!qmount) WriteOut(MSG_Get("PROGRAM_MOUNT_UMOUNT_NOT_MOUNTED"), letter);
                 return false;
             }
         }
@@ -4700,7 +4704,7 @@ private:
                 }
             }
             if (errorMessage) {
-                WriteOut(errorMessage);
+                if (!qmount) WriteOut(errorMessage);
                 for (ct = 0; ct < imgDisks.size(); ct++) {
                     delete imgDisks[ct];
                 }
@@ -4715,7 +4719,7 @@ private:
         for (i = 1; i < paths.size(); i++) {
             tmp += "; " + (wpcolon&&paths[i].length()>1&&paths[i].c_str()[0]==':'?paths[i].substr(1):paths[i]);
         }
-        WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_2"), drive, tmp.c_str());
+        if (!qmount) WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_2"), drive, tmp.c_str());
 
         if (imgDisks.size() == 1) {
             imageDisk* image = ((fatDrive*)imgDisks[0])->loadedDisk;
@@ -5078,11 +5082,11 @@ private:
 	if (yet_detected) {
             //"Image geometry auto detection: -size %u,%u,%u,%u\r\n",
             //sizes[0],sizes[1],sizes[2],sizes[3]);
-            WriteOut(MSG_Get("PROGRAM_IMGMOUNT_AUTODET_VALUES"), sizes[0], sizes[1], sizes[2], sizes[3]);
+            if (!qmount) WriteOut(MSG_Get("PROGRAM_IMGMOUNT_AUTODET_VALUES"), sizes[0], sizes[1], sizes[2], sizes[3]);
             return true;
         }
         else {
-            WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_GEOMETRY"));
+            if (!qmount) WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_GEOMETRY"));
             return false;
         }
     }
@@ -5378,6 +5382,12 @@ private:
 
 void IMGMOUNT_ProgramStart(Program * * make) {
     *make=new IMGMOUNT;
+}
+
+void runImgmount(const char *str) {
+	IMGMOUNT imgmount;
+	imgmount.cmd=new CommandLine("IMGMOUNT", str);
+	imgmount.Run();
 }
 
 Bitu DOS_SwitchKeyboardLayout(const char* new_layout, Bit32s& tried_cp);

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -4184,7 +4184,7 @@ public:
                 if (strcasecmp(temp_line.c_str(), "-u")) WriteOut(MSG_Get("PROGRAM_IMGMOUNT_SPECIFY_FILE"));
                 return; 
             }
-			if (!rtype&&!rfstype&&paths[0].length()>4) {
+			if (!rtype&&!rfstype&&fstype!="none"&&paths[0].length()>4) {
 				char ext[5];
 				strncpy(ext, paths[0].substr(paths[0].length()-4).c_str(), 4);
 				ext[4]=0;

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1202,6 +1202,11 @@ fatDrive::fatDrive(const char* sysFilename, Bit32u bytesector, Bit32u cylsector,
 	readonly = wpcolon&&strlen(sysFilename)>1&&sysFilename[0]==':';
 	diskfile = fopen64(readonly?sysFilename+1:sysFilename, readonly?"rb":"rb+");
 	if(!diskfile) {created_successfully = false;return;}
+    opts.bytesector = bytesector;
+    opts.cylsector = cylsector;
+    opts.headscyl = headscyl;
+    opts.cylinders = cylinders;
+    opts.regmount = true;
 
     // all disk I/O is in sector-sized blocks.
     // modern OSes have good caching.
@@ -1273,6 +1278,7 @@ fatDrive::fatDrive(imageDisk *sourceLoadedDisk, std::vector<std::string> &option
 		imgDTAPtr = RealMake(imgDTASeg, 0);
 		imgDTA    = new DOS_DTA(imgDTAPtr);
 	}
+    opts = {0,0,0,0, false};
 
     loadedDisk = sourceLoadedDisk;
 

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1206,7 +1206,7 @@ fatDrive::fatDrive(const char* sysFilename, Bit32u bytesector, Bit32u cylsector,
     opts.cylsector = cylsector;
     opts.headscyl = headscyl;
     opts.cylinders = cylinders;
-    opts.regmount = true;
+    opts.mounttype = 0;
 
     // all disk I/O is in sector-sized blocks.
     // modern OSes have good caching.
@@ -1278,7 +1278,20 @@ fatDrive::fatDrive(imageDisk *sourceLoadedDisk, std::vector<std::string> &option
 		imgDTAPtr = RealMake(imgDTASeg, 0);
 		imgDTA    = new DOS_DTA(imgDTAPtr);
 	}
-    opts = {0,0,0,0, false};
+    opts = {0,0,0,0,-1};
+    imageDiskElToritoFloppy *idelt=dynamic_cast<imageDiskElToritoFloppy *>(sourceLoadedDisk);
+    imageDiskMemory* idmem=dynamic_cast<imageDiskMemory *>(sourceLoadedDisk);
+    imageDiskVHD* idvhd=dynamic_cast<imageDiskVHD *>(sourceLoadedDisk);
+    if (idelt!=NULL) {
+        opts.mounttype = 1;
+        el.CDROM_drive = idelt->CDROM_drive;
+        el.cdrom_sector_offset = idelt->cdrom_sector_offset;
+        el.floppy_emu_type = idelt->floppy_type;
+    } else if (idmem!=NULL) {
+        opts.mounttype=2;
+    } else if (idvhd!=NULL) {
+        opts.mounttype=3;
+    }
 
     loadedDisk = sourceLoadedDisk;
 
@@ -1742,7 +1755,7 @@ void fatDrive::fatDriveInit(const char *sysFilename, Bit32u bytesector, Bit32u c
 	if ((BPB.v.BPB_SecPerClus == 0) ||
 		(BPB.v.BPB_NumFATs == 0) ||
 		(BPB.v.BPB_NumHeads == 0 && !IS_PC98_ARCH) ||
-		(BPB.v.BPB_NumHeads > headscyl && !IS_PC98_ARCH) ||
+		//(BPB.v.BPB_NumHeads > headscyl && !IS_PC98_ARCH) ||
 		(BPB.v.BPB_SecPerTrk == 0 && !IS_PC98_ARCH) ||
 		(BPB.v.BPB_SecPerTrk > cylsector && !IS_PC98_ARCH)) {
 		LOG_MSG("Sanity checks failed");

--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -424,6 +424,8 @@ char * DOS_Drive::GetBaseDir(void) {
 void DOS_Drive::SaveState( std::ostream& stream )
 {
 	// - pure data
+	WRITE_POD( &nocachedir, nocachedir );
+	WRITE_POD( &readonly, readonly );
 	WRITE_POD( &curdir, curdir );
 	WRITE_POD( &info, info );
 }
@@ -431,6 +433,8 @@ void DOS_Drive::SaveState( std::ostream& stream )
 void DOS_Drive::LoadState( std::istream& stream )
 {
 	// - pure data
+	READ_POD( &nocachedir, nocachedir );
+	READ_POD( &readonly, readonly );
 	READ_POD( &curdir, curdir );
 	READ_POD( &info, info );
 }

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -411,6 +411,14 @@ public:
 	imageDisk *loadedDisk = NULL;
 	uint8_t req_ver_major = 0,req_ver_minor = 0;
 	bool created_successfully = true;
+    struct {
+        Bit32u bytesector;
+        Bit32u cylsector;
+        Bit32u headscyl;
+        Bit32u cylinders;
+        bool regmount;
+    } opts = {0, 0, 0, 0, false};
+
 private:
 	char* Generate_SFN(const char *path, const char *name);
 	Bit32u getClusterValue(Bit32u clustNum);

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -416,8 +416,13 @@ public:
         Bit32u cylsector;
         Bit32u headscyl;
         Bit32u cylinders;
-        bool regmount;
-    } opts = {0, 0, 0, 0, false};
+        int mounttype;
+    } opts = {0, 0, 0, 0, -1};
+    struct {
+        unsigned char CDROM_drive;
+        unsigned long cdrom_sector_offset;
+        unsigned char floppy_emu_type;
+    } el = {0, 0, 0};
 
 private:
 	char* Generate_SFN(const char *path, const char *name);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -135,6 +135,7 @@ extern void         GFX_SetTitle(Bit32s cycles,Bits frameskip,Bits timing,bool p
 extern bool         force_nocachedir;
 extern bool         freesizecap;
 extern bool         wpcolon;
+extern bool         clearline;
 
 extern Bitu         frames;
 extern Bitu         cycle_count;
@@ -4863,6 +4864,7 @@ void SaveState::load(size_t slot) const { //throw (Error)
 		return;
 	}
 	SDL_PauseAudio(0);
+    clearline=true;
 	extern const char* RunningProgram;
 	bool read_version=false;
 	bool read_title=false;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -4853,6 +4853,21 @@ void savestatecorrupt(const char* part) {
     GFX_LosingFocus();
 }
 
+bool confres=false;
+bool loadstateconfirm(int ind) {
+    if (ind<0||ind>2) return false;
+    confres=false;
+    void MAPPER_ReleaseAllKeys(void);
+    MAPPER_ReleaseAllKeys();
+    GFX_LosingFocus();
+    GUI_Shortcut(22+ind);
+    MAPPER_ReleaseAllKeys();
+    GFX_LosingFocus();
+    bool ret=confres;
+    confres=false;
+    return ret;
+}
+
 void SaveState::load(size_t slot) const { //throw (Error)
 //	if (isEmpty(slot)) return;
 	bool load_err=false;
@@ -4935,11 +4950,7 @@ void SaveState::load(size_t slot) const { //throw (Error)
 			if (p!=NULL) *p=0;
 			std::string emulatorversion = std::string("DOSBox-X ") + VERSION + std::string(" (") + SDL_STRING + std::string(")\n") + GetPlatform();
 			if (p==NULL||strcasecmp(buffer,emulatorversion.c_str())) {
-#if defined(WIN32)
-				if(!force_load_state&&MessageBox(GetHWND(),"DOSBox-X version mismatch. Load the state anyway?","Warning",MB_YESNO|MB_DEFBUTTON2)==IDNO) {
-#else
-				if(!force_load_state) {
-#endif
+				if(!force_load_state&&!loadstateconfirm(0)) {
 					LOG_MSG("Aborted. Check your DOSBox-X version: %s",buffer);
 					load_err=true;
 					goto delete_all;
@@ -4968,11 +4979,7 @@ void SaveState::load(size_t slot) const { //throw (Error)
 			check_title.read (buffer, length);
 			check_title.close();
 			if (!length||(size_t)length!=strlen(RunningProgram)||strncmp(buffer,RunningProgram,length)) {
-#if defined(WIN32)
-				if(!force_load_state&&MessageBox(GetHWND(),"Program name mismatch. Load the state anyway?","Warning",MB_YESNO|MB_DEFBUTTON2)==IDNO) {
-#else
-				if(!force_load_state) {
-#endif
+				if(!force_load_state&&!loadstateconfirm(1)) {
 					buffer[length]='\0';
 					LOG_MSG("Aborted. Check your program name: %s",buffer);
 					load_err=true;
@@ -5014,11 +5021,7 @@ void SaveState::load(size_t slot) const { //throw (Error)
 			char str[10];
 			itoa((int)MEM_TotalPages(), str, 10);
 			if(strncmp(buffer,str,length)) {
-#if defined(WIN32)
-				if(!force_load_state&&MessageBox(GetHWND(),"Memory size mismatch. Load the state anyway?","Warning",MB_YESNO|MB_DEFBUTTON2)==IDNO) {
-#else
-				if(!force_load_state) {
-#endif
+				if(!force_load_state&&!loadstateconfirm(2)) {
 					buffer[length]='\0';
 					LOG_MSG("Aborted. Check your memory size.");
 					load_err=true;

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -68,6 +68,7 @@ extern unsigned char        GFX_Gshift;
 extern uint32_t             GFX_Bmask;
 extern unsigned char        GFX_Bshift;
 
+extern std::string          saveloaderr;
 extern bool                 dos_kernel_disabled, confres;
 extern Bitu                 currentWindowWidth, currentWindowHeight;
 
@@ -1798,6 +1799,10 @@ static void UI_Select(GUI::ScreenSDL *screen, int select) {
         case 24: {
             auto *np7 = new ShowLoadWarning(screen, 150, 120, "Memory size mismatch. Load the state anyway?");
             np7->raise();
+            } break;
+        case 25: if (saveloaderr.size()) {
+            auto *np8 = new ShowStateCorrupt(screen, 150, 120, saveloaderr.c_str());
+            np8->raise();
             } break;
         default:
             break;

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -68,7 +68,7 @@ extern unsigned char        GFX_Gshift;
 extern uint32_t             GFX_Bmask;
 extern unsigned char        GFX_Bshift;
 
-extern bool                 dos_kernel_disabled;
+extern bool                 dos_kernel_disabled, confres;
 extern Bitu                 currentWindowWidth, currentWindowHeight;
 
 extern bool                 MSG_Write(const char *);
@@ -1448,6 +1448,28 @@ public:
     }
 };
 
+class ShowLoadWarning : public GUI::ToplevelWindow {
+protected:
+    GUI::Input *name;
+public:
+    ShowLoadWarning(GUI::Screen *parent, int x, int y, const char *title) :
+        ToplevelWindow(parent, x, y, 430, 120, "Warning") {
+            new GUI::Label(this, strncmp(title, "DOSBox-X ", 9)?30:10, 20, title);
+            (new GUI::Button(this, 140, 50, "Yes", 70))->addActionHandler(this);
+            (new GUI::Button(this, 230, 50, "No", 70))->addActionHandler(this);
+    }
+
+    void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
+        (void)b;//UNUSED
+        if (arg == "Yes")
+            confres=true;
+        if (arg == "No")
+            confres=false;
+        close();
+        if (shortcut) running = false;
+    }
+};
+
 class ConfigurationWindow : public GUI::ToplevelWindow {
 public:
     GUI::Button *saveButton, *closeButton;
@@ -1764,6 +1786,18 @@ static void UI_Select(GUI::ScreenSDL *screen, int select) {
         case 21: {
             auto *np6 = new ShowStateCorrupt(screen, 150, 120, "Save state corrupted! Program may not work.");
             np6->raise();
+            } break;
+        case 22: {
+            auto *np7 = new ShowLoadWarning(screen, 150, 120, "DOSBox-X version mismatch. Load the state anyway?");
+            np7->raise();
+            } break;
+        case 23: {
+            auto *np7 = new ShowLoadWarning(screen, 150, 120, "Program name mismatch. Load the state anyway?");
+            np7->raise();
+            } break;
+        case 24: {
+            auto *np7 = new ShowLoadWarning(screen, 150, 120, "Memory size mismatch. Load the state anyway?");
+            np7->raise();
             } break;
         default:
             break;

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -268,6 +268,8 @@ static KeyBlock combo_4[11] =
     {".>","period",KBD_period},                     {"/?","slash",KBD_slash},
 };
 
+static bool initjoy=true;
+
 static void                                     SetActiveEvent(CEvent * event);
 static void                                     SetActiveBind(CBind * _bind);
 static void                                     change_action_text(const char* text,Bit8u col);
@@ -4103,6 +4105,7 @@ static void InitializeJoysticks(void) {
                 joytype=JOY_NONE;
             }
         }
+        initjoy=false;
     }
     else {
         LOG(LOG_MISC,LOG_DEBUG)("Joystick type none, not initializing");
@@ -4414,7 +4417,7 @@ void MAPPER_Init(void) {
     mapper.exit=true;
 
     MAPPER_CheckKeyboardLayout();
-    InitializeJoysticks();
+    if (initjoy) InitializeJoysticks();
     if (buttons.empty()) CreateLayout();
     if (bindgroups.empty()) CreateBindGroups();
     if (!MAPPER_LoadBinds()) CreateDefaultBinds();
@@ -4703,6 +4706,7 @@ void MAPPER_Shutdown() {
         }
     }
     handlergroup.clear();
+    initjoy=true;
 }
 
 void ext_signal_host_key(bool enable) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -187,7 +187,7 @@ unsigned int page=0;
 ScreenSizeInfo          screen_size_info;
 
 extern bool dos_kernel_disabled;
-extern bool bootguest, bootvm;
+extern bool bootguest, bootfast, bootvm;
 extern int bootdrive;
 
 void runBoot(void);
@@ -3374,11 +3374,11 @@ void RebootGuest(bool pressed) {
 			char msg[]="[2J";
 			Bit16u s = (Bit16u)strlen(msg);
 			DOS_WriteFile(STDERR,(Bit8u*)msg,&s);
+            throw int(6);
 	    } else {
-		    reg_ax=(Bit16u)CurMode->mode;
-		    CALLBACK_RunRealInt(0x10);
+            bootfast=true;
+            throw int(3);
 	    }
-		throw int(6);
 	}
 	bootguest=true;
 	throw int(3);

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -96,7 +96,7 @@ void pc98_update_display_page_ptr(void);
 void pc98_update_palette(void);
 bool MEM_map_ROM_alias_physmem(Bitu start,Bitu end);
 void MOUSE_Startup(Section *sec);
-void runBoot();
+void runBoot(const char *str);
 
 bool bochs_port_e9 = false;
 bool isa_memory_hole_512kb = false;
@@ -8571,7 +8571,9 @@ private:
 
 		if ((bootguest||(!bootvm&&use_quick_reboot))&&bootdrive>=0&&imageDiskList[bootdrive]) {
 			MOUSE_Startup(NULL);
-			runBoot();
+			char drive[] = "-Q A:";
+			drive[3]='A'+bootdrive;
+			runBoot(drive);
 		}
 		if (use_quick_reboot&&!bootvm&&bootdrive<0&&first_shell != NULL) throw int(6);
 		bootvm=false;

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -280,7 +280,7 @@ extern int user_cursor_sw,user_cursor_sh;
 extern int master_cascade_irq,bootdrive;
 extern bool enable_slave_pic;
 extern bool bootguest, use_quick_reboot;
-bool bootvm = false;
+bool bootvm = false, bootfast = false;
 static std::string dosbox_int_debug_out;
 
 void VGA_SetCaptureStride(uint32_t v);
@@ -8447,7 +8447,7 @@ private:
             emscripten_sleep_with_yield(100);
         }
 #else
-        if (!control->opt_fastbioslogo&&!bootguest&&(bootvm||!use_quick_reboot)) {
+        if (!control->opt_fastbioslogo&&!bootguest&&!bootfast&&(bootvm||!use_quick_reboot)) {
             bool wait_for_user = false;
             Bit32u lasttick=GetTicks();
             while ((GetTicks()-lasttick)<1000) {
@@ -8569,14 +8569,15 @@ private:
 
         for (Bitu i=0;i < 0x400;i++) mem_writeb(0x7C00+i,0);
 
-		if ((bootguest||(!bootvm&&use_quick_reboot))&&bootdrive>=0&&imageDiskList[bootdrive]) {
+		if ((bootguest||(!bootvm&&use_quick_reboot))&&!bootfast&&bootdrive>=0&&imageDiskList[bootdrive]) {
 			MOUSE_Startup(NULL);
 			char drive[] = "-Q A:";
 			drive[3]='A'+bootdrive;
 			runBoot(drive);
 		}
-		if (use_quick_reboot&&!bootvm&&bootdrive<0&&first_shell != NULL) throw int(6);
+		if (use_quick_reboot&&!bootvm&&!bootfast&&bootdrive<0&&first_shell != NULL) throw int(6);
 		bootvm=false;
+		bootfast=false;
 		bootguest=false;
 		bootdrive=-1;
         // Begin booting the DOSBox-X shell. NOTE: VM_Boot_DOSBox_Kernel will change CS:IP instruction pointer!

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -49,6 +49,7 @@ bool usecon = true;
 Bit16u shell_psp = 0;
 Bitu call_int2e = 0;
 
+void runMount(const char *str);
 void MSG_Replace(const char * _name, const char* _val);
 void DOS_SetCountry(Bit16u countryNo);
 void CALLBACK_DeAllocate(Bitu in);
@@ -570,10 +571,12 @@ void DOS_Shell::Run(void) {
 						if (type!=DRIVE_NO_ROOT_DIR) {
 							WriteOut("Mounting %c: => %s..\n", name[0], name);
 							char mountstring[DOS_PATHLENGTH+CROSS_LEN+20];
-							sprintf(mountstring,"MOUNT %c ",name[0]);
+							name[2]=' ';
+							strcpy(mountstring,name);
+							name[2]='\\';
 							strcat(mountstring,name);
-							strcat(mountstring," >nul");
-							ParseLine(mountstring);
+							strcat(mountstring," -Q");
+							runMount(mountstring);
 							if (!Drives[i]) WriteOut("Drive %c: failed to mount.\n",name[0]);
 							else if(mountwarning && type==DRIVE_FIXED && (strcasecmp(name,"C:\\")==0)) WriteOut("Warning: %s", MSG_Get("SHELL_EXECUTE_DRIVE_ACCESS_WARNING_WIN"));
 						}


### PR DESCRIPTION
I have further improved the save state feature's handling of changed drive assignments. As a result, when the drive assignments in the saved states are different from the current state, DOSBox-X can automatically restore the drive assignments in most (although not all) cases without showing the "Save state corrupted" error, including all drive types such as regular FAT and ISO drives if the image files still exist.

Also fixed Issue #1789 related to the joystick in the SDL1 build, and added direct download links in the INSTALL.md page to the release files.

Tested in both Windows and Linux to confirm the code works (or compiles).