### PR TITLE
Add support for XDG_DATA_HOME

### DIFF
--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -80,13 +80,12 @@ void Cross::GetPlatformResDir(std::string& in) {
 	// Let's check if the above exists, otherwise use RESDIR
 	struct stat info;
 	if ((stat(in.c_str(), &info) != 0) || (!(info.st_mode & S_IFDIR))) {
-		LOG_MSG("XDG_DATA_HOME (%s) does not exist. Using %s", in.c_str(), RESDIR);
+		//LOG_MSG("XDG_DATA_HOME (%s) does not exist. Using %s", in.c_str(), RESDIR);
 	        in = RESDIR;
 	}
 #elif defined(RESDIR)
 	in = RESDIR;
 #endif
-	LOG_MSG("Data dir: %s", in.c_str());
 	if (!in.empty())
 		in += CROSS_FILESPLIT;
 }

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -23,6 +23,8 @@
 #include <string>
 #include <limits.h>
 #include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 
 #if defined(MACOSX)
 std::string MacOSXEXEPath;
@@ -69,11 +71,24 @@ void Cross::GetPlatformResDir(std::string& in) {
 	in = MacOSXResPath;
 #elif defined(RISCOS)
 	in = "/<DosBox-X$Dir>/resources";
+#elif defined(LINUX)
+	const char *xdg_data_home = getenv("XDG_DATA_HOME");
+	const std::string data_home = xdg_data_home && xdg_data_home[0] == '/' ? xdg_data_home: "~/.local/share";
+	in = data_home + "/dosbox-x";
+	ResolveHomedir(in);
+
+	// Let's check if the above exists, otherwise use RESDIR
+	struct stat info;
+	if ((stat(in.c_str(), &info) != 0) || (!(info.st_mode & S_IFDIR))) {
+		LOG_MSG("XDG_DATA_HOME (%s) does not exist. Using %s", in.c_str(), RESDIR);
+	        in = RESDIR;
+	}
 #elif defined(RESDIR)
 	in = RESDIR;
 #endif
-    if (!in.empty())
-	    in += CROSS_FILESPLIT;
+	LOG_MSG("Data dir: %s", in.c_str());
+	if (!in.empty())
+		in += CROSS_FILESPLIT;
 }
 
 void Cross::GetPlatformConfigDir(std::string& in) {


### PR DESCRIPTION
# Description

Add check for if XDG_DATA_HOME is set, and if the directory exists.
If not, it falls back to the old location (e.g. /usr/share/dosbox-x)

**Does this PR address some issue(s) ?**

Checking XDG_DATA_HOME is needed for flatpak support, as that is
the location that files like FREECG98.BMP will be located. Without this
dosbox-x is not able to find FREECG98.BMP on flatpak.

**Does this PR introduce new feature(s) ?**

Support for XDG_DATA_HOME

**Are there any breaking changes ?**

If both the system-wide location (e.g. /usr/share/dosbox-x) and the XDG_DATA_HOME location exists, it will only use the later to locate additional resources such as FREECG98.BMP

So if the user decides he wants to use a user controlled location, he needs to ensure it has all the files needed.
