### PR TITLE
New config/menu options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,14 +1,4 @@
 0.83.9
-  - synchronize time fixed to synchronize to host time
-    if and only if the timer is running at the standard
-    18.2Hz tick rate. Any other rate does not make
-    sense and will cause only jitter and error. Fix for
-    synchronize time and two Demoscene entries sl_fokus
-    and sl_haloo which use BIOS_TIMER with a faster
-    hardware tick rate.
-  - synchronize time fixed to work from IRQ0 handler
-    (where BIOS_TIMER is processed) rather than from
-    VGA vsync.
   - Added menu option "Create blank disk images..."
     (under "DOS" menu) to create blank floppy or hard
     disk images of a common disk size, including 360KB,
@@ -18,12 +8,23 @@
     is also added to IMGMAKE command. (Wengier)
   - The Configuration Tool will now be centered within
     the DOSBox-X window for a better looking. (Wengier)
-  - DOSBox-X will now automatically synchronize the
-    date/time with the host system by default, which
-    can be turned off by setting the new config option
-    "synchronize time" to "false" in [dosbox] section,
-    or if you manually change the date/time. (Wengier)
-  - Improved compatability with Watcom C++ 2.0 when
+  - Added config option "synchronize time" in [dosbox]
+    section which when set to true will allow DOSBox-X
+    to automatically synchronize the date and time with
+    the host system, unless you manually change date
+    and/or time. A menu option "Synchronize host date/
+    time" is added to the DOS menu. The function uses
+    IRQ0 handler; it will not work in PC-98 mode nor if
+    the timer isn't running at the standard 18.2Hz tick
+    rate, as any other rate does not make sense and
+    will cause only jitter and error. Also fixed two
+    Demoscene entries sl_fokus and sl_haloo which use
+    BIOS_TIMER with a faster hardware tick rate.
+  - Added config option "showdetails" which when set to
+    true enables the menu option "Show FPS and RT speed
+    in title bar" at start. It is equivalent to -showrt
+    and -showcycles command-line options. (Wengier)
+  - Improved compatibility with Watcom C++ 2.0 when
     long filename (LFN) support is enabled. (Wengier)
   - Added support for starting DOSBox-X in a specific
     display on a multi-screen setup (Windows builds as

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -52,6 +52,7 @@
 #                      Possible values: true, false, auto.
 #DOSBOX-X-ADV:#          overscan: Width of overscan border (0 to 10). (works only if output=surface)
 #          titlebar: Change the string displayed in the DOSBox-X title bar.
+#       showdetails: If set, DOSBox-X will show the cycles count (FPS) and emulation speed relative to realtime in the title bar.
 #          showmenu: Whether to show the menu bar (if supported). Default true.
 fullscreen        = false
 fulldouble        = false
@@ -76,6 +77,7 @@ mapperfile        = mapper-dosbox-x.map
 usescancodes      = auto
 #DOSBOX-X-ADV:overscan          = 0
 titlebar          = 
+showdetails       = false
 showmenu          = true
 
 [log]
@@ -1581,6 +1583,7 @@ joy2deadzone7+ = 0.60
 #                  Additional parameters:
 #                      timeout:<milliseconds> = how long to wait before closing the file on inactivity (default:0),
 #                      squote to use single quotes instad of double quotes for quoted program commands.
+#                      shellhide to hide the command window when opening programs on the Windows system.
 #                      openwith:<program>: start a program to open the output file.
 #                      openerror:<program>: start a program to open the output file if an error had occurred.
 #                  for directserial: realport (required), rxdelay (optional).
@@ -1643,6 +1646,7 @@ phonebookfile = phonebook-dosbox-x.txt
 #                  Additional parameters:
 #                  timeout:<milliseconds> = how long to wait before closing the file on inactivity (default:0 or 500),
 #                  squote to use single quotes instad of double quotes for quoted program commands.
+#                  shellhide to hide the command window when opening programs on the Windows system.
 #                  addFF to add a formfeed when closing, addLF to add a linefeed if the app doesn't.
 #                  cp:<codepage number> to perform codepage translation, i.e. cp:437
 #                  openps:<program>: start a program to open the file if the print output is detected to be PostScript.
@@ -1688,6 +1692,7 @@ dongle    = false
 #    fontpath: The path where the printer fonts (courier.ttf, ocra.ttf, roman.ttf, sansserif.ttf, script.ttf) are located.
 #    openwith: Start the specified program to open the output file.
 #   openerror: Start the specified program to open the output file if an error had occurred.
+#   shellhide: If set, the command window will be hidden for openwith/openerror options on the Windows system.
 #     timeout: (in milliseconds) if nonzero: the time the page will be ejected automatically after when no more data arrives at the printer.
 printer     = true
 dpi         = 360
@@ -1699,6 +1704,7 @@ docpath     = .
 fontpath    = FONTS
 openwith    = 
 openerror   = 
+shellhide   = false
 timeout     = 0
 
 [dos]

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -47,6 +47,7 @@
 #                      If set to "auto" (default), it is enabled for SDL1 and non-US keyboards.
 #                      Possible values: true, false, auto.
 #          titlebar: Change the string displayed in the DOSBox-X title bar.
+#       showdetails: If set, DOSBox-X will show the cycles count (FPS) and emulation speed relative to realtime in the title bar.
 #          showmenu: Whether to show the menu bar (if supported). Default true.
 fullscreen        = false
 fulldouble        = false
@@ -67,6 +68,7 @@ priority          = higher,normal
 mapperfile        = mapper-dosbox-x.map
 usescancodes      = auto
 titlebar          = 
+showdetails       = false
 showmenu          = true
 
 [log]
@@ -552,6 +554,7 @@ joy2deadzone7+ = 0.60
 #                  Additional parameters:
 #                      timeout:<milliseconds> = how long to wait before closing the file on inactivity (default:0),
 #                      squote to use single quotes instad of double quotes for quoted program commands.
+#                      shellhide to hide the command window when opening programs on the Windows system.
 #                      openwith:<program>: start a program to open the output file.
 #                      openerror:<program>: start a program to open the output file if an error had occurred.
 #                  for directserial: realport (required), rxdelay (optional).
@@ -599,6 +602,7 @@ phonebookfile = phonebook-dosbox-x.txt
 #                  Additional parameters:
 #                  timeout:<milliseconds> = how long to wait before closing the file on inactivity (default:0 or 500),
 #                  squote to use single quotes instad of double quotes for quoted program commands.
+#                  shellhide to hide the command window when opening programs on the Windows system.
 #                  addFF to add a formfeed when closing, addLF to add a linefeed if the app doesn't.
 #                  cp:<codepage number> to perform codepage translation, i.e. cp:437
 #                  openps:<program>: start a program to open the file if the print output is detected to be PostScript.
@@ -632,6 +636,7 @@ dongle    = false
 #    fontpath: The path where the printer fonts (courier.ttf, ocra.ttf, roman.ttf, sansserif.ttf, script.ttf) are located.
 #    openwith: Start the specified program to open the output file.
 #   openerror: Start the specified program to open the output file if an error had occurred.
+#   shellhide: If set, the command window will be hidden for openwith/openerror options on the Windows system.
 #     timeout: (in milliseconds) if nonzero: the time the page will be ejected automatically after when no more data arrives at the printer.
 printer     = true
 dpi         = 360
@@ -643,6 +648,7 @@ docpath     = .
 fontpath    = FONTS
 openwith    = 
 openerror   = 
+shellhide   = false
 timeout     = 0
 
 [dos]

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -52,6 +52,7 @@
 #                      Possible values: true, false, auto.
 #          overscan: Width of overscan border (0 to 10). (works only if output=surface)
 #          titlebar: Change the string displayed in the DOSBox-X title bar.
+#       showdetails: If set, DOSBox-X will show the cycles count (FPS) and emulation speed relative to realtime in the title bar.
 #          showmenu: Whether to show the menu bar (if supported). Default true.
 fullscreen        = false
 fulldouble        = false
@@ -76,6 +77,7 @@ mapperfile_sdl2   =
 usescancodes      = auto
 overscan          = 0
 titlebar          = 
+showdetails       = false
 showmenu          = true
 
 [log]
@@ -1581,6 +1583,7 @@ joy2deadzone7+ = 0.60
 #                  Additional parameters:
 #                      timeout:<milliseconds> = how long to wait before closing the file on inactivity (default:0),
 #                      squote to use single quotes instad of double quotes for quoted program commands.
+#                      shellhide to hide the command window when opening programs on the Windows system.
 #                      openwith:<program>: start a program to open the output file.
 #                      openerror:<program>: start a program to open the output file if an error had occurred.
 #                  for directserial: realport (required), rxdelay (optional).
@@ -1643,6 +1646,7 @@ phonebookfile = phonebook-dosbox-x.txt
 #                  Additional parameters:
 #                  timeout:<milliseconds> = how long to wait before closing the file on inactivity (default:0 or 500),
 #                  squote to use single quotes instad of double quotes for quoted program commands.
+#                  shellhide to hide the command window when opening programs on the Windows system.
 #                  addFF to add a formfeed when closing, addLF to add a linefeed if the app doesn't.
 #                  cp:<codepage number> to perform codepage translation, i.e. cp:437
 #                  openps:<program>: start a program to open the file if the print output is detected to be PostScript.
@@ -1688,6 +1692,7 @@ dongle    = false
 #    fontpath: The path where the printer fonts (courier.ttf, ocra.ttf, roman.ttf, sansserif.ttf, script.ttf) are located.
 #    openwith: Start the specified program to open the output file.
 #   openerror: Start the specified program to open the output file if an error had occurred.
+#   shellhide: If set, the command window will be hidden for openwith/openerror options on the Windows system.
 #     timeout: (in milliseconds) if nonzero: the time the page will be ejected automatically after when no more data arrives at the printer.
 printer     = true
 dpi         = 360
@@ -1699,6 +1704,7 @@ docpath     = .
 fontpath    = FONTS
 openwith    = 
 openerror   = 
+shellhide   = false
 timeout     = 0
 
 [dos]

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3443,6 +3443,7 @@ void DOSBOX_SetupConfigSections(void) {
         "Additional parameters:\n"
         "    timeout:<milliseconds> = how long to wait before closing the file on inactivity (default:0),\n"
         "    squote to use single quotes instad of double quotes for quoted program commands.\n"
+        "    shellhide to hide the command window when opening programs on the Windows system.\n"
         "    openwith:<program>: start a program to open the output file.\n"
         "    openerror:<program>: start a program to open the output file if an error had occurred.\n"
         "for directserial: realport (required), rxdelay (optional).\n"
@@ -3548,6 +3549,7 @@ void DOSBOX_SetupConfigSections(void) {
             "    Additional parameters:\n"
             "    timeout:<milliseconds> = how long to wait before closing the file on inactivity (default:0 or 500),\n"
             "    squote to use single quotes instad of double quotes for quoted program commands.\n"
+            "    shellhide to hide the command window when opening programs on the Windows system.\n"
             "    addFF to add a formfeed when closing, addLF to add a linefeed if the app doesn't.\n"
             "    cp:<codepage number> to perform codepage translation, i.e. cp:437\n"
             "    openps:<program>: start a program to open the file if the print output is detected to be PostScript.\n"
@@ -3632,6 +3634,10 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring = secprop->Add_string("openerror", Property::Changeable::WhenIdle, "");
     Pstring->Set_help("Start the specified program to open the output file if an error had occurred.");
     Pstring->SetBasic(true);
+
+    Pbool = secprop->Add_bool("shellhide", Property::Changeable::WhenIdle, false);
+    Pbool->Set_help("If set, the command window will be hidden for openwith/openerror options on the Windows system.");
+    Pbool->SetBasic(true);
 
     Pint = secprop->Add_int("timeout", Property::Changeable::WhenIdle, 0);
     Pint->Set_help("(in milliseconds) if nonzero: the time the page will be ejected automatically after when no more data arrives at the printer.");

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -483,21 +483,21 @@ static const char *def_menu_video[] =
 /* DOS menu ("DOSMenu") */
 static const char *def_menu_dos[] =
 {
-    "DOSMouseMenu",
-    "--",
-    "DOSVerMenu",
-    "DOSLFNMenu",
-    "DOSEMSMenu",
-    "--",
-#if defined(WIN32) && !defined(HX_DOS)
-    "DOSWinMenu",
-#endif
-    "shell_config_commands",
 #if !defined(HX_DOS)
     "mapper_quickrun",
 #endif
+    "DOSVerMenu",
+    "DOSLFNMenu",
+    "--",
+    "DOSMouseMenu",
+    "DOSEMSMenu",
+#if defined(WIN32) && !defined(HX_DOS)
+    "DOSWinMenu",
+#endif
     "--",
     "quick_reboot",
+    "sync_host_datetime",
+    "shell_config_commands",
     "--",
     "mapper_swapimg",
     "mapper_swapcd",

--- a/src/hardware/parport/filelpt.cpp
+++ b/src/hardware/parport/filelpt.cpp
@@ -41,6 +41,9 @@ CFileLPT::CFileLPT (Bitu nr, uint8_t initIrq, CommandLine* cmd, bool sq)
 	std::string str;
 	ack = false;
     squote = sq;
+    shellhide = false;
+
+	if(cmd->FindStringBegin("shellhide",str,false))	shellhide = true;
 
 	// add a formfeed when closing?
 	if(cmd->FindStringBegin("addFF",str,false))	addFF = true;
@@ -144,6 +147,7 @@ void CFileLPT::doAction() {
 #if defined(WIN32)
         bool q=false;
         int pos=-1;
+        std::string para=name;
         for (int i=0; i<action.size(); i++) {
             if (action[i]=='"') q=!q;
             else if (action[i]==' ' && !q) {
@@ -151,20 +155,20 @@ void CFileLPT::doAction() {
                 break;
             }
         }
-        std::string para = name;
         if (pos>-1) {
             para=action.substr(pos+1)+" "+name;
             action=action.substr(0, pos);
         }
-        fail=(INT_PTR)ShellExecute(NULL, "open", action.c_str(), para.c_str(), NULL, SW_SHOWNORMAL)<=32;
+        fail=(INT_PTR)ShellExecute(NULL, "open", action.c_str(), para.c_str(), NULL, shellhide?SW_HIDE:SW_NORMAL)<=32;
 #else
         fail=system((action+" "+name).c_str())!=0;
 #endif
         if (action4.size()&&fail) {
             action=action4;
 #if defined(WIN32)
-            para = name;
+            q=false;
             pos=-1;
+            para=name;
             for (int i=0; i<action.size(); i++) {
                 if (action[i]=='"') q=!q;
                 else if (action[i]==' ' && !q) {
@@ -176,7 +180,7 @@ void CFileLPT::doAction() {
                 para=action.substr(pos+1)+" "+name;
                 action=action.substr(0, pos);
             }
-            fail=(INT_PTR)ShellExecute(NULL, "open", action.c_str(), para.c_str(), NULL, SW_SHOWNORMAL)<=32;
+            fail=(INT_PTR)ShellExecute(NULL, "open", action.c_str(), para.c_str(), NULL, shellhide?SW_HIDE:SW_NORMAL)<=32;
 #else
             fail=system((action+" "+name).c_str())!=0;
 #endif

--- a/src/hardware/parport/filelpt.h
+++ b/src/hardware/parport/filelpt.h
@@ -39,6 +39,7 @@ public:
 	FILE* file = NULL;
 	std::string name;			// name of the thing to open
 	std::string action1, action2, action3, action4; // open with a program or batch script
+	bool shellhide;
 	bool addFF;					// add a formfeed character before closing the file/device
 	bool addLF;					// if set, add line feed after carriage return if not used by app
     bool squote;

--- a/src/hardware/serialport/serialfile.h
+++ b/src/hardware/serialport/serialfile.h
@@ -44,6 +44,7 @@ public:
 
 	FILE* fp = NULL;
 	bool squote;
+	bool shellhide;
 	unsigned int timeout = 0;
 	Bitu lastUsedTick = 0;
 	std::string filename;


### PR DESCRIPTION
This adds a "showdetails" config option which when set to true will enable the menu option "Show FPS and RT speed in title bar" at start. Also cleaned up the changelog on the contents about the time synchronization feature and made it clear it is disabled by default,; a "Synchronize host date/time" menu option under "DOS" is added which can be used to toggle it status. Also added a "shellhide" option for the serial/parallel port file options which can be used to hide the command window on the Windows system.