### PR TITLE
Fix AVX2 when not building with -mavx2 or similar

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -100,7 +100,7 @@
 #include <list>
 
 /*===================================TODO: Move to it's own file==============================*/
-#if defined(__SSE__) && !(defined(_M_AMD64) || defined(__e2k__))
+#ifdef __SSE__
 bool sse2_available = false;
 bool avx2_available = false;
 
@@ -114,7 +114,7 @@ bool avx2_available = false;
     __asm mov d, edx
 # endif /* _MSC_VER */
 
-void CheckSSESupport()
+static void CheckX86ExtensionsSupport()
 {
 #if defined(__GNUC__) && !defined(EMSCRIPTEN)
     sse2_available = __builtin_cpu_supports("sse2");
@@ -1357,8 +1357,8 @@ void DOSBOX_SetupConfigSections(void) {
         0
     };
 
-#if defined(__SSE__) && !(defined(_M_AMD64) || defined(__e2k__)) && !defined(EMSCRIPTEN)
-    CheckSSESupport();
+#ifdef __SSE__
+    CheckX86ExtensionsSupport();
 #endif
     SDLNetInited = false;
 


### PR DESCRIPTION
In generic builds, we have to tell the compiler to change the target for
a specific function and to make sure to call it only if we know the
extension is supported by the CPU.  This is achieved using this target
function.

I’ve tested this code on both gcc and clang, with -march=native and
without, with different optimisation levels, and it seems sound this
time, sorry for breaking the generic build.

From another project, MSVC doesn’t have this restriction.

Fixes #1880.
Fixes #1881.