### PR TITLE
ref-nmake: Support libpcap ne2000

### DIFF
--- a/ref-nmake/config.h
+++ b/ref-nmake/config.h
@@ -88,7 +88,7 @@
 #undef C_MODEM
 
 /* Define to 1 to enable NE2000 ethernet passthrough, requires libpcap */
-//#define C_NE2000 1
+#define C_NE2000 1
 
 /* Define to 1 to use opengl display output support */
 #if !defined(C_SDL2)

--- a/ref-nmake/nMakefile
+++ b/ref-nmake/nMakefile
@@ -14,10 +14,12 @@ LPNG = ..\vs2015\libpng
 
 PDCURSES = ..\vs2015\libpdcurses
 
+PCAP = ..\vs2015\pcap
+
 CXXFLAGS =  -utf-8 -nologo -O2 -MT -EHsc -DNDEBUG -DWIN32 -D__WIN32__ -D_FILE_OFFSET_BITS=64 -DC_OPENGL=1 -DC_MT32=1 -I. \
 			-D_WIN32_WINNT=0x0501 \
 			-Dmain=SDL_main -I$(SDLDIR)\include \
-			-I$(LPNG) -I$(ZLIB) -I$(PDCURSES) \
+			-I$(LPNG) -I$(ZLIB) -I$(PDCURSES) -I$(PCAP) \
 			-I$(DBX_PATH) \
 			-I$(DBX_PATH)/include \
 			-I$(DBX_PATH)/src \


### PR DESCRIPTION
# Description

This enables ne2000 in the ref-nmake build.

**Does this PR address some issue(s) ?**

No

**Does this PR introduce new feature(s) ?**

The ref-nmake build now can use the ne2000 interface and libpcap

**Are there any breaking changes ?**

No

**Additional information**

N/A