### PR TITLE
Support for standard/monochrome dual-screen mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,6 +46,8 @@
     "windowheight" so that commmands like "CONFIG -GET
     screenwidth" and "CONFIG -GET screenheight" will
     get the current screen width and height. (Wengier)
+  - BOOT command without a parameter will now try to
+    boot the current drive if possible. (Wengier)
   - You can now change properties such as "fullscreen",
     "glshader" and "windowposition" dynamically with
     CONFIG command. For example, command "config -set

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,11 @@
     sin(0) and cos(0)) and many advanced mathematical
     expressions in either command-line mode and or the
     interactive mode. (Wengier)
+  - Added support for standard (VGA/EGA/CGA) and mono
+    mode dual-screen setup by porting the patch. You
+    can now start DOSBox-X with the option -display2
+    followed by a color (white, green, amber) to enable
+    this feature on debug builds. (Wengier)
   - You can now translate texts in DOSBox-X's drop-down
     menus. The message files as written by the config
     tool (CLI or GUI) will contain the menu texts for

--- a/include/control.h
+++ b/include/control.h
@@ -77,6 +77,7 @@ public:
         opt_startui = false;
         initialised = false;
         opt_console = false;
+        opt_display2 = false;
         opt_logint21 = false;
         opt_userconf = false;
         opt_noconfig = false;
@@ -150,6 +151,7 @@ public:
     bool opt_resetconf;
     bool opt_printconf;
     bool opt_logint21;
+    bool opt_display2;
     bool opt_userconf;
     bool opt_noconfig;
     bool opt_console;

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -52,6 +52,7 @@ using namespace std;
 #include "../cpu/lazyflags.h"
 #include "keyboard.h"
 #include "setup.h"
+#include "control.h"
 
 #ifdef WIN32
 void WIN32_Console();
@@ -3408,7 +3409,7 @@ void DEBUG_FlushInput(void);
 
 static bool hidedebugger=false;
 void DEBUG_Enable_Handler(bool pressed) {
-	if (!pressed)
+	if (!pressed || control->opt_display2)
 		return;
 
 #if defined(WIN32)

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1731,8 +1731,14 @@ public:
             stack_seg = max_seg - 0x20;
 
         if(!cmd->GetCount()) {
-            printError();
-            return;
+            uint8_t drv = dos_kernel_disabled?26:DOS_GetDefaultDrive();
+            if (drv < 4 && Drives[drv] && !strncmp(Drives[drv]->GetInfo(), "fatDrive ", 9)) {
+                drive = 'A' + drv;
+                bootbyDrive = true;
+            } else {
+                printError();
+                return;
+            }
         } else if (cmd->GetCount()==1) {
 			cmd->FindCommand(1, temp_line);
 			if (temp_line.length()==2&&toupper(temp_line[0])>='A'&&toupper(temp_line[0])<='Z'&&temp_line[1]==':') {
@@ -7051,12 +7057,12 @@ void DOS_SetupPrograms(void) {
         "For this command, one can specify a succession of floppy disks swappable\n"
         "by the menu command, and drive: specifies the mounted drive to boot from.\n"
         "If no drive letter is specified, this defaults to boot from the A drive.\n"
+        "If no parameter is specified, it will try to boot from the current drive.\n"
         "The only bootable drive letters are A, C, and D.  For booting from a hard\n"
         "drive (C or D), ensure the image is already mounted by \033[34;1mIMGMOUNT\033[0m command.\n\n"
-        "The syntax of this command is:\n\n"
+        "The syntax of this command is one of the following:\n\n"
+        "\033[34;1mBOOT [driveletter:]\033[0m\n\n"
         "\033[34;1mBOOT diskimg1.img [diskimg2.img ...] [-L driveletter]\033[0m\n\n"
-		"Or:\n\n"
-        "\033[34;1mBOOT driveletter:\033[0m\n\n"
         "Note: An image file with a leading colon (:) will be booted in write-protected\n"
 		"mode if the \"leading colon write protect image\" option is enabled.\n\n"
         "Examples:\n\n"

--- a/src/gui/display2.cpp
+++ b/src/gui/display2.cpp
@@ -1,0 +1,266 @@
+/*
+ *  Copyright (C) 2002-2020  The DOSBox Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+
+#include <curses.h>
+#include <string.h>
+#ifdef WIN32
+#include <windows.h>
+#endif
+#include "dosbox.h"
+#include "paging.h"
+#include "inout.h"
+#include "pic.h"
+
+#define REFRESH_DELAY 1000.0/50.0
+
+struct {
+	uint8_t* memory;
+	uint8_t* render;
+	bool update;
+	uint8_t index;
+	struct {
+		bool enable;
+		bool update;
+		uint8_t sline;
+		uint8_t eline;
+		uint16_t pos;
+	} cursor;
+} disp2;
+
+static bool disp2_init=false;
+
+bool DISP2_Active(void) {
+	return disp2_init;
+}
+
+static void DISP2_WriteChar(uint16_t row,uint16_t col,uint16_t chat) {
+	uint8_t ch=(uint8_t)(chat&0xff),at=(uint8_t)(chat>>8);
+	if (GCC_UNLIKELY((at&0x77)==0)) attrset(COLOR_PAIR(1) | A_INVIS);
+	else if ((at&0x77)==0x70) attrset(COLOR_PAIR(1) | A_REVERSE);
+	else if (at&8) attrset(COLOR_PAIR(1) | A_BOLD);
+	else attrset(COLOR_PAIR(1) | A_NORMAL);
+	mvaddch(row,col,ch);
+}
+
+#define new_pos disp2.cursor.pos
+
+static void DISP2_Refresh(Bitu /*val*/) {
+	static Bitu blink=0;
+	static uint16_t old_pos=0;
+	static uint8_t map_ch=0,old_ch=0;
+	bool need_refresh=false;
+	if (disp2.update) {
+		for (uint16_t addr=0;addr<4000;addr+=2) {
+			uint16_t memory=host_readw(&disp2.memory[addr]);
+			if (memory!=host_readw(&disp2.render[addr])) {
+				DISP2_WriteChar(addr/160,(addr%160)>>1,memory);
+				host_writew(&disp2.render[addr],memory);
+			}
+		}
+		disp2.update=false;
+		need_refresh=true;
+	}
+	if (disp2.cursor.update) {
+		if (!disp2.cursor.enable || disp2.cursor.eline<disp2.cursor.sline) {
+			map_ch=0; // cursor off
+		} else if (disp2.cursor.sline<4) {
+			if (disp2.cursor.eline>10) map_ch=0xdb; // full block
+			else map_ch=0xdf; // upper half block
+		} else if (disp2.cursor.sline<10) {
+			if (disp2.cursor.eline>12) map_ch=0xdc; // lower half block
+			else map_ch=0x2d; // minus sign
+		} else map_ch=0x5f; // underscore
+		disp2.cursor.update=false;
+	}
+	uint8_t new_ch=(++blink&8)?map_ch:0;
+	if ((old_ch) && old_pos<2000 && (new_ch==0 || new_pos!=old_pos)) {
+		DISP2_WriteChar(old_pos/80,old_pos%80,host_readw(&disp2.memory[old_pos<<1]));
+		need_refresh=true;
+	}
+	if ((new_ch) && new_pos<2000 && (new_ch!=old_ch || new_pos!=old_pos)) {
+		DISP2_WriteChar(new_pos/80,new_pos%80,host_readw(&disp2.memory[new_pos<<1])&0xff00|new_ch);
+		need_refresh=true;
+	}
+	old_ch=new_ch;
+	old_pos=new_pos;
+	if (need_refresh) refresh();
+	PIC_AddEvent(DISP2_Refresh,REFRESH_DELAY);
+}
+
+class DISP2_PageHandler : public PageHandler {
+public:
+	DISP2_PageHandler() {
+		flags=PFLAG_NOCODE;
+	}
+	// the 4kB map area is repeated in the 32kB range
+	uint8_t readb(PhysPt addr) {
+		return disp2.memory[addr&0xfff];
+	}
+	void writeb(PhysPt addr,uint8_t val) {
+		disp2.memory[addr&0xfff]=val;
+		disp2.update=true;
+	}
+};
+
+static DISP2_PageHandler disp2_page_handler;
+
+void DISP2_SetPageHandler(void) {
+	if (machine!=MCH_HERC && machine!=MCH_MDA && disp2_init) MEM_SetPageHandler(0xB0,8,&disp2_page_handler);
+}
+
+static void DISP2_write_crtc_index(Bitu /*port*/,Bitu val,Bitu /*iolen*/) {
+	disp2.index=(uint8_t)(val&0x1f);
+}
+
+static void DISP2_write_crtc_data(Bitu /*port*/,Bitu val,Bitu /*iolen*/) {
+	switch (disp2.index) {
+	case 0x0a: // cursor start
+		disp2.cursor.enable=((val&0x60)!=0x20);
+		disp2.cursor.sline=(uint8_t)(val&0x1f);
+		disp2.cursor.update=true;
+		break;
+	case 0x0b: // cursor end
+		disp2.cursor.eline=(uint8_t)(val&0x1f);
+		disp2.cursor.update=true;
+		break;
+	case 0x0e: // cursor position high
+		disp2.cursor.pos=(disp2.cursor.pos&0x00ff)|(uint16_t)((val&0x0f)<<8);
+		break;
+	case 0x0f: // cursor position low
+		disp2.cursor.pos=(disp2.cursor.pos&0xff00)|(uint16_t)val;
+		break;
+	}
+}
+
+static Bitu DISP2_read_crtc_data(Bitu /*port*/,Bitu /*iolen*/) {
+	switch (disp2.index) {
+	case 0x0e: // cursor position high
+		return (uint8_t)(disp2.cursor.pos>>8);
+	case 0x0f: // cursor position low
+		return (uint8_t)(disp2.cursor.pos&0xff);
+	default:
+		return (Bitu)(~0);
+	}
+}
+
+static Bitu DISP2_read_status(Bitu /*port*/,Bitu /*iolen*/) {
+	static uint8_t status=0xf0;
+	status^=0x09; // toggle stream and hsync bits for detection
+	return status;
+}
+
+void DISP2_RegisterPorts(void) {
+	if (machine!=MCH_HERC && machine!=MCH_MDA && disp2_init) {
+		for (Bitu i=0;i<4;i++) {
+			IO_RegisterWriteHandler(0x3b0+i*2,DISP2_write_crtc_index,IO_MB);
+			IO_RegisterWriteHandler(0x3b0+i*2+1,DISP2_write_crtc_data,IO_MB);
+			IO_RegisterReadHandler(0x3b0+i*2+1,DISP2_read_crtc_data,IO_MB);
+		}
+		IO_RegisterReadHandler(0x3ba,DISP2_read_status,IO_MB);
+		PIC_AddEvent(DISP2_Refresh,REFRESH_DELAY);
+	}
+}
+
+#ifdef WIN32
+static void DISP2_ResizeConsole( HANDLE hConsole, SHORT xSize, SHORT ySize ) {   
+	CONSOLE_SCREEN_BUFFER_INFO csbi; // Hold Current Console Buffer Info 
+	BOOL bSuccess;   
+	SMALL_RECT srWindowRect;         // Hold the New Console Size 
+	COORD coordScreen;    
+
+	bSuccess = GetConsoleScreenBufferInfo( hConsole, &csbi );
+
+	// Get the Largest Size we can size the Console Window to 
+	coordScreen = GetLargestConsoleWindowSize( hConsole );
+
+	// Define the New Console Window Size and Scroll Position 
+	srWindowRect.Right  = (SHORT)(std::min(xSize, coordScreen.X) - 1);
+	srWindowRect.Bottom = (SHORT)(std::min(ySize, coordScreen.Y) - 1);
+	srWindowRect.Left   = srWindowRect.Top = (SHORT)0;
+
+	// Define the New Console Buffer Size    
+	coordScreen.X = xSize;
+	coordScreen.Y = ySize;
+
+	// If the Current Buffer is Larger than what we want, Resize the 
+	// Console Window First, then the Buffer 
+	if( (DWORD)csbi.dwSize.X * csbi.dwSize.Y > (DWORD) xSize * ySize)
+	{
+		bSuccess = SetConsoleWindowInfo( hConsole, TRUE, &srWindowRect );
+		bSuccess = SetConsoleScreenBufferSize( hConsole, coordScreen );
+	}
+
+	// If the Current Buffer is Smaller than what we want, Resize the 
+	// Buffer First, then the Console Window 
+	if( (DWORD)csbi.dwSize.X * csbi.dwSize.Y < (DWORD) xSize * ySize )
+	{
+		bSuccess = SetConsoleScreenBufferSize( hConsole, coordScreen );
+		bSuccess = SetConsoleWindowInfo( hConsole, TRUE, &srWindowRect );
+	}
+
+	// If the Current Buffer *is* the Size we want, Don't do anything! 
+	return;
+}
+#endif
+
+void DISP2_Init(uint8_t color) {
+	// initialize console
+#ifdef WIN32
+	AllocConsole();
+	SetConsoleTitle("DOSBox-X Secondary Display");
+	DISP2_ResizeConsole(GetStdHandle(STD_OUTPUT_HANDLE),80,25);
+#endif
+	// initialize curses
+	initscr();
+	resize_term(25,80);
+	curs_set(0);
+	start_color();
+	if (!has_colors()) return;
+	switch (color) {
+	case 1: // amber
+		if (can_change_color()) {
+			init_color(7,667,333,0);
+			init_color(15,1000,667,0);
+			init_pair(1,7,COLOR_BLACK);
+		} else init_pair(1,COLOR_YELLOW,COLOR_BLACK);
+		break;
+	case 2: // green
+		if (can_change_color()) {
+			init_color(7,0,500,0);
+			init_color(15,0,1000,0);
+			init_pair(1,7,COLOR_BLACK);
+		} else init_pair(1,COLOR_GREEN,COLOR_BLACK);
+		break;
+	default: // white
+		if (can_change_color()) {
+			init_color(7,667,667,667);
+			init_color(15,1000,1000,1000);
+			init_pair(1,7,COLOR_BLACK);
+		} else init_pair(1,COLOR_WHITE,COLOR_BLACK);
+		break;
+	}
+	// initialize data
+	memset(&disp2,0,sizeof(disp2));
+	disp2.memory=new uint8_t[4096];
+	memset(disp2.memory,0,4096);
+	disp2.render=new uint8_t[4000];
+	memset(disp2.render,0,4000);
+	// initialization complete
+	disp2_init=true;
+}

--- a/src/hardware/vga_memory.cpp
+++ b/src/hardware/vga_memory.cpp
@@ -29,6 +29,7 @@
 #include "inout.h"
 #include "setup.h"
 #include "cpu.h"
+#include "control.h"
 #include "pc98_cg.h"
 #include "pc98_gdc.h"
 #include "zipfile.h"
@@ -2184,6 +2185,7 @@ void VGA_ChangedBank(void) {
 void MEM_ResetPageHandler_Unmapped(Bitu phys_page, Bitu pages);
 void MEM_ResetPageHandler_RAM(Bitu phys_page, Bitu pages);
 
+extern void DISP2_SetPageHandler(void);
 void VGA_SetupHandlers(void) {
 	vga.svga.bank_read_full = vga.svga.bank_read*vga.svga.bank_size;
 	vga.svga.bank_write_full = vga.svga.bank_write*vga.svga.bank_size;
@@ -2397,6 +2399,9 @@ void VGA_SetupHandlers(void) {
     non_cga_ignore_oddeven_engage = (non_cga_ignore_oddeven && !(vga.mode == M_TEXT || vga.mode == M_CGA2 || vga.mode == M_CGA4));
 
 range_done:
+#if C_DEBUG
+	if (control->opt_display2) DISP2_SetPageHandler();
+#endif
 	PAGING_ClearTLB();
 }
 

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -804,6 +804,7 @@ CX	640x480	800x600	  1024x768/1280x1024
 	return CBRET_NONE;
 }
 
+bool DISP2_Active(void);
 static void INT10_Seg40Init(void) {
 	// the default char height
 	real_writeb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT,16);
@@ -812,7 +813,12 @@ static void INT10_Seg40Init(void) {
 	// Set the basic screen we have
 	real_writeb(BIOSMEM_SEG,BIOSMEM_SWITCHES,0xF9);
 	// Set the basic modeset options
-	real_writeb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL,0x51); // why is display switching enabled (bit 6) ?
+#if C_DEBUG
+    if (control->opt_display2)
+		real_writeb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL,0x10|(DISP2_Active()?0:1));
+    else
+#endif
+		real_writeb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL,0x51); // why is display switching enabled (bit 6) ?
 	// Set the  default MSR
 	real_writeb(BIOSMEM_SEG,BIOSMEM_CURRENT_MSR,0x09);
 	// Set the pointer to video save pointer table

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -663,10 +663,18 @@ static void SetTextLines(void) {
 	}
 }
 
+bool DISP2_Active(void);
 bool INT10_SetCurMode(void) {
 	bool mode_changed=false;
 	uint16_t bios_mode=(uint16_t)real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE);
 	if (CurMode == NULL || CurMode->mode != bios_mode) {
+#if C_DEBUG
+		if (bios_mode==7 && DISP2_Active()) {
+			if ((real_readw(BIOSMEM_SEG,BIOSMEM_INITIAL_MODE)&0x30)!=0x30) return false;
+			CurMode=&Hercules_Mode;
+			return true;
+		}
+#endif
 		switch (machine) {
 		case MCH_CGA:
 			if (bios_mode<7) mode_changed=SetCurMode(ModeList_OTHER,bios_mode);
@@ -797,7 +805,11 @@ static void FinishSetMode(bool clearmem) {
 	real_writeb(BIOSMEM_SEG,BIOSMEM_SWITCHES,0x09);
 
 	// this is an index into the dcc table:
+#if C_DEBUG
+	if (IS_VGA_ARCH) real_writeb(BIOSMEM_SEG,BIOSMEM_DCC_INDEX,DISP2_Active()?0x0c:0x0b);
+#else
 	if (IS_VGA_ARCH) real_writeb(BIOSMEM_SEG,BIOSMEM_DCC_INDEX,0x0b);
+#endif
 
 	// Set cursor shape
 	if (CurMode->type==M_TEXT) {
@@ -1215,6 +1227,17 @@ bool INT10_SetVideoMode(uint16_t mode) {
 
 	int10.vesa_setmode=0xffff;
 	LOG(LOG_INT10,LOG_NORMAL)("Set Video Mode %X",mode);
+#if C_DEBUG
+	if (mode==7 && DISP2_Active()) {
+		if ((real_readw(BIOSMEM_SEG,BIOSMEM_INITIAL_MODE)&0x30)!=0x30) return false;
+		CurMode=&Hercules_Mode;
+		FinishSetMode(clearmem);
+		// EGA/VGA inactive
+		if (IS_EGAVGA_ARCH) real_writeb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL,(0x68|(clearmem?0:0x80)));
+		INT10_SetCursorShape(0x0b,0x0c);
+		return true;
+	}
+#endif
 	if (!IS_EGAVGA_ARCH) return INT10_SetVideoMode_OTHER(mode,clearmem);
 
 	/* First read mode setup settings from bios area */


### PR DESCRIPTION
Issue #2197 has requested monochrome/VGA Multi-Screen Emulation. So this ports the patch to implement this feature. The feature is confirmed to work on both SDL1 and SDL2 builds, but later on SDL2 multi-window capabilities may be added for further enhancement of the feature on SDL2 build. For now it is enabled on debug builds only since it requires pdcurses. Tested on Windows, Linux and macOS and seems to work.