### PR TITLE
Handle trap flag after POPF in dynamic cores

### DIFF
--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -119,7 +119,8 @@ enum BlockReturn {
 #endif
 	BR_Iret,
 	BR_CallBack,
-	BR_SMCBlock
+	BR_SMCBlock,
+	BR_Trap
 };
 
 #define SMC_CURRENT_BLOCK	0xffff
@@ -378,6 +379,17 @@ run_block:
 			}
 		}
 		goto restart_core;
+	case BR_Trap:
+			// trapflag is set, switch to the trap-aware decoder
+	#if C_DEBUG
+	#if C_HEAVY_DEBUG
+			if (DEBUG_HeavyIsBreakpoint()) {
+				return debugCallback;
+			}
+	#endif
+	#endif
+			cpudecoder=CPU_Core_Dyn_X86_Trap_Run;
+			return CBRET_NONE;
 	}
 	return CBRET_NONE;
 }

--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -361,6 +361,7 @@ restart_prefix:
 		case 0x9d:	// popf
 			gen_call_function_I(CPU_POPF,decode.big_op);
 			dyn_check_exception(FC_RETOP);
+			dyn_check_trapflag();
 			InvalidateFlags();
 			break;
 

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -426,6 +426,8 @@ static void INLINE dyn_get_modrm(void) {
 #define MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(host_reg, reg_index, high_byte) gen_mov_regbyte_to_reg_low_canuseword(host_reg,(DRC_PTR_SIZE_IM)(DRCD_REG_BYTE(reg_index,high_byte)) - (DRC_PTR_SIZE_IM)(&cpu_regs))
 #define MOV_REG_BYTE_FROM_HOST_REG_LOW(host_reg, reg_index, high_byte) gen_mov_regbyte_from_reg_low(host_reg,(DRC_PTR_SIZE_IM)(DRCD_REG_BYTE(reg_index,high_byte)) - (DRC_PTR_SIZE_IM)(&cpu_regs))
 
+#define MOV_FLAGS_TO_HOST_REG(host_reg) gen_mov_regval32_to_reg(host_reg,(DRC_PTR_SIZE_IM)(DRCD_REG_FLAGS) - (DRC_PTR_SIZE_IM)(&cpu_regs))
+
 #else
 
 #define MOV_REG_VAL_TO_HOST_REG(host_reg, reg_index) gen_mov_word_to_reg(host_reg,DRCD_REG_VAL(reg_index),true)
@@ -442,6 +444,8 @@ static void INLINE dyn_get_modrm(void) {
 #define MOV_REG_BYTE_TO_HOST_REG_LOW(host_reg, reg_index, high_byte) gen_mov_byte_to_reg_low(host_reg,DRCD_REG_BYTE(reg_index,high_byte))
 #define MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(host_reg, reg_index, high_byte) gen_mov_byte_to_reg_low_canuseword(host_reg,DRCD_REG_BYTE(reg_index,high_byte))
 #define MOV_REG_BYTE_FROM_HOST_REG_LOW(host_reg, reg_index, high_byte) gen_mov_byte_from_reg_low(host_reg,DRCD_REG_BYTE(reg_index,high_byte))
+
+#define MOV_FLAGS_TO_HOST_REG(host_reg) gen_mov_word_to_reg(host_reg,DRCD_REG_FLAGS,true)
 
 #endif
 
@@ -610,7 +614,7 @@ template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_mm(const T
 
 
 
-enum save_info_type {db_exception, cycle_check, string_break};
+enum save_info_type {db_exception, cycle_check, string_break, trap};
 
 
 // function that is called on exceptions
@@ -670,6 +674,13 @@ static void dyn_fill_blocks(void) {
 				gen_add_direct_word(&reg_eip,save_info_dynrec[sct].eip_change,decode.big_op);
 				dyn_return(BR_Cycles);
 				break;
+			case trap:
+				// trapflag is set, switch to trap-aware decoder
+				decode.cycles=save_info_dynrec[sct].cycles;
+				dyn_reduce_cycles();
+				gen_add_direct_word(&reg_eip,save_info_dynrec[sct].eip_change,decode.big_op);
+				dyn_return(BR_Trap);
+				break;
 		}
 	}
 	used_save_info_dynrec=0;
@@ -694,6 +705,19 @@ static void dyn_check_exception(HostReg reg) {
 	save_info_dynrec[used_save_info_dynrec].eip_change=decode.op_start-decode.code_start;
 	if (!cpu.code.big) save_info_dynrec[used_save_info_dynrec].eip_change&=0xffff;
 	save_info_dynrec[used_save_info_dynrec].type=db_exception;
+	used_save_info_dynrec++;
+}
+
+
+// check and branch if the trap flag is turned on
+static void dyn_check_trapflag(void) {
+	MOV_FLAGS_TO_HOST_REG(FC_OP1);
+	gen_and_imm(FC_OP1, FLAG_TF);
+	save_info_dynrec[used_save_info_dynrec].branch_pos=gen_create_branch_long_nonzero(FC_OP1,true);
+	save_info_dynrec[used_save_info_dynrec].cycles=decode.cycles;
+	save_info_dynrec[used_save_info_dynrec].eip_change=decode.code-decode.code_start;
+	if (!cpu.code.big) save_info_dynrec[used_save_info_dynrec].eip_change&=0xffff;
+	save_info_dynrec[used_save_info_dynrec].type=trap;
 	used_save_info_dynrec++;
 }
 


### PR DESCRIPTION
# Description

Until now in the dynamic core, the trap flag was checked and handled only after IRET. But if a program turns on the trap flag using POPFD, the dynamic core ignores it and a trap interrupt won't be executed until the next IRET (which may be in another context that doesn't except a trap interrupt, which will crash the program).

**Does this PR address some issue(s) ?**

This PR fixes some incorrect behavior in dynamic core that I encountered in some game . I wrote more details below.

**Does this PR introduce new feature(s) ?**

No.

**Are there any breaking changes ?**

No.

I ran into a game that constantly crashed during startup when using dynamic core, but worked using the normal core,. If I switched to dynamic core after startup, the game worked perfectly and much faster than normal core. (Well not perfectly, it has audio glitches, but it isn't related to this issue)
The crashed was caused by exception 01H in KERENL32.DLL.
The line of the crash was:
```0167:BFF7CE67  cmp  dword [ebp-0004],0000```
But the weird thing was that one line before that was an opcode that accessed the same ebp:
```0167:BFF7CE64  mov  [ebp-0004],eax```
After more debugging I saw that this what happens:
```
0028:C0001525  iret                                                   EAX:C1466DB0 EBX:00000002 ECX:81571BC4 EDX:00000008 ESI:00000000 EDI:00000000 EBP:00ACFDC0 ESP:C7E35F94 DS:016F ES:016F FS:2277 GS:0000 SS:0030 CF:0 ZF:0 SF:1 OF:0 AF:0 PF:0 IF:0
0167:BFF7CE64  mov  [ebp-0004],eax             [illegal]              EAX:C1466DB0 EBX:00000002 ECX:81571BC4 EDX:00000008 ESI:00000000 EDI:00000000 EBP:00ACFDC0 ESP:00ACFDB8 DS:016F ES:016F FS:2277 GS:0000 SS:016F CF:0 ZF:0 SF:0 OF:0 AF:0 PF:1 IF:1
0028:C0001360  sub  esp,0004                                          EAX:C1466DB0 EBX:00000002 ECX:81571BC4 EDX:00000008 ESI:00000000 EDI:00000000 EBP:00ACFDC0 ESP:C7E35F94 DS:016F ES:016F FS:2277 GS:0000 SS:0030 CF:0 ZF:0 SF:0 OF:0 AF:0 PF:1 IF:0
```
I debugged and saw that BFF7CE64 was triggered by `CPU_Core_Dyn_X86_Trap_Run` instead of `CPU_Core_Dyn_X86_Run`.
So for same reason it returned from iret with TF=1.

After more debugging I found the culprit:
```
0167:00403D35  sub  esp,0005                                          EAX:0000552B EBX:00000000 ECX:004027BD EDX:00000000 ESI:00ACFF78 EDI:00ACFF78 EBP:00ACFE30 ESP:00ACFE18 DS:016F ES:016F FS:224F GS:0000 SS:016F CF:0 ZF:0 SF:0 OF:0 AF:0 PF:0 IF:1 TF:0
0167:00403D38  mov  edx,000001C5                                      EAX:0000552B EBX:00000000 ECX:004027BD EDX:00000000 ESI:00ACFF78 EDI:00ACFF78 EBP:00ACFE30 ESP:00ACFE13 DS:016F ES:016F FS:224F GS:0000 SS:016F CF:0 ZF:0 SF:0 OF:0 AF:0 PF:0 IF:1 TF:0
0167:00403D3D  mov  dword [esp],00000100       [illegal]              EAX:0000552B EBX:00000000 ECX:004027BD EDX:000001C5 ESI:00ACFF78 EDI:00ACFF78 EBP:00ACFE30 ESP:00ACFE13 DS:016F ES:016F FS:224F GS:0000 SS:016F CF:0 ZF:0 SF:0 OF:0 AF:0 PF:0 IF:1 TF:0
0167:00403D44  popfd                                                  EAX:0000552B EBX:00000000 ECX:004027BD EDX:000001C5 ESI:00ACFF78 EDI:00ACFF78 EBP:00ACFE30 ESP:00ACFE13 DS:016F ES:016F FS:224F GS:0000 SS:016F CF:0 ZF:0 SF:0 OF:0 AF:0 PF:0 IF:1 TF:0
0167:00403D45  shl  edx,1                                             EAX:0000552B EBX:00000000 ECX:004027BD EDX:000001C5 ESI:00ACFF78 EDI:00ACFF78 EBP:00ACFE30 ESP:00ACFE17 DS:016F ES:016F FS:224F GS:0000 SS:016F CF:0 ZF:0 SF:0 OF:0 AF:0 PF:0 IF:1 TF:1
0167:00403D47  pushfd                                                 EAX:0000552B EBX:00000000 ECX:004027BD EDX:0000038A ESI:00ACFF78 EDI:00ACFF78 EBP:00ACFE30 ESP:00ACFE17 DS:016F ES:016F FS:224F GS:0000 SS:016F CF:0 ZF:0 SF:0 OF:0 AF:0 PF:0 IF:1 TF:1
```
This code enables the trap flag.
While this is what happens in normal core:
```
0167:00403D35  sub  esp,0005                                          EAX:000074F2 EBX:00000000 ECX:004027BD EDX:00000000 ESI:00ACFF78 EDI:00ACFF78 EBP:00ACFE30 ESP:00ACFE18 DS:016F ES:016F FS:23DF GS:0000 SS:016F CF:0 ZF:0 SF:0 OF:0 AF:0 PF:0 IF:1 TF:0
0167:00403D38  mov  edx,000001C5                                      EAX:000074F2 EBX:00000000 ECX:004027BD EDX:00000000 ESI:00ACFF78 EDI:00ACFF78 EBP:00ACFE30 ESP:00ACFE13 DS:016F ES:016F FS:23DF GS:0000 SS:016F CF:0 ZF:0 SF:0 OF:0 AF:0 PF:1 IF:1 TF:0
0167:00403D3D  mov  dword [esp],00000100       [illegal]              EAX:000074F2 EBX:00000000 ECX:004027BD EDX:000001C5 ESI:00ACFF78 EDI:00ACFF78 EBP:00ACFE30 ESP:00ACFE13 DS:016F ES:016F FS:23DF GS:0000 SS:016F CF:0 ZF:0 SF:0 OF:0 AF:0 PF:1 IF:1 TF:0
0167:00403D44  popfd                                                  EAX:000074F2 EBX:00000000 ECX:004027BD EDX:000001C5 ESI:00ACFF78 EDI:00ACFF78 EBP:00ACFE30 ESP:00ACFE13 DS:016F ES:016F FS:23DF GS:0000 SS:016F CF:0 ZF:0 SF:0 OF:0 AF:0 PF:1 IF:1 TF:0
0167:00403D45  shl  edx,1                                             EAX:000074F2 EBX:00000000 ECX:004027BD EDX:000001C5 ESI:00ACFF78 EDI:00ACFF78 EBP:00ACFE30 ESP:00ACFE17 DS:016F ES:016F FS:23DF GS:0000 SS:016F CF:0 ZF:0 SF:0 OF:0 AF:0 PF:0 IF:1 TF:1
0028:C0001360  sub  esp,0004                                          EAX:000074F2 EBX:00000000 ECX:004027BD EDX:0000038A ESI:00ACFF78 EDI:00ACFF78 EBP:00ACFE30 ESP:C7E37F94 DS:016F ES:016F FS:23DF GS:0000 SS:0030 CF:0 ZF:0 SF:0 OF:0 AF:1 PF:0 IF:0 TF:0
```
The dynamic core doesn't trigger an interrupt after the trap flag is turned on, so it is triggered after the next iret.
So I implemented a code that checks the trap flag after POPF, as it does in normal core.

After my fix the game starts normally with dynamic_x86/dynamic_rec cores.

I did notice that the normal core checks for the trap flag after jmps/calls too. But I am not sure if that is necessary? In which cases the core won't be already in trap mode? Right now I implemented the check only after POPF.