### PR TITLE
Fix C4244 warnings

### DIFF
--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -135,7 +135,7 @@ bool CDROM_Interface_Image::BinaryFile::seek(uint32_t offset)
 uint16_t CDROM_Interface_Image::BinaryFile::decode(uint8_t *buffer)
 {
 	file->read((char*)buffer, chunkSize);
-	return file->gcount();
+	return (uint16_t)file->gcount();
 }
 
 CDROM_Interface_Image::AudioFile::AudioFile(const char *filename, bool &error)
@@ -232,7 +232,7 @@ int CDROM_Interface_Image::AudioFile::getLength()
 		// ... so convert ms to "Red Book bytes" by multiplying with 176.4f,
 		// which is 44,100 samples/second * 2-channels * 2 bytes/sample
 		// / 1000 milliseconds/second
-		length = round(duration_ms * 176.4f);
+		length = (int)round(duration_ms * 176.4f);
 	}
     #ifdef DEBUG
     LOG_MSG("%s CDROM: AudioFile::getLength is %d bytes", get_time(), length);
@@ -443,7 +443,7 @@ bool CDROM_Interface_Image::PlayAudioSector(unsigned long start, unsigned long l
 				player.addSamples = channels ==  2  ? &MixerChannel::AddSamples_s16_nonnative \
 				                                    : &MixerChannel::AddSamples_m16_nonnative;
 
-			const float bytesPerMs = rate * channels * 2 / 1000.0;
+			const float bytesPerMs = (float)(rate * channels * 2 / 1000.0);
 			player.playbackTotal = lround(len * tracks[track].sectorSize * bytesPerMs / 176.4);
 			player.playbackRemaining = player.playbackTotal;
 
@@ -581,7 +581,7 @@ void CDROM_Interface_Image::CDAudioCallBack(Bitu len)
 	// determine bytes per request (16-bit samples)
 	const uint8_t channels = player.trackFile->getChannels();
 	const uint8_t bytes_per_request = channels * 2;
-	uint16_t total_requested = len * bytes_per_request;
+	uint16_t total_requested = (uint16_t)(len * bytes_per_request);
 
 	while (total_requested > 0) {
 		uint16_t requested = total_requested;
@@ -643,7 +643,7 @@ void CDROM_Interface_Image::CDAudioCallBack(Bitu len)
 				// CDROM Red Book rate, which is more work than simply scaling).
 				//
 				const float playbackPercentSoFar = static_cast<float>(player.playbackTotal - player.playbackRemaining) / player.playbackTotal;
-				player.currFrame = player.startFrame + ceil(player.numFrames * playbackPercentSoFar);
+				player.currFrame = (uint32_t)(player.startFrame + ceil(player.numFrames * playbackPercentSoFar));
 				break;
 				// printProgress( (player.bufferPos - player.bufferConsumed)/(float)AUDIO_DECODE_BUFFER_SIZE, "consume");
 			}

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2477,7 +2477,7 @@ public:
 
             uint32_t rom_base = PhysMake(0xf000, 0); // override regular dosbox bios
                     /* write buffer into ROM */
-            for (Bitu i = 0; i < data_read; i++) phys_writeb(rom_base + i, buffer[i]);
+            for (Bitu i = 0; i < data_read; i++) phys_writeb((PhysPt)(rom_base + i), buffer[i]);
 
             //Start executing this bios
             memset(&cpu_regs, 0, sizeof(cpu_regs));

--- a/src/gui/midi_mt32.h
+++ b/src/gui/midi_mt32.h
@@ -144,7 +144,7 @@ private:
                 SDL_UnlockMutex(lock);
             }
         } else {
-            service->renderint16_t((int16_t *)MixTemp, len);
+            service->renderint16_t((int16_t *)MixTemp, (MT32Emu::uint32_t)len);
             chan->AddSamples_s16(len, (int16_t *)MixTemp);
         }
     }
@@ -165,7 +165,7 @@ private:
                 SDL_CondWait(framesInBufferChanged, lock);
                 SDL_UnlockMutex(lock);
             } else {
-                service->renderint16_t(audioBuffer + renderPosSnap, framesToRender);
+                service->renderint16_t(audioBuffer + renderPosSnap, (MT32Emu::uint32_t)framesToRender);
                 renderPos = (renderPosSnap + samplesToRender) % audioBufferSize;
                 if (renderPosSnap == playPos) {
                     SDL_LockMutex(lock);
@@ -308,7 +308,7 @@ public:
             framesPerAudioBuffer = (latency * sampleRate) / MILLIS_PER_SECOND;
             audioBufferSize = framesPerAudioBuffer << 1;
             audioBuffer = new int16_t[audioBufferSize];
-            service->renderint16_t(audioBuffer, framesPerAudioBuffer - 1);
+            service->renderint16_t(audioBuffer, (MT32Emu::uint32_t)(framesPerAudioBuffer - 1));
             renderPos = (framesPerAudioBuffer - 1) << 1;
             playedBuffers = 1;
             lock = SDL_CreateMutex();
@@ -360,9 +360,9 @@ public:
 
 	void PlaySysex(uint8_t *sysex, Bitu len) {
         if (renderInThread) {
-            service->playSysexAt(sysex, len, getMidiEventTimestamp());
+            service->playSysexAt(sysex, (MT32Emu::uint32_t)len, getMidiEventTimestamp());
         } else {
-            service->playSysex(sysex, len);
+            service->playSysex(sysex, (MT32Emu::uint32_t)len);
         }
 	}
 };

--- a/src/gui/midi_synth.h
+++ b/src/gui/midi_synth.h
@@ -56,7 +56,7 @@ static void synth_log(int level,
 
 static void synth_CallBack(Bitu len) {
 	if (synth_soft != NULL) {
-		fluid_synth_write_s16(synth_soft, len, MixTemp, 0, 2, MixTemp, 1, 2);
+		fluid_synth_write_s16(synth_soft, (int)len, MixTemp, 0, 2, MixTemp, 1, 2);
 		synthchan->AddSamples_s16(len,(int16_t *)MixTemp);
 	}
 }
@@ -80,7 +80,7 @@ private:
 		case 0xf0:
 		case 0xf7:
 			LOG(LOG_MISC,LOG_DEBUG)("SYNTH: sysex 0x%02x len %lu", (int)event, (long unsigned)len);
-			fluid_synth_sysex(synth_soft, (char *)(msg + 1), len - 1, NULL, NULL, NULL, 0);
+			fluid_synth_sysex(synth_soft, (char *)(msg + 1), (int)(len - 1), NULL, NULL, NULL, 0);
 			return;
 		case 0xf9:
 			LOG(LOG_MISC,LOG_DEBUG)("SYNTH: midi tick");
@@ -225,7 +225,7 @@ public:
 	MidiHandler_fluidsynth() : MidiHandler() {};
 	const char* GetName(void) { return "fluidsynth"; }
 	void PlaySysex(uint8_t * sysex, Bitu len) {
-		fluid_synth_sysex(synth, (char*)sysex, len, NULL, NULL, NULL, 0);
+		fluid_synth_sysex(synth, (char*)sysex, (int)len, NULL, NULL, NULL, 0);
 	}
 
 	void PlayMsg(uint8_t * msg) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -7538,7 +7538,7 @@ bool cpu_speed_emulate_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * 
         Section* sec = control->GetSection("cpu");
         if (sec) {
             double perc = static_cast<Section_prop *>(sec)->Get_int("cycle emulation percentage adjust");
-            cyclemu*=(100+perc)/100;
+            cyclemu*=(int)((100+perc)/100);
             std::string tmp("cycles="+std::to_string(cyclemu));
             sec->HandleInputline(tmp);
         }

--- a/src/hardware/glide.cpp
+++ b/src/hardware/glide.cpp
@@ -561,7 +561,7 @@ static void grSplash(void)
     }
 
     fxSplashInit(0, screenWidth, screenHeight, 2, 1, GR_COLORFORMAT_ABGR);
-    fxSplash(0, 0, screenWidth, screenHeight, 0);
+    fxSplash(0, 0, (float)screenWidth, (float)screenHeight, 0);
 
     // OpenGlide does not restore this state
     FP.grFunction1i = (pfunc1i)fn_pt[_grSstOrigin4];

--- a/src/libs/decoders/flac.c
+++ b/src/libs/decoders/flac.c
@@ -133,7 +133,7 @@ static Uint32 FLAC_read(Sound_Sample *sample)
     const drflac_uint64 rc = drflac_read_pcm_frames_s16(dr,
                                                         internal->buffer_size / (dr->channels * sizeof(drflac_int16)),
                                                         (drflac_int16 *) internal->buffer);
-    return rc * dr->channels * sizeof (drflac_int16);
+    return (Uint32)(rc * dr->channels * sizeof (drflac_int16));
 } /* FLAC_read */
 
 

--- a/src/libs/decoders/mp3.cpp
+++ b/src/libs/decoders/mp3.cpp
@@ -113,7 +113,7 @@ static Uint32 MP3_read(Sound_Sample* const sample)
         const drmp3_uint16 num_frames = (remaining_frames > in_buffer_frame_capacity) ? in_buffer_frame_capacity : remaining_frames;
 
         // LOG_MSG("read-while: num_frames: %u", num_frames);
-        const drmp3_uint16 frames_just_read = drmp3_read_pcm_frames_f32(p_mp3->p_dr, num_frames, in_buffer);
+        const drmp3_uint16 frames_just_read = (drmp3_uint16)drmp3_read_pcm_frames_f32(p_mp3->p_dr, num_frames, in_buffer);
 
         // LOG_MSG("read-while: frames_just_read: %u", frames_just_read);
         if (frames_just_read == 0) break; // Reached the end.

--- a/src/libs/decoders/wav.c
+++ b/src/libs/decoders/wav.c
@@ -140,7 +140,7 @@ static Uint32 WAV_read(Sound_Sample *sample)
     const drwav_uint64 frames_read = drwav_read_pcm_frames_s16(dr,
                                          internal->buffer_size / (dr->channels * sizeof(drwav_int16)),
                                          (drwav_int16 *) internal->buffer);
-    return frames_read * dr->channels * sizeof (drwav_int16);
+    return (Uint32)(frames_read * dr->channels * sizeof (drwav_int16));
 } /* WAV_read */
 
 

--- a/src/libs/fluidsynth/bindings/fluid_cmd.c
+++ b/src/libs/fluidsynth/bindings/fluid_cmd.c
@@ -751,7 +751,7 @@ fluid_handle_reverbsetroomsize(fluid_synth_t* synth, int ac, char** av, fluid_os
     fluid_ostream_printf(out, "rev_setroomsize: too few arguments.\n");
     return -1;
   }
-  room_size = atof(av[0]);
+  room_size = (fluid_real_t)atof(av[0]);
   if (room_size < 0){
     fluid_ostream_printf(out, "rev_setroomsize: Room size must be positive!\n");
     return -1;
@@ -776,7 +776,7 @@ fluid_handle_reverbsetdamp(fluid_synth_t* synth, int ac, char** av, fluid_ostrea
     fluid_ostream_printf(out, "rev_setdamp: too few arguments.\n");
     return -1;
   }
-  damp = atof(av[0]);
+  damp = (fluid_real_t)atof(av[0]);
   if ((damp < 0.0f) || (damp > 1)){
     fluid_ostream_printf(out, "rev_setdamp: damp must be between 0 and 1!\n");
     return -1;
@@ -797,7 +797,7 @@ fluid_handle_reverbsetwidth(fluid_synth_t* synth, int ac, char** av, fluid_ostre
     fluid_ostream_printf(out, "rev_setwidth: too few arguments.\n");
     return -1;
   }
-  width = atof(av[0]);
+  width = (fluid_real_t)atof(av[0]);
   if ((width < 0) || (width > 100)){
     fluid_ostream_printf(out, "rev_setroomsize: Too wide! (0..100)\n");
     return 0;
@@ -818,8 +818,8 @@ fluid_handle_reverbsetlevel(fluid_synth_t* synth, int ac, char** av, fluid_ostre
     fluid_ostream_printf(out, "rev_setlevel: too few arguments.\n");
     return -1;
   }
-  level = atof(av[0]);
-  if (abs(level) > 30){
+  level = (fluid_real_t)atof(av[0]);
+  if (abs((int)level) > 30){
     fluid_ostream_printf(out, "rev_setlevel: Value too high! (Value of 10 =+20 dB)\n");
     return 0;
   }
@@ -876,7 +876,7 @@ fluid_handle_choruslevel(fluid_synth_t* synth, int ac, char** av, fluid_ostream_
     fluid_ostream_printf(out, "cho_set_level: too few arguments.\n");
     return -1;
   }
-  level = atof(av[0]);
+  level = (fluid_real_t)atof(av[0]);
   return fluid_synth_set_chorus_full (synth, FLUID_CHORUS_SET_LEVEL, 0, level, 0.0, 0.0, 0);
 }
 
@@ -890,7 +890,7 @@ fluid_handle_chorusspeed(fluid_synth_t* synth, int ac, char** av, fluid_ostream_
     fluid_ostream_printf(out, "cho_set_speed: too few arguments.\n");
     return -1;
   }
-  speed = atof(av[0]);
+  speed = (fluid_real_t)atof(av[0]);
   return fluid_synth_set_chorus_full (synth, FLUID_CHORUS_SET_SPEED, 0, 0.0, speed, 0.0, 0);
 }
 
@@ -904,7 +904,7 @@ fluid_handle_chorusdepth(fluid_synth_t* synth, int ac, char** av, fluid_ostream_
     fluid_ostream_printf(out, "cho_set_depth: too few arguments.\n");
     return -1;
   }
-  depth = atof(av[0]);
+  depth = (fluid_real_t)atof(av[0]);
   return fluid_synth_set_chorus_full (synth, FLUID_CHORUS_SET_DEPTH, 0, 0.0, 0.0, depth, 0);
 }
 
@@ -971,7 +971,7 @@ fluid_handle_gain(fluid_synth_t* synth, int ac, char** av, fluid_ostream_t out)
     return -1;
   }
 
-  gain = atof(av[0]);
+  gain = (float)atof(av[0]);
 
   if ((gain < 0.0f) || (gain > 5.0f)) {
     fluid_ostream_printf(out, "gain: value should be between '0' and '5'.\n");

--- a/src/libs/fluidsynth/drivers/fluid_dsound.c
+++ b/src/libs/fluidsynth/drivers/fluid_dsound.c
@@ -162,11 +162,11 @@ new_fluid_dsound_audio_driver(fluid_settings_t* settings, fluid_synth_t* synth)
 
 	dev->buffer_byte_size = period_size * dev->frame_size;
 	dev->queue_byte_size = periods * dev->buffer_byte_size;
-	dev->bytes_per_second = sample_rate * dev->frame_size;
+	dev->bytes_per_second = (int)(sample_rate * dev->frame_size);
 
 	/* Finish to initialize the buffer format */
 	format.nChannels = 2;
-	format.wBitsPerSample = dev->frame_size * 4;
+	format.wBitsPerSample = (WORD)(dev->frame_size * 4);
 	format.nSamplesPerSec = (DWORD)sample_rate;
 	format.nBlockAlign = (WORD)dev->frame_size;
 	format.nAvgBytesPerSec = dev->bytes_per_second;

--- a/src/libs/fluidsynth/fluid_dll.c
+++ b/src/libs/fluidsynth/fluid_dll.c
@@ -84,7 +84,7 @@ static long FAR PASCAL fluid_win32_wndproc(HWND hWnd, UINT message, WPARAM wPara
   case WM_DESTROY:
     break;
   default:
-    return DefWindowProc(hWnd, message, wParam, lParam);
+    return (long)DefWindowProc(hWnd, message, wParam, lParam);
     break;
   }
   return(0L);

--- a/src/libs/fluidsynth/midi/fluid_midi.c
+++ b/src/libs/fluidsynth/midi/fluid_midi.c
@@ -638,7 +638,7 @@ fluid_midi_file_read_event(fluid_midi_file *mf, fluid_track_t *track)
                     break;
                 }
                 nominator = metadata[0];
-                denominator = pow(2.0, (double) metadata[1]);
+                denominator = (int)pow(2.0, (double) metadata[1]);
                 clocks = metadata[2];
                 notes = metadata[3];
 

--- a/src/libs/fluidsynth/midi/fluid_midi_router.c
+++ b/src/libs/fluidsynth/midi/fluid_midi_router.c
@@ -877,7 +877,7 @@ fluid_midi_router_handle_chan (fluid_synth_t* synth, int ac, char** av,
   }
 
   fluid_midi_router_rule_set_chan (router->cmd_rule, atoi (av[0]), atoi (av[1]),
-                                   atof (av[2]), atoi (av[3]));
+                                   (float)atof (av[2]), atoi (av[3]));
   return FLUID_OK;
 }
 
@@ -901,7 +901,7 @@ fluid_midi_router_handle_par1 (fluid_synth_t* synth, int ac, char** av, fluid_os
   }
 
   fluid_midi_router_rule_set_param1 (router->cmd_rule, atoi (av[0]), atoi (av[1]),
-                                     atof (av[2]), atoi (av[3]));
+                                     (float)atof (av[2]), atoi (av[3]));
   return FLUID_OK;
 }
 
@@ -926,7 +926,7 @@ fluid_midi_router_handle_par2 (fluid_synth_t* synth, int ac, char** av,
   }
 
   fluid_midi_router_rule_set_param2 (router->cmd_rule, atoi (av[0]), atoi (av[1]),
-                                     atof (av[2]), atoi (av[3]));
+                                     (float)atof (av[2]), atoi (av[3]));
   return FLUID_OK;
 }
 

--- a/src/libs/fluidsynth/midi/fluid_seq.c
+++ b/src/libs/fluidsynth/midi/fluid_seq.c
@@ -504,7 +504,7 @@ fluid_sequencer_get_tick (fluid_sequencer_t* seq)
 	double nowFloat;
 	unsigned int now;
 	nowFloat = ((double)(absMs - seq->startMs))*seq->scale/1000.0f;
-	now = nowFloat;
+	now = (unsigned int)nowFloat;
 	return now;
 }
 
@@ -541,7 +541,7 @@ fluid_sequencer_set_time_scale (fluid_sequencer_t* seq, double scale)
 		seq->scale = scale;
 
 		// change start0 so that cellNb is preserved
-		seq->queue0StartTime =  (seq->queue0StartTime + seq->prevCellNb)*(seq->scale/oldScale) - seq->prevCellNb;
+		seq->queue0StartTime = (int)((seq->queue0StartTime + seq->prevCellNb)*(seq->scale/oldScale) - seq->prevCellNb);
 
 		// change all preQueue events for new scale
 		{
@@ -549,7 +549,7 @@ fluid_sequencer_set_time_scale (fluid_sequencer_t* seq, double scale)
 			tmp = seq->preQueue;
 			while (tmp) {
 				if (tmp->entryType == FLUID_EVT_ENTRY_INSERT)
-					tmp->evt.time = tmp->evt.time*seq->scale/oldScale;
+					tmp->evt.time = (unsigned int)(tmp->evt.time*seq->scale/oldScale);
 
 				tmp = tmp->next;
 			}

--- a/src/libs/fluidsynth/rvoice/fluid_chorus.c
+++ b/src/libs/fluidsynth/rvoice/fluid_chorus.c
@@ -157,9 +157,9 @@ new_fluid_chorus(fluid_real_t sample_rate)
 	chorus->sinc_table[i][ii] = (fluid_real_t)1.;
 
       } else {
-	chorus->sinc_table[i][ii] = (fluid_real_t)sin(i_shifted * M_PI) / (M_PI * i_shifted);
+	chorus->sinc_table[i][ii] = (fluid_real_t)((fluid_real_t)sin(i_shifted * M_PI) / (M_PI * i_shifted));
 	/* Hamming window */
-	chorus->sinc_table[i][ii] *= (fluid_real_t)0.5 * (1.0 + cos(2.0 * M_PI * i_shifted / (fluid_real_t)INTERPOLATION_SAMPLES));
+	chorus->sinc_table[i][ii] *= (fluid_real_t)((fluid_real_t)0.5 * (1.0 + cos(2.0 * M_PI * i_shifted / (fluid_real_t)INTERPOLATION_SAMPLES)));
       };
     };
   };
@@ -290,7 +290,7 @@ fluid_chorus_set(fluid_chorus_t* chorus, int set, int nr, float level,
   }
 
   /* The modulating LFO goes through a full period every x samples: */
-  chorus->modulation_period_samples = chorus->sample_rate / chorus->speed_Hz;
+  chorus->modulation_period_samples = (long)(chorus->sample_rate / chorus->speed_Hz);
 
   /* The variation in delay time is x: */
   modulation_depth_samples = (int)

--- a/src/libs/fluidsynth/rvoice/fluid_iir_filter.c
+++ b/src/libs/fluidsynth/rvoice/fluid_iir_filter.c
@@ -281,7 +281,7 @@ void fluid_iir_filter_calc(fluid_iir_filter_t* iir_filter,
     fres = 5;
 
   /* if filter enabled and there is a significant frequency change.. */
-  if ((abs (fres - iir_filter->last_fres) > 0.01))
+  if ((abs ((int)(fres - iir_filter->last_fres)) > 0.01))
   {
    /* The filter coefficients have to be recalculated (filter
     * parameters have changed). Recalculation for various reasons is

--- a/src/libs/fluidsynth/rvoice/fluid_rev.c
+++ b/src/libs/fluidsynth/rvoice/fluid_rev.c
@@ -351,30 +351,30 @@ fluid_set_revmodel_buffers(fluid_revmodel_t* rev, fluid_real_t sample_rate) {
 
   float srfactor = sample_rate/44100.0f;
 
-  fluid_comb_setbuffer(&rev->combL[0], combtuningL1*srfactor);
-  fluid_comb_setbuffer(&rev->combR[0], combtuningR1*srfactor);
-  fluid_comb_setbuffer(&rev->combL[1], combtuningL2*srfactor);
-  fluid_comb_setbuffer(&rev->combR[1], combtuningR2*srfactor);
-  fluid_comb_setbuffer(&rev->combL[2], combtuningL3*srfactor);
-  fluid_comb_setbuffer(&rev->combR[2], combtuningR3*srfactor);
-  fluid_comb_setbuffer(&rev->combL[3], combtuningL4*srfactor);
-  fluid_comb_setbuffer(&rev->combR[3], combtuningR4*srfactor);
-  fluid_comb_setbuffer(&rev->combL[4], combtuningL5*srfactor);
-  fluid_comb_setbuffer(&rev->combR[4], combtuningR5*srfactor);
-  fluid_comb_setbuffer(&rev->combL[5], combtuningL6*srfactor);
-  fluid_comb_setbuffer(&rev->combR[5], combtuningR6*srfactor);
-  fluid_comb_setbuffer(&rev->combL[6], combtuningL7*srfactor);
-  fluid_comb_setbuffer(&rev->combR[6], combtuningR7*srfactor);
-  fluid_comb_setbuffer(&rev->combL[7], combtuningL8*srfactor);
-  fluid_comb_setbuffer(&rev->combR[7], combtuningR8*srfactor);
-  fluid_allpass_setbuffer(&rev->allpassL[0], allpasstuningL1*srfactor);
-  fluid_allpass_setbuffer(&rev->allpassR[0], allpasstuningR1*srfactor);
-  fluid_allpass_setbuffer(&rev->allpassL[1], allpasstuningL2*srfactor);
-  fluid_allpass_setbuffer(&rev->allpassR[1], allpasstuningR2*srfactor);
-  fluid_allpass_setbuffer(&rev->allpassL[2], allpasstuningL3*srfactor);
-  fluid_allpass_setbuffer(&rev->allpassR[2], allpasstuningR3*srfactor);
-  fluid_allpass_setbuffer(&rev->allpassL[3], allpasstuningL4*srfactor);
-  fluid_allpass_setbuffer(&rev->allpassR[3], allpasstuningR4*srfactor);
+  fluid_comb_setbuffer(&rev->combL[0], (int)(combtuningL1*srfactor));
+  fluid_comb_setbuffer(&rev->combR[0], (int)(combtuningR1*srfactor));
+  fluid_comb_setbuffer(&rev->combL[1], (int)(combtuningL2*srfactor));
+  fluid_comb_setbuffer(&rev->combR[1], (int)(combtuningR2*srfactor));
+  fluid_comb_setbuffer(&rev->combL[2], (int)(combtuningL3*srfactor));
+  fluid_comb_setbuffer(&rev->combR[2], (int)(combtuningR3*srfactor));
+  fluid_comb_setbuffer(&rev->combL[3], (int)(combtuningL4*srfactor));
+  fluid_comb_setbuffer(&rev->combR[3], (int)(combtuningR4*srfactor));
+  fluid_comb_setbuffer(&rev->combL[4], (int)(combtuningL5*srfactor));
+  fluid_comb_setbuffer(&rev->combR[4], (int)(combtuningR5*srfactor));
+  fluid_comb_setbuffer(&rev->combL[5], (int)(combtuningL6*srfactor));
+  fluid_comb_setbuffer(&rev->combR[5], (int)(combtuningR6*srfactor));
+  fluid_comb_setbuffer(&rev->combL[6], (int)(combtuningL7*srfactor));
+  fluid_comb_setbuffer(&rev->combR[6], (int)(combtuningR7*srfactor));
+  fluid_comb_setbuffer(&rev->combL[7], (int)(combtuningL8*srfactor));
+  fluid_comb_setbuffer(&rev->combR[7], (int)(combtuningR8*srfactor));
+  fluid_allpass_setbuffer(&rev->allpassL[0], (int)(allpasstuningL1*srfactor));
+  fluid_allpass_setbuffer(&rev->allpassR[0], (int)(allpasstuningR1*srfactor));
+  fluid_allpass_setbuffer(&rev->allpassL[1], (int)(allpasstuningL2*srfactor));
+  fluid_allpass_setbuffer(&rev->allpassR[1], (int)(allpasstuningR2*srfactor));
+  fluid_allpass_setbuffer(&rev->allpassL[2], (int)(allpasstuningL3*srfactor));
+  fluid_allpass_setbuffer(&rev->allpassR[2], (int)(allpasstuningR3*srfactor));
+  fluid_allpass_setbuffer(&rev->allpassL[3], (int)(allpasstuningL4*srfactor));
+  fluid_allpass_setbuffer(&rev->allpassR[3], (int)(allpasstuningR4*srfactor));
 
   /* Clear all buffers */
   fluid_revmodel_init(rev);
@@ -416,7 +416,7 @@ fluid_revmodel_processreplace(fluid_revmodel_t* rev, fluid_real_t *in,
      * is set to the sum of the left and right input sample. Since
      * this code works on a mono signal, 'input' is set to twice the
      * input sample. */
-    input = (2.0f * in[k] + DC_OFFSET) * rev->gain;
+    input = (fluid_real_t)((2.0f * in[k] + DC_OFFSET) * rev->gain);
 
     /* Accumulate comb filters in parallel */
     for (i = 0; i < numcombs; i++) {
@@ -454,7 +454,7 @@ fluid_revmodel_processmix(fluid_revmodel_t* rev, fluid_real_t *in,
      * is set to the sum of the left and right input sample. Since
      * this code works on a mono signal, 'input' is set to twice the
      * input sample. */
-    input = (2.0f * in[k] + DC_OFFSET) * rev->gain;
+    input = (fluid_real_t)((2.0f * in[k] + DC_OFFSET) * rev->gain);
 
     /* Accumulate comb filters in parallel */
     for (i = 0; i < numcombs; i++) {

--- a/src/libs/fluidsynth/rvoice/fluid_rvoice.c
+++ b/src/libs/fluidsynth/rvoice/fluid_rvoice.c
@@ -197,7 +197,7 @@ fluid_rvoice_check_sample_sanity(fluid_rvoice_t* voice)
 	  && (int)voice->dsp.loopend <= (int)voice->dsp.sample->loopend){
 	/* Is there a valid peak amplitude available for the loop, and can we use it? */
 	if (voice->dsp.sample->amplitude_that_reaches_noise_floor_is_valid && voice->dsp.samplemode == FLUID_LOOP_DURING_RELEASE){
-	  voice->dsp.amplitude_that_reaches_noise_floor_loop=voice->dsp.sample->amplitude_that_reaches_noise_floor / voice->dsp.synth_gain;
+	  voice->dsp.amplitude_that_reaches_noise_floor_loop=(fluid_real_t)(voice->dsp.sample->amplitude_that_reaches_noise_floor / voice->dsp.synth_gain);
 	} else {
 	  /* Worst case */
 	  voice->dsp.amplitude_that_reaches_noise_floor_loop=voice->dsp.amplitude_that_reaches_noise_floor_nonloop;
@@ -514,9 +514,9 @@ fluid_rvoice_noteoff(fluid_rvoice_t* voice, unsigned int min_ticks)
      */
     if (fluid_adsr_env_get_val(&voice->envlfo.volenv) > 0){
       fluid_real_t lfo = fluid_lfo_get_val(&voice->envlfo.modlfo) * -voice->envlfo.modlfo_to_vol;
-      fluid_real_t amp = fluid_adsr_env_get_val(&voice->envlfo.volenv) * pow (10.0, lfo / -200);
-      fluid_real_t env_value = - ((-200 * log (amp) / log (10.0) - lfo) / 960.0 - 1);
-      fluid_clip (env_value, 0.0, 1.0);
+      fluid_real_t amp = (fluid_real_t)(fluid_adsr_env_get_val(&voice->envlfo.volenv) * pow (10.0, lfo / -200));
+      fluid_real_t env_value = -(fluid_real_t)((-200 * log (amp) / log (10.0) - lfo) / 960.0 - 1);
+      fluid_clip (env_value, (fluid_real_t)0.0, (fluid_real_t)1.0);
       fluid_adsr_env_set_val(&voice->envlfo.volenv, env_value);
     }
   }

--- a/src/libs/fluidsynth/rvoice/fluid_rvoice_dsp.c
+++ b/src/libs/fluidsynth/rvoice/fluid_rvoice_dsp.c
@@ -103,7 +103,7 @@ void fluid_rvoice_dsp_config (void)
       }
       else v = 1.0;
 
-      sinc_table7[FLUID_INTERP_MAX - i2 - 1][i] = v;
+      sinc_table7[FLUID_INTERP_MAX - i2 - 1][i] = (fluid_real_t)v;
     }
   }
 

--- a/src/libs/fluidsynth/rvoice/fluid_rvoice_mixer.c
+++ b/src/libs/fluidsynth/rvoice/fluid_rvoice_mixer.c
@@ -669,13 +669,13 @@ void fluid_rvoice_mixer_set_chorus_params(fluid_rvoice_mixer_t* mixer, int set,
 				         int nr, double level, double speed, 
 				         double depth_ms, int type)
 {
-  fluid_chorus_set(mixer->fx.chorus, set, nr, level, speed, depth_ms, type);
+  fluid_chorus_set(mixer->fx.chorus, set, nr, (float)level, (float)speed, (float)depth_ms, type);
 }
 void fluid_rvoice_mixer_set_reverb_params(fluid_rvoice_mixer_t* mixer, int set, 
 					 double roomsize, double damping, 
 					 double width, double level)
 {
-  fluid_revmodel_set(mixer->fx.reverb, set, roomsize, damping, width, level); 
+  fluid_revmodel_set(mixer->fx.reverb, set, (float)roomsize, (float)damping, (float)width, (float)level);
 }
 
 void fluid_rvoice_mixer_reset_fx(fluid_rvoice_mixer_t* mixer)

--- a/src/libs/fluidsynth/sfloader/fluid_defsfont.c
+++ b/src/libs/fluidsynth/sfloader/fluid_defsfont.c
@@ -855,10 +855,10 @@ fluid_defpreset_noteon(fluid_defpreset_t* preset, fluid_synth_t* synth, int chan
 	     * the default generator -> voice_gen_set */
 
 	    if (inst_zone->gen[i].flags){
-	      fluid_voice_gen_set(voice, i, inst_zone->gen[i].val);
+	      fluid_voice_gen_set(voice, i, (float)inst_zone->gen[i].val);
 
 	    } else if ((global_inst_zone != NULL) && (global_inst_zone->gen[i].flags)) {
-	      fluid_voice_gen_set(voice, i, global_inst_zone->gen[i].val);
+	      fluid_voice_gen_set(voice, i, (float)global_inst_zone->gen[i].val);
 
 	    } else {
 	      /* The generator has not been defined in this instrument.
@@ -944,9 +944,9 @@ fluid_defpreset_noteon(fluid_defpreset_t* preset, fluid_synth_t* synth, int chan
 	       * summing node -> voice_gen_incr */
 
 	      if (preset_zone->gen[i].flags) {
-		fluid_voice_gen_incr(voice, i, preset_zone->gen[i].val);
+		fluid_voice_gen_incr(voice, i, (float)preset_zone->gen[i].val);
 	      } else if ((global_preset_zone != NULL) && global_preset_zone->gen[i].flags) {
-		fluid_voice_gen_incr(voice, i, global_preset_zone->gen[i].val);
+		fluid_voice_gen_incr(voice, i, (float)global_preset_zone->gen[i].val);
 	      } else {
 		/* The generator has not been defined in this preset
 		 * Do nothing, leave it unchanged.
@@ -1273,7 +1273,7 @@ fluid_preset_zone_import_sfont(fluid_preset_zone_t* zone, SFZone *sfzone, fluid_
     }
 
     /* *** Dest *** */
-    mod_dest->dest = mod_src->dest; /* index of controlled generator */
+    mod_dest->dest = (unsigned char)mod_src->dest; /* index of controlled generator */
 
     /* *** Amount source *** */
     mod_dest->src2 = mod_src->amtsrc & 127; /* index of source 2, seven-bit value, SF2.01 section 8.2, p.50 */
@@ -1678,7 +1678,7 @@ fluid_inst_zone_import_sfont(fluid_inst_zone_t* zone, SFZone *sfzone, fluid_defs
     }
 
     /* *** Dest *** */
-    mod_dest->dest=mod_src->dest; /* index of controlled generator */
+    mod_dest->dest= (unsigned char)mod_src->dest; /* index of controlled generator */
 
     /* *** Amount source *** */
     mod_dest->src2=mod_src->amtsrc & 127; /* index of source 2, seven-bit value, SF2.01 section 8.2, page 50 */
@@ -3102,7 +3102,7 @@ fixup_pgen (SFData * sf)
       while (p2)
 	{			/* traverse this preset's zones */
 	  z = (SFZone *) (p2->data);
-	  if ((i = POINTER_TO_INT (z->instsamp)))
+	  if ((i = (int)POINTER_TO_INT (z->instsamp)))
 	    {			/* load instrument # */
 	      p3 = fluid_list_nth (sf->inst, i - 1);
 	      if (!p3)
@@ -3137,7 +3137,7 @@ fixup_igen (SFData * sf)
       while (p2)
 	{			/* traverse instrument's zones */
 	  z = (SFZone *) (p2->data);
-	  if ((i = POINTER_TO_INT (z->instsamp)))
+	  if ((i = (int)POINTER_TO_INT (z->instsamp)))
 	    {			/* load sample # */
 	      p3 = fluid_list_nth (sf->sample, i - 1);
 	      if (!p3)

--- a/src/libs/fluidsynth/sfloader/fluid_ramsfont.c
+++ b/src/libs/fluidsynth/sfloader/fluid_ramsfont.c
@@ -949,10 +949,10 @@ fluid_rampreset_noteon (fluid_rampreset_t* preset, fluid_synth_t* synth, int cha
 	     * the default generator -> voice_gen_set */
 
 	    if (inst_zone->gen[i].flags){
-	      fluid_voice_gen_set(voice, i, inst_zone->gen[i].val);
+	      fluid_voice_gen_set(voice, i, (float)inst_zone->gen[i].val);
 
 	    } else if (global_inst_zone != NULL && global_inst_zone->gen[i].flags){
-	      fluid_voice_gen_set(voice, i, global_inst_zone->gen[i].val);
+	      fluid_voice_gen_set(voice, i, (float)global_inst_zone->gen[i].val);
 
 	    } else {
 	      /* The generator has not been defined in this instrument.
@@ -1038,7 +1038,7 @@ fluid_rampreset_noteon (fluid_rampreset_t* preset, fluid_synth_t* synth, int cha
 	       * summing node -> voice_gen_incr */
 
 	      if (preset_zone->gen[i].flags){
-		fluid_voice_gen_incr(voice, i, preset_zone->gen[i].val);
+		fluid_voice_gen_incr(voice, i, (float)preset_zone->gen[i].val);
 	      } else {
 		/* The generator has not been defined in this preset
 		 * Do nothing, leave it unchanged.

--- a/src/libs/fluidsynth/synth/fluid_mod.c
+++ b/src/libs/fluidsynth/synth/fluid_mod.c
@@ -211,7 +211,7 @@ fluid_mod_get_value(fluid_mod_t* mod, fluid_channel_t* chan, fluid_voice_t* voic
   /* get the initial value of the first source */
   if (mod->src1 > 0) {
     if (mod->flags1 & FLUID_MOD_CC) {
-      v1 = fluid_channel_get_cc(chan, mod->src1);
+      v1 = (fluid_real_t)fluid_channel_get_cc(chan, mod->src1);
     } else {  /* source 1 is one of the direct controllers */
       switch (mod->src1) {
       case FLUID_MOD_NONE:         /* SF 2.01 8.2.1 item 0: src enum=0 => value is 1 */
@@ -224,17 +224,17 @@ fluid_mod_get_value(fluid_mod_t* mod, fluid_channel_t* chan, fluid_voice_t* voic
 	v1 = voice->key;
 	break;
       case FLUID_MOD_KEYPRESSURE:
-	v1 = fluid_channel_get_key_pressure (chan);
+	v1 = (fluid_real_t)fluid_channel_get_key_pressure (chan);
 	break;
       case FLUID_MOD_CHANNELPRESSURE:
-	v1 = fluid_channel_get_channel_pressure (chan);
+	v1 = (fluid_real_t)fluid_channel_get_channel_pressure (chan);
 	break;
       case FLUID_MOD_PITCHWHEEL:
-	v1 = fluid_channel_get_pitch_bend (chan);
+	v1 = (fluid_real_t)fluid_channel_get_pitch_bend (chan);
 	range1 = 0x4000;
 	break;
       case FLUID_MOD_PITCHWHEELSENS:
-	v1 = fluid_channel_get_pitch_wheel_sensitivity (chan);
+	v1 = (fluid_real_t)fluid_channel_get_pitch_wheel_sensitivity (chan);
 	break;
       default:
 	v1 = 0.0;
@@ -304,7 +304,7 @@ fluid_mod_get_value(fluid_mod_t* mod, fluid_channel_t* chan, fluid_voice_t* voic
   /* get the second input source */
   if (mod->src2 > 0) {
     if (mod->flags2 & FLUID_MOD_CC) {
-      v2 = fluid_channel_get_cc(chan, mod->src2);
+      v2 = (fluid_real_t)fluid_channel_get_cc(chan, mod->src2);
     } else {
       switch (mod->src2) {
       case FLUID_MOD_NONE:         /* SF 2.01 8.2.1 item 0: src enum=0 => value is 1 */
@@ -317,16 +317,16 @@ fluid_mod_get_value(fluid_mod_t* mod, fluid_channel_t* chan, fluid_voice_t* voic
 	v2 = voice->key;
 	break;
       case FLUID_MOD_KEYPRESSURE:
-	v2 = fluid_channel_get_key_pressure (chan);
+	v2 = (fluid_real_t)fluid_channel_get_key_pressure (chan);
 	break;
       case FLUID_MOD_CHANNELPRESSURE:
-	v2 = fluid_channel_get_channel_pressure (chan);
+	v2 = (fluid_real_t)fluid_channel_get_channel_pressure (chan);
 	break;
       case FLUID_MOD_PITCHWHEEL:
-	v2 = fluid_channel_get_pitch_bend (chan);
+	v2 = (fluid_real_t)fluid_channel_get_pitch_bend (chan);
 	break;
       case FLUID_MOD_PITCHWHEELSENS:
-	v2 = fluid_channel_get_pitch_wheel_sensitivity (chan);
+	v2 = (fluid_real_t)fluid_channel_get_pitch_wheel_sensitivity (chan);
 	break;
       default:
 	v1 = 0.0f;

--- a/src/libs/fluidsynth/synth/fluid_voice.c
+++ b/src/libs/fluidsynth/synth/fluid_voice.c
@@ -369,7 +369,7 @@ fluid_voice_gen_incr(fluid_voice_t* voice, int i, float val)
 float
 fluid_voice_gen_get(fluid_voice_t* voice, int gen)
 {
-  return voice->gen[gen].val;
+  return (float)voice->gen[gen].val;
 }
 
 fluid_real_t fluid_voice_gen_value(fluid_voice_t* voice, int num)
@@ -892,7 +892,7 @@ fluid_voice_update_param(fluid_voice_t* voice, int gen)
      * */
     x = _GEN(voice, GEN_KEYNUM);
     if (x >= 0){
-      voice->key = x;
+      voice->key = (fluid_real_t)x;
     }
     break;
 
@@ -906,7 +906,7 @@ fluid_voice_update_param(fluid_voice_t* voice, int gen)
      * enabled or not. But here we rely on the default value of -1.  */
     x = _GEN(voice, GEN_VELOCITY);
     if (x > 0) {
-      voice->vel = x;
+      voice->vel = (fluid_real_t)x;
     }
     break;
 
@@ -1431,7 +1431,7 @@ fluid_voice_get_lower_boundary_for_attenuation(fluid_voice_t* voice)
 	&& ((mod->flags1 & FLUID_MOD_CC) || (mod->flags2 & FLUID_MOD_CC))) {
 
       fluid_real_t current_val = fluid_mod_get_value(mod, voice->channel, voice);
-      fluid_real_t v = fabs(mod->amount);
+      fluid_real_t v = (fluid_real_t)fabs(mod->amount);
 
       if ((mod->src1 == FLUID_MOD_PITCHWHEEL)
 	  || (mod->flags1 & FLUID_MOD_BIPOLAR)
@@ -1556,7 +1556,7 @@ fluid_voice_optimize_sample(fluid_sample_t* s)
      */
 
     /* 16 bits => 96+4=100 dB dynamic range => 0.00001 */
-    normalized_amplitude_during_loop = ((fluid_real_t)peak)/32768.;
+    normalized_amplitude_during_loop = (fluid_real_t)(((fluid_real_t)peak)/32768.);
     result = FLUID_NOISE_FLOOR / normalized_amplitude_during_loop;
 
     /* Store in sample */


### PR DESCRIPTION
Fixes many C4244 warnings (implicit conversion from a larger type to a smaller type).

The number of Visual Studio 2019 SDL1 build warnings is reduced from 568 in master to 432.

