### PR TITLE
Update in-tree flatpak to closer match flathub

### DIFF
--- a/contrib/linux/com.dosbox_x.DOSBox-X-sdl2.yaml
+++ b/contrib/linux/com.dosbox_x.DOSBox-X-sdl2.yaml
@@ -5,12 +5,11 @@ sdk: org.freedesktop.Sdk
 
 command: dosbox-x-sdl2
 
-finish-args:	# flatpak permissions
-  - --device=all	# needed for gamepads and serial/parallel
-  - --share=ipc	# needed for X11
-  - --share=network	# needed for networking (NE2000, IPX)
+finish-args: # flatpak permissions
+  - --device=all # needed for gamepads and serial/parallel
+  - --share=ipc	 # needed for X11
+  - --share=network # needed for networking (NE2000, IPX)
   - --socket=x11
-  - --nosocket=wayland
   - --socket=pulseaudio
   - --filesystem=home
 
@@ -25,7 +24,7 @@ cleanup:
 
 modules:
 
-# Build Mesa / GLU
+# Build Mesa GLU
   - name: GLU
     config-opts:
       - --disable-static
@@ -39,8 +38,7 @@ modules:
       - /lib/*.la
       - /lib/pkgconfig
   
-# Build final FluidSynth 1.x release
-# FluidSynth 2.x causes "checking for fluid_synth_sysex in -lfluidsynth... no"
+# Build FluidSynth
   - name: FluidSynth
     buildsystem: cmake-ninja
     config-opts:
@@ -53,44 +51,26 @@ modules:
       - "*.so"
     sources:
       - type: archive
-        url: https://github.com/FluidSynth/fluidsynth/archive/v1.1.11.tar.gz
-        sha256: da8878ff374d12392eecf87e96bad8711b8e76a154c25a571dd8614d1af80de8
+        url: https://github.com/FluidSynth/fluidsynth/archive/v2.1.5.tar.gz
+        sha256: b539b7c65a650b56f01cd60a4e83c6125c217c5a63c0c214ef6274894a677d00
 
-# Build libpcap for NE2000 (and run setcap at the end)
-  - name: libpcap
-    cleanup:
-      - "/include"
-      - "/share"
-      - "/lib/pkgconfig"
-    sources:
-      - type: archive
-        url: https://www.tcpdump.org/release/libpcap-1.9.1.tar.gz
-        sha256: 635237637c5b619bcceba91900666b64d56ecb7be63f298f601ec786ce087094
-
-# Build DOSBox-X
+# Build DOSBox-X SDL2
   - name: dosbox-x
     rm-configure: true
+    config-opts:
+      - --enable-core-inline
+      - --enable-debug=heavy
+      - --enable-sdl2
     sources:
       - type: dir
         path: ../..
-      - type: file
-        path: ../icons/dosbox-x.svg
-      - type: file
-        path: dosbox-x.metainfo.xml
-      - type: file
-        path: dosbox-x.desktop
-    buildsystem: simple
-    build-commands:
-      # Build the SDL2 debugger enabled version of DOSBox-X
-      - ./build-debug-sdl2
     post-install:
-      - install -D src/dosbox-x /app/bin/dosbox-x-sdl2
-#      - setcap cap_net_raw+ep /app/bin/dosbox-x # fails due to needing root permission
-      - install -Dm644 dosbox-x.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
-      - install -Dm644 dosbox-x.metainfo.xml /app/share/metainfo/${FLATPAK_ID}.metainfo.xml
-      - sed -i 's/<id>com.dosbox_x.DOSBox-X</<id>com.dosbox_x.DOSBox-X-sdl2</' /app/share/metainfo/${FLATPAK_ID}.metainfo.xml
-      - sed -i 's/<name>DOSBox-X</<name>DOSBox-X SDL2</' /app/share/metainfo/${FLATPAK_ID}.metainfo.xml
-      - install -Dm644 dosbox-x.desktop /app/share/applications/${FLATPAK_ID}.desktop
-      - sed -i s/Icon=.*/Icon=com.dosbox_x.DOSBox-X-sdl2/ /app/share/applications/${FLATPAK_ID}.desktop
-      - sed -i 's/Name=.*/Name=DOSBox-X SDL2/' /app/share/applications/${FLATPAK_ID}.desktop
-      - sed -i s/Exec=.*/Exec=dosbox-x-sdl2/ /app/share/applications/${FLATPAK_ID}.desktop
+      - install -Dm755 /app/bin/dosbox-x /app/bin/dosbox-x-sdl2
+      - install -Dm644 /app/share/applications/dosbox-x.desktop /app/share/applications/${FLATPAK_ID}.desktop
+      - install -Dm644 /app/share/icons/hicolor/scalable/apps/dosbox-x.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+      - install -Dm644 /app/share/metainfo/dosbox-x.metainfo.xml /app/share/metainfo/${FLATPAK_ID}.metainfo.xml
+      - desktop-file-edit --set-key=Icon --set-value=${FLATPAK_ID} /app/share/applications/${FLATPAK_ID}.desktop
+      - desktop-file-edit --set-key=Exec --set-value=dosbox-x-sdl2 /app/share/applications/${FLATPAK_ID}.desktop
+      - desktop-file-edit --set-key=Name --set-value="DOSBox-X SDL2" /app/share/applications/${FLATPAK_ID}.desktop
+      - appstream-util modify /app/share/metainfo/${FLATPAK_ID}.metainfo.xml id dosbox-x-sdl2
+      - appstream-util modify /app/share/metainfo/${FLATPAK_ID}.metainfo.xml name "DOSBox-X SDL2"

--- a/contrib/linux/com.dosbox_x.DOSBox-X.yaml
+++ b/contrib/linux/com.dosbox_x.DOSBox-X.yaml
@@ -5,12 +5,11 @@ sdk: org.freedesktop.Sdk
 
 command: dosbox-x
 
-finish-args:	# flatpak permissions
-  - --device=all	# needed for gamepads and serial/parallel
-  - --share=ipc	# needed for X11
-  - --share=network	# needed for networking (NE2000, IPX)
+finish-args: # flatpak permissions
+  - --device=all # needed for gamepads and serial/parallel
+  - --share=ipc  # needed for X11
+  - --share=network # needed for networking (NE2000, IPX)
   - --socket=x11
-  - --nosocket=wayland	# wayland does not work atm
   - --socket=pulseaudio
   - --filesystem=home
 
@@ -25,7 +24,7 @@ cleanup:
 
 modules:
 
-# Build Mesa / GLU
+# Build Mesa GLU
   - name: GLU
     config-opts:
       - --disable-static
@@ -39,8 +38,7 @@ modules:
       - /lib/*.la
       - /lib/pkgconfig
   
-# Build final FluidSynth 1.x release
-# FluidSynth 2.x causes "checking for fluid_synth_sysex in -lfluidsynth... no"
+# Build FluidSynth
   - name: FluidSynth
     buildsystem: cmake-ninja
     config-opts:
@@ -53,42 +51,24 @@ modules:
       - "*.so"
     sources:
       - type: archive
-        url: https://github.com/FluidSynth/fluidsynth/archive/v1.1.11.tar.gz
-        sha256: da8878ff374d12392eecf87e96bad8711b8e76a154c25a571dd8614d1af80de8
+        url: https://github.com/FluidSynth/fluidsynth/archive/v2.1.5.tar.gz
+        sha256: b539b7c65a650b56f01cd60a4e83c6125c217c5a63c0c214ef6274894a677d00
 
-# Build libpcap for NE2000 (and run setcap at the end)
-  - name: libpcap
-    cleanup:
-      - "/include"
-      - "/share"
-      - "/lib/pkgconfig"
-    sources:
-      - type: archive
-        url: https://www.tcpdump.org/release/libpcap-1.9.1.tar.gz
-        sha256: 635237637c5b619bcceba91900666b64d56ecb7be63f298f601ec786ce087094
-
-# Build DOSBox-X
+# Build DOSBox-X SDL1
   - name: dosbox-x
     rm-configure: true
     sources:
       - type: dir
         path: ../..
-      - type: file
-        path: ../icons/dosbox-x.svg
-      - type: file
-        path: dosbox-x.metainfo.xml
-      - type: file
-        path: dosbox-x.desktop
     buildsystem: simple
     build-commands:
       # We need to first build the included (modified) SDL1, otherwise the build will fail
       - cd vs2015/sdl ; ./build-dosbox.sh
       # Build the SDL1 debugger enabled version of DOSBox-X
       - ./build-debug
+      - make bindir=/app/bin prefix=/app install
     post-install:
-      - install -D src/dosbox-x /app/bin/dosbox-x
-#      - setcap cap_net_raw+ep /app/bin/dosbox-x # fails due to needing root permission
-      - install -Dm644 dosbox-x.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
-      - install -Dm644 dosbox-x.metainfo.xml /app/share/metainfo/${FLATPAK_ID}.metainfo.xml
-      - install -Dm644 dosbox-x.desktop /app/share/applications/${FLATPAK_ID}.desktop
-      - sed -i s/Icon=.*/Icon=com.dosbox_x.DOSBox-X/ /app/share/applications/${FLATPAK_ID}.desktop
+      - install -Dm644 /app/share/applications/dosbox-x.desktop /app/share/applications/${FLATPAK_ID}.desktop
+      - install -Dm644 /app/share/icons/hicolor/scalable/apps/dosbox-x.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+      - install -Dm644 /app/share/metainfo/dosbox-x.metainfo.xml /app/share/metainfo/${FLATPAK_ID}.metainfo.xml
+      - desktop-file-edit --set-key=Icon --set-value=${FLATPAK_ID} /app/share/applications/${FLATPAK_ID}.desktop

--- a/make-flatpak-sdl2.sh
+++ b/make-flatpak-sdl2.sh
@@ -1,20 +1,27 @@
 #!/bin/sh
 
-# flatpak build will fail immediately if it cannot find the metainfo.xml file
-# But we have a dosbox-x.metainfo.xml.in file that first needs processing by autotools
-./autogen.sh
-./configure
+if [[ ! -x $(which flatpak-builder) ]]; then
+	echo Please install flatpak-builder
+	exit
+fi
 
-cd contrib/linux
-flatpak-builder --repo=../../repo --force-clean ../../build-flatpak com.dosbox_x.DOSBox-X-sdl2.yaml
+if [[ ! $(flatpak list|grep org.freedesktop.Sdk|wc -l) -ge 1 ]]; then 
+	echo Please ensure the necessary SDK and matching runtime are installed by running:
+	echo flatpak install flathub org.freedesktop.Platform//20.08 org.freedesktop.Sdk//20.08
+	exit
+fi
+
+flatpak-builder --repo=myrepo --force-clean build-flatpak contrib/linux/com.dosbox_x.DOSBox-X-sdl2.yaml
 if [ $? -eq 0 ]; then
+	echo
 	echo You can now install the flatpak by running the following commands:
 	echo
 	echo  flatpak --user remote-add --no-gpg-verify myrepo repo
 	echo  flatpak --user install myrepo com.dosbox_x.DOSBox-X-sdl2
 	echo
+	echo You can then run the flatpak as follows:
+	echo  flatpak run com.dosbox_x.DOSBox-X-sdl2
+	echo
 	echo Or you can test it without installing by running:
 	echo  flatpak-builder --run build-flatpak contrib/linux/com.dosbox_x.DOSBox-X-sdl2.yaml dosbox-x-sdl2
 fi
-
-cd ../..

--- a/make-flatpak.sh
+++ b/make-flatpak.sh
@@ -1,19 +1,27 @@
 #!/bin/sh
 
-# flatpak build will fail immediately if it cannot find the metainfo.xml file
-# But we have a dosbox-x.metainfo.xml.in file that first needs processing by autotools
-./autogen.sh
-./configure
+if [[ ! -x $(which flatpak-builder) ]]; then
+	echo Please install flatpak-builder
+	exit
+fi
 
-cd contrib/linux
-flatpak-builder --repo=../../repo --force-clean ../../build-flatpak com.dosbox_x.DOSBox-X.yaml
+if [[ ! $(flatpak list|grep org.freedesktop.Sdk|wc -l) -ge 1 ]]; then 
+	echo Please ensure the necessary SDK and matching runtime are installed by running:
+	echo flatpak install flathub org.freedesktop.Platform//20.08 org.freedesktop.Sdk//20.08
+	exit
+fi
+
+flatpak-builder --repo=myrepo --force-clean build-flatpak contrib/linux/com.dosbox_x.DOSBox-X.yaml
 if [ $? -eq 0 ]; then
+	echo
 	echo You can now install the flatpak by running the following commands:
 	echo
 	echo  flatpak --user remote-add --no-gpg-verify myrepo repo
 	echo  flatpak --user install myrepo com.dosbox_x.DOSBox-X
 	echo
+	echo You can then run the flatpak as follows:
+	echo  flatpak run com.dosbox_x.DOSBox-X
+	echo
 	echo Or you can test it without installing by running:
 	echo  flatpak-builder --run build-flatpak contrib/linux/com.dosbox_x.DOSBox-X.yaml dosbox-x
 fi
-cd ../..


### PR DESCRIPTION
This updates the in-tree flatpak manifests to closer match
that used by flathub. This should make it easier to diagnose
problems.

It also adds some new checks to the make-flatpak*.sh scripts.
