### PR TITLE
Add windowposition config option

### DIFF
--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -11,6 +11,7 @@
 #                        If you end up with small window on a large screen, try an output different from surface.
 #  windowresolution: Scale the window to this size IF the output device supports hardware scaling.
 #                        (output=surface does not!)
+#    windowposition: Set the window position at startup.
 #            output: What video system to use for output.
 #                      Possible values: default, surface, overlay, opengl, openglnb, openglhq, ddraw.
 #          autolock: Mouse will automatically lock, if you click on the screen. (Press CTRL-F10 to unlock)
@@ -54,6 +55,7 @@ fullscreen        = false
 fulldouble        = false
 fullresolution    = desktop
 windowresolution  = original
+windowposition    = 
 output            = default
 autolock          = false
 autolock_feedback = beep

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -11,7 +11,7 @@
 #                        If you end up with small window on a large screen, try an output different from surface.
 #  windowresolution: Scale the window to this size IF the output device supports hardware scaling.
 #                        (output=surface does not!)
-#    windowposition: Set the window position at startup.
+#    windowposition: Set the window position at startup in the positionX,positionY format (e.g.: 1300,200)
 #            output: What video system to use for output.
 #                      Possible values: default, surface, overlay, opengl, openglnb, openglhq, ddraw.
 #          autolock: Mouse will automatically lock, if you click on the screen. (Press CTRL-F10 to unlock)

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3875,6 +3875,35 @@ static void GUI_StartUp() {
     sdl.overscan_width=(unsigned int)section->Get_int("overscan");
 //  sdl.overscan_color=section->Get_int("overscancolor");
 
+    // Getting window position (if configured)
+    int posx = -1;
+    int posy = -1;
+    const char* windowposition = section->Get_string("windowposition");
+    LOG_MSG("Configured windowposition: %s", windowposition);
+    if (windowposition && *windowposition) {
+        char result[100];
+        safe_strncpy(result, windowposition, sizeof(result));
+        char* y = strchr(result, ',');
+        if (y && *y) {
+            *y = 0;
+            posx = atoi(result);
+            posy = atoi(y + 1);
+        }
+    }
+
+    // Setting SDL1 window position before a call to SDL_SetVideoMode() is made. If the user provided
+    // SDL_VIDEO_WINDOW_POS environment variable then "windowposition" setting should have no effect.
+    // SDL2 position is set later, using SDL_SetWindowPosition()
+#if !defined(C_SDL2)
+    if (posx >= 0 && posy >= 0 && SDL_getenv("SDL_VIDEO_WINDOW_POS") == NULL) {
+        const char* windowposition = section->Get_string("windowposition");
+        char pos[100];
+        safe_strncpy(pos, "SDL_VIDEO_WINDOW_POS=", sizeof(pos));
+        safe_strcat(pos, windowposition);
+        SDL_putenv(pos);
+    }
+#endif
+
     bool initgl = false;
 #if C_OPENGL
     /*std::string f = (std::string)(static_cast<Section_prop *>(control->GetSection("render"))->Get_path("glshader")->GetValue());
@@ -3980,23 +4009,14 @@ static void GUI_StartUp() {
     GFX_LogSDLState();
     GFX_Stop();
 
+
 #if defined(C_SDL2)
     SDL_SetWindowTitle(sdl.window,"DOSBox-X");
+    if (posx >= 0 && posy >= 0)
+        SDL_SetWindowPosition(sdl.window, posx, posy);
 #else
     SDL_WM_SetCaption("DOSBox-X",VERSION);
 #endif
-
-    const char* windowposition = section->Get_string("windowposition");
-    if (windowposition && *windowposition) {
-        char res[100];
-        safe_strncpy(res, windowposition, sizeof(res));
-        windowposition = lowcase(res);//so x and X are allowed
-        char* height = const_cast<char*>(strchr(windowposition, 'x'));
-        if (height && *height) {
-            *height = 0;
-            SDL_SetWindowPosition(sdl.window, atoi(res), atoi(height + 1));
-        }
-    }
 
     /* Please leave the Splash screen stuff in working order in DOSBox-X. We spend a lot of time making DOSBox-X. */
     //ShowSplashScreen();   /* I will keep the splash screen alive. But now, the BIOS will do it --J.C. */
@@ -6422,7 +6442,7 @@ void SDL_SetupConfigSection() {
     Pstring->SetBasic(true);
 
     Pstring = sdl_sec->Add_string("windowposition", Property::Changeable::Always, "");
-    Pstring->Set_help("Set the window position at startup.");
+    Pstring->Set_help("Set the window position at startup in the positionX,positionY format (e.g.: 1300,200)");
     Pstring->SetBasic(true);
 
     const char* outputs[] = {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3986,6 +3986,18 @@ static void GUI_StartUp() {
     SDL_WM_SetCaption("DOSBox-X",VERSION);
 #endif
 
+    const char* windowposition = section->Get_string("windowposition");
+    if (windowposition && *windowposition) {
+        char res[100];
+        safe_strncpy(res, windowposition, sizeof(res));
+        windowposition = lowcase(res);//so x and X are allowed
+        char* height = const_cast<char*>(strchr(windowposition, 'x'));
+        if (height && *height) {
+            *height = 0;
+            SDL_SetWindowPosition(sdl.window, atoi(res), atoi(height + 1));
+        }
+    }
+
     /* Please leave the Splash screen stuff in working order in DOSBox-X. We spend a lot of time making DOSBox-X. */
     //ShowSplashScreen();   /* I will keep the splash screen alive. But now, the BIOS will do it --J.C. */
 
@@ -6407,6 +6419,10 @@ void SDL_SetupConfigSection() {
     Pstring = sdl_sec->Add_string("windowresolution",Property::Changeable::Always,"original");
     Pstring->Set_help("Scale the window to this size IF the output device supports hardware scaling.\n"
                       "  (output=surface does not!)");
+    Pstring->SetBasic(true);
+
+    Pstring = sdl_sec->Add_string("windowposition", Property::Changeable::Always, "");
+    Pstring->Set_help("Set the window position at startup.");
     Pstring->SetBasic(true);
 
     const char* outputs[] = {


### PR DESCRIPTION
# Description

Normally, at least on Windows, the window open with SDL1 is positioned randomly on the screen, which is pretty annoying. It can be overriden by setting SDL_VIDEO_WINDOW_POS, but it's cumbersome.

SDL2 is even worse, as SDL_VIDEO_WINDOW_POS does nothing and the window always ends up in the same, weird place on the screen (top left corner is around the middle of the screen on my main 4k monitor, resulting in bottom right corner outside of the visible area).

Added "windowposition" option to allow users to configure the exact placement of the window when DOSBox starts. If the config value is empty, no change will be made.

**Does this PR address some issue(s) ?**

No

**Does this PR introduce new feature(s) ?**

 "windowposition" configuration option.

**Are there any breaking changes ?**

No.


**Additional information**

I saw the DOSBox code for the first time only yesterday, so please bear with me if I missed something obvious.