### PR TITLE
Fix build with -Werror=format-security

### DIFF
--- a/src/gui/midi_synth.h
+++ b/src/gui/midi_synth.h
@@ -45,15 +45,15 @@ static void synth_log(int level,
 	switch (level) {
 	case FLUID_PANIC:
 	case FLUID_ERR:
-		LOG(LOG_ALL,LOG_ERROR)(message);
+		LOG(LOG_ALL,LOG_ERROR)("%s", message);
 		break;
 
 	case FLUID_WARN:
-		LOG(LOG_ALL,LOG_WARN)(message);
+		LOG(LOG_ALL,LOG_WARN)("%s", message);
 		break;
 
 	default:
-		LOG(LOG_ALL,LOG_NORMAL)(message);
+		LOG(LOG_ALL,LOG_NORMAL)("%s", message);
 		break;
 	}
 }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -10472,7 +10472,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
                 ""
 #endif
         " %s)",VERSION,SDL_STRING);
-        LOG(LOG_MISC,LOG_NORMAL)(("Copyright 2011-"+std::string(COPYRIGHT_END_YEAR)+" The DOSBox-X Team. Project maintainer: joncampbell123 (The Great Codeholio). DOSBox-X published under GNU GPL.").c_str());
+        LOG(LOG_MISC,LOG_NORMAL)(("Copyright 2011-%s The DOSBox-X Team. Project maintainer: joncampbell123 (The Great Codeholio). DOSBox-X published under GNU GPL."),std::string(COPYRIGHT_END_YEAR).c_str());
 
 #if defined(MACOSX)
         LOG_MSG("macOS EXE path: %s",MacOSXEXEPath.c_str());


### PR DESCRIPTION
Some build environmaents harden their security flags. For
-Werror=format-security build failed with:

| midi_synth.h: In function 'void synth_log(int, char*, void*)':
| midi_synth.h:48:33: error: format not a string literal and no format arguments [-Werror=format-security]
|    48 |   LOG(LOG_ALL,LOG_ERROR)(message);
|       |                                 ^
| midi_synth.h:52:32: error: format not a string literal and no format arguments [-Werror=format-security]
|    52 |   LOG(LOG_ALL,LOG_WARN)(message);
|       |                                ^
| midi_synth.h:56:34: error: format not a string literal and no format arguments [-Werror=format-security]
|    56 |   LOG(LOG_ALL,LOG_NORMAL)(message);
|       |                                  ^

and

| sdlmain.cpp: In function 'int main(int, char**)':
| sdlmain.cpp:9696:207: error: format not a string literal and no format arguments [-Werror=format-security]

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>

# Description

_Summary of changes brought by this PR._


**Does this PR address some issue(s) ?**

_Add the issue(s) fixed, e.g. ```#1234```_


**Does this PR introduce new feature(s) ?**

_Describe the feature(s) introduced._


**Are there any breaking changes ?**

_Describe the breaking changes in detail._


**Additional information**

_Add any additional information that may be useful._
