### PR TITLE
Support for starting DOSBox-X on a specific display

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,12 @@
 0.83.9
+  - Added support for starting DOSBox-X in a specific
+    display on a multi-screen setup (Windows builds as
+    well as Linux/macOS SDL2 builds). A config option
+    "display" is added to the [sdl] section that users
+    can specify a display for the DOSBox-X window to
+    start. The option can be combined with the existing
+    "windowposition" config option to specify the
+    position on the specified display/screen. (Wengier)
   - DOSBox-X will now pop up a message box to inform
     the user when a Direct3D pixel shader is loaded
     from the menu on the Windows platform. (Wengier)

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -12,6 +12,7 @@
 #  windowresolution: Scale the window to this size IF the output device supports hardware scaling.
 #                        (output=surface does not!)
 #    windowposition: Set the window position at startup in the positionX,positionY format (e.g.: 1300,200)
+#           display: Specify a screen/display number to use for a multi-screen setup (0 = default).
 #            output: What video system to use for output.
 #                      Possible values: default, surface, overlay, opengl, openglnb, openglhq, ddraw, ttf.
 #          autolock: Mouse will automatically lock, if you click on the screen. (Press CTRL-F10 to unlock)
@@ -57,6 +58,7 @@ fulldouble        = false
 fullresolution    = desktop
 windowresolution  = original
 windowposition    = 
+display           = 0
 output            = default
 autolock          = false
 #DOSBOX-X-ADV:autolock_feedback = beep

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -12,6 +12,7 @@
 #  windowresolution: Scale the window to this size IF the output device supports hardware scaling.
 #                        (output=surface does not!)
 #    windowposition: Set the window position at startup in the positionX,positionY format (e.g.: 1300,200)
+#           display: Specify a screen/display number to use for a multi-screen setup (0 = default).
 #            output: What video system to use for output.
 #                      Possible values: default, surface, overlay, opengl, openglnb, openglhq, ddraw, ttf.
 #          autolock: Mouse will automatically lock, if you click on the screen. (Press CTRL-F10 to unlock)
@@ -52,6 +53,7 @@ fulldouble        = false
 fullresolution    = desktop
 windowresolution  = original
 windowposition    = 
+display           = 0
 output            = default
 autolock          = false
 clip_mouse_button = right

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -12,6 +12,7 @@
 #  windowresolution: Scale the window to this size IF the output device supports hardware scaling.
 #                        (output=surface does not!)
 #    windowposition: Set the window position at startup in the positionX,positionY format (e.g.: 1300,200)
+#           display: Specify a screen/display number to use for a multi-screen setup (0 = default).
 #            output: What video system to use for output.
 #                      Possible values: default, surface, overlay, opengl, openglnb, openglhq, ddraw, ttf.
 #          autolock: Mouse will automatically lock, if you click on the screen. (Press CTRL-F10 to unlock)
@@ -57,6 +58,7 @@ fulldouble        = false
 fullresolution    = desktop
 windowresolution  = original
 windowposition    = 
+display           = 0
 output            = default
 autolock          = false
 autolock_feedback = beep

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -143,12 +143,12 @@ struct SDL_Block {
     SDL_Window * window = NULL;
     SDL_Renderer * renderer = NULL;
     const char * rendererDriver = NULL;
-    int displayNumber = 0;
     struct {
         SDL_Texture * texture = NULL;
         SDL_PixelFormat * pixelFormat = NULL;
     } texture;
 #endif
+    int displayNumber = 0;
     SDL_cond *cond = NULL;
     struct {
         bool autolock = false;


### PR DESCRIPTION
This adds support for starting the DOSBox-X window on a specific display on a multi-screen setup. It can be used in combination with the existing "windowposition" config option to specify the position on the specified display/screen.

Currently supported in Windows (both SDL1 & SDL2 builds), and SDL2 builds of Linux and macOS platforms.