### PR TITLE
Alternate A20 disable hack for EXEPACK error, as an alternative to LO…

### DIFF
--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -1707,6 +1707,7 @@ timeout     = 0
 #                                              lfn: Enable long filename support. If set to auto (default), it is enabled if the reported DOS version is at least 7.0.
 #                                                     If set to autostart, the builtin VER command won't activate/disactivate LFN support according to the reported DOS version.
 #                                                     Possible values: true, false, 1, 0, auto, autostart.
+#                                       autoa20fix: If set (default), DOSBox-X will automatically re-run the executable with the A20 gate disabled if it failed with the "Packed file is corrupt" error.
 #                                      autoloadfix: If set (default), DOSBox-X will automatically re-run the executable with LOADFIX if it failed with the "Packed file is corrupt" error.
 #                                        automount: Enable automatic drive mounting in Windows.
 #                                     automountall: Automatically mount all available Windows drives at start.
@@ -1801,6 +1802,7 @@ umb                                              = true
 quick reboot                                     = false
 ver                                              = 
 lfn                                              = auto
+autoa20fix                                       = true
 autoloadfix                                      = true
 automount                                        = true
 automountall                                     = false

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -624,6 +624,7 @@ timeout     = 0
 #                             lfn: Enable long filename support. If set to auto (default), it is enabled if the reported DOS version is at least 7.0.
 #                                    If set to autostart, the builtin VER command won't activate/disactivate LFN support according to the reported DOS version.
 #                                    Possible values: true, false, 1, 0, auto, autostart.
+#                      autoa20fix: If set (default), DOSBox-X will automatically re-run the executable with the A20 gate disabled if it failed with the "Packed file is corrupt" error.
 #                     autoloadfix: If set (default), DOSBox-X will automatically re-run the executable with LOADFIX if it failed with the "Packed file is corrupt" error.
 #                       automount: Enable automatic drive mounting in Windows.
 #                    automountall: Automatically mount all available Windows drives at start.
@@ -651,6 +652,7 @@ umb                             = true
 quick reboot                    = false
 ver                             = 
 lfn                             = auto
+autoa20fix                      = true
 autoloadfix                     = true
 automount                       = true
 automountall                    = false

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -1707,6 +1707,7 @@ timeout     = 0
 #                                              lfn: Enable long filename support. If set to auto (default), it is enabled if the reported DOS version is at least 7.0.
 #                                                     If set to autostart, the builtin VER command won't activate/disactivate LFN support according to the reported DOS version.
 #                                                     Possible values: true, false, 1, 0, auto, autostart.
+#                                       autoa20fix: If set (default), DOSBox-X will automatically re-run the executable with the A20 gate disabled if it failed with the "Packed file is corrupt" error.
 #                                      autoloadfix: If set (default), DOSBox-X will automatically re-run the executable with LOADFIX if it failed with the "Packed file is corrupt" error.
 #                                        automount: Enable automatic drive mounting in Windows.
 #                                     automountall: Automatically mount all available Windows drives at start.
@@ -1801,6 +1802,7 @@ private area in umb                              = true
 quick reboot                                     = false
 ver                                              = 
 lfn                                              = auto
+autoa20fix                                       = true
 autoloadfix                                      = true
 automount                                        = true
 automountall                                     = false

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3660,6 +3660,10 @@ void DOSBOX_SetupConfigSections(void) {
                       "If set to autostart, the builtin VER command won't activate/disactivate LFN support according to the reported DOS version.");
     Pstring->SetBasic(true);
 
+    Pbool = secprop->Add_bool("autoa20fix",Property::Changeable::WhenIdle,true);
+    Pbool->Set_help("If set (default), DOSBox-X will automatically re-run the executable with the A20 gate disabled if it failed with the \"Packed file is corrupt\" error.");
+    Pbool->SetBasic(true);
+
     Pbool = secprop->Add_bool("autoloadfix",Property::Changeable::WhenIdle,true);
     Pbool->Set_help("If set (default), DOSBox-X will automatically re-run the executable with LOADFIX if it failed with the \"Packed file is corrupt\" error.");
     Pbool->SetBasic(true);

--- a/src/ints/xms.cpp
+++ b/src/ints/xms.cpp
@@ -398,6 +398,15 @@ Bitu XMS_LocalDisableA20(void) {
     return 0;
 }
 
+void XMS_DOS_LocalA20DisableIfNotEnabled(void) {
+    /* This is one of two hacks to deal with EXEPACK'd executables loaded too low */
+    if (XMS_GetEnabledA20()) {
+        LOG(LOG_DOSMISC,LOG_DEBUG)("Temporarily disabling A20 gate. As a hack this will FORCE local A20 enable to zero (from count=%d)",xms_local_enable_count);
+        xms_local_enable_count = 1;
+        XMS_LocalDisableA20();
+    }
+}
+
 void XMS_DOS_LocalA20EnableIfNotEnabled(void) {
     /* Confirmed MS-DOS behavior if DOS=HIGH */
     if (!XMS_GetEnabledA20()) {


### PR DESCRIPTION
…ADFIX

# Description

Adds an alternate workaround for EXEPACK errors. Instead of running LOADFIX, disable the A20 gate.

**Does this PR introduce new feature(s) ?**

This adds a dosbox.conf option that enables the workaround as an option alongside running LOADFIX.

**Additional information**

The faulty EXEPACK code fails on any CPU that can address more than 1MB of memory (higher than the 8086) unless the A20 (20th bit) is masked off to emulate the 8086, if the EXE is loaded too low.