### PR TITLE
Recent SVN commit

### DIFF
--- a/patch-integration/Skipped SVN commits.txt
+++ b/patch-integration/Skipped SVN commits.txt
@@ -31,5 +31,5 @@ Commit#:	Reason for skipping:
 (Status for commits in this interval needs to be added)
 
 4357		Conflict
-4359		Already in DOSBox-X
 4360		Conflict
+4367		Conflict


### PR DESCRIPTION
Addresses the latest 2 SVN commits.

https://sourceforge.net/p/dosbox/code-0/4366/ - Skipped, as the modified code is different. (Pretty much all SVN commits to sdlmain.cpp that I've looked at get skipped because of this)
https://sourceforge.net/p/dosbox/code-0/4367/ - Added

Instead of using Bit64u, etc., I followed the example of https://github.com/joncampbell123/dosbox-x/pull/1889, as I assume that is the new standard for DOSBox-X.

I updated Skipped SVN commits.txt. I removed one entry I put in last time for already being implemented in DOSBox-X, because I remembered that I wasn't putting those ones in the file, as the reason I made the file is to be a record of commits that might be worth taking another look at for integrating into DOSBox-X.