### PR TITLE
Revert adding alternative homepage

### DIFF
--- a/contrib/linux/dosbox-x.spec.in
+++ b/contrib/linux/dosbox-x.spec.in
@@ -9,7 +9,7 @@ Version: @PACKAGE_VERSION@
 Release: 0%{?dist}
 Summary: DOS emulator for running DOS games and applications including Windows 3.x/9x
 License: GPL
-URL: https://dosbox-x.com or http://dosbox-x.software
+URL: https://dosbox-x.com
 Group: Applications/Emulators
 Source0: @PACKAGE_NAME@-@PACKAGE_VERSION@.tar.xz
 Source1: dosbox-x.desktop


### PR DESCRIPTION
@Wengier 

This is not a free form text field.

```
$ rpmlint dosbox-x.spec 
dosbox-x.spec: E: specfile-error error: line 12: Tag takes single token only: URL: https://dosbox-x.com or http://dosbox-x.software
dosbox-x.spec: E: specfile-error error: query of specfile dosbox-x.spec failed, can't parse
0 packages and 1 specfiles checked; 2 errors, 0 warnings.
```

# Description

_Summary of changes brought by this PR._


**Does this PR address some issue(s) ?**

_Add the issue(s) fixed, e.g. ```#1234```_


**Does this PR introduce new feature(s) ?**

_Describe the feature(s) introduced._


**Are there any breaking changes ?**

_Describe the breaking changes in detail._


**Additional information**

_Add any additional information that may be useful._
