### PR TITLE
Fix typo in CHANGELOG and one control character

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,8 +42,8 @@
     running in the batch file or with CALL command
     (or COMMAND /C) as in real DOS. (Wengier)
   - DOSBox-X will allow control characters 8 (BS),
-    9 (TAB), and 27 (ESC) when executing GOTO command
-    in batch programs without warnings. (Wengier)
+    9 (TAB), 26 (SUB), and 27 (ESC) when executing GOTO
+    command in batch files without warnings. (Wengier)
   - Normal core: REP MOVSD now checks segment limits
     for ES:(E)DI and throws a GP fault if exceeded.
     Demoscene productions marked as using VESA BIOS

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,8 +7,8 @@
     files (.conf) and folders in the Windows Explorer
     so that you could quickly run or open them with
     DOSBox-X from the Windows Explorer. More icons
-    are added to the DOSBox-X program group of within
-    the Start menu as well. (Wengier)
+    are added to the DOSBox-X program group within the
+    Start menu as well. (Wengier)
   - Added config option "startbanner" in [dosbox]
     section which if set to "false" would skip the
     welcome banner when DOSBox-X starts. Also added
@@ -85,7 +85,7 @@
   - DOSBox-X will now search for system fonts if the
     fonts required for the printing feature cannot be
     found in the FONTS directory. (Wengier)
-  - Added menu item "Send Feed-form" under the DOS menu
+  - Added menu item "Send form-feed" under the DOS menu
     for manually ejecting new pages to print. (Wengier)
   - Added "Quick launch program..." menu (under "DOS")
     to quickly run the specified program as selected

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -73,7 +73,7 @@ emptyline:
 				//So we continue reading till EOL/EOF
 				if (((cmd_write - temp) + 1) < (CMD_MAXLINE - 1))
 					*cmd_write++ = (char)c;
-			} else {
+			} else if (c!=0x1a) {
                             if (c != '\n' && c != '\r')
 					shell->WriteOut(MSG_Get("SHELL_ILLEGAL_CONTROL_CHARACTER"), c, c);
                         }

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -179,7 +179,7 @@ again:
 			if (c>31) {
 				if (((cmd_write - cmd_buffer) + 1) < (CMD_MAXLINE - 1))
 					*cmd_write++ = (char)c;
-			} else if (c!=0x1b && c!='\t' && c!=8) {
+			} else if (c!=0x1a && c!=0x1b && c!='\t' && c!=8) {
                                 if (c != '\n' && c != '\r')
 					shell->WriteOut(MSG_Get("SHELL_ILLEGAL_CONTROL_CHARACTER"), c, c);
                         }

--- a/windows-installer/DOSBox-X-setup.iss
+++ b/windows-installer/DOSBox-X-setup.iss
@@ -143,7 +143,7 @@ begin
 end;
 procedure HelpButtonOnClick(Sender: TObject);
 begin
-  MsgBox('The Setup pre-selects a Windows build for you according to your platform automatically, but you can change the default build to run if you encounter specific problem(s) with the pre-selected one.' #13#13 'For example, while the SDL1 version is the default version to run, the SDL2 version may be prefered over the SDL1 version for certain features such as touchscreen input support. Also, MinGW builds may be used for lower-end systems.', mbConfirmation, MB_OK);
+  MsgBox('The Setup pre-selects a Windows build for you according to your platform automatically, but you can change the default build to run if you encounter specific problem(s) with the pre-selected one.' #13#13 'For example, while the SDL1 version is the default version to run, the SDL2 version may be preferred over the SDL1 version for certain features such as touchscreen input support. Also, MinGW builds may be used for lower-end systems.' #13#13 'If you are not sure about which build to use, then you can just leave it unmodified and use the pre-selected one as the default build.', mbConfirmation, MB_OK);
 end;
 procedure CreateHelpButton(X: integer; Y: integer; W: integer; H: integer);
 begin
@@ -184,7 +184,7 @@ begin
     else
       PageBuild.Values[4] := True;
     CreateHelpButton(ScaleX(20), WizardForm.CancelButton.Top, WizardForm.CancelButton.Width, WizardForm.CancelButton.Height);
-    msg:='You can specify a default DOS version for DOSBox-X to report to itself and DOS programs. This can sometimes change the feature sets of DOSBox-X. For example, specifying the reported DOS version as 7.10 will enable long filename (LFN) and FAT32 disk image support by default.' #13#13 'If you leave this unselected, a preset DOS version will be reported (usually 5.00).' #13#13 'This setting can be later modified in the DOSBox-X''s configuration file (dosbox-x.conf).';
+    msg:='You can specify a default DOS version for DOSBox-X to report to itself and DOS programs. This can sometimes change the feature sets of DOSBox-X. For example, specifying the reported DOS version as 7.10 will enable long filename (LFN) and FAT32 disk image support by default.' #13#13 'If you are not sure about which DOS version to report, then you can just leave this unselected, and a preset DOS version will be reported (usually 5.00).' #13#13 'This setting can be later modified in the DOSBox-X''s configuration file (dosbox-x.conf).';
     PageVer:=CreateInputOptionPage(100, 'Reported DOS version', 'Specify the default DOS version to report', msg, True, False);
     PageVer.Add('DOS version 3.30');
     PageVer.Add('DOS version 5.00');

--- a/windows-installer/DOSBox-X-setup.iss
+++ b/windows-installer/DOSBox-X-setup.iss
@@ -184,7 +184,7 @@ begin
     else
       PageBuild.Values[4] := True;
     CreateHelpButton(ScaleX(20), WizardForm.CancelButton.Top, WizardForm.CancelButton.Width, WizardForm.CancelButton.Height);
-    msg:='You can specify a default DOS version for DOSBox-X to report to itself and DOS programs. This can sometimes change the feature sets of DOSBox-X. For example, specifying the reported DOS version as 7.10 will enable long filename (LFN) and FAT32 disk image support by default.' #13#13 'If you are not sure about which DOS version to report, then you can just leave this unselected, and a preset DOS version will be reported (usually 5.00).' #13#13 'This setting can be later modified in the DOSBox-X''s configuration file (dosbox-x.conf).';
+    msg:='You can specify a default DOS version for DOSBox-X to report to itself and DOS programs. This can sometimes change the feature sets of DOSBox-X. For example, selecting 7.10 as the reported DOS version will enable support for Windows-style long filenames (LFN) and FAT32 disk images (>2GB disk images) by default.' #13#13 'If you are not sure about which DOS version to report, you can also leave this unselected, then a preset DOS version will be reported (usually 5.00).' #13#13 'This setting can be later modified in the DOSBox-X''s configuration file (dosbox-x.conf).';
     PageVer:=CreateInputOptionPage(100, 'Reported DOS version', 'Specify the default DOS version to report', msg, True, False);
     PageVer.Add('DOS version 3.30');
     PageVer.Add('DOS version 5.00');


### PR DESCRIPTION
I know this is a last minute fix, but I notice there is typo in the CHANGELOG file, so I fixed it. Also made a very minor fix to the code that will prevent the warning from showing for the ASCII character 26 in the batch file (shown by for example Jungle Strike batch file when no CD is found), which I am very sure has no negative effect.