### PR TITLE
Add missing key symbols in sdl_mapper

### DIFF
--- a/include/mapper.h
+++ b/include/mapper.h
@@ -24,10 +24,10 @@
 enum MapKeys {
     MK_nothing,
 	MK_f1,MK_f2,MK_f3,MK_f4,MK_f5,MK_f6,MK_f7,MK_f8,MK_f9,MK_f10,MK_f11,MK_f12,
-	MK_return,MK_kpminus,MK_kpplus,MK_minus,MK_equals,MK_scrolllock,MK_printscreen,MK_pause,MK_home,MK_rightarrow,
-	MK_1, MK_2, MK_3, MK_4,
-    MK_a, MK_b, MK_c, MK_d, MK_f, MK_i, MK_l, MK_m, MK_o, MK_p, MK_q, MK_r, MK_s, MK_v, MK_w,
-    MK_escape,MK_delete,MK_uparrow,MK_downarrow,MK_leftarrow,
+	MK_return,MK_kpminus,MK_kpplus,MK_minus,MK_equals,MK_scrolllock,MK_printscreen,MK_pause,MK_home,MK_end,
+	MK_0, MK_1, MK_2, MK_3, MK_4, MK_5, MK_6, MK_7, MK_8, MK_9,
+    MK_a, MK_b, MK_c, MK_d, MK_e, MK_f, MK_g, MK_h, MK_i, MK_j, MK_k, MK_l, MK_m, MK_n, MK_o, MK_p, MK_q, MK_r, MK_s, MK_t, MK_u, MK_v, MK_w, MK_x, MK_y, MK_z,
+    MK_escape,MK_delete,MK_uparrow,MK_downarrow,MK_leftarrow,MK_rightarrow,MK_pageup,MK_pagedown,
     MK_lbracket,MK_rbracket,MK_comma,MK_period,
 
     MK_MAX

--- a/include/mapper.h
+++ b/include/mapper.h
@@ -24,12 +24,12 @@
 enum MapKeys {
     MK_nothing,
 	MK_f1,MK_f2,MK_f3,MK_f4,MK_f5,MK_f6,MK_f7,MK_f8,MK_f9,MK_f10,MK_f11,MK_f12,
-	MK_return,MK_kpminus,MK_kpplus,MK_minus,MK_equals,MK_scrolllock,MK_printscreen,MK_pause,MK_home,MK_end,
+	MK_return,MK_tab,MK_slash,MK_backslash,MK_space,MK_backspace,
+	MK_kpminus,MK_kpplus,MK_minus,MK_equals,MK_scrolllock,MK_printscreen,MK_pause,MK_home,MK_end,MK_insert,MK_delete,
 	MK_0, MK_1, MK_2, MK_3, MK_4, MK_5, MK_6, MK_7, MK_8, MK_9,
     MK_a, MK_b, MK_c, MK_d, MK_e, MK_f, MK_g, MK_h, MK_i, MK_j, MK_k, MK_l, MK_m, MK_n, MK_o, MK_p, MK_q, MK_r, MK_s, MK_t, MK_u, MK_v, MK_w, MK_x, MK_y, MK_z,
-    MK_escape,MK_delete,MK_uparrow,MK_downarrow,MK_leftarrow,MK_rightarrow,MK_pageup,MK_pagedown,
-    MK_lbracket,MK_rbracket,MK_comma,MK_period,
-
+    MK_escape,MK_uparrow,MK_downarrow,MK_leftarrow,MK_rightarrow,MK_pageup,MK_pagedown,
+    MK_lbracket,MK_rbracket,MK_comma,MK_period,MK_semicolon,MK_quote,MK_grave,
     MK_MAX
 };
 

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2753,14 +2753,26 @@ public:
         case MK_printscreen:
             key=SDL_SCANCODE_PRINTSCREEN;
             break;
-        case MK_home: 
+        case MK_home:
             key=SDL_SCANCODE_HOME;
+            break;
+        case MK_end:
+            key=SDL_SCANCODE_END;
+            break;
+        case MK_pageup:
+            key=SDL_SCANCODE_PAGEUP;
+            break;
+        case MK_pagedown:
+            key=SDL_SCANCODE_PAGEDOWN;
             break;
         case MK_comma:
             key=SDL_SCANCODE_COMMA;
             break;
         case MK_period:
             key=SDL_SCANCODE_PERIOD;
+            break;
+        case MK_0:
+            key=SDL_SCANCODE_0;
             break;
         case MK_1:
             key=SDL_SCANCODE_1;
@@ -2774,6 +2786,21 @@ public:
         case MK_4:
             key=SDL_SCANCODE_4;
             break;
+        case MK_5:
+            key=SDL_SCANCODE_5;
+            break;
+        case MK_6:
+            key=SDL_SCANCODE_6;
+            break;
+        case MK_7:
+            key=SDL_SCANCODE_7;
+            break;
+        case MK_8:
+            key=SDL_SCANCODE_8;
+            break;
+        case MK_9:
+            key=SDL_SCANCODE_9;
+            break;
         case MK_a:
             key=SDL_SCANCODE_A;
             break;
@@ -2786,17 +2813,35 @@ public:
         case MK_d:
             key=SDL_SCANCODE_D;
             break;
+        case MK_e:
+            key=SDL_SCANCODE_E;
+            break;
         case MK_f:
             key=SDL_SCANCODE_F;
             break;
+        case MK_g:
+            key=SDL_SCANCODE_G;
+            break;
+        case MK_h:
+            key=SDL_SCANCODE_H;
+            break;
         case MK_i:
             key=SDL_SCANCODE_I;
+            break;
+        case MK_j:
+            key=SDL_SCANCODE_J;
+            break;
+        case MK_k:
+            key=SDL_SCANCODE_K;
             break;
         case MK_l:
             key=SDL_SCANCODE_L;
             break;
         case MK_m:
             key=SDL_SCANCODE_M;
+            break;
+        case MK_n:
+            key=SDL_SCANCODE_N;
             break;
         case MK_o:
             key=SDL_SCANCODE_O;
@@ -2813,11 +2858,26 @@ public:
         case MK_s:
             key=SDL_SCANCODE_S;
             break;
+        case MK_t:
+            key=SDL_SCANCODE_T;
+            break;
+        case MK_u:
+            key=SDL_SCANCODE_U;
+            break;
         case MK_v:
             key=SDL_SCANCODE_V;
             break;
         case MK_w:
             key=SDL_SCANCODE_W;
+            break;
+        case MK_x:
+            key=SDL_SCANCODE_X;
+            break;
+        case MK_y:
+            key=SDL_SCANCODE_Y;
+            break;
+        case MK_z:
+            key=SDL_SCANCODE_Z;
             break;
         case MK_escape:
             key=SDL_SCANCODE_ESCAPE;
@@ -2900,11 +2960,23 @@ public:
         case MK_home:
             key=SDLK_HOME; 
             break;
+        case MK_end:
+            key=SDLK_END;
+            break;
+        case MK_pageup:
+            key=SDLK_PAGEUP;
+            break;
+        case MK_pagedown:
+            key=SDLK_PAGEDOWN;
+            break;
         case MK_comma:
             key=SDLK_COMMA;
             break;
         case MK_period:
             key=SDLK_PERIOD;
+            break;
+        case MK_0:
+            key=SDLK_0;
             break;
         case MK_1:
             key=SDLK_1;
@@ -2918,6 +2990,21 @@ public:
         case MK_4:
             key=SDLK_4;
             break;
+        case MK_5:
+            key=SDLK_5;
+            break;
+        case MK_6:
+            key=SDLK_6;
+            break;
+        case MK_7:
+            key=SDLK_7;
+            break;
+        case MK_8:
+            key=SDLK_8;
+            break;
+        case MK_9:
+            key=SDLK_9;
+            break;
         case MK_a:
             key=SDLK_a;
             break;
@@ -2930,17 +3017,35 @@ public:
         case MK_d:
             key=SDLK_d;
             break;
+        case MK_e:
+            key=SDLK_e;
+            break;
         case MK_f:
             key=SDLK_f;
             break;
+        case MK_g:
+            key=SDLK_g;
+            break;
+        case MK_h:
+            key=SDLK_h;
+            break;
         case MK_i:
             key=SDLK_i;
+            break;
+        case MK_j:
+            key=SDLK_j;
+            break;
+        case MK_k:
+            key=SDLK_k;
             break;
         case MK_l:
             key=SDLK_l;
             break;
         case MK_m:
             key=SDLK_m;
+            break;
+        case MK_n:
+            key=SDLK_n;
             break;
         case MK_o:
             key=SDLK_o;
@@ -2957,11 +3062,26 @@ public:
         case MK_s:
             key=SDLK_s;
             break;
+        case MK_t:
+            key=SDLK_t;
+            break;
+        case MK_u:
+            key=SDLK_u;
+            break;
         case MK_v:
             key=SDLK_v;
             break;
         case MK_w:
             key=SDLK_w;
+            break;
+        case MK_x:
+            key=SDLK_x;
+            break;
+        case MK_y:
+            key=SDLK_y;
+            break;
+        case MK_z:
+            key=SDLK_z;
             break;
         case MK_escape:
             key=SDLK_ESCAPE;

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2732,6 +2732,36 @@ public:
         case MK_return:
             key=SDL_SCANCODE_RETURN;
             break;
+        case MK_tab:
+            key=SDL_SCANCODE_TAB;
+            break;
+        case MK_slash:
+            key=SDL_SCANCODE_SLASH;
+            break;
+        case MK_backslash:
+            key=SDL_SCANCODE_BACKSLASH;
+            break;
+        case MK_space:
+            key=SDL_SCANCODE_SPACE;
+            break;
+        case MK_backspace:
+            key=SDL_SCANCODE_BACKSPACE;
+            break;
+        case MK_delete:
+            key=SDL_SCANCODE_DELETE;
+            break;
+        case MK_insert:
+            key=SDL_SCANCODE_INSERT;
+            break;
+        case MK_semicolon:
+            key=SDL_SCANCODE_SEMICOLON;
+            break;
+        case MK_quote:
+            key=SDL_SCANCODE_APOSTROPHE;
+            break;
+        case MK_grave:
+            key=SDL_SCANCODE_GRAVE;
+            break;
         case MK_kpminus:
             key=SDL_SCANCODE_KP_MINUS;
             break;
@@ -2882,9 +2912,6 @@ public:
         case MK_escape:
             key=SDL_SCANCODE_ESCAPE;
             break;
-        case MK_delete:
-            key=SDL_SCANCODE_DELETE;
-            break;
         case MK_lbracket:
             key=SDL_SCANCODE_LEFTBRACKET;
             break;
@@ -2927,6 +2954,36 @@ public:
             break;
         case MK_return:
             key=SDLK_RETURN;
+            break;
+        case MK_tab:
+            key=SDLK_TAB;
+            break;
+        case MK_slash:
+            key=SDLK_SLASH;
+            break;
+        case MK_backslash:
+            key=SDLK_BACKSLASH;
+            break;
+        case MK_space:
+            key=SDLK_SPACE;
+            break;
+        case MK_backspace:
+            key=SDLK_BACKSPACE;
+            break;
+        case MK_delete:
+            key=SDLK_DELETE;
+            break;
+        case MK_insert:
+            key=SDLK_INSERT;
+            break;
+        case MK_semicolon:
+            key=SDLK_SEMICOLON;
+            break;
+        case MK_quote:
+            key=SDLK_QUOTE;
+            break;
+        case MK_grave:
+            key=SDLK_BACKQUOTE;
             break;
         case MK_kpminus:
             key=SDLK_KP_MINUS;
@@ -3085,9 +3142,6 @@ public:
             break;
         case MK_escape:
             key=SDLK_ESCAPE;
-            break;
-        case MK_delete:
-            key=SDLK_DELETE;
             break;
         case MK_lbracket:
             key=SDLK_LEFTBRACKET;


### PR DESCRIPTION
As revealed in Issue #2130, it appears that there are a couple of key symbols missing the sdl_mapper file, apart from PgUp and PgDn. For example, there are symbols for keys 1-4, but no symbols for keys 5-9 and 0; there are symbols for keys A, B, C, D, F, but no symbols for keys E, G, H; and so on. So I have added the missing symbols for such keys in the code.