### PR TITLE
Fix some Visual Studio warnings

### DIFF
--- a/include/render.h
+++ b/include/render.h
@@ -57,7 +57,7 @@ typedef struct {
 	Bitu last;
 } RenderPal_t;
 
-typedef struct {
+typedef struct Render_t {
 	struct {
 		Bitu width, start;
 		Bitu height;

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -376,7 +376,7 @@ bool DOS_PSP::SetNumFiles(uint16_t fileNum) {
 	//20 minimum. clipper program.
 	if (fileNum < 20) fileNum = 20;
 	 
-	if (fileNum > 20 && ((fileNum+2) > sGet(sPSP,max_files))) {
+	if (fileNum > 20 && ((uint32_t)(fileNum+2) > sGet(sPSP,max_files))) {
 		// Allocate needed paragraphs
 		fileNum+=2;	// Add a few more files for safety
 		uint16_t para = (fileNum/16)+((fileNum%16)>0);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -745,7 +745,7 @@ public:
         ++slot;
         slot %= SaveState::SLOT_COUNT*SaveState::MAX_PAGE;
         if (page!=GetGameState()/SaveState::SLOT_COUNT) {
-            page=GetGameState()/SaveState::SLOT_COUNT;
+            page=(unsigned int)GetGameState()/SaveState::SLOT_COUNT;
             refresh_slots();
         }
     }
@@ -755,7 +755,7 @@ public:
         slot += SaveState::SLOT_COUNT*SaveState::MAX_PAGE - 1;
         slot %= SaveState::SLOT_COUNT*SaveState::MAX_PAGE;
         if (page!=GetGameState()/SaveState::SLOT_COUNT) {
-            page=GetGameState()/SaveState::SLOT_COUNT;
+            page=(unsigned int)GetGameState()/SaveState::SLOT_COUNT;
             refresh_slots();
         }
     }
@@ -797,7 +797,7 @@ void SetGameState(int value) {
 	mainMenu.get_item(name).check(false).refresh_item(mainMenu);
     currentSlot.set(value);
     if (page!=currentSlot/SaveState::SLOT_COUNT) {
-        page=currentSlot/SaveState::SLOT_COUNT;
+        page=(unsigned int)(currentSlot/SaveState::SLOT_COUNT);
         refresh_slots();
     }
     name[4]='0'+(char)(currentSlot%SaveState::SLOT_COUNT);
@@ -814,7 +814,7 @@ void SaveGameState(bool pressed) {
         LOG_MSG("Saving state to slot: %d", (int)currentSlot + 1);
         SaveState::instance().save(currentSlot);
         if (page!=GetGameState()/SaveState::SLOT_COUNT)
-            SetGameState(currentSlot);
+            SetGameState((int)currentSlot);
         else
             refresh_slots();
     }
@@ -5508,7 +5508,7 @@ void SaveState::removeState(size_t slot) const {
         check_slot.open(save.c_str(), std::ifstream::in);
         if (!check_slot.fail()) notifyError("Failed to remove the state in the save slot.");
         if (page!=GetGameState()/SaveState::SLOT_COUNT)
-            SetGameState(slot);
+            SetGameState((int)slot);
         else
             refresh_slots();
     }

--- a/src/libs/decoders/mp3.cpp
+++ b/src/libs/decoders/mp3.cpp
@@ -105,7 +105,7 @@ static Uint32 MP3_read(Sound_Sample* const sample)
 
     // setup our 16-bit output buffer
     drmp3_int16* out_buffer = (drmp3_int16 *)(internal->buffer);
-    drmp3_uint16 remaining_frames = (internal->buffer_size  / sizeof(drmp3_int16)) / channels;
+    drmp3_uint16 remaining_frames = (drmp3_uint16)((internal->buffer_size  / sizeof(drmp3_int16)) / channels);
 
     // LOG_MSG("read: remaining_frames: %u", remaining_frames);
     drmp3_uint16 total_samples_read = 0;

--- a/src/libs/fluidsynth/bindings/fluid_cmd.c
+++ b/src/libs/fluidsynth/bindings/fluid_cmd.c
@@ -1371,7 +1371,7 @@ static void fluid_handle_settings_iter1(void* data, char* name, int type)
 {
   struct _fluid_handle_settings_data_t* d = (struct _fluid_handle_settings_data_t*) data;
 
-  int len = FLUID_STRLEN(name);
+  int len = (int)FLUID_STRLEN(name);
   if (len > d->len) {
     d->len = len;
   }
@@ -1381,7 +1381,7 @@ static void fluid_handle_settings_iter2(void* data, char* name, int type)
 {
   struct _fluid_handle_settings_data_t* d = (struct _fluid_handle_settings_data_t*) data;
 
-  int len = FLUID_STRLEN(name);
+  int len = (int)FLUID_STRLEN(name);
   fluid_ostream_printf(d->out, "%s", name);
   while (len++ < d->len) {
     fluid_ostream_printf(d->out, " ");

--- a/src/libs/fluidsynth/bindings/fluid_filerenderer.c
+++ b/src/libs/fluidsynth/bindings/fluid_filerenderer.c
@@ -385,7 +385,7 @@ fluid_file_renderer_process_block(fluid_file_renderer_t* dev)
 
 	for (offset = 0; offset < dev->buf_size; offset += n) {
 
-		n = fwrite((char*) dev->buf + offset, 1, dev->buf_size - offset, dev->file);
+		n = (int)fwrite((char*) dev->buf + offset, 1, dev->buf_size - offset, dev->file);
 		if (n < 0) {
 			FLUID_LOG(FLUID_ERR, "Audio output file write error: %s",
 				  strerror (errno));

--- a/src/libs/fluidsynth/midi/fluid_midi.c
+++ b/src/libs/fluidsynth/midi/fluid_midi.c
@@ -64,7 +64,7 @@ new_fluid_midi_file(const char* buffer, size_t length)
     mf->running_status = -1;
 
     mf->buffer = buffer;
-    mf->buf_len = length;
+    mf->buf_len = (int)length;
     mf->buf_pos = 0;
     mf->eof = FALSE;
 
@@ -1081,7 +1081,7 @@ fluid_track_set_name(fluid_track_t *track, char *name)
         track->name = NULL;
         return FLUID_OK;
     }
-    len = FLUID_STRLEN(name);
+    len = (int)FLUID_STRLEN(name);
     track->name = FLUID_MALLOC(len + 1);
     if (track->name == NULL) {
         FLUID_LOG(FLUID_ERR, "Out of memory");

--- a/src/libs/fluidsynth/sfloader/fluid_defsfont.c
+++ b/src/libs/fluidsynth/sfloader/fluid_defsfont.c
@@ -1127,7 +1127,7 @@ new_fluid_preset_zone(char *name)
     return NULL;
   }
   zone->next = NULL;
-  size = 1 + FLUID_STRLEN(name);
+  size = (int)(1 + FLUID_STRLEN(name));
   zone->name = FLUID_MALLOC(size);
   if (zone->name == NULL) {
     FLUID_LOG(FLUID_ERR, "Out of memory");
@@ -1528,7 +1528,7 @@ new_fluid_inst_zone(char* name)
     return NULL;
   }
   zone->next = NULL;
-  size = 1 + FLUID_STRLEN(name);
+  size = (int)(1 + FLUID_STRLEN(name));
   zone->name = FLUID_MALLOC(size);
   if (zone->name == NULL) {
     FLUID_LOG(FLUID_ERR, "Out of memory");

--- a/src/libs/fluidsynth/utils/fluid_settings.c
+++ b/src/libs/fluidsynth/utils/fluid_settings.c
@@ -1476,11 +1476,11 @@ fluid_settings_option_concat (fluid_settings_t *settings, const char *name,
     if (option)
     {
       newlist = fluid_list_append (newlist, option);
-      len += strlen (option);
+      len += (int)strlen (option);
     }
   }
 
-  if (count > 1) len += (count - 1) * strlen (separator);
+  if (count > 1) len += (int)((count - 1) * strlen (separator));
   len++;        /* For terminator */
 
   /* Sort by name */
@@ -1524,7 +1524,7 @@ fluid_settings_foreach_iter (void* key, void* value, void* data)
   int pathlen;
   char *s;
 
-  pathlen = strlen (bag->path);
+  pathlen = (int)strlen (bag->path);
 
   if (pathlen > 0)
   {

--- a/src/libs/fluidsynth/utils/fluid_sys.c
+++ b/src/libs/fluidsynth/utils/fluid_sys.c
@@ -1072,10 +1072,10 @@ fluid_ostream_printf (fluid_ostream_t out, char* format, ...)
 
     /* Handle write differently depending on if its a socket or file descriptor */
     if (!(out & WIN32_SOCKET_FLAG))
-      return write(out, buf, strlen (buf));
+      return write(out, buf, (unsigned int)strlen (buf));
 
     /* Socket */
-    retval = send (out & ~WIN32_SOCKET_FLAG, buf, strlen (buf), 0);
+    retval = send (out & ~WIN32_SOCKET_FLAG, buf, (int)strlen (buf), 0);
 
     return retval != SOCKET_ERROR ? retval : -1;
   }

--- a/src/libs/tinyfiledialogs/tinyfiledialogs.c
+++ b/src/libs/tinyfiledialogs/tinyfiledialogs.c
@@ -813,7 +813,7 @@ static int dirExists(char const * aDirPath)
 
 		if (!aDirPath)
 			return 0;
-		lDirLen = strlen(aDirPath);
+		lDirLen = (int)strlen(aDirPath);
 		if (!lDirLen)
 			return 1;
 		if ( (lDirLen == 2) && (aDirPath[1] == ':') )
@@ -1834,7 +1834,7 @@ wchar_t * tinyfd_openFileDialogW(
         ofn.nMaxCustFilter = 0;
         ofn.nFilterIndex = 1;
         ofn.lpstrFile = lBuff;
-		ofn.nMaxFile = lFullBuffLen;
+		ofn.nMaxFile = (DWORD)lFullBuffLen;
         ofn.lpstrFileTitle = NULL;
         ofn.nMaxFileTitle = MAX_PATH_OR_CMD / 2;
         ofn.lpstrInitialDir = wcslen(lDirname) ? lDirname : NULL;
@@ -2467,7 +2467,7 @@ static char * openFileDialogWinGuiA(
         ofn.nMaxCustFilter  = 0 ;
         ofn.nFilterIndex    = 1 ;
 		ofn.lpstrFile = lBuff;
-		ofn.nMaxFile = lFullBuffLen;
+		ofn.nMaxFile = (DWORD)lFullBuffLen;
         ofn.lpstrFileTitle  = NULL ;
         ofn.nMaxFileTitle       = MAX_PATH_OR_CMD / 2;
         ofn.lpstrInitialDir = strlen(lDirname) ? lDirname : NULL;
@@ -3069,7 +3069,7 @@ static void writeUtf8( char const * aUtf8String )
 
 	lConsoleHandle = GetStdHandle(STD_OUTPUT_HANDLE);
 	lTmpWChar = tinyfd_utf8to16(aUtf8String);
-	(void)WriteConsoleW(lConsoleHandle, lTmpWChar, wcslen(lTmpWChar), &lNum, NULL);
+	(void)WriteConsoleW(lConsoleHandle, lTmpWChar, (DWORD)wcslen(lTmpWChar), &lNum, NULL);
 }
 
 

--- a/vs2015/dosbox-x.vcxproj
+++ b/vs2015/dosbox-x.vcxproj
@@ -658,7 +658,7 @@ copy "$(SolutionDir)\..\contrib\windows\shaders\*.*" "$(OutputPath)\shaders\"</C
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <AdditionalIncludeDirectories>$(SolutionDir)pcap;$(SolutionDir);$(SolutionDir)..;$(SolutionDir)..\include;$(SolutionDir)..\src;$(SolutionDir)..\src\aviwriter;$(SolutionDir)..\src\libs\mt32;$(SolutionDir)..\src\hardware\snd_pc98\cbus;$(SolutionDir)..\src\hardware\snd_pc98\common;$(SolutionDir)..\src\hardware\snd_pc98\generic;$(SolutionDir)..\src\hardware\snd_pc98\sound;$(SolutionDir)..\src\hardware\snd_pc98\x11;$(SolutionDir)..\src\hardware\snd_pc98\sound\getsnd;$(SolutionDir)libpdcurses;$(SolutionDir)zlib;$(SolutionDir)libpng;$(SolutionDir)freetype\include;$(SolutionDir)sdl\include;$(SolutionDir)sdlnet;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;__WIN32__;_CRT_SECURE_NO_WARNINGS;_FILE_OFFSET_BITS=64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;__WIN32__;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_FILE_OFFSET_BITS=64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>


### PR DESCRIPTION
Visual Studio builds currently have a lot of warnings, many of which come from the FluidSynth code. Some also come from newly added warnings in Visual Studio, and as usual there are the usual type-conversion warnings.

This PR reduces the number of warnings from the 649 of current master branch to 567.

One new warning, C4996, (https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996?view=vs-2019#posix-function-names) appears for some functions like `chdir`.

The warning suggests changing these to `_chdir`, which is a name change for compliance with "C99 and C++03 constraints on reserved and global implementation-defined names".

However, the warning's page also notes:

"To fix this issue, we usually recommend you change your code to use the suggested function names instead. However, the updated names are Microsoft-specific. If you need to use the existing function names for portability reasons, you can turn off these warnings."

so I decided to just disable this warning.