### PR TITLE
Compile fix

### DIFF
--- a/src/output/direct3d/hq2x_d3d.h
+++ b/src/output/direct3d/hq2x_d3d.h
@@ -23,6 +23,7 @@
 
 #include "config.h"
 #include <math.h>
+#include <stdint.h>
 
 #if C_D3DSHADERS
 


### PR DESCRIPTION
With current master (db1d59c), the Release x64 bit configuration (SDL1) fails to build in the latest VS2019 (Version 16.7.5).

The first in the list of compiler errors that appears is:

dosbox-x\src\output\direct3d\hq2x_d3d.h(31,88): error C2061: syntax error: identifier 'uint8_t'

By including stdint.h, where uint8_t is declared, into this file, compilation is fixed for me.