### PR TITLE
Fixed TTF resizing not declared in scope

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5107,11 +5107,13 @@ static void GUI_StartUp() {
     MAPPER_AddHandler(&GUI_Run, MK_c,MMODHOST, "gui", "Configuration tool", &item);
     item->set_text("Configuration tool");
 
+#if defined(USE_TTF)
     MAPPER_AddHandler(&TTF_IncreaseSize, MK_uparrow, MMODHOST, "ttf_incsize", "Increase TTF size", &item);
     item->set_text("Increase TTF font size");
 
     MAPPER_AddHandler(&TTF_DecreaseSize, MK_downarrow, MMODHOST, "ttf_decsize", "Decrease TTF size", &item);
     item->set_text("Decrease TTF font size");
+#endif
 
     MAPPER_AddHandler(&GUI_ResetResize, MK_nothing, 0, "resetsize", "Reset window size", &item);
     item->set_text("Reset window size");


### PR DESCRIPTION
# Description

I was building dosbox-x for my new Raspberry Pi and had the following error:
```
sdlmain.cpp:5086:24: error: ‘TTF_IncreaseSize’ was not declared in this scope
 5086 |     MAPPER_AddHandler(&TTF_IncreaseSize, MK_uparrow, MMODHOST, "ttf_incsize", "Increase TTF size", &item);
      |                        ^~~~~~~~~~~~~~~~
sdlmain.cpp:5089:24: error: ‘TTF_DecreaseSize’ was not declared in this scope
 5089 |     MAPPER_AddHandler(&TTF_DecreaseSize, MK_downarrow, MMODHOST, "ttf_decsize", "Decrease TTF size", &item);
      |                        ^~~~~~~~~~~~~~~~
```
I added some missing macros around the code block that was in error.

**Does this PR address some issue(s) ?**

No

**Does this PR introduce new feature(s) ?**

No

**Are there any breaking changes ?**

No

**Additional information**

N/A
