### PR TITLE
SVN commits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,12 @@
       instead of the wrongly 19, this makes it possible
       to switch 64 integers which in turn fixes some
       rounding issues. (jmarsh)
+    - r4282,r4283: Switch to a different way to calculate
+      DBOPL table offsets.
+    - r4280: Prevent GenerateDMASound from running with
+      input of 0.
+    - r4279: Remove DMA_TRANSFEREND and replace with
+      DMA_MASKED.
     - r4277: Remove cases not needed after r4276
     - r4276: Remove defunct code related to the initial
       display mode of the system BIOS during video mode

--- a/include/dma.h
+++ b/include/dma.h
@@ -25,7 +25,7 @@ enum DMAEvent {
 	DMA_REACHED_TC,
 	DMA_MASKED,
 	DMA_UNMASKED,
-	DMA_TRANSFEREND
+//	DMA_TRANSFEREND, this shouldn't really be a signal
 };
 
 enum DMATransfer {

--- a/patch-integration/Skipped SVN commits.txt
+++ b/patch-integration/Skipped SVN commits.txt
@@ -32,8 +32,9 @@ Commit#:	Reason for skipping:
 4245		Conflict
 4267		IMGMOUNT rewrite part skipped due to conflict
 4270		Conflict
-4271		core_dyn_86
-4272		core_dyn_86
+4278		Conflict
+4281		Conflict
+4285		Website
 
 (Status for commits in this interval needs to be added)
 

--- a/src/hardware/dbopl.cpp
+++ b/src/hardware/dbopl.cpp
@@ -1098,14 +1098,14 @@ void Chip::WriteBD( uint8_t val ) {
 #define REGOP( _FUNC_ )															\
 	index = ( ( reg >> 3) & 0x20 ) | ( reg & 0x1f );								\
 	if ( OpOffsetTable[ index ] ) {													\
-		Operator* regOp = (Operator*)( ((char *)this ) + OpOffsetTable[ index ] );	\
+		Operator* regOp = (Operator*)( ((char *)this ) + OpOffsetTable[ index ]-1 );	\
 		regOp->_FUNC_( this, val );													\
 	}
 
 #define REGCHAN( _FUNC_ )																\
 	index = ( ( reg >> 4) & 0x10 ) | ( reg & 0xf );										\
 	if ( ChanOffsetTable[ index ] ) {													\
-		Channel* regChan = (Channel*)( ((char *)this ) + ChanOffsetTable[ index ] );	\
+		Channel* regChan = (Channel*)( ((char *)this ) + ChanOffsetTable[ index ]-1 );	\
 		regChan->_FUNC_( this, val );													\
 	}
 
@@ -1442,7 +1442,6 @@ void InitTables( void ) {
 		TremoloTable[TREMOLO_TABLE - 1 - i] = val;
 	}
 	//Create a table with offsets of the channels from the start of the chip
-	DBOPL::Chip* chip = 0;
 	for ( Bitu i = 0; i < 32; i++ ) {
 		Bitu index = i & 0xf;
 		if ( index >= 9 ) {
@@ -1456,8 +1455,7 @@ void InitTables( void ) {
 		//Add back the bits for highest ones
 		if ( i >= 16 )
 			index += 9;
-		Bitu blah = reinterpret_cast<Bitu>( &(chip->chan[ index ]) );
-		ChanOffsetTable[i] = (uint16_t)blah;
+		ChanOffsetTable[i] = 1+(uint16_t)(index*sizeof(DBOPL::Channel));
 	}
 	//Same for operators
 	for ( Bitu i = 0; i < 64; i++ ) {
@@ -1470,16 +1468,15 @@ void InitTables( void ) {
 		if ( chNum >= 12 )
 			chNum += 16 - 12;
 		Bitu opNum = ( i % 8 ) / 3;
-		DBOPL::Channel* chan = 0;
-		Bitu blah = reinterpret_cast<Bitu>( &(chan->op[opNum]) );
-		OpOffsetTable[i] = (uint16_t)(ChanOffsetTable[ chNum ] + blah);
+		OpOffsetTable[i] = ChanOffsetTable[chNum]+(uint16_t)(opNum*sizeof(DBOPL::Operator));
 	}
 #if 0
+	DBOPL::Chip* chip = 0;
 	//Stupid checks if table's are correct
 	for ( Bitu i = 0; i < 18; i++ ) {
 		uint32_t find = (uint16_t)( &(chip->chan[ i ]) );
 		for ( Bitu c = 0; c < 32; c++ ) {
-			if ( ChanOffsetTable[c] == find ) {
+			if ( ChanOffsetTable[c] == find+1 ) {
 				find = 0;
 				break;
 			}
@@ -1491,7 +1488,7 @@ void InitTables( void ) {
 	for ( Bitu i = 0; i < 36; i++ ) {
 		uint32_t find = (uint16_t)( &(chip->chan[ i / 2 ].op[i % 2]) );
 		for ( Bitu c = 0; c < 64; c++ ) {
-			if ( OpOffsetTable[c] == find ) {
+			if ( OpOffsetTable[c] == find+1 ) {
 				find = 0;
 				break;
 			}

--- a/src/hardware/dbopl.h
+++ b/src/hardware/dbopl.h
@@ -156,7 +156,7 @@ public:
 };
 
 struct Channel {
-	Operator op[2];
+	Operator op[2]; //Leave on top of struct for simpler pointer math.
 	inline Operator* Op( Bitu index ) {
 		return &( ( this + (index >> 1) )->op[ index & 1 ]);
 	}
@@ -192,6 +192,9 @@ struct Channel {
 };
 
 struct Chip {
+	//18 channels with 2 operators each. Leave on top of struct for simpler pointer math.
+	Channel chan[18];
+
 	//This is used as the base counter for vibrato and tremolo
 	uint32_t lfoCounter = 0;
 	uint32_t lfoAdd = 0;
@@ -207,9 +210,6 @@ struct Chip {
     uint32_t linearRates[76] = {};
 	//Best match attack rates for the rate of this chip
     uint32_t attackRates[76] = {};
-
-	//18 channels with 2 operators each
-	Channel chan[18];
 
 	uint8_t reg104;
 	uint8_t reg08;

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -488,7 +488,7 @@ Bitu DmaChannel::Read(Bitu want, uint8_t * buffer) {
             } else {
                 masked = true;
                 UpdateEMSMapping();
-                DoCallBack(DMA_TRANSFEREND);
+                DoCallBack(DMA_MASKED);
                 break;
             }
         }
@@ -574,7 +574,7 @@ Bitu DmaChannel::Write(Bitu want, uint8_t * buffer) {
             } else {
                 masked = true;
                 UpdateEMSMapping();
-                DoCallBack(DMA_TRANSFEREND);
+                DoCallBack(DMA_MASKED);
                 break;
             }
         }

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -442,8 +442,6 @@ static void DSP_DMA_CallBack(DmaChannel * chan, DMAEvent event) {
             sb.mode=MODE_DMA_MASKED;
             LOG(LOG_SB,LOG_NORMAL)("DMA masked,stopping output, left %d",chan->currcnt);
         }
-    } else if (event==DMA_TRANSFEREND) {
-        if (sb.mode==MODE_DMA) sb.mode=MODE_DMA_MASKED;
     } else if (event==DMA_UNMASKED) {
         if (sb.mode==MODE_DMA_MASKED && sb.dma.mode!=DSP_DMA_NONE) {
             DSP_ChangeMode(MODE_DMA);

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -437,9 +437,9 @@ static void DSP_DMA_CallBack(DmaChannel * chan, DMAEvent event) {
             min_size *= 2;
             if (sb.dma.left > min_size) {
                 if (s > (sb.dma.left-min_size)) s = sb.dma.left - min_size;
-                GenerateDMASound(s);
+                if (s) GenerateDMASound(s);
             }
-            sb.mode=MODE_DMA_MASKED;
+            sb.mode = MODE_DMA_MASKED;
             LOG(LOG_SB,LOG_NORMAL)("DMA masked,stopping output, left %d",chan->currcnt);
         }
     } else if (event==DMA_UNMASKED) {


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/4279/
https://sourceforge.net/p/dosbox/code-0/4280/
https://sourceforge.net/p/dosbox/code-0/4282/
https://sourceforge.net/p/dosbox/code-0/4283/ - Combined with 4282 here

Note that r4278 and r4279 undo https://sourceforge.net/p/dosbox/code-0/4176/, which was supposed to "prevent issues with some games". r4278 is skipped here because of conflicts with DOSBox-X code, but the commenting out of `DMA_TRANSFEREND` in r4279 meant that to make that commit build I needed to remove the use of `DMA_TRANSFEREND` in `sblaster.cpp`, which was done in r4278 in SVN. 