### PR TITLE
Add initial flatpak support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1090,6 +1090,7 @@ src/xBRZ/Makefile
 include/Makefile
 contrib/macos/dosbox-x.plist
 contrib/linux/dosbox-x.spec
+contrib/linux/dosbox-x.appdata.xml
 make-rpm.sh
 ])
 AC_OUTPUT

--- a/contrib/linux/com.dosbox_x.DOSBox-X-sdl2.yaml
+++ b/contrib/linux/com.dosbox_x.DOSBox-X-sdl2.yaml
@@ -1,0 +1,96 @@
+app-id: com.dosbox_x.DOSBox-X-sdl2
+runtime: org.freedesktop.Platform
+runtime-version: '20.08'
+sdk: org.freedesktop.Sdk
+
+command: dosbox-x-sdl2
+
+finish-args:	# flatpak permissions
+  - --device=all	# needed for gamepads and serial/parallel
+  - --share=ipc	# needed for X11
+  - --share=network	# needed for networking (NE2000, IPX)
+  - --socket=x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --filesystem=home
+
+cleanup:
+  - '/include'
+  - '/lib/pkgconfig'
+  - '/share/aclocal'
+  - '/share/man'
+  - '*.la'
+  - '*.a'
+  - '/share/doc'
+
+modules:
+
+# Build Mesa / GLU
+  - name: GLU
+    config-opts:
+      - --disable-static
+    sources:
+      - type: archive
+        url:  https://mesa.freedesktop.org/archive/glu/glu-9.0.1.tar.xz
+        sha256: fb5a4c2dd6ba6d1c21ab7c05129b0769544e1d68e1e3b0ffecb18e73c93055bc
+    cleanup:
+      - /include
+      - /lib/*.a
+      - /lib/*.la
+      - /lib/pkgconfig
+  
+# Build final FluidSynth 1.x release
+# FluidSynth 2.x causes "checking for fluid_synth_sysex in -lfluidsynth... no"
+  - name: FluidSynth
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DLIB_SUFFIX=
+    cleanup:
+      - /bin
+      - /include
+      - /lib/pkgconfig
+      - /share/man
+      - "*.so"
+    sources:
+      - type: archive
+        url: https://github.com/FluidSynth/fluidsynth/archive/v1.1.11.tar.gz
+        sha256: da8878ff374d12392eecf87e96bad8711b8e76a154c25a571dd8614d1af80de8
+
+# Build libpcap for NE2000 (and run setcap at the end)
+  - name: libpcap
+    cleanup:
+      - "/include"
+      - "/share"
+      - "/lib/pkgconfig"
+    sources:
+      - type: archive
+        url: https://www.tcpdump.org/release/libpcap-1.9.1.tar.gz
+        sha256: 635237637c5b619bcceba91900666b64d56ecb7be63f298f601ec786ce087094
+
+# Build DOSBox-X
+  - name: dosbox-x
+    rm-configure: true
+    sources:
+      - type: dir
+        path: ../..
+      - type: file
+        path: ../icons/dosbox-x.svg
+      - type: file
+        path: dosbox-x.appdata.xml
+      - type: file
+        path: dosbox-x.desktop
+    buildsystem: simple
+    build-commands:
+      # Build the SDL2 debugger enabled version of DOSBox-X
+      - ./build-debug-sdl2
+    post-install:
+      - install -D src/dosbox-x /app/bin/dosbox-x-sdl2
+#      - setcap cap_net_raw+ep /app/bin/dosbox-x # fails due to needing root permission
+      - install -Dm644 dosbox-x.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+      - install -Dm644 dosbox-x.appdata.xml /app/share/metainfo/${FLATPAK_ID}.appdata.xml
+      - sed -i 's/<id>com.dosbox_x.DOSBox-X</<id>com.dosbox_x.DOSBox-X-sdl2</' /app/share/metainfo/${FLATPAK_ID}.appdata.xml
+      - sed -i 's/<name>DOSBox-X</<name>DOSBox-X SDL2</' /app/share/metainfo/${FLATPAK_ID}.appdata.xml
+      - install -Dm644 dosbox-x.desktop /app/share/applications/${FLATPAK_ID}.desktop
+      - sed -i s/Icon=.*/Icon=com.dosbox_x.DOSBox-X-sdl2/ /app/share/applications/${FLATPAK_ID}.desktop
+      - sed -i 's/Name=.*/Name=DOSBox-X SDL2/' /app/share/applications/${FLATPAK_ID}.desktop
+      - sed -i s/Exec=.*/Exec=dosbox-x-sdl2/ /app/share/applications/${FLATPAK_ID}.desktop

--- a/contrib/linux/com.dosbox_x.DOSBox-X.yaml
+++ b/contrib/linux/com.dosbox_x.DOSBox-X.yaml
@@ -1,0 +1,94 @@
+app-id: com.dosbox_x.DOSBox-X
+runtime: org.freedesktop.Platform
+runtime-version: '20.08'
+sdk: org.freedesktop.Sdk
+
+command: dosbox-x
+
+finish-args:	# flatpak permissions
+  - --device=all	# needed for gamepads and serial/parallel
+  - --share=ipc	# needed for X11
+  - --share=network	# needed for networking (NE2000, IPX)
+  - --socket=x11
+  #- --socket=wayland	# pointless with SDL1
+  - --socket=pulseaudio
+  - --filesystem=home
+
+cleanup:
+  - '/include'
+  - '/lib/pkgconfig'
+  - '/share/aclocal'
+  - '/share/man'
+  - '*.la'
+  - '*.a'
+  - '/share/doc'
+
+modules:
+
+# Build Mesa / GLU
+  - name: GLU
+    config-opts:
+      - --disable-static
+    sources:
+      - type: archive
+        url:  https://mesa.freedesktop.org/archive/glu/glu-9.0.1.tar.xz
+        sha256: fb5a4c2dd6ba6d1c21ab7c05129b0769544e1d68e1e3b0ffecb18e73c93055bc
+    cleanup:
+      - /include
+      - /lib/*.a
+      - /lib/*.la
+      - /lib/pkgconfig
+  
+# Build final FluidSynth 1.x release
+# FluidSynth 2.x causes "checking for fluid_synth_sysex in -lfluidsynth... no"
+  - name: FluidSynth
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DLIB_SUFFIX=
+    cleanup:
+      - /bin
+      - /include
+      - /lib/pkgconfig
+      - /share/man
+      - "*.so"
+    sources:
+      - type: archive
+        url: https://github.com/FluidSynth/fluidsynth/archive/v1.1.11.tar.gz
+        sha256: da8878ff374d12392eecf87e96bad8711b8e76a154c25a571dd8614d1af80de8
+
+# Build libpcap for NE2000 (and run setcap at the end)
+  - name: libpcap
+    cleanup:
+      - "/include"
+      - "/share"
+      - "/lib/pkgconfig"
+    sources:
+      - type: archive
+        url: https://www.tcpdump.org/release/libpcap-1.9.1.tar.gz
+        sha256: 635237637c5b619bcceba91900666b64d56ecb7be63f298f601ec786ce087094
+
+# Build DOSBox-X
+  - name: dosbox-x
+    rm-configure: true
+    sources:
+      - type: dir
+        path: ../..
+      - type: file
+        path: ../icons/dosbox-x.svg
+      - type: file
+        path: dosbox-x.appdata.xml
+      - type: file
+        path: dosbox-x.desktop
+    buildsystem: simple
+    build-commands:
+      # We need to first build the included (modified) SDL1, otherwise the build will fail
+      - cd vs2015/sdl ; ./build-dosbox.sh
+      # Build the SDL1 debugger enabled version of DOSBox-X
+      - ./build-debug
+    post-install:
+      - install -D src/dosbox-x /app/bin/dosbox-x
+#      - setcap cap_net_raw+ep /app/bin/dosbox-x # fails due to needing root permission
+      - install -Dm644 dosbox-x.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+      - install -Dm644 dosbox-x.appdata.xml /app/share/metainfo/${FLATPAK_ID}.appdata.xml
+      - install -Dm644 dosbox-x.desktop /app/share/applications/${FLATPAK_ID}.desktop
+      - sed -i s/Icon=.*/Icon=com.dosbox_x.DOSBox-X/ /app/share/applications/${FLATPAK_ID}.desktop

--- a/contrib/linux/dosbox-x.appdata.xml.in
+++ b/contrib/linux/dosbox-x.appdata.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2020 Jonathan Campbell -->
+<!-- Copyright 2011-2020 Jonathan Campbell -->
 <component type="desktop">
   <id>com.dosbox_x.DOSBox-X</id>
   <project_license>GPL-2.0</project_license>

--- a/contrib/linux/dosbox-x.appdata.xml.in
+++ b/contrib/linux/dosbox-x.appdata.xml.in
@@ -1,17 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2020 Jonathan Campbell -->
 <component type="desktop">
   <id>dosbox-x.desktop</id>
   <project_license>GPL-2.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <name>DOSBox-X</name>
   <summary>x86/DOS emulator with sound and graphics</summary>
+  <categories>
+    <category>Emulation</category>
+  </categories>
+  <releases>
+          <release version="@PACKAGE_VERSION@" date="2020-9-15"/>
+  </releases>
+  <screenshots>
+	  <screenshot/>
+  </screenshots>
+  <content_rating type="oars-1.1" />
+  <translation/>
+  <update_contact>noreply@example.com</update_contact>
   <description>
     <p>
-    DOSBox-X is a cross-platform DOS emulator based on DOSBox-X. It aims to be a complete and accurate DOS
+    DOSBox-X is a cross-platform DOS emulator based on DOSBox. It aims to be a complete and accurate DOS
     emulation package, including the ability to run Windows 95 and 98. It also adds support for the NEC PC-98.
     </p>
     <p>
     DOSBox-X emulates a legacy IBM PC and DOS environment, and has many emulation options and features such as:
+    </p>
     <ul>
     <li>8086, 286, 386, 486, Pentium, Pentium MMX and Pentium Pro CPU options</li>
     <li>Mounting host directory, Harddisk Images, Diskette Images and CD-ROM images</li>
@@ -24,7 +38,7 @@
     <li>Support for running Windows 3.1, Windows 95 and Windows 98</li>
     </ul>
     With the help of DOSBox-X, it can run plenty of the old classics that don't run on your new computer!
-    </p>
   </description>
   <url type="homepage">https://www.dosbox-x.com</url>
+  <url type="wiki">https://github.com/joncampbell123/dosbox-x/wiki</url>
 </component>

--- a/contrib/linux/dosbox-x.appdata.xml.in
+++ b/contrib/linux/dosbox-x.appdata.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2020 Jonathan Campbell -->
 <component type="desktop">
-  <id>dosbox-x.desktop</id>
+  <id>com.dosbox_x.DOSBox-X</id>
   <project_license>GPL-2.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <name>DOSBox-X</name>
@@ -40,5 +40,5 @@
     With the help of DOSBox-X, it can run plenty of the old classics that don't run on your new computer!
   </description>
   <url type="homepage">https://www.dosbox-x.com</url>
-  <url type="wiki">https://github.com/joncampbell123/dosbox-x/wiki</url>
+  <url type="bugtracker">https://github.com/joncampbell123/dosbox-x/issues</url>
 </component>

--- a/make-flatpak-sdl2.sh
+++ b/make-flatpak-sdl2.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# flatpak build will fail immediately if it cannot find the appdata.xml file
+# But we have a dosbox-x.appdata.xml.in file that first needs processing by autotools
+./autogen.sh
+./configure
+
+cd contrib/linux
+flatpak-builder --repo=../../repo --force-clean ../../build-flatpak com.dosbox_x.DOSBox-X-sdl2.yaml
+if [ $? -eq 0 ]; then
+	echo If the build was successful, you can now install the flatpak by running the following commands:
+	echo
+	echo flatpak --user remote-add --no-gpg-verify myrepo repo
+	echo flatpak --user install myrepo com.dosbox_x.DOSBox-X-sdl2
+	echo
+	echo Or you can test it without installing by running:
+	echo flatpak-builder --run build-flatpak contrib/linux/com.dosbox_x.DOSBox-X-sdl2.yaml dosbox-x-sdl2
+fi
+
+cd ../..

--- a/make-flatpak-sdl2.sh
+++ b/make-flatpak-sdl2.sh
@@ -8,13 +8,13 @@
 cd contrib/linux
 flatpak-builder --repo=../../repo --force-clean ../../build-flatpak com.dosbox_x.DOSBox-X-sdl2.yaml
 if [ $? -eq 0 ]; then
-	echo If the build was successful, you can now install the flatpak by running the following commands:
+	echo You can now install the flatpak by running the following commands:
 	echo
-	echo flatpak --user remote-add --no-gpg-verify myrepo repo
-	echo flatpak --user install myrepo com.dosbox_x.DOSBox-X-sdl2
+	echo  flatpak --user remote-add --no-gpg-verify myrepo repo
+	echo  flatpak --user install myrepo com.dosbox_x.DOSBox-X-sdl2
 	echo
 	echo Or you can test it without installing by running:
-	echo flatpak-builder --run build-flatpak contrib/linux/com.dosbox_x.DOSBox-X-sdl2.yaml dosbox-x-sdl2
+	echo  flatpak-builder --run build-flatpak contrib/linux/com.dosbox_x.DOSBox-X-sdl2.yaml dosbox-x-sdl2
 fi
 
 cd ../..

--- a/make-flatpak.sh
+++ b/make-flatpak.sh
@@ -8,12 +8,12 @@
 cd contrib/linux
 flatpak-builder --repo=../../repo --force-clean ../../build-flatpak com.dosbox_x.DOSBox-X.yaml
 if [ $? -eq 0 ]; then
-	echo If the build was successful, you can now install the flatpak by running the following commands:
+	echo You can now install the flatpak by running the following commands:
 	echo
-	echo flatpak --user remote-add --no-gpg-verify myrepo repo
-	echo flatpak --user install myrepo com.dosbox_x.DOSBox-X
+	echo  flatpak --user remote-add --no-gpg-verify myrepo repo
+	echo  flatpak --user install myrepo com.dosbox_x.DOSBox-X
 	echo
 	echo Or you can test it without installing by running:
-	echo flatpak-builder --run build-flatpak contrib/linux/com.dosbox_x.DOSBox-X.yaml dosbox-x
+	echo  flatpak-builder --run build-flatpak contrib/linux/com.dosbox_x.DOSBox-X.yaml dosbox-x
 fi
 cd ../..

--- a/make-flatpak.sh
+++ b/make-flatpak.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# flatpak build will fail immediately if it cannot find the appdata.xml file
+# But we have a dosbox-x.appdata.xml.in file that first needs processing by autotools
+./autogen.sh
+./configure
+
+cd contrib/linux
+flatpak-builder --repo=../../repo --force-clean ../../build-flatpak com.dosbox_x.DOSBox-X.yaml
+if [ $? -eq 0 ]; then
+	echo If the build was successful, you can now install the flatpak by running the following commands:
+	echo
+	echo flatpak --user remote-add --no-gpg-verify myrepo repo
+	echo flatpak --user install myrepo com.dosbox_x.DOSBox-X
+	echo
+	echo Or you can test it without installing by running:
+	echo flatpak-builder --run build-flatpak contrib/linux/com.dosbox_x.DOSBox-X.yaml dosbox-x
+fi
+cd ../..

--- a/update-build-timestamp.pl
+++ b/update-build-timestamp.pl
@@ -34,7 +34,7 @@ while (my $line = <FILE>) {
 	if ($line =~ /date=/) {
 		push @lines, ("          <release version=\"\@PACKAGE_VERSION\@\" date=\"" . $year . "-" . $mon . "-" . $mday . "\"/>\n");
 	} elsif ($line =~ /<!-- Copyright/) {
-		push @lines, ("<!-- Copyright $year Jonathan Campbell -->\n");
+		push @lines, ("<!-- Copyright 2020-$year Jonathan Campbell -->\n");
 	} else {
 		push @lines, $line;
 	}

--- a/update-build-timestamp.pl
+++ b/update-build-timestamp.pl
@@ -22,3 +22,25 @@ print X "#define GIT_COMMIT_HASH \"$commit\"\n";
 print X "#define COPYRIGHT_END_YEAR \"$year\"\n";
 close(X);
 
+# why perl....
+use strict;
+use warnings;
+
+my $file = "contrib/linux/dosbox-x.appdata.xml.in";
+open FILE, $file or die "Can't read from $file!\n";
+
+my @lines;
+while (my $line = <FILE>) {
+	if ($line =~ /date=/) {
+		push @lines, ("          <release version=\"\@PACKAGE_VERSION\@\" date=\"" . $year . "-" . $mon . "-" . $mday . "\"/>\n");
+	} elsif ($line =~ /<!-- Copyright/) {
+		push @lines, ("<!-- Copyright $year Jonathan Campbell -->\n");
+	} else {
+		push @lines, $line;
+	}
+}
+close FILE;
+
+open FILE, '>', $file or die "Can't write to $file!\n";
+print FILE @lines;
+close FILE;

--- a/update-build-timestamp.pl
+++ b/update-build-timestamp.pl
@@ -34,7 +34,7 @@ while (my $line = <FILE>) {
 	if ($line =~ /date=/) {
 		push @lines, ("          <release version=\"\@PACKAGE_VERSION\@\" date=\"" . $year . "-" . $mon . "-" . $mday . "\"/>\n");
 	} elsif ($line =~ /<!-- Copyright/) {
-		push @lines, ("<!-- Copyright 2020-$year Jonathan Campbell -->\n");
+		push @lines, ("<!-- Copyright 2011-$year Jonathan Campbell -->\n");
 	} else {
 		push @lines, $line;
 	}


### PR DESCRIPTION
# Description
This adds flatpak manifest files for SDL1 and SDL2 builds.

This has been tested locally, against a local repo, which is automatically created if you use the scripts.

The SDL1 build is "flaky". In that sometimes, it fails with a broken pipe during the compilation of DOSBox-X. The point of failure however varies each time, and it can fail twice in a row and then suddenly succeed the third time, or it can complete the first time.

The SDL2 build has not failed once for me. And if we want to add DOSBox-X to the most popular repository (flathub), my suggestion would be to use the SDL2 version.

I still need to see about what to do about SoundFonts. A flatpak cannot access any 'random' files under /usr so it cannot system installed soundfont files. The only solution is to add a soundfont to the flatpak, but they are rather large. So instead of adding it to the flatpak during compilation, I will look into adding it via "extra-data" at install time.

Another issue is that FluidSynth support does not work right now with FluidSynth v2.


**Does this PR address some issue(s) ?**

- https://github.com/joncampbell123/dosbox-x/issues/1826
- https://github.com/joncampbell123/dosbox-x/issues/1203
