### PR TITLE
Add support for out-of-tree builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -227,7 +227,7 @@ LIBS_BACKUP=$LIBS;
 LIBS="$LIBS -lm";
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <math.h>]],[[
         powf(1.0f, 1.0f);
-]])], [AC_MSG_RESULT(yes)], [AC_DEFINE([DB_HAVE_NO_POWF],[1],[libm doesn't include powf])])
+]])], [AC_MSG_RESULT(yes)], [AC_DEFINE([DB_HAVE_NO_POWF],[1],[libm doesn’t include powf])])
 LIBS=$LIBS_BACKUP
 
 dnl Look for clock_gettime, a DB_HAVE_CLOCK_GETTIME is set when present
@@ -385,12 +385,12 @@ else
 fi
 
 # FIXME: Arrggh we need the WHOLE PATH
-pwd=`pwd`
+pwd=`realpath $srcdir`
 
-CFLAGS="$CFLAGS -I$pwd/vs2015/sdlnet/linux-host/include -I$pwd/vs2015/sdlnet/linux-host/include/SDL"
+CFLAGS="$CFLAGS -I$pwd -I$pwd/vs2015/sdlnet/linux-host/include -I$pwd/vs2015/sdlnet/linux-host/include/SDL"
 LDFLAGS="$LDFLAGS -L$pwd/vs2015/sdlnet/linux-host/lib"
-CPPFLAGS="$CPPFLAGS -I$pwd/vs2015/sdlnet/linux-host/include -I$pwd/vs2015/sdlnet/linux-host/include/SDL"
-CXXFLAGS="$CXXFLAGS -I$pwd/vs2015/sdlnet/linux-host/include -I$pwd/vs2015/sdlnet/linux-host/include/SDL"
+CPPFLAGS="$CPPFLAGS -I$pwd -I$pwd/vs2015/sdlnet/linux-host/include -I$pwd/vs2015/sdlnet/linux-host/include/SDL"
+CXXFLAGS="$CXXFLAGS -I$pwd -I$pwd/vs2015/sdlnet/linux-host/include -I$pwd/vs2015/sdlnet/linux-host/include/SDL"
 
 dnl LIBRARY TEST: SDLnet initial test
 AC_CHECK_HEADER(SDL_net.h,have_sdl_net_h=yes,)
@@ -1099,5 +1099,5 @@ AC_OUTPUT
 chmod +x make-rpm.sh
 
 # HACK: Write all PACKAGE defines to vs2015/config_package.h so Windows builds are kept in sync
-grep -E 'PACKAGE|VERSION' config.h >vs2015/config_package.h
+grep -E 'PACKAGE|VERSION' config.h > $srcdir/vs2015/config_package.h
 


### PR DESCRIPTION
# Description

There were very few changes required to support this feature of
autotools, namely replacing `pwd` with $srcdir, and using it everywhere
required.

**Does this PR address some issue(s) ?**

```
../configure: line 11293: vs2015/config_package.h: No such file or directory
```

**Does this PR introduce new feature(s) ?**

The ability of being in any arbitrary directory and running the `configure` script from there, thereafter building everything in the current directory.

This also allows multiple build directories to exist at once for a given source checkout.

**Are there any breaking changes ?**

None that I know of.

**Additional information**

N/A