### PR TITLE
ne2000: Use 3 second timeout when opening pcap

### DIFF
--- a/src/hardware/ne2000.cpp
+++ b/src/hardware/ne2000.cpp
@@ -1664,7 +1664,7 @@ public:
             65536,            // portion of the packet to capture
                               // 65536 = whole packet 
             PCAP_OPENFLAG_PROMISCUOUS,    // promiscuous mode
-            -1,             // read timeout
+            3000,             // read timeout
             NULL,             // authentication on the remote machine
             errbuf            // error buffer
             ) ) == NULL)
@@ -1676,7 +1676,7 @@ public:
             65536,            // portion of the packet to capture
                               // 65536 = whole packet 
             true,    // promiscuous mode
-            -1,             // read timeout
+            3000,             // read timeout
             errbuf            // error buffer
             ) ) == NULL)
 


### PR DESCRIPTION
 # Description

This fixes a pcap bug on macOS.

**Does this PR address some issue(s) ?**

#2150

**Does this PR introduce new feature(s) ?**

No

**Are there any breaking changes ?**

No

**Additional information**

I haven't tested this outside compiling on Linux. It could well be possible there's more breakage on macOS.