### PR TITLE
Expand paths for printing and port options etc

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
 0.83.10
+  - Added abliity to resolve file paths that include
+    environment variables on Windows or tildes (~) on
+    other platforms for file outputs in the serial and
+    parallel ports and printing options. (Wengier)
   - You can now translate texts in DOSBox-X's drop-down
     menus. The message files as written by the config
     tool (CLI or GUI) will contain the menu texts for

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -2863,7 +2863,10 @@ public:
 			}
 			dos_clipboard_device_name=valid?upcase(dos_clipboard_device_name):(char *)dos_clipboard_device_default;
 			LOG(LOG_DOSMISC,LOG_NORMAL)("DOS clipboard device (%s access) is enabled with the name %s\n", dos_clipboard_device_access==1?"dummy":(dos_clipboard_device_access==2?"read":(dos_clipboard_device_access==3?"write":"full")), dos_clipboard_device_name);
-            mainMenu.get_item("clipboard_device").set_text("Enable DOS clipboard device access: "+std::string(dos_clipboard_device_name)).check(dos_clipboard_device_access==4&&!control->SecureMode()).enable(true).refresh_item(mainMenu);
+            std::string text=mainMenu.get_item("clipboard_device").get_text();
+            std::size_t found = text.find(":");
+            if (found!=std::string::npos) text = text.substr(0, found);
+            mainMenu.get_item("clipboard_device").set_text(text+": "+std::string(dos_clipboard_device_name)).check(dos_clipboard_device_access==4&&!control->SecureMode()).enable(true).refresh_item(mainMenu);
 		} else
             mainMenu.get_item("clipboard_device").enable(false).refresh_item(mainMenu);
 #else

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -4062,7 +4062,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring->SetBasic(true);
 
     Pstring = secprop->Add_string("pcaptimeout", Property::Changeable::WhenIdle,"default");
-    Pstring->Set_help("Specifies the read timeout for pcap in milliseconds, or the default value will be used.");
+    Pstring->Set_help("Specifies the read timeout for the device in milliseconds for the pcap backend, or the default value will be used.");
 
     /* IDE emulation options and setup */
     for (size_t i=0;i < MAX_IDE_CONTROLLERS;i++) {
@@ -4272,6 +4272,7 @@ void DOSBOX_SetupConfigSections(void) {
             "# They are used to (briefly) document the effect of each option.\n"
         "# To write out ALL options, use command 'config -all' with -wc or -writeconf options.\n");
     MSG_Add("CONFIG_SUGGESTED_VALUES", "Possible values");
+    MSG_Add("EMPTY_SLOT","Empty slot");
 }
 
 int utf8_encode(char **ptr, const char *fence, uint32_t code) {
@@ -5840,7 +5841,7 @@ void SaveState::removeState(size_t slot) const {
 }
 
 std::string SaveState::getName(size_t slot, bool nl) const {
-	if (slot >= SLOT_COUNT*MAX_PAGE) return "[Empty slot]";
+	if (slot >= SLOT_COUNT*MAX_PAGE) return "["+std::string(MSG_Get("EMPTY_SLOT"))+"]";
 	std::string path;
 	bool Get_Custom_SaveDir(std::string& savedir);
 	if(Get_Custom_SaveDir(path)) {
@@ -5864,7 +5865,7 @@ std::string SaveState::getName(size_t slot, bool nl) const {
 	std::string save=nl&&use_save_file&&savefilename.size()?savefilename:temp+slotname.str()+".sav";
 	std::ifstream check_slot;
 	check_slot.open(save.c_str(), std::ifstream::in);
-	if (check_slot.fail()) return nl?"(Empty state)":"[Empty slot]";
+	if (check_slot.fail()) return nl?"(Empty state)":"["+std::string(MSG_Get("EMPTY_SLOT"))+"]";
 	my_miniunz((char **)save.c_str(),"Program_Name",temp.c_str());
 	std::ifstream check_title;
 	int length = 8;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -10687,7 +10687,10 @@ bool use_save_file_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * con
 }
 
 void refresh_slots() {
-    mainMenu.get_item("current_page").set_text("Current page: "+to_string(page+1)+"/10").refresh_item(mainMenu);
+    std::string text=mainMenu.get_item("current_page").get_text();
+    std::size_t found = text.find(":");
+    if (found!=std::string::npos) text = text.substr(0, found);
+    mainMenu.get_item("current_page").set_text(text+": "+to_string(page+1)+"/10").refresh_item(mainMenu);
 	for (unsigned int i=0; i<SaveState::SLOT_COUNT; i++) {
 		char name[6]="slot0";
 		name[4]='0'+i;
@@ -12281,8 +12284,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 				char name[6]="slot0";
 				for (unsigned int i=0; i<SaveState::SLOT_COUNT; i++) {
 					name[4]='0'+i;
-					std::string command=SaveState::instance().getName(page*SaveState::SLOT_COUNT+i);
-					std::string str="Slot "+to_string(page*SaveState::SLOT_COUNT+i+1)+(command==""?"":" "+command);
+					std::string str="Slot "+to_string(page*SaveState::SLOT_COUNT+i+1);
 					mainMenu.alloc_item(DOSBoxMenu::item_type_id,name).set_text(str.c_str()).set_callback_function(save_slot_callback);
 				}
             }
@@ -12594,6 +12596,13 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"pc98_use_uskb").set_text("Use US keyboard layout").set_callback_function(pc98_force_uskb_menu_callback).check(pc98_force_ibm_layout);
         MSG_Init();
 
+        char name[6]="slot0";
+        for (unsigned int i=0; i<SaveState::SLOT_COUNT; i++) {
+            name[4]='0'+i;
+            std::string command=SaveState::instance().getName(page*SaveState::SLOT_COUNT+i);
+            std::string str="Slot "+to_string(page*SaveState::SLOT_COUNT+i+1)+(command==""?"":" "+command);
+            mainMenu.get_item(name).set_text(str.c_str());
+        }
         mainMenu.get_item("wheel_updown").check(wheel_key==1).refresh_item(mainMenu);
         mainMenu.get_item("wheel_leftright").check(wheel_key==2).refresh_item(mainMenu);
         mainMenu.get_item("wheel_pageupdown").check(wheel_key==3).refresh_item(mainMenu);
@@ -12610,7 +12619,10 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         mainMenu.get_item("hostkey_altshift").check(hostkeyalt==3).refresh_item(mainMenu);
         std::string mapper_keybind = mapper_event_keybind_string("host");
         if (mapper_keybind.empty()) mapper_keybind = "unbound";
-        mainMenu.get_item("hostkey_mapper").check(hostkeyalt==0).set_text("Mapper-defined: "+mapper_keybind).refresh_item(mainMenu);
+        std::string text=mainMenu.get_item("hostkey_mapper").get_text();
+        std::size_t found = text.find(":");
+        if (found!=std::string::npos) text = text.substr(0, found);
+        mainMenu.get_item("hostkey_mapper").check(hostkeyalt==0).set_text(text+": "+mapper_keybind).refresh_item(mainMenu);
 
         bool MENU_get_swapstereo(void);
         mainMenu.get_item("mixer_swapstereo").check(MENU_get_swapstereo()).refresh_item(mainMenu);

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -2184,6 +2184,9 @@ public:
 		myGUS.rate=(unsigned int)section->Get_int("gusrate");
 
         ultradir = section->Get_string("ultradir");
+        void ResolvePath(std::string& in);
+        ResolvePath(ultradir);
+
 
 		x = section->Get_int("gusmemsize");
 		if (x >= 0) myGUS.memsize = (unsigned int)x*1024u;

--- a/src/hardware/ne2000.cpp
+++ b/src/hardware/ne2000.cpp
@@ -1660,11 +1660,11 @@ public:
 		const char *timeoutstr = section->Get_string("pcaptimeout");
         char *end;
         int timeout = -1;
-        if (!strlen(timeoutstr)||timeoutstr[0]!='-'&&!isdigit(timeoutstr[0])) {
+        if (!strlen(timeoutstr)||timeoutstr[0]!='-'&&!isdigit(timeoutstr[0])) { // Default timeout values
 #ifdef WIN32
-            timeout = -1;
+            timeout = -1; // For Windows, use -1 which appears to be specific to WinPCap and means "non-blocking mode"
 #else
-            timeout = 3000;
+            timeout = 3000; // For other platforms, use 3000ms as the timeout which should work for platforms like macOS
 #endif
         } else
             timeout = strtoul(timeoutstr,&end,10);

--- a/src/hardware/parport/filelpt.cpp
+++ b/src/hardware/parport/filelpt.cpp
@@ -77,6 +77,8 @@ CFileLPT::CFileLPT (Bitu nr, uint8_t initIrq, CommandLine* cmd, bool sq)
 		name = str.c_str();
 		filetype = FILE_DEV;
 	} else if(cmd->FindStringBegin("file:",str,false)) {
+        void ResolvePath(std::string& in);
+        ResolvePath(str);
 		name = str.c_str();
 		filetype = FILE_DEV;
         is_file = true;

--- a/src/hardware/parport/printer.cpp
+++ b/src/hardware/parport/printer.cpp
@@ -46,8 +46,8 @@ static CPrinter* defaultPrinter = NULL;
 static uint16_t confdpi, confwidth, confheight;
 static Bitu printer_timout;
 static bool timeout_dirty;
-static const char* document_path;
-static const char* font_path;
+static std::string document_path;
+static std::string font_path;
 static char confoutputDevice[50];
 static bool confmultipageOutput, shellhide;
 static std::string actstd, acterr;
@@ -256,12 +256,7 @@ void CPrinter::updateFont()
 	if (curFont != NULL)
 		FT_Done_Face(curFont);
 
-	std::string fontName, basedir;
-#if defined(WIN32)
-    basedir = font_path;
-#else
-    basedir = font_path;
-#endif
+	std::string fontName, basedir = font_path;
     if (basedir.back()!='\\' && basedir.back()!='/')
         basedir += CROSS_FILESPLIT;
 
@@ -1643,7 +1638,7 @@ void CPrinter::formFeed()
 static void findNextName(const char* front, const char* ext, char* fname)
 {
 	int i = 1;
-	Bitu slen = (Bitu)strlen(document_path);
+	Bitu slen = (Bitu)document_path.size();
 	if(slen > (200 - 15))
     {
 		fname[0] = 0;
@@ -1653,7 +1648,7 @@ static void findNextName(const char* front, const char* ext, char* fname)
     FILE *test = NULL;
 	do
 	{
-		strcpy(fname, document_path);
+		strcpy(fname, document_path.c_str());
 #ifdef WIN32
 		const char* const pathstring = "\\%s%d%s";
 #else 
@@ -2235,6 +2230,7 @@ bool PRINTER_isInited()
 	return inited;
 }
 
+void ResolvePath(std::string& in);
 void PRINTER_Init() 
 {
 	Section_prop * section = static_cast<Section_prop *>(control->GetSection("printer"));
@@ -2246,7 +2242,9 @@ void PRINTER_Init()
 	if (!section->Get_bool("printer")) return;
 	inited = true;
 	document_path = section->Get_string("docpath");
+	ResolvePath(document_path);
 	font_path = section->Get_string("fontpath");
+	ResolvePath(font_path);
 	confdpi = section->Get_int("dpi");
 	confwidth = section->Get_int("width");
 	confheight = section->Get_int("height");

--- a/src/hardware/serialport/serialfile.cpp
+++ b/src/hardware/serialport/serialfile.cpp
@@ -39,6 +39,8 @@ CSerialFile::CSerialFile(Bitu id,CommandLine* cmd,bool sq):CSerial(id, cmd) {
 
     filename = "serial"; // Default output filename
     cmd->FindStringBegin("file:", filename, false); // if the user specifies serial1=file file:something, set it to that
+    void ResolvePath(std::string& in);
+    ResolvePath(filename);
     LOG_MSG("Serial: port %d will write to file %s", int(id), filename.c_str());
 
     std::string str;

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -47,6 +47,20 @@ std::string MacOSXResPath;
 #define _mkdir(x) mkdir(x)
 #endif
 
+void ResolvePath(std::string& in) {
+#if defined(WIN32)
+    char path[300],temp[300],*tempd=temp;
+    strcpy(tempd, in.c_str());
+    if (strchr(tempd, '%')&&ExpandEnvironmentStrings(tempd,path,300))
+        tempd=path;
+    in=std::string(tempd);
+#else
+    struct stat test;
+    if (stat(in.c_str(),&test))
+        Cross::ResolveHomedir(in);
+#endif
+}
+
 #if defined(WIN32) && !defined(HX_DOS)
 static void W32_ConfDir(std::string& in,bool create) {
 	int c = create?1:0;

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -150,8 +150,14 @@ bool MSG_Write(const char * location) {
 	}
 	std::vector<DOSBoxMenu::item> master_list = mainMenu.get_master_list();
 	for (auto &id : master_list) {
-		if (id.is_allocated()&&id.get_type()!=DOSBoxMenu::separator_type_id&&id.get_type()!=DOSBoxMenu::vseparator_type_id)
-			fprintf(out,":MENU:%s\n%s\n.\n",id.get_name().c_str(),id.get_text().c_str());
+		if (id.is_allocated()&&id.get_type()!=DOSBoxMenu::separator_type_id&&id.get_type()!=DOSBoxMenu::vseparator_type_id&&!(id.get_name().size()==5&&id.get_name().substr(0,4)=="slot")) {
+            std::string text = id.get_text();
+            if (id.get_name()=="hostkey_mapper"||id.get_name()=="clipboard_device") {
+                std::size_t found = text.find(":");
+                if (found!=std::string::npos) text = text.substr(0, found);
+            }
+            fprintf(out,":MENU:%s\n%s\n.\n",id.get_name().c_str(),text.c_str());
+        }
 	}
 	fclose(out);
 	return true;


### PR DESCRIPTION
This will allow the file paths for file output options for printing and serial/parallel ports to be  expanded. For Windows systems, environment variables in such options will be expanded, and in non-Windows systems the tildes will be expanded. Also fixed some issues for drop-down menu translations as mentioned in Issue #2174, and added some comments to the pcap code.