### PR TITLE
Fix build with -Werror=format-security

### DIFF
--- a/src/gui/sdl_ttf.c
+++ b/src/gui/sdl_ttf.c
@@ -316,7 +316,6 @@ static void TTF_SetFTError(const char *msg, FT_Error error)
 	};
 	int i;
 	const char *err_msg;
-	char buffer[1024];
 
 	err_msg = NULL;
 	for ( i=0; i<((sizeof ft_errors)/(sizeof ft_errors[0])); ++i ) {
@@ -328,10 +327,9 @@ static void TTF_SetFTError(const char *msg, FT_Error error)
 	if ( ! err_msg ) {
 		err_msg = "unknown FreeType error";
 	}
-	sprintf(buffer, "%s: %s", msg, err_msg);
-	TTF_SetError(buffer);
+	TTF_SetError("%s: %s", msg, err_msg);
 #else
-	TTF_SetError(msg);
+	TTF_SetError("%s", msg);
 #endif /* USE_FREETYPE_ERRORS */
 }
 
@@ -533,7 +531,7 @@ TTF_Font* TTF_OpenFontIndex( const char *file, int ptsize, long index )
 {
 	SDL_RWops *rw = SDL_RWFromFile(file, "rb");
 	if ( rw == NULL ) {
-		TTF_SetError(SDL_GetError());
+		TTF_SetError("%s", SDL_GetError());
 		return NULL;
 	}
 	return TTF_OpenFontIndexRW(rw, 1, ptsize, index);


### PR DESCRIPTION
Some build environments harden their security flags. For
-Werror=format-security build failed with:

| sdl_ttf.c:334:18: error: format not a string literal and no format arguments [-Werror=format-security]
|   334 |  TTF_SetError(msg);
|       |                  ^

and

| sdl_ttf.c:534:30: error: format not a string literal and no format arguments [-Werror=format-security]
|   534 |   TTF_SetError(SDL_GetError());
|       |                              ^

While at it fix/simpify code path with defined USE_FREETYPE_ERRORS

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>

# Description

_Summary of changes brought by this PR._


**Does this PR address some issue(s) ?**

_Add the issue(s) fixed, e.g. ```#1234```_


**Does this PR introduce new feature(s) ?**

_Describe the feature(s) introduced._


**Are there any breaking changes ?**

_Describe the breaking changes in detail._


**Additional information**

_Add any additional information that may be useful._
