### PR TITLE
menu: Fix segfaults during menu-creation in some environments

### DIFF
--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -1292,12 +1292,18 @@ void ConstructSubMenu(DOSBoxMenu::item_handle_t item_id, const char * const * li
          *      array lookup, this is not very inefficient at all. */
 
         if (!strcmp(ref,"--")) {
+            /* separator is allocated on the fly by separator_get and we cannot
+             * rely that parameters are expanded from right to left
+             * -> we must get separator handle first */
+            DOSBoxMenu::item_handle_t separator_handle = separator_get(DOSBoxMenu::separator_type_id);
             mainMenu.displaylist_append(
-                mainMenu.get_item(item_id).display_list, separator_get(DOSBoxMenu::separator_type_id));
+                mainMenu.get_item(item_id).display_list, separator_handle);
         }
         else if (!strcmp(ref,"||")) {
+            /* dito */
+            DOSBoxMenu::item_handle_t separator_handle = separator_get(DOSBoxMenu::vseparator_type_id);
             mainMenu.displaylist_append(
-                mainMenu.get_item(item_id).display_list, separator_get(DOSBoxMenu::vseparator_type_id));
+                mainMenu.get_item(item_id).display_list, separator_handle);
         }
         else if (mainMenu.item_exists(ref)) {
             mainMenu.displaylist_append(


### PR DESCRIPTION
Yocto/Openembedded builds of dosbox-x for armv7 (Raspi4/32Bit/GCC10) segfaultet
at startup. Remote debug sessions showed that mainMenu.get_item was called
before separator_get so that vector separators was not yet prepared.

To get around, ensure separator_get is called before continuing.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>

# Description

_Summary of changes brought by this PR._


**Does this PR address some issue(s) ?**

_Add the issue(s) fixed, e.g. ```#1234```_


**Does this PR introduce new feature(s) ?**

_Describe the feature(s) introduced._


**Are there any breaking changes ?**

_Describe the breaking changes in detail._


**Additional information**

_Add any additional information that may be useful._
