### PR TITLE
Enhanced file printing options and add read-only option for mounting from menu

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,8 +16,10 @@
     program to open the file if the print output is
     detected to be PCL; "openps" to start a program if
     the print output is detected to be PostScript (PS);
-    "openwith" to start a program otherwise. If any of
-    the specified program cannot be executed, DOSBox-X
+    "openwith" to start a program otherwise. If you'd
+    like to specify parameters then be sure to properly
+    quote the string(s). Furthermore, if any of the
+    specified program(s) cannot be executed, DOSBox-X
     will try to start a program as specified with the
     "openerror" action, or show an error. (Wengier)
   - Implemented file locking support for mounting disk

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,7 +16,10 @@
     program to open the file if the print output is
     detected to be PCL; "openps" to start a program if
     the print output is detected to be PostScript (PS);
-    "openwith" to start a program otherwise. (Wengier)
+    "openwith" to start a program otherwise. If any of
+    the specified program cannot be executed, DOSBox-X
+    will try to start a program as specified with the
+    "openerror" action, or show an error. (Wengier)
   - Implemented file locking support for mounting disk
     image files so that you cannot mount the same disk
     image files in read/write mode at the same time as

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.83.9
+  - Added read-only options to the Drive menu to mount
+    the specified drive in read-only mode. (Wengier)
   - Added support for starting DOSBox-X in a specific
     display on a multi-screen setup (Windows builds as
     well as Linux/macOS SDL2 builds). A config option

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -1608,6 +1608,7 @@ phonebookfile = phonebook-dosbox-x.txt
 #                  openps:<program>: start a program to open the file if the print output is detected to be PostScript.
 #                  openpcl:<program>: start a program to open the file if the print output is detected to be PCL.
 #                  openwith:<program>: start a program to open the file in all other conditions.
+#                  openerror:<program>: start a program to open the file if an error had occurred.
 #                for printer:
 #                  printer still has it's own configuration section above.
 # parallel2: see parallel1

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -595,6 +595,7 @@ phonebookfile = phonebook-dosbox-x.txt
 #                  openps:<program>: start a program to open the file if the print output is detected to be PostScript.
 #                  openpcl:<program>: start a program to open the file if the print output is detected to be PCL.
 #                  openwith:<program>: start a program to open the file in all other conditions.
+#                  openerror:<program>: start a program to open the file if an error had occurred.
 #                for printer:
 #                  printer still has it's own configuration section above.
 # parallel2: see parallel1

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -1608,6 +1608,7 @@ phonebookfile = phonebook-dosbox-x.txt
 #                  openps:<program>: start a program to open the file if the print output is detected to be PostScript.
 #                  openpcl:<program>: start a program to open the file if the print output is detected to be PCL.
 #                  openwith:<program>: start a program to open the file in all other conditions.
+#                  openerror:<program>: start a program to open the file if an error had occurred.
 #                for printer:
 #                  printer still has it's own configuration section above.
 # parallel2: see parallel1

--- a/include/programs.h
+++ b/include/programs.h
@@ -57,6 +57,7 @@ public:
 	bool FindString(char const * const name,std::string & value,bool remove=false);
 	bool FindCommand(unsigned int which,std::string & value);
 	bool FindStringBegin(char const * const begin,std::string & value, bool remove=false);
+	bool FindStringFullBegin(char const * const begin,std::string & value, bool remove=false);
 	bool FindStringRemain(char const * const name,std::string & value);
 	bool FindStringRemainBegin(char const * const name,std::string & value);
 	bool GetStringRemain(std::string & value);

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -3324,9 +3324,13 @@ void DOS_EnableDriveMenu(char drv) {
 		mainMenu.get_item(name).enable(empty).refresh_item(mainMenu);
 		name = std::string("drive_") + drv + "_mountfd";
 		mainMenu.get_item(name).enable(empty).refresh_item(mainMenu);
+		name = std::string("drive_") + drv + "_mountfro";
+		mainMenu.get_item(name).enable(empty).refresh_item(mainMenu);
 		name = std::string("drive_") + drv + "_mountimg";
 		mainMenu.get_item(name).enable(empty).refresh_item(mainMenu);
 		name = std::string("drive_") + drv + "_mountimgs";
+		mainMenu.get_item(name).enable(empty).refresh_item(mainMenu);
+		name = std::string("drive_") + drv + "_mountiro";
 		mainMenu.get_item(name).enable(empty).refresh_item(mainMenu);
 		name = std::string("drive_") + drv + "_unmount";
 		mainMenu.get_item(name).enable(!dos_kernel_disabled && Drives[drv-'A'] != NULL && (drv-'A') != ZDRIVE_NUM).refresh_item(mainMenu);

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -77,6 +77,7 @@ bool startwait = true;
 bool startquiet = false;
 bool mountwarning = true;
 bool qmount = false;
+extern bool mountfro[26], mountiro[26];
 
 void DOS_EnableDriveMenu(char drv);
 void runBoot(const char *str), runMount(const char *str), runImgmount(const char *str), runRescan(const char *str);
@@ -307,7 +308,10 @@ void MountHelper(char drive, const char drive2[DOS_PATHLENGTH], std::string driv
 				return;
 			}
 		}
-	} else newdrive=new localDrive(temp_line.c_str(),sizes[0],bit8size,sizes[2],sizes[3],mediaid,options);
+	} else {
+        newdrive=new localDrive(temp_line.c_str(),sizes[0],bit8size,sizes[2],sizes[3],mediaid,options);
+        newdrive->readonly = mountfro[drive-'A'];
+    }
 
 	if (!newdrive) E_Exit("DOS:Can't create drive");
 	Drives[drive-'A']=newdrive;
@@ -419,7 +423,10 @@ void MenuMountDrive(char drive, const char drive2[DOS_PATHLENGTH]) {
 				return;
 			}
 		}
-	} else newdrive=new localDrive(temp_line.c_str(),sizes[0],bit8size,sizes[2],sizes[3],mediaid,options);
+	} else {
+        newdrive=new localDrive(temp_line.c_str(),sizes[0],bit8size,sizes[2],sizes[3],mediaid,options);
+        newdrive->readonly = mountfro[drive-'A'];
+    }
 
 	if (!newdrive) E_Exit("DOS:Can't create drive");
 	if(error && (type==DRIVE_CDROM)) return;
@@ -508,7 +515,8 @@ void MenuBrowseImageFile(char drive, bool boot, bool multiple) {
 		if (!multiple) strcat(mountstring,"\"");
 		strcat(mountstring,files.size()?files.c_str():lTheOpenFileName);
 		if (!multiple) strcat(mountstring,"\"");
-		if (boot) strcat(mountstring," -U");
+		if (mountiro[drive-'A']) strcat(mountstring," -ro");
+		if (boot) strcat(mountstring," -u");
 		qmount=true;
 		runImgmount(mountstring);
 		qmount=false;
@@ -524,9 +532,9 @@ void MenuBrowseImageFile(char drive, bool boot, bool multiple) {
 			std::string drive_warn="Drive "+std::string(1, drive)+": failed to boot.";
 			tinyfd_messageBox("Error",drive_warn.c_str(),"ok","error", 1);
 		} else if (multiple) {
-			tinyfd_messageBox("Information",("Mounted disk images to Drive "+std::string(1,drive)+":\n"+files).c_str(),"ok","info", 1);
+			tinyfd_messageBox("Information",("Mounted disk images to Drive "+std::string(1,drive)+":\n"+files+(mountiro[drive-'A']?"\n(Read-only mode)":"")).c_str(),"ok","info", 1);
 		} else {
-			tinyfd_messageBox("Information",("Mounted disk image to Drive "+std::string(1,drive)+":\n"+std::string(lTheOpenFileName)).c_str(),"ok","info", 1);
+			tinyfd_messageBox("Information",("Mounted disk image to Drive "+std::string(1,drive)+":\n"+std::string(lTheOpenFileName)+(mountiro[drive-'A']?"\n(Read-only mode)":"")).c_str(),"ok","info", 1);
 		}
 	}
 	chdir( Temp_CurrentDir );

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3485,6 +3485,7 @@ void DOSBOX_SetupConfigSections(void) {
             "    openps:<program>: start a program to open the file if the print output is detected to be PostScript.\n"
             "    openpcl:<program>: start a program to open the file if the print output is detected to be PCL.\n"
             "    openwith:<program>: start a program to open the file in all other conditions.\n"
+            "    openerror:<program>: start a program to open the file if an error had occurred.\n"
             "  for printer:\n"
             "    printer still has it's own configuration section above."
     );

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -54,6 +54,7 @@ extern bool pc98_force_ibm_layout;
 extern bool enable_config_as_shell_commands;
 bool winrun=false, use_save_file=false;
 bool direct_mouse_clipboard=false;
+bool mountfro[26], mountiro[26];
 
 bool OpenGL_using(void), Direct3D_using(void);
 void GFX_OpenGLRedrawScreen(void);
@@ -418,6 +419,17 @@ bool drive_mountfd_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * cons
     return true;
 }
 
+bool drive_mountfro_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+
+    const char *mname = menuitem->get_name().c_str();
+    int drive = mname[6] - 'A';
+    mountfro[drive] = !mountfro[drive];
+    mainMenu.get_item("drive_" + std::string(1, drive + 'A') + "_mountfro").check(mountfro[drive]).refresh_item(mainMenu);
+
+    return true;
+}
+
 bool drive_mountimg_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
     (void)menuitem;//UNUSED
@@ -461,6 +473,18 @@ bool drive_mountimgs_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * co
 
     return true;
 }
+
+bool drive_mountiro_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+
+    const char *mname = menuitem->get_name().c_str();
+    int drive = mname[6] - 'A';
+    mountiro[drive] = !mountiro[drive];
+    mainMenu.get_item("drive_" + std::string(1, drive + 'A') + "_mountiro").check(mountiro[drive]).refresh_item(mainMenu);
+
+    return true;
+}
+
 bool drive_bootimg_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
     (void)menuitem;//UNUSED
@@ -613,9 +637,11 @@ const DOSBoxMenu::callback_t drive_callbacks[] = {
     drive_mounthd_menu_callback,
     drive_mountcd_menu_callback,
     drive_mountfd_menu_callback,
+    drive_mountfro_menu_callback,
     NULL,
     drive_mountimg_menu_callback,
     drive_mountimgs_menu_callback,
+    drive_mountiro_menu_callback,
     NULL,
     drive_unmount_menu_callback,
     drive_rescan_menu_callback,
@@ -657,9 +683,11 @@ const char *drive_opts[][2] = {
 	{ "mounthd",                "Mount folder as hard drive" },
 	{ "mountcd",                "Mount folder as CD drive" },
 	{ "mountfd",                "Mount folder as floppy drive" },
+	{ "mountfro",               "Option: mount folder read-only" },
 	{ "div1",                   "--" },
 	{ "mountimg",               "Mount a disk or CD image file" },
 	{ "mountimgs",              "Mount multiple disk/CD images" },
+	{ "mountiro",               "Option: mount images read-only" },
     { "div2",                   "--" },
     { "unmount",                "Unmount drive" },
     { "rescan",                 "Rescan drive" },
@@ -12051,6 +12079,8 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
             item.set_text("Drive");
 
             for (char c='A';c <= 'Z';c++) {
+                mountfro[c-'A']=false;
+                mountiro[c-'A']=false;
                 std::string dmenu = "Drive";
                 dmenu += c;
 
@@ -12062,7 +12092,8 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 
                 for (size_t i=0;drive_opts[i][0] != NULL;i++) {
                     const std::string name = std::string("drive_") + c + "_" + drive_opts[i][0];
-                    if ((!strcmp(drive_opts[i][0], "boot")||!strcmp(drive_opts[i][0], "bootimg")||!strcmp(drive_opts[i][0], "div3"))&&(c!='A'&&c!='C'&&c!='D')) continue;
+                    if ((!strcmp(drive_opts[i][0], "boot")||!strcmp(drive_opts[i][0], "bootimg")||!strcmp(drive_opts[i][0], "div3"))&&(c!='A'&&c!='C'&&c!='D'))
+                        continue;
                     if (!strcmp(drive_opts[i][1], "--"))
                         mainMenu.alloc_item(DOSBoxMenu::separator_type_id,name);
                     else

--- a/src/hardware/parport/filelpt.cpp
+++ b/src/hardware/parport/filelpt.cpp
@@ -81,16 +81,16 @@ CFileLPT::CFileLPT (Bitu nr, uint8_t initIrq, CommandLine* cmd)
 		filetype = FILE_APPEND;
 	} else filetype = FILE_CAPTURE;
 
-	if (cmd->FindStringBegin("openps:",str,false)) {
+	if (cmd->FindStringFullBegin("openps:",str,false)) {
 		action1 = str.c_str();
     }
-	if (cmd->FindStringBegin("openpcl:",str,false)) {
+	if (cmd->FindStringFullBegin("openpcl:",str,false)) {
 		action2 = str.c_str();
     }
-	if (cmd->FindStringBegin("openwith:",str,false)) {
+	if (cmd->FindStringFullBegin("openwith:",str,false)) {
 		action3 = str.c_str();
     }
-	if (cmd->FindStringBegin("openerror:",str,false)) {
+	if (cmd->FindStringFullBegin("openerror:",str,false)) {
 		action4 = str.c_str();
     }
 
@@ -248,13 +248,25 @@ void CFileLPT::handleUpperEvent(uint16_t type) {
                 std::string action=action1.size()&&isPS?action1:(action2.size()&&isPCL?action2:action3);
                 bool fail=false;
 #if defined(WIN32)
-                fail=(int)ShellExecute(NULL, "open", action.c_str(), name.c_str(), NULL, SW_SHOWNORMAL)<=32;
+                std::size_t found = action.find_first_of(" ");
+                std::string para = name;
+                if (found!=std::string::npos) {
+                    para=action.substr(found+1)+" "+name;
+                    action=action.substr(0, found);
+                }
+                fail=(INT_PTR)ShellExecute(NULL, "open", action.c_str(), para.c_str(), NULL, SW_SHOWNORMAL)<=32;
 #else
                 fail=system((action+" "+name).c_str())!=0;
 #endif
                 if (action4.size()&&fail) {
 #if defined(WIN32)
-                    fail=(int)ShellExecute(NULL, "open", action4.c_str(), name.c_str(), NULL, SW_SHOWNORMAL)<=32;
+                    std::size_t found = action4.find_first_of(" ");
+                    para = name;
+                    if (found!=std::string::npos) {
+                        para=action4.substr(found+1)+" "+name;
+                        action4=action4.substr(0, found);
+                    }
+                    fail=(INT_PTR)ShellExecute(NULL, "open", action4.c_str(), para.c_str(), NULL, SW_SHOWNORMAL)<=32;
 #else
                     fail=system((action4+" "+name).c_str())!=0;
 #endif

--- a/src/hardware/parport/filelpt.h
+++ b/src/hardware/parport/filelpt.h
@@ -38,7 +38,7 @@ public:
 	DFTYPE filetype = (DFTYPE)0;			// which mode to operate in (capture,fileappend,device)
 	FILE* file = NULL;
 	std::string name;			// name of the thing to open
-	std::string action1, action2, action3; // open with a program or batch script
+	std::string action1, action2, action3, action4; // open with a program or batch script
 	bool addFF;					// add a formfeed character before closing the file/device
 	bool addLF;					// if set, add line feed after carriage return if not used by app
 

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1222,6 +1222,33 @@ bool CommandLine::FindStringBegin(char const* const begin,std::string & value, b
     return false;
 }
 
+bool CommandLine::FindStringFullBegin(char const* const begin,std::string & value, bool remove) {
+    size_t len = strlen(begin);
+    for (cmd_it it=cmds.begin();it!=cmds.end();++it) {
+        if (strncmp(begin,(*it).c_str(),len)==0) {
+            bool q=(*it)[len]=='"';
+            value=((*it).c_str() + len + (q?1:0));
+            if (remove) cmds.erase(it);
+            if (q) {
+                std::string str=value;
+                if (str.back()=='"')
+                    value.pop_back();
+                else while (str.size()&&++it!=cmds.end()) {
+                    str=(*it);
+                    if (remove) cmds.erase(it);
+                    value+=" "+str;
+                    if (str.back()=='"') {
+                        value.pop_back();
+                        break;
+                    }
+                }
+            }
+            return true;
+        }
+    }
+    return false;
+}
+
 bool CommandLine::FindStringRemain(char const * const name,std::string & value) {
     cmd_it it;value="";
     if (!FindEntry(name,it)) return false;


### PR DESCRIPTION
This enhanced the file printing options to add a separate error handler action and also to allow parameters to be specified in "openps", "openpcl", "openwith", and "openerror" actions. Quotes are needed in such cases, e.g. openpcl="pcl6 parameter".

Also added options in the Drive menu to allow mounting folders/disk images in read-only mode. 