### PR TITLE
Fixes to the mapper keys and clipboard

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -118,6 +118,10 @@
     information" have been added to the key mapper so
     that you can now define your own shortcut keys to
     activate these functions. (Wengier)
+  - The default shortcuts for the "Copy to clipboard",
+    "Paste from clipboard", and the "Reset window size"
+    functions are now Ctrl+F5, Ctrl+F6 and Host(F11/F12)
+    +BackSpace respectively. (Wengier)
   - Added ttf.fontbold, ttf.fontital, and ttf.fontboit
     config options so that you can specify actual bold
     italic, and bold-italic TrueType fonts for use with

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -122,6 +122,8 @@
     "Paste from clipboard", and the "Reset window size"
     functions are now Ctrl+F5, Ctrl+F6 and Host(F11/F12)
     +BackSpace respectively. (Wengier)
+  - Added -defaultmapper command-line option which will
+    use default key bindings for the mapper. (Wengier)
   - Added ttf.fontbold, ttf.fontital, and ttf.fontboit
     config options so that you can specify actual bold
     italic, and bold-italic TrueType fonts for use with

--- a/include/control.h
+++ b/include/control.h
@@ -97,6 +97,7 @@ public:
         opt_resetmapper = false;
         opt_startmapper = false;
         opt_fastbioslogo = false;
+        opt_defaultmapper = false;
         opt_alt_vga_render = false;
         opt_date_host_forced = false;
         opt_disable_numlock_check = false;
@@ -130,6 +131,7 @@ public:
     bool opt_disable_numlock_check;
     bool opt_date_host_forced;
     bool opt_alt_vga_render;
+    bool opt_defaultmapper;
     bool opt_fastbioslogo;
     bool opt_break_start;
     bool opt_erasemapper;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1101,12 +1101,12 @@ void DOSBOX_RealInit() {
 	}
 
 	//add support for loading/saving game states
-    MAPPER_AddHandler(ShowStateInfo, MK_nothing, 0,"showstate","Display state info", &item);
-        item->set_text("Display state information");
 	MAPPER_AddHandler(SaveGameState, MK_s, MMODHOST,"savestate","Save state", &item);
         item->set_text("Save state");
 	MAPPER_AddHandler(LoadGameState, MK_l, MMODHOST,"loadstate","Load state", &item);
         item->set_text("Load state");
+    MAPPER_AddHandler(ShowStateInfo, MK_nothing, 0,"showstate","Display state info", &item);
+        item->set_text("Display state information");
 	MAPPER_AddHandler(PreviousSaveSlot, MK_comma, MMODHOST,"prevslot","Previous save slot", &item);
         item->set_text("Select previous slot");
 	MAPPER_AddHandler(NextSaveSlot, MK_period, MMODHOST,"nextslot","Next save slot", &item);

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -4817,6 +4817,7 @@ void MAPPER_Init(void) {
 
 std::string GetDOSBoxXPath();
 void ReloadMapper(Section_prop *section, bool init) {
+    if (!init&&control->opt_defaultmapper) return;
     Prop_path* pp;
 #if defined(C_SDL2)
 	pp = section->Get_path("mapperfile_sdl2");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8617,6 +8617,7 @@ bool DOSBOX_parse_argv() {
             fprintf(stderr,"  -savedir <path>                         Set path for the save slots\n");
             fprintf(stderr,"  -defaultdir <path>                      Set the default working path for DOSBox-X\n");
             fprintf(stderr,"  -defaultconf                            Use the default config settings for DOSBox-X\n");
+            fprintf(stderr,"  -defaultmapper                          Use the default key mappings for DOSBox-X\n");
 #if defined(WIN32)
             fprintf(stderr,"  -disable-numlock-check                  Disable NumLock check (Windows version only)\n");
 #endif
@@ -8790,6 +8791,9 @@ bool DOSBOX_parse_argv() {
         }
         else if (optname == "printconf") {
             control->opt_printconf = true;
+        }
+        else if (optname == "defaultmapper") {
+            control->opt_defaultmapper = true;
         }
         else if (optname == "erasemapper") {
             control->opt_erasemapper = true;
@@ -12491,6 +12495,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 
         /* finally, the mapper */
         MAPPER_Init();
+        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"hostkey_mapper").set_text("Mapper-defined").set_callback_function(hostkey_preset_menu_callback);
 
         /* stop at this point, and show the mapper, if instructed */
         if (control->opt_startmapper) {
@@ -12522,7 +12527,6 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"hostkey_ctrlalt").set_text("Ctrl+Alt").set_callback_function(hostkey_preset_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"hostkey_ctrlshift").set_text("Ctrl+Shift").set_callback_function(hostkey_preset_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"hostkey_altshift").set_text("Alt+Shift").set_callback_function(hostkey_preset_menu_callback);
-        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"hostkey_mapper").set_text("Mapper-defined").set_callback_function(hostkey_preset_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_mapper_winlogo").set_text("Mapper \"Send special key\": logo key").set_callback_function(sendkey_mapper_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_mapper_winmenu").set_text("Mapper \"Send special key\": menu key").set_callback_function(sendkey_mapper_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_mapper_alttab").set_text("Mapper \"Send special key\": Alt+Tab").set_callback_function(sendkey_mapper_menu_callback);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8010,7 +8010,11 @@ void PasteClipboard(bool bPressed) {
 
 bool PasteClipboardNext() {
     if (strPasteBuffer.length() == 0) return false;
-	BIOS_AddKeyToBuffer(strPasteBuffer[0]<0?strPasteBuffer[0]&0xff:strPasteBuffer[0]);
+    if (strPasteBuffer[0]==13) {
+        KEYBOARD_AddKey(KBD_enter, true);
+        KEYBOARD_AddKey(KBD_enter, false);
+    } else
+        BIOS_AddKeyToBuffer(strPasteBuffer[0]<0?strPasteBuffer[0]&0xff:strPasteBuffer[0]);
     strPasteBuffer = strPasteBuffer.substr(1, strPasteBuffer.length());
 	return true;
 }
@@ -8057,12 +8061,17 @@ void PasteClipboard(bool bPressed) {
             result+=asc != NULL?std::string(asc):std::string(1, text[i]);
         }
     }
+    delete text;
     strPasteBuffer.append(result.c_str());
 }
 
 bool PasteClipboardNext() {
     if (strPasteBuffer.length() == 0) return false;
-	BIOS_AddKeyToBuffer(strPasteBuffer[0]<0?strPasteBuffer[0]&0xff:strPasteBuffer[0]);
+    if (strPasteBuffer[0]==13) {
+        KEYBOARD_AddKey(KBD_enter, true);
+        KEYBOARD_AddKey(KBD_enter, false);
+    } else
+        BIOS_AddKeyToBuffer(strPasteBuffer[0]<0?strPasteBuffer[0]&0xff:strPasteBuffer[0]);
     strPasteBuffer = strPasteBuffer.substr(1, strPasteBuffer.length());
 	return true;
 }
@@ -8162,7 +8171,11 @@ void PasteClipboard(bool bPressed) {
 
 bool PasteClipboardNext() {
     if (strPasteBuffer.length() == 0) return false;
-	BIOS_AddKeyToBuffer(strPasteBuffer[0]<0?strPasteBuffer[0]&0xff:strPasteBuffer[0]);
+    if (strPasteBuffer[0]==13) {
+        KEYBOARD_AddKey(KBD_enter, true);
+        KEYBOARD_AddKey(KBD_enter, false);
+    } else
+        BIOS_AddKeyToBuffer(strPasteBuffer[0]<0?strPasteBuffer[0]&0xff:strPasteBuffer[0]);
     strPasteBuffer = strPasteBuffer.substr(1, strPasteBuffer.length());
 	return true;
 }
@@ -8182,7 +8195,7 @@ bool PasteClipboardNext() {
 #if defined (WIN32)
 void CopyClipboard(int all) {
 	uint16_t len=0;
-	const char* text = (char *)(all==2?Mouse_GetSelected(0-sdl.clip.x,0-sdl.clip.y,currentWindowWidth-1-sdl.clip.x,currentWindowHeight-1-sdl.clip.y,(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len):(all==1?Mouse_GetSelected(selscol, selsrow, selecol, selerow, -1, -1, &len):Mouse_GetSelected(mouse_start_x-sdl.clip.x,mouse_start_y-sdl.clip.y,mouse_end_x-sdl.clip.x,mouse_end_y-sdl.clip.y,(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len)));
+	const char* text = (char *)(all==2?Mouse_GetSelected(0,0,currentWindowWidth-1-sdl.clip.x,currentWindowHeight-1-sdl.clip.y,(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len):(all==1?Mouse_GetSelected(selscol, selsrow, selecol, selerow, -1, -1, &len):Mouse_GetSelected(mouse_start_x-sdl.clip.x,mouse_start_y-sdl.clip.y,mouse_end_x-sdl.clip.x,mouse_end_y-sdl.clip.y,(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len)));
 	if (OpenClipboard(NULL)&&EmptyClipboard()) {
 		HGLOBAL clipbuffer = GlobalAlloc(GMEM_DDESHARE, (len+1)*2);
 		LPWSTR buffer = static_cast<LPWSTR>(GlobalLock(clipbuffer));
@@ -8216,7 +8229,7 @@ typedef char host_cnv_char_t;
 host_cnv_char_t *CodePageGuestToHost(const char *s);
 void CopyClipboard(int all) {
 	uint16_t len=0;
-	char* text = (char *)(all==2?Mouse_GetSelected(0-sdl.clip.x,0-sdl.clip.y,currentWindowWidth-1-sdl.clip.x,currentWindowHeight-1-sdl.clip.y,(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len):(all==1?Mouse_GetSelected(selscol, selsrow, selecol, selerow, -1, -1, &len):Mouse_GetSelected(mouse_start_x-sdl.clip.x,mouse_start_y-sdl.clip.y,mouse_end_x-sdl.clip.x,mouse_end_y-sdl.clip.y,(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len)));
+	char* text = (char *)(all==2?Mouse_GetSelected(0,0,currentWindowWidth-1-sdl.clip.x,currentWindowHeight-1-sdl.clip.y,(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len):(all==1?Mouse_GetSelected(selscol, selsrow, selecol, selerow, -1, -1, &len):Mouse_GetSelected(mouse_start_x-sdl.clip.x,mouse_start_y-sdl.clip.y,mouse_end_x-sdl.clip.x,mouse_end_y-sdl.clip.y,(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len)));
     unsigned int k=0;
     for (unsigned int i=0; i<len; i++)
         if (text[i]&&text[i]!=13)

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5346,12 +5346,12 @@ static void GUI_StartUp() {
     MAPPER_AddHandler(QuickEdit,MK_nothing, 0,"fastedit", "Quick edit mode", &item);
     item->set_text("Quick edit: copy on select and paste text");
 
-    MAPPER_AddHandler(CopyAllClipboard,MK_a,MMODHOST,"copyall", "Copy to clipboard", &item);
+    MAPPER_AddHandler(CopyAllClipboard,MK_f5,MMOD1,"copyall", "Copy to clipboard", &item);
     item->set_text("Copy all text on the DOS screen");
 #endif
 
 #if defined(C_SDL2) || defined(WIN32) || defined(MACOSX) || defined(LINUX) && C_X11
-    MAPPER_AddHandler(PasteClipboard,MK_v,MMODHOST,"paste", "Paste from clipboard", &item); //end emendelson; improved by Wengier
+    MAPPER_AddHandler(PasteClipboard,MK_f6,MMOD1,"paste", "Paste from clipboard", &item); //end emendelson; improved by Wengier
     item->set_text("Pasting from the clipboard");
 
     MAPPER_AddHandler(PasteClipStop,MK_nothing, 0,"pasteend", "Stop clipboard paste", &item);
@@ -5367,6 +5367,9 @@ static void GUI_StartUp() {
     MAPPER_AddHandler(&GUI_Run, MK_c,MMODHOST, "gui", "Configuration tool", &item);
     item->set_text("Configuration tool");
 
+    MAPPER_AddHandler(&GUI_ResetResize, MK_backspace, MMODHOST, "resetsize", "Reset window size", &item);
+    item->set_text("Reset window size");
+
 #if defined(USE_TTF)
     MAPPER_AddHandler(&TTF_IncreaseSize, MK_uparrow, MMODHOST, "ttf_incsize", "Increase TTF size", &item);
     item->set_text("Increase TTF font size");
@@ -5374,9 +5377,6 @@ static void GUI_StartUp() {
     MAPPER_AddHandler(&TTF_DecreaseSize, MK_downarrow, MMODHOST, "ttf_decsize", "Decrease TTF size", &item);
     item->set_text("Decrease TTF font size");
 #endif
-
-    MAPPER_AddHandler(&GUI_ResetResize, MK_nothing, 0, "resetsize", "Reset window size", &item);
-    item->set_text("Reset window size");
 
     UpdateWindowDimensions();
 }

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -1922,11 +1922,11 @@ void CAPTURE_Init() {
 	MAPPER_AddHandler(OPL_SaveRawEvent,MK_nothing,0,"caprawopl","Record FM/OPL output",&item);
 	item->set_text("Record FM (OPL) output");
 #if (C_SSHOT)
-	MAPPER_AddHandler(CAPTURE_ScreenShotEvent,MK_p,MMODHOST,"scrshot","Take screenshot", &item);
-	item->set_text("Take screenshot");
-
 	MAPPER_AddHandler(CAPTURE_VideoEvent,MK_i,MMODHOST,"video","Record video to AVI", &item);
 	item->set_text("Record video to AVI");
+
+	MAPPER_AddHandler(CAPTURE_ScreenShotEvent,MK_p,MMODHOST,"scrshot","Take screenshot", &item);
+	item->set_text("Take screenshot");
 #endif
 #endif
 

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -722,7 +722,7 @@ const char* Mouse_GetSelected(int x1, int y1, int x2, int y2, int w, int h, uint
 		r=(uint16_t)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
 	}
     int c1=x1, r1=y1, c2=x2, r2=y2, t;
-    if (w>-1&&h>-1) {
+    if (w>0&&h>0) {
         c1=c*x1/w;
         r1=r*y1/h;
         c2=c*x2/w;
@@ -785,7 +785,7 @@ void Mouse_Select(int x1, int y1, int x2, int y2, int w, int h, bool select) {
         c=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
         r=(uint16_t)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
     }
-    if (w>-1&&h>-1) {
+    if (w>0&&h>0) {
         c1=c*x1/w;
         r1=r*y1/h;
         c2=c*x2/w;


### PR DESCRIPTION
This fixes some issues related to the mapper keys and the clipboard, such as the CR issue in Windows SDL2 build as mentioned in Issue #2098, and modified default shortcuts for Paste Clipboard etc to avoid the problem as discussed in Issue #2136.