### PR TITLE
[WIP] Support non recursive page fault handling in dynamic_x86 core

### DIFF
--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -51,7 +51,7 @@
 #include "inout.h"
 #include "fpu.h"
 
-#define CACHE_MAXSIZE	(4096*3)
+#define CACHE_MAXSIZE	(4096*4)
 #define CACHE_TOTAL		(1024*1024*8)
 #define CACHE_PAGES		(512)
 #define CACHE_BLOCKS	(64*1024)

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -75,7 +75,7 @@ enum {
 	G_ES,G_CS,G_SS,G_DS,G_FS,G_GS,
 	G_FLAGS,G_NEWESP,G_EIP,
 	G_EA,G_STACK,G_CYCLES,
-	G_TMPB,G_TMPW,G_SHIFT,
+	G_TMPB,G_TMPW,G_TMPD,G_SHIFT,
 	G_EXIT,
 	G_MAX,
 };
@@ -157,7 +157,7 @@ static DynReg DynRegs[G_MAX];
 #define DREG(_WHICH_) &DynRegs[G_ ## _WHICH_ ]
 
 static struct {
-	uint32_t ea,tmpb,tmpd,stack,shift,newesp;
+	uint32_t ea,tmpb,tmpw,tmpd,stack,shift,newesp;
 } extra_regs;
 
 #define IllegalOption(msg) E_Exit("DYNX86: illegal option in " msg)
@@ -566,8 +566,10 @@ void CPU_Core_Dyn_X86_Init(void) {
 	DynRegs[G_CYCLES].flags=DYNFLG_LOAD|DYNFLG_SAVE;
 	DynRegs[G_TMPB].data=&extra_regs.tmpb;
 	DynRegs[G_TMPB].flags=DYNFLG_HAS8|DYNFLG_HAS16;
-	DynRegs[G_TMPW].data=&extra_regs.tmpd;
+	DynRegs[G_TMPW].data=&extra_regs.tmpw;
 	DynRegs[G_TMPW].flags=DYNFLG_HAS16;
+	DynRegs[G_TMPD].data=&extra_regs.tmpd;
+	DynRegs[G_TMPD].flags=DYNFLG_HAS16;
 	DynRegs[G_SHIFT].data=&extra_regs.shift;
 	DynRegs[G_SHIFT].flags=DYNFLG_HAS8|DYNFLG_HAS16;
 	DynRegs[G_EXIT].data=0;

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -168,6 +168,7 @@ static struct {
 	Bitu callback;
 	Bitu readdata;
 #ifdef DYN_NON_RECURSIVE_PAGEFAULT
+	void *call_func;
 	Bitu pagefault_old_stack;
 #ifdef CPU_FPU
 	Bitu pagefault_old_fpu_top;

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -51,7 +51,7 @@
 #include "inout.h"
 #include "fpu.h"
 
-#define CACHE_MAXSIZE	(4096*4)
+#define CACHE_MAXSIZE	(4096*8)
 #define CACHE_TOTAL		(1024*1024*8)
 #define CACHE_PAGES		(512)
 #define CACHE_BLOCKS	(64*1024)

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -209,6 +209,13 @@ static struct dyn_dh_fpu {
 #endif
 
 #ifdef DYN_NON_RECURSIVE_PAGEFAULT
+#define DYN_DEBUG_PAGEFAULT
+
+#ifdef DYN_DEBUG_PAGEFAULT
+#define DYN_PF_LOG_MSG LOG_MSG
+#else
+#define DYN_PF_LOG_MSG(...)
+#endif
 
 #define DYN_PAGEFAULT_CHECK(x) { \
 	try { \
@@ -216,6 +223,7 @@ static struct dyn_dh_fpu {
 	} catch (const GuestPageFaultException &pf) { \
 		core_dyn.pagefault_faultcode = pf.faultcode; \
 		core_dyn.pagefault = true; \
+		DYN_PF_LOG_MSG("Catched pagefault at %s:%d (%s)", __FILE__, __LINE__, __FUNCTION__); \
 	} \
 	return 0; \
 }

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -223,7 +223,7 @@ static struct dyn_dh_fpu {
 	} catch (const GuestPageFaultException &pf) { \
 		core_dyn.pagefault_faultcode = pf.faultcode; \
 		core_dyn.pagefault = true; \
-		DYN_PF_LOG_MSG("Catched pagefault at %s:%d (%s)", __FILE__, __LINE__, __FUNCTION__); \
+		DYN_PF_LOG_MSG("Caught pagefault at %s:%d (%s)", __FILE__, __LINE__, __FUNCTION__); \
 	} \
 	return 0; \
 }

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -2820,9 +2820,9 @@ restart_prefix:
 				decode.big_addr ? decode_fetchd() : decode_fetchw());
 			dyn_write_word_release(DREG(EA),DREG(EAX),decode.big_op);
 			break;
-		/* MOVSB/W/D*/
-		case 0xa4:dyn_string(STR_MOVSB);break;
-		case 0xa5:dyn_string(decode.big_op ? STR_MOVSD : STR_MOVSW);break;
+		/* CMPSB/W/D*/
+		case 0xa6:dyn_string(STR_CMPSB);break;
+		case 0xa7:dyn_string(decode.big_op ? STR_CMPSD : STR_CMPSW);break;
 		/* TEST AL,AX Imm */
 		case 0xa8:gen_discardflags();gen_dop_byte_imm(DOP_TEST,DREG(EAX),0,decode_fetchb());break;
 		case 0xa9:gen_discardflags();gen_dop_word_imm(DOP_TEST,decode.big_op,DREG(EAX),decode.big_op ? decode_fetchd() :  decode_fetchw());break;
@@ -2832,6 +2832,9 @@ restart_prefix:
 		/* LODSB/W/D*/
 		case 0xac:dyn_string(STR_LODSB);break;
 		case 0xad:dyn_string(decode.big_op ? STR_LODSD : STR_LODSW);break;
+		/* SCASB/W/D*/
+		case 0xae:dyn_string(STR_SCASB);break;
+		case 0xaf:dyn_string(decode.big_op ? STR_SCASD : STR_SCASW);break;
 		//Mov Byte reg,Imm byte
 		case 0xb0:case 0xb1:case 0xb2:case 0xb3:case 0xb4:case 0xb5:case 0xb6:case 0xb7:	
 			gen_dop_byte_imm(DOP_MOV,&DynRegs[opcode&3],opcode&4,decode_fetchb());

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -482,7 +482,7 @@ static void dyn_check_pagefault(void) {
 }
 
 static void dyn_save_stack_for_pagefault(void) {
-	gen_save_host(&core_dyn.pagefault_old_stack, DREG(ESP), 1);
+	gen_save_host(&core_dyn.pagefault_old_stack, DREG(ESP), 4);
 	decode.pf_restore.data.stack = 1;
 }
 

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -477,7 +477,7 @@ static void dyn_check_trapflag(void) {
 
 #ifdef DYN_NON_RECURSIVE_PAGEFAULT
 static void dyn_check_pagefault(void) {
-	gen_test_host_byte(&core_dyn.pagefault);
+	gen_test_host_byte(&core_dyn.pagefault, 1);
 	save_info[used_save_info].branch_pos=gen_create_branch_long(BR_NZ);
 	dyn_savestate(&save_info[used_save_info].state);
 	if (!decode.cycles) decode.cycles++;

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -19,11 +19,7 @@
 #define X86_DYNFPU_DH_ENABLED
 #define X86_INLINED_MEMACCESS
 
-#undef X86_DYNREC_MMX_ENABLED
-
-#ifdef X86_DYNREC_MMX_ENABLED
-void dyn_mmx_restore();
-#endif
+#define X86_DYNREC_MMX_ENABLED
 
 enum REP_Type {
 	REP_NONE=0,REP_NZ,REP_Z

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -1102,7 +1102,7 @@ static void dyn_read_byte(DynReg * addr,DynReg * dst,bool high,bool release=fals
 	if (release) gen_releasereg(addr);
 	dyn_savestate(&callstate);
 
-	if (gendst->index>3) IllegalOption("dyn_read_byte");
+	if (high && gendst->index>3) IllegalOption("dyn_read_byte");
 
 	opcode(tmp).setrm(gensrc->index).Emit8(0x8B); // mov tmp, src
 	opcode(5).setrm(tmp).setimm(12,1).Emit8(0xC1); // shr tmp,12

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -2079,7 +2079,6 @@ static void dyn_load_seg_off_ea(SegNames seg) {
 }
 
 static void dyn_mov_seg_ev(void) {
-	dyn_get_modrm();
 	SegNames seg=(SegNames)decode.modrm.reg;
 	if (GCC_UNLIKELY(seg==cs)) IllegalOption("dyn_mov_seg_ev");
 	if (decode.modrm.mod<3) {
@@ -2749,7 +2748,11 @@ restart_prefix:
 			}
 			break;
 		/* Mov seg,ev */
-		case 0x8e:dyn_mov_seg_ev();break;
+		case 0x8e:
+			dyn_get_modrm();
+			if (GCC_UNLIKELY((SegNames)decode.modrm.reg==cs)) goto illegalopcode;
+			dyn_mov_seg_ev();
+			break;
 		/* POP Ev */
 		case 0x8f:dyn_pop_ev();break;
 		case 0x90:	//NOP

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -1036,7 +1036,7 @@ static void dyn_read_word(DynReg * addr,DynReg * dst,bool dword,bool release=fal
 	uint8_t *nomap=gen_create_branch(BR_Z);
 	//mov dst, [tmp+src]
 	opcode(gendst->index,dword).setea(tmp,gensrc->index).Emit8(0x8B);
-	uint8_t* jmp_loc = gen_create_short_jump();
+	uint8_t* jmp_loc = gen_create_jump();
 
 	gen_fill_branch(page_brk);
 	gen_load_imm(tmp, (Bitu)(dword?(void*)mem_unalignedreadd_checked:(void*)mem_unalignedreadw_checked));
@@ -1061,7 +1061,7 @@ static void dyn_read_word(DynReg * addr,DynReg * dst,bool dword,bool release=fal
 
 	dyn_synchstate(&callstate);
 	dst->flags |= DYNFLG_CHANGED;
-	gen_fill_short_jump(jmp_loc);
+	gen_fill_jump(jmp_loc);
 }
 
 static void dyn_read_byte(DynReg * addr,DynReg * dst,bool high,bool release=false) {
@@ -1091,7 +1091,7 @@ static void dyn_read_byte(DynReg * addr,DynReg * dst,bool high,bool release=fals
 	}
 	// mov dst, byte [tmp+src]
 	opcode(gendst->index,true,high?4:0).setea(tmp,src).Emit8(0x8A);
-	uint8_t* jmp_loc=gen_create_short_jump();
+	uint8_t* jmp_loc=gen_create_jump();
 
 	gen_fill_branch(nomap);
 	if (gensrc->index != ARG0_REG) {
@@ -1109,7 +1109,7 @@ static void dyn_read_byte(DynReg * addr,DynReg * dst,bool high,bool release=fals
 
 	dyn_synchstate(&callstate);
 	dst->flags |= DYNFLG_CHANGED;
-	gen_fill_short_jump(jmp_loc);
+	gen_fill_jump(jmp_loc);
 }
 
 static void dyn_write_word(DynReg * addr,DynReg * val,bool dword,bool release=false) {
@@ -1145,7 +1145,7 @@ static void dyn_write_word(DynReg * addr,DynReg * val,bool dword,bool release=fa
 	uint8_t *nomap=gen_create_branch(BR_Z);
 	//mov [tmp+src], dst
 	opcode(genval->index,dword).setea(tmp,gendst->index).Emit8(0x89);
-	uint8_t* jmp_loc = gen_create_short_jump();
+	uint8_t* jmp_loc = gen_create_jump();
 
 	gen_fill_branch(page_brk);
 	gen_load_imm(tmp, (Bitu)(dword?(void*)mem_unalignedwrited_checked:(void*)mem_unalignedwritew_checked));
@@ -1165,7 +1165,7 @@ static void dyn_write_word(DynReg * addr,DynReg * val,bool dword,bool release=fa
 #endif
 	dyn_check_bool_exception_al();
 	dyn_synchstate(&callstate);
-	gen_fill_short_jump(jmp_loc);
+	gen_fill_jump(jmp_loc);
 }
 
 static void dyn_write_byte(DynReg * addr,DynReg * val,bool high,bool release=false) {

--- a/src/cpu/core_dyn_x86/dyn_fpu.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu.h
@@ -60,13 +60,11 @@ static void FPU_FFREE(Bitu st) {
 	gen_load_host(&TOP,DREG(TMPB),4);			\
 }
 
-#ifdef DYN_NON_RECURSIVE_PAGEFAULT
 static void dyn_save_fpu_top_for_pagefault() {
 	gen_load_host(&TOP,DREG(TMPB),4); 
 	gen_save_host(&core_dyn.pagefault_old_fpu_top, DREG(TMPB), 4);
 	decode.pf_restore.data.fpu_top = 1;
 }
-#endif
 
 static void dyn_eatree() {
 	Bitu group=(decode.modrm.val >> 3) & 7;
@@ -296,9 +294,7 @@ static void dyn_fpu_esc1(){
 		switch(group){
 		case 0x00: /* FLD float*/
 			gen_protectflags(); 
-#ifdef DYN_NON_RECURSIVE_PAGEFAULT
-			dyn_save_fpu_top_for_pagefault();
-#endif
+			if (use_dynamic_core_with_paging) dyn_save_fpu_top_for_pagefault();
 			gen_call_function((void*)&FPU_PREP_PUSH,"");
 			gen_load_host(&TOP,DREG(TMPB),4); 
 			dyn_call_function_pagefault_check((void*)&FPU_FLD_F32,"%Drd%Drd",DREG(EA),DREG(TMPB));
@@ -403,9 +399,7 @@ static void dyn_fpu_esc3(){
 		dyn_fill_ea(); 
 		switch(group){
 		case 0x00:	/* FILD */
-#ifdef DYN_NON_RECURSIVE_PAGEFAULT
-			dyn_save_fpu_top_for_pagefault();
-#endif
+			if (use_dynamic_core_with_paging) dyn_save_fpu_top_for_pagefault();
 			gen_call_function((void*)&FPU_PREP_PUSH,"");
 			gen_protectflags(); 
 			gen_load_host(&TOP,DREG(TMPB),4); 
@@ -422,9 +416,7 @@ static void dyn_fpu_esc3(){
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;
 		case 0x05:	/* FLD 80 Bits Real */
-#ifdef DYN_NON_RECURSIVE_PAGEFAULT
-			dyn_save_fpu_top_for_pagefault();
-#endif
+			if (use_dynamic_core_with_paging) dyn_save_fpu_top_for_pagefault();
 			gen_call_function((void*)&FPU_PREP_PUSH,"");
 			dyn_call_function_pagefault_check((void*)&FPU_FLD_F80,"%Drd",DREG(EA));
 			break;
@@ -519,9 +511,7 @@ static void dyn_fpu_esc5(){
 		dyn_fill_ea(); 
 		switch(group){
 		case 0x00:  /* FLD double real*/
-#ifdef DYN_NON_RECURSIVE_PAGEFAULT
-			dyn_save_fpu_top_for_pagefault();
-#endif
+			if (use_dynamic_core_with_paging) dyn_save_fpu_top_for_pagefault();
 			gen_call_function((void*)&FPU_PREP_PUSH,"");
 			gen_protectflags(); 
 			gen_load_host(&TOP,DREG(TMPB),4); 
@@ -649,9 +639,7 @@ static void dyn_fpu_esc7(){
 		dyn_fill_ea(); 
 		switch(group){
 		case 0x00:  /* FILD Bit16s */
-#ifdef DYN_NON_RECURSIVE_PAGEFAULT
-			dyn_save_fpu_top_for_pagefault();
-#endif
+			if (use_dynamic_core_with_paging) dyn_save_fpu_top_for_pagefault();
 			gen_call_function((void*)&FPU_PREP_PUSH,"");
 			gen_load_host(&TOP,DREG(TMPB),4); 
 			dyn_call_function_pagefault_check((void*)&FPU_FLD_I16,"%Drd%Drd",DREG(EA),DREG(TMPB));
@@ -667,17 +655,13 @@ static void dyn_fpu_esc7(){
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;
 		case 0x04:   /* FBLD packed BCD */
-#ifdef DYN_NON_RECURSIVE_PAGEFAULT
-			dyn_save_fpu_top_for_pagefault();
-#endif
+			if (use_dynamic_core_with_paging) dyn_save_fpu_top_for_pagefault();
 			gen_call_function((void*)&FPU_PREP_PUSH,"");
 			gen_load_host(&TOP,DREG(TMPB),4);
 			dyn_call_function_pagefault_check((void*)&FPU_FBLD,"%Drd%Drd",DREG(EA),DREG(TMPB));
 			break;
 		case 0x05:  /* FILD Bit64s */
-#ifdef DYN_NON_RECURSIVE_PAGEFAULT
-			dyn_save_fpu_top_for_pagefault();
-#endif
+			if (use_dynamic_core_with_paging) dyn_save_fpu_top_for_pagefault();
 			gen_call_function((void*)&FPU_PREP_PUSH,"");
 			gen_load_host(&TOP,DREG(TMPB),4);
 			dyn_call_function_pagefault_check((void*)&FPU_FLD_I64,"%Drd%Drd",DREG(EA),DREG(TMPB));

--- a/src/cpu/core_dyn_x86/dyn_fpu.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu.h
@@ -60,6 +60,14 @@ static void FPU_FFREE(Bitu st) {
 	gen_load_host(&TOP,DREG(TMPB),4);			\
 }
 
+#ifdef DYN_NON_RECURSIVE_PAGEFAULT
+static void dyn_save_fpu_top_for_pagefault() {
+	gen_load_host(&TOP,DREG(TMPB),4); 
+	gen_save_host(&core_dyn.pagefault_old_fpu_top, DREG(TMPB), 4);
+	decode.pf_restore.data.fpu_top = 1;
+}
+#endif
+
 static void dyn_eatree() {
 	Bitu group=(decode.modrm.val >> 3) & 7;
 	switch (group){
@@ -130,7 +138,7 @@ static void dyn_fpu_esc0(){
 		}
 	} else { 
 		dyn_fill_ea();
-		gen_call_function((void*)&FPU_FLD_F32_EA,"%Drd",DREG(EA)); 
+		dyn_call_function_pagefault_check((void*)&FPU_FLD_F32_EA,"%Drd",DREG(EA)); 
 		gen_load_host(&TOP,DREG(TMPB),4);
 		dyn_eatree();
 	}
@@ -288,31 +296,34 @@ static void dyn_fpu_esc1(){
 		switch(group){
 		case 0x00: /* FLD float*/
 			gen_protectflags(); 
+#ifdef DYN_NON_RECURSIVE_PAGEFAULT
+			dyn_save_fpu_top_for_pagefault();
+#endif
 			gen_call_function((void*)&FPU_PREP_PUSH,"");
 			gen_load_host(&TOP,DREG(TMPB),4); 
-			gen_call_function((void*)&FPU_FLD_F32,"%Drd%Drd",DREG(EA),DREG(TMPB));
+			dyn_call_function_pagefault_check((void*)&FPU_FLD_F32,"%Drd%Drd",DREG(EA),DREG(TMPB));
 			break;
 		case 0x01: /* UNKNOWN */
 			FPU_LOG_WARN(1,true,group,sub);
 			break;
 		case 0x02: /* FST float*/
-			gen_call_function((void*)&FPU_FST_F32,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_F32,"%Drd",DREG(EA));
 			break;
 		case 0x03: /* FSTP float*/
-			gen_call_function((void*)&FPU_FST_F32,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_F32,"%Drd",DREG(EA));
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;
 		case 0x04: /* FLDENV */
-			gen_call_function((void*)&FPU_FLDENV,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FLDENV,"%Drd",DREG(EA));
 			break;
 		case 0x05: /* FLDCW */
-			gen_call_function((void *)&FPU_FLDCW,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void *)&FPU_FLDCW,"%Drd",DREG(EA));
 			break;
 		case 0x06: /* FSTENV */
-			gen_call_function((void *)&FPU_FSTENV,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void *)&FPU_FSTENV,"%Drd",DREG(EA));
 			break;
 		case 0x07:  /* FNSTCW*/
-			gen_call_function((void *)&FPU_FNSTCW,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void *)&FPU_FNSTCW,"%Drd",DREG(EA));
 			break;
 		default:
 			FPU_LOG_WARN(1,true,group,sub);
@@ -350,7 +361,7 @@ static void dyn_fpu_esc2(){
 		}
 	} else {
 		dyn_fill_ea(); 
-		gen_call_function((void*)&FPU_FLD_I32_EA,"%Drd",DREG(EA)); 
+		dyn_call_function_pagefault_check((void*)&FPU_FLD_I32_EA,"%Drd",DREG(EA)); 
 		gen_load_host(&TOP,DREG(TMPB),4); 
 		dyn_eatree();
 	}
@@ -392,27 +403,33 @@ static void dyn_fpu_esc3(){
 		dyn_fill_ea(); 
 		switch(group){
 		case 0x00:	/* FILD */
+#ifdef DYN_NON_RECURSIVE_PAGEFAULT
+			dyn_save_fpu_top_for_pagefault();
+#endif
 			gen_call_function((void*)&FPU_PREP_PUSH,"");
 			gen_protectflags(); 
 			gen_load_host(&TOP,DREG(TMPB),4); 
-			gen_call_function((void*)&FPU_FLD_I32,"%Drd%Drd",DREG(EA),DREG(TMPB));
+			dyn_call_function_pagefault_check((void*)&FPU_FLD_I32,"%Drd%Drd",DREG(EA),DREG(TMPB));
 			break;
 		case 0x01:	/* FISTTP */
 			FPU_LOG_WARN(3,false,1,sub);
 			break;
 		case 0x02:	/* FIST */
-			gen_call_function((void*)&FPU_FST_I32,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_I32,"%Drd",DREG(EA));
 			break;
 		case 0x03:	/* FISTP */
-			gen_call_function((void*)&FPU_FST_I32,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_I32,"%Drd",DREG(EA));
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;
 		case 0x05:	/* FLD 80 Bits Real */
+#ifdef DYN_NON_RECURSIVE_PAGEFAULT
+			dyn_save_fpu_top_for_pagefault();
+#endif
 			gen_call_function((void*)&FPU_PREP_PUSH,"");
-			gen_call_function((void*)&FPU_FLD_F80,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FLD_F80,"%Drd",DREG(EA));
 			break;
 		case 0x07:	/* FSTP 80 Bits Real */
-			gen_call_function((void*)&FPU_FST_F80,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_F80,"%Drd",DREG(EA));
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;
 		default:
@@ -459,7 +476,7 @@ static void dyn_fpu_esc4(){
 		}
 	} else { 
 		dyn_fill_ea(); 
-		gen_call_function((void*)&FPU_FLD_F64_EA,"%Drd",DREG(EA)); 
+		dyn_call_function_pagefault_check((void*)&FPU_FLD_F64_EA,"%Drd",DREG(EA)); 
 		gen_load_host(&TOP,DREG(TMPB),4); 
 		dyn_eatree();
 	}
@@ -502,33 +519,36 @@ static void dyn_fpu_esc5(){
 		dyn_fill_ea(); 
 		switch(group){
 		case 0x00:  /* FLD double real*/
+#ifdef DYN_NON_RECURSIVE_PAGEFAULT
+			dyn_save_fpu_top_for_pagefault();
+#endif
 			gen_call_function((void*)&FPU_PREP_PUSH,"");
 			gen_protectflags(); 
 			gen_load_host(&TOP,DREG(TMPB),4); 
-			gen_call_function((void*)&FPU_FLD_F64,"%Drd%Drd",DREG(EA),DREG(TMPB));
+			dyn_call_function_pagefault_check((void*)&FPU_FLD_F64,"%Drd%Drd",DREG(EA),DREG(TMPB));
 			break;
 		case 0x01:  /* FISTTP longint*/
 			FPU_LOG_WARN(5,true,1,sub);
 			break;
 		case 0x02:   /* FST double real*/
-			gen_call_function((void*)&FPU_FST_F64,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_F64,"%Drd",DREG(EA));
 			break;
 		case 0x03:	/* FSTP double real*/
-			gen_call_function((void*)&FPU_FST_F64,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_F64,"%Drd",DREG(EA));
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;
 		case 0x04:	/* FRSTOR */
-			gen_call_function((void*)&FPU_FRSTOR,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FRSTOR,"%Drd",DREG(EA));
 			break;
 		case 0x06:	/* FSAVE */
-			gen_call_function((void*)&FPU_FSAVE,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FSAVE,"%Drd",DREG(EA));
 			break;
 		case 0x07:   /*FNSTSW */
 			gen_protectflags(); 
 			gen_load_host(&TOP,DREG(TMPB),4); 
 			gen_call_function((void*)&FPU_SET_TOP,"%Dd",DREG(TMPB));
 			gen_load_host(&fpu.sw,DREG(TMPB),4); 
-			gen_call_function((void*)&mem_writew,"%Drd%Drd",DREG(EA),DREG(TMPB));
+			dyn_call_function_pagefault_check((void*)&mem_writew,"%Drd%Drd",DREG(EA),DREG(TMPB));
 			break;
 		default:
 			FPU_LOG_WARN(5,true,group,sub);
@@ -582,7 +602,7 @@ static void dyn_fpu_esc6(){
 		gen_call_function((void*)&FPU_FPOP,"");		
 	} else {
 		dyn_fill_ea(); 
-		gen_call_function((void*)&FPU_FLD_I16_EA,"%Drd",DREG(EA)); 
+		dyn_call_function_pagefault_check((void*)&FPU_FLD_I16_EA,"%Drd",DREG(EA)); 
 		gen_load_host(&TOP,DREG(TMPB),4); 
 		dyn_eatree();
 	}
@@ -629,36 +649,45 @@ static void dyn_fpu_esc7(){
 		dyn_fill_ea(); 
 		switch(group){
 		case 0x00:  /* FILD Bit16s */
+#ifdef DYN_NON_RECURSIVE_PAGEFAULT
+			dyn_save_fpu_top_for_pagefault();
+#endif
 			gen_call_function((void*)&FPU_PREP_PUSH,"");
 			gen_load_host(&TOP,DREG(TMPB),4); 
-			gen_call_function((void*)&FPU_FLD_I16,"%Drd%Drd",DREG(EA),DREG(TMPB));
+			dyn_call_function_pagefault_check((void*)&FPU_FLD_I16,"%Drd%Drd",DREG(EA),DREG(TMPB));
 			break;
 		case 0x01:
 			FPU_LOG_WARN(7,true,group,sub);
 			break;
 		case 0x02:   /* FIST Bit16s */
-			gen_call_function((void*)&FPU_FST_I16,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_I16,"%Drd",DREG(EA));
 			break;
 		case 0x03:	/* FISTP Bit16s */
-			gen_call_function((void*)&FPU_FST_I16,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_I16,"%Drd",DREG(EA));
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;
 		case 0x04:   /* FBLD packed BCD */
+#ifdef DYN_NON_RECURSIVE_PAGEFAULT
+			dyn_save_fpu_top_for_pagefault();
+#endif
 			gen_call_function((void*)&FPU_PREP_PUSH,"");
 			gen_load_host(&TOP,DREG(TMPB),4);
-			gen_call_function((void*)&FPU_FBLD,"%Drd%Drd",DREG(EA),DREG(TMPB));
+			dyn_call_function_pagefault_check((void*)&FPU_FBLD,"%Drd%Drd",DREG(EA),DREG(TMPB));
 			break;
 		case 0x05:  /* FILD Bit64s */
+#ifdef DYN_NON_RECURSIVE_PAGEFAULT
+			dyn_save_fpu_top_for_pagefault();
+#endif
 			gen_call_function((void*)&FPU_PREP_PUSH,"");
 			gen_load_host(&TOP,DREG(TMPB),4);
-			gen_call_function((void*)&FPU_FLD_I64,"%Drd%Drd",DREG(EA),DREG(TMPB));
+			dyn_call_function_pagefault_check((void*)&FPU_FLD_I64,"%Drd%Drd",DREG(EA),DREG(TMPB));
 			break;
 		case 0x06:	/* FBSTP packed BCD */
-			gen_call_function((void*)&FPU_FBST,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FBST,"%Drd",DREG(EA));
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;
 		case 0x07:  /* FISTP Bit64s */
-			gen_call_function((void*)&FPU_FST_I64,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_I64,"%Drd",DREG(EA));
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;
 		default:

--- a/src/cpu/core_dyn_x86/dyn_fpu_dh.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu_dh.h
@@ -158,7 +158,6 @@ static void dh_fpu_mem(uint8_t inst, Bitu reg=decode.modrm.reg, void* mem=&dyn_d
 #endif
 }
 
-#ifdef DYN_NON_RECURSIVE_PAGEFAULT
 static void dh_fpu_save_mem_revert(uint8_t inst, uint8_t group) {
 	decode.pf_restore.data.dh_fpu_inst = inst;
 	decode.pf_restore.data.dh_fpu_group = group;
@@ -167,7 +166,6 @@ static void dh_fpu_save_mem_revert(uint8_t inst, uint8_t group) {
 static void dh_fpu_mem_revert(uint8_t inst, uint8_t group) {
 	dh_fpu_mem(inst, group);
 }
-#endif
 
 static void dh_fpu_esc0(){
 	dyn_get_modrm(); 
@@ -203,9 +201,7 @@ static void dh_fpu_esc1(){
 			dyn_call_function_pagefault_check((void*)&FPU_FST_32,"%Drd",DREG(EA));
 			break;
 		case 0x03: /* FSTP float*/
-#ifdef DYN_NON_RECURSIVE_PAGEFAULT
-			dh_fpu_save_mem_revert(0xd9, 0x00);
-#endif
+			if (use_dynamic_core_with_paging) dh_fpu_save_mem_revert(0xd9, 0x00);
 			dh_fpu_mem(0xd9);
 			dyn_call_function_pagefault_check((void*)&FPU_FST_32,"%Drd",DREG(EA));
 			break;
@@ -293,9 +289,7 @@ static void dh_fpu_esc3(){
 			dyn_call_function_pagefault_check((void*)&FPU_FST_32,"%Drd",DREG(EA));
 			break;
 		case 0x03:	/* FISTP */
-#ifdef DYN_NON_RECURSIVE_PAGEFAULT
-			dh_fpu_save_mem_revert(0xdb, 0x00);
-#endif
+			if (use_dynamic_core_with_paging) dh_fpu_save_mem_revert(0xdb, 0x00);
 			dh_fpu_mem(0xdb);
 			dyn_call_function_pagefault_check((void*)&FPU_FST_32,"%Drd",DREG(EA));
 			break;
@@ -304,9 +298,7 @@ static void dh_fpu_esc3(){
 			dh_fpu_mem(0xdb);
 			break;
 		case 0x07:	/* FSTP 80 Bits Real */
-#ifdef DYN_NON_RECURSIVE_PAGEFAULT
-			dh_fpu_save_mem_revert(0xdb, 0x05);
-#endif
+			if (use_dynamic_core_with_paging) dh_fpu_save_mem_revert(0xdb, 0x05);
 			dh_fpu_mem(0xdb);
 			dyn_call_function_pagefault_check((void*)&FPU_FST_80,"%Drd",DREG(EA));
 			break;
@@ -351,9 +343,7 @@ static void dh_fpu_esc5(){
 			dyn_call_function_pagefault_check((void*)&FPU_FST_64,"%Drd",DREG(EA));
 			break;
 		case 0x03:	/* FSTP double real*/
-#ifdef DYN_NON_RECURSIVE_PAGEFAULT
-			dh_fpu_save_mem_revert(0xdd, 0x00);
-#endif
+			if (use_dynamic_core_with_paging) dh_fpu_save_mem_revert(0xdd, 0x00);
 			dh_fpu_mem(0xdd);
 			dyn_call_function_pagefault_check((void*)&FPU_FST_64,"%Drd",DREG(EA));
 			break;
@@ -440,9 +430,7 @@ static void dh_fpu_esc7(){
 			dyn_call_function_pagefault_check((void*)&FPU_FST_16,"%Drd",DREG(EA));
 			break;
 		case 0x03:	/* FISTP int16_t */
-#ifdef DYN_NON_RECURSIVE_PAGEFAULT
-			dh_fpu_save_mem_revert(0xdf, 0x00);
-#endif
+			if (use_dynamic_core_with_paging) dh_fpu_save_mem_revert(0xdf, 0x00);
 			dh_fpu_mem(0xdf);
 			dyn_call_function_pagefault_check((void*)&FPU_FST_16,"%Drd",DREG(EA));
 			break;
@@ -455,16 +443,12 @@ static void dh_fpu_esc7(){
 			dh_fpu_mem(0xdf);
 			break;
 		case 0x06:	/* FBSTP packed BCD */
-#ifdef DYN_NON_RECURSIVE_PAGEFAULT
-			dh_fpu_save_mem_revert(0xdf, 0x04);
-#endif
+			if (use_dynamic_core_with_paging) dh_fpu_save_mem_revert(0xdf, 0x04);
 			dh_fpu_mem(0xdf);
 			dyn_call_function_pagefault_check((void*)&FPU_FST_80,"%Drd",DREG(EA));
 			break;
 		case 0x07:  /* FISTP Bit64s */
-#ifdef DYN_NON_RECURSIVE_PAGEFAULT
-			dh_fpu_save_mem_revert(0xdf, 0x05);
-#endif
+			if (use_dynamic_core_with_paging) dh_fpu_save_mem_revert(0xdf, 0x05);
 			dh_fpu_mem(0xdf);
 			dyn_call_function_pagefault_check((void*)&FPU_FST_64,"%Drd",DREG(EA));
 			break;

--- a/src/cpu/core_dyn_x86/dyn_fpu_dh.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu_dh.h
@@ -158,6 +158,17 @@ static void dh_fpu_mem(uint8_t inst, Bitu reg=decode.modrm.reg, void* mem=&dyn_d
 #endif
 }
 
+#ifdef DYN_NON_RECURSIVE_PAGEFAULT
+static void dh_fpu_save_mem_revert(uint8_t inst, uint8_t group) {
+	decode.pf_restore.data.dh_fpu_inst = inst;
+	decode.pf_restore.data.dh_fpu_group = group;
+}
+
+static void dh_fpu_mem_revert(uint8_t inst, uint8_t group) {
+	dh_fpu_mem(inst, group);
+}
+#endif
+
 static void dh_fpu_esc0(){
 	dyn_get_modrm(); 
 	if (decode.modrm.val >= 0xc0) {
@@ -165,7 +176,7 @@ static void dh_fpu_esc0(){
 		cache_addb(decode.modrm.val);
 	} else { 
 		dyn_fill_ea();
-		gen_call_function((void*)&FPU_FLD_32,"%Drd",DREG(EA));
+		dyn_call_function_pagefault_check((void*)&FPU_FLD_32,"%Drd",DREG(EA));
 		dh_fpu_mem(0xd8);
 	}
 }
@@ -181,7 +192,7 @@ static void dh_fpu_esc1(){
 		dyn_fill_ea(); 
 		switch(group){
 		case 0x00: /* FLD float*/
-			gen_call_function((void*)&FPU_FLD_32,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FLD_32,"%Drd",DREG(EA));
 			dh_fpu_mem(0xd9);
 			break;
 		case 0x01: /* UNKNOWN */
@@ -189,26 +200,29 @@ static void dh_fpu_esc1(){
 			break;
 		case 0x02: /* FST float*/
 			dh_fpu_mem(0xd9);
-			gen_call_function((void*)&FPU_FST_32,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_32,"%Drd",DREG(EA));
 			break;
 		case 0x03: /* FSTP float*/
+#ifdef DYN_NON_RECURSIVE_PAGEFAULT
+			dh_fpu_save_mem_revert(0xd9, 0x00);
+#endif
 			dh_fpu_mem(0xd9);
-			gen_call_function((void*)&FPU_FST_32,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_32,"%Drd",DREG(EA));
 			break;
 		case 0x04: /* FLDENV */
-			gen_call_function((void*)&FPU_FLDENV_DH,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FLDENV_DH,"%Drd",DREG(EA));
 			dh_fpu_mem(0xd9);
 			break;
 		case 0x05: /* FLDCW */
-			gen_call_function((void *)&FPU_FLDCW_DH,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void *)&FPU_FLDCW_DH,"%Drd",DREG(EA));
 			dh_fpu_mem(0xd9);
 			break;
 		case 0x06: /* FSTENV */
 			dh_fpu_mem(0xd9);
-			gen_call_function((void*)&FPU_FSTENV_DH,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FSTENV_DH,"%Drd",DREG(EA));
 			break;
 		case 0x07:  /* FNSTCW*/
-			gen_call_function((void*)&FPU_FNSTCW_DH,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FNSTCW_DH,"%Drd",DREG(EA));
 			break;
 		default:
 			FPU_LOG_WARN(1,true,group,sub);
@@ -224,7 +238,7 @@ static void dh_fpu_esc2(){
 		cache_addb(decode.modrm.val);
 	} else {
 		dyn_fill_ea(); 
-		gen_call_function((void*)&FPU_FLD_32,"%Drd",DREG(EA)); 
+		dyn_call_function_pagefault_check((void*)&FPU_FLD_32,"%Drd",DREG(EA)); 
 		dh_fpu_mem(0xda);
 	}
 }
@@ -268,7 +282,7 @@ static void dh_fpu_esc3(){
 		dyn_fill_ea(); 
 		switch(group){
 		case 0x00:	/* FILD */
-			gen_call_function((void*)&FPU_FLD_32,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FLD_32,"%Drd",DREG(EA));
 			dh_fpu_mem(0xdb);
 			break;
 		case 0x01:	/* FISTTP */
@@ -276,19 +290,25 @@ static void dh_fpu_esc3(){
 			break;
 		case 0x02:	/* FIST */
 			dh_fpu_mem(0xdb);
-			gen_call_function((void*)&FPU_FST_32,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_32,"%Drd",DREG(EA));
 			break;
 		case 0x03:	/* FISTP */
+#ifdef DYN_NON_RECURSIVE_PAGEFAULT
+			dh_fpu_save_mem_revert(0xdb, 0x00);
+#endif
 			dh_fpu_mem(0xdb);
-			gen_call_function((void*)&FPU_FST_32,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_32,"%Drd",DREG(EA));
 			break;
 		case 0x05:	/* FLD 80 Bits Real */
-			gen_call_function((void*)&FPU_FLD_80,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FLD_80,"%Drd",DREG(EA));
 			dh_fpu_mem(0xdb);
 			break;
 		case 0x07:	/* FSTP 80 Bits Real */
+#ifdef DYN_NON_RECURSIVE_PAGEFAULT
+			dh_fpu_save_mem_revert(0xdb, 0x05);
+#endif
 			dh_fpu_mem(0xdb);
-			gen_call_function((void*)&FPU_FST_80,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_80,"%Drd",DREG(EA));
 			break;
 		default:
 			FPU_LOG_WARN(3,true,group,sub);
@@ -304,7 +324,7 @@ static void dh_fpu_esc4(){
 		cache_addb(decode.modrm.val);
 	} else { 
 		dyn_fill_ea(); 
-		gen_call_function((void*)&FPU_FLD_64,"%Drd",DREG(EA)); 
+		dyn_call_function_pagefault_check((void*)&FPU_FLD_64,"%Drd",DREG(EA)); 
 		dh_fpu_mem(0xdc);
 	}
 }
@@ -320,7 +340,7 @@ static void dh_fpu_esc5(){
 		Bitu sub=(decode.modrm.val & 7);
 		switch(group){
 		case 0x00:  /* FLD double real*/
-			gen_call_function((void*)&FPU_FLD_64,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FLD_64,"%Drd",DREG(EA));
 			dh_fpu_mem(0xdd);
 			break;
 		case 0x01:  /* FISTTP longint*/
@@ -328,24 +348,27 @@ static void dh_fpu_esc5(){
 			break;
 		case 0x02:   /* FST double real*/
 			dh_fpu_mem(0xdd);
-			gen_call_function((void*)&FPU_FST_64,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_64,"%Drd",DREG(EA));
 			break;
 		case 0x03:	/* FSTP double real*/
+#ifdef DYN_NON_RECURSIVE_PAGEFAULT
+			dh_fpu_save_mem_revert(0xdd, 0x00);
+#endif
 			dh_fpu_mem(0xdd);
-			gen_call_function((void*)&FPU_FST_64,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_64,"%Drd",DREG(EA));
 			break;
 		case 0x04:	/* FRSTOR */
-			gen_call_function((void*)&FPU_FRSTOR_DH,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FRSTOR_DH,"%Drd",DREG(EA));
 			dh_fpu_mem(0xdd, decode.modrm.reg, &(dyn_dh_fpu.temp_state[0]));
 			break;
 		case 0x06:	/* FSAVE */
 			dh_fpu_mem(0xdd, decode.modrm.reg, &(dyn_dh_fpu.temp_state[0]));
-			gen_call_function((void*)&FPU_FSAVE_DH,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FSAVE_DH,"%Drd",DREG(EA));
 			cache_addw(0xE3DB);
 			break;
 		case 0x07:   /* FNSTSW */
 			dh_fpu_mem(0xdd);
-			gen_call_function((void*)&FPU_FST_16,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_16,"%Drd",DREG(EA));
 			break;
 		default:
 			FPU_LOG_WARN(5,true,group,sub);
@@ -361,7 +384,7 @@ static void dh_fpu_esc6(){
 		cache_addb(decode.modrm.val);
 	} else {
 		dyn_fill_ea(); 
-		gen_call_function((void*)&FPU_FLD_16,"%Drd",DREG(EA)); 
+		dyn_call_function_pagefault_check((void*)&FPU_FLD_16,"%Drd",DREG(EA)); 
 		dh_fpu_mem(0xde);
 	}
 }
@@ -406,7 +429,7 @@ static void dh_fpu_esc7(){
 		dyn_fill_ea(); 
 		switch(group){
 		case 0x00:  /* FILD int16_t */
-			gen_call_function((void*)&FPU_FLD_16,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FLD_16,"%Drd",DREG(EA));
 			dh_fpu_mem(0xdf);
 			break;
 		case 0x01:
@@ -414,27 +437,36 @@ static void dh_fpu_esc7(){
 			break;
 		case 0x02:   /* FIST int16_t */
 			dh_fpu_mem(0xdf);
-			gen_call_function((void*)&FPU_FST_16,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_16,"%Drd",DREG(EA));
 			break;
 		case 0x03:	/* FISTP int16_t */
+#ifdef DYN_NON_RECURSIVE_PAGEFAULT
+			dh_fpu_save_mem_revert(0xdf, 0x00);
+#endif
 			dh_fpu_mem(0xdf);
-			gen_call_function((void*)&FPU_FST_16,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_16,"%Drd",DREG(EA));
 			break;
 		case 0x04:   /* FBLD packed BCD */
-			gen_call_function((void*)&FPU_FLD_80,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FLD_80,"%Drd",DREG(EA));
 			dh_fpu_mem(0xdf);
 			break;
 		case 0x05:  /* FILD Bit64s */
-			gen_call_function((void*)&FPU_FLD_64,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FLD_64,"%Drd",DREG(EA));
 			dh_fpu_mem(0xdf);
 			break;
 		case 0x06:	/* FBSTP packed BCD */
+#ifdef DYN_NON_RECURSIVE_PAGEFAULT
+			dh_fpu_save_mem_revert(0xdf, 0x04);
+#endif
 			dh_fpu_mem(0xdf);
-			gen_call_function((void*)&FPU_FST_80,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_80,"%Drd",DREG(EA));
 			break;
 		case 0x07:  /* FISTP Bit64s */
+#ifdef DYN_NON_RECURSIVE_PAGEFAULT
+			dh_fpu_save_mem_revert(0xdf, 0x05);
+#endif
 			dh_fpu_mem(0xdf);
-			gen_call_function((void*)&FPU_FST_64,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FST_64,"%Drd",DREG(EA));
 			break;
 		default:
 			FPU_LOG_WARN(7,true,group,sub);

--- a/src/cpu/core_dyn_x86/mmx_gen.h
+++ b/src/cpu/core_dyn_x86/mmx_gen.h
@@ -1,7 +1,7 @@
 
 #include "mmx.h"
 
-MMX_reg mmxtmp;
+static MMX_reg mmxtmp;
 
 static void MMX_LOAD_32(PhysPt addr) {
 	mmxtmp.ud.d0 = mem_readd(addr);
@@ -22,30 +22,38 @@ static void MMX_STORE_64(PhysPt addr) {
 }
 
 // add simple instruction (that operates only with mm regs)
-void dyn_mmx_simple(Bit8u op, Bit8u modrm) {
+static void dyn_mmx_simple(uint8_t op, uint8_t modrm) {
 	cache_addw(0x0F | (op << 8)); cache_addb(modrm);
 }
 
 // same but with imm8 also
-void dyn_mmx_simple_imm8(Bit8u op, Bit8u modrm, Bit8u imm) {
+static void dyn_mmx_simple_imm8(uint8_t op, uint8_t modrm, uint8_t imm) {
 	cache_addw(0x0F | (op << 8)); cache_addb(modrm); cache_addb(imm);
 }
 
+static void dyn_mmx_mem(uint8_t op, Bitu reg=decode.modrm.reg, void* mem=&mmxtmp) {
+#if C_TARGETCPU == X86
+	cache_addw(0x0F | (op << 8));
+	cache_addb(0x05|(reg<<3));
+	cache_addd((uint32_t)(mem));
+#else // X86_64
+	opcode(reg).setabsaddr(mem).Emit16(0x0F | (op << 8));
+#endif
+}
+
 // mmx OP mm, mm/m64 template
-void dyn_mmx_op(Bit8u op) {
+static void dyn_mmx_op(uint8_t op) {
 	dyn_get_modrm();
 
 	if (decode.modrm.mod < 3) {
 		dyn_fill_ea();
-		gen_call_function((void*)&MMX_LOAD_64, "%Ddr", DREG(EA));
-		cache_addw(0x0F | (op << 8));
-		cache_addb(0x05 | (decode.modrm.val & 0x38));
-		cache_addd((uintptr_t)&mmxtmp);
+		dyn_call_function_pagefault_check((void*)&MMX_LOAD_64, "%Ddr", DREG(EA));
+		dyn_mmx_mem(op);
 	} else dyn_mmx_simple(op, decode.modrm.val);
 }
 
 // mmx SHIFT mm, imm8 template 
-void dyn_mmx_shift_imm8(Bit8u op) {
+static void dyn_mmx_shift_imm8(uint8_t op) {
 	dyn_get_modrm();
 	Bitu imm; decode_fetchb_imm(imm);
 	
@@ -53,50 +61,37 @@ void dyn_mmx_shift_imm8(Bit8u op) {
 }
 
 // 0x6E - MOVD mm, r/m32
-void dyn_mmx_movd_pqed() {
+static void dyn_mmx_movd_pqed() {
 	dyn_get_modrm();
 
 	if (decode.modrm.mod < 3) {
 		// movd mm, m32 - resolve EA and load data
 		dyn_fill_ea();
 		// generate call to mmxtmp load
-		gen_call_function((void*)&MMX_LOAD_32, "%Ddr", DREG(EA));
+		dyn_call_function_pagefault_check((void*)&MMX_LOAD_32, "%Ddr", DREG(EA));
 		// mmxtmp contains loaded value - finish by loading it to mm
-		cache_addw(0x6E0F);	// movd  mm, m32
-		cache_addb(0x05 | (decode.modrm.val & 0x38));
-		cache_addd((uintptr_t)&mmxtmp);
+		dyn_mmx_mem(0x6E); // movd  mm, m32
 	}
 	else {
 		// movd mm, r32 - r32->mmxtmp->mm
-		// resolve dynreg
-		DynReg *reg = &DynRegs[decode.modrm.rm];
-		// resolve genreg
-		GenReg *gr = FindDynReg(reg);
-		// move from genreg to mmxtmp
-		cache_addb(0x89);	// mov m32, r32
-		cache_addb(0x05 | (gr->index << 3));
-		cache_addd((uintptr_t)&mmxtmp);
+		gen_save_host((void*)&mmxtmp, &DynRegs[decode.modrm.rm], 4);
 		// mmxtmp contains loaded value - finish by loading it to mm
-		cache_addw(0x6E0F);	// movd  mm, m32
-		cache_addb(0x05 | (decode.modrm.val & 0x38));
-		cache_addd((uintptr_t)&mmxtmp);
+		dyn_mmx_mem(0x6E); // movd  mm, m32
 	}
 }
 
 
 // 0x6F - MOVQ mm, mm/m64
-void dyn_mmx_movq_pqqq() {
+static void dyn_mmx_movq_pqqq() {
 	dyn_get_modrm(); 
 
 	if (decode.modrm.mod < 3) {
 		// movq mm, m64 - resolve EA and load data
 		dyn_fill_ea();
 		// generate call to mmxtmp load
-		gen_call_function((void*)&MMX_LOAD_64, "%Ddr", DREG(EA));
+		dyn_call_function_pagefault_check((void*)&MMX_LOAD_64, "%Ddr", DREG(EA));
 		// mmxtmp contains loaded value - finish by loading it to mm
-		cache_addw(0x6F0F);	// movq  mm, m64
-		cache_addb(0x05 | (decode.modrm.val & 0x38));
-		cache_addd((uintptr_t)&mmxtmp);
+		dyn_mmx_mem(0x6F); // movq  mm, m64
 	}
 	else {
 		// movq mm, mm
@@ -105,51 +100,37 @@ void dyn_mmx_movq_pqqq() {
 }
 
 // 0x7E - MOVD r/m32, mm 
-void dyn_mmx_movd_edpq() {
+static void dyn_mmx_movd_edpq() {
 	dyn_get_modrm();
 
 	if (decode.modrm.mod < 3) {
 		// movd m32, mm - resolve EA and load data
 		dyn_fill_ea();
 		// fill mmxtmp
-		cache_addw(0x7E0F);	// movd  mm, m32
-		cache_addb(0x05 | (decode.modrm.val & 0x38));
-		cache_addd((uintptr_t)&mmxtmp);
+		dyn_mmx_mem(0x7E); // movd  mm, m32
 		// generate call to mmxtmp store
-		gen_call_function((void*)&MMX_STORE_32, "%Ddr", DREG(EA));
+		dyn_call_function_pagefault_check((void*)&MMX_STORE_32, "%Ddr", DREG(EA));
 	}
 	else {
 		// movd r32, mm - mm->mmxtmp->r32
-		// resolve dynreg
-		DynReg *reg = &DynRegs[decode.modrm.rm];
-		// resolve genreg
-		GenReg *gr = FindDynReg(reg);
 		// fill mmxtmp
-		cache_addw(0x7E0F);	// movd  mm, m32
-		cache_addb(0x05 | (decode.modrm.val & 0x38));
-		cache_addd((uintptr_t)&mmxtmp);
+		dyn_mmx_mem(0x7E); // movd  mm, m32
 		// move from mmxtmp to genreg
-		cache_addb(0x8b);	// mov r32, m32
-		cache_addb(0x05 | (gr->index << 3));
-		cache_addd((uintptr_t)&mmxtmp);
-		// mark dynreg as changed
-		reg->flags |= DYNFLG_CHANGED;
+		gen_load_host((void*)&mmxtmp, &DynRegs[decode.modrm.rm], 4);
 	}
 }
 
 // 0x7F - MOVQ mm/m64, mm
-void dyn_mmx_movq_qqpq() {
+static void dyn_mmx_movq_qqpq() {
 	dyn_get_modrm();
 
 	if (decode.modrm.mod < 3) {
 		// movq m64, mm - resolve EA and load data
 		dyn_fill_ea();
 		// fill mmxtmp
-		cache_addw(0x7F0F);	// movq  mm, m64
-		cache_addb(0x05 | (decode.modrm.val & 0x38));
-		cache_addd((uintptr_t)&mmxtmp);
+		dyn_mmx_mem(0x7F); // movq  mm, m64
 		// generate call to mmxtmp store
-		gen_call_function((void*)&MMX_STORE_64, "%Ddr", DREG(EA));
+		dyn_call_function_pagefault_check((void*)&MMX_STORE_64, "%Ddr", DREG(EA));
 	}
 	else {
 		// movq mm, mm
@@ -158,6 +139,6 @@ void dyn_mmx_movq_qqpq() {
 }
 
 // 0x77 - EMMS
-void dyn_mmx_emms() {
+static void dyn_mmx_emms() {
 	cache_addw(0x770F);
 }

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -1229,6 +1229,13 @@ static void gen_save_host_direct(void *data,Bitu imm) {
 		opcode(0).set64().setimm(imm,4).setabsaddr(data).Emit8(0xC7); // mov qword[], int32_t
 }
 
+static void gen_test_host_byte(void * data) {
+	opcode(0).Emit8Reg(0x50); // push rax
+	opcode(0).setabsaddr(data).Emit8(0x8A); // mov al, byte []
+	opcode(0).setrm(0).Emit8(0x84); // test al, al
+	opcode(0).Emit8Reg(0x58); // pop rax
+}
+
 static void gen_return(BlockReturn retcode) {
 	gen_protectflags();
 	opcode(1).setea(4,-1,0,CALLSTACK).Emit8(0x8B); // mov ecx, [rsp+8/40]

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -541,7 +541,7 @@ static void gen_mov_host(void * data,DynReg * dr1,Bitu size,Bitu di1=0) {
 }
 
 static void gen_save_host(void * data,DynReg * dr1,Bitu size,Bitu di1=0) {
-	int idx = FindDynReg(dr1,size==4)->index;
+	int idx = FindDynReg(dr1)->index;
 	opcode op;
 	uint8_t tmp;
 	switch (size) {

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -1138,9 +1138,9 @@ static void gen_call_write(DynReg * dr,uint32_t val,Bitu write_size) {
 	gen_load_arg_reg(0,dr,"rd");
 
 	switch (write_size) {
-		case 1: func = (void*)mem_writeb_checked_pagefault; break;
-		case 2: func = (void*)mem_writew_checked_pagefault; break;
-		case 4: func = (void*)mem_writed_checked_pagefault; break;
+		case 1: func = (void*)(use_dynamic_core_with_paging ? mem_writeb_checked_pagefault : mem_writeb_checked); break;
+		case 2: func = (void*)(use_dynamic_core_with_paging ? mem_writew_checked_pagefault : mem_writew_checked); break;
+		case 4: func = (void*)(use_dynamic_core_with_paging ? mem_writed_checked_pagefault : mem_writed_checked); break;
 		default: IllegalOption("gen_call_write");
 	}
 

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -1229,11 +1229,8 @@ static void gen_save_host_direct(void *data,Bitu imm) {
 		opcode(0).set64().setimm(imm,4).setabsaddr(data).Emit8(0xC7); // mov qword[], int32_t
 }
 
-static void gen_test_host_byte(void * data) {
-	opcode(0).Emit8Reg(0x50); // push rax
-	opcode(0).setabsaddr(data).Emit8(0x8A); // mov al, byte []
-	opcode(0).setrm(0).Emit8(0x84); // test al, al
-	opcode(0).Emit8Reg(0x58); // pop rax
+static void gen_test_host_byte(void * data, uint8_t imm) {
+	opcode(0).setimm(imm,1).setabsaddr(data).Emit8(0xF6); // test byte[], uint8_t
 }
 
 static void gen_return(BlockReturn retcode) {

--- a/src/cpu/core_dyn_x86/risc_x86.h
+++ b/src/cpu/core_dyn_x86/risc_x86.h
@@ -1052,6 +1052,14 @@ static void gen_save_host_direct(void * data,Bits imm) {
 	cache_addd(imm);
 }
 
+static void gen_test_host_byte(void * data) {
+	cache_addb(0x50); // push eax
+	cache_addw(0x058a);	//mov al, byte []
+	cache_addd((uint32_t)data);
+	cache_addw(0xc084); // test al, al
+	cache_addb(0x58); // pop eax
+}
+
 static void gen_return(BlockReturn retcode) {
 	gen_protectflags();
 	cache_addb(0x59);			//POP ECX, the flags

--- a/src/cpu/core_dyn_x86/risc_x86.h
+++ b/src/cpu/core_dyn_x86/risc_x86.h
@@ -1014,6 +1014,20 @@ static void gen_fill_jump(uint8_t * data,uint8_t * to=cache.pos) {
 	*(uint32_t*)data=(to-data-4);
 }
 
+static uint8_t * gen_create_short_jump(void) {
+	cache_addw(0x00EB);
+	return cache.pos-1;
+}
+
+static void gen_fill_short_jump(uint8_t * data, uint8_t * to=cache.pos) {
+#if C_DEBUG
+	Bits len=to-data-1;
+	if (len<0) len=~len;
+	if (len>127)
+		LOG_MSG("Big jump %d",len);
+#endif
+	data[0] = (uint8_t)(to-data-1);
+}
 
 static void gen_jmp_ptr(void * ptr,Bits imm=0) {
 	cache_addb(0xa1);

--- a/src/cpu/core_dyn_x86/risc_x86.h
+++ b/src/cpu/core_dyn_x86/risc_x86.h
@@ -1066,12 +1066,10 @@ static void gen_save_host_direct(void * data,Bits imm) {
 	cache_addd(imm);
 }
 
-static void gen_test_host_byte(void * data) {
-	cache_addb(0x50); // push eax
-	cache_addw(0x058a);	//mov al, byte []
+static void gen_test_host_byte(void * data, uint8_t imm) {
+	cache_addw(0x05f6); // test [],byte
 	cache_addd((uint32_t)data);
-	cache_addw(0xc084); // test al, al
-	cache_addb(0x58); // pop eax
+	cache_addb(imm);
 }
 
 static void gen_return(BlockReturn retcode) {

--- a/src/cpu/core_dyn_x86/risc_x86.h
+++ b/src/cpu/core_dyn_x86/risc_x86.h
@@ -325,6 +325,19 @@ static void gen_mov_host(void * data,DynReg * dr1,Bitu size,Bitu di1=0) {
 	dr1->flags|=DYNFLG_CHANGED;
 }
 
+static void gen_save_host(void * data,DynReg * dr1,Bitu size,Bitu di1=0) {
+	GenReg * gr1=FindDynReg(dr1,(size==4));
+	switch (size) {
+	case 1:cache_addb(0x88);break;	//mov byte
+	case 2:cache_addb(0x66);		//mov word
+	case 4:cache_addb(0x89);break;	//mov
+	default:
+		IllegalOption("gen_save_host");
+	}
+	cache_addb(0x5+((gr1->index+di1)<<3));
+	cache_addd((uint32_t)data);
+	dr1->flags|=DYNFLG_CHANGED;
+}
 
 static void gen_dop_byte(DualOps op,DynReg * dr1,uint8_t di1,DynReg * dr2,uint8_t di2) {
 	GenReg * gr1=FindDynReg(dr1);GenReg * gr2=FindDynReg(dr2);
@@ -948,9 +961,9 @@ static void gen_call_write(DynReg * dr,uint32_t val,Bitu write_size) {
 	/* Do the actual call to the procedure */
 	cache_addb(0xe8);
 	switch (write_size) {
-		case 1: cache_addd((uint32_t)mem_writeb_checked - (uint32_t)cache_rwtox(cache.pos)-4); break;
-		case 2: cache_addd((uint32_t)mem_writew_checked - (uint32_t)cache_rwtox(cache.pos)-4); break;
-		case 4: cache_addd((uint32_t)mem_writed_checked - (uint32_t)cache_rwtox(cache.pos)-4); break;
+		case 1: cache_addd((uint32_t)mem_writeb_checked_pagefault - (uint32_t)cache_rwtox(cache.pos)-4); break;
+		case 2: cache_addd((uint32_t)mem_writew_checked_pagefault - (uint32_t)cache_rwtox(cache.pos)-4); break;
+		case 4: cache_addd((uint32_t)mem_writed_checked_pagefault - (uint32_t)cache_rwtox(cache.pos)-4); break;
 		default: IllegalOption("gen_call_write");
 	}
 

--- a/src/cpu/core_dyn_x86/risc_x86.h
+++ b/src/cpu/core_dyn_x86/risc_x86.h
@@ -961,9 +961,9 @@ static void gen_call_write(DynReg * dr,uint32_t val,Bitu write_size) {
 	/* Do the actual call to the procedure */
 	cache_addb(0xe8);
 	switch (write_size) {
-		case 1: cache_addd((uint32_t)mem_writeb_checked_pagefault - (uint32_t)cache_rwtox(cache.pos)-4); break;
-		case 2: cache_addd((uint32_t)mem_writew_checked_pagefault - (uint32_t)cache_rwtox(cache.pos)-4); break;
-		case 4: cache_addd((uint32_t)mem_writed_checked_pagefault - (uint32_t)cache_rwtox(cache.pos)-4); break;
+		case 1: cache_addd((uint32_t)(use_dynamic_core_with_paging ? mem_writeb_checked_pagefault : mem_writeb_checked) - (uint32_t)cache_rwtox(cache.pos)-4); break;
+		case 2: cache_addd((uint32_t)(use_dynamic_core_with_paging ? mem_writew_checked_pagefault : mem_writew_checked) - (uint32_t)cache_rwtox(cache.pos)-4); break;
+		case 4: cache_addd((uint32_t)(use_dynamic_core_with_paging ? mem_writed_checked_pagefault : mem_writed_checked) - (uint32_t)cache_rwtox(cache.pos)-4); break;
 		default: IllegalOption("gen_call_write");
 	}
 

--- a/src/cpu/core_dyn_x86/risc_x86.h
+++ b/src/cpu/core_dyn_x86/risc_x86.h
@@ -326,7 +326,7 @@ static void gen_mov_host(void * data,DynReg * dr1,Bitu size,Bitu di1=0) {
 }
 
 static void gen_save_host(void * data,DynReg * dr1,Bitu size,Bitu di1=0) {
-	GenReg * gr1=FindDynReg(dr1,(size==4));
+	GenReg * gr1=FindDynReg(dr1);
 	switch (size) {
 	case 1:cache_addb(0x88);break;	//mov byte
 	case 2:cache_addb(0x66);		//mov word

--- a/src/cpu/core_dyn_x86/string.h
+++ b/src/cpu/core_dyn_x86/string.h
@@ -196,7 +196,6 @@ static void dyn_string(STRING_OP op) {
 			if (usedi) gen_dop_word(DOP_ADD,decode.big_addr,DREG(EDI),DREG(TMPW));
 
 			gen_sop_word(SOP_DEC,decode.big_addr,DREG(ECX));
-			gen_sop_word(SOP_DEC,true,DREG(CYCLES));
 
 			dyn_synchstate(&rep_state);
 		}

--- a/src/cpu/core_dyn_x86/string.h
+++ b/src/cpu/core_dyn_x86/string.h
@@ -29,7 +29,7 @@ enum STRING_OP {
 static void dyn_string(STRING_OP op) {
 	DynReg * si_base=decode.segprefix ? decode.segprefix : DREG(DS);
 	DynReg * di_base=DREG(ES);
-	DynReg * tmp_reg;bool usesi;bool usedi;
+	DynReg * tmp_reg;bool usesi;bool usedi;bool cmp=false;
 	gen_protectflags();
 	if (decode.rep) {
 		gen_dop_word_imm(DOP_SUB,true,DREG(CYCLES),decode.cycles);
@@ -38,14 +38,16 @@ static void dyn_string(STRING_OP op) {
 	}
 	/* Check what each string operation will be using */
 	switch (op) {
-	case STR_MOVSB:	case STR_MOVSW:	case STR_MOVSD:
 	case STR_CMPSB:	case STR_CMPSW:	case STR_CMPSD:
+		cmp=true;
+	case STR_MOVSB:	case STR_MOVSW:	case STR_MOVSD:
 		tmp_reg=DREG(TMPB);usesi=true;usedi=true;break;
 	case STR_LODSB:	case STR_LODSW:	case STR_LODSD:
 		tmp_reg=DREG(EAX);usesi=true;usedi=false;break;
 	case STR_OUTSB:	case STR_OUTSW:	case STR_OUTSD:
 		tmp_reg=DREG(TMPB);usesi=true;usedi=false;break;
 	case STR_SCASB:	case STR_SCASW:	case STR_SCASD:
+		cmp=true;
 	case STR_STOSB:	case STR_STOSW:	case STR_STOSD:
 		tmp_reg=DREG(EAX);usesi=false;usedi=true;break;
 	case STR_INSB:	case STR_INSW:	case STR_INSD:
@@ -76,10 +78,10 @@ static void dyn_string(STRING_OP op) {
 		gen_preloadreg(DREG(ECX));
 		DynRegs[G_ECX].flags|=DYNFLG_CHANGED;
 	}
-	DynState rep_state;
+	DynState rep_state, cmp_state;
 	dyn_savestate(&rep_state);
 	uint8_t * rep_start=cache.pos;
-	uint8_t * rep_ecx_jmp;
+	uint8_t * rep_ecx_jmp, * rep_cmp_jmp;
 	/* Check if ECX!=zero */
 	if (decode.rep) {
 		gen_dop_word(DOP_TEST,decode.big_addr,DREG(ECX),DREG(ECX));
@@ -113,6 +115,14 @@ static void dyn_string(STRING_OP op) {
 		} else {
 			gen_lea(DREG(EA),di_base,DREG(EDI),0,0);
 		}
+		if (cmp) {
+			switch (op&3) {
+			case 0:dyn_read_byte(DREG(EA),DREG(TMPD),false);break;
+			case 1:dyn_read_word(DREG(EA),DREG(TMPD),false);break;
+			case 2:dyn_read_word(DREG(EA),DREG(TMPD),true);break;
+			}
+			gen_needflags();
+		}
 		/* Maybe something special to be done to fill the value */
 		switch (op) {
 		case STR_INSB:
@@ -121,11 +131,19 @@ static void dyn_string(STRING_OP op) {
 		case STR_STOSB:
 			dyn_write_byte(DREG(EA),tmp_reg,false);
 			break;
+		case STR_CMPSB:
+		case STR_SCASB:
+			gen_dop_byte(DOP_CMP,tmp_reg,0,DREG(TMPD),0);
+			break;
 		case STR_INSW:
 			gen_call_function((void*)&IO_ReadW,"%Dw%Rw",DREG(EDX),tmp_reg);
 		case STR_MOVSW:
 		case STR_STOSW:
 			dyn_write_word(DREG(EA),tmp_reg,false);
+			break;
+		case STR_CMPSW:
+		case STR_SCASW:
+			gen_dop_word(DOP_CMP,false,tmp_reg,DREG(TMPD));
 			break;
 		case STR_INSD:
 			gen_call_function((void*)&IO_ReadD,"%Dw%Rd",DREG(EDX),tmp_reg);
@@ -133,8 +151,20 @@ static void dyn_string(STRING_OP op) {
 		case STR_STOSD:
 			dyn_write_word(DREG(EA),tmp_reg,true);
 			break;
+		case STR_CMPSD:
+		case STR_SCASD:
+			gen_dop_word(DOP_CMP,true,tmp_reg,DREG(TMPD));
+			break;
 		default:
 			IllegalOption("dyn_string op");
+		}
+		if (cmp) {
+			gen_protectflags();
+			
+			if (decode.rep) {
+				dyn_savestate(&cmp_state);
+				rep_cmp_jmp=gen_create_branch_long(decode.rep == REP_NZ ? BR_Z : BR_NZ);
+			}
 		}
 	}
 	gen_releasereg(DREG(EA));gen_releasereg(DREG(TMPB));
@@ -156,6 +186,20 @@ static void dyn_string(STRING_OP op) {
 		/* Jump back to start of ECX check */
 		dyn_synchstate(&rep_state);
 		gen_create_jump(rep_start);
+
+		if (cmp) {
+			dyn_loadstate(&cmp_state);
+			gen_fill_branch_long(rep_cmp_jmp);
+
+			/* update registers */
+			if (usesi) gen_dop_word(DOP_ADD,decode.big_addr,DREG(ESI),DREG(TMPW));
+			if (usedi) gen_dop_word(DOP_ADD,decode.big_addr,DREG(EDI),DREG(TMPW));
+
+			gen_sop_word(SOP_DEC,decode.big_addr,DREG(ECX));
+			gen_sop_word(SOP_DEC,true,DREG(CYCLES));
+
+			dyn_synchstate(&rep_state);
+		}
 
 		dyn_loadstate(&rep_state);
 		gen_fill_branch_long(rep_ecx_jmp);

--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -269,8 +269,6 @@ void PrintPageInfo(const char* string, PhysPt lin_addr, bool writing, bool prepa
 bool use_dynamic_core_with_paging = false; /* allow dynamic core even with paging (AT YOUR OWN RISK!!!!) */
 bool dosbox_allow_nonrecursive_page_fault = false;	/* when set, do nonrecursive mode (when executing instruction) */
 
-bool CPU_IsDynamicCore(void);
-
 void PAGING_PageFault(PhysPt lin_addr,Bitu page_addr,Bitu faultcode) {
 	/* Save the state of the cpu cores */
 	LazyFlags old_lflags;
@@ -312,7 +310,7 @@ static void PAGING_NewPageFault(PhysPt lin_addr, Bitu page_addr, bool prepare_on
 	if (prepare_only) {
 		cpu.exception.which = EXCEPTION_PF;
 		cpu.exception.error = faultcode;
-	} else if (dosbox_allow_nonrecursive_page_fault && !CPU_IsDynamicCore()) {
+	} else if (dosbox_allow_nonrecursive_page_fault) {
 		throw GuestPageFaultException(lin_addr,page_addr,faultcode);
 	} else {
 		// Save the state of the cpu cores


### PR DESCRIPTION
# Description

This is an experimental branch to add support for non recursive page fault handling in dynamic_x86 core to make the dynamic core usable in Windows 95/98.


**Does this PR address some issue(s) ?**

dynamic core doesn't work so well in Windows 95/98 because of the known issue of page fault handling that causes context switching.

**Does this PR introduce new feature(s) ?**

This PR tries to add introduce non recursive page fault that already exists in normal to dynamic_x86 core.

**Are there any breaking changes ?**

Hopefully not.


**Additional information**

The first commit allows parts of the dynamic core that use normal core use non-recursive page fault. It already improves the stability without changing much. (For example if there is a pagefault when running a code that is in the invalidation map or in the internal loop after a pagefault, which uses a normal code. So I think that it helps because it can prevent too much nesting in some cases. It seems that once you are nested twice, things stop working properly. And it is seems that a pagefault during INT10 during another pagefault causes that many times)
 
The second commit adds full support for non recursive page fault.
There were few challenges in making this work. C++ exceptions doesn't work in dynamically generated code.  So any call from the dynamically generated code that may cause a page fault exception, must be wrapped with try/catch.
For most of the places I was able to achieve it by creating a macro that can be used instead of gen_call_function, that macro calls to gen_call_function with a wrapper function (with try/catch), and after that call it checks if there was a pagefault and handle it properly. (calls to CPU_Exception)

After that the issue was making sure that instructions are recovering from the abrupt stop properly. By looking on the changes that dosbox-x did for the normal cpu, I saw that it had to restore the stack pointer in few instructions, and restore the fpu top in some fpu instructions. So I added a code to do so. While testing my code I saw some incorrect behavior, which I was able to trace back to exception during dh fpu (duh, it is used instead of the normal fpu code by default), so I had to add a recovery to that. The issue happened when we pop value from the host FPU and than there is an exception when we write it to the guest memory, so we need to restore it when there is an exception, so the solution was simply to add an instruction that does the opposite (FLD after FSTP)

Another issue was that a pagefault can happen while generating the code, AKA CreateCacheBlock (because that part read things from the memory). From what I tried, that code can't handle exceptions, it causes some things to be corrupted. So my solution was to wrap decode_fetchX with try/catch, and in case of exception, I mark it, and let CreateCacheBlock finish after that instruction, and after that I invalidate the block, and raise the exception back to Normal_Loop.

Theoretically there may be an exception during MakeCodePage too, but it is the first call in that function, so that exception will just go to Normal_loop and won't corrupt anything. 


From my tests it seems that is very stable and usable, pretty much the same stability as the normal core, but it need to be tested more thoroughly. I may have missed some cases. Also, this code adds a little bit overhead to the dynamic core (few opcode to each call), but I didn't notice any performance hit.
I would appreciate any feedback.