### PR TITLE
TTF output auto-switch in PC98 mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -74,6 +74,8 @@
     section are being ignored. (Wengier)
   - Improved the dynamic core including the way its
     cache is allocated and to support dual mapping.
+  - Added support for automatic switching from TTF
+    ouptut to another output in PC-98 mode. (Wengier)
   - Added OPL3Duo support, which passes OPL3 output
     to an OPL3Duo Arduino board with a specific
     configuration if desired. Set the config option

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -919,7 +919,10 @@ static bool RENDER_GetShader(std::string& shader_path, char *old_src) {
         buf << fshader.rdbuf();
         empty=buf.str().empty();
         fshader.close();
-        if (empty) buf=std::stringstream();
+        if (empty) {
+            buf.clear();
+            buf.str("");
+        }
     }
 	if (!empty) ;
 	else if (shader_path == "advinterp2x") buf << advinterp2x_glsl;

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -595,68 +595,7 @@ static void CAPTURE_AddAviChunk(const char * tag, uint32_t size, void * data, ui
 #endif
 
 #if defined(USE_TTF)
-extern int switchoutput;
-extern bool resetreq;
-bool Direct3D_using(void);
-void resetFontSize(), OUTPUT_TTF_Select(int fsize), RENDER_Reset(void), KEYBOARD_Clear(void), change_output(int output);
-bool ttfswitch=false;
-
-void ttf_switch_off() {
-    if (ttf.inUse) {
-        std::string output="surface";
-        int out=switchoutput;
-        if (switchoutput==0)
-            output = "surface";
-#if C_OPENGL
-        else if (switchoutput==3)
-            output = "opengl";
-        else if (switchoutput==4)
-            output = "openglnb";
-#endif
-#if C_DIRECT3D
-        else if (switchoutput==5)
-            output = "direct3d";
-#endif
-        else {
-#if C_DIRECT3D
-            out = 5;
-            output = "direct3d";
-#elif C_OPENGL
-            out = 3;
-            output = "opengl";
-#else
-            out = 0;
-            output = "surface";
-#endif
-        }
-        KEYBOARD_Clear();
-        change_output(out);
-        SetVal("sdl", "output", output);
-        void OutputSettingMenuUpdate(void);
-        OutputSettingMenuUpdate();
-        ttfswitch = true;
-        //if (GFX_IsFullscreen()) GFX_SwitchFullscreenNoReset();
-        mainMenu.get_item("output_ttf").enable(false).refresh_item(mainMenu);
-        RENDER_Reset();
-    }
-}
-
-void ttf_switch_on() {
-    if (ttfswitch && !(CaptureState & CAPTURE_IMAGE) && !(CaptureState & CAPTURE_VIDEO)) {
-        change_output(10);
-        SetVal("sdl", "output", "ttf");
-        void OutputSettingMenuUpdate(void);
-        OutputSettingMenuUpdate();
-        ttfswitch = false;
-        mainMenu.get_item("output_ttf").enable(true).refresh_item(mainMenu);
-        if (ttf.fullScrn) {
-            if (!GFX_IsFullscreen()) GFX_SwitchFullscreenNoReset();
-            OUTPUT_TTF_Select(2);
-            resetreq = true;
-        }
-        resetFontSize();
-    }
-}
+void ttf_switch_on(bool ss=true), ttf_switch_off(bool ss=true);
 #endif
 
 #if (C_SSHOT)
@@ -697,12 +636,14 @@ void CAPTURE_VideoEvent(bool pressed) {
 			capture.video.codec = NULL;
 		}
 #if defined(USE_TTF)
-        ttf_switch_on();
+        if (!(CaptureState & CAPTURE_IMAGE) && !(CaptureState & CAPTURE_VIDEO))
+            ttf_switch_on();
 #endif
 	} else {
 		CaptureState |= CAPTURE_VIDEO;
 #if defined(USE_TTF)
-        ttf_switch_off();
+        if (!(CaptureState & CAPTURE_IMAGE) && !(CaptureState & CAPTURE_VIDEO))
+            ttf_switch_off();
 #endif
 	}
 
@@ -1488,7 +1429,8 @@ skip_shot:
     }
 
 #if defined(USE_TTF)
-    ttf_switch_on();
+    if (!(CaptureState & CAPTURE_IMAGE) && !(CaptureState & CAPTURE_VIDEO))
+        ttf_switch_on();
 #endif
     return;
 skip_video:
@@ -1499,7 +1441,8 @@ skip_video:
 # endif
 #endif
 #if defined(USE_TTF)
-    ttf_switch_on();
+    if (!(CaptureState & CAPTURE_IMAGE) && !(CaptureState & CAPTURE_VIDEO))
+        ttf_switch_on();
 #endif
 	return;
 }

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -3317,8 +3317,16 @@ static Bitu INT18_PC98_Handler(void) {
         case 0x0C: /* text layer enable */
             pc98_gdc[GDC_MASTER].force_fifo_complete();
             pc98_gdc[GDC_MASTER].display_enable = true;
+#if defined(USE_TTF)
+            void ttf_switch_on(bool ss);
+            ttf_switch_on(false);
+#endif
             break;
         case 0x0D: /* text layer disable */
+#if defined(USE_TTF)
+            void ttf_switch_off(bool ss);
+            ttf_switch_off(false);
+#endif
             pc98_gdc[GDC_MASTER].force_fifo_complete();
             pc98_gdc[GDC_MASTER].display_enable = false;
             break;


### PR DESCRIPTION
I noticed that the TTF output auto switch did not work for PC-98 mode, so this should make it work similar to the normal mode. Also cleaned up the related code.