### PR TITLE
Implemented text selection using arrow keys

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -108,6 +108,13 @@
     fonts (e.g. consolab, consolai, consolaz instead of
     consola) instead of making the original TTF font
     bold, italic, bold-italic automatically. (Wengier)
+  - DOSBox-X now supports the use of arrow keys (left,
+    right, up, down, home, end) to select and copy text
+    to the host clipboard in addition to a mouse button
+    (subject to the specified key modifier, or use the
+    QuickEdit function). Set "clip_mouse_button=arrows"
+    to enable it, or select it from "Shared clipboard
+    functions" menu group. (Wengier)
   - You can now press the key combination Ctrl+Tab in
     the shell to see a list of files/directories that
     can be completed by the Tab completion. (Wengier)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -97,9 +97,10 @@
     with the mapperfile config option, or you can set
     the mapperfile_sdl1 and mapperfile_sdl2 config
     options to override mapperfile option. (Wengier)
-  - The functions "Load mapper file" & "Stop clipboard
-    pasting" are added to the mapper so that you can
-    defined shortcut keys for them. (Wengier)
+  - The menu functions "Load mapper file", "Quick edit
+    mode" and "Stop clipboard pasting" are added to the
+    mapper so that you can now define your own shortcut
+    keys to activate these functions. (Wengier)
   - Added ttf.fontbold, ttf.fontital, and ttf.fontboit
     config options so that you can specify actual bold
     italic, and bold-italic TrueType fonts for use with

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -18,10 +18,11 @@
 #          autolock: Mouse will automatically lock, if you click on the screen. (Press CTRL-F10 to unlock)
 #DOSBOX-X-ADV:# autolock_feedback: Autolock status feedback type, i.e. visual, auditive, none.
 #DOSBOX-X-ADV:#                      Possible values: none, beep, flash.
-# clip_mouse_button: Select the mouse button for the shared clipboard copy/paste function.
-#                      The default mouse button is "right". Set to "middle" if the middle mouse button is desired, or "none" to disable this feature.
-#                      Possible values: none, middle, right.
-# clip_key_modifier: Change the keyboard modifier for the shared clipboard copy/paste function using the right mouse button.
+# clip_mouse_button: Select the mouse button or use arrow keys for the shared clipboard copy/paste function.
+#                      The default mouse button is "right", which means using the right mouse button to select text, copy to and paste from the host clipboard.
+#                      Set to "middle" to use the middle mouse button, "arrows" to use arrow keys instead of a mouse button, or "none" to disable this feature.
+#                      Possible values: none, middle, right, arrows.
+# clip_key_modifier: Change the keyboard modifier for the shared clipboard copy/paste function using a mouse button or arrow keys.
 #                      The default modifier is "shift" (both left and right shift keys). Set to "none" if no modifier is desired.
 #                      Possible values: none, alt, lalt, ralt, ctrl, lctrl, rctrl, shift, lshift, rshift.
 #  clip_paste_speed: Set keyboard speed for pasting from the shared clipboard.

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -16,10 +16,11 @@
 #            output: What video system to use for output.
 #                      Possible values: default, surface, overlay, opengl, openglnb, openglhq, ddraw, ttf.
 #          autolock: Mouse will automatically lock, if you click on the screen. (Press CTRL-F10 to unlock)
-# clip_mouse_button: Select the mouse button for the shared clipboard copy/paste function.
-#                      The default mouse button is "right". Set to "middle" if the middle mouse button is desired, or "none" to disable this feature.
-#                      Possible values: none, middle, right.
-# clip_key_modifier: Change the keyboard modifier for the shared clipboard copy/paste function using the right mouse button.
+# clip_mouse_button: Select the mouse button or use arrow keys for the shared clipboard copy/paste function.
+#                      The default mouse button is "right", which means using the right mouse button to select text, copy to and paste from the host clipboard.
+#                      Set to "middle" to use the middle mouse button, "arrows" to use arrow keys instead of a mouse button, or "none" to disable this feature.
+#                      Possible values: none, middle, right, arrows.
+# clip_key_modifier: Change the keyboard modifier for the shared clipboard copy/paste function using a mouse button or arrow keys.
 #                      The default modifier is "shift" (both left and right shift keys). Set to "none" if no modifier is desired.
 #                      Possible values: none, alt, lalt, ralt, ctrl, lctrl, rctrl, shift, lshift, rshift.
 #  clip_paste_speed: Set keyboard speed for pasting from the shared clipboard.

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -18,10 +18,11 @@
 #          autolock: Mouse will automatically lock, if you click on the screen. (Press CTRL-F10 to unlock)
 # autolock_feedback: Autolock status feedback type, i.e. visual, auditive, none.
 #                      Possible values: none, beep, flash.
-# clip_mouse_button: Select the mouse button for the shared clipboard copy/paste function.
-#                      The default mouse button is "right". Set to "middle" if the middle mouse button is desired, or "none" to disable this feature.
-#                      Possible values: none, middle, right.
-# clip_key_modifier: Change the keyboard modifier for the shared clipboard copy/paste function using the right mouse button.
+# clip_mouse_button: Select the mouse button or use arrow keys for the shared clipboard copy/paste function.
+#                      The default mouse button is "right", which means using the right mouse button to select text, copy to and paste from the host clipboard.
+#                      Set to "middle" to use the middle mouse button, "arrows" to use arrow keys instead of a mouse button, or "none" to disable this feature.
+#                      Possible values: none, middle, right, arrows.
+# clip_key_modifier: Change the keyboard modifier for the shared clipboard copy/paste function using a mouse button or arrow keys.
 #                      The default modifier is "shift" (both left and right shift keys). Set to "none" if no modifier is desired.
 #                      Possible values: none, alt, lalt, ralt, ctrl, lctrl, rctrl, shift, lshift, rshift.
 #  clip_paste_speed: Set keyboard speed for pasting from the shared clipboard.

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -190,7 +190,7 @@ static const char *def_menu_main_wheelarrow[] =
 static const char *def_menu_main_clipboard[] =
 {
 #if defined(WIN32) || defined(C_SDL2)
-    "clipboard_quick",
+    "mapper_fastedit",
     "clipboard_right",
     "clipboard_middle",
     "clipboard_arrows",

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -193,6 +193,7 @@ static const char *def_menu_main_clipboard[] =
     "clipboard_quick",
     "clipboard_right",
     "clipboard_middle",
+    "clipboard_arrows",
 #endif
 #if defined(WIN32)
     "--",

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1019,6 +1019,7 @@ void CopyClipboard(int all);
 void CopyAllClipboard(bool bPressed);
 void PasteClipboard(bool bPressed);
 void PasteClipStop(bool bPressed);
+void QuickEdit(bool bPressed);
 
 #if C_DYNAMIC_X86
 void CPU_Core_Dyn_X86_Shutdown(void);
@@ -5340,6 +5341,9 @@ static void GUI_StartUp() {
     item->set_text("Toggle fullscreen");
 
 #if defined(C_SDL2) || defined(WIN32)
+    MAPPER_AddHandler(QuickEdit,MK_nothing, 0,"fastedit", "Quick edit mode", &item);
+    item->set_text("Quick edit: copy on select and paste text");
+
     MAPPER_AddHandler(CopyAllClipboard,MK_a,MMODHOST,"copyall", "Copy to clipboard", &item);
     item->set_text("Copy all text on the DOS screen");
 #endif
@@ -5968,7 +5972,7 @@ void ClipKeySelect(int sym) {
         if (selsrow>-1 && selscol>-1) Mouse_Select(selscol, selsrow, selmark?selecol:selscol, selmark?selerow:selsrow, -1, -1, false);
         selmark = false;
         selsrow = selscol = selerow = selecol = -1;
-    } else if ((sym==SDLK_LEFT || sym==SDLK_RIGHT || sym==SDLK_UP || sym==SDLK_DOWN)) {
+    } else if (sym==SDLK_LEFT || sym==SDLK_RIGHT || sym==SDLK_UP || sym==SDLK_DOWN) {
         if (selsrow==-1 || selscol==-1) {
             int p=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
             selscol = CURSOR_POS_COL(p);
@@ -10422,14 +10426,6 @@ bool autolock_mouse_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * co
 }
 
 #if defined (WIN32) || defined(C_SDL2)
-bool direct_mouse_clipboard_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
-    (void)menu;//UNUSED
-    (void)menuitem;//UNUSED
-    direct_mouse_clipboard = !direct_mouse_clipboard;
-    mainMenu.get_item("clipboard_quick").check(direct_mouse_clipboard).refresh_item(mainMenu);
-    return true;
-}
-
 bool arrow_keys_clipboard_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
     (void)menuitem;//UNUSED
@@ -10465,6 +10461,13 @@ bool screen_to_clipboard_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item
     (void)menuitem;//UNUSED
     CopyClipboard(2);
     return true;
+}
+
+void QuickEdit(bool bPressed)
+{
+    if (!bPressed) return;
+    direct_mouse_clipboard = !direct_mouse_clipboard;
+    mainMenu.get_item("mapper_fastedit").check(direct_mouse_clipboard).refresh_item(mainMenu);
 }
 
 void CopyAllClipboard(bool bPressed) {
@@ -12468,7 +12471,6 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"showdetails").set_text("Show FPS and RT speed in title bar").set_callback_function(showdetails_menu_callback).check(!menu.hidecycles && menu.showrt);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"auto_lock_mouse").set_text("Autolock mouse").set_callback_function(autolock_mouse_menu_callback).check(sdl.mouse.autoenable);
 #if defined (WIN32) || defined(C_SDL2)
-        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_quick").set_text("Quick edit: copy on select & paste with mouse button or arrows").set_callback_function(direct_mouse_clipboard_menu_callback).check(direct_mouse_clipboard);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_right").set_text("Via right mouse button").set_callback_function(right_mouse_clipboard_menu_callback).check(mbutton==3);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_middle").set_text("Via middle mouse button").set_callback_function(middle_mouse_clipboard_menu_callback).check(mbutton==2);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_arrows").set_text("Via arrow keys (Home=start, End=end)").set_callback_function(arrow_keys_clipboard_menu_callback).check(mbutton==4);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -42,6 +42,9 @@ int posx = -1;
 int posy = -1;
 int initgl = 0;
 int switchoutput=-1;
+int selsrow = -1, selscol = -1;
+int selerow = -1, selecol = -1;
+bool selmark = false;
 extern int enablelfn;
 extern bool blinking;
 extern bool dpi_aware_enable;
@@ -1012,7 +1015,7 @@ void FreeBIOSDiskList();
 void GFX_ShutDown(void);
 void MAPPER_Shutdown();
 void SHELL_Init(void);
-void CopyClipboard(bool all);
+void CopyClipboard(int all);
 void CopyAllClipboard(bool bPressed);
 void PasteClipboard(bool bPressed);
 void PasteClipStop(bool bPressed);
@@ -5057,6 +5060,7 @@ static void GUI_StartUp() {
     const char *clip_mouse_button = section->Get_string("clip_mouse_button");
     if (!strcmp(clip_mouse_button, "middle")) mbutton=2;
     else if (!strcmp(clip_mouse_button, "right")) mbutton=3;
+    else if (!strcmp(clip_mouse_button, "arrows")) mbutton=4;
     else mbutton=0;
     modifier = section->Get_string("clip_key_modifier");
     paste_speed = (unsigned int)section->Get_int("clip_paste_speed");
@@ -5928,6 +5932,60 @@ void MenuFreeScreen(void) {
 }
 #endif
 
+#if defined(WIN32) || defined(C_SDL2)
+bool isModifierApplied() {
+    return direct_mouse_clipboard || !strcmp(modifier,"none") || ((!strcmp(modifier,"alt") || !strcmp(modifier,"lalt")) && sdl.laltstate==SDL_KEYDOWN) || ((!strcmp(modifier,"alt") || !strcmp(modifier,"ralt")) && sdl.raltstate==SDL_KEYDOWN) || ((!strcmp(modifier,"ctrl") || !strcmp(modifier,"lctrl")) && sdl.lctrlstate==SDL_KEYDOWN) || ((!strcmp(modifier,"ctrl") || !strcmp(modifier,"rctrl")) && sdl.rctrlstate==SDL_KEYDOWN) || ((!strcmp(modifier,"shift") || !strcmp(modifier,"lshift")) && sdl.lshiftstate==SDL_KEYDOWN) || ((!strcmp(modifier,"shift") || !strcmp(modifier,"rshift")) && sdl.rshiftstate==SDL_KEYDOWN);
+}
+
+void ClipKeySelect(int sym) {
+    if (mbutton!=4 || (CurMode->type!=M_TEXT && !IS_PC98_ARCH)) return;
+    if (sym==SDLK_HOME) {
+        if (selsrow==-1 || selscol==-1) {
+            int p=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
+            selscol = CURSOR_POS_COL(p);
+            selsrow = CURSOR_POS_ROW(p);
+        } else {
+            if (selsrow>-1 && selscol>-1) Mouse_Select(selscol, selsrow, selmark?selecol:selscol, selmark?selerow:selsrow, -1, -1, false);
+            if (selmark) {
+                selscol = selecol;
+                selsrow = selerow;
+            }
+        }
+        selmark = true;
+        selecol = selscol;
+        selerow = selsrow;
+        Mouse_Select(selscol, selsrow, selecol, selerow, -1, -1, true);
+    } else if (sym==SDLK_END) {
+        if (selmark) {
+            if (selsrow>-1 && selscol>-1 && selerow > -1 && selecol > -1) {
+                Mouse_Select(selscol, selsrow, selecol, selerow, -1, -1, false);
+                CopyClipboard(1);
+            }
+            selmark = false;
+            selsrow = selscol = selerow = selecol = -1;
+        }
+    } else if (sym==SDLK_ESCAPE) {
+        if (selsrow>-1 && selscol>-1) Mouse_Select(selscol, selsrow, selmark?selecol:selscol, selmark?selerow:selsrow, -1, -1, false);
+        selmark = false;
+        selsrow = selscol = selerow = selecol = -1;
+    } else if ((sym==SDLK_LEFT || sym==SDLK_RIGHT || sym==SDLK_UP || sym==SDLK_DOWN)) {
+        if (selsrow==-1 || selscol==-1) {
+            int p=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
+            selscol = CURSOR_POS_COL(p);
+            selsrow = CURSOR_POS_ROW(p);
+            selerow = selecol = -1;
+            selmark = false;
+        } else
+            Mouse_Select(selscol, selsrow, selmark?selecol:selscol, selmark?selerow:selsrow, -1, -1, false);
+        if (sym==SDLK_LEFT && selscol>0) (selmark?selecol:selscol)--;
+        else if (sym==SDLK_RIGHT && selscol<(IS_PC98_ARCH?80:real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS))-1) (selmark?selecol:selscol)++;
+        else if (sym==SDLK_UP && selsrow>0) (selmark?selerow:selsrow)--;
+        else if (sym==SDLK_DOWN && selsrow<real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)) (selmark?selerow:selsrow)++;
+        Mouse_Select(selscol, selsrow, selmark?selecol:selscol, selmark?selerow:selsrow, -1, -1, true);
+    }
+}
+#endif
+
 static void HandleMouseButton(SDL_MouseButtonEvent * button, SDL_MouseMotionEvent * motion) {
 #if !defined(WIN32)
     (void)motion;
@@ -6435,7 +6493,7 @@ static void HandleMouseButton(SDL_MouseButtonEvent * button, SDL_MouseMotionEven
     case SDL_PRESSED:
         if (inMenu || !inputToScreen) return;
 #if defined(WIN32) || defined(C_SDL2)
-		if (!sdl.mouse.locked && button->button == SDL_BUTTON_LEFT && !strcmp(modifier,"none") && mouse_start_x >= 0 && mouse_start_y >= 0 && fx >= 0 && fy >= 0) {
+		if (!sdl.mouse.locked && button->button == SDL_BUTTON_LEFT && isModifierApplied() && mouse_start_x >= 0 && mouse_start_y >= 0 && fx >= 0 && fy >= 0) {
 			Mouse_Select(mouse_start_x-sdl.clip.x,mouse_start_y-sdl.clip.y,fx-sdl.clip.x,fy-sdl.clip.y,(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), false);
 			mouse_start_x = -1;
 			mouse_start_y = -1;
@@ -6444,11 +6502,7 @@ static void HandleMouseButton(SDL_MouseButtonEvent * button, SDL_MouseMotionEven
 			fx = -1;
 			fy = -1;
 		}
-		if (!sdl.mouse.locked && ((mbutton==2 && button->button == SDL_BUTTON_MIDDLE) || (mbutton==3 && button->button == SDL_BUTTON_RIGHT)) && (direct_mouse_clipboard || !strcmp(modifier,"none")
-			|| ((!strcmp(modifier,"alt") || !strcmp(modifier,"lalt")) && sdl.laltstate==SDL_KEYDOWN) || ((!strcmp(modifier,"alt") || !strcmp(modifier,"ralt")) && sdl.raltstate==SDL_KEYDOWN)
-			|| ((!strcmp(modifier,"ctrl") || !strcmp(modifier,"lctrl")) && sdl.lctrlstate==SDL_KEYDOWN) || ((!strcmp(modifier,"ctrl") || !strcmp(modifier,"rctrl")) && sdl.rctrlstate==SDL_KEYDOWN)
-			|| ((!strcmp(modifier,"shift") || !strcmp(modifier,"lshift")) && sdl.lshiftstate==SDL_KEYDOWN) || ((!strcmp(modifier,"shift") || !strcmp(modifier,"rshift")) && sdl.rshiftstate==SDL_KEYDOWN)
-			)) {
+		if (!sdl.mouse.locked && ((mbutton==2 && button->button == SDL_BUTTON_MIDDLE) || (mbutton==3 && button->button == SDL_BUTTON_RIGHT)) && isModifierApplied()) {
 			mouse_start_x=motion->x;
 			mouse_start_y=motion->y;
 			break;
@@ -6529,7 +6583,7 @@ static void HandleMouseButton(SDL_MouseButtonEvent * button, SDL_MouseMotionEven
 				if (abs(mouse_end_x - mouse_start_x) + abs(mouse_end_y - mouse_start_y)<5) {
 					PasteClipboard(true);
 				} else
-					CopyClipboard(false);
+					CopyClipboard(0);
 			}
 			mouse_start_x = -1;
 			mouse_start_y = -1;
@@ -7098,6 +7152,8 @@ void GFX_Events() {
             if (event.key.keysym.sym==SDLK_RCTRL) sdl.rctrlstate = event.key.type;
             if (event.key.keysym.sym==SDLK_LSHIFT) sdl.lshiftstate = event.key.type;
             if (event.key.keysym.sym==SDLK_RSHIFT) sdl.rshiftstate = event.key.type;
+            if (event.type == SDL_KEYDOWN && isModifierApplied())
+                ClipKeySelect(event.key.keysym.sym);
 #endif
 #if defined (MACOSX)
             /* On macs CMD-Q is the default key to close an application */
@@ -7368,6 +7424,8 @@ void GFX_Events() {
             if (event.key.keysym.sym==SDLK_LSHIFT) sdl.lshiftstate = event.key.type;
             if (event.key.keysym.sym==SDLK_RSHIFT) sdl.rshiftstate = event.key.type;
 #if defined(WIN32)
+            if (event.type == SDL_KEYDOWN && isModifierApplied())
+                ClipKeySelect(event.key.keysym.sym);
             if (((event.key.keysym.sym==SDLK_TAB)) &&
                 ((sdl.laltstate==SDL_KEYDOWN) || (sdl.raltstate==SDL_KEYDOWN))) { MAPPER_LosingFocus(); break; }
             // This can happen as well.
@@ -7468,17 +7526,18 @@ void SDL_SetupConfigSection() {
     Pstring->Set_help("Autolock status feedback type, i.e. visual, auditive, none.");
     Pstring->Set_values(feeds);
 
-	const char* clipboardbutton[] = { "none", "middle", "right", 0};
+	const char* clipboardbutton[] = { "none", "middle", "right", "arrows", 0};
 	Pstring = sdl_sec->Add_string("clip_mouse_button",Property::Changeable::Always, "right");
 	Pstring->Set_values(clipboardbutton);
-	Pstring->Set_help("Select the mouse button for the shared clipboard copy/paste function.\n"
-		"The default mouse button is \"right\". Set to \"middle\" if the middle mouse button is desired, or \"none\" to disable this feature.");
+	Pstring->Set_help("Select the mouse button or use arrow keys for the shared clipboard copy/paste function.\n"
+		"The default mouse button is \"right\", which means using the right mouse button to select text, copy to and paste from the host clipboard.\n"
+		"Set to \"middle\" to use the middle mouse button, \"arrows\" to use arrow keys instead of a mouse button, or \"none\" to disable this feature.");
     Pstring->SetBasic(true);
 
 	const char* clipboardmodifier[] = { "none", "alt", "lalt", "ralt", "ctrl", "lctrl", "rctrl", "shift", "lshift", "rshift", 0};
 	Pstring = sdl_sec->Add_string("clip_key_modifier",Property::Changeable::Always, "shift");
 	Pstring->Set_values(clipboardmodifier);
-	Pstring->Set_help("Change the keyboard modifier for the shared clipboard copy/paste function using the right mouse button.\n"
+	Pstring->Set_help("Change the keyboard modifier for the shared clipboard copy/paste function using a mouse button or arrow keys.\n"
 		"The default modifier is \"shift\" (both left and right shift keys). Set to \"none\" if no modifier is desired.");
     Pstring->SetBasic(true);
 
@@ -8091,9 +8150,9 @@ bool PasteClipboardNext() {
 #endif
 
 #if defined (WIN32)
-void CopyClipboard(bool all) {
+void CopyClipboard(int all) {
 	uint16_t len=0;
-	const char* text = (char *)(all?Mouse_GetSelected(0-sdl.clip.x,0-sdl.clip.y,currentWindowWidth-1-sdl.clip.x,currentWindowHeight-1-sdl.clip.y,(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len):Mouse_GetSelected(mouse_start_x-sdl.clip.x,mouse_start_y-sdl.clip.y,mouse_end_x-sdl.clip.x,mouse_end_y-sdl.clip.y,(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len));
+	const char* text = (char *)(all==2?Mouse_GetSelected(0-sdl.clip.x,0-sdl.clip.y,currentWindowWidth-1-sdl.clip.x,currentWindowHeight-1-sdl.clip.y,(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len):(all==1?Mouse_GetSelected(selscol, selsrow, selecol, selerow, -1, -1, &len):Mouse_GetSelected(mouse_start_x-sdl.clip.x,mouse_start_y-sdl.clip.y,mouse_end_x-sdl.clip.x,mouse_end_y-sdl.clip.y,(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len)));
 	if (OpenClipboard(NULL)&&EmptyClipboard()) {
 		HGLOBAL clipbuffer = GlobalAlloc(GMEM_DDESHARE, (len+1)*2);
 		LPWSTR buffer = static_cast<LPWSTR>(GlobalLock(clipbuffer));
@@ -8125,9 +8184,9 @@ static BOOL WINAPI ConsoleEventHandler(DWORD event) {
 #elif defined(C_SDL2)
 typedef char host_cnv_char_t;
 host_cnv_char_t *CodePageGuestToHost(const char *s);
-void CopyClipboard(bool all) {
+void CopyClipboard(int all) {
 	uint16_t len=0;
-	char* text = (char *)(all?Mouse_GetSelected(0-sdl.clip.x,0-sdl.clip.y,currentWindowWidth-1-sdl.clip.x,currentWindowHeight-1-sdl.clip.y,(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len):Mouse_GetSelected(mouse_start_x-sdl.clip.x,mouse_start_y-sdl.clip.y,mouse_end_x-sdl.clip.x,mouse_end_y-sdl.clip.y,(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len));
+	char* text = (char *)(all==2?Mouse_GetSelected(0-sdl.clip.x,0-sdl.clip.y,currentWindowWidth-1-sdl.clip.x,currentWindowHeight-1-sdl.clip.y,(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len):(all==1?Mouse_GetSelected(selscol, selsrow, selecol, selerow, -1, -1, &len):Mouse_GetSelected(mouse_start_x-sdl.clip.x,mouse_start_y-sdl.clip.y,mouse_end_x-sdl.clip.x,mouse_end_y-sdl.clip.y,(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len)));
     unsigned int k=0;
     for (unsigned int i=0; i<len; i++)
         if (text[i]&&text[i]!=13)
@@ -10371,12 +10430,23 @@ bool direct_mouse_clipboard_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::i
     return true;
 }
 
+bool arrow_keys_clipboard_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+    mbutton = 4;
+    mainMenu.get_item("clipboard_right").check(false).refresh_item(mainMenu);
+    mainMenu.get_item("clipboard_middle").check(false).refresh_item(mainMenu);
+    mainMenu.get_item("clipboard_arrows").check(true).refresh_item(mainMenu);
+    return true;
+}
+
 bool right_mouse_clipboard_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
     (void)menuitem;//UNUSED
     mbutton = 3;
     mainMenu.get_item("clipboard_right").check(true).refresh_item(mainMenu);
     mainMenu.get_item("clipboard_middle").check(false).refresh_item(mainMenu);
+    mainMenu.get_item("clipboard_arrows").check(false).refresh_item(mainMenu);
     return true;
 }
 
@@ -10386,19 +10456,20 @@ bool middle_mouse_clipboard_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::i
     mbutton = 2;
     mainMenu.get_item("clipboard_right").check(false).refresh_item(mainMenu);
     mainMenu.get_item("clipboard_middle").check(true).refresh_item(mainMenu);
+    mainMenu.get_item("clipboard_arrows").check(false).refresh_item(mainMenu);
     return true;
 }
 
 bool screen_to_clipboard_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
     (void)menuitem;//UNUSED
-    CopyClipboard(true);
+    CopyClipboard(2);
     return true;
 }
 
 void CopyAllClipboard(bool bPressed) {
     if (!bPressed) return;
-    CopyClipboard(true);
+    CopyClipboard(2);
 }
 #else
 void CopyAllClipboard(bool bPressed) {
@@ -12397,9 +12468,10 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"showdetails").set_text("Show FPS and RT speed in title bar").set_callback_function(showdetails_menu_callback).check(!menu.hidecycles && menu.showrt);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"auto_lock_mouse").set_text("Autolock mouse").set_callback_function(autolock_mouse_menu_callback).check(sdl.mouse.autoenable);
 #if defined (WIN32) || defined(C_SDL2)
-        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_quick").set_text("Quick edit: copy on select and paste with mouse button").set_callback_function(direct_mouse_clipboard_menu_callback).check(direct_mouse_clipboard);
+        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_quick").set_text("Quick edit: copy on select & paste with mouse button or arrows").set_callback_function(direct_mouse_clipboard_menu_callback).check(direct_mouse_clipboard);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_right").set_text("Via right mouse button").set_callback_function(right_mouse_clipboard_menu_callback).check(mbutton==3);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_middle").set_text("Via middle mouse button").set_callback_function(middle_mouse_clipboard_menu_callback).check(mbutton==2);
+        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_arrows").set_text("Via arrow keys (Home=start, End=end)").set_callback_function(arrow_keys_clipboard_menu_callback).check(mbutton==4);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"screen_to_clipboard").set_text("Copy all text on the DOS screen").set_callback_function(screen_to_clipboard_menu_callback);
 #endif
 #if defined (WIN32)

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1951,6 +1951,7 @@ void SDL_Prepare(void) {
 
     SDL_PumpEvents();
     DragAcceptFiles(GetHWND(), TRUE);
+    SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY, SDL_DEFAULT_REPEAT_INTERVAL);
 #endif
 #endif
 }

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -3202,6 +3202,7 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
         Bitu vidstart = vga.config.real_start + vga.draw.bytes_skip;
         vidstart *= 2;
         ttf_cell* draw = newAttrChar;
+        ttf_cell* drawc = curAttrChar;
 
         if (IS_PC98_ARCH) {
             const uint16_t* charram = (uint16_t*)&vga.draw.linear_base[0x0000];         // character data
@@ -3216,6 +3217,7 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
                 bool dbw=false;
 
                 *draw = ttf_cell();
+                (*draw).selected = (*drawc).selected;
 
                 /* NTS: PC-98 hardware does not require both cells of a double-wide to match,
                  *      in fact if the hardware sees a double-wide in the first cell it will just render the double-wide
@@ -3297,15 +3299,18 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
                 (*draw).fg = foreground;
                 (*draw).bg = background;
                 draw++;
+                drawc++;
 
                 if (dbw) {
                     /* extra cell. Should not draw */
                     *draw = ttf_cell();
+                    (*draw).selected = (*drawc).selected;
                     (*draw).skipped = 1;
                     (*draw).chr = 'x'; // should not see this
                     (*draw).fg = 4|8; // bright red, in case this is visible
                     (*draw).bg = 4; // dark red, in case this is visible
                     draw++;
+                    drawc++;
                     charram++;
                     attrram++;
                     if (blocks != 0) blocks--; /* careful! The for loop is written to stop when blocks == 0 */
@@ -3319,6 +3324,7 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
                         // NTS: Note this assumes EGA/VGA text mode that uses the "Odd/Even" mode memory mapping scheme to present video memory
                         //      to the CPU as if CGA compatible text mode. Character data on plane 0, attributes on plane 1.
                         *draw = ttf_cell();
+                        (*draw).selected = (*drawc).selected;
                         (*draw).chr = *vidmem & 0xFF;
                         Bitu attr = (*vidmem >> 8u) & 0xFFu;
                         vidmem+=2; // because planar EGA/VGA, and odd/even mode as real hardware arranges alphanumeric mode in VRAM
@@ -3331,6 +3337,7 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
                         (*draw).fg = foreground;
                         (*draw).bg = background;
                         draw++;
+                        drawc++;
                     }
                     vidstart += vga.draw.address_add;
                 }
@@ -3339,6 +3346,7 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
                     const uint16_t* vidmem = (uint16_t*)VGA_Text_Memwrap(vidstart);	// pointer to chars+attribs (EGA/VGA planar memory)
                     for (Bitu col=0;col < ttf.cols;col++) {
                         *draw = ttf_cell();
+                        (*draw).selected = (*drawc).selected;
                         (*draw).chr = *vidmem;
                         Bitu attr = (*vidmem >> 8u) & 0xFFu;
                         vidmem++;
@@ -3351,6 +3359,7 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
                         (*draw).fg = foreground;
                         (*draw).bg = background;
                         draw++;
+                        drawc++;
                     }
                     vidstart += vga.draw.address_add;
                 }

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -721,7 +721,13 @@ const char* Mouse_GetSelected(int x1, int y1, int x2, int y2, int w, int h, uint
 		c=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
 		r=(uint16_t)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
 	}
-	int c1=c*x1/w, r1=r*y1/h, c2=c*x2/w, r2=r*y2/h, t;
+    int c1=x1, r1=y1, c2=x2, r2=y2, t;
+    if (w>-1&&h>-1) {
+        c1=c*x1/w;
+        r1=r*y1/h;
+        c2=c*x2/w;
+        r2=r*y2/h;
+    }
 	if (c1>c2) {
 		t=c1;
 		c1=c2;
@@ -769,16 +775,22 @@ const char* Mouse_GetSelected(int x1, int y1, int x2, int y2, int w, int h, uint
 }
 
 void Mouse_Select(int x1, int y1, int x2, int y2, int w, int h, bool select) {
-	uint8_t page = real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
-	uint16_t c=0, r=0;
-	if (IS_PC98_ARCH) {
-		c=80;
-		r=real_readb(0x60,0x113) & 0x01 ? 25 : 20;
-	} else {
-		c=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-		r=(uint16_t)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
-	}
-	int c1=c*x1/w, r1=r*y1/h, c2=c*x2/w, r2=r*y2/h, t;
+    int c1=x1, r1=y1, c2=x2, r2=y2, t;
+    uint8_t page = real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
+    uint16_t c=0, r=0;
+    if (IS_PC98_ARCH) {
+        c=80;
+        r=real_readb(0x60,0x113) & 0x01 ? 25 : 20;
+    } else {
+        c=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
+        r=(uint16_t)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
+    }
+    if (w>-1&&h>-1) {
+        c1=c*x1/w;
+        r1=r*y1/h;
+        c2=c*x2/w;
+        r2=r*y2/h;
+    }
 	if (c1>c2) {
 		t=c1;
 		c1=c2;


### PR DESCRIPTION
@emendelson and @JoeC4281 have requested the ability to do text selection using the keyboard for the clipboard in Issue #2116, so here it is. There is now an option to select text using the arrow keys, which can be enabled by either setting "clip_mouse_button=arrows" or selecting from "Shared clipboard functions" menu group, in addition to the other existing options.