### PR TITLE
Fix issue #2165

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -61,7 +61,8 @@
   - Fixed incorrect behavior for handling trap flags
     in the dynamic core. (koolkdev)
   - Updated the Tiny File Dialog library to the latest
-    version v3.8.4. (Wengier)
+    version v3.8.5, which fixes issues such as the
+    compatibility problem with Windows XP. (Wengier)
   - Improved OPL3Duo support, such as adding a buffer
     thread to get rid of slowdowns & breakups in audio
     playback when using the board. (DhrBaksteen)

--- a/src/libs/tinyfiledialogs/tinyfiledialogs.h
+++ b/src/libs/tinyfiledialogs/tinyfiledialogs.h
@@ -2,9 +2,9 @@
 with a C++ compiler, then comment out << extern "C" >> bellow in this header file) */
 
 /*_________
- /         \ tinyfiledialogs.h v3.8.4 [Dec 23, 2020] zlib licence
+ /         \ tinyfiledialogs.h v3.8.5 [Jan 17, 2021] zlib licence
  |tiny file| Unique header file created [November 9, 2014]
- | dialogs | Copyright (c) 2014 - 2020 Guillaume Vareille http://ysengrin.com
+ | dialogs | Copyright (c) 2014 - 2021 Guillaume Vareille http://ysengrin.com
  \____  ___/ http://tinyfiledialogs.sourceforge.net
       \|     git clone http://git.code.sf.net/p/tinyfiledialogs/code tinyfd
  ____________________________________________
@@ -52,7 +52,7 @@ misrepresented as being the original software.
 #ifdef	__cplusplus
 /* if tinydialogs.c is compiled as C++ code rather than C code, you may need to comment this out
 				and the corresponding closing bracket near the end of this file. */
-extern "C" { 
+extern "C" {
 #endif
 
 /******************************************************************************************************/


### PR DESCRIPTION
This fixes the problem that Quick Launch Program does not work on Windows XP, as discussed in Issue #2165. The tinyfd library has been updated by its maintainer to solve this.