### PR TITLE
Add an AVX2 version of the render cache

### DIFF
--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -131,6 +131,7 @@ extern bool				DEPRECATED mainline_compatible_bios_mapping;
 
 #ifdef __SSE__
 extern bool				sse2_available;
+extern bool				avx2_available;
 #endif
 
 void					MSG_Add(const char*,const char*); //add messages to the internal languagefile

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -130,7 +130,6 @@ extern bool				DEPRECATED mainline_compatible_mapping;
 extern bool				DEPRECATED mainline_compatible_bios_mapping;
 
 #ifdef __SSE__
-extern bool				sse1_available;
 extern bool				sse2_available;
 #endif
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -102,6 +102,7 @@
 /*===================================TODO: Move to it's own file==============================*/
 #if defined(__SSE__) && !(defined(_M_AMD64) || defined(__e2k__))
 bool sse2_available = false;
+bool avx2_available = false;
 
 # if defined(_MSC_VER)
 #  define cpuid(func,a,b,c,d)\
@@ -117,10 +118,12 @@ void CheckSSESupport()
 {
 #if defined(__GNUC__) && !defined(EMSCRIPTEN)
     sse2_available = __builtin_cpu_supports("sse2");
+    avx2_available = __builtin_cpu_supports("avx2");
 #elif (_MSC_VER) && !defined(EMSCRIPTEN)
     Bitu a, b, c, d;
     cpuid(1, a, b, c, d);
     sse2_available = ((d >> 26) & 1)?true:false;
+    avx2_available = ((b >> 5) & 1)?true:false;
 #endif
 }
 #endif
@@ -136,6 +139,7 @@ extern bool         clearline;
 extern Bitu         frames;
 extern Bitu         cycle_count;
 extern bool         sse2_available;
+extern bool         avx2_available;
 extern bool         dynamic_dos_kernel_alloc;
 extern Bitu         DOS_PRIVATE_SEGMENT_Size;
 extern bool         VGA_BIOS_dont_duplicate_CGA_first_half;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -103,12 +103,6 @@
 #if defined(__SSE__) && !(defined(_M_AMD64) || defined(__e2k__))
 bool sse2_available = false;
 
-# ifdef __GNUC__
-#  define cpuid(func,ax,bx,cx,dx)\
-    __asm__ __volatile__ ("cpuid":\
-    "=a" (ax), "=b" (bx), "=c" (cx), "=d" (dx) : "a" (func));
-# endif /* __GNUC__ */
-
 # if defined(_MSC_VER)
 #  define cpuid(func,a,b,c,d)\
     __asm mov eax, func\
@@ -121,7 +115,9 @@ bool sse2_available = false;
 
 void CheckSSESupport()
 {
-#if (defined (__GNUC__) || (_MSC_VER)) && !defined(EMSCRIPTEN)
+#if defined(__GNUC__) && !defined(EMSCRIPTEN)
+    sse2_available = __builtin_cpu_supports("sse2");
+#elif (_MSC_VER) && !defined(EMSCRIPTEN)
     Bitu a, b, c, d;
     cpuid(1, a, b, c, d);
     sse2_available = ((d >> 26) & 1)?true:false;

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -129,7 +129,6 @@ static void RENDER_EmptyLineHandler(const void * src) {
 # define sse2_available (1) /* SSE2 is always available on x86_64 and Elbrus */
 #else
 # ifdef __SSE__
-extern bool             sse1_available;
 extern bool             sse2_available;
 # endif
 #endif

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -125,11 +125,18 @@ static void RENDER_EmptyLineHandler(const void * src) {
 }
 
 /*HACK*/
-#if defined(__SSE__) && (defined(_M_AMD64) || defined(__amd64__) || defined(__e2k__))
-# define sse2_available (1) /* SSE2 is always available on x86_64 and Elbrus */
+#if defined(__AVX2__)
+/* We’re building with -mavx2 */
+# define sse2_available (1)
+# define avx2_available (1)
+#elif defined(__SSE__) && (defined(_M_AMD64) || defined(__amd64__) || defined(__e2k__))
+/* SSE2 is always available on x86_64 and Elbrus */
+# define sse2_available (1)
+extern bool             avx2_available;
 #else
 # ifdef __SSE__
 extern bool             sse2_available;
+extern bool             avx2_available;
 # endif
 #endif
 /*END HACK*/
@@ -158,8 +165,18 @@ static inline bool RENDER_DrawLine_scanline_cacheHit(const void *s) {
         Bitu *cache = (Bitu*)(render.scale.cacheRead);
         Bits count = (Bits)render.src.start;
 #if defined(__SSE__)
-        if (sse2_available) {
 #define MY_SIZEOF_INT_P sizeof(*src)
+        if (avx2_available) {
+            static const Bitu simd_inc = 32/MY_SIZEOF_INT_P;
+            while (count >= (Bits)simd_inc) {
+                __m256i v = _mm256_loadu_si256((const __m256i*)src);
+                __m256i c = _mm256_loadu_si256((const __m256i*)cache);
+                __m256i cmp = _mm256_cmpeq_epi32(v, c);
+                if (GCC_UNLIKELY((unsigned int)_mm256_movemask_epi8(cmp) != 0xFFFFFFFF))
+                    goto cacheMiss;
+                count-=(Bits)simd_inc; src+=simd_inc; cache+=simd_inc;
+            }
+        } else if (sse2_available) {
             static const Bitu simd_inc = 16/MY_SIZEOF_INT_P;
             while (count >= (Bits)simd_inc) {
                 __m128i v = _mm_loadu_si128((const __m128i*)src);
@@ -169,8 +186,8 @@ static inline bool RENDER_DrawLine_scanline_cacheHit(const void *s) {
                     goto cacheMiss;
                 count-=(Bits)simd_inc; src+=simd_inc; cache+=simd_inc;
             }
-#undef MY_SIZEOF_INT_P
         }
+#undef MY_SIZEOF_INT_P
         else
 #endif
         {

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -125,7 +125,7 @@ static void RENDER_EmptyLineHandler(const void * src) {
 }
 
 /*HACK*/
-#if defined(__SSE__) && (defined(_M_AMD64) || defined(__e2k__))
+#if defined(__SSE__) && (defined(_M_AMD64) || defined(__amd64__) || defined(__e2k__))
 # define sse2_available (1) /* SSE2 is always available on x86_64 and Elbrus */
 #else
 # ifdef __SSE__


### PR DESCRIPTION
# Description

* Clean up the SSE2 checks.
* Check for AVX2 support at runtime.
* Add an AVX2 codepath for `RENDER_DrawLine_scanline_cacheHit()`.

**Does this PR address some issue(s) ?**

It removes an unused extern variable, and lowers the runtime cost of `RENDER_StartLineHandler()` from 8.3% to 6.2% of the total execution time on the DOS prompt.

**Does this PR introduce new feature(s) ?**

It allows AVX2 to be checked at runtime, enabling some more efficient SIMD.

**Are there any breaking changes ?**

No.

**Additional information**

None that I could think of.