### PR TITLE
Fix warnings in the SDL2 build

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -7041,7 +7041,9 @@ bool DOSBOX_parse_argv() {
         else if (optname == "defaultdir") {
             if (control->cmdline->NextOptArgv(tmp)) {
                 struct stat st;
-                if (stat(tmp.c_str(), &st) == 0 && st.st_mode & S_IFDIR) chdir(tmp.c_str());
+                if (stat(tmp.c_str(), &st) == 0 && st.st_mode & S_IFDIR)
+                    if (chdir(tmp.c_str()) < 0)
+                        return false;
             }
         }
         else if (optname == "userconf") {
@@ -8541,9 +8543,11 @@ bool help_open_url_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const me
 #if defined(WIN32)
       ShellExecute(NULL, "open", url.c_str(), NULL, NULL, SW_SHOWNORMAL);
 #elif defined(LINUX)
-      system(("xdg-open "+url).c_str());
+      int ret = system(("xdg-open "+url).c_str());
+      return WIFEXITED(ret) && WEXITSTATUS(ret);
 #elif defined(MACOSX)
-      system(("open "+url).c_str());
+      int ret = system(("open "+url).c_str());
+      return WIFEXITED(ret) && WEXITSTATUS(ret);
 #endif
     }
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8554,7 +8554,7 @@ bool help_open_url_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const me
     return true;
 }
 
-bool help_intro_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
+bool help_intro_callback(DOSBoxMenu * const /*menu*/, DOSBoxMenu::item * const /*menuitem*/) {
     MAPPER_ReleaseAllKeys();
 
     GFX_LosingFocus();
@@ -8568,7 +8568,7 @@ bool help_intro_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menui
     return true;
 }
 
-bool help_about_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
+bool help_about_callback(DOSBoxMenu * const /*menu*/, DOSBoxMenu::item * const /*menuitem*/) {
     MAPPER_ReleaseAllKeys();
 
     GFX_LosingFocus();

--- a/src/hardware/voodoo_opengl.cpp
+++ b/src/hardware/voodoo_opengl.cpp
@@ -1628,7 +1628,9 @@ void voodoo_ogl_reset_videomode(void) {
 
 	GFX_TearDown();
 
+#if !defined(C_SDL2)
 	bool full_sdl_restart = true;	// make dependent on surface=opengl
+#endif
 
 	SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
 	SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);

--- a/src/output/output_opengl.h
+++ b/src/output/output_opengl.h
@@ -84,7 +84,7 @@ struct SDL_OpenGL {
     int clear_countdown;
     bool use_shader;
     GLuint program_object;
-    bool shader_def=false;
+    bool shader_def;
     const char *shader_src;
     struct {
         GLint texture_size;
@@ -98,6 +98,7 @@ struct SDL_OpenGL {
     SDL_GLContext context;
 #endif
 };
+static_assert(std::is_pod<SDL_OpenGL>::value, "SDL_OpenGL must be POD, otherwise memset() is undefined");
 
 static char const shader_src_default[] =
 	"varying vec2 v_texCoord;\n"


### PR DESCRIPTION
# Description

This fixes some warnings, this is best read commit per commit.

The POD one especially could cause the constructor pointer to be overwritten with `NULL` since the memory layout of non-POD objects is undefined.

**Does this PR address some issue(s) ?**

A few warnings when building with SDL2 on Linux.

**Does this PR introduce new feature(s) ?**

None.

**Are there any breaking changes ?**

When passing -defaultdir and `chdir()` fails, dosbox-x now exits with an error instead of staying in the current directory.

**Additional information**

N/A