### PR TITLE
Show mounted drive numbers in menu (under "DOS")

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,9 @@
     least one file handle is still open, or you are
     currently running a guest system. (Wengier)
   - DOSBox-X will allow control characters 8, 9, and
-    27 in the batch file without warnings. (Wengier)
+    27 in the batch file without warnings. Also, when
+    running the batch file COPY command will assume
+    /Y automatically as in real DOS. (Wengier)
   - Add command-line option "-defaultdir" to specify
     a directory (instead of the current directory) as
     the working directory. DOSBox-X will look for the

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,7 +20,10 @@
     "usescancodes=auto" when a non-US keyboard layout
     is activated on the SDL1 build. (Wengier)
   - Added "Drive information" menu item under "Drive"
-    to show the information for the drive. (Wengier)
+    menu to show information for the specified drive,
+    and added "Show mounted drive numbers" menu item
+    under "DOS" menu to show details for all mounted
+    drive numbers (0-5). (Wengier)
   - The command "Swap CD" now swaps only CD drives (as
     the name), not all non-floppy drives. Also added
     "Swap disk" menu item under the "Drive" menu for
@@ -34,7 +37,9 @@
     disk position and number of swap disks, as well as
     the IDE controller (if applicable). (Wengier)
   - Add "-ro" option for IMGMOUNT command to mark all
-    disk imaages as read-only at once. (Wengier)
+    disk images as read-only at once. You could also
+    mark read-only disk images individually using the
+    leading colon as in previous versions. (Wengier)
   - Added option to the Windows installer which allows
     to automatically upgrade the DOSBox-X config file
     (dosbox-x.conf) to the latest version format while
@@ -53,6 +58,8 @@
     El Torito floppy drives (if any) too. (Wengier)
   - Updated xxHash library by Yann Collet from 0.7.4
     to the stable version 0.8.0. (Wengier)
+  - Added support for the OPL2 audio board by setting
+    the config option "oplemu=opl2board".
   - Added "Quick launch program..." menu (under "DOS")
     to quickly run the specified program as selected
     by the Windows file browser in DOSBox-X. (Wengier)

--- a/include/build_timestamp.h
+++ b/include/build_timestamp.h
@@ -1,4 +1,4 @@
 /*auto-generated*/
-#define UPDATED_STR "Aug 19, 2020 3:37:58pm"
-#define GIT_COMMIT_HASH "edf5726"
+#define UPDATED_STR "Aug 20, 2020 8:51:11pm"
+#define GIT_COMMIT_HASH "5c9a9bc"
 #define COPYRIGHT_END_YEAR "2020"

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -3980,7 +3980,7 @@ public:
         DOS_DTA dta(dos.dta());
 
         WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_1"));
-        WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_FORMAT"),"Drive","Type","Label","Swap Pos");
+        WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_FORMAT"),"Drive","Type","Label","Swap slot");
         int cols=IS_PC98_ARCH?80:real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
         if (!cols) cols=80;
         for(int p = 0;p < cols;p++) WriteOut("-");
@@ -4008,7 +4008,7 @@ public:
         if (none) WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_NONE"));
 		WriteOut("\n");
 		WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_2"));
-		WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_NUMBER_FORMAT"),"Drive number","Disk name","IDE position","Swap Pos");
+		WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_NUMBER_FORMAT"),"Drive number","Disk name","IDE position","Swap slot");
         for(int p = 0;p < cols;p++) WriteOut("-");
         none=true;
 		for (int index = 0; index < MAX_DISK_IMAGES; index++)

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1285,6 +1285,7 @@ fatDrive::fatDrive(imageDisk *sourceLoadedDisk, std::vector<std::string> &option
     imageDiskMemory* idmem=dynamic_cast<imageDiskMemory *>(sourceLoadedDisk);
     imageDiskVHD* idvhd=dynamic_cast<imageDiskVHD *>(sourceLoadedDisk);
     if (idelt!=NULL) {
+        readonly = true;
         opts.mounttype = 1;
         el.CDROM_drive = idelt->CDROM_drive;
         el.cdrom_sector_offset = idelt->cdrom_sector_offset;

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -410,6 +410,7 @@ static const char *def_menu_dos[] =
     "mapper_swapcd",
     "--",
     "mapper_rescanall",
+    "list_drivenum",
 #if C_DEBUG
     "--",
     "DOSDebugMenu",

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1505,10 +1505,10 @@ public:
                 new GUI::Label(this, 40, 100, "Overlay at: "+overlay);
                 new GUI::Label(this, 40, 125, "Disk label: "+std::string(name));
                 new GUI::Label(this, 40, 150, "Read only : "+std::string(readonly?"Yes":"No"));
-                new GUI::Label(this, 40, 175, "Swap Pos  : "+swappos);
+                new GUI::Label(this, 40, 175, "Swap slot : "+swappos);
             }
             dos.dta(save_dta);
-            (new GUI::Button(this, 140, 200, "Close", 70))->addActionHandler(this);
+            (new GUI::Button(this, 140, 205, "Close", 70))->addActionHandler(this);
     }
 
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1165,7 +1165,7 @@ bool CheckQuit(void) {
         bool ret=quit_confirm;
         quit_confirm=false;
         return ret;
-    } else if (warn == "false")
+    } else if (warn == "false" || glide.enabled)
         return true;
     if (dos_kernel_disabled) {
         quit_confirm=false;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -500,6 +500,17 @@ const DOSBoxMenu::callback_t drive_callbacks[] = {
     NULL
 };
 
+bool list_drivenum_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+    MAPPER_ReleaseAllKeys();
+    GFX_LosingFocus();
+    GUI_Shortcut(32);
+    MAPPER_ReleaseAllKeys();
+    GFX_LosingFocus();
+    return true;
+}
+
 const char *drive_opts[][2] = {
 #if defined(WIN32)
 	{ "mountauto",              "Mount Automatically" },
@@ -9483,6 +9494,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"highdpienable").set_text("High DPI enable").set_callback_function(highdpienable_menu_callback).check(dpi_aware_enable);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"shell_config_commands").set_text("Config options as commands").set_callback_function(shell_config_commands_menu_callback).check(enable_config_as_shell_commands);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"quick_reboot").set_text("Enable quick reboot").set_callback_function(quick_reboot_menu_callback).check(use_quick_reboot);
+        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"list_drivenum").set_text("Show mounted drive numbers").set_callback_function(list_drivenum_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"force_loadstate").set_text("Force load state mode").set_callback_function(force_loadstate_menu_callback).check(force_load_state);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"removestate").set_text("Remove state in slot").set_callback_function(remove_state_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"refreshslot").set_text("Refresh display status").set_callback_function(refresh_slots_menu_callback);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1702,6 +1702,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 	while(ScanCMDBool(args,"T")) ; //Shouldn't this be A ?
 	while(ScanCMDBool(args,"A")) ;
 	bool optY=ScanCMDBool(args,"Y");
+	if (bf) optY=true;
 	std::string line;
 	if(GetEnvStr("COPYCMD",line)){
 		std::string::size_type idx = line.find('=');


### PR DESCRIPTION
The previous code added support for showing details for each drive (A-Z) from the "Drive" menu. This pull request further added the ability to show detailed information for mounted drive numbers (0-5) from the "DOS" menu. Unlike drive letters (A-Z), drive numbers will work even when booting into a guest system, so this function allows the user to see the currently inserted disk (and information like swap position or IDE controller) when running a guest system too.