### PR TITLE
Fix identicalInnerCondition warnings (Cppcheck)

### DIFF
--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -411,7 +411,7 @@ static void DestroySubWindows(void) {
         WINDOW* &ref = dbg.get_win_ref((int)wnd);
 
         if (ref != NULL) {
-            if (ref) delwin(ref);
+            delwin(ref);
             ref = NULL;
         }
     }

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -1269,7 +1269,7 @@ bool CSerial::Putchar(uint8_t data, bool wait_dsr, bool wait_cts, Bitu timeout) 
 	}
 	// wait for DSR+CTS on
 	if(wait_dsr||wait_cts) {
-		if(wait_dsr||wait_cts) {
+		if(wait_dsr&&wait_cts) {
 			while(((Read_MSR()&0x30)!=0x30)&&(starttime>PIC_FullIndex()-timeout))
 				CALLBACK_Idle();
 		} else if(wait_dsr) {


### PR DESCRIPTION
The fix to `serialport.cpp` was also in dosbox-staging. They have since rewritten the function.

https://github.com/dosbox-staging/dosbox-staging/commit/c57ba6a66b8c211b1743bafb910c7e2afd7cf06c#diff-b40eaa55ac8d3033317d144486722e491cf861c5524004c7e5a74aaf687ff648