### PR TITLE
Look for TTF fonts in program directory and default font path too

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,6 +42,10 @@
     to the change, ancient versions of the API dating
     back to the mid 2000s were used which no longer
     work on Big Sur.
+  - DOSBox-X will now look for the dosbox-x.conf (and
+    dosbox.conf) file in the directory containing the
+    DOSBox-X executable too if the config file cannot
+    be found in DOSBox-X working directory. (Wengier)
   - The system menu in Windows SDL1 builds is now also
     available for Windows SDL2 builds, and menu items
     "Reset font size", "Increase TTF font size" and

--- a/include/whereami.h
+++ b/include/whereami.h
@@ -1,0 +1,67 @@
+// (‑●‑●)> dual licensed under the WTFPL v2 and MIT licenses
+//   without any warranty.
+//   by Gregory Pakosz (@gpakosz)
+// https://github.com/gpakosz/whereami
+
+#ifndef WHEREAMI_H
+#define WHEREAMI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef WAI_FUNCSPEC
+  #define WAI_FUNCSPEC
+#endif
+#ifndef WAI_PREFIX
+#define WAI_PREFIX(function) wai_##function
+#endif
+
+/**
+ * Returns the path to the current executable.
+ *
+ * Usage:
+ *  - first call `int length = wai_getExecutablePath(NULL, 0, NULL);` to
+ *    retrieve the length of the path
+ *  - allocate the destination buffer with `path = (char*)malloc(length + 1);`
+ *  - call `wai_getExecutablePath(path, length, NULL)` again to retrieve the
+ *    path
+ *  - add a terminal NUL character with `path[length] = '\0';`
+ *
+ * @param out destination buffer, optional
+ * @param capacity destination buffer capacity
+ * @param dirname_length optional recipient for the length of the dirname part
+ *   of the path.
+ *
+ * @return the length of the executable path on success (without a terminal NUL
+ * character), otherwise `-1`
+ */
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length);
+
+/**
+ * Returns the path to the current module
+ *
+ * Usage:
+ *  - first call `int length = wai_getModulePath(NULL, 0, NULL);` to retrieve
+ *    the length  of the path
+ *  - allocate the destination buffer with `path = (char*)malloc(length + 1);`
+ *  - call `wai_getModulePath(path, length, NULL)` again to retrieve the path
+ *  - add a terminal NUL character with `path[length] = '\0';`
+ *
+ * @param out destination buffer, optional
+ * @param capacity destination buffer capacity
+ * @param dirname_length optional recipient for the length of the dirname part
+ *   of the path.
+ *
+ * @return the length of the module path on success (without a terminal NUL
+ * character), otherwise `-1`
+ */
+WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // #ifndef WHEREAMI_H

--- a/src/gui/sdl_ttf.c
+++ b/src/gui/sdl_ttf.c
@@ -385,7 +385,7 @@ TTF_Font* TTF_OpenFontIndexRW( SDL_RWops *src, int freesrc, int ptsize, long ind
 	}
 
 	/* Check to make sure we can seek in this stream */
-	position = SDL_RWtell(src);
+	position = (int)SDL_RWtell(src);
 	if ( position < 0 ) {
 		TTF_SetError( "Can't seek in stream" );
 		return NULL;

--- a/src/gui/whereami.c
+++ b/src/gui/whereami.c
@@ -1,0 +1,690 @@
+// (‑●‑●)> dual licensed under the WTFPL v2 and MIT licenses
+//   without any warranty.
+//   by Gregory Pakosz (@gpakosz)
+// https://github.com/gpakosz/whereami
+
+// in case you want to #include "whereami.c" in a larger compilation unit
+#if !defined(WHEREAMI_H)
+#include <whereami.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(WAI_MALLOC) || !defined(WAI_FREE) || !defined(WAI_REALLOC)
+#include <stdlib.h>
+#endif
+
+#if !defined(WAI_MALLOC)
+#define WAI_MALLOC(size) malloc(size)
+#endif
+
+#if !defined(WAI_FREE)
+#define WAI_FREE(p) free(p)
+#endif
+
+#if !defined(WAI_REALLOC)
+#define WAI_REALLOC(p, size) realloc(p, size)
+#endif
+
+#ifndef WAI_NOINLINE
+#if defined(_MSC_VER)
+#define WAI_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__)
+#define WAI_NOINLINE __attribute__((noinline))
+#else
+#error unsupported compiler
+#endif
+#endif
+
+#if defined(_MSC_VER)
+#define WAI_RETURN_ADDRESS() _ReturnAddress()
+#elif defined(__GNUC__)
+#define WAI_RETURN_ADDRESS() __builtin_extract_return_addr(__builtin_return_address(0))
+#else
+#error unsupported compiler
+#endif
+
+#if defined(_WIN32)
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#if defined(_MSC_VER)
+#pragma warning(push, 3)
+#endif
+#include <windows.h>
+#include <intrin.h>
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+static int WAI_PREFIX(getModulePath_)(HMODULE module, char* out, int capacity, int* dirname_length)
+{
+  wchar_t buffer1[MAX_PATH];
+  wchar_t buffer2[MAX_PATH];
+  wchar_t* path = NULL;
+  int length = -1;
+
+  for (;;)
+  {
+    DWORD size;
+    int length_, length__;
+
+    size = GetModuleFileNameW(module, buffer1, sizeof(buffer1) / sizeof(buffer1[0]));
+
+    if (size == 0)
+      break;
+    else if (size == (DWORD)(sizeof(buffer1) / sizeof(buffer1[0])))
+    {
+      DWORD size_ = size;
+      do
+      {
+        wchar_t* path_;
+
+        path_ = (wchar_t*)WAI_REALLOC(path, sizeof(wchar_t) * size_ * 2);
+        if (!path_)
+          break;
+        size_ *= 2;
+        path = path_;
+        size = GetModuleFileNameW(module, path, size_);
+      }
+      while (size == size_);
+
+      if (size == size_)
+        break;
+    }
+    else
+      path = buffer1;
+
+    if (!_wfullpath(buffer2, path, MAX_PATH))
+      break;
+    length_ = (int)wcslen(buffer2);
+    length__ = WideCharToMultiByte(CP_UTF8, 0, buffer2, length_ , out, capacity, NULL, NULL);
+
+    if (length__ == 0)
+      length__ = WideCharToMultiByte(CP_UTF8, 0, buffer2, length_, NULL, 0, NULL, NULL);
+    if (length__ == 0)
+      break;
+
+    if (length__ <= capacity && dirname_length)
+    {
+      int i;
+
+      for (i = length__ - 1; i >= 0; --i)
+      {
+        if (out[i] == '\\')
+        {
+          *dirname_length = i;
+          break;
+        }
+      }
+    }
+
+    length = length__;
+
+    break;
+  }
+
+  if (path != buffer1)
+    WAI_FREE(path);
+
+  return length;
+}
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  return WAI_PREFIX(getModulePath_)(NULL, out, capacity, dirname_length);
+}
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  HMODULE module;
+  int length = -1;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4054)
+#endif
+  if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (LPCTSTR)WAI_RETURN_ADDRESS(), &module))
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+  {
+    length = WAI_PREFIX(getModulePath_)(module, out, capacity, dirname_length);
+  }
+
+  return length;
+}
+
+#elif defined(__linux__) || defined(__CYGWIN__) || defined(__sun) || defined(WAI_USE_PROC_SELF_EXE)
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#if defined(__linux__)
+#include <linux/limits.h>
+#else
+#include <limits.h>
+#endif
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+#include <inttypes.h>
+
+#if !defined(WAI_PROC_SELF_EXE)
+#if defined(__sun)
+#define WAI_PROC_SELF_EXE "/proc/self/path/a.out"
+#else
+#define WAI_PROC_SELF_EXE "/proc/self/exe"
+#endif
+#endif
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer[PATH_MAX];
+  char* resolved = NULL;
+  int length = -1;
+
+  for (;;)
+  {
+    resolved = realpath(WAI_PROC_SELF_EXE, buffer);
+    if (!resolved)
+      break;
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  return length;
+}
+
+#if !defined(WAI_PROC_SELF_MAPS_RETRY)
+#define WAI_PROC_SELF_MAPS_RETRY 5
+#endif
+
+#if !defined(WAI_PROC_SELF_MAPS)
+#if defined(__sun)
+#define WAI_PROC_SELF_MAPS "/proc/self/map"
+#else
+#define WAI_PROC_SELF_MAPS "/proc/self/maps"
+#endif
+#endif
+
+#if defined(__ANDROID__) || defined(ANDROID)
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  int length = -1;
+  FILE* maps = NULL;
+
+  for (int r = 0; r < WAI_PROC_SELF_MAPS_RETRY; ++r)
+  {
+    maps = fopen(WAI_PROC_SELF_MAPS, "r");
+    if (!maps)
+      break;
+
+    for (;;)
+    {
+      char buffer[PATH_MAX < 1024 ? 1024 : PATH_MAX];
+      uint64_t low, high;
+      char perms[5];
+      uint64_t offset;
+      uint32_t major, minor;
+      char path[PATH_MAX];
+      uint32_t inode;
+
+      if (!fgets(buffer, sizeof(buffer), maps))
+        break;
+
+      if (sscanf(buffer, "%" PRIx64 "-%" PRIx64 " %s %" PRIx64 " %x:%x %u %s\n", &low, &high, perms, &offset, &major, &minor, &inode, path) == 8)
+      {
+        uint64_t addr = (uintptr_t)WAI_RETURN_ADDRESS();
+        if (low <= addr && addr <= high)
+        {
+          char* resolved;
+
+          resolved = realpath(path, buffer);
+          if (!resolved)
+            break;
+
+          length = (int)strlen(resolved);
+#if defined(__ANDROID__) || defined(ANDROID)
+          if (length > 4
+              &&buffer[length - 1] == 'k'
+              &&buffer[length - 2] == 'p'
+              &&buffer[length - 3] == 'a'
+              &&buffer[length - 4] == '.')
+          {
+            int fd = open(path, O_RDONLY);
+            if (fd == -1)
+            {
+              length = -1; // retry
+              break;
+            }
+
+            char* begin = (char*)mmap(0, offset, PROT_READ, MAP_SHARED, fd, 0);
+            if (begin == MAP_FAILED)
+            {
+              close(fd);
+              length = -1; // retry
+              break;
+            }
+
+            char* p = begin + offset - 30; // minimum size of local file header
+            while (p >= begin) // scan backwards
+            {
+              if (*((uint32_t*)p) == 0x04034b50UL) // local file header signature found
+              {
+                uint16_t length_ = *((uint16_t*)(p + 26));
+
+                if (length + 2 + length_ < (int)sizeof(buffer))
+                {
+                  memcpy(&buffer[length], "!/", 2);
+                  memcpy(&buffer[length + 2], p + 30, length_);
+                  length += 2 + length_;
+                }
+
+                break;
+              }
+
+              --p;
+            }
+
+            munmap(begin, offset);
+            close(fd);
+          }
+#endif
+          if (length <= capacity)
+          {
+            memcpy(out, resolved, length);
+
+            if (dirname_length)
+            {
+              int i;
+
+              for (i = length - 1; i >= 0; --i)
+              {
+                if (out[i] == '/')
+                {
+                  *dirname_length = i;
+                  break;
+                }
+              }
+            }
+          }
+
+          break;
+        }
+      }
+    }
+
+    fclose(maps);
+    maps = NULL;
+
+    if (length != -1)
+      break;
+  }
+
+  if (maps)
+    fclose(maps);
+
+  return length;
+}
+
+#elif defined(__APPLE__)
+
+#define _DARWIN_BETTER_REALPATH
+#include <mach-o/dyld.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dlfcn.h>
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer1[PATH_MAX];
+  char buffer2[PATH_MAX];
+  char* path = buffer1;
+  char* resolved = NULL;
+  int length = -1;
+
+  for (;;)
+  {
+    uint32_t size = (uint32_t)sizeof(buffer1);
+    if (_NSGetExecutablePath(path, &size) == -1)
+    {
+      path = (char*)WAI_MALLOC(size);
+      if (!_NSGetExecutablePath(path, &size))
+        break;
+    }
+
+    resolved = realpath(path, buffer2);
+    if (!resolved)
+      break;
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  if (path != buffer1)
+    WAI_FREE(path);
+
+  return length;
+}
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer[PATH_MAX];
+  char* resolved = NULL;
+  int length = -1;
+
+  for(;;)
+  {
+    Dl_info info;
+
+    if (dladdr(WAI_RETURN_ADDRESS(), &info))
+    {
+      resolved = realpath(info.dli_fname, buffer);
+      if (!resolved)
+        break;
+
+      length = (int)strlen(resolved);
+      if (length <= capacity)
+      {
+        memcpy(out, resolved, length);
+
+        if (dirname_length)
+        {
+          int i;
+
+          for (i = length - 1; i >= 0; --i)
+          {
+            if (out[i] == '/')
+            {
+              *dirname_length = i;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  return length;
+}
+
+#elif defined(__QNXNTO__)
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dlfcn.h>
+
+#if !defined(WAI_PROC_SELF_EXE)
+#define WAI_PROC_SELF_EXE "/proc/self/exefile"
+#endif
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer1[PATH_MAX];
+  char buffer2[PATH_MAX];
+  char* resolved = NULL;
+  FILE* self_exe = NULL;
+  int length = -1;
+
+  for (;;)
+  {
+    self_exe = fopen(WAI_PROC_SELF_EXE, "r");
+    if (!self_exe)
+      break;
+
+    if (!fgets(buffer1, sizeof(buffer1), self_exe))
+      break;
+
+    resolved = realpath(buffer1, buffer2);
+    if (!resolved)
+      break;
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  fclose(self_exe);
+
+  return length;
+}
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer[PATH_MAX];
+  char* resolved = NULL;
+  int length = -1;
+
+  for(;;)
+  {
+    Dl_info info;
+
+    if (dladdr(WAI_RETURN_ADDRESS(), &info))
+    {
+      resolved = realpath(info.dli_fname, buffer);
+      if (!resolved)
+        break;
+
+      length = (int)strlen(resolved);
+      if (length <= capacity)
+      {
+        memcpy(out, resolved, length);
+
+        if (dirname_length)
+        {
+          int i;
+
+          for (i = length - 1; i >= 0; --i)
+          {
+            if (out[i] == '/')
+            {
+              *dirname_length = i;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  return length;
+}
+
+#elif defined(__DragonFly__) || defined(__FreeBSD__) || \
+      defined(__FreeBSD_kernel__) || defined(__NetBSD__)
+
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <dlfcn.h>
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer1[PATH_MAX];
+  char buffer2[PATH_MAX];
+  char* path = buffer1;
+  char* resolved = NULL;
+  int length = -1;
+
+  for (;;)
+  {
+#if defined(__NetBSD__)
+    int mib[4] = { CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME };
+#else
+    int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
+#endif
+    size_t size = sizeof(buffer1);
+
+    if (sysctl(mib, (u_int)(sizeof(mib) / sizeof(mib[0])), path, &size, NULL, 0) != 0)
+        break;
+
+    resolved = realpath(path, buffer2);
+    if (!resolved)
+      break;
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  if (path != buffer1)
+    WAI_FREE(path);
+
+  return length;
+}
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer[PATH_MAX];
+  char* resolved = NULL;
+  int length = -1;
+
+  for(;;)
+  {
+    Dl_info info;
+
+    if (dladdr(WAI_RETURN_ADDRESS(), &info))
+    {
+      resolved = realpath(info.dli_fname, buffer);
+      if (!resolved)
+        break;
+
+      length = (int)strlen(resolved);
+      if (length <= capacity)
+      {
+        memcpy(out, resolved, length);
+
+        if (dirname_length)
+        {
+          int i;
+
+          for (i = length - 1; i >= 0; --i)
+          {
+            if (out[i] == '/')
+            {
+              *dirname_length = i;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  return length;
+}
+
+#else
+
+#error unsupported platform
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -643,9 +643,6 @@ void ttf_switch_off() {
 
 void ttf_switch_on() {
     if (ttfswitch && !(CaptureState & CAPTURE_IMAGE) && !(CaptureState & CAPTURE_VIDEO)) {
-#if C_DIRECT3D
-        if (Direct3D_using()) change_output(0);
-#endif
         change_output(10);
         SetVal("sdl", "output", "ttf");
         void OutputSettingMenuUpdate(void);

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -1119,7 +1119,7 @@ bool INT10_SetVideoMode_OTHER(uint16_t mode,bool clearmem) {
 #if defined(USE_TTF)
 extern bool resetreq;
 bool GFX_IsFullscreen(void), Direct3D_using(void);
-void ttf_reset(void), resetFontSize(), OUTPUT_TTF_Select(int fsize), KEYBOARD_Clear(), GFX_SwitchFullscreenNoReset(void);
+void ttf_reset(void), resetFontSize(), OUTPUT_TTF_Select(int fsize), RENDER_Reset(void), KEYBOARD_Clear(), GFX_SwitchFullscreenNoReset(void);
 #endif
 
 bool unmask_irq0_on_int10_setmode = true;
@@ -2013,9 +2013,6 @@ dac_text16:
         if (ttf.inUse)
             ttf_reset();
         else if (switch_output_from_ttf) {
-#if C_DIRECT3D
-            if (Direct3D_using()) change_output(0);
-#endif
             change_output(10);
             SetVal("sdl", "output", "ttf");
             void OutputSettingMenuUpdate(void);
@@ -2064,6 +2061,7 @@ dac_text16:
         switch_output_from_ttf = true;
         //if (GFX_IsFullscreen()) GFX_SwitchFullscreenNoReset();
         mainMenu.get_item("output_ttf").enable(false).refresh_item(mainMenu);
+        RENDER_Reset();
 #endif
     }
 	// Enable screen memory access

--- a/src/output/output_opengl.cpp
+++ b/src/output/output_opengl.cpp
@@ -211,7 +211,7 @@ retry:
 #elif defined(SDL_DOSBOX_X_SPECIAL)
     sdl.surface = SDL_SetVideoMode(windowWidth, windowHeight, (int)bpp, (unsigned int)sdl_flags | (unsigned int)(setSizeButNotResize() ? SDL_HAX_NORESIZEWINDOW : 0));
 #else
-    sdl.surface = SDL_SetVideoMode(windowWidth, windowHeight, (int)bpp, (unsigned int)sdl_flags | (unsigned int)(setSizeButNotResize()));
+    sdl.surface = SDL_SetVideoMode(windowWidth, windowHeight, (int)bpp, (unsigned int)sdl_flags);
 #endif
     if (sdl.surface == NULL && sdl.desktop.fullscreen) {
         LOG_MSG("Fullscreen not supported: %s", SDL_GetError());


### PR DESCRIPTION
This allows TTF fonts and the DOSBox-X config file (dosbox-x.conf/dosbox.conf) to be searched in the DOSBox-X executable directory if they cannot be found in the current working directory, which is done in the cross-platform manner thanks to the library. Also, DOSBox-X will search for default font path (/usr/share/fonts/truetype on Linux and /Library/Fonts in macOS) in addition to C:\WINDOWS\fonts on Windows. Tested in Windows, Linux, and macOS. There are also some smaller fixups.