### PR TITLE
Support for listing file completions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -86,6 +86,9 @@
     fonts (e.g. consolab, consolai, consolaz instead of
     consola) instead of making the original TTF font
     bold, italic, bold-italic automatically. (Wengier)
+  - You can now press the key combination Ctrl+Tab in
+    the shell to see a list of files/directories that
+    can be completed by the Tab completion. (Wengier)
   - Added SETCOLOR command to view or change the text-
     mode color scheme settings. Also fixed the color
     palette for the TTF output. (Wengier)

--- a/include/shell.h
+++ b/include/shell.h
@@ -117,6 +117,10 @@ public:
      */
 	Bitu GetRedirection(char *s, char **ifn, char **ofn, char **toc,bool * append);
 
+    /*! \brief      Build Tab completion
+     */
+	bool BuildCompletions(char * line, uint16_t str_len);
+
     /*! \brief      Command line input and keyboard handling
      */
 	void InputCommand(char * line);

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -642,8 +642,7 @@ void CAPTURE_VideoEvent(bool pressed) {
 	} else {
 		CaptureState |= CAPTURE_VIDEO;
 #if defined(USE_TTF)
-        if (!(CaptureState & CAPTURE_IMAGE) && !(CaptureState & CAPTURE_VIDEO))
-            ttf_switch_off();
+        ttf_switch_off();
 #endif
 	}
 

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -602,7 +602,7 @@ continue_1:
 	dos.dta(save_dta);
 }
 
-static size_t GetPauseCount() {
+size_t GetPauseCount() {
 	uint16_t rows;
 	if (IS_PC98_ARCH)
 		rows=real_readb(0x60,0x113) & 0x01 ? 25 : 20;


### PR DESCRIPTION
This allows you to press the key combination Ctrl+Tab in the shell to see a list of files/directories that can be completed by the Tab completion, so that it is easier to see all files/directories following the current pattern.