### PR TITLE
Change P5 stepping to D1

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -2813,7 +2813,7 @@ bool CPU_CPUID(void) {
 			reg_ecx=0;			/* No features */
 			reg_edx=enable_fpu?1:0;	/* FPU */
 		} else if (CPU_ArchitectureType == CPU_ARCHTYPE_PENTIUM) {
-			reg_eax=0x513;		/* intel pentium */
+			reg_eax=0x517;		/* intel pentium */
 			reg_ebx=0;			/* Not Supported */
 			reg_ecx=0;			/* No features */
 			reg_edx=0x00000010|(enable_fpu?1:0);	/* FPU+TimeStamp/RDTSC */


### PR DESCRIPTION
# Description
Original Pentium B1 and C1 steppings have the FDIV bug, and reporting such a stepping can therefore make software think we have the FDIV bug, so change to the fixed D1 stepping.

**Does this PR address some issue(s) ?**
https://github.com/joncampbell123/dosbox-x/issues/1966
