### PR TITLE
Add new blank disk image size and more

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,13 @@
 0.83.9
   - Added menu option "Create blank disk images..."
     (under "DOS" menu) to create blank floppy or hard
-    disk images of a common disk size, including 1.2MB,
-    1.44MB, 2.88MB for floppy images and 250MB, 520MB,
-    1GB, 2GB, 4GB & 8GB for hard disk images. The 1GB
-    option is also added to IMGMAKE command. (Wengier)
+    disk images of a common disk size, including 360KB,
+    400KB, 720KB, 1.2MB, 1.44MB and 2.88MB for floppy
+    disk images and 250MB, 520MB, 1GB, 2GB, 4GB and 8GB
+    for hard disk images. The 1GB option (-t hd_1gig)
+    is also added to IMGMAKE command. (Wengier)
+  - The Configuration Tool will now be centered within
+    the DOSBox-X window for a better looking. (Wengier)
   - DOSBox-X will now automatically synchronize the
     date/time with the host system by default, which
     can be turned off by setting the new config option
@@ -12,10 +15,6 @@
     or if you manually change the date/time. (Wengier)
   - Improved compatability with Watcom C++ 2.0 when
     long filename (LFN) support is enabled. (Wengier)
-  - Extended parallel (LPT) ports from LPT1-LPT3 to
-    LPT1-LPT9. Since LPT4-9 are not backed by the BIOS,
-    you will need to specify base addresses for these
-    ports if they are enabled. (Wengier)
   - Added read-only options to the Drive menu to mount
     the specified drive in read-only mode. (Wengier)
   - Added support for starting DOSBox-X in a specific
@@ -29,6 +28,9 @@
   - DOSBox-X will now pop up a message box to inform
     the user when a Direct3D pixel shader is loaded
     from the menu on the Windows platform. (Wengier)
+  - Extended parallel (LPT) ports from LPT1-LPT3 to
+    LPT1-LPT9. You can also optionally specify base
+    addresses and IRQs for these ports. (Wengier)
   - Enhanced parallel1-3 config options in [parallel]
     section to allow the generated files to be started
     with the specified action: "openpcl" to start a
@@ -74,7 +76,8 @@
     cache is allocated and to support dual mapping.
   - Added OPL3Duo support, which passes OPL3 output
     to an OPL3Duo Arduino board with a specific
-    configuration if desired. (josephillips85)
+    configuration if desired. Set the config option
+    "oplemu=opl3duoboard" to use it. (josephillips85)
 0.83.8
   - Added support for scalable TrueType font (TTF)
     output for text-mode programs. Set "output=ttf"

--- a/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
+++ b/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
@@ -10,7 +10,7 @@
     <category>Emulation</category>
   </categories>
   <releases>
-          <release version="@PACKAGE_VERSION@" date="2020-12-12"/>
+          <release version="@PACKAGE_VERSION@" date="2020-12-13"/>
   </releases>
   <screenshots>
 	  <screenshot type="default">

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -1613,7 +1613,8 @@ phonebookfile = phonebook-dosbox-x.txt
 #                  openerror:<program>: start a program to open the file if an error had occurred.
 #                for printer:
 #                  printer still has it's own configuration section above.
-#              Note: LPT1-3 are standard LPT ports. For LPT4-9 you will need to specify a base address if enabled.
+#              Note: LPT1-3 are standard LPT ports in DOS, whereas LPT4-9 are extended LPT ports.
+#                    You can optionally specify base addresses and IRQs for them with base: and irq: options.
 # parallel2: see parallel1
 # parallel3: see parallel1
 #DOSBOX-X-ADV:# parallel4: see parallel1

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -598,7 +598,8 @@ phonebookfile = phonebook-dosbox-x.txt
 #                  openerror:<program>: start a program to open the file if an error had occurred.
 #                for printer:
 #                  printer still has it's own configuration section above.
-#              Note: LPT1-3 are standard LPT ports. For LPT4-9 you will need to specify a base address if enabled.
+#              Note: LPT1-3 are standard LPT ports in DOS, whereas LPT4-9 are extended LPT ports.
+#                    You can optionally specify base addresses and IRQs for them with base: and irq: options.
 # parallel2: see parallel1
 # parallel3: see parallel1
 #    dongle: Enable dongle

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -1613,7 +1613,8 @@ phonebookfile = phonebook-dosbox-x.txt
 #                  openerror:<program>: start a program to open the file if an error had occurred.
 #                for printer:
 #                  printer still has it's own configuration section above.
-#              Note: LPT1-3 are standard LPT ports. For LPT4-9 you will need to specify a base address if enabled.
+#              Note: LPT1-3 are standard LPT ports in DOS, whereas LPT4-9 are extended LPT ports.
+#                    You can optionally specify base addresses and IRQs for them with base: and irq: options.
 # parallel2: see parallel1
 # parallel3: see parallel1
 # parallel4: see parallel1

--- a/include/build_timestamp.h
+++ b/include/build_timestamp.h
@@ -1,4 +1,4 @@
 /*auto-generated*/
-#define UPDATED_STR "Dec 12, 2020 11:23:28pm"
-#define GIT_COMMIT_HASH "968170f"
+#define UPDATED_STR "Dec 13, 2020 7:34:05pm"
+#define GIT_COMMIT_HASH "76da114"
 #define COPYRIGHT_END_YEAR "2020"

--- a/include/render.h
+++ b/include/render.h
@@ -98,11 +98,8 @@ typedef struct Render_t {
 		Bitu inHeight, inLine, outLine;
 	} scale;
 	struct {
-		bool invalid;
-		bool nextInvalid;
 		uint8_t *pointer;
 		Bitu width, height;
-		int start_x, past_x, start_y, past_y, curr_y;
 	} cache;
 #if C_OPENGL
 	char* shader_src;

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -75,7 +75,7 @@ public:
 		return false;
 	}
 	bool Write(const uint8_t * data,uint16_t * size) {
-		for(int i = 0; i < 3; i++) {
+		for(int i = 0; i < 9; i++) {
 			// look up a parallel port
 			if(parallelPortObjects[i] != NULL) {
 				// send the data

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3494,7 +3494,8 @@ void DOSBOX_SetupConfigSections(void) {
             "    openerror:<program>: start a program to open the file if an error had occurred.\n"
             "  for printer:\n"
             "    printer still has it's own configuration section above.\n"
-            "Note: LPT1-3 are standard LPT ports. For LPT4-9 you will need to specify a base address if enabled."
+            "Note: LPT1-3 are standard LPT ports in DOS, whereas LPT4-9 are extended LPT ports.\n"
+            "      You can optionally specify base addresses and IRQs for them with base: and irq: options."
     );
     Pstring->SetBasic(true);
     Pstring = secprop->Add_string("parallel2",Property::Changeable::WhenIdle,"disabled");

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -954,7 +954,7 @@ void RENDER_SetForceUpdate(bool f) {
 #if C_OPENGL
 static bool RENDER_GetShader(std::string& shader_path, char *old_src) {
 	char* src;
-	std::stringstream buf, tmp;
+	std::stringstream buf;
 	std::ifstream fshader(shader_path.c_str(), std::ios_base::binary);
 	if (!fshader.is_open()) fshader.open((shader_path + ".glsl").c_str(), std::ios_base::binary);
     bool empty=true;
@@ -962,7 +962,7 @@ static bool RENDER_GetShader(std::string& shader_path, char *old_src) {
         buf << fshader.rdbuf();
         empty=buf.str().empty();
         fshader.close();
-        if (empty) buf.swap(tmp);
+        if (empty) buf=std::stringstream();
     }
 	if (!empty) ;
 	else if (shader_path == "advinterp2x") buf << advinterp2x_glsl;

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -304,34 +304,7 @@ static void RENDER_ClearCacheHandler(const void * src) {
     render.scale.lineHandler( src );
 }
 
-#define RENDER_MAXWIDTH 800
-#define RENDER_MAXHEIGHT 600
 extern void GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused);
-uint8_t rendererCache[RENDER_MAXHEIGHT * RENDER_MAXWIDTH];
-void SimpleRenderer(const void *s) {
-	render.cache.curr_y++;
-	if (render.cache.invalid) {
-		wmemcpy((wchar_t*)render.cache.pointer, (wchar_t*)s, render.cache.width>>1);
-		render.cache.past_y = render.cache.curr_y;
-		render.cache.start_x = 0;
-	} else {
-		uint32_t *cache = (uint32_t *)render.cache.pointer;
-		uint32_t *source = (uint32_t *)s;
-		for (Bitu index = render.cache.width/4; index; index--) {
-			if (*source != *cache) {
-				index *= 4;
-				if ((Bitu)render.cache.start_x > render.cache.width - index)
-					render.cache.start_x = render.cache.width - index;
-				wmemcpy((wchar_t*)cache, (wchar_t*)source, index>>1);
-				render.cache.past_y = render.cache.curr_y;
-				break;
-			}
-			source++;
-			cache++;
-		}
-	}
-	render.cache.pointer += render.cache.width;
-}
 
 bool RENDER_StartUpdate(void) {
     if (GCC_UNLIKELY(render.updating))
@@ -353,20 +326,7 @@ bool RENDER_StartUpdate(void) {
     render.scale.outPitch = 0;
     Scaler_ChangedLines[0] = 0;
     Scaler_ChangedLineIndex = 0;
-#if defined(USE_TTF)
-    if (ttf.inUse) {
-        if (render.cache.nextInvalid) {		// Always do a full screen update
-            render.cache.nextInvalid = false;
-            render.cache.invalid = true;
-            if (!GFX_StartUpdate( render.scale.outWrite, render.scale.outPitch ))
-                return false;
-            RENDER_DrawLine = SimpleRenderer;
-        } else
-            RENDER_DrawLine = RENDER_StartLineHandler;
-    /* Clearing the cache will first process the line to make sure it's never the same */
-    } else
-#endif
-        if (GCC_UNLIKELY( render.scale.clearCache) ) {
+    if (GCC_UNLIKELY( render.scale.clearCache) ) {
 //      LOG_MSG("Clearing cache");
         //Will always have to update the screen with this one anyway, so let's update already
         if (GCC_UNLIKELY(!GFX_StartUpdate( render.scale.outWrite, render.scale.outPitch )))
@@ -836,10 +796,7 @@ forcenormal:
 
     last_gfx_flags = gfx_flags;
 #if defined(USE_TTF)
-    if (sdl.desktop.want_type == SCREEN_TTF) {
-        render.cache.nextInvalid = true;
-        if (resetreq) resetFontSize();
-    }
+    if (sdl.desktop.want_type == SCREEN_TTF && resetreq) resetFontSize();
 #endif
 }
 

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -2053,13 +2053,16 @@ public:
             else if (imghd8gig->isChecked())
                temp="hd_8gig";
             if (temp.size()) {
-#if !defined(HX_DOS)
+#if defined(HX_DOS)
+                char const * lTheSaveFileName = "IMGMAKE.IMG";
+#else
                 char CurrentDir[512];
                 char * Temp_CurrentDir = CurrentDir;
                 getcwd(Temp_CurrentDir, 512);
                 const char *lFilterPatterns[] = {"*.img","*.IMG"};
                 const char *lFilterDescription = "Disk image files (*.img)";
                 char const * lTheSaveFileName = tinyfd_saveFileDialog("Select a disk image file","IMGMAKE.IMG",2,lFilterPatterns,lFilterDescription);
+#endif
                 if (lTheSaveFileName!=NULL) {
                     temp="-force -t "+temp+" "+std::string(lTheSaveFileName);
                     void runImgmake(const char *str);
@@ -2070,7 +2073,6 @@ public:
                     }
                 }
                 chdir( Temp_CurrentDir );
-#endif
             }
             if (shortcut) running = false;
         }

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -116,7 +116,7 @@ const char *aboutmsg = "DOSBox-X version " VERSION " (" SDL_STRING ", "
 #endif
 	"-bit)\nBuild date: " UPDATED_STR "\nCopyright 2011-" COPYRIGHT_END_YEAR " The DOSBox-X Team\nProject maintainer: joncampbell123\nDOSBox-X homepage: https://dosbox-x.com";
 
-const char *intromsg = "Welcome to DOSBox-X, a complete open-source DOS emulator.\nDOSBox-X creates a DOS shell which looks like the plain DOS.\nYou can also run Windows 3.x and 9x inside the DOS machine.";
+const char *intromsg = "Welcome to DOSBox-X, a free and complete DOS emulation package.\nDOSBox-X creates a DOS shell which looks like the plain DOS.\nYou can also run Windows 3.x and 95/98 inside the DOS machine.";
 
 /* Prepare screen for UI */
 void GUI_LoadFonts(void) {
@@ -811,7 +811,7 @@ std::string RestoreName(std::string name) {
     return dispname;
 }
 
-GUI::Checkbox *advopt, *saveall, *imgfd1200, *imgfd1440, *imgfd2880, *imghd250, *imghd520, *imghd1gig, *imghd2gig, *imghd4gig, *imghd8gig;
+GUI::Checkbox *advopt, *saveall, *imgfd360, *imgfd400, *imgfd720, *imgfd1200, *imgfd1440, *imgfd2880, *imghd250, *imghd520, *imghd1gig, *imghd2gig, *imghd4gig, *imghd8gig;
 static std::map< std::vector<GUI::Char>, GUI::ToplevelWindow* > cfg_windows_active;
 
 class HelpWindow : public GUI::MessageBox2 {
@@ -847,6 +847,7 @@ public:
             name += "_CONFIGFILE_HELP";
             setText(MSG_Get(name.c_str()));
         }
+        move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     };
 
     ~HelpWindow() {
@@ -979,6 +980,7 @@ public:
             resize((columns * column_width) + border_left + border_right + 2/*wiw border*/ + /*wiw->vscroll_display_width*//*scrollbar*/ + 10,
                     button_row_y + button_row_h + button_row_padding_y + border_top + border_bottom);
         }
+        move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     ~SectionEditor() {
@@ -1196,6 +1198,7 @@ public:
             resize((columns * column_width) + border_left + border_right + 2/*wiw border*/ + /*wiw->vscroll_display_width*//*scrollbar*/ + 10,
                     button_row_y + button_row_h + button_row_padding_y + border_top + border_bottom);
         }
+        move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     ~ConfigEditor() {
@@ -1281,6 +1284,7 @@ public:
         if (shell_idle) (new GUI::Button(this, 180, 220, "Execute Now"))->addActionHandler(this);
         (closeButton = new GUI::Button(this, 290, 220, "Cancel", 70))->addActionHandler(this);
         (new GUI::Button(this, 360, 220, "OK", 70))->addActionHandler(this);
+        move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     ~AutoexecEditor() {
@@ -1347,6 +1351,7 @@ public:
         saveall->setChecked(section->Get_bool("show advanced options"));
         (new GUI::Button(this, 220, 120, "OK", 70))->addActionHandler(this);
         (new GUI::Button(this, 310, 120, "Cancel", 70))->addActionHandler(this);
+        move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
@@ -1392,6 +1397,7 @@ public:
         name->setText("messages.txt");
         (new GUI::Button(this, 120, 60, "OK", 70))->addActionHandler(this);
         (new GUI::Button(this, 210, 60, "Cancel", 70))->addActionHandler(this);
+        move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
@@ -1450,6 +1456,7 @@ public:
         name->setText(cycles.c_str());
         (new GUI::Button(this, 120, 60, "Cancel", 70))->addActionHandler(this);
         (new GUI::Button(this, 210, 60, "OK", 70))->addActionHandler(this);
+        move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
 
         name->raise(); /* make sure keyboard focus is on the text field, ready for the user */
         name->posToEnd(); /* position the cursor at the end where the user is most likely going to edit */
@@ -1485,6 +1492,7 @@ public:
             name->setText("");
         (new GUI::Button(this, 120, 70, "Cancel", 70))->addActionHandler(this);
         (new GUI::Button(this, 210, 70, "OK", 70))->addActionHandler(this);
+        move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
@@ -1521,6 +1529,7 @@ public:
             name->setText(buffer);
             (new GUI::Button(this, 120, 70, "Cancel", 70))->addActionHandler(this);
             (new GUI::Button(this, 210, 70, "OK", 70))->addActionHandler(this);
+            move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
@@ -1556,6 +1565,7 @@ public:
             name->setText(buffer);
             (new GUI::Button(this, 120, 70, "Cancel", 70))->addActionHandler(this);
             (new GUI::Button(this, 210, 70, "OK", 70))->addActionHandler(this);
+            move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
@@ -1837,35 +1847,80 @@ protected:
     GUI::Input *name;
 public:
     MakeDiskImage(GUI::Screen *parent, int x, int y, const char *title) :
-        ToplevelWindow(parent, x, y, 500, 270, title) {
+        ToplevelWindow(parent, x, y, 500, 300, title) {
             new GUI::Label(this, 100, 30, "Select a floppy disk image size:");
-            imgfd1200 = new GUI::Checkbox(this, 110, 60, "1.2MB");
+            imgfd360 = new GUI::Checkbox(this, 110, 60, "360KB");
+            imgfd360->addActionHandler(this);
+            imgfd400 = new GUI::Checkbox(this, 210, 60, "400KB");
+            imgfd400->addActionHandler(this);
+            imgfd720 = new GUI::Checkbox(this, 310, 60, "720KB");
+            imgfd720->addActionHandler(this);
+            imgfd1200 = new GUI::Checkbox(this, 110, 90, "1.2MB");
             imgfd1200->addActionHandler(this);
-            imgfd1440 = new GUI::Checkbox(this, 210, 60, "1.44MB");
+            imgfd1440 = new GUI::Checkbox(this, 210, 90, "1.44MB");
             imgfd1440->addActionHandler(this);
-            imgfd2880 = new GUI::Checkbox(this, 310, 60, "2.88MB");
+            imgfd2880 = new GUI::Checkbox(this, 310, 90, "2.88MB");
             imgfd2880->addActionHandler(this);
-            new GUI::Label(this, 100, 90, "Select a hard disk image size:");
-            imghd250 = new GUI::Checkbox(this, 110, 120, "250MB");
+            new GUI::Label(this, 100, 120, "Select a hard disk image size:");
+            imghd250 = new GUI::Checkbox(this, 110, 150, "250MB");
             imghd250->addActionHandler(this);
-            imghd520 = new GUI::Checkbox(this, 210, 120, "520MB");
+            imghd520 = new GUI::Checkbox(this, 210, 150, "520MB");
             imghd520->addActionHandler(this);
-            imghd1gig = new GUI::Checkbox(this, 310, 120, "1GB");
+            imghd1gig = new GUI::Checkbox(this, 310, 150, "1GB");
             imghd1gig->addActionHandler(this);
-            imghd2gig = new GUI::Checkbox(this, 110, 150, "2GB");
+            imghd2gig = new GUI::Checkbox(this, 110, 180, "2GB");
             imghd2gig->addActionHandler(this);
-            imghd4gig = new GUI::Checkbox(this, 210, 150, "4GB");
+            imghd4gig = new GUI::Checkbox(this, 210, 180, "4GB");
             imghd4gig->addActionHandler(this);
-            imghd8gig = new GUI::Checkbox(this, 310, 150, "8GB");
+            imghd8gig = new GUI::Checkbox(this, 310, 180, "8GB");
             imghd8gig->addActionHandler(this);
-            (new GUI::Button(this, 160, 190, "OK", 70))->addActionHandler(this);
-            (new GUI::Button(this, 260, 190, "Close", 70))->addActionHandler(this);
+            (new GUI::Button(this, 160, 220, "OK", 70))->addActionHandler(this);
+            (new GUI::Button(this, 260, 220, "Cancel", 70))->addActionHandler(this);
             move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
         (void)b;//UNUSED
-        if (arg == "1.2MB" && imgfd1200->isChecked()) {
+        if (arg == "360KB" && imgfd360->isChecked()) {
+            imgfd400->setChecked(false);
+            imgfd720->setChecked(false);
+            imgfd1200->setChecked(false);
+            imgfd1440->setChecked(false);
+            imgfd2880->setChecked(false);
+            imghd250->setChecked(false);
+            imghd520->setChecked(false);
+            imghd1gig->setChecked(false);
+            imghd2gig->setChecked(false);
+            imghd4gig->setChecked(false);
+            imghd8gig->setChecked(false);
+        } else if (arg == "720KB" && imgfd720->isChecked()) {
+            imgfd360->setChecked(false);
+            imgfd400->setChecked(false);
+            imgfd1200->setChecked(false);
+            imgfd1440->setChecked(false);
+            imgfd2880->setChecked(false);
+            imghd250->setChecked(false);
+            imghd520->setChecked(false);
+            imghd1gig->setChecked(false);
+            imghd2gig->setChecked(false);
+            imghd4gig->setChecked(false);
+            imghd8gig->setChecked(false);
+        } else if (arg == "400KB" && imgfd400->isChecked()) {
+            imgfd360->setChecked(false);
+            imgfd720->setChecked(false);
+            imgfd1200->setChecked(false);
+            imgfd1440->setChecked(false);
+            imgfd2880->setChecked(false);
+            imghd250->setChecked(false);
+            imghd520->setChecked(false);
+            imghd1gig->setChecked(false);
+            imghd2gig->setChecked(false);
+            imghd4gig->setChecked(false);
+            imghd8gig->setChecked(false);
+        } else if (arg == "1.2MB" && imgfd1200->isChecked()) {
+            imgfd360->setChecked(false);
+            imgfd400->setChecked(false);
+            imgfd720->setChecked(false);
             imgfd1440->setChecked(false);
             imgfd2880->setChecked(false);
             imghd250->setChecked(false);
@@ -1875,6 +1930,9 @@ public:
             imghd4gig->setChecked(false);
             imghd8gig->setChecked(false);
         } else if (arg == "1.44MB" && imgfd1440->isChecked()) {
+            imgfd360->setChecked(false);
+            imgfd400->setChecked(false);
+            imgfd720->setChecked(false);
             imgfd1200->setChecked(false);
             imgfd2880->setChecked(false);
             imghd250->setChecked(false);
@@ -1884,6 +1942,9 @@ public:
             imghd4gig->setChecked(false);
             imghd8gig->setChecked(false);
         } else if (arg == "2.88MB" && imgfd2880->isChecked()) {
+            imgfd360->setChecked(false);
+            imgfd400->setChecked(false);
+            imgfd720->setChecked(false);
             imgfd1200->setChecked(false);
             imgfd1440->setChecked(false);
             imghd250->setChecked(false);
@@ -1893,6 +1954,9 @@ public:
             imghd4gig->setChecked(false);
             imghd8gig->setChecked(false);
         } else if (arg == "250MB" && imghd250->isChecked()) {
+            imgfd360->setChecked(false);
+            imgfd400->setChecked(false);
+            imgfd720->setChecked(false);
             imgfd1200->setChecked(false);
             imgfd1440->setChecked(false);
             imgfd2880->setChecked(false);
@@ -1902,6 +1966,9 @@ public:
             imghd4gig->setChecked(false);
             imghd8gig->setChecked(false);
         } else if (arg == "520MB" && imghd520->isChecked()) {
+            imgfd360->setChecked(false);
+            imgfd400->setChecked(false);
+            imgfd720->setChecked(false);
             imgfd1200->setChecked(false);
             imgfd1440->setChecked(false);
             imgfd2880->setChecked(false);
@@ -1911,6 +1978,9 @@ public:
             imghd4gig->setChecked(false);
             imghd8gig->setChecked(false);
         } else if (arg == "1GB" && imghd1gig->isChecked()) {
+            imgfd360->setChecked(false);
+            imgfd400->setChecked(false);
+            imgfd720->setChecked(false);
             imgfd1200->setChecked(false);
             imgfd1440->setChecked(false);
             imgfd2880->setChecked(false);
@@ -1920,6 +1990,9 @@ public:
             imghd4gig->setChecked(false);
             imghd8gig->setChecked(false);
         } else if (arg == "2GB" && imghd2gig->isChecked()) {
+            imgfd360->setChecked(false);
+            imgfd400->setChecked(false);
+            imgfd720->setChecked(false);
             imgfd1200->setChecked(false);
             imgfd1440->setChecked(false);
             imgfd2880->setChecked(false);
@@ -1929,6 +2002,9 @@ public:
             imghd4gig->setChecked(false);
             imghd8gig->setChecked(false);
         } else if (arg == "4GB" && imghd4gig->isChecked()) {
+            imgfd360->setChecked(false);
+            imgfd400->setChecked(false);
+            imgfd720->setChecked(false);
             imgfd1200->setChecked(false);
             imgfd1440->setChecked(false);
             imgfd2880->setChecked(false);
@@ -1938,6 +2014,9 @@ public:
             imghd2gig->setChecked(false);
             imghd8gig->setChecked(false);
         } else if (arg == "8GB" && imghd8gig->isChecked()) {
+            imgfd360->setChecked(false);
+            imgfd400->setChecked(false);
+            imgfd720->setChecked(false);
             imgfd1200->setChecked(false);
             imgfd1440->setChecked(false);
             imgfd2880->setChecked(false);
@@ -1949,7 +2028,13 @@ public:
         }
         if (arg == "OK") {
             std::string temp="";
-            if (imgfd1200->isChecked())
+            if (imgfd360->isChecked())
+               temp="fd_360";
+            else if (imgfd400->isChecked())
+               temp="fd_400";
+            else if (imgfd720->isChecked())
+               temp="fd_720";
+            else if (imgfd1200->isChecked())
                temp="fd_1200";
             else if (imgfd1440->isChecked())
                temp="fd_1440";
@@ -1989,7 +2074,7 @@ public:
             }
             if (shortcut) running = false;
         }
-        else if (arg == "Close") {
+        else if (arg == "Close" || arg == "Cancel") {
             close();
             if (shortcut) running = false;
         }
@@ -2170,6 +2255,7 @@ public:
                closerow_y + closeButton->getHeight() + 12 + border_top + border_bottom);
 
         bar->resize(getWidth(),bar->getHeight());
+        move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
     ~ConfigurationWindow() { running = false; cfg_windows_active.clear(); }
@@ -2242,9 +2328,11 @@ public:
             system(("open "+url).c_str());
 #endif
         } else if (arg == "About") {
-            new GUI::MessageBox2(getScreen(), 100, 150, 330, "About DOSBox-X", aboutmsg);
+            //new GUI::MessageBox2(getScreen(), 100, 150, 330, "About DOSBox-X", aboutmsg);
+            new GUI::MessageBox2(getScreen(), getScreen()->getWidth()>330?(parent->getWidth()-330)/2:0, 150, 330, "About DOSBox-X", aboutmsg);
         } else if (arg == "Introduction") {
-            new GUI::MessageBox2(getScreen(), 20, 50, 540, "Introduction", intromsg);
+            //new GUI::MessageBox2(getScreen(), 20, 50, 540, "Introduction", intromsg);
+            new GUI::MessageBox2(getScreen(), getScreen()->getWidth()>540?(parent->getWidth()-540)/2:0, 50, 540, "Introduction", intromsg);
         } else if (arg == "Getting Started") {
             std::string msg = MSG_Get("PROGRAM_INTRO_MOUNT_START");
 #ifdef WIN32
@@ -2254,9 +2342,11 @@ public:
 #endif
             msg += MSG_Get("PROGRAM_INTRO_MOUNT_END");
 
-            new GUI::MessageBox2(getScreen(), 0, 50, 680, std::string("Getting Started"), msg);
+            //new GUI::MessageBox2(getScreen(), 0, 50, 680, std::string("Getting Started"), msg);
+            new GUI::MessageBox2(getScreen(), getScreen()->getWidth()>680?(parent->getWidth()-680)/2:0, 50, 680, std::string("Getting Started"), msg);
         } else if (arg == "CD-ROM Support") {
-            new GUI::MessageBox2(getScreen(), 20, 50, 640, "CD-ROM Support", MSG_Get("PROGRAM_INTRO_CDROM"));
+            //new GUI::MessageBox2(getScreen(), 20, 50, 640, "CD-ROM Support", MSG_Get("PROGRAM_INTRO_CDROM"));
+            new GUI::MessageBox2(getScreen(), getScreen()->getWidth()>640?(parent->getWidth()-640)/2:0, 50, 640, "CD-ROM Support", MSG_Get("PROGRAM_INTRO_CDROM"));
         } else if (arg == "Save...") {
             new SaveDialog(getScreen(), 50, 100, "Save Configuration...");
         } else if (arg == "Save Language File...") {

--- a/src/gui/whereami.c
+++ b/src/gui/whereami.c
@@ -265,7 +265,11 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
       if (!fgets(buffer, sizeof(buffer), maps))
         break;
 
-      if (sscanf(buffer, "%" PRIx64 "-%" PRIx64 " %s %" PRIx64 " %x:%x %u %s\n", &low, &high, perms, &offset, &major, &minor, &inode, path) == 8)
+#if !defined(PRIx64)
+#define PRIx64 "lx"
+#endif
+      std::string format = std::string("%") + PRIx64 + std::string("-%") + PRIx64 + std::string(" %s %") + PRIx64 + std::string(" %x:%x %u %s\n");
+      if (sscanf(buffer, format.c_str(), &low, &high, perms, &offset, &major, &minor, &inode, path) == 8)
       {
         uint64_t addr = (uintptr_t)WAI_RETURN_ADDRESS();
         if (low <= addr && addr <= high)

--- a/src/hardware/parport/parport.cpp
+++ b/src/hardware/parport/parport.cpp
@@ -350,10 +350,6 @@ public:
             if(cmd.FindStringBegin("irq:",str,true))
 				defaultirq[i] = strtol(str.c_str(), NULL, 10);
 			cmd.FindCommand(1,str);
-            if (parallel_baseaddr[i]==0) {
-				if (str!="disabled") LOG_MSG("LPT%d: A valid base address is required",(int)i+1);
-				parallelPortObjects[i] = 0;
-            } else
 #if C_DIRECTLPT
 			if(str=="reallpt") {
 				CDirectLPT* cdlpt= new CDirectLPT(i, defaultirq[i],&cmd);

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -2999,176 +2999,6 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
         BIOS_HostTimeSync();
     }
 
-#if defined(USE_TTF)
-    if (ttf.inUse) {
-		GFX_StartUpdate(render.scale.outWrite, render.scale.outPitch);
-		vga.draw.blink = ((vga.draw.blinking & time(NULL)) || !vga.draw.blinking) ? true : false;	// eventually blink once per second
-		vga.draw.cursor.address = vga.config.cursor_start*2;
-		Bitu vidstart = vga.config.real_start + vga.draw.bytes_skip;
-		vidstart *= 2;
-
-		ttf_cell* draw = newAttrChar;
-
-        if (IS_PC98_ARCH) {
-            const uint16_t* charram = (uint16_t*)&vga.draw.linear_base[0x0000];         // character data
-            const uint16_t* attrram = (uint16_t*)&vga.draw.linear_base[0x2000];         // attribute data
-            uint16_t uname[4];
-
-            // TTF output only looks at VGA emulation state for cursor status,
-            // which PC-98 mode does not update.
-            vga.draw.cursor.enabled = pc98_gdc[GDC_MASTER].cursor_enable;
-
-            for (Bitu blocks = ttf.cols * ttf.lins; blocks; blocks--) {
-                bool dbw=false;
-
-                *draw = ttf_cell();
-
-                /* NTS: PC-98 hardware does not require both cells of a double-wide to match,
-                 *      in fact if the hardware sees a double-wide in the first cell it will just render the double-wide
-                 *      for two cells and ignore the second cell. There are some exceptions though, including the custom
-                 *      modificable cells in RAM (responsible for such bugs as the Touhou Project ~idnight level name display bug). */
-                if (*charram & 0xFF00u) {
-                    if ((*charram & 0x7Cu) == 0x08u) {
-                        /* Single wide, yet DBCS encoding.
-                         * This includes proprietary box characters specific to PC-98 */
-                        // Manually convert box characters to Unicode for now
-                        if (*charram==0x330B) // ASCII 201
-                            (*draw).chr=0x250C;
-                        else if (*charram==0x250B) // ASCII 205
-                            (*draw).chr=0x2500;
-                        else if (*charram==0x370B) // ASCII 187
-                            (*draw).chr=0x2510;
-                        else if (*charram==0x270B) // ASCII 186
-                            (*draw).chr=0x2502;
-                        else if (*charram==0x3B0B) // ASCII 200
-                            (*draw).chr=0x2514;
-                        else if (*charram==0x3F0B) // ASCII 188
-                            (*draw).chr=0x2518;
-                        else
-                            (*draw).chr=' ';
-                        (*draw).unicode=1;
-                    }
-                    else {
-                        uint16_t ch = *charram&0x7F7Fu;
-                        uint8_t j1=(ch%0x100)+0x20, j2=ch/0x100;
-                        if (j1>32&&j1<127&&j2>32&&j2<127) {
-                            char text[3];
-                            text[0]=(j1+1)/2+(j1<95?112:176);
-                            text[1]=j2+(j1%2?31+(j2/96):126);
-                            text[2]=0;
-                            uname[0]=0;
-                            uname[1]=0;
-                            CodePageGuestToHostUint16(uname,text);
-                            if (uname[0]!=0&&uname[1]==0) {
-                                (*draw).chr=uname[0];
-                                (*draw).doublewide=1;
-                                (*draw).unicode=1;
-                                dbw=true;
-                            }
-                            else {
-                                (*draw).chr=' ';
-                            }
-                        } else {
-                            (*draw).chr=' ';
-                        }
-                    }
-                } else
-                    (*draw).chr = *charram & 0xFF;
-                charram++;
-
-                Bitu attr = *attrram;
-                attrram++;
-                // for simplicity at this time, just map PC-98 attributes to VGA colors. Wengier and I can clean this up later --J.C.
-                Bitu background = 0;
-                Bitu foreground = 0;
-                // PC-98 does not use RGB, it uses GRB. Remap accordingly.
-                if (attr & 0x80) foreground += 2;
-                if (attr & 0x40) foreground += 4;
-                if (attr & 0x20) foreground += 1;
-                if (foreground) foreground += 8; // everything is fullbright on PC-98
-
-                if (attr & 8) {//underline
-                    // TODO
-                }
-                if (attr & 4) {//reverse
-                    background = foreground;
-                    foreground = 0;
-                }
-                if (attr & 2) {//blink
-                    // TODO
-                }
-                if (!(attr & 1)) {//invisible
-                    (*draw).chr = 0x20;
-                }
-                (*draw).fg = foreground;
-                (*draw).bg = background;
-                draw++;
-
-                if (dbw) {
-                    /* extra cell. Should not draw */
-                    *draw = ttf_cell();
-                    (*draw).skipped = 1;
-                    (*draw).chr = 'x'; // should not see this
-                    (*draw).fg = 4|8; // bright red, in case this is visible
-                    (*draw).bg = 4; // dark red, in case this is visible
-                    draw++;
-                    charram++;
-                    attrram++;
-                    if (blocks != 0) blocks--; /* careful! The for loop is written to stop when blocks == 0 */
-                }
-            }
-        } else if (CurMode&&CurMode->type==M_TEXT) {
-            if (IS_EGAVGA_ARCH) {
-                for (Bitu row=0;row < ttf.lins;row++) {
-                    const uint32_t* vidmem = ((uint32_t*)vga.draw.linear_base)+vidstart;	// pointer to chars+attribs (EGA/VGA planar memory)
-                    for (Bitu col=0;col < ttf.cols;col++) {
-                        // NTS: Note this assumes EGA/VGA text mode that uses the "Odd/Even" mode memory mapping scheme to present video memory
-                        //      to the CPU as if CGA compatible text mode. Character data on plane 0, attributes on plane 1.
-                        *draw = ttf_cell();
-                        (*draw).chr = *vidmem & 0xFF;
-                        Bitu attr = (*vidmem >> 8u) & 0xFFu;
-                        vidmem+=2; // because planar EGA/VGA, and odd/even mode as real hardware arranges alphanumeric mode in VRAM
-                        Bitu background = attr >> 4;
-                        if (vga.draw.blinking)									// if blinking is enabled bit7 is not mapped to attributes
-                            background &= 7;
-                        // choose foreground color if blinking not set for this cell or blink on
-                        Bitu foreground = (vga.draw.blink || (!(attr&0x80))) ? (attr&0xf) : background;
-                        // How about underline?
-                        (*draw).fg = foreground;
-                        (*draw).bg = background;
-                        draw++;
-                    }
-                    vidstart += vga.draw.address_add;
-                }
-            } else {
-                for (Bitu row=0;row < ttf.lins;row++) {
-                    const uint16_t* vidmem = (uint16_t*)VGA_Text_Memwrap(vidstart);	// pointer to chars+attribs (EGA/VGA planar memory)
-                    for (Bitu col=0;col < ttf.cols;col++) {
-                        *draw = ttf_cell();
-                        (*draw).chr = *vidmem;
-                        Bitu attr = (*vidmem >> 8u) & 0xFFu;
-                        vidmem++;
-                        Bitu background = attr >> 4;
-                        if (vga.draw.blinking)									// if blinking is enabled bit7 is not mapped to attributes
-                            background &= 7;
-                        // choose foreground color if blinking not set for this cell or blink on
-                        Bitu foreground = (vga.draw.blink || (!(attr&0x80))) ? (attr&0xf) : background;
-                        // How about underline?
-                        (*draw).fg = foreground;
-                        (*draw).bg = background;
-                        draw++;
-                    }
-                    vidstart += vga.draw.address_add;
-                }
-            }
-        }
-
-		render.cache.past_y = 1;
-		RENDER_EndUpdate(false);
-		return;
-	}
-#endif
-
     vga.draw.address_line = vga.config.hlines_skip;
     if (IS_EGAVGA_ARCH) VGA_Update_SplitLineCompare();
     vga.draw.address = vga.config.real_start;
@@ -3391,6 +3221,172 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
         else PIC_AddEvent(VGA_DrawSingleLine,(float)(vga.draw.delay.htotal/4.0 + draw_skip));
         break;
     }
+
+#if defined(USE_TTF)
+    if (ttf.inUse) {
+        GFX_StartUpdate(render.scale.outWrite, render.scale.outPitch);
+        vga.draw.blink = ((vga.draw.blinking & time(NULL)) || !vga.draw.blinking) ? true : false;	// eventually blink once per second
+        vga.draw.cursor.address = vga.config.cursor_start*2;
+        Bitu vidstart = vga.config.real_start + vga.draw.bytes_skip;
+        vidstart *= 2;
+        ttf_cell* draw = newAttrChar;
+
+        if (IS_PC98_ARCH) {
+            const uint16_t* charram = (uint16_t*)&vga.draw.linear_base[0x0000];         // character data
+            const uint16_t* attrram = (uint16_t*)&vga.draw.linear_base[0x2000];         // attribute data
+            uint16_t uname[4];
+
+            // TTF output only looks at VGA emulation state for cursor status,
+            // which PC-98 mode does not update.
+            vga.draw.cursor.enabled = pc98_gdc[GDC_MASTER].cursor_enable;
+
+            for (Bitu blocks = ttf.cols * ttf.lins; blocks; blocks--) {
+                bool dbw=false;
+
+                *draw = ttf_cell();
+
+                /* NTS: PC-98 hardware does not require both cells of a double-wide to match,
+                 *      in fact if the hardware sees a double-wide in the first cell it will just render the double-wide
+                 *      for two cells and ignore the second cell. There are some exceptions though, including the custom
+                 *      modificable cells in RAM (responsible for such bugs as the Touhou Project ~idnight level name display bug). */
+                if (*charram & 0xFF00u) {
+                    if ((*charram & 0x7Cu) == 0x08u) {
+                        /* Single wide, yet DBCS encoding.
+                         * This includes proprietary box characters specific to PC-98 */
+                        // Manually convert box characters to Unicode for now
+                        if (*charram==0x330B) // ASCII 201
+                            (*draw).chr=0x250C;
+                        else if (*charram==0x250B) // ASCII 205
+                            (*draw).chr=0x2500;
+                        else if (*charram==0x370B) // ASCII 187
+                            (*draw).chr=0x2510;
+                        else if (*charram==0x270B) // ASCII 186
+                            (*draw).chr=0x2502;
+                        else if (*charram==0x3B0B) // ASCII 200
+                            (*draw).chr=0x2514;
+                        else if (*charram==0x3F0B) // ASCII 188
+                            (*draw).chr=0x2518;
+                        else
+                            (*draw).chr=' ';
+                        (*draw).unicode=1;
+                    }
+                    else {
+                        uint16_t ch = *charram&0x7F7Fu;
+                        uint8_t j1=(ch%0x100)+0x20, j2=ch/0x100;
+                        if (j1>32&&j1<127&&j2>32&&j2<127) {
+                            char text[3];
+                            text[0]=(j1+1)/2+(j1<95?112:176);
+                            text[1]=j2+(j1%2?31+(j2/96):126);
+                            text[2]=0;
+                            uname[0]=0;
+                            uname[1]=0;
+                            CodePageGuestToHostUint16(uname,text);
+                            if (uname[0]!=0&&uname[1]==0) {
+                                (*draw).chr=uname[0];
+                                (*draw).doublewide=1;
+                                (*draw).unicode=1;
+                                dbw=true;
+                            }
+                            else {
+                                (*draw).chr=' ';
+                            }
+                        } else {
+                            (*draw).chr=' ';
+                        }
+                    }
+                } else
+                    (*draw).chr = *charram & 0xFF;
+                charram++;
+
+                Bitu attr = *attrram;
+                attrram++;
+                // for simplicity at this time, just map PC-98 attributes to VGA colors. Wengier and I can clean this up later --J.C.
+                Bitu background = 0;
+                Bitu foreground = 0;
+                // PC-98 does not use RGB, it uses GRB. Remap accordingly.
+                if (attr & 0x80) foreground += 2;
+                if (attr & 0x40) foreground += 4;
+                if (attr & 0x20) foreground += 1;
+                if (foreground) foreground += 8; // everything is fullbright on PC-98
+
+                if (attr & 8) {//underline
+                    // TODO
+                }
+                if (attr & 4) {//reverse
+                    background = foreground;
+                    foreground = 0;
+                }
+                if (attr & 2) {//blink
+                    // TODO
+                }
+                if (!(attr & 1)) {//invisible
+                    (*draw).chr = 0x20;
+                }
+                (*draw).fg = foreground;
+                (*draw).bg = background;
+                draw++;
+
+                if (dbw) {
+                    /* extra cell. Should not draw */
+                    *draw = ttf_cell();
+                    (*draw).skipped = 1;
+                    (*draw).chr = 'x'; // should not see this
+                    (*draw).fg = 4|8; // bright red, in case this is visible
+                    (*draw).bg = 4; // dark red, in case this is visible
+                    draw++;
+                    charram++;
+                    attrram++;
+                    if (blocks != 0) blocks--; /* careful! The for loop is written to stop when blocks == 0 */
+                }
+            }
+        } else if (CurMode&&CurMode->type==M_TEXT) {
+            if (IS_EGAVGA_ARCH) {
+                for (Bitu row=0;row < ttf.lins;row++) {
+                    const uint32_t* vidmem = ((uint32_t*)vga.draw.linear_base)+vidstart;	// pointer to chars+attribs (EGA/VGA planar memory)
+                    for (Bitu col=0;col < ttf.cols;col++) {
+                        // NTS: Note this assumes EGA/VGA text mode that uses the "Odd/Even" mode memory mapping scheme to present video memory
+                        //      to the CPU as if CGA compatible text mode. Character data on plane 0, attributes on plane 1.
+                        *draw = ttf_cell();
+                        (*draw).chr = *vidmem & 0xFF;
+                        Bitu attr = (*vidmem >> 8u) & 0xFFu;
+                        vidmem+=2; // because planar EGA/VGA, and odd/even mode as real hardware arranges alphanumeric mode in VRAM
+                        Bitu background = attr >> 4;
+                        if (vga.draw.blinking)									// if blinking is enabled bit7 is not mapped to attributes
+                            background &= 7;
+                        // choose foreground color if blinking not set for this cell or blink on
+                        Bitu foreground = (vga.draw.blink || (!(attr&0x80))) ? (attr&0xf) : background;
+                        // How about underline?
+                        (*draw).fg = foreground;
+                        (*draw).bg = background;
+                        draw++;
+                    }
+                    vidstart += vga.draw.address_add;
+                }
+            } else {
+                for (Bitu row=0;row < ttf.lins;row++) {
+                    const uint16_t* vidmem = (uint16_t*)VGA_Text_Memwrap(vidstart);	// pointer to chars+attribs (EGA/VGA planar memory)
+                    for (Bitu col=0;col < ttf.cols;col++) {
+                        *draw = ttf_cell();
+                        (*draw).chr = *vidmem;
+                        Bitu attr = (*vidmem >> 8u) & 0xFFu;
+                        vidmem++;
+                        Bitu background = attr >> 4;
+                        if (vga.draw.blinking)									// if blinking is enabled bit7 is not mapped to attributes
+                            background &= 7;
+                        // choose foreground color if blinking not set for this cell or blink on
+                        Bitu foreground = (vga.draw.blink || (!(attr&0x80))) ? (attr&0xf) : background;
+                        // How about underline?
+                        (*draw).fg = foreground;
+                        (*draw).bg = background;
+                        draw++;
+                    }
+                    vidstart += vga.draw.address_add;
+                }
+            }
+        }
+        RENDER_EndUpdate(false);
+    }
+#endif
 }
 
 void VGA_CheckScanLength(void) {


### PR DESCRIPTION
This adds 360KB, 400KB and 720KB as the blank floppy disk image size, as discussed in Issue #1988. Also centered the Configuration Tool UI for a better looking, made the LPT4-9 base address optional, along with some other cleanups.