### PR TITLE
Fix lines starting with % being ignored in [autoexec] section

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,10 @@
 0.83.9
+  - Fixed full-screen TTF output may not fully cover
+    the background screen in Linux. (Wengier)
+  - Fixed that lines starting with "%" in [autoexec]
+    section are being ignored. (Wengier)
+  - Improved the dynamic core including the way its
+    cache is allocated and to support dual mapping.
   - Added OPL3Duo support, which passes OPL3 output
     to an OPL3Duo Arduino board with a specific
     configuration if desired. (josephillips85)

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1088,7 +1088,6 @@ bool Config::ParseConfigFile(char const * const configfilename) {
         if (!gegevens.size()) continue;
 
         switch(gegevens[0]) {
-        case '%':
         case '\0':
         case '#':
         case ' ':
@@ -1105,6 +1104,8 @@ bool Config::ParseConfigFile(char const * const configfilename) {
             testsec = NULL;
         }
             break;
+        case '%':
+            if (strcasecmp(currentsection->GetName(), "autoexec")) continue;
         default:
             try {
                 if (currentsection) {


### PR DESCRIPTION
As mentioned in Issue #2054, lines starting with % in [autoexec] section are being ignored, and this will fix the issue. Also updated the CHANGELOG to mention recent updates.