### PR TITLE
A20GATE command to show current status

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -103,8 +103,9 @@ int maxfcb=100;
 int maxdrive=1;
 int enablelfn=-1;
 bool uselfn;
+extern int infix;
 extern bool int15_wait_force_unmask_irq;
-extern bool infix, winrun, startcmd, startwait, startquiet, winautorun;
+extern bool winrun, startcmd, startwait, startquiet, winautorun;
 extern bool startup_state_numlock, mountwarning, clipboard_dosapi;
 std::string startincon;
 
@@ -3191,7 +3192,7 @@ public:
         }
 	}
 	~DOS(){
-		infix=false;
+		infix=-1;
 #if defined(WIN32) && !defined(HX_DOS)
 		if (startwait) {
 			void EndStartProcess(), EndRunProcess();

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3661,12 +3661,11 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring->SetBasic(true);
 
     Pbool = secprop->Add_bool("autoa20fix",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("If set (default), DOSBox-X will automatically re-run the executable with the A20 gate disabled if it failed with the \"Packed file is corrupt\" error.");
-    Pbool->SetBasic(true);
+    Pbool->Set_help("If set (default), DOSBox-X will automatically re-run the executable with the A20 gate disabled if it failed with the \"Packed file is corrupt\" error.\n"
+                    "If both autoa20fix and autoloadfix are set, the former will be tried first, and then the latter.");
 
     Pbool = secprop->Add_bool("autoloadfix",Property::Changeable::WhenIdle,true);
     Pbool->Set_help("If set (default), DOSBox-X will automatically re-run the executable with LOADFIX if it failed with the \"Packed file is corrupt\" error.");
-    Pbool->SetBasic(true);
 
     Pbool = secprop->Add_bool("automount",Property::Changeable::WhenIdle,true);
     Pbool->Set_help("Enable automatic drive mounting in Windows.");
@@ -3696,7 +3695,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring->Set_help("START command will start these commands (separated by space) in a console and wait for a key press before exiting.");
 
     Pbool = secprop->Add_bool("int33",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("Enable INT 33H (mouse) support.");
+    Pbool->Set_help("Enable INT 33H for mouse support.");
     Pbool->SetBasic(true);
 
     Pbool = secprop->Add_bool("int33 hide host cursor if interrupt subroutine",Property::Changeable::WhenIdle,true);

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -1609,7 +1609,13 @@ class A20GATE : public Program {
 public:
     /*! \brief      Program entry point, when the command is run */
     void Run(void) {
-        if (cmd->FindString("SET",temp_line,false)) {
+        if (cmd->FindExist("-?", false) || cmd->FindExist("/?", false)) {
+            WriteOut("Turns on/off or changes the A20 gate mode.\n\n");
+            WriteOut("A20GATE [ON | OFF | SET [off | off_fake | on | on_fake | mask | fast]]\n\n"
+                    "  [ON | OFF | SET] Turns the A20 gate ON/OFF, or sets the A20 gate mode.\n\n"
+                    "Type A20GATE with no parameters to display the current A20 gate status.\n");
+        }
+        else if (cmd->FindString("SET",temp_line,false)) {
             char *x = (char*)temp_line.c_str();
 
             a20_fast_changeable = false;
@@ -1621,56 +1627,54 @@ public:
                 MEM_A20_Enable(false);
                 a20_guest_changeable = false;
                 a20_fake_changeable = true;
-                WriteOut("A20 gate now off_fake mode\n");
+                WriteOut("A20 gate is now in off_fake mode.\n");
             }
             else if (!strncasecmp(x,"off",3)) {
                 MEM_A20_Enable(false);
                 a20_guest_changeable = false;
                 a20_fake_changeable = false;
-                WriteOut("A20 gate now off mode\n");
+                WriteOut("A20 gate is now in off mode.\n");
             }
             else if (!strncasecmp(x,"on_fake",7)) {
                 MEM_A20_Enable(true);
                 a20_guest_changeable = false;
                 a20_fake_changeable = true;
-                WriteOut("A20 gate now on_fake mode\n");
+                WriteOut("A20 gate is now in on_fake mode.\n");
             }
             else if (!strncasecmp(x,"on",2)) {
                 MEM_A20_Enable(true);
                 a20_guest_changeable = false;
                 a20_fake_changeable = false;
-                WriteOut("A20 gate now on mode\n");
+                WriteOut("A20 gate is now in on mode.\n");
             }
             else if (!strncasecmp(x,"mask",4)) {
                 MEM_A20_Enable(false);
                 a20_guest_changeable = true;
                 a20_fake_changeable = false;
                 memory.a20.enabled = 0;
-                WriteOut("A20 gate now mask mode\n");
+                WriteOut("A20 gate is now in mask mode.\n");
             }
             else if (!strncasecmp(x,"fast",4)) {
                 MEM_A20_Enable(false);
                 a20_guest_changeable = true;
                 a20_fake_changeable = false;
                 a20_fast_changeable = true;
-                WriteOut("A20 gate now fast mode\n");
+                WriteOut("A20 gate is now in fast mode\n");
             }
             else {
-                WriteOut("Unknown setting\n");
+                WriteOut("Unknown setting - %s\n", x);
             }
         }
         else if (cmd->FindExist("ON")) {
+            WriteOut("Enabling A20 gate...\n");
             MEM_A20_Enable(true);
-            WriteOut("Enabling A20 gate\n");
         }
         else if (cmd->FindExist("OFF")) {
+            WriteOut("Disabling A20 gate...\n");
             MEM_A20_Enable(false);
-            WriteOut("Disabling A20 gate\n");
         }
         else {
-			WriteOut("Turns on/off or changes the A20 gate mode.\n\n");
-            WriteOut("A20GATE SET [off | off_fake | on | on_fake | mask | fast]\n");
-            WriteOut("A20GATE [ON | OFF]\n");
+            WriteOut("A20 gate is currently %s.\n", MEM_A20_Enabled()?"ON":"OFF");
         }
     }
 };

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -1150,7 +1150,7 @@ continue_1:
 #endif
 		if (packerr&&infix<0&&sec->Get_bool("autoa20fix")) {
 			LOG(LOG_DOSMISC,LOG_DEBUG)("Attempting autoa20fix workaround for EXEPACK error");
-			WriteOut("\r\n\033[41;1m\033[1;37;1mDOSBox-X\033[0m Failed to load the executable\r\n\033[41;1m\033[37;1mDOSBox-X\033[0m Now try again with A20 disable...\r\n");
+			WriteOut("\r\n\033[41;1m\033[1;37;1mDOSBox-X\033[0m Failed to load the executable\r\n\033[41;1m\033[37;1mDOSBox-X\033[0m Now try again with A20 fix...\r\n");
 			infix=0;
 			dos_a20_disable_on_exec=true;
 			Execute(name, args);


### PR DESCRIPTION
I have somewhat enhanced the A20GATE command to show the current status (ON or OFF) if no command-line parameter is given. I also changed the config file comments to mention that if both autoa20fix and autoloadfix are set, the former will be tried first, and then the latter. Also fixed the compiling issue in the file src/dos/dos.cpp regarding the type of the infix variable.