### PR TITLE
Debuggable ST registers

### DIFF
--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -326,6 +326,19 @@ static list<string>::iterator histBuffPos = histBuff.end();
 /* Helpers */
 /***********/
 
+/* dest here must be a string with a minimum length of 11. */
+static char* F80ToString(int regIndex, char* dest) {
+#if C_FPU_X86
+	snprintf(dest, 11, "%08.2Lf", reinterpret_cast<long double&>(fpu.p_regs[regIndex]));
+#elif defined(HAS_LONG_DOUBLE)
+	snprintf(dest, 11, "%08.2Lf", fpu.regs_80[regIndex].v);
+#else
+	snprintf(dest, 11, "%08.2f", fpu.regs[regIndex].d);
+#endif
+	
+	return dest;
+}
+
 static const uint64_t mem_no_address = (uint64_t)(~0ULL);
 
 uint64_t LinMakeProt(uint16_t selector, uint32_t offset)
@@ -1046,6 +1059,19 @@ static void DrawRegisters(void) {
 	SetColor(SegValue(gs)!=oldsegs[gs].val);mvwprintw (dbg.win_reg,0,61,"%04X",SegValue(gs));
 	SetColor(SegValue(ss)!=oldsegs[ss].val);mvwprintw (dbg.win_reg,0,71,"%04X",SegValue(ss));
 	SetColor(SegValue(cs)!=oldsegs[cs].val);mvwprintw (dbg.win_reg,1,31,"%04X",SegValue(cs));
+	
+	char x87buf[12] = {};
+	SetColor(false);mvwprintw (dbg.win_reg,4,4,"%s", F80ToString(STV(0), x87buf));
+	SetColor(false);mvwprintw (dbg.win_reg,5,4,"%s", F80ToString(STV(4), x87buf));
+	
+	SetColor(false);mvwprintw (dbg.win_reg,4,18,"%s", F80ToString(STV(1), x87buf));
+	SetColor(false);mvwprintw (dbg.win_reg,5,18,"%s", F80ToString(STV(5), x87buf));
+	
+	SetColor(false);mvwprintw (dbg.win_reg,4,32,"%s", F80ToString(STV(2), x87buf));
+	SetColor(false);mvwprintw (dbg.win_reg,5,32,"%s", F80ToString(STV(6), x87buf));
+	
+	SetColor(false);mvwprintw (dbg.win_reg,4,46,"%s", F80ToString(STV(3), x87buf));
+	SetColor(false);mvwprintw (dbg.win_reg,5,46,"%s", F80ToString(STV(7), x87buf));
 
 	/*Individual flags*/
 	Bitu changed_flags = reg_flags ^ oldflags;

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -277,6 +277,8 @@ static bool debugging = false;
 static bool debug_running = false;
 static bool check_rescroll = false;
 
+static FPU_rec oldfpu;
+
 bool IsDebuggerActive(void) {
     return debugging;
 }
@@ -337,6 +339,20 @@ static char* F80ToString(int regIndex, char* dest) {
 #endif
 	
 	return dest;
+}
+
+static bool F80TestUpdate(int regIndex) {
+	if(fpu.top != oldfpu.top) { /* If the top changed then all registers rotated places, thus updated. */
+		return true;
+	}
+	
+#if C_FPU_X86
+	return !(fpu.p_regs[regIndex].m1 == oldfpu.p_regs[regIndex].m1 && fpu.p_regs[regIndex].m2 == oldfpu.p_regs[regIndex].m2 && fpu.p_regs[regIndex].m3 == oldfpu.p_regs[regIndex].m3);
+#elif defined(HAS_LONG_DOUBLE)
+	return fpu.regs_80[regIndex].v != oldfpu.regs_80[regIndex].v; /* I'm certain that strict float equality can be used here. */
+#else
+	return fpu.regs[regIndex].d != oldfpu.regs[regIndex].d;
+#endif
 }
 
 static const uint64_t mem_no_address = (uint64_t)(~0ULL);
@@ -1030,6 +1046,8 @@ void DrawRegistersUpdateOld(void) {
 	oldsegs[gs].val=SegValue(gs);
 	oldsegs[ss].val=SegValue(ss);
 	oldsegs[cs].val=SegValue(cs);
+	
+	oldfpu = fpu; /* Slow? */
 
 	/*Individual flags*/
 	oldflags = reg_flags;
@@ -1061,17 +1079,17 @@ static void DrawRegisters(void) {
 	SetColor(SegValue(cs)!=oldsegs[cs].val);mvwprintw (dbg.win_reg,1,31,"%04X",SegValue(cs));
 	
 	char x87buf[12] = {};
-	SetColor(false);mvwprintw (dbg.win_reg,4,4,"%s", F80ToString(STV(0), x87buf));
-	SetColor(false);mvwprintw (dbg.win_reg,5,4,"%s", F80ToString(STV(4), x87buf));
+	SetColor(F80TestUpdate(STV(0)));mvwprintw (dbg.win_reg,4,4,"%s", F80ToString(STV(0), x87buf));
+	SetColor(F80TestUpdate(STV(4)));mvwprintw (dbg.win_reg,5,4,"%s", F80ToString(STV(4), x87buf));
 	
-	SetColor(false);mvwprintw (dbg.win_reg,4,18,"%s", F80ToString(STV(1), x87buf));
-	SetColor(false);mvwprintw (dbg.win_reg,5,18,"%s", F80ToString(STV(5), x87buf));
+	SetColor(F80TestUpdate(STV(1)));mvwprintw (dbg.win_reg,4,18,"%s", F80ToString(STV(1), x87buf));
+	SetColor(F80TestUpdate(STV(5)));mvwprintw (dbg.win_reg,5,18,"%s", F80ToString(STV(5), x87buf));
 	
-	SetColor(false);mvwprintw (dbg.win_reg,4,32,"%s", F80ToString(STV(2), x87buf));
-	SetColor(false);mvwprintw (dbg.win_reg,5,32,"%s", F80ToString(STV(6), x87buf));
+	SetColor(F80TestUpdate(STV(2)));mvwprintw (dbg.win_reg,4,32,"%s", F80ToString(STV(2), x87buf));
+	SetColor(F80TestUpdate(STV(6)));mvwprintw (dbg.win_reg,5,32,"%s", F80ToString(STV(6), x87buf));
 	
-	SetColor(false);mvwprintw (dbg.win_reg,4,46,"%s", F80ToString(STV(3), x87buf));
-	SetColor(false);mvwprintw (dbg.win_reg,5,46,"%s", F80ToString(STV(7), x87buf));
+	SetColor(F80TestUpdate(STV(3)));mvwprintw (dbg.win_reg,4,46,"%s", F80ToString(STV(3), x87buf));
+	SetColor(F80TestUpdate(STV(7)));mvwprintw (dbg.win_reg,5,46,"%s", F80ToString(STV(7), x87buf));
 
 	/*Individual flags*/
 	Bitu changed_flags = reg_flags ^ oldflags;

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -350,6 +350,18 @@ static void Draw_RegisterLayout(void) {
 	mvwaddstr(dbg.win_reg,2,75,"CPL");
 	mvwaddstr(dbg.win_reg,2,68,"IOPL");
 
+	mvwaddstr(dbg.win_reg,4,0,"ST0=");
+	mvwaddstr(dbg.win_reg,5,0,"ST4=");
+
+	mvwaddstr(dbg.win_reg,4,14,"ST1=");
+	mvwaddstr(dbg.win_reg,5,14,"ST5=");
+
+	mvwaddstr(dbg.win_reg,4,28,"ST2=");
+	mvwaddstr(dbg.win_reg,5,28,"ST6=");
+
+	mvwaddstr(dbg.win_reg,4,42,"ST3=");
+	mvwaddstr(dbg.win_reg,5,42,"ST7=");
+
 	mvwaddstr(dbg.win_reg,1,52,"C  Z  S  O  A  P  D  I  T ");
 }
 

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -77,7 +77,7 @@ std::string DBGBlock::windowlist_by_name(void) {
 }
 
 const unsigned int dbg_def_win_height[DBGBlock::WINI_MAX_INDEX] = {
-    5,          /* WINI_REG */
+    7,          /* WINI_REG */
     9,          /* WINI_DATA */
     12,         /* WINI_CODE */
     5,          /* WINI_VAR */


### PR DESCRIPTION
# Description

Adds a view of the FPU stack to the debugger, to improve quality of debugging experience.

**Does this PR address some issue(s) ?**

Fixes issue #1940.

**Does this PR introduce new feature(s) ?**

Increases the register view to 7 lines to fit the ST registers, and draws them.

**Are there any breaking changes ?**

No.

**Additional information**

The registers shown have a fixed layout of 5 digits before and 2 after the decimal point. This doesn't fit all kinds of values that are possible, obviously, but perhaps it's good enough for now?
