### PR TITLE
Resolve [config] section paths for environment variables or tildes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,8 +3,9 @@
     environment variables on Windows or tildes (~) on
     other platforms for various options in the config
     file, such as language and mapper file paths, MT32
-    ROM and FluidSynth soundfont paths, as well as file
-    outputs for the printing functions. (Wengier)
+    ROM & FluidSynth soundfont paths, [config] section
+    options as well as file outputs for the printing
+    and serial/parallel port functions. (Wengier)
   - You can now translate texts in DOSBox-X's drop-down
     menus. The message files as written by the config
     tool (CLI or GUI) will contain the menu texts for
@@ -42,7 +43,8 @@
     DOSBox-X directly so that it will be mounted as C:
     drive when DOSBox-X starts. (Wengeir)
   - Fixed Ctrl+C not working in GNU ed. (Wengier)
-  - Fixed large ISO images unable to mount. (Wengier)
+  - Fixed large ISO images (>2GB) unable to be mounted
+    using IMGMOUNT command. (Wengier)
   - Fixed incorrect behavior for handling trap flags
     in the dynamic core. (koolkdev)
   - Updated the Tiny File Dialog library to the latest

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -1128,8 +1128,8 @@ void CONFIG::Run(void) {
 							}
 							if (!strcasecmp(inputline.substr(0, 11).c_str(), "fullscreen=")) {
                                 if (section->Get_bool("fullscreen")) {
-                                    if (!GFX_IsFullscreen()) GFX_SwitchFullScreen();
-                                } else if (GFX_IsFullscreen()) GFX_SwitchFullScreen();
+                                    if (!GFX_IsFullscreen()) {GFX_LosingFocus();GFX_SwitchFullScreen();}
+                                } else if (GFX_IsFullscreen()) {GFX_LosingFocus();GFX_SwitchFullScreen();}
                             }
 #if defined(C_SDL2)
 							if (!strcasecmp(inputline.substr(0, 16).c_str(), "mapperfile_sdl2=")) ReloadMapper(section,true);
@@ -1146,7 +1146,7 @@ void CONFIG::Run(void) {
                                 if (pp->realpath=="") ReloadMapper(section,true);
                             }
 							if (!strcasecmp(inputline.substr(0, 13).c_str(), "usescancodes=")) {
-								void setScanCode(Section_prop * section), loadScanCode(), GFX_LosingFocus(), MAPPER_Init();
+								void setScanCode(Section_prop * section), loadScanCode(), MAPPER_Init();
 								setScanCode(section);
 								loadScanCode();
 								GFX_LosingFocus();

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -59,6 +59,7 @@ Bitu call_int2e = 0;
 
 std::string GetDOSBoxXPath(bool withexe=false);
 void runMount(const char *str);
+void ResolvePath(std::string& in);
 void DOS_SetCountry(uint16_t countryNo);
 void CALLBACK_DeAllocate(Bitu in);
 void GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused);
@@ -593,6 +594,7 @@ void DOS_Shell::Run(void) {
 			}
 			const char * extra = const_cast<char*>(section->data.c_str());
 			if (extra) {
+				std::string vstr;
 				std::istringstream in(extra);
 				char linestr[CROSS_LEN+1], cmdstr[CROSS_LEN], valstr[CROSS_LEN], tmpstr[CROSS_LEN];
 				char *cmd=cmdstr, *val=valstr, *tmp=tmpstr, *p;
@@ -615,10 +617,14 @@ void DOS_Shell::Run(void) {
 							strcat(config_data, val);
 							strcat(config_data, "\r\n");
 						}
-						if (!strncasecmp(cmd, "set ", 4))
-							DoCommand((char *)(std::string(cmd)+"="+std::string(val)).c_str());
-						else if (!strcasecmp(cmd, "install")||!strcasecmp(cmd, "installhigh")||!strcasecmp(cmd, "device")||!strcasecmp(cmd, "devicehigh")) {
-							strcpy(tmp, val);
+						if (!strncasecmp(cmd, "set ", 4)) {
+							vstr=std::string(val);
+							ResolvePath(vstr);
+							DoCommand((char *)(std::string(cmd)+"="+vstr).c_str());
+						} else if (!strcasecmp(cmd, "install")||!strcasecmp(cmd, "installhigh")||!strcasecmp(cmd, "device")||!strcasecmp(cmd, "devicehigh")) {
+							vstr=std::string(val);
+							ResolvePath(vstr);
+							strcpy(tmp, vstr.c_str());
 							char *name=StripArg(tmp);
 							if (!*name) continue;
 							if (!DOS_FileExists(name)) {
@@ -626,13 +632,13 @@ void DOS_Shell::Run(void) {
 								continue;
 							}
 							if (!strcasecmp(cmd, "install"))
-								DoCommand(val);
+								DoCommand((char *)vstr.c_str());
 							else if (!strcasecmp(cmd, "installhigh"))
-								DoCommand((char *)("lh "+std::string(val)).c_str());
+								DoCommand((char *)("lh "+vstr).c_str());
 							else if (!strcasecmp(cmd, "device"))
-								DoCommand((char *)("device "+std::string(val)).c_str());
+								DoCommand((char *)("device "+vstr).c_str());
 							else if (!strcasecmp(cmd, "devicehigh"))
-								DoCommand((char *)("lh device "+std::string(val)).c_str());
+								DoCommand((char *)("lh device "+vstr).c_str());
 						}
 					} else if (!strncasecmp(line.c_str(), "rem ", 4)) {
 						strcat(config_data, line.c_str());


### PR DESCRIPTION
@emendelson has requested the ability in #2189 to access Windows environment variables, at least including a list of variables that DOSBox-X would inherit from the host. And this will make it possible.

For example, you could now set the following in the config file:

```
[config]
SET WIN_COMSPEC=COMSPEC: %COMSPEC%
```

And then %COMSPEC% will be expanded to the actual Windows environment variable.

This will only work for [config] section, but seems to be good enough for our purpose.

Also fixed the keyboard issue when toggling full-screen mode with CONFIG command mentioned in #2159.