### PR TITLE
Fix build with -Werror=format-security

### DIFF
--- a/src/hardware/ne2000.cpp
+++ b/src/hardware/ne2000.cpp
@@ -1603,7 +1603,7 @@ public:
 #endif
  		{
             niclist = "Cannot enumerate network interfaces: "+std::string(errbuf);
-			LOG_MSG(niclist.c_str());
+			LOG_MSG("%s", niclist.c_str());
 			load_success = false;
 			return;
 		}
@@ -1621,7 +1621,7 @@ public:
 			// print list and quit
             std::istringstream in(("\n"+niclist+"\n").c_str());
             if (in)	for (std::string line; std::getline(in, line); )
-                LOG_MSG(line.c_str());
+                LOG_MSG("%s", line.c_str());
 			pcap_freealldevs(alldevs);
 			load_success = false;
 			return;


### PR DESCRIPTION
Some build environmaents harden their security flags. For
-Werror=format-security build failed with:
| ne2000.cpp: In constructor 'NE2K::NE2K(Section*)':
| ne2000.cpp:1606:27: error: format not a string literal and no format arguments [-Werror=format-security]
|  1606 |    LOG_MSG(niclist.c_str());
|       |                           ^
| ne2000.cpp:1624:37: error: format not a string literal and no format arguments [-Werror=format-security]
|  1624 |                 LOG_MSG(line.c_str());
|       |                                     ^

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>

# Description

_Summary of changes brought by this PR._


**Does this PR address some issue(s) ?**

_Add the issue(s) fixed, e.g. ```#1234```_


**Does this PR introduce new feature(s) ?**

_Describe the feature(s) introduced._


**Are there any breaking changes ?**

_Describe the breaking changes in detail._


**Additional information**

_Add any additional information that may be useful._
