### PR TITLE
Logging of loaded MT-32/CM-32L ROM set + adjust fluid.gain

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2523,7 +2523,7 @@ void DOSBOX_SetupConfigSections(void) {
 	Pstring = secprop->Add_string("fluid.samplerate",Property::Changeable::WhenIdle,"48000");
 	Pstring->Set_help("Sample rate to use with Fluidsynth.");
 
-	Pstring = secprop->Add_string("fluid.gain",Property::Changeable::WhenIdle,".6");
+	Pstring = secprop->Add_string("fluid.gain",Property::Changeable::WhenIdle,".2");
 	Pstring->Set_help("Fluidsynth gain.");
 
 	Pint = secprop->Add_int("fluid.polyphony",Property::Changeable::WhenIdle,256);

--- a/src/gui/midi_mt32.h
+++ b/src/gui/midi_mt32.h
@@ -138,11 +138,11 @@ public:
                 user_romhelp();
                 return false;
             } else {
-		LOG_MSG("MT32: Loaded MT-32 ROM set (MT32_CONTROL.ROM and MT32_PCM.ROM)");
-	    }
+                LOG_MSG("MT32: Loaded MT-32 ROM set (MT32_CONTROL.ROM and MT32_PCM.ROM)");
+            }
         } else {
-	    LOG_MSG("MT32: Loaded CM-32L ROM set (CM32L_CONTROL.ROM and CM32L_PCM.ROM");
-	}
+            LOG_MSG("MT32: Loaded CM-32L ROM set (CM32L_CONTROL.ROM and CM32L_PCM.ROM");
+        }
 
 		const MT32Emu::ROMImage *controlROMImage = MT32Emu::ROMImage::makeROMImage(&controlROMFile);
 		const MT32Emu::ROMImage *pcmROMImage = MT32Emu::ROMImage::makeROMImage(&pcmROMFile);

--- a/src/gui/midi_mt32.h
+++ b/src/gui/midi_mt32.h
@@ -137,8 +137,12 @@ public:
                 LOG(LOG_MISC,LOG_WARN)("MT32: PCM ROM file not found");
                 user_romhelp();
                 return false;
-            }
-        }
+            } else {
+		LOG_MSG("MT32: Loaded MT-32 ROM set (MT32_CONTROL.ROM and MT32_PCM.ROM)");
+	    }
+        } else {
+	    LOG_MSG("MT32: Loaded CM-32L ROM set (CM32L_CONTROL.ROM and CM32L_PCM.ROM");
+	}
 
 		const MT32Emu::ROMImage *controlROMImage = MT32Emu::ROMImage::makeROMImage(&controlROMFile);
 		const MT32Emu::ROMImage *pcmROMImage = MT32Emu::ROMImage::makeROMImage(&pcmROMFile);


### PR DESCRIPTION
# Description

To help with diagnosing MT32 problems, add the loaded ROM set to the LOG.

This is not perfect, as it does not help to clarify if the loaded ROM set is a MT-32 "old" or "new" variation.

--------------
Change default fluid.gain from 0.6 to 0.2

Upstream Fluidsynth development uses a gain of 0.2 by default.
For some reason the Fluidsynth in DOSBox-X (and DOSBox ECE) instead
uses a value of 0.6

This causes problems with games that use both MIDI and SoundBlaster
for speech and sound effects. The MIDI output will overpower the
SoundBlaster volume. Changing the gain to 0.2 fixes this.

Reducing the gain also reduces the chance of clipping as also mentioned here:
https://github.com/dosbox-staging/dosbox-staging/issues/572