### PR TITLE
Fix XDG base directory path

### DIFF
--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -90,7 +90,7 @@ void Cross::GetPlatformConfigDir(std::string& in) {
 	in = "/<Choices$Write>/DosBox-X";
 #elif !defined(HX_DOS)
 	const char *xdg_conf_home = getenv("XDG_CONFIG_HOME");
-	const std::string conf_home = xdg_conf_home ? xdg_conf_home: "~/.config";
+	const std::string conf_home = xdg_conf_home && xdg_conf_home[0] == '/' ? xdg_conf_home: "~/.config";
 	in = conf_home + "/dosbox-x";
 	ResolveHomedir(in);
 #endif
@@ -126,7 +126,9 @@ void Cross::CreatePlatformConfigDir(std::string& in) {
 	in = "/<Choices$Write>/DosBox-X";
 	mkdir(in.c_str(),0700);
 #elif !defined(HX_DOS)
-	in = "~/.config/dosbox-x";
+	const char *xdg_conf_home = getenv("XDG_CONFIG_HOME");
+	const std::string conf_home = xdg_conf_home && xdg_conf_home[0] == '/' ? xdg_conf_home: "~/.config";
+	in = conf_home + "/dosbox-x";
 	ResolveHomedir(in);
 	mkdir(in.c_str(),0700);
 #endif


### PR DESCRIPTION
# Description

a7281f9d903b4a2d40779e6b08dc7d212e24d1b0 moved the Get part to correctly
read the environment variable, but missed the check for absolute path,
and more importantly the Create part.

**Does this PR address some issue(s) ?**

None that had been reported.

**Does this PR introduce new feature(s) ?**

No.

**Are there any breaking changes ?**

I sure hope not. ^^

**Additional information**

None that I know of.