### PR TITLE
Video mode fix for TTF output

### DIFF
--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -3036,25 +3036,43 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
                 *draw++ = (background<<4) + foreground;
             }
         } else if (IS_EGAVGA_ARCH&&CurMode&&CurMode->type==M_TEXT) {
-            for (Bitu row=0;row < ttf.lins;row++) {
-                const uint32_t* vidmem = ((uint32_t*)vga.draw.linear_base)+vidstart;	// pointer to chars+attribs (EGA/VGA planar memory)
-
-                for (Bitu col=0;col < ttf.cols;col++) {
+            const uint32_t* vidmem = (uint32_t*)&vga.draw.linear_base[vidstart];       // pointer to chars+attribs (EGA/VGA planar memory)
+            if (1) {                                                                   // NTS: Use this code for now for different ttf.lins & cols support
+                for (Bitu blocks = ttf.cols * ttf.lins; blocks; blocks--) {
                     // NTS: Note this assumes EGA/VGA text mode that uses the "Odd/Even" mode memory mapping scheme to present video memory
                     //      to the CPU as if CGA compatible text mode. Character data on plane 0, attributes on plane 1.
                     *draw++ = *vidmem;
                     Bitu attr = *((uint8_t*)vidmem+1);
                     vidmem+=2;
                     Bitu background = attr >> 4;
-                    if (vga.draw.blinking)									// if blinking is enabled bit7 is not mapped to attributes
+                    if (vga.draw.blinking)                                                                 // if blinking is enabled bit7 is not mapped to attributes
                         background &= 7;
                     // choose foreground color if blinking not set for this cell or blink on
                     Bitu foreground = (vga.draw.blink || (!(attr&0x80))) ? (attr&0xf) : background;
                     // How about underline?
                     *draw++ = (background<<4) + foreground;
                 }
+            } else {
+                for (Bitu row=0;row < ttf.lins;row++) {
+                    const uint32_t* vidmem = ((uint32_t*)vga.draw.linear_base)+vidstart;	// pointer to chars+attribs (EGA/VGA planar memory)
 
-                vidstart += vga.draw.address_add;
+                    for (Bitu col=0;col < ttf.cols;col++) {
+                        // NTS: Note this assumes EGA/VGA text mode that uses the "Odd/Even" mode memory mapping scheme to present video memory
+                        //      to the CPU as if CGA compatible text mode. Character data on plane 0, attributes on plane 1.
+                        *draw++ = *vidmem;
+                        Bitu attr = *((uint8_t*)vidmem+1);
+                        vidmem+=2;
+                        Bitu background = attr >> 4;
+                        if (vga.draw.blinking)									// if blinking is enabled bit7 is not mapped to attributes
+                            background &= 7;
+                        // choose foreground color if blinking not set for this cell or blink on
+                        Bitu foreground = (vga.draw.blink || (!(attr&0x80))) ? (attr&0xf) : background;
+                        // How about underline?
+                        *draw++ = (background<<4) + foreground;
+                    }
+
+                    vidstart += vga.draw.address_add;
+                }
             }
         } else if (CurMode&&CurMode->type==M_TEXT) {
             for (Bitu row=0;row < ttf.lins;row++) {


### PR DESCRIPTION
The code fix should make the video mode change works better for TTF output.

In the previous commit I added support for toggling between windowed and full-screen mode in the TTF output, along with better support for different machine types in this output.