### PR TITLE
Auto-switch output from TTF for screenshot taking and add menu option for loading mapper file

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,7 +15,8 @@
     on-screen text-style and 512-character font (WP)
     features. When using the TTF output DOSBox-X will
     temporarily switch to a different output when a
-    graphical mode is requested (and will auto-switch
+    graphical mode is requested (or when trying to take
+    a screenshot); the TTF output will be auto-switched
     back later), which can be customized via config
     option "ttf.outputswitch" (which defaults to auto).
     Menu items in the "Text-mode" menu group (under
@@ -25,6 +26,10 @@
     bold, italics, underline and strikeout). You can
     also select a TTF font to use at run-time with the
     "Select TrueType font (TTF)" menu option. (Wengier)
+  - Added the "Load mapper file..." menu option (under
+    "Main") to select and load a DOSBox-X mapper file
+    at run-time. Be sure to select a SDL1 mapper file
+    for SDL1 builds, and similar for SDL2. (Wengier)
   - You can now select a host key from the menu (under
     "Main") including Ctrl+Alt, Ctrl+Shift, Alt+Shift,
     or use the mapper-defined host key as in previous
@@ -57,6 +62,10 @@
     shell command (DIR, CD, etc). (Wengier)
   - Configuration Tool now provides the option to save
     to the primary or user config files. (Wengier)
+  - Certain config options (e.g. doublescan) that were
+    marked as advanced options are now general config
+    options and will appear in dosbox-x.reference.conf
+    apart from dosbox-x.reference.full.conf. (Wengier)
   - Added config options "saveremark" (default: true)
     and "forceloadstate" (default: false) in [dosbox]
     section which can be used to control if DOSBox-X

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -87,7 +87,6 @@ void                                                GUI_ResetResize(bool pressed
 
 MENU_Block                                          menu;
 
-int                                                 ttfpos=-1;
 unsigned int                                        hdd_defsize=16000;
 char                                                hdd_size[20]="";
 
@@ -114,6 +113,7 @@ static const char *def_menu_main[] =
 {
     "mapper_gui",
     "mapper_mapper",
+    "load_mapper_file",
     "--",
     "MainSendKey",
     "MainHostKey",
@@ -1768,8 +1768,8 @@ void MSG_WM_COMMAND_handle(SDL_SysWMmsg &Message) {
             PauseDOSBox(true);
         }
         if (LOWORD(wParam) == ID_WIN_SYSMENU_RESETSIZE) {
-            extern void resetFontSize();
-            resetFontSize();
+            void GUI_ResetResize(bool pressed);
+            GUI_ResetResize(true);
         }
 #if defined(USE_TTF)
         if (LOWORD(wParam) == ID_WIN_SYSMENU_TTFINCSIZE) {
@@ -1802,10 +1802,17 @@ void DOSBox_SetSysMenu(void) {
 
     AppendMenu(sysmenu, MF_SEPARATOR, -1, "");
 
+    std::string get_mapper_shortcut(const char *name), key="";
+    char msg[512];
+
 #if DOSBOXMENU_TYPE == DOSBOXMENU_HMENU
     {
-        const char *msg = "Show &menu bar";
-
+        strcpy(msg, "Show &menu bar");
+        key=get_mapper_shortcut("togmenu");
+        if (key.size()) {
+            strcat(msg, "\t");
+            strcat(msg, key.c_str());
+        }
         memset(&mii, 0, sizeof(mii));
         mii.cbSize = sizeof(mii);
         mii.fMask = MIIM_ID | MIIM_STRING | MIIM_STATE;
@@ -1819,8 +1826,12 @@ void DOSBox_SetSysMenu(void) {
 #endif
 
     {
-        const char *msg = "&Pause";
-
+        strcpy(msg, "&Pause emulation");
+        key=get_mapper_shortcut("pause");
+        if (key.size()) {
+            strcat(msg, "\t");
+            strcat(msg, key.c_str());
+        }
         memset(&mii, 0, sizeof(mii));
         mii.cbSize = sizeof(mii);
         mii.fMask = MIIM_ID | MIIM_STRING | MIIM_STATE;
@@ -1835,8 +1846,7 @@ void DOSBox_SetSysMenu(void) {
     AppendMenu(sysmenu, MF_SEPARATOR, -1, "");
 
     {
-        const char *msg = "Reset window size";
-
+        strcpy(msg, "Reset window size");
         memset(&mii, 0, sizeof(mii));
         mii.cbSize = sizeof(mii);
         mii.fMask = MIIM_ID | MIIM_STRING | MIIM_STATE;
@@ -1850,10 +1860,13 @@ void DOSBox_SetSysMenu(void) {
 
 #if defined(USE_TTF)
     bool TTF_using(void);
-    ttfpos = GetMenuItemCount(sysmenu);
     {
-        const char *msg = "Increase TTF font size";
-
+        strcpy(msg, "Increase TTF font size");
+        key=get_mapper_shortcut("ttf_incsize");
+        if (key.size()) {
+            strcat(msg, "\t");
+            strcat(msg, key.c_str());
+        }
         memset(&mii, 0, sizeof(mii));
         mii.cbSize = sizeof(mii);
         mii.fMask = MIIM_ID | MIIM_STRING | MIIM_STATE;
@@ -1866,8 +1879,12 @@ void DOSBox_SetSysMenu(void) {
     }
 
     {
-        const char *msg = "Decrease TTF font size";
-
+        strcpy(msg, "Decrease TTF font size");
+        key=get_mapper_shortcut("ttf_decsize");
+        if (key.size()) {
+            strcat(msg, "\t");
+            strcat(msg, key.c_str());
+        }
         memset(&mii, 0, sizeof(mii));
         mii.cbSize = sizeof(mii);
         mii.fMask = MIIM_ID | MIIM_STRING | MIIM_STATE;
@@ -1883,8 +1900,12 @@ void DOSBox_SetSysMenu(void) {
     AppendMenu(sysmenu, MF_SEPARATOR, -1, "");
 
     {
-        const char *msg = "Configuration &Tool";
-
+        strcpy(msg, "Configuration &tool");
+        key=get_mapper_shortcut("gui");
+        if (key.size()) {
+            strcat(msg, "\t");
+            strcat(msg, key.c_str());
+        }
         memset(&mii, 0, sizeof(mii));
         mii.cbSize = sizeof(mii);
         mii.fMask = MIIM_ID | MIIM_STRING | MIIM_STATE;
@@ -1897,8 +1918,12 @@ void DOSBox_SetSysMenu(void) {
     }
 
     {
-        const char *msg = "Mapper &Editor";
-
+        strcpy(msg, "Mapper &editor");
+        key=get_mapper_shortcut("mapper");
+        if (key.size()) {
+            strcat(msg, "\t");
+            strcat(msg, key.c_str());
+        }
         memset(&mii, 0, sizeof(mii));
         mii.cbSize = sizeof(mii);
         mii.fMask = MIIM_ID | MIIM_STRING | MIIM_STATE;

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -4329,9 +4329,12 @@ void MAPPER_Run(bool pressed) {
 }
 
 void update_all_shortcuts() {
-    for (auto &ev : events) {
+    for (auto &ev : events)
         if (ev != NULL) ev->update_menu_shortcut();
-    }
+#if defined(WIN32)
+    void DOSBox_SetSysMenu(void);
+    DOSBox_SetSysMenu();
+#endif
 }
 
 void MAPPER_RunInternal() {
@@ -4483,6 +4486,9 @@ void MAPPER_RunInternal() {
 #if DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW
     mainMenu.rebuild();
 #endif
+    std::string mapper_keybind = mapper_event_keybind_string("host");
+    if (mapper_keybind.empty()) mapper_keybind = "unbound";
+    mainMenu.get_item("hostkey_mapper").check(hostkeyalt==0).set_text("Mapper-defined: "+mapper_keybind).refresh_item(mainMenu);
 
     GFX_ForceRedrawScreen();
 
@@ -4586,6 +4592,9 @@ void MAPPER_Init(void) {
 
     /* and then the menu items need to be updated */
     update_all_shortcuts();
+#if DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW
+    mainMenu.rebuild();
+#endif
 }
 
 void ReloadMapper(Section_prop *section, bool init) {
@@ -4877,3 +4886,9 @@ std::string mapper_event_keybind_string(const std::string &x) {
     return std::string();
 }
 
+std::string get_mapper_shortcut(const char *name) {
+    for (CHandlerEventVector_it it=handlergroup.begin();it!=handlergroup.end();++it)
+        if ((*it)!=NULL&&!strcmp(name, (*it)->eventname.c_str()))
+            return (*it)->GetBindMenuText();
+    return "";
+}

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -2633,6 +2633,11 @@ void AUX_INT33_Takeover() {
     keyb.ps2mouse.int33_taken = 1;
 }
 
+void KEYBOARD_Clear() {
+    keyb.repeat.key=KBD_NONE;
+    KEYBOARD_ClrBuffer();
+}
+
 void KEYBOARD_Reset() {
     /* Init the keyb struct */
     keyb.active=true;

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -1119,7 +1119,7 @@ bool INT10_SetVideoMode_OTHER(uint16_t mode,bool clearmem) {
 #if defined(USE_TTF)
 extern bool resetreq;
 bool GFX_IsFullscreen(void), Direct3D_using(void);
-void ttf_reset(void), resetFontSize(), OUTPUT_TTF_Select(int fsize), GFX_SwitchFullscreenNoReset(void);
+void ttf_reset(void), resetFontSize(), OUTPUT_TTF_Select(int fsize), KEYBOARD_Clear(), GFX_SwitchFullscreenNoReset(void);
 #endif
 
 bool unmask_irq0_on_int10_setmode = true;
@@ -2056,6 +2056,7 @@ dac_text16:
             output = "surface";
 #endif
         }
+        KEYBOARD_Clear();
         change_output(out);
         SetVal("sdl", "output", output);
         void OutputSettingMenuUpdate(void);


### PR DESCRIPTION
Since screenshot function is not yet fully supported for TTF output, I have implemented the function to automatically switch output from TTF to another output to take screenshot/video capture and switch back. Also added menu option for loading mapper file at run-time, along with a few fixes and cleanups.