### PR TITLE
MinGW: Support compiling with pcap

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -909,12 +909,21 @@ fi
 
 dnl FEATURE: Whether to use libpcap, and enable NE2000 emulation
 AH_TEMPLATE(C_NE2000,[Define to 1 to enable NE2000 ethernet passthrough, requires libpcap])
-if test x$have_pcap_lib = xyes -a x$have_pcap_h = xyes ; then
-  LIBS="$LIBS -lpcap";
-  AC_DEFINE(C_NE2000,1)
-else
-  AC_MSG_WARN([Can't find libpcap, NE2000 ethernet passthrough disabled])
-fi
+case "$host" in
+    *-*-cygwin* | *-*-mingw32*)
+       CFLAGS="$CFLAGS -I$pwd/vs2015/pcap"
+       CXXFLAGS="$CXXFLAGS -I$pwd/vs2015/pcap"
+       AC_DEFINE(C_NE2000,1)
+    ;;
+    *)
+       if test x$have_pcap_lib = xyes -a x$have_pcap_h = xyes ; then
+         LIBS="$LIBS -lpcap";
+         AC_DEFINE(C_NE2000,1)
+       else
+         AC_MSG_WARN([Can't find libpcap, NE2000 ethernet passthrough disabled])
+       fi
+    ;;
+esac
 
 if test x$enable_x11 != xno; then
   dnl FEATURE: Whether to use X11 XKBlib


### PR DESCRIPTION
# Description

This lets MinGW support compiling with pcap. The configure.ac will refuse to build it if libpcap is not installed system-wide. On Windows we just need the headers, so we can always compile with it.

**Does this PR address some issue(s) ?**

No.

**Does this PR introduce new feature(s) ?**

pcap on Windows when compiled with MinGW?

**Are there any breaking changes ?**

None

**Additional information**

**I haven't tested running this as I'm getting other MinGW errors.** I may need to append more commits to get pcap running with MinGW, but this commit is currently required regardless.
