### PR TITLE
Fix issue #2110 and more cleanup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,8 +15,6 @@
     or if you manually change the date/time. (Wengier)
   - Improved compatability with Watcom C++ 2.0 when
     long filename (LFN) support is enabled. (Wengier)
-  - Added read-only options to the Drive menu to mount
-    the specified drive in read-only mode. (Wengier)
   - Added support for starting DOSBox-X in a specific
     display on a multi-screen setup (Windows builds as
     well as Linux/macOS SDL2 builds). A config option
@@ -64,10 +62,15 @@
     the path ("FONTS" by default) where the printer TTF
     fonts (including courier.ttf, ocra.ttf, roman.ttf,
     sansserif.ttf, script.ttf) are located. (Wengier)
+  - Added read-only options to the Drive menu to mount
+    host folders/drives or image files to the specified
+    drive letter in read-only mode. (Wengier)
   - Implemented PhysFS support so that you can mount
     archives (such as zip) as drives in read-only mode,
     e.g. "MOUNT C TEST.ZIP" or "MOUNT D FILES.7Z". Some
-    code is ported from a custom DOSBox fork. (Wengier)
+    code is ported from a custom DOSBox fork. The menu
+    option "Mount an archive file (ZIP/7Z)" is added to
+    Drive menu to mount archives as Drives. (Wengier)
   - Implemented file locking support for mounting disk
     image files so that you cannot mount the same disk
     image files in read/write mode at the same time as

--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ Although based on the DOSBox project, DOSBox-X is now a separate project because
 
 * Support for long filenames and FAT32 disk images (DOS 7+ features)
 
-* Support for printer output, either a real or virtual printer
+* Support for TrueType font (TTF) output for text-mode DOS programs
 
-* Support for 3dfx Voodoo chip and Glide emulation
+* Support for printing features, either to a real or to a virtual printer
+
+* Support for 3dfx Voodoo chip and Glide emulation (including Glide wrapper)
 
 * Support for cue sheets with FLAC, MP3, WAV, OGG Vorbis and Opus CD-DA tracks
 

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -87,10 +87,10 @@ public:
     uint32_t sectors = 0;
     bool hardDrive = false;
     uint64_t diskSizeK = 0;
+    FILE* diskimg = NULL;
 
 protected:
 	imageDisk(IMAGE_TYPE class_id);
-    FILE* diskimg = NULL;
     uint8_t floppytype = 0;
 
     uint32_t reserved_cylinders = 0;

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -3329,6 +3329,8 @@ void DOS_EnableDriveMenu(char drv) {
 		mainMenu.get_item(name).enable(empty).refresh_item(mainMenu);
 		name = std::string("drive_") + drv + "_mountfro";
 		mainMenu.get_item(name).enable(empty).refresh_item(mainMenu);
+		name = std::string("drive_") + drv + "_mountarc";
+		mainMenu.get_item(name).enable(empty).refresh_item(mainMenu);
 		name = std::string("drive_") + drv + "_mountimg";
 		mainMenu.get_item(name).enable(empty).refresh_item(mainMenu);
 		name = std::string("drive_") + drv + "_mountimgs";

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -2272,7 +2272,7 @@ void POD_Load_DOS_Files( std::istream& stream )
                     std::size_t found=str.find(", ");
                     if (found!=std::string::npos)
                         str=str.substr(0,found);
-                    Drives[lcv]=new physfsDrive((":"+str+"\\").c_str(),lalloc.bytes_sector,lalloc.sectors_cluster,lalloc.total_clusters,lalloc.free_clusters,lalloc.mediaid,options);
+                    Drives[lcv]=new physfsDrive('A'+lcv,(":"+str+"\\").c_str(),lalloc.bytes_sector,lalloc.sectors_cluster,lalloc.total_clusters,lalloc.free_clusters,lalloc.mediaid,options);
                     if (Drives[lcv]) {
                         DOS_EnableDriveMenu('A'+lcv);
                         mem_writeb(Real2Phys(dos.tables.mediaid)+lcv*dos.tables.dpb_size,lalloc.mediaid);

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -2240,14 +2240,14 @@ void POD_Load_DOS_Files( std::istream& stream )
                         DOS_EnableDriveMenu('A'+lcv);
                         mem_writeb(Real2Phys(dos.tables.mediaid)+lcv*dos.tables.dpb_size,lalloc.mediaid);
                         if (strlen(overlaydir)) {
-                            uint8_t o_error = 0;
-                            Drives[lcv]=new Overlay_Drive(dynamic_cast<localDrive*>(Drives[lcv])->getBasedir(),overlaydir,oalloc.bytes_sector,oalloc.sectors_cluster,oalloc.total_clusters,oalloc.free_clusters,oalloc.mediaid,o_error,options);
+                            uint8_t error = 0;
+                            Drives[lcv]=new Overlay_Drive(dynamic_cast<localDrive*>(Drives[lcv])->getBasedir(),overlaydir,oalloc.bytes_sector,oalloc.sectors_cluster,oalloc.total_clusters,oalloc.free_clusters,oalloc.mediaid,error,options);
                         }
                     } else
                         LOG_MSG("Error: Cannot restore drive from directory %s\n", dinfo+16);
                 } else if (!strncmp(dinfo,"CDRom ",6) || !strncmp(dinfo,"PhysFS CDRom ",13)) {
                     int num = -1;
-                    int error;
+                    int error = 0;
                     int id, major, minor;
                     DOSBox_CheckOS(id, major, minor);
                     if ((id==VER_PLATFORM_WIN32_NT) && (major>5))
@@ -2268,11 +2268,12 @@ void POD_Load_DOS_Files( std::istream& stream )
                     } else
                         LOG_MSG("Error: Cannot restore drive from directory %s\n", dinfo+6);
                 } else if (!strncmp(dinfo,"PhysFS directory ",17)) {
+                    int error = 0;
                     std::string str=std::string(dinfo+17);
                     std::size_t found=str.find(", ");
                     if (found!=std::string::npos)
                         str=str.substr(0,found);
-                    Drives[lcv]=new physfsDrive('A'+lcv,(":"+str+"\\").c_str(),lalloc.bytes_sector,lalloc.sectors_cluster,lalloc.total_clusters,lalloc.free_clusters,lalloc.mediaid,options);
+                    Drives[lcv]=new physfsDrive('A'+lcv,(":"+str+"\\").c_str(),lalloc.bytes_sector,lalloc.sectors_cluster,lalloc.total_clusters,lalloc.free_clusters,lalloc.mediaid,error,options);
                     if (Drives[lcv]) {
                         DOS_EnableDriveMenu('A'+lcv);
                         mem_writeb(Real2Phys(dos.tables.mediaid)+lcv*dos.tables.dpb_size,lalloc.mediaid);

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1177,7 +1177,7 @@ public:
 #endif
                 }
                 if (is_physfs) {
-					newdrive=new physfsDrive(temp_line.c_str(),sizes[0],bit8size,sizes[2],sizes[3],mediaid,options);
+					newdrive=new physfsDrive(drive,temp_line.c_str(),sizes[0],bit8size,sizes[2],sizes[3],mediaid,options);
                 } else if(type == "overlay") {
                   //Ensure that the base drive exists:
                   if (!Drives[drive-'A']) { 

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -2076,9 +2076,12 @@ bool physfsDrive::read_directory_next(void* dirp, char* entry_name, char* entry_
 }
 
 static uint8_t physfs_used = 0;
-physfsDrive::physfsDrive(const char * startdir,uint16_t _bytes_sector,uint8_t _sectors_cluster,uint16_t _total_clusters,uint16_t _free_clusters,uint8_t _mediaid, std::vector<std::string> &options)
+physfsDrive::physfsDrive(const char driveLetter, const char * startdir,uint16_t _bytes_sector,uint8_t _sectors_cluster,uint16_t _total_clusters,uint16_t _free_clusters,uint8_t _mediaid, std::vector<std::string> &options)
 		   :localDrive(startdir,_bytes_sector,_sectors_cluster,_total_clusters,_free_clusters,_mediaid,options)
 {
+	this->driveLetter = driveLetter;
+	this->mountarc = "";
+	char mp[3] = {'_', driveLetter, 0};
 	char newname[CROSS_LEN+1];
 	strcpy(newname,startdir);
 	CROSS_FILENAME(newname);
@@ -2100,13 +2103,19 @@ physfsDrive::physfsDrive(const char * startdir,uint16_t _bytes_sector,uint8_t _s
 			dir[tmp++] = CROSS_FILESPLIT;
 			dir[tmp] = '\0';
 		}
-		if (*lastdir && PHYSFS_addToSearchPath(lastdir,true) == 0) {
-			LOG_MSG("PHYSFS couldn't add '%s': %s",lastdir,PHYSFS_getLastError());
-		}
+		if (*lastdir) {
+            if (PHYSFS_mount(lastdir,mp,true) == 0)
+                LOG_MSG("PHYSFS couldn't mount '%s': %s",lastdir,PHYSFS_getLastError());
+            else {
+                if (mountarc.size()) mountarc+=", ";
+                mountarc+= lastdir;
+            }
+        }
 		lastdir = dir;
 		dir = strchr(lastdir+(((lastdir[0]|0x20) >= 'a' && (lastdir[0]|0x20) <= 'z')?2:0),':');
 	}
-	strcpy(basedir,lastdir);
+	strcpy(basedir,"\\");
+	strcat(basedir,mp);
 
 	allocation.bytes_sector=_bytes_sector;
 	allocation.sectors_cluster=_sectors_cluster;
@@ -2130,14 +2139,7 @@ physfsDrive::~physfsDrive(void) {
 }
 
 const char *physfsDrive::GetInfo() {
-	char **files = PHYSFS_getSearchPath(), **list = files;
-	sprintf(info,"PhysFS directory ");
-	while (*files != NULL) {
-		strcat(info,*files++);
-		strcat(info,", ");
-	}
-	if (info[strlen(info)-1]==' '&&info[strlen(info)-2]==',') info[strlen(info)-2]=0;
-	PHYSFS_freeList(list);
+	sprintf(info,"PhysFS directory %s", mountarc.c_str());
 	return info;
 }
 
@@ -2324,6 +2326,8 @@ bool physfsDrive::isRemovable(void) {
 }
 
 Bits physfsDrive::UnMount(void) {
+	char mp[3] = {'_', driveLetter, 0};
+	PHYSFS_unmount(mp);
 	delete this;
 	return 0;
 }
@@ -2420,24 +2424,18 @@ bool physfsFile::UpdateDateTimeFromHost(void) {
 }
 
 physfscdromDrive::physfscdromDrive(const char driveLetter, const char * startdir,uint16_t _bytes_sector,uint8_t _sectors_cluster,uint16_t _total_clusters,uint16_t _free_clusters,uint8_t _mediaid, int& error, std::vector<std::string> &options)
-		   :physfsDrive(startdir,_bytes_sector,_sectors_cluster,_total_clusters,_free_clusters,_mediaid,options)
+		   :physfsDrive(driveLetter,startdir,_bytes_sector,_sectors_cluster,_total_clusters,_free_clusters,_mediaid,options)
 {
 	// Init mscdex
 	error = MSCDEX_AddDrive(driveLetter,startdir,subUnit);
+	this->driveLetter = driveLetter;
 	// Get Volume Label
 	char name[32];
 	if (MSCDEX_GetVolumeName(subUnit,name)) dirCache.SetLabel(name,true,true);
 };
 
 const char *physfscdromDrive::GetInfo() {
-	char **files = PHYSFS_getSearchPath(), **list = files;
-	sprintf(info,"PhysFS CDRom ");
-	while (*files != NULL) {
-		strcat(info,*files++);
-		strcat(info,", ");
-	}
-	if (info[strlen(info)-1]==' '&&info[strlen(info)-2]==',') info[strlen(info)-1]=info[strlen(info)-2]=0;
-	PHYSFS_freeList(list);
+	sprintf(info,"PhysFS CDRom %s", mountarc.c_str());
 	return info;
 }
 

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -2076,7 +2076,7 @@ bool physfsDrive::read_directory_next(void* dirp, char* entry_name, char* entry_
 }
 
 static uint8_t physfs_used = 0;
-physfsDrive::physfsDrive(const char driveLetter, const char * startdir,uint16_t _bytes_sector,uint8_t _sectors_cluster,uint16_t _total_clusters,uint16_t _free_clusters,uint8_t _mediaid, std::vector<std::string> &options)
+physfsDrive::physfsDrive(const char driveLetter, const char * startdir,uint16_t _bytes_sector,uint8_t _sectors_cluster,uint16_t _total_clusters,uint16_t _free_clusters,uint8_t _mediaid,int &error,std::vector<std::string> &options)
 		   :localDrive(startdir,_bytes_sector,_sectors_cluster,_total_clusters,_free_clusters,_mediaid,options)
 {
 	this->driveLetter = driveLetter;
@@ -2114,6 +2114,8 @@ physfsDrive::physfsDrive(const char driveLetter, const char * startdir,uint16_t 
 		lastdir = dir;
 		dir = strchr(lastdir+(((lastdir[0]|0x20) >= 'a' && (lastdir[0]|0x20) <= 'z')?2:0),':');
 	}
+	error = 0;
+	if (!mountarc.size()) {error = 10;return;}
 	strcpy(basedir,"\\");
 	strcat(basedir,mp);
 
@@ -2424,9 +2426,10 @@ bool physfsFile::UpdateDateTimeFromHost(void) {
 }
 
 physfscdromDrive::physfscdromDrive(const char driveLetter, const char * startdir,uint16_t _bytes_sector,uint8_t _sectors_cluster,uint16_t _total_clusters,uint16_t _free_clusters,uint8_t _mediaid, int& error, std::vector<std::string> &options)
-		   :physfsDrive(driveLetter,startdir,_bytes_sector,_sectors_cluster,_total_clusters,_free_clusters,_mediaid,options)
+		   :physfsDrive(driveLetter,startdir,_bytes_sector,_sectors_cluster,_total_clusters,_free_clusters,_mediaid,error,options)
 {
 	// Init mscdex
+	if (!mountarc.size()) {error = 10;return;}
 	error = MSCDEX_AddDrive(driveLetter,startdir,subUnit);
 	this->driveLetter = driveLetter;
 	// Get Volume Label

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -2010,6 +2010,7 @@ bool physfsDrive::FileStat(const char* name, FileStat_Block * const stat_block) 
 }
 
 struct opendirinfo {
+	char dir[CROSS_LEN];
 	char **files;
 	int pos;
 };
@@ -2029,6 +2030,7 @@ void *physfsDrive::opendir(const char *name) {
 	if (!PHYSFS_isDirectory(myname)) return NULL;
 
 	struct opendirinfo *oinfo = (struct opendirinfo *)malloc(sizeof(struct opendirinfo));
+	strcpy(oinfo->dir, myname);
 	oinfo->files = PHYSFS_enumerateFiles(myname);
 	if (oinfo->files == NULL) {
 		LOG_MSG("PHYSFS: nothing found for %s (%s)",myname,PHYSFS_getLastError());
@@ -2036,7 +2038,7 @@ void *physfsDrive::opendir(const char *name) {
 		return NULL;
 	}
 
-	oinfo->pos = (myname[1] == 0?0:-2);
+	oinfo->pos = (myname[4] == 0?0:-2);
 	return (void *)oinfo;
 }
 
@@ -2071,7 +2073,7 @@ bool physfsDrive::read_directory_next(void* dirp, char* entry_name, char* entry_
 	if (!oinfo->files || !oinfo->files[oinfo->pos]) return false;
 	safe_strncpy(entry_name,oinfo->files[oinfo->pos++],CROSS_LEN);
 	*entry_sname=0;
-	is_directory = isdir(entry_name);
+	is_directory = isdir(strlen(oinfo->dir)?(std::string(oinfo->dir)+"/"+std::string(entry_name)).c_str():entry_name);
 	return true;
 }
 
@@ -2118,6 +2120,7 @@ physfsDrive::physfsDrive(const char driveLetter, const char * startdir,uint16_t 
 	if (!mountarc.size()) {error = 10;return;}
 	strcpy(basedir,"\\");
 	strcat(basedir,mp);
+	strcat(basedir,"\\");
 
 	allocation.bytes_sector=_bytes_sector;
 	allocation.sectors_cluster=_sectors_cluster;

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -122,7 +122,7 @@ private:
 	char driveLetter;
 
 public:
-	physfsDrive(const char driveLetter, const char * startdir,uint16_t _bytes_sector,uint8_t _sectors_cluster,uint16_t _total_clusters,uint16_t _free_clusters,uint8_t _mediaid, std::vector<std::string> &options);
+	physfsDrive(const char driveLetter, const char * startdir,uint16_t _bytes_sector,uint8_t _sectors_cluster,uint16_t _total_clusters,uint16_t _free_clusters,uint8_t _mediaid, int& error, std::vector<std::string> &options);
 	virtual bool FileOpen(DOS_File * * file,const char * name,uint32_t flags);
 	virtual bool FileCreate(DOS_File * * file,const char * name,uint16_t attributes);
 	virtual bool FileUnlink(const char * name);

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -119,9 +119,10 @@ protected:
 class physfsDrive : public localDrive {
 private:
 	bool isdir(const char *dir);
+	char driveLetter;
 
 public:
-	physfsDrive(const char * startdir,uint16_t _bytes_sector,uint8_t _sectors_cluster,uint16_t _total_clusters,uint16_t _free_clusters,uint8_t _mediaid, std::vector<std::string> &options);
+	physfsDrive(const char driveLetter, const char * startdir,uint16_t _bytes_sector,uint8_t _sectors_cluster,uint16_t _total_clusters,uint16_t _free_clusters,uint8_t _mediaid, std::vector<std::string> &options);
 	virtual bool FileOpen(DOS_File * * file,const char * name,uint32_t flags);
 	virtual bool FileCreate(DOS_File * * file,const char * name,uint16_t attributes);
 	virtual bool FileUnlink(const char * name);
@@ -151,6 +152,9 @@ public:
 	virtual const char *GetInfo(void);
 	Bits UnMount();
 	virtual ~physfsDrive(void);
+
+protected:
+	std::string mountarc;
 };
 
 #ifdef _MSC_VER

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3256,6 +3256,12 @@ void setVGADAC() {
 
 bool setColors(const char *colorArray, int n) {
     if (IS_PC98_ARCH) return false;
+    if (!colorChanged)
+        for (uint8_t i = 0; i < 0x10; i++) {
+            altBGR1[i].red=rgbColors[i].red;
+            altBGR1[i].green=rgbColors[i].green;
+            altBGR1[i].blue=rgbColors[i].blue;
+        }
 	const char * nextRGB = colorArray;
 	uint8_t * altPtr = (uint8_t *)altBGR1;
 	int rgbVal[3] = {-1,-1,-1};

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -308,7 +308,7 @@ extern bool bootguest, bootfast, bootvm;
 extern int bootdrive;
 
 void MenuBrowseFolder(char drive, std::string drive_type);
-void MenuBrowseImageFile(char drive, bool boot, bool multiple);
+void MenuBrowseImageFile(char drive, bool arc, bool boot, bool multiple);
 void MenuBootDrive(char drive);
 void MenuUnmountDrive(char drive);
 void MenuBrowseProgramFile(void);
@@ -430,6 +430,28 @@ bool drive_mountfro_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * con
     return true;
 }
 
+bool drive_mountarc_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+
+    /* menu item has name "drive_A_" ... */
+    int drive;
+    const char *mname = menuitem->get_name().c_str();
+    if (!strncmp(mname,"drive_",6)) {
+        drive = mname[6] - 'A';
+        if (drive < 0 || drive >= DOS_DRIVES) return false;
+    }
+    else {
+        return false;
+    }
+
+    if (dos_kernel_disabled) return true;
+
+    MenuBrowseImageFile(drive+'A', true, false, false);
+
+    return true;
+}
+
 bool drive_mountimg_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
     (void)menuitem;//UNUSED
@@ -447,7 +469,7 @@ bool drive_mountimg_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * con
 
     if (dos_kernel_disabled) return true;
 
-    MenuBrowseImageFile(drive+'A', false, false);
+    MenuBrowseImageFile(drive+'A', false, false, false);
 
     return true;
 }
@@ -469,7 +491,7 @@ bool drive_mountimgs_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * co
 
     if (dos_kernel_disabled) return true;
 
-    MenuBrowseImageFile(drive+'A', false, true);
+    MenuBrowseImageFile(drive+'A', false, false, true);
 
     return true;
 }
@@ -501,7 +523,7 @@ bool drive_bootimg_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * cons
 
     if (dos_kernel_disabled) return true;
 
-    MenuBrowseImageFile(drive+'A', true, false);
+    MenuBrowseImageFile(drive+'A', false, true, false);
 
     return true;
 }
@@ -639,6 +661,7 @@ const DOSBoxMenu::callback_t drive_callbacks[] = {
     drive_mountfd_menu_callback,
     drive_mountfro_menu_callback,
     NULL,
+    drive_mountarc_menu_callback,
     drive_mountimg_menu_callback,
     drive_mountimgs_menu_callback,
     drive_mountiro_menu_callback,
@@ -696,6 +719,7 @@ const char *drive_opts[][2] = {
 	{ "mountfd",                "Mount folder as floppy drive" },
 	{ "mountfro",               "Option: mount folder read-only" },
 	{ "div1",                   "--" },
+	{ "mountarc",               "Mount an archive file (ZIP/7Z)" },
 	{ "mountimg",               "Mount a disk or CD image file" },
 	{ "mountimgs",              "Mount multiple disk/CD images" },
 	{ "mountiro",               "Option: mount images read-only" },

--- a/src/libs/physfs/physfs_lzmasdk.h
+++ b/src/libs/physfs/physfs_lzmasdk.h
@@ -1253,7 +1253,15 @@ static void MY_FAST_CALL CrcGenerateTable()
       #endif
     }
     else if (p[0] != 1 || p[1] != 2)
+      #if CRC_NUM_TABLES < 4
       g_CrcUpdate = CrcUpdateT1;
+      #else
+      g_CrcUpdate = CrcUpdateT4;
+        #ifdef MY_CPU_X86_OR_AMD64
+        if (!CPU_Is_InOrder())
+          g_CrcUpdate = CrcUpdateT8;
+        #endif
+      #endif
     else
     #endif
     {


### PR DESCRIPTION
This tries to fix the build issue with VS2019 ARM64 target as mentioned in Issue #2110 so that the ARM64 target should now build fine, although I don't have a Windows ARM64 system to actually run the build myself. Also did more cleanups to the drive mounting, including some fixes to the PhysFS drive code and a menu option to mount archives as drives, which fixes Issue #2111.