### PR TITLE
Improve mapper interface and add list network interface menu option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,13 @@
     options such as increasing/decreasing the TTF font
     sizes and on-screen text style toggling (including
     bold, italics, underline and strikeout). (Wengier)
+  - Cleaned up the mapper editor interface to allow
+    more keyboard shortcuts to be added, shown in
+    multiple pages in the mapper, navigable with the
+    "Previous Page" and "Next Page" buttons. (Wengier)
+  - Added menu item "List network interfaces" under
+    "Help" menu to list network interfaces in the host
+    system for the NE2000 feature. (Wengier)
   - Added menu group "DOS commands" under "Help" menu
     to display the help content for the selected DOS
     shell command (DIR, CD, etc). (Wengier)

--- a/include/mapper.h
+++ b/include/mapper.h
@@ -27,7 +27,7 @@ enum MapKeys {
 	MK_return,MK_kpminus,MK_kpplus,MK_minus,MK_equals,MK_scrolllock,MK_printscreen,MK_pause,MK_home,MK_rightarrow,
 	MK_1, MK_2, MK_3, MK_4,
     MK_a, MK_c, MK_d, MK_f, MK_m, MK_q, MK_r, MK_s, MK_v, MK_w,
-    MK_escape,MK_delete,
+    MK_escape,MK_delete,MK_uparrow,MK_downarrow,
     MK_lbracket,MK_rbracket,MK_leftarrow,
 
     MK_MAX

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -311,7 +311,7 @@ void menu_update_core(void) {
               cpudecoder == &CPU_Core8086_Prefetch_Run).
         refresh_item(mainMenu);
 #if !defined(C_EMSCRIPTEN)//FIXME: Shutdown causes problems with Emscripten
-    mainMenu.get_item("menu_simple").
+    mainMenu.get_item("mapper_simple").
         check(cpudecoder == &CPU_Core_Simple_Run).
         enable((cpudecoder != &CPU_Core_Prefetch_Run) &&
                (cpudecoder != &CPU_Core286_Prefetch_Run) &&
@@ -319,7 +319,7 @@ void menu_update_core(void) {
                (cpudecoder != &CPU_Core286_Normal_Run) &&
                (cpudecoder != &CPU_Core8086_Normal_Run)).
         refresh_item(mainMenu);
-    mainMenu.get_item("menu_full").
+    mainMenu.get_item("mapper_full").
         check(cpudecoder == &CPU_Core_Full_Run).
         enable((cpudecoder != &CPU_Core_Prefetch_Run) &&
                (cpudecoder != &CPU_Core286_Prefetch_Run) &&
@@ -3003,32 +3003,27 @@ static void CPU_ToggleAutoCycles(bool pressed) {
 }
 
 #if !defined(C_EMSCRIPTEN)
-bool CPU_ToggleFullCore(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
-    (void)menuitem;
-    (void)menu;
+static void CPU_ToggleFullCore(bool pressed) {
+    if (!pressed) return;
     Section* sec=control->GetSection("cpu");
     if(sec) {
 	std::string tmp="core=full";
 	sec->HandleInputline(tmp);
     }
-    return true;
 }
 
-bool CPU_ToggleSimpleCore(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
-    (void)menuitem;
-    (void)menu;
+static void CPU_ToggleSimpleCore(bool pressed) {
+    if (!pressed) return;
     Section* sec=control->GetSection("cpu");
-    std::string tmp="core=simple";
     if(sec) {
+	std::string tmp="core=simple";
 	sec->HandleInputline(tmp);
     }
-    return true;
 }
 #endif
 
 static void CPU_ToggleNormalCore(bool pressed) {
-    if (!pressed)
-	return;
+    if (!pressed) return;
     Section* sec=control->GetSection("cpu");
     if(sec) {
 	std::string tmp="core=normal";
@@ -3038,8 +3033,7 @@ static void CPU_ToggleNormalCore(bool pressed) {
 
 #if (C_DYNAMIC_X86) || (C_DYNREC)
 static void CPU_ToggleDynamicCore(bool pressed) {
-    if (!pressed)
-	return;
+    if (!pressed) return;
     Section* sec=control->GetSection("cpu");
     if(sec) {
 	std::string tmp="core=dynamic";
@@ -3213,28 +3207,28 @@ public:
 #if (C_DYNREC)
 		CPU_Core_Dynrec_Init();
 #endif
-		MAPPER_AddHandler(CPU_CycleDecrease,MK_minus,MMODHOST,"cycledown","Dec Cycles",&item);
-		item->set_text("Decrement cycles");
-
-		MAPPER_AddHandler(CPU_CycleIncrease,MK_equals,MMODHOST,"cycleup"  ,"Inc Cycles",&item);
-		item->set_text("Increment cycles");
-
-		MAPPER_AddHandler(CPU_ToggleAutoCycles,MK_nothing,0,"cycauto","AutoCycles",&item);
+		MAPPER_AddHandler(CPU_ToggleAutoCycles,MK_nothing,0,"cycauto","Toggle auto cycles",&item);
 		item->set_text("Auto cycles");
 		item->set_description("Enable automatic cycle count");
 
-		MAPPER_AddHandler(CPU_ToggleNormalCore,MK_nothing,0,"normal"  ,"NormalCore", &item);
+		MAPPER_AddHandler(CPU_CycleDecrease,MK_minus,MMODHOST,"cycledown","Decrement cycles",&item);
+		item->set_text("Decrement cycles");
+
+		MAPPER_AddHandler(CPU_CycleIncrease,MK_equals,MMODHOST,"cycleup","Increment cycles",&item);
+		item->set_text("Increment cycles");
+
+		MAPPER_AddHandler(CPU_ToggleNormalCore,MK_nothing,0,"normal"  ,"CPU: normal core", &item);
 		item->set_text("Normal core");
 
 #if (C_DYNAMIC_X86) || (C_DYNREC)
-		MAPPER_AddHandler(CPU_ToggleDynamicCore,MK_nothing,0,"dynamic","DynaCore",&item);
+		MAPPER_AddHandler(CPU_ToggleDynamicCore,MK_nothing,0,"dynamic","CPU: dynamic core",&item);
 		item->set_text("Dynamic core");
 #endif
 #if !defined(C_EMSCRIPTEN)
-        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"menu_simple").
-            set_text("Simple core").set_callback_function(CPU_ToggleSimpleCore);
-        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"menu_full").
-            set_text("Full core").set_callback_function(CPU_ToggleFullCore);
+		MAPPER_AddHandler(CPU_ToggleSimpleCore,MK_nothing,0,"simple","CPU: imple core",&item);
+		item->set_text("Simple core");
+		MAPPER_AddHandler(CPU_ToggleFullCore,MK_nothing,0,"full","CPU: full core",&item);
+		item->set_text("Full core");
 #endif
 
         /* these are not mapper shortcuts, and probably should not be mapper shortcuts */

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -4197,9 +4197,9 @@ void DEBUG_Init() {
 	#if defined(MACOSX)
 		// OSX NOTE: ALT-F12 to launch debugger. pause maps to F16 on macOS,
 		// which is not easy to input on a modern mac laptop
-		MAPPER_AddHandler(DEBUG_Enable_Handler,MK_f12,MMOD2,"debugger","Debugger", &item);
+		MAPPER_AddHandler(DEBUG_Enable_Handler,MK_f12,MMOD2,"debugger","Show debugger", &item);
 	#else
-		MAPPER_AddHandler(DEBUG_Enable_Handler,MK_pause,MMOD2,"debugger","Debugger",&item);
+		MAPPER_AddHandler(DEBUG_Enable_Handler,MK_pause,MMOD2,"debugger","Show debugger",&item);
 	#endif
 	item->set_text("Show debugger");
 	/* Reset code overview and input line */

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -3415,7 +3415,7 @@ void DOS_Init() {
 
     DOSBoxMenu::item *item;
 
-    MAPPER_AddHandler(DOS_RescanAll,MK_nothing,0,"rescanall","RescanAll",&item);
+    MAPPER_AddHandler(DOS_RescanAll,MK_nothing,0,"rescanall","Rescan all drives",&item);
     item->enable(false).refresh_item(mainMenu);
     item->set_text("Rescan all drives");
     for (char drv='A';drv <= 'Z';drv++) DOS_EnableDriveMenu(drv);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1070,40 +1070,40 @@ void SetCyclesCount_mapper_shortcut(bool pressed);
 void DOSBOX_RealInit() {
     DOSBoxMenu::item *item;
 
-    LOG(LOG_MISC,LOG_DEBUG)("DOSBOX_RealInit: loading settings and initializing");
+    LOG(LOG_MISC,LOG_DEBUG)("DOSBOX-X RealInit: loading settings and initializing");
 
-    MAPPER_AddHandler(DOSBOX_UnlockSpeed, MK_rightarrow, MMODHOST,"speedlock","Speedlock");
+    MAPPER_AddHandler(DOSBOX_UnlockSpeed, MK_rightarrow, MMODHOST,"speedlock","Toggle Speedlock");
     {
-        MAPPER_AddHandler(DOSBOX_UnlockSpeed2, MK_nothing, 0, "speedlock2", "Speedlock2", &item);
+        MAPPER_AddHandler(DOSBOX_UnlockSpeed2, MK_nothing, 0, "speedlock2", "Turbo (Fast Forward)", &item);
         item->set_description("Toggle emulation speed, to allow running faster than realtime (fast forward)");
         item->set_text("Turbo (Fast Forward)");
     }
     {
-        MAPPER_AddHandler(DOSBOX_NormalSpeed, MK_leftarrow, MMODHOST, "speednorm","SpeedNrm", &item);
+        MAPPER_AddHandler(DOSBOX_NormalSpeed, MK_leftarrow, MMODHOST, "speednorm","Normal speed", &item);
         item->set_description("Restore normal emulation speed");
         item->set_text("Normal speed");
     }
     {
-        MAPPER_AddHandler(DOSBOX_SpeedUp, MK_rbracket, MMODHOST, "speedup","SpeedUp", &item);
+        MAPPER_AddHandler(DOSBOX_SpeedUp, MK_rbracket, MMODHOST, "speedup","Speed up", &item);
         item->set_text("Speed up");
     }
     {
-        MAPPER_AddHandler(DOSBOX_SlowDown, MK_lbracket, MMODHOST,"slowdown","SlowDown", &item);
+        MAPPER_AddHandler(DOSBOX_SlowDown, MK_lbracket, MMODHOST,"slowdown","Slow down", &item);
         item->set_text("Slow down");
     }
 	{
-		MAPPER_AddHandler(&SetCyclesCount_mapper_shortcut, MK_nothing, 0, "editcycles", "EditCycles", &item);
+		MAPPER_AddHandler(&SetCyclesCount_mapper_shortcut, MK_nothing, 0, "editcycles", "Edit cycles", &item);
 		item->set_text("Edit cycles");
 	}
 
 	//add support for loading/saving game states
-	MAPPER_AddHandler(SaveGameState, MK_f7, MMOD1,"savestate","SaveState", &item);
+	MAPPER_AddHandler(SaveGameState, MK_f7, MMOD1,"savestate","Save state", &item);
         item->set_text("Save state");
-	MAPPER_AddHandler(LoadGameState, MK_f8, MMOD1,"loadstate","LoadState", &item);
+	MAPPER_AddHandler(LoadGameState, MK_f8, MMOD1,"loadstate","Load state", &item);
         item->set_text("Load state");
-	MAPPER_AddHandler(PreviousSaveSlot, MK_f7, MMOD1|MMOD2,"prevslot","PrevSlot", &item);
+	MAPPER_AddHandler(PreviousSaveSlot, MK_f7, MMOD1|MMOD2,"prevslot","Previous save slot", &item);
         item->set_text("Select previous slot");
-	MAPPER_AddHandler(NextSaveSlot, MK_f8, MMOD1|MMOD2,"nextslot","NextSlot", &item);
+	MAPPER_AddHandler(NextSaveSlot, MK_f8, MMOD1|MMOD2,"nextslot","Next save slot", &item);
         item->set_text("Select next slot");
 
     Section_prop *section = static_cast<Section_prop *>(control->GetSection("dosbox"));

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -229,8 +229,8 @@ static const char *def_menu_cpu_core[] =
     "mapper_dynamic",
 #endif
 #if !defined(C_EMSCRIPTEN)//FIXME: Shutdown causes problems with Emscripten
-    "menu_simple",
-    "menu_full",
+    "mapper_simple",
+    "mapper_full",
 #endif
     NULL
 };
@@ -339,8 +339,8 @@ static const char *def_menu_video_textmode[] =
     "line_132x60",
 #if defined(USE_TTF)
     "--",
-    "ttf_window_inc",
-    "ttf_window_dec",
+    "mapper_ttf_incsize",
+    "mapper_ttf_decsize",
     "ttf_showbold",
     "ttf_showital",
     "ttf_showline",
@@ -713,8 +713,9 @@ static const char *def_menu_help[] =
     "help_wiki",
     "help_issue",
 #endif
-#if C_DEBUG || !defined(MACOSX) && !defined(LINUX) && !defined(HX_DOS) && !defined(C_EMSCRIPTEN)
     "--",
+    "help_nic",
+#if C_DEBUG || !defined(MACOSX) && !defined(LINUX) && !defined(HX_DOS) && !defined(C_EMSCRIPTEN)
     "HelpDebugMenu",
 #endif
     "--",

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -1252,12 +1252,12 @@ void RENDER_Init() {
 
     render.frameskip.max=(Bitu)section->Get_int("frameskip");
 
-    MAPPER_AddHandler(DecreaseFrameSkip,MK_nothing,0,"decfskip","Dec Fskip");
-    MAPPER_AddHandler(IncreaseFrameSkip,MK_nothing,0,"incfskip","Inc Fskip");
+    MAPPER_AddHandler(DecreaseFrameSkip,MK_nothing,0,"decfskip","Decrease frameskip");
+    MAPPER_AddHandler(IncreaseFrameSkip,MK_nothing,0,"incfskip","Increase frameskip");
 
 	DOSBoxMenu::item *item;
 
-	MAPPER_AddHandler(&AspectRatio_mapper_shortcut, MK_nothing, 0, "aspratio", "AspRatio", &item);
+	MAPPER_AddHandler(&AspectRatio_mapper_shortcut, MK_nothing, 0, "aspratio", "Aspect ratio", &item);
 	item->set_text("Fit to aspect ratio");
 
     mainMenu.get_item("vga_9widetext").check(vga.draw.char9_set).refresh_item(mainMenu);

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1578,6 +1578,7 @@ public:
             }
             (new GUI::Button(this, 140, r+30, "Close", 70))->addActionHandler(this);
             resize(350, r+110);
+            move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
@@ -1606,6 +1607,7 @@ public:
                 new GUI::Label(this, 40, r, line.c_str());
             }
             (new GUI::Button(this, 130, r+30, "Close", 70))->addActionHandler(this);
+            move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
@@ -1639,6 +1641,7 @@ public:
                 new GUI::Label(this, 40, r, line.c_str());
             }
             (new GUI::Button(this, 130, r+30, "Close", 70))->addActionHandler(this);
+            move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
@@ -1724,6 +1727,7 @@ public:
             }
             dos.dta(save_dta);
             (new GUI::Button(this, 165, 205, "Close", 70))->addActionHandler(this);
+            move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
@@ -1762,6 +1766,7 @@ public:
             new GUI::Label(this, 40, 25*(index+1), std::to_string(index) + " - " + str);
         }
         (new GUI::Button(this, 190, 25*(MAX_DISK_IMAGES+1)+5, "Close", 70))->addActionHandler(this);
+        move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
@@ -1787,6 +1792,7 @@ public:
             }
             (new GUI::Button(this, 110, r+30, "Close", 70))->addActionHandler(this);
             resize(300, r+110);
+            move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
@@ -1806,6 +1812,7 @@ public:
             new GUI::Label(this, strncmp(title, "DOSBox-X ", 9)?30:10, 20, title);
             (new GUI::Button(this, 140, 50, "Yes", 70))->addActionHandler(this);
             (new GUI::Button(this, 230, 50, "No", 70))->addActionHandler(this);
+            move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
@@ -1832,6 +1839,33 @@ public:
                 new GUI::Label(this, 40, r, line.c_str());
             }
             (new GUI::Button(this, 260, 110, "Close", 70))->addActionHandler(this);
+            move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
+    }
+
+    void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
+        (void)b;//UNUSED
+        if (arg == "Close")
+            close();
+        if (shortcut) running = false;
+    }
+};
+
+std::string niclist="NE2000 networking is not enabled.";
+class ShowHelpNIC : public GUI::ToplevelWindow {
+protected:
+    GUI::Input *name;
+public:
+    ShowHelpNIC(GUI::Screen *parent, int x, int y, const char *title) :
+        ToplevelWindow(parent, x, y, 700, 230, title) {
+            std::istringstream in(niclist.c_str());
+            int r=0;
+            if (in)	for (std::string line; std::getline(in, line); ) {
+                r+=25;
+                new GUI::Label(this, 40, r, line.c_str());
+            }
+            (new GUI::Button(this, 330, r+40, "Close", 70))->addActionHandler(this);
+            resize(700, r+120);
+            move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
@@ -1855,6 +1889,7 @@ public:
                 new GUI::Label(this, 40, r, line.c_str());
             }
             (new GUI::Button(this, 180, 155, "Close", 70))->addActionHandler(this);
+            move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
@@ -1888,6 +1923,7 @@ public:
             }
             (new GUI::Button(this, 350, r+40, "Close", 70))->addActionHandler(this);
             resize(750, r+120);
+            move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
@@ -2270,12 +2306,16 @@ static void UI_Select(GUI::ScreenSDL *screen, int select) {
             np11->raise();
             } break;
         case 35: {
-            auto *np11 = new ShowHelpAbout(screen, 110, 70, "About");
-            np11->raise();
+            auto *np12 = new ShowHelpAbout(screen, 110, 70, "About");
+            np12->raise();
             } break;
         case 36: {
-            auto *np12 = new ShowHelpCommand(screen, 150, 120, ("Help on DOS command: "+helpcmd).c_str());
-            np12->raise();
+            auto *np13 = new ShowHelpCommand(screen, 150, 120, ("Help on DOS command: "+helpcmd).c_str());
+            np13->raise();
+            } break;
+        case 37: {
+            auto *np14 = new ShowHelpNIC(screen, 70, 70, "Network interface list");
+            np14->raise();
             } break;
         default:
             break;

--- a/src/gui/sdl_ttf.c
+++ b/src/gui/sdl_ttf.c
@@ -1581,7 +1581,7 @@ SDL_Surface* TTF_RenderUNICODE_Shaded( TTF_Font* font,
 		return NULL;
 	}
 
-    if (width < expect_width)
+    if (width < (int)expect_width)
         width = expect_width;
 
 	/* Create the target surface */

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -1884,22 +1884,22 @@ void CAPTURE_Init() {
 
 #if !defined(C_EMSCRIPTEN)
 	// mapper shortcuts for capture
-	MAPPER_AddHandler(CAPTURE_WaveEvent,MK_w,MMOD3|MMODHOST,"recwave","Rec Wave", &item);
+	MAPPER_AddHandler(CAPTURE_WaveEvent,MK_w,MMOD3|MMODHOST,"recwave","Record audio to WAV", &item);
 	item->set_text("Record audio to WAV");
 
-	MAPPER_AddHandler(CAPTURE_MTWaveEvent,MK_nothing,0,"recmtwave","Rec MTWav", &item);
+	MAPPER_AddHandler(CAPTURE_MTWaveEvent,MK_nothing,0,"recmtwave","Record to M.T. AVI", &item);
 	item->set_text("Record audio to multi-track AVI");
 
-	MAPPER_AddHandler(CAPTURE_MidiEvent,MK_nothing,0,"caprawmidi","Cap MIDI", &item);
+	MAPPER_AddHandler(CAPTURE_MidiEvent,MK_nothing,0,"caprawmidi","Record MIDI output", &item);
 	item->set_text("Record MIDI output");
 
-	MAPPER_AddHandler(OPL_SaveRawEvent,MK_nothing,0,"caprawopl","Cap OPL",&item);
+	MAPPER_AddHandler(OPL_SaveRawEvent,MK_nothing,0,"caprawopl","Record FM/OPL output",&item);
 	item->set_text("Record FM (OPL) output");
 #if (C_SSHOT)
-	MAPPER_AddHandler(CAPTURE_ScreenShotEvent,MK_s,MMOD3|MMODHOST,"scrshot","Screenshot", &item);
+	MAPPER_AddHandler(CAPTURE_ScreenShotEvent,MK_s,MMOD3|MMODHOST,"scrshot","Take screenshot", &item);
 	item->set_text("Take screenshot");
 
-	MAPPER_AddHandler(CAPTURE_VideoEvent,MK_v,MMOD3|MMODHOST,"video","Video", &item);
+	MAPPER_AddHandler(CAPTURE_VideoEvent,MK_v,MMOD3|MMODHOST,"video","Record video to AVI", &item);
 	item->set_text("Record video to AVI");
 #endif
 #endif

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1128,16 +1128,16 @@ void MAPPER_RecVolumeDown(bool pressed) {
 void MIXER_Controls_Init() {
     DOSBoxMenu::item *item;
 
-    MAPPER_AddHandler(MAPPER_VolumeUp  ,MK_kpplus, MMODHOST,"volup","VolUp",&item);
+    MAPPER_AddHandler(MAPPER_VolumeUp  ,MK_kpplus, MMODHOST,"volup","Increase volume",&item);
     item->set_text("Increase volume");
     
-    MAPPER_AddHandler(MAPPER_VolumeDown,MK_kpminus,MMODHOST,"voldown","VolDown",&item);
+    MAPPER_AddHandler(MAPPER_VolumeDown,MK_kpminus,MMODHOST,"voldown","Decrease volume",&item);
     item->set_text("Decrease volume");
 
-    MAPPER_AddHandler(MAPPER_RecVolumeUp  ,MK_nothing, 0,"recvolup","RecVolUp",&item);
+    MAPPER_AddHandler(MAPPER_RecVolumeUp  ,MK_nothing, 0,"recvolup","Increase rec. volume",&item);
     item->set_text("Increase recording volume");
 
-    MAPPER_AddHandler(MAPPER_RecVolumeDown,MK_nothing, 0,"recvoldown","RecVolDn",&item);
+    MAPPER_AddHandler(MAPPER_RecVolumeDown,MK_nothing, 0,"recvoldown","Decrease rec. volume",&item);
     item->set_text("Decrease recording volume");
 }
 

--- a/src/hardware/parport/printer.cpp
+++ b/src/hardware/parport/printer.cpp
@@ -2200,7 +2200,7 @@ void PRINTER_Init()
 	//IO_RegisterReadHandler(LPTPORT+2,PRINTER_readcontrol,IO_MB);
 
     DOSBoxMenu::item *item;
-	MAPPER_AddHandler(FormFeed, MK_f2 , MMOD1, "ejectpage", "FormFeed", &item);
+	MAPPER_AddHandler(FormFeed, MK_f2 , MMOD1, "ejectpage", "Send form-feed", &item);
     item->set_text("Send form-feed");
 }
 

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -9164,11 +9164,11 @@ void BIOS_Init() {
     for (int i=0;i < MAX_ISA_PNP_SYSDEVNODES;i++) ISAPNP_SysDevNodes[i] = NULL;
 
     /* make sure CD swap and floppy swap mapper events are available */
-    MAPPER_AddHandler(swapInNextDisk,MK_d,MMODHOST|MMOD1,"swapimg","SwapFloppy",&item); /* Originally "Swap Image" but this version does not swap CDs */
-    item->set_text("Swap floppy");
+    MAPPER_AddHandler(swapInNextDisk,MK_d,MMODHOST|MMOD1,"swapimg","Swap floppy drive",&item); /* Originally "Swap Image" but this version does not swap CDs */
+    item->set_text("Swap floppy drive");
 
-    MAPPER_AddHandler(swapInNextCD,MK_c,MMODHOST|MMOD1,"swapcd","SwapCD",&item); /* Variant of "Swap Image" for CDs */
-    item->set_text("Swap CD");
+    MAPPER_AddHandler(swapInNextCD,MK_c,MMODHOST|MMOD1,"swapcd","Swap CD drive",&item); /* Variant of "Swap Image" for CDs */
+    item->set_text("Swap CD drive");
 
     /* NTS: VM_EVENT_BIOS_INIT this callback must be first. */
     AddExitFunction(AddExitFunctionFuncPair(BIOS_Destroy),false);


### PR DESCRIPTION
As discussed in Issue #2024, I have now cleaned up the mapper interface so that it allows more keyboard shortcuts to be added, shown in multiple pages in the mapper, navigable with the "Previous Page" and "Next Page" buttons. The text in the buttons are now longer and certainly clearer than before. Also added "List network interface" menu option under "Help" menu so that it is no longer required to look at the log file to see the list of network interfaces for the NE2000 feature.