### PR TITLE
Fix Issue #2064, #2071 etc

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -170,6 +170,10 @@
     section are being ignored. (Wengier)
   - Fixed issues with building the code with original
     MinGW using the ./build-mingw script. (Wengier)
+  - Fixed option "output=ttf" not working properly with
+    -startui/startmapper command-line option. (Wengier)
+  - When the mouse is captured, the title bar will show
+    the shortcut to release the mouse. (Wengier)
   - IMGMOUNT now assumes the ISO type for .GOG/.INS
     files (which are equivalent to .CUE/.INS files)
     if no type is specified by the user. (Wengier)

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -496,6 +496,10 @@ static void UI_Shutdown(GUI::ScreenSDL *screen) {
     GFX_SetTitle(-1,-1,-1,false);
 
     void GFX_ForceRedrawScreen(void);
+#if defined(USE_TTF)
+    bool TTF_using(void);
+    if (!TTF_using() || ttf.inUse)
+#endif
     GFX_ForceRedrawScreen();
 
     in_gui = false;
@@ -2151,7 +2155,7 @@ public:
     }
 };
 
-std::string niclist="NE2000 networking is not enabled.";
+std::string niclist="NE2000 networking is not enabled. Check [ne2000] section of the configuration.";
 class ShowHelpNIC : public GUI::ToplevelWindow {
 protected:
     GUI::Input *name;

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -280,7 +280,6 @@ static KeyBlock combo_4[11] =
 static bool initjoy=true;
 static int cpage=1, maxpage=1;
 
-
 static void                                     SetActiveEvent(CEvent * event);
 static void                                     SetActiveBind(CBind * _bind);
 static void                                     change_action_text(const char* text,uint8_t col);
@@ -2230,6 +2229,7 @@ protected:
 };
 
 class CEventButton;
+static CEventButton * hostbutton = NULL;
 static CEventButton * last_clicked = NULL;
 static std::vector<CEventButton *> ceventbuttons;
 
@@ -3396,6 +3396,10 @@ static void AddModButton(Bitu x,Bitu y,Bitu dx,Bitu dy,char const * const title,
     CModEvent * event=new CModEvent(buf,_mod);
     CEventButton *button=new CEventButton(x,y,dx,dy,title,event);
     event->notifybutton(button);
+    if (_mod == 4) {
+        button->Enable(hostkeyalt == 0);
+        hostbutton=button;
+    }
 
     assert(_mod < 8);
     mod_event[_mod] = event;
@@ -4533,6 +4537,7 @@ void MAPPER_ReleaseAllKeys(void) {
 }
 
 void MAPPER_RunEvent(Bitu /*val*/) {
+    if (hostbutton != NULL) hostbutton->Enable(hostkeyalt == 0);
     KEYBOARD_ClrBuffer();   //Clear buffer
     GFX_LosingFocus();      //Release any keys pressed (buffer gets filled again).
     MAPPER_RunInternal();

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -4702,6 +4702,10 @@ void MAPPER_RunInternal() {
     if (mapper_keybind.empty()) mapper_keybind = "unbound";
     mainMenu.get_item("hostkey_mapper").check(hostkeyalt==0).set_text("Mapper-defined: "+mapper_keybind).refresh_item(mainMenu);
 
+#if defined(USE_TTF)
+    bool TTF_using(void);
+    if (!TTF_using() || ttf.inUse)
+#endif
     GFX_ForceRedrawScreen();
 
     mapper.running = false;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1386,7 +1386,8 @@ void GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused) {
 
     if (sdl.mouse.locked) {
         std::string get_mapper_shortcut(const char *name);
-        strcat(title, (" ["+get_mapper_shortcut("capmouse")+" releases mouse]").c_str());
+        std::string key=get_mapper_shortcut("capmouse");
+        strcat(title, key.size()?(" ["+key+" releases mouse]").c_str():" [mouse locked]");
     }
 
     if (paused) strcat(title," PAUSED");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1341,7 +1341,7 @@ void GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused) {
 //  static Bits internal_frameskip=0;
     static int32_t internal_cycles=0;
 //  static Bits internal_timing=0;
-    char title[200] = {0};
+    char title[250] = {0};
 
     Section_prop *section = static_cast<Section_prop *>(control->GetSection("SDL"));
     assert(section != NULL);
@@ -1382,6 +1382,11 @@ void GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused) {
         char *p = title + strlen(title); // append to end of string
 
         sprintf(p,", %2d%%/RT",(int)floor((rtdelta / 10) + 0.5));
+    }
+
+    if (sdl.mouse.locked) {
+        std::string get_mapper_shortcut(const char *name);
+        strcat(title, (" ["+get_mapper_shortcut("capmouse")+" releases mouse]").c_str());
     }
 
     if (paused) strcat(title," PAUSED");
@@ -3049,6 +3054,8 @@ void GFX_CaptureMouse(bool capture) {
             GFX_SDLMenuTrackHilight(mainMenu,DOSBoxMenu::unassigned_item_handle);
         }
 #endif
+
+    GFX_SetTitle(-1,-1,-1,false);
 
     /* keep the menu updated (it might not exist yet) */
     if (mainMenu.item_exists("mapper_capmouse"))


### PR DESCRIPTION
These are relatively small fixes that solve issues #2064 and #2071 and fixed the bug when -startui or -startmapper is used in combination with output=ttf. For #2064, as @emendelson stated the "Host" key may still confuse users when the alternative host key system is enabled, even though the comment for the config option has been improved since then. So with this the "Host" key will not be shown in the mapper when the alternative host key system is enabled.