### PR TITLE
Fix TTF with mode mono and improve automountall option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,9 @@
     with the mapperfile config option, or you can set
     the mapperfile_sdl1 and mapperfile_sdl2 config
     options to override mapperfile option. (Wengier)
+  - The functions "Load mapper file" & "Stop clipboard
+    pasting" are added to the mapper so that you can
+    defined shortcut keys for them. (Wengier)
   - Added SETCOLOR command to view or change the text-
     mode color scheme settings. Also fixed the color
     palette for the TTF output. (Wengier)

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -113,7 +113,7 @@ static const char *def_menu_main[] =
 {
     "mapper_gui",
     "mapper_mapper",
-    "load_mapper_file",
+    "mapper_loadmap",
     "--",
     "MainSendKey",
     "MainHostKey",
@@ -204,7 +204,7 @@ static const char *def_menu_main_clipboard[] =
     "mapper_copyall",
 #endif
     "mapper_paste",
-    "clipboard_paste_stop",
+    "mapper_pasteend",
     NULL
 };
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -659,6 +659,12 @@ const char *drive_opts[][2] = {
     { NULL, NULL }
 };
 
+void LoadMapFile(bool bPressed) {
+    if (!bPressed) return;
+    void Load_mapper_file();
+    Load_mapper_file();
+}
+
 void QuickLaunch(bool bPressed) {
     if (!bPressed) return;
     if (dos_kernel_disabled) return;
@@ -928,9 +934,10 @@ void FreeBIOSDiskList();
 void GFX_ShutDown(void);
 void MAPPER_Shutdown();
 void SHELL_Init(void);
+void CopyClipboard(bool all);
 void CopyAllClipboard(bool bPressed);
 void PasteClipboard(bool bPressed);
-void CopyClipboard(bool all);
+void PasteClipStop(bool bPressed);
 
 #if C_DYNAMIC_X86
 void CPU_Core_Dyn_X86_Shutdown(void);
@@ -5133,6 +5140,9 @@ static void GUI_StartUp() {
     item->set_text("Reboot guest system");
 
 #if !defined(HX_DOS)
+    MAPPER_AddHandler(LoadMapFile, MK_nothing, 0, "loadmap", "Load mapper file", &item);
+    item->set_text("Load mapper file...");
+
     MAPPER_AddHandler(QuickLaunch, MK_q, MMODHOST, "quickrun", "Quick launch program", &item);
     item->set_text("Quick launch program...");
 #endif
@@ -5156,6 +5166,9 @@ static void GUI_StartUp() {
 #if defined(C_SDL2) || defined(WIN32) || defined(MACOSX) || defined(LINUX) && C_X11
     MAPPER_AddHandler(PasteClipboard,MK_v,MMODHOST,"paste", "Paste from clipboard", &item); //end emendelson; improved by Wengier
     item->set_text("Pasting from the clipboard");
+
+    MAPPER_AddHandler(PasteClipStop,MK_nothing, 0,"pasteend", "Stop clipboard paste", &item);
+    item->set_text("Stop clipboard pasting");
 #endif
 
     MAPPER_AddHandler(&PauseDOSBox, MK_pause, MMODHOST, "pause", "Pause emulation");
@@ -7943,6 +7956,13 @@ void CopyClipboard(bool all) {
 }
 #endif
 
+#if defined(C_SDL2) || defined (WIN32) || defined(MACOSX) || defined(LINUX) && C_X11
+void PasteClipStop(bool bPressed) {
+    if (!bPressed) return;
+    strPasteBuffer = "";
+}
+#endif
+
 void SDL_OnSectionPropChange(Section *x) {
     (void)x;//UNUSED
     Section_prop * section = static_cast<Section_prop *>(control->GetSection("sdl"));
@@ -9599,10 +9619,7 @@ bool vid_select_ttf_font_menu_callback(DOSBoxMenu* const menu, DOSBoxMenu::item*
 }
 #endif
 
-bool vid_select_mapper_file_menu_callback(DOSBoxMenu* const menu, DOSBoxMenu::item* const menuitem) {
-    (void)menu;//UNUSED
-    (void)menuitem;//UNUSED
-
+void Load_mapper_file() {
     Section_prop* section = static_cast<Section_prop*>(control->GetSection("sdl"));
     assert(section != NULL);
 
@@ -9651,8 +9668,6 @@ bool vid_select_mapper_file_menu_callback(DOSBoxMenu* const menu, DOSBoxMenu::it
     }
     chdir( Temp_CurrentDir );
 #endif
-
-    return true;
 }
 
 bool vid_pc98_graphics_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
@@ -10188,15 +10203,6 @@ bool dos_clipboard_device_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::ite
     if (dos_clipboard_device_access == 4) dos_clipboard_device_access=1;
     else if (dos_clipboard_device_access) dos_clipboard_device_access=4;
     mainMenu.get_item("clipboard_device").check(dos_clipboard_device_access==4&&!control->SecureMode()).refresh_item(mainMenu);
-    return true;
-}
-#endif
-
-#if defined(C_SDL2) || defined (WIN32) || defined(MACOSX) || defined(LINUX) && C_X11
-bool clipboard_paste_stop_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
-    (void)menu;//UNUSED
-    (void)menuitem;//UNUSED
-    strPasteBuffer = "";
     return true;
 }
 #endif
@@ -12150,7 +12156,6 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         /* more */
         std::string doubleBufString = std::string("desktop.doublebuf");
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"showdetails").set_text("Show FPS and RT speed in title bar").set_callback_function(showdetails_menu_callback).check(!menu.hidecycles && !menu.showrt);
-        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"load_mapper_file").set_text("Load mapper file...").set_callback_function(vid_select_mapper_file_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"auto_lock_mouse").set_text("Autolock mouse").set_callback_function(autolock_mouse_menu_callback).check(sdl.mouse.autoenable);
 #if defined (WIN32) || defined(C_SDL2)
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_quick").set_text("Quick edit: copy on select and paste with mouse button").set_callback_function(direct_mouse_clipboard_menu_callback).check(direct_mouse_clipboard);
@@ -12162,9 +12167,6 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         if (control->SecureMode()) clipboard_dosapi = false;
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_device").set_text("Enable DOS clipboard device access").set_callback_function(dos_clipboard_device_menu_callback).check(dos_clipboard_device_access==4&&!control->SecureMode());
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_dosapi").set_text("Enable DOS clipboard API for applications").set_callback_function(dos_clipboard_api_menu_callback).check(clipboard_dosapi);
-#endif
-#if defined (WIN32) || defined(C_SDL2) || defined(MACOSX) || defined(LINUX) && C_X11
-        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_paste_stop").set_text("Stop clipboard pasting").set_callback_function(clipboard_paste_stop_menu_callback);
 #endif
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_winlogo").set_text("Send logo key").set_callback_function(sendkey_preset_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_winmenu").set_text("Send menu key").set_callback_function(sendkey_preset_menu_callback);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3392,12 +3392,9 @@ void OUTPUT_TTF_Select(int fsize=-1) {
                 if (ttf.cols != c || ttf.lins != r) alter_vmode = true;
             }
             if (alter_vmode) {
-                for (Bitu i = 0; ModeList_VGA[i].mode != 0xffff; i++) {										// set the cols and lins in video mode 3
-                    if (ModeList_VGA[i].mode <= 7) {
-                        ModeList_VGA[i].twidth = ttf.cols;
-                        ModeList_VGA[i].theight = ttf.lins;
-                        break;
-                    }
+                for (Bitu i = 0; ModeList_VGA[i].mode <= 7; i++) {								// Set the cols and lins in video mode 2,3,7
+                    ModeList_VGA[i].twidth = ttf.cols;
+                    ModeList_VGA[i].theight = ttf.lins;
                 }
                 if (!IS_PC98_ARCH) {
                     real_writeb(BIOSMEM_SEG,BIOSMEM_NB_COLS,ttf.cols);
@@ -9862,8 +9859,6 @@ void GetMaxWidthHeight(int *pmaxWidth, int *pmaxHeight) {
 }
 
 void ttf_setlines(int cols, int lins) {
-    (void)cols;
-    (void)lins;
     SetVal("render", "ttf.cols", std::to_string(cols));
     SetVal("render", "ttf.lins", std::to_string(lins));
     firstset=true;

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -782,10 +782,9 @@ static void FinishSetMode(bool clearmem) {
         if (ttf.inUse) {
             ttf.cols = CurMode->twidth;
             ttf.lins = CurMode->theight;
-        } else if (firstset && ttf.lins && ttf.cols) {
+        } else if (ttf.lins && ttf.cols && !IS_PC98_ARCH && !IS_VGA_ARCH && CurMode->mode == 3) {
             CurMode->twidth = ttf.cols;
             CurMode->theight = ttf.lins;
-            firstset = false;
         }
     }
 #endif

--- a/src/libs/decoders/dr_mp3.h
+++ b/src/libs/decoders/dr_mp3.h
@@ -1,6 +1,6 @@
 /*
 MP3 audio decoder. Choice of public domain or MIT-0. See license statements at the end of this file.
-dr_mp3 - v0.6.22 - 2020-12-02
+dr_mp3 - v0.6.24 - 2020-12-07
 
 David Reid - mackron@gmail.com
 
@@ -95,7 +95,7 @@ extern "C" {
 
 #define DRMP3_VERSION_MAJOR     0
 #define DRMP3_VERSION_MINOR     6
-#define DRMP3_VERSION_REVISION  22
+#define DRMP3_VERSION_REVISION  23
 #define DRMP3_VERSION_STRING    DRMP3_XSTRINGIFY(DRMP3_VERSION_MAJOR) "." DRMP3_XSTRINGIFY(DRMP3_VERSION_MINOR) "." DRMP3_XSTRINGIFY(DRMP3_VERSION_REVISION)
 
 #include <stddef.h> /* For size_t. */
@@ -2831,7 +2831,7 @@ static drmp3_bool32 drmp3_init_internal(drmp3* pMP3, drmp3_read_proc onRead, drm
 
     /* Decode the first frame to confirm that it is indeed a valid MP3 stream. */
     if (!drmp3_decode_next_frame(pMP3)) {
-        drmp3_uninit(pMP3);
+        drmp3__free_from_callbacks(pMP3->pData, &pMP3->allocationCallbacks);    /* The call above may have allocated memory. Need to make sure it's freed before aborting. */
         return DRMP3_FALSE; /* Not a valid MP3 stream. */
     }
 
@@ -4458,6 +4458,12 @@ counts rather than sample counts.
 /*
 REVISION HISTORY
 ================
+v0.6.24 - 2020-12-07
+  - Fix a typo in version date for 0.6.23.
+
+v0.6.23 - 2020-12-03
+  - Fix an error where a file can be closed twice when initialization of the decoder fails.
+
 v0.6.22 - 2020-12-02
   - Fix an error where it's possible for a file handle to be left open when initialization of the decoder fails.
 

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -551,7 +551,7 @@ private:
 	}
 };
 
-void dos_ver_menu(bool start), ReloadMapper(Section_prop *sec, bool init), SetGameState_Run(int value), update_dos_ems_menu(void);
+void dos_ver_menu(bool start), ReloadMapper(Section_prop *sec, bool init), SetGameState_Run(int value), update_dos_ems_menu(void), MountAllDrives(Program * program);
 bool set_ver(char *s);
 void CONFIG::Run(void) {
 	static const char* const params[] = {
@@ -1152,6 +1152,8 @@ void CONFIG::Run(void) {
 								enable_config_as_shell_commands = section->Get_bool("shell configuration as commands");
 								mainMenu.get_item("shell_config_commands").check(enable_config_as_shell_commands).enable(true).refresh_item(mainMenu);
 #if defined(WIN32) && !defined(HX_DOS)
+                            } else if (!strcasecmp(inputline.substr(0, 13).c_str(), "automountall=")) {
+                                if (section->Get_bool("automountall")) MountAllDrives(this);
                             } else if (!strcasecmp(inputline.substr(0, 9).c_str(), "dos clipboard api=")) {
                                 clipboard_dosapi = section->Get_bool("dos clipboard api");          
 							} else if (!strcasecmp(inputline.substr(0, 9).c_str(), "startcmd=")) {

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -93,6 +93,7 @@ typedef std::list<std::string>::iterator auto_it;
 
 void VFILE_Remove(const char *name);
 
+#if defined(WIN32)
 void MountAllDrives(Program * program) {
     uint32_t drives = GetLogicalDrives();
     char name[4]="A:\\";
@@ -116,6 +117,7 @@ void MountAllDrives(Program * program) {
         }
     }
 }
+#endif
 
 void AutoexecObject::Install(const std::string &in) {
 	if(GCC_UNLIKELY(installed)) E_Exit("autoexec: already created %s",buf.c_str());


### PR DESCRIPTION
This allows ttf.cols and ttf.lins set in the config file to work with MODE MONO. So improved the automountall config option so that you can do this at the run-time in addition to at start.