### PR TITLE
Improved OPL3 Duo support

### DIFF
--- a/src/hardware/opl3duoboard/opl3duoboard.h
+++ b/src/hardware/opl3duoboard/opl3duoboard.h
@@ -1,7 +1,9 @@
+#include <thread>
 #include "../serialport/libserial.h"
 
 #ifndef OPL3_DUO_BOARD
 	#define OPL3_DUO_BOARD
+    #define OPL3_DUO_BUFFER_SIZE 9000
 
 	// Output debug information to the DosBox console if set to 1
 	#define OPL3_DUO_BOARD_DEBUG 0
@@ -15,6 +17,14 @@
 			void write(uint32_t reg, uint8_t val);
 
 		private:
-			COMPORT comport;
+            void resetBuffer();
+            void writeBuffer();
+
+            std::thread thread;
+            COMPORT comport;
+            bool stopOPL3DuoThread;
+            uint8_t sendBuffer[OPL3_DUO_BUFFER_SIZE];
+            uint16_t bufferRdPos = 0;
+            uint16_t bufferWrPos = 0;
 	};
 #endif


### PR DESCRIPTION
# Description

* This change adds a buffer thread to get rid of slowdowns and breakups in audio playback when using the OPL3 Duo board
* Fixed a bug where only the first bank of registers were cleared during reset (Second OPL3 chip is still ignored!)
* Reset the OPL chip when Dosbox is closed, so if a game is running when closing the program the OPL3 Duo is not left playing any sounds

**Does this PR address some issue(s) ?**
No

**Does this PR introduce new feature(s) ?**
No

**Are there any breaking changes ?**
No

**Additional information**
Tested with games using both OPL2 and OPL3 audio. 

Stunts will still overwhelm the buffer due to it writing loads of duplicate register values.