### PR TITLE
MinGW: Fix building with MSYS2

### DIFF
--- a/README.MinGW
+++ b/README.MinGW
@@ -17,3 +17,11 @@ export CC="$TRIPLET-gcc"
 export CXX="$TRIPLET-g++"
 
 # autoreconf && ./configure && make
+
+# Alternatively install MSYS2 on Windows,
+# Open the MSYS2 MinGW 64-bit prompt,
+# then run:
+pacman -Syu # Keep up to date!
+pacman -S mingw-w64-x86_64-toolchain mingw-w64-x86_64-SDL2
+cd /path/to/dosbox-code
+./build-mingw-sdl2

--- a/configure.ac
+++ b/configure.ac
@@ -393,7 +393,7 @@ if test x$enable_emscripten != xyes; then
 dnl Some target detection and actions for them
 case "$host" in
     *-*-cygwin* | *-*-mingw32*)
-       LIBS="$LIBS -lwinmm -limm32 -lole32"
+       LIBS="$LIBS -lwinmm -limm32 -lole32 -loleaut32 -lversion -lsetupapi"
        CXXFLAGS="$CXXFLAGS -mno-ms-bitfields"
        if test x$have_sdl_net_h = xyes ; then
          dnl HACK: We have to put SDL_net THEN winsock libraries or else the linker can't resolve things properly


### PR DESCRIPTION
# Description

This makes building with MSYS2 on Windows work.

**Does this PR address some issue(s) ?**

I don't think so.

**Does this PR introduce new feature(s) ?**

No

**Are there any breaking changes ?**

No

**Additional information**

I also added a quick note on how to build with MinGW to README.MinGW