### PR TITLE
Add support for single mapper file for SDL1/SDL2 (Issue #2045) and fix issue #2010 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,18 @@
 0.83.9
+  - You can now use a single mapper file for both SDL1
+    and SDL2 versions of DOSBox-X! The new mapper file
+    will be divided to sections [SDL1] and [SDL2] for
+    both versions. The mapper file can be specified
+    with the mapperfile config option, or you can set
+    the mapperfile_sdl1 and mapperfile_sdl2 config
+    options to override mapperfile option. (Wengier)
   - Added SETCOLOR command to view or change the text-
     mode color scheme settings. Also fixed the color
     palette for the TTF output. (Wengier)
   - The "Show menu bar" option now appears in system
     menu of the Windows SDL2 build too. (Wengier)
+  - Fixed the color palette problem when switching to
+    graphic mode from mono mode. (Wengier)
   - Fixed full-screen TTF output may not fully cover
     the background screen in Linux. (Wengier)
   - Fixed that lines starting with "%" in [autoexec]

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -44,7 +44,8 @@
 #                        pause is only valid for the second entry.
 #                      Possible values: lowest, lower, normal, higher, highest, pause.
 #        mapperfile: File used to load/save the key/event mappings from. Resetmapper only works with the default value.
-#   mapperfile_sdl2: File used to load/save the key/event mappings from (SDL2 builds). Resetmapper only works with the default value.
+#DOSBOX-X-ADV:#   mapperfile_sdl1: File used to load/save the key/event mappings from DOSBox-X SDL1 builds. If set it will override "mapperfile" for SDL1 builds.
+#DOSBOX-X-ADV:#   mapperfile_sdl2: File used to load/save the key/event mappings from DOSBox-X SDL2 builds. If set it will override "mapperfile" for SDL2 builds.
 #      usescancodes: Avoid usage of symkeys, might not work on all operating systems.
 #                      If set to "auto" (default), it is enabled for SDL1 and non-US keyboards.
 #                      Possible values: true, false, auto.
@@ -67,8 +68,9 @@ mouse_emulation   = locked
 mouse_wheel_key   = -1
 waitonerror       = true
 priority          = higher,normal
-mapperfile        = mapper-dosbox-x.sdl1.map
-mapperfile_sdl2   = mapper-dosbox-x.sdl2.map
+mapperfile        = mapper-dosbox-x.map
+#DOSBOX-X-ADV:mapperfile_sdl1   = 
+#DOSBOX-X-ADV:mapperfile_sdl2   = 
 usescancodes      = auto
 #DOSBOX-X-ADV:overscan          = 0
 titlebar          = 
@@ -1427,7 +1429,7 @@ ps1audiorate                           = 22050
 #                  fcs (Thrustmaster), ch (CH Flightstick).
 #                  none disables joystick emulation.
 #                  auto chooses emulation depending on real joystick(s).
-#                  (Remember to reset dosbox's mapperfile if you saved it earlier)
+#                  (Remember to reset DOSBox-X's mapperfile if you saved it earlier)
 #                  Possible values: auto, 2axis, 4axis, 4axis_2, fcs, ch, none.
 #         timed: enable timed intervals for axis. Experiment with this option, if your joystick drifts (away).
 #      autofire: continuously fires as long as you keep the button pressed.

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -42,7 +42,6 @@
 #                        pause is only valid for the second entry.
 #                      Possible values: lowest, lower, normal, higher, highest, pause.
 #        mapperfile: File used to load/save the key/event mappings from. Resetmapper only works with the default value.
-#   mapperfile_sdl2: File used to load/save the key/event mappings from (SDL2 builds). Resetmapper only works with the default value.
 #      usescancodes: Avoid usage of symkeys, might not work on all operating systems.
 #                      If set to "auto" (default), it is enabled for SDL1 and non-US keyboards.
 #                      Possible values: true, false, auto.
@@ -63,8 +62,7 @@ mouse_emulation   = locked
 mouse_wheel_key   = -1
 waitonerror       = true
 priority          = higher,normal
-mapperfile        = mapper-dosbox-x.sdl1.map
-mapperfile_sdl2   = mapper-dosbox-x.sdl2.map
+mapperfile        = mapper-dosbox-x.map
 usescancodes      = auto
 titlebar          = 
 showmenu          = true
@@ -465,7 +463,7 @@ ps1audiorate = 22050
 #                 fcs (Thrustmaster), ch (CH Flightstick).
 #                 none disables joystick emulation.
 #                 auto chooses emulation depending on real joystick(s).
-#                 (Remember to reset dosbox's mapperfile if you saved it earlier)
+#                 (Remember to reset DOSBox-X's mapperfile if you saved it earlier)
 #                 Possible values: auto, 2axis, 4axis, 4axis_2, fcs, ch, none.
 #        timed: enable timed intervals for axis. Experiment with this option, if your joystick drifts (away).
 #     autofire: continuously fires as long as you keep the button pressed.

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -44,7 +44,8 @@
 #                        pause is only valid for the second entry.
 #                      Possible values: lowest, lower, normal, higher, highest, pause.
 #        mapperfile: File used to load/save the key/event mappings from. Resetmapper only works with the default value.
-#   mapperfile_sdl2: File used to load/save the key/event mappings from (SDL2 builds). Resetmapper only works with the default value.
+#   mapperfile_sdl1: File used to load/save the key/event mappings from DOSBox-X SDL1 builds. If set it will override "mapperfile" for SDL1 builds.
+#   mapperfile_sdl2: File used to load/save the key/event mappings from DOSBox-X SDL2 builds. If set it will override "mapperfile" for SDL2 builds.
 #      usescancodes: Avoid usage of symkeys, might not work on all operating systems.
 #                      If set to "auto" (default), it is enabled for SDL1 and non-US keyboards.
 #                      Possible values: true, false, auto.
@@ -67,8 +68,9 @@ mouse_emulation   = locked
 mouse_wheel_key   = -1
 waitonerror       = true
 priority          = higher,normal
-mapperfile        = mapper-dosbox-x.sdl1.map
-mapperfile_sdl2   = mapper-dosbox-x.sdl2.map
+mapperfile        = mapper-dosbox-x.map
+mapperfile_sdl1   = 
+mapperfile_sdl2   = 
 usescancodes      = auto
 overscan          = 0
 titlebar          = 
@@ -1427,7 +1429,7 @@ ps1audiorate                           = 22050
 #                  fcs (Thrustmaster), ch (CH Flightstick).
 #                  none disables joystick emulation.
 #                  auto chooses emulation depending on real joystick(s).
-#                  (Remember to reset dosbox's mapperfile if you saved it earlier)
+#                  (Remember to reset DOSBox-X's mapperfile if you saved it earlier)
 #                  Possible values: auto, 2axis, 4axis, 4axis_2, fcs, ch, none.
 #         timed: enable timed intervals for axis. Experiment with this option, if your joystick drifts (away).
 #      autofire: continuously fires as long as you keep the button pressed.

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -6140,6 +6140,7 @@ extern alt_rgb altBGR1[16];
 extern bool colorChanged;
 bool setColors(const char *colorArray, int n);
 void resetFontSize();
+
 class SETCOLOR : public Program {
 public:
     void Run(void);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3303,7 +3303,7 @@ void DOSBOX_SetupConfigSections(void) {
         "fcs (Thrustmaster), ch (CH Flightstick).\n"
         "none disables joystick emulation.\n"
         "auto chooses emulation depending on real joystick(s).\n"
-        "(Remember to reset dosbox's mapperfile if you saved it earlier)");
+        "(Remember to reset DOSBox-X's mapperfile if you saved it earlier)");
     Pstring->SetBasic(true);
 
     Pbool = secprop->Add_bool("timed",Property::Changeable::WhenIdle,true);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1090,13 +1090,9 @@ void UpdateWindowDimensions(void)
     PrintScreenSizeInfo();
 }
 
+#define MAPPERFILE              "mapper-dosbox-x.map"
 #define MAPPERFILE_SDL1         "mapper-dosbox-x.sdl1.map"
 #define MAPPERFILE_SDL2         "mapper-dosbox-x.sdl2.map"
-#if defined(C_SDL2)
-# define MAPPERFILE             MAPPERFILE_SDL2
-#else
-# define MAPPERFILE             MAPPERFILE_SDL1
-#endif
 
 void                        GUI_ResetResize(bool);
 void                        GUI_LoadFonts();
@@ -7352,13 +7348,15 @@ void SDL_SetupConfigSection() {
     Pstring = Pmulti->GetSection()->Add_string("inactive",Property::Changeable::Always,"normal");
     Pstring->Set_values(inactt);
 
-    Pstring = sdl_sec->Add_path("mapperfile",Property::Changeable::Always,MAPPERFILE_SDL1);
+    Pstring = sdl_sec->Add_path("mapperfile",Property::Changeable::Always,MAPPERFILE);
     Pstring->Set_help("File used to load/save the key/event mappings from. Resetmapper only works with the default value.");
     Pstring->SetBasic(true);
 
-    Pstring = sdl_sec->Add_path("mapperfile_sdl2",Property::Changeable::Always,MAPPERFILE_SDL2);
-    Pstring->Set_help("File used to load/save the key/event mappings from (SDL2 builds). Resetmapper only works with the default value.");
-    Pstring->SetBasic(true);
+    Pstring = sdl_sec->Add_path("mapperfile_sdl1",Property::Changeable::Always,"");
+    Pstring->Set_help("File used to load/save the key/event mappings from DOSBox-X SDL1 builds. If set it will override \"mapperfile\" for SDL1 builds.");
+
+    Pstring = sdl_sec->Add_path("mapperfile_sdl2",Property::Changeable::Always,"");
+    Pstring->Set_help("File used to load/save the key/event mappings from DOSBox-X SDL2 builds. If set it will override \"mapperfile\" for SDL2 builds.");
 
 	const char* truefalseautoopt[] = { "true", "false", "auto", 0};
     Pstring = sdl_sec->Add_string("usescancodes",Property::Changeable::OnlyAtStart,"auto");
@@ -9635,11 +9633,21 @@ bool vid_select_mapper_file_menu_callback(DOSBoxMenu* const menu, DOSBoxMenu::it
         }
 
         if (*name) {
+            Prop_path* pp;
 #if defined(C_SDL2)
-			SetVal("sdl", "mapperfile_sdl2", name);
+            pp = section->Get_path("mapperfile_sdl2");
 #else
-            SetVal("sdl", "mapperfile", name);
+            pp = section->Get_path("mapperfile_sdl1");
 #endif
+            if (pp->realpath=="")
+                SetVal("sdl", "mapperfile", name);
+            else {
+#if defined(C_SDL2)
+                SetVal("sdl", "mapperfile_sdl2", name);
+#else
+                SetVal("sdl", "mapperfile_sdl1", name);
+#endif
+            }
             void ReloadMapper(Section_prop *sec, bool init);
             ReloadMapper(section,true);
         }
@@ -10537,7 +10545,7 @@ bool sendkey_preset_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * co
     return true;
 }
 
-void update_all_shortcuts();
+void update_all_shortcuts(), DOSBox_SetSysMenu();
 bool hostkey_preset_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
     if (menuitem->get_name()=="hostkey_ctrlalt") hostkeyalt=1;
@@ -10551,6 +10559,9 @@ bool hostkey_preset_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * co
     update_all_shortcuts();
 #if DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW
     mainMenu.rebuild();
+#endif
+#if defined(WIN32) && !defined(HX_DOS)
+    DOSBox_SetSysMenu();
 #endif
     return true;
 }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3148,6 +3148,21 @@ void res_input(bool type, const char * res) {
 void GFX_SelectFontByPoints(int ptsize);
 bool lastmenu = true, initttf = false;
 int lastfontsize = 0;
+void setVGADAC() {
+    if (ttf.inUse&&CurMode&&IS_VGA_ARCH) {
+        std::map<uint8_t,int> imap;
+        for (uint8_t i = 0; i < 0x10; i++) {
+            IO_ReadB(mem_readw(BIOS_VIDEO_PORT)+6);
+            IO_WriteB(VGAREG_ACTL_ADDRESS, i+32);
+            imap[i]=IO_ReadB(VGAREG_ACTL_READ_DATA);
+            IO_WriteB(VGAREG_DAC_WRITE_ADDRESS, imap[i]);
+            IO_WriteB(VGAREG_DAC_DATA, altBGR1[i].red*63/255);
+            IO_WriteB(VGAREG_DAC_DATA, altBGR1[i].green*63/255);
+            IO_WriteB(VGAREG_DAC_DATA, altBGR1[i].blue*63/255);
+        }
+    }
+}
+
 bool setColors(const char *colorArray, int n) {
     if (IS_PC98_ARCH) return false;
 	const char * nextRGB = colorArray;
@@ -3181,18 +3196,7 @@ bool setColors(const char *colorArray, int n) {
 		altBGR0[i].green = (altBGR1[i].green*2 + 128)/4;
 		altBGR0[i].red = (altBGR1[i].red*2 + 128)/4;
 	}
-    if (ttf.inUse&&CurMode&&IS_VGA_ARCH) {
-        std::map<uint8_t,int> imap;
-        for (uint8_t i = 0; i < 0x10; i++) {
-            IO_ReadB(mem_readw(BIOS_VIDEO_PORT)+6);
-            IO_WriteB(VGAREG_ACTL_ADDRESS, i+32);
-            imap[i]=IO_ReadB(VGAREG_ACTL_READ_DATA);
-            IO_WriteB(VGAREG_DAC_WRITE_ADDRESS, imap[i]);
-            IO_WriteB(VGAREG_DAC_DATA, altBGR1[i].red*63/255);
-            IO_WriteB(VGAREG_DAC_DATA, altBGR1[i].green*63/255);
-            IO_WriteB(VGAREG_DAC_DATA, altBGR1[i].blue*63/255);
-        }
-    }
+    setVGADAC();
     colorChanged=true;
 	return true;
 }

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -1117,14 +1117,18 @@ bool INT10_SetVideoMode_OTHER(uint16_t mode,bool clearmem) {
 }
 
 #if defined(USE_TTF)
-extern bool resetreq;
+extern bool resetreq, colorChanged;
 bool GFX_IsFullscreen(void), Direct3D_using(void);
-void ttf_reset(void), resetFontSize(), OUTPUT_TTF_Select(int fsize), RENDER_Reset(void), KEYBOARD_Clear(), GFX_SwitchFullscreenNoReset(void);
+void ttf_reset(void), resetFontSize(), setVGADAC(), OUTPUT_TTF_Select(int fsize), RENDER_Reset(void), KEYBOARD_Clear(), GFX_SwitchFullscreenNoReset(void);
 #endif
 
 bool unmask_irq0_on_int10_setmode = true;
 bool switch_output_from_ttf = false;
 bool INT10_SetVideoMode(uint16_t mode) {
+    if (CurMode&&CurMode->mode==7&&mode==18) {
+        SetCurMode(svgaCard==SVGA_TsengET4K||svgaCard==SVGA_TsengET3K?ModeList_VGA:(svgaCard==SVGA_ParadisePVGA1A?ModeList_VGA_Paradise:(IS_VGA_ARCH?ModeList_VGA:ModeList_EGA)),3);
+        FinishSetMode(true);
+    }
 	//LOG_MSG("set mode %x",mode);
 	bool clearmem=true;Bitu i;
 	if (mode>=0x100) {
@@ -2014,6 +2018,7 @@ dac_text16:
             ttf_reset();
         else if (switch_output_from_ttf) {
             change_output(10);
+            if (colorChanged) setVGADAC();
             SetVal("sdl", "output", "ttf");
             void OutputSettingMenuUpdate(void);
             OutputSettingMenuUpdate();

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -1125,9 +1125,17 @@ void ttf_reset(void), resetFontSize(), setVGADAC(), OUTPUT_TTF_Select(int fsize)
 bool unmask_irq0_on_int10_setmode = true;
 bool switch_output_from_ttf = false;
 bool INT10_SetVideoMode(uint16_t mode) {
-    if (CurMode&&CurMode->mode==7&&mode==18) {
-        SetCurMode(svgaCard==SVGA_TsengET4K||svgaCard==SVGA_TsengET3K?ModeList_VGA:(svgaCard==SVGA_ParadisePVGA1A?ModeList_VGA_Paradise:(IS_VGA_ARCH?ModeList_VGA:ModeList_EGA)),3);
-        FinishSetMode(true);
+    if (CurMode&&CurMode->mode==7&&!IS_PC98_ARCH) {
+        VideoModeBlock *modelist=svgaCard==SVGA_TsengET4K||svgaCard==SVGA_TsengET3K?ModeList_VGA:(svgaCard==SVGA_ParadisePVGA1A?ModeList_VGA_Paradise:(IS_VGA_ARCH?ModeList_VGA:ModeList_EGA));
+        for (Bitu i = 0; modelist[i].mode != 0xffff; i++) {
+            if (modelist[i].mode == mode) {
+                if (modelist[i].type != M_TEXT) {
+                    SetCurMode(modelist,3);
+                    FinishSetMode(true);
+                }
+                break;
+            }
+        }
     }
 	//LOG_MSG("set mode %x",mode);
 	bool clearmem=true;Bitu i;

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -1103,8 +1103,17 @@ void CONFIG::Run(void) {
 #if defined(C_SDL2)
 							if (!strcasecmp(inputline.substr(0, 16).c_str(), "mapperfile_sdl2=")) ReloadMapper(section,true);
 #else
-							if (!strcasecmp(inputline.substr(0, 11).c_str(), "mapperfile=")) ReloadMapper(section,true);
+							if (!strcasecmp(inputline.substr(0, 16).c_str(), "mapperfile_sdl1=")) ReloadMapper(section,true);
 #if !defined(HAIKU) && !defined(RISCOS)
+							if (!strcasecmp(inputline.substr(0, 11).c_str(), "mapperfile=")) {
+                                Prop_path* pp;
+#if defined(C_SDL2)
+                                pp = section->Get_path("mapperfile_sdl2");
+#else
+                                pp = section->Get_path("mapperfile_sdl1");
+#endif
+                                if (pp->realpath=="") ReloadMapper(section,true);
+                            }
 							if (!strcasecmp(inputline.substr(0, 13).c_str(), "usescancodes=")) {
 								void setScanCode(Section_prop * section), loadScanCode(), GFX_LosingFocus(), MAPPER_Init();
 								setScanCode(section);


### PR DESCRIPTION
This adds support for a single mapper file for both SDL1 and SDL2 builds (divided by sections), which can be specified by a unified mapper_file config option for all builds. SDL-version-specific mapper files can still be specified with mapper_file_sdl1 or mapper_file_sdl2 config options, or the mapper_file config option as well. This solves issue #2045.

Also fixed the color palette problem when switching to graphic mode from mode mono, per issue #2010.