### PR TITLE
Some fixups to the PC98 and video output

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -43,6 +43,7 @@ A list of features ported from DOSBox Staging:
 A list of features ported from vDosPlus by Wengier:
 
 * Long filename support (improved for FAT drives since then by Wengier and joncampbell123)
+* TrueType font (TTF) output support (originally by Jos Schaars and heavily improved since then by Wengier)
 * Improved support for automatic drive mounting (Windows)
 * Support for clipboard copy and paste (improved since then by Wengier)
 * Several shell improvements

--- a/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
+++ b/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
@@ -10,7 +10,7 @@
     <category>Emulation</category>
   </categories>
   <releases>
-          <release version="@PACKAGE_VERSION@" date="2020-11-16"/>
+          <release version="@PACKAGE_VERSION@" date="2020-11-18"/>
   </releases>
   <screenshots>
 	  <screenshot type="default">

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -775,9 +775,10 @@ pc-98 force ibm keyboard layout          = false
 #DOSBOX-X-ADV:#                            gray scaled color scheme: (0,0,0)  #0e0e0e  (75,75,75) (89,89,89) (38,38,38) (52,52,52) #717171 #c0c0c0 #808080 (28,28,28) (150,150,150) (178,178,178) (76,76,76) (104,104,104) (226,226,226) (255,255,255)
 #             ttf.winperc: Specifies the window percentage for the TTF output (100 = full screen). Ignored if the ttf.ptsize setting is specified.
 #              ttf.ptsize: Specifies the font point size for the TTF output. If specified (minimum: 10), it will override the ttf.winperc setting.
-#DOSBOX-X-ADV:#                ttf.lins: Specifies the number of rows on the screen for the TTF output (0 = default).
-#DOSBOX-X-ADV:#                ttf.cols: Specifies the number of columns on the screen for the TTF output (0 = default).
-#DOSBOX-X-ADV:#                  ttf.wp: You can optionally specify a word processor version for the TTF output.
+#                ttf.lins: Specifies the number of rows on the screen for the TTF output (0 = default).
+#                ttf.cols: Specifies the number of columns on the screen for the TTF output (0 = default).
+#DOSBOX-X-ADV:#               ttf.wpver: You can optionally specify a word processor version for the TTF output (WordPerfect>0, XyWrite=-1, WordStar=-2).
+#DOSBOX-X-ADV:#                ttf.wpbg: You can optionally specify a color to match the background color of the word processor for the TTF output.
 #DOSBOX-X-ADV:#              ttf.blinkc: If set, the cursor will blink for the TTF output.
 frameskip               = 0
 #DOSBOX-X-ADV:alt render              = false
@@ -797,9 +798,10 @@ ttf.font                =
 #DOSBOX-X-ADV:ttf.colors              = 
 ttf.winperc             = 75
 ttf.ptsize              = 0
-#DOSBOX-X-ADV:ttf.lins                = 0
-#DOSBOX-X-ADV:ttf.cols                = 0
-#DOSBOX-X-ADV:ttf.wp                  = 0
+ttf.lins                = 0
+ttf.cols                = 0
+#DOSBOX-X-ADV:ttf.wpver               = 0
+#DOSBOX-X-ADV:ttf.wpbg                = -1
 #DOSBOX-X-ADV:ttf.blinkc              = false
 
 [vsync]

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -195,6 +195,8 @@ pc-98 force ibm keyboard layout = false
 #       ttf.font: Specifies a TrueType font to use for the TTF output. If not specified, the built-in TrueType font will be used.
 #    ttf.winperc: Specifies the window percentage for the TTF output (100 = full screen). Ignored if the ttf.ptsize setting is specified.
 #     ttf.ptsize: Specifies the font point size for the TTF output. If specified (minimum: 10), it will override the ttf.winperc setting.
+#       ttf.lins: Specifies the number of rows on the screen for the TTF output (0 = default).
+#       ttf.cols: Specifies the number of columns on the screen for the TTF output (0 = default).
 frameskip      = 0
 aspect         = false
 euro           = -1
@@ -206,6 +208,8 @@ monochrome_pal = green
 ttf.font       = 
 ttf.winperc    = 75
 ttf.ptsize     = 0
+ttf.lins       = 0
+ttf.cols       = 0
 
 [vsync]
 # vsyncmode: Synchronize vsync timing to the host display. Requires calibration within DOSBox-X.

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -777,7 +777,8 @@ pc-98 show graphics layer on initialize  = true
 #              ttf.ptsize: Specifies the font point size for the TTF output. If specified (minimum: 10), it will override the ttf.winperc setting.
 #                ttf.lins: Specifies the number of rows on the screen for the TTF output (0 = default).
 #                ttf.cols: Specifies the number of columns on the screen for the TTF output (0 = default).
-#                  ttf.wp: You can optionally specify a word processor version for the TTF output.
+#               ttf.wpver: You can optionally specify a word processor version for the TTF output (WordPerfect>0, XyWrite=-1, WordStar=-2).
+#                ttf.wpbg: You can optionally specify a color to match the background color of the word processor for the TTF output.
 #              ttf.blinkc: If set, the cursor will blink for the TTF output.
 frameskip               = 0
 alt render              = false
@@ -799,7 +800,8 @@ ttf.winperc             = 75
 ttf.ptsize              = 0
 ttf.lins                = 0
 ttf.cols                = 0
-ttf.wp                  = 0
+ttf.wpver               = 0
+ttf.wpbg                = -1
 ttf.blinkc              = false
 
 [vsync]

--- a/include/build_timestamp.h
+++ b/include/build_timestamp.h
@@ -1,4 +1,4 @@
 /*auto-generated*/
-#define UPDATED_STR "Nov 16, 2020 1:37:02am"
-#define GIT_COMMIT_HASH "0a10305"
+#define UPDATED_STR "Nov 18, 2020 11:44:43pm"
+#define GIT_COMMIT_HASH "708ce98"
 #define COPYRIGHT_END_YEAR "2020"

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -119,6 +119,24 @@ bool String_ASCII_TO_HOST(host_cnv_char_t *d/*CROSS_LEN*/,const char *s/*CROSS_L
     return true;
 }
 
+template <class MT> bool String_SBCS_TO_HOST_uint16(uint16_t *d/*CROSS_LEN*/,const char *s/*CROSS_LEN*/,const MT *map,const size_t map_max) {
+    const uint16_t* df = d + CROSS_LEN - 1;
+	const char *sf = s + CROSS_LEN - 1;
+
+    while (*s != 0 && s < sf) {
+        unsigned char ic = (unsigned char)(*s++);
+        if (ic >= map_max) return false; // non-representable
+        MT wc = map[ic]; // output: unicode character
+
+        *d++ = (uint16_t)wc;
+    }
+
+    assert(d <= df);
+    *d = 0;
+
+    return true;
+}
+
 template <class MT> bool String_SBCS_TO_HOST(host_cnv_char_t *d/*CROSS_LEN*/,const char *s/*CROSS_LEN*/,const MT *map,const size_t map_max) {
     const host_cnv_char_t* df = d + CROSS_LEN - 1;
 	const char *sf = s + CROSS_LEN - 1;
@@ -365,10 +383,32 @@ bool CodePageHostToGuest(char *d/*CROSS_LEN*/,const host_cnv_char_t *s/*CROSS_LE
 
 bool CodePageGuestToHostUint16(uint16_t *d/*CROSS_LEN*/,const char *s/*CROSS_LEN*/) {
     switch (dos.loaded_codepage) {
+        case 437:
+            return String_SBCS_TO_HOST_uint16<uint16_t>(d,s,cp437_to_unicode,sizeof(cp437_to_unicode)/sizeof(cp437_to_unicode[0]));
+        case 808:
+            return String_SBCS_TO_HOST_uint16<uint16_t>(d,s,cp808_to_unicode,sizeof(cp808_to_unicode)/sizeof(cp808_to_unicode[0]));
+        case 850:
+            return String_SBCS_TO_HOST_uint16<uint16_t>(d,s,cp850_to_unicode,sizeof(cp850_to_unicode)/sizeof(cp850_to_unicode[0]));
+        case 852:
+            return String_SBCS_TO_HOST_uint16<uint16_t>(d,s,cp852_to_unicode,sizeof(cp852_to_unicode)/sizeof(cp852_to_unicode[0]));
+        case 853:
+            return String_SBCS_TO_HOST_uint16<uint16_t>(d,s,cp853_to_unicode,sizeof(cp853_to_unicode)/sizeof(cp853_to_unicode[0]));
+        case 855:
+            return String_SBCS_TO_HOST_uint16<uint16_t>(d,s,cp855_to_unicode,sizeof(cp855_to_unicode)/sizeof(cp855_to_unicode[0]));
+        case 857:
+            return String_SBCS_TO_HOST_uint16<uint16_t>(d,s,cp857_to_unicode,sizeof(cp857_to_unicode)/sizeof(cp857_to_unicode[0]));
+        case 858:
+            return String_SBCS_TO_HOST_uint16<uint16_t>(d,s,cp858_to_unicode,sizeof(cp858_to_unicode)/sizeof(cp858_to_unicode[0]));
+        case 866:
+            return String_SBCS_TO_HOST_uint16<uint16_t>(d,s,cp866_to_unicode,sizeof(cp866_to_unicode)/sizeof(cp866_to_unicode[0]));
+        case 869:
+            return String_SBCS_TO_HOST_uint16<uint16_t>(d,s,cp869_to_unicode,sizeof(cp869_to_unicode)/sizeof(cp869_to_unicode[0]));
+        case 872:
+            return String_SBCS_TO_HOST_uint16<uint16_t>(d,s,cp872_to_unicode,sizeof(cp872_to_unicode)/sizeof(cp872_to_unicode[0]));
         case 932:
             return String_DBCS_TO_HOST_SHIFTJIS_uint16<uint16_t>(d,s,cp932_to_unicode_hitbl,cp932_to_unicode_raw,sizeof(cp932_to_unicode_raw)/sizeof(cp932_to_unicode_raw[0]));
-        default:
-            break;
+        default: // Otherwise just use code page 437
+            return String_SBCS_TO_HOST_uint16<uint16_t>(d,s,cp437_to_unicode,sizeof(cp437_to_unicode)/sizeof(cp437_to_unicode[0]));
     }
 
     return false;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2351,12 +2351,14 @@ void DOSBOX_SetupConfigSections(void) {
 
 	Pint = secprop->Add_int("ttf.lins", Property::Changeable::Always, 0);
     Pint->Set_help("Specifies the number of rows on the screen for the TTF output (0 = default).");
+    Pint->SetBasic(true);
 
 	Pint = secprop->Add_int("ttf.cols", Property::Changeable::Always, 0);
     Pint->Set_help("Specifies the number of columns on the screen for the TTF output (0 = default).");
+    Pint->SetBasic(true);
 
 	Pint = secprop->Add_int("ttf.wpver", Property::Changeable::Always, 0);
-    Pint->Set_help("You can optionally specify a word processor version for the TTF output.");
+    Pint->Set_help("You can optionally specify a word processor version for the TTF output (WordPerfect>0, XyWrite=-1, WordStar=-2).");
 
 	Pint = secprop->Add_int("ttf.wpbg", Property::Changeable::Always, -1);
     Pint->Set_help("You can optionally specify a color to match the background color of the word processor for the TTF output.");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1179,6 +1179,10 @@ void DOSBOX_RealInit() {
 
     else E_Exit("DOSBOX:Unknown machine type %s",mtype.c_str());
 
+#if defined(USE_TTF)
+    if (IS_PC98_ARCH) ttf.cols = 80; // The number of columns on the screen is apparently fixed to 80 in PC-98 mode at this time
+#endif
+
     // TODO: should be parsed by motherboard emulation
     // FIXME: This re-uses the existing ISA bus delay code for C-BUS in PC-98 mode
     std::string isabclk;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -9401,6 +9401,13 @@ bool output_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menui
     else if (!strcmp(what,"ttf")) {
 #if defined(USE_TTF)
         if (sdl.desktop.want_type == SCREEN_TTF || CurMode->type!=M_TEXT) return true;
+#if C_DIRECT3D
+        if (sdl.desktop.want_type == SCREEN_DIRECT3D) change_output(0);
+#endif
+#if !defined(C_SDL2)
+        putenv("SDL_VIDEO_CENTERED=center");
+#endif
+        firstset=false;
         change_output(9);
 #endif
     }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3827,7 +3827,7 @@ void processWP(uint8_t *pcolorBG, uint8_t *pcolorFG) {
     int style = 0;
     if (CurMode->mode == 7)															// Mono (Hercules)
     {
-        TTF_SetFontStyle(ttf.SDL_font, (colorFG&7) == 1 ? TTF_STYLE_UNDERLINE : TTF_STYLE_NORMAL);
+        style = (colorFG&7) == 1 ? TTF_STYLE_UNDERLINE : TTF_STYLE_NORMAL;
         if ((colorFG&0xa) == colorFG && (colorBG&15) == 0)
             colorFG = 8;
         else if (colorFG&7)
@@ -3963,6 +3963,7 @@ void GFX_EndTextLines(bool force=false) {
 				int x1 = x;
 
 				uint8_t ascii = newAC[x]&255;
+				bool next=false;
 				if (ascii > 175 && ascii < 179) {					// special: shade characters 176-178
 					ttf_bgColor.b = (ttf_bgColor.b*(179-ascii) + ttf_fgColor.b*(ascii-175))>>2;
 					ttf_bgColor.g = (ttf_bgColor.g*(179-ascii) + ttf_fgColor.g*(ascii-175))>>2;
@@ -3980,6 +3981,8 @@ void GFX_EndTextLines(bool force=false) {
                         if ((newAC[x]&0xFFFF) != 32) dbchar = false;
                         if (dbchar) {
                             dbchar = false;
+                            next=true;
+                            break;
                         } else {
                             dbchar = IS_PC98_ARCH&&(newAC[x]&0xFF00);
                             unimap[x-x1] = dbchar?newAC[x]&0xFFFF:cpMap[ascii];
@@ -3989,14 +3992,16 @@ void GFX_EndTextLines(bool force=false) {
 					}
 					while (x < ttf.cols && newAC[x] != curAC[x] && newAC[x]>>8 == color && (ascii < 176 || ascii > 178));
 				}
-				unimap[x-x1] = 0;
-				xmax = max(x-1, xmax);
+                if (!next) {
+                    unimap[x-x1] = 0;
+                    xmax = max(x-1, xmax);
 
-                SDL_Surface* textSurface = TTF_RenderUNICODE_Shaded(ttf.SDL_font, unimap, ttf_fgColor, ttf_bgColor);
-                ttf_textClip.w = (x-x1)*ttf.width*(dbchar?2:1);
-                SDL_BlitSurface(textSurface, &ttf_textClip, sdl.surface, &ttf_textRect);
-                SDL_FreeSurface(textSurface);
-				x--;
+                    SDL_Surface* textSurface = TTF_RenderUNICODE_Shaded(ttf.SDL_font, unimap, ttf_fgColor, ttf_bgColor);
+                    ttf_textClip.w = (x-x1)*ttf.width*(dbchar?2:1);
+                    SDL_BlitSurface(textSurface, &ttf_textClip, sdl.surface, &ttf_textRect);
+                    SDL_FreeSurface(textSurface);
+                    x--;
+                }
 			}
 		}
 		curAC += ttf.cols;

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -3060,27 +3060,11 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
                 }
                 *draw++ = (background<<4) + foreground;
             }
-        } else if (IS_EGAVGA_ARCH&&CurMode&&CurMode->type==M_TEXT) {
-            if (1) {                                                                   // NTS: Use this code for now for different ttf.lins & cols support
-                const uint32_t* vidmem = (uint32_t*)&vga.draw.linear_base[vidstart];   // pointer to chars+attribs (EGA/VGA planar memory)
-                for (Bitu blocks = ttf.cols * ttf.lins; blocks; blocks--) {
-                    // NTS: Note this assumes EGA/VGA text mode that uses the "Odd/Even" mode memory mapping scheme to present video memory
-                    //      to the CPU as if CGA compatible text mode. Character data on plane 0, attributes on plane 1.
-                    *draw++ = *vidmem;
-                    Bitu attr = *((uint8_t*)vidmem+1);
-                    vidmem+=2;
-                    Bitu background = attr >> 4;
-                    if (vga.draw.blinking)                                             // if blinking is enabled bit7 is not mapped to attributes
-                        background &= 7;
-                    // choose foreground color if blinking not set for this cell or blink on
-                    Bitu foreground = (vga.draw.blink || (!(attr&0x80))) ? (attr&0xf) : background;
-                    // How about underline?
-                    *draw++ = (background<<4) + foreground;
-                }
-            } else {
+        } else if (CurMode&&CurMode->type==M_TEXT) {
+            vga.draw.address_add = ttf.cols * 2;
+            if (IS_EGAVGA_ARCH) {
                 for (Bitu row=0;row < ttf.lins;row++) {
                     const uint32_t* vidmem = ((uint32_t*)vga.draw.linear_base)+vidstart;	// pointer to chars+attribs (EGA/VGA planar memory)
-
                     for (Bitu col=0;col < ttf.cols;col++) {
                         // NTS: Note this assumes EGA/VGA text mode that uses the "Odd/Even" mode memory mapping scheme to present video memory
                         //      to the CPU as if CGA compatible text mode. Character data on plane 0, attributes on plane 1.
@@ -3095,31 +3079,11 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
                         // How about underline?
                         *draw++ = (background<<4) + foreground;
                     }
-
                     vidstart += vga.draw.address_add;
-                }
-            }
-        } else if (CurMode&&CurMode->type==M_TEXT) {
-            if (1) {                                                                   // NTS: Use this code for now for different ttf.lins & cols support
-                const uint16_t* vidmem = (uint16_t*)VGA_Text_Memwrap(vidstart);        // pointer to chars+attribs (EGA/VGA planar memory)
-                for (Bitu blocks = ttf.cols * ttf.lins; blocks; blocks--) {
-                    // NTS: Note this assumes EGA/VGA text mode that uses the "Odd/Even" mode memory mapping scheme to present video memory
-                    //      to the CPU as if CGA compatible text mode. Character data on plane 0, attributes on plane 1.
-                    *draw++ = *vidmem;
-                    Bitu attr = *((uint8_t*)vidmem+1);
-                    vidmem++;
-                    Bitu background = attr >> 4;
-                    if (vga.draw.blinking)                                             // if blinking is enabled bit7 is not mapped to attributes
-                        background &= 7;
-                    // choose foreground color if blinking not set for this cell or blink on
-                    Bitu foreground = (vga.draw.blink || (!(attr&0x80))) ? (attr&0xf) : background;
-                    // How about underline?
-                    *draw++ = (background<<4) + foreground;
                 }
             } else {
                 for (Bitu row=0;row < ttf.lins;row++) {
                     const uint16_t* vidmem = (uint16_t*)VGA_Text_Memwrap(vidstart);	// pointer to chars+attribs (EGA/VGA planar memory)
-
                     for (Bitu col=0;col < ttf.cols;col++) {
                         *draw++ = *vidmem;
                         Bitu attr = *((uint8_t*)vidmem+1);
@@ -3132,7 +3096,6 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
                         // How about underline?
                         *draw++ = (background<<4) + foreground;
                     }
-
                     vidstart += vga.draw.address_add;
                 }
             }

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -3033,8 +3033,7 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
                         uname[0]=0;
                         uname[1]=0;
                         CodePageGuestToHostUint16(uname,text);
-                        assert(uname[1]==0);
-                        if (uname[0]!=0) {
+                        if (uname[0]!=0&&uname[1]==0) {
                             *draw++=uname[0];
                             dbw=true;
                         }
@@ -3079,7 +3078,6 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
                 }
             }
         } else if (CurMode&&CurMode->type==M_TEXT) {
-            vga.draw.address_add = ttf.cols * 2;
             if (IS_EGAVGA_ARCH) {
                 for (Bitu row=0;row < ttf.lins;row++) {
                     const uint32_t* vidmem = ((uint32_t*)vga.draw.linear_base)+vidstart;	// pointer to chars+attribs (EGA/VGA planar memory)
@@ -4418,6 +4416,9 @@ void VGA_SetupDrawing(Bitu /*val*/) {
     }
     width *= pix_per_char;
     VGA_CheckScanLength();
+#if defined(USE_TTF)
+    if (ttf.inUse) vga.draw.address_add = ttf.cols * 2;
+#endif
 
     /* for MCGA, need to "double scan" the screen in some cases */
     if (vga.other.mcga_mode_control & 2) { // 640x480 2-color

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -6814,6 +6814,7 @@ void DrawDOSBoxLogoVGA(unsigned int x,unsigned int y) {
 static int bios_pc98_posx = 0;
 
 static void BIOS_Int10RightJustifiedPrint(const int x,int &y,const char *msg) {
+    if (control->opt_fastlaunch) return;
     const char *s = msg;
 
     if (machine != MCH_PC98) {

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -746,7 +746,11 @@ const char* Mouse_GetSelected(int x1, int y1, int x2, int y2, int w, int h, uint
 						text[len++]=(j1+1)/2+(j1<95?112:176);
 						text[len++]=j2+(j1%2?31+(j2/96):126);
 					}
-				} else
+				} else if (j==c1&&c1>0) {
+                    uint16_t prevres=mem_readw(where-2);
+                    if (!((prevres & 0xFF00u) != 0u && (prevres & 0xFCu) != 0x08u && prevres==result))
+                        text[len++]=result;
+                } else
 					text[len++]=result;
 			} else {
 				ReadCharAttr(j,i,page,&result);
@@ -791,14 +795,13 @@ void Mouse_Select(int x1, int y1, int x2, int y2, int w, int h) {
         for (int y = 0; y < ttf.lins; y++) {
             if (y>=r1&&y<=r2)
                 for (int x = 0; x < ttf.cols; x++)
-                    if (x>=c1&&x<=c2)
+                    if ((x>=c1||(IS_PC98_ARCH&&c1>0&&x==c1-1&&(newAC[x]&0xFF00)&&(newAC[x+1]&0xFF)==32))&&x<=c2)
                         newAC[x]&=((newAC[x]>>16)<<20)+((newAC[x]>>20)<<16)+(newAC[x]&0xFFFF);
             newAC += ttf.cols;
         }
         void GFX_EndTextLines(bool force=false);
         GFX_EndTextLines();
-        return;
-    }
+    } else
 #endif
 	for (int i=r1; i<=r2; i++)
 		for (int j=c1; j<=c2; j++) {


### PR DESCRIPTION
I have made some additional fixups to the PC98 mode, as well as other small updates to the TTF output to make it work better. The code in the vga_draw.cpp that was temporarily disabled has been reactivated since it now works with a fix applied.