### PR TITLE
Support for OPL2 Audio Board

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1237,7 +1237,7 @@ void DOSBOX_SetupConfigSections(void) {
     const char* irqssb[] = { "7", "5", "3", "9", "10", "11", "12", 0 };
     const char* dmasgus[] = { "3", "0", "1", "5", "6", "7", 0 };
     const char* dmassb[] = { "1", "5", "0", "3", "6", "7", 0 };
-    const char* oplemus[] = { "default", "compat", "fast", "nuked", "mame", 0 };
+    const char* oplemus[] = { "default", "compat", "fast", "nuked", "mame", "opl2board", 0 };
     const char *qualityno[] = { "0", "1", "2", "3", 0 };
     const char* tandys[] = { "auto", "on", "off", 0};
     const char* ps1opt[] = { "on", "off", 0};
@@ -2598,6 +2598,9 @@ void DOSBOX_SetupConfigSections(void) {
     Pint->Set_values(oplrates);
     Pint->Set_help("Sample rate of OPL music emulation. Use 49716 for highest quality (set the mixer rate accordingly).");
 
+    Pstring = secprop->Add_string("oplport", Property::Changeable::WhenIdle, "");
+	Pstring->Set_help("Serial port of the OPL2 Audio Board when oplemu=opl2board, opl2mode will become 'opl2' automatically.");
+    
     Phex = secprop->Add_hex("hardwarebase",Property::Changeable::WhenIdle,0x220);
     Phex->Set_help("base address of the real hardware soundblaster:\n"\
         "210,220,230,240,250,260,280");

--- a/src/hardware/Makefile.am
+++ b/src/hardware/Makefile.am
@@ -18,5 +18,5 @@ libhardware_a_SOURCES = adlib.cpp dma.cpp gameblaster.cpp hardware.cpp iohandler
 			snd_pc98/common/parts.c snd_pc98/generic/keydisp.c snd_pc98/sound/adpcmc.c snd_pc98/sound/adpcmg.c \
 			snd_pc98/sound/rhythmc.c snd_pc98/sound/sound.c snd_pc98/sound/getsnd/getwave.c snd_pc98/sound/getsnd/getsmix.c \
 			snd_pc98/sound/getsnd/getsnd.c snd_pc98/x11/dosio.c snd_pc98/sound/fmboard.c snd_pc98/sound/soundrom.c \
-			snd_pc98/cbus/board86.c snd_pc98/sound/fmtimer.c snd_pc98/cbus/board26k.c 8255.cpp
+			snd_pc98/cbus/board86.c snd_pc98/sound/fmtimer.c snd_pc98/cbus/board26k.c 8255.cpp opl2board/opl2board.cpp
 

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -32,6 +32,7 @@
 #include "mame/emu.h"
 #include "mame/fmopl.h"
 #include "mame/ymf262.h"
+#include "opl2board/opl2board.h"
 
 #define OPL2_INTERNAL_FREQ    3600000   // The OPL2 operates at 3.6MHz
 #define OPL3_INTERNAL_FREQ    14400000  // The OPL3 operates at 14.4MHz
@@ -338,6 +339,34 @@ struct Handler : public Adlib::Handler {
 	}
 };
 
+}
+
+namespace OPL2BOARD {
+	OPL2AudioBoard opl2AudioBoard;
+
+	struct Handler : public Adlib::Handler {
+		Handler(const char* port) {
+			opl2AudioBoard.connect(port);
+		}
+		virtual void WriteReg(Bit32u reg, Bit8u val) {
+			opl2AudioBoard.write(reg, val);
+		}
+		virtual Bit32u WriteAddr(Bit32u port, Bit8u val) {
+			return val;
+		}
+
+		virtual void Generate(MixerChannel* chan, Bitu samples) {
+			Bit16s buf[1] = { 0 };
+			chan->AddSamples_m16(1, buf);
+		}
+		virtual void Init(Bitu rate) {
+			opl2AudioBoard.reset();
+		}
+		~Handler() {
+			opl2AudioBoard.reset();
+			opl2AudioBoard.disconnect();
+		}
+	};
 }
 
 #define RAW_SIZE 1024
@@ -1024,6 +1053,7 @@ Module::Module( Section* configuration ) : Module_base(configuration) {
 	std::string oplemu( section->Get_string( "oplemu" ) );
 	ctrl.mixer = section->Get_bool("sbmixer");
 
+	std::string oplport(section->Get_string("oplport"));
 	adlib_force_timer_overflow_on_polling = section->Get_bool("adlib force timer overflow on detect");
 
 	mixerChan = mixerObject.Install(OPL_CallBack,rate,"FM");
@@ -1043,6 +1073,10 @@ Module::Module( Section* configuration ) : Module_base(configuration) {
 	} else if (oplemu == "nuked") {
 		handler = new NukedOPL::Handler();
 	}
+	  else if (oplemu == "opl2board") {
+		oplmode = OPL_opl2;
+		handler = new OPL2BOARD::Handler(oplport.c_str());
+		}
 	else if (oplemu == "mame") {
 		if (oplmode == OPL_opl2) {
 			handler = new MAMEOPL2::Handler();

--- a/src/hardware/opl2board/opl2board.cpp
+++ b/src/hardware/opl2board/opl2board.cpp
@@ -1,0 +1,54 @@
+#include "../serialport/libserial.h"
+#include "setup.h"
+#include "opl2board.h"
+
+OPL2AudioBoard::OPL2AudioBoard() {
+}
+
+void OPL2AudioBoard::connect(const char* port) {
+	printf("OPL2 Audio Board: Connecting to port %s... ", port);
+
+	comport = 0;
+	if (SERIAL_open(port, &comport)) {
+		SERIAL_setCommParameters(comport, 115200, 'n', SERIAL_1STOP, 8);
+		printf("OK\n");
+	} else {
+		printf("FAIL\n");
+	}
+}
+
+void OPL2AudioBoard::disconnect() {
+	#if OPL2_AUDIO_BOARD_DEBUG
+		printf("OPL2 Audio Board: Disconnect");
+	#endif
+
+	if (comport) {
+		SERIAL_close(comport);
+	}
+}
+
+void OPL2AudioBoard::reset() {
+	#if OPL2_AUDIO_BOARD_DEBUG
+		printf("OPL2 Audio Board: Reset\n");
+	#endif
+
+	for (uint8_t i = 0x00; i < 0xFF; i++) {
+		if (i >= 0x40 && i <= 0x55) {
+			// Set channel volumes to minimum.
+			write(i, 0x3F);
+		} else {
+			write(i, 0x00);
+		}
+	}
+}
+
+void OPL2AudioBoard::write(uint8_t reg, uint8_t val) {
+	if (comport) {
+		#if OPL2_AUDIO_BOARD_DEBUG
+			printf("OPL2 Audio Board: Write %d --> %d\n", val, reg);
+		#endif
+
+		SERIAL_sendchar(comport, reg);
+		SERIAL_sendchar(comport, val);
+	}
+}

--- a/src/hardware/opl2board/opl2board.h
+++ b/src/hardware/opl2board/opl2board.h
@@ -1,0 +1,20 @@
+#include "../serialport/libserial.h"
+
+#ifndef OPL2_AUDIO_BOARD
+	#define OPL2_AUDIO_BOARD
+
+	// Output debug information to the DosBox console if set to 1
+	#define OPL2_AUDIO_BOARD_DEBUG 0
+
+	class OPL2AudioBoard {
+		public:
+			OPL2AudioBoard();
+			void connect(const char* port);
+			void disconnect();
+			void reset();
+			void write(uint8_t reg, uint8_t val);
+
+		private:
+			COMPORT comport;
+	};
+#endif

--- a/vs2015/dosbox-x.vcxproj
+++ b/vs2015/dosbox-x.vcxproj
@@ -1019,6 +1019,7 @@ copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
     <ClCompile Include="..\src\hardware\memory.cpp" />
     <ClCompile Include="..\src\hardware\mixer.cpp" />
     <ClCompile Include="..\src\hardware\mpu401.cpp" />
+    <ClCompile Include="..\src\hardware\opl2board\opl2board.cpp" />
     <ClCompile Include="..\src\hardware\ne2000.cpp" />
     <ClCompile Include="..\src\hardware\nukedopl.cpp" />
     <ClCompile Include="..\src\hardware\opl.cpp" />
@@ -1293,6 +1294,7 @@ copy "$(SolutionDir)\..\shaders\*.*" "$(OutputPath)\shaders\"</Command>
     <ClInclude Include="..\src\hardware\mame\sn76496.h" />
     <ClInclude Include="..\src\hardware\mame\ymdeltat.h" />
     <ClInclude Include="..\src\hardware\mame\ymf262.h" />
+    <ClInclude Include="..\src\hardware\opl2board\opl2board.h" />
     <ClInclude Include="..\src\hardware\nukedopl.h" />
     <ClInclude Include="..\src\hardware\opl.h" />
     <ClInclude Include="..\src\hardware\parport\directlpt_win32.h" />

--- a/vs2015/dosbox-x.vcxproj.filters
+++ b/vs2015/dosbox-x.vcxproj.filters
@@ -115,6 +115,9 @@
     <Filter Include="Sources\libs\zmbv">
       <UniqueIdentifier>{fd585132-36d9-4941-8490-3821d36aec5a}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Sources\hardware\sound\opl2board">
+      <UniqueIdentifier>{b7907a19-6377-4a5d-9acd-3b02efefbc09}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\aviwriter\avi_rw_iobuf.cpp">
@@ -305,6 +308,9 @@
     </ClCompile>
     <ClCompile Include="..\src\fpu\fpu.cpp">
       <Filter>Sources\fpu</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\hardware\opl2board\opl2board.cpp">
+      <Filter>Sources\hardware\sound\opl2board</Filter>
     </ClCompile>
     <ClCompile Include="..\src\gui\menu.cpp">
       <Filter>Sources\gui</Filter>
@@ -989,6 +995,9 @@
     <ClInclude Include="..\src\fpu\fpu_instructions.h">
       <Filter>Sources\fpu</Filter>
     </ClInclude>
+    <ClCompile Include="..\src\hardware\opl2board\opl2board.h">
+      <Filter>Sources\hardware\sound\opl2board</Filter>
+    </ClCompile>
     <ClInclude Include="..\src\gui\dosbox.cga640.bmp.h">
       <Filter>Sources\gui</Filter>
     </ClInclude>


### PR DESCRIPTION
Support for Adlib OPL2 sound board .
https://www.tindie.com/products/cheerful/opl2-audio-board/

with this patch you can configure dosbox-x to use this soundboard with a arduino using the serialpassthrough sketch on Arduino

Please refer to https://github.com/DhrBaksteen/ArduinoOPL2
