### PR TITLE
Overlay support for PhysFS drives

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,12 +12,16 @@
     OpenGL on x86/x64 SDL2 builds), OpenGL output with
     pixel-perfect scaling for improved image quality,
     and the TrueType font (TTF) output. (Wengier)
+  - You can now supply a ZIP/7Z file as a parameter to
+    DOSBox-X directly so that it will be mounted as C:
+    drive when DOSBox-X starts. (Wengier)
   - Added overlay support for mounting PhysFS drives
     so that you can specify a write location when you
-    mounted a ZIP/7Z archive. For example, the command
-    "MOUNT C C:\DIR -T OVERLAY" will specify the path
-    C:\DIR as the write location after you had mounted
-    C: drive as a PhysFS drive. (Wengier)
+    mounted a ZIP/7Z archive by adopting an old patch.
+    For example, command "MOUNT C C:\DIR -T OVERLAY"
+    will specify path C:\DIR(\C_DRIVE) as the write
+    location after mounting C: drive as a PhysFS drive
+    with a command like "MOUNT FILES.ZIP". (Wengier)
   - Added abliity to resolve file paths that include
     environment variables on Windows or tildes (~) on
     other platforms for various options in the config
@@ -85,9 +89,6 @@
     dynamically using CONFIG command, e.g. "config -set
     ttf.font=test", "config -set ttf.lins=30", and
     "config -set ttf.cols=100". (Wengier)
-  - You can now supply a ZIP/7Z file as a parameter to
-    DOSBox-X directly so that it will be mounted as C:
-    drive when DOSBox-X starts. (Wengier)
   - Implemented the DOS network redirector functions so
     that the host name can be reported to DOS programs,
     unless the secure mode is enabled. You may need to

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,12 @@
     OpenGL on x86/x64 SDL2 builds), OpenGL output with
     pixel-perfect scaling for improved image quality,
     and the TrueType font (TTF) output. (Wengier)
+  - Added overlay support for mounting PhysFS drives
+    so that you can specify a write location when you
+    mounted a ZIP/7Z archive. For example, the command
+    "MOUNT C C:\DIR -T OVERLAY" will specify the path
+    C:\DIR as the write location after you had mounted
+    C: drive as a PhysFS drive. (Wengier)
   - Added abliity to resolve file paths that include
     environment variables on Windows or tildes (~) on
     other platforms for various options in the config

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -913,9 +913,9 @@ vsyncrate = 75
 #                             cycleup: Amount of cycles to decrease/increase with keycombos.(CTRL-F11/CTRL-F12)
 #                           cycledown: Setting it lower than 100 will be a percentage.
 #   cycle emulation percentage adjust: The percentage adjustment for use with the "Emulate CPU speed" feature. Default is 0 (no adjustment), but you can adjust it (between -25% and 25%) if necessary.
-#DOSBOX-X-ADV:#     use dynamic core with paging on: Allow dynamic core with 386 paging enabled. This is generally OK for DOS games and Windows 3.1.
-#DOSBOX-X-ADV:#                                        If the game becomes unstable, turn off this option.
-#DOSBOX-X-ADV:#                                        WARNING: Do NOT use this option with preemptive multitasking OSes including Windows 95 and Windows NT.
+#     use dynamic core with paging on: Allow dynamic cores (dynamic_x86 and dynamic_rec) to be used with 386 paging enabled.
+#                                        If the dynamic_x86 core is set, this allows Windows 9x/ME to run properly, but may somewhat decrease the performance.
+#                                        If the dynamic_rec core is set, this disables the dynamic core if the 386 paging functions are currently enabled.
 #DOSBOX-X-ADV:#                    ignore opcode 63: When debugging, do not report illegal opcode 0x63.
 #DOSBOX-X-ADV:#                                        Enable this option to ignore spurious errors while debugging from within Windows 3.1/9x/ME
 #                             apmbios: Emulate Advanced Power Management BIOS calls
@@ -954,7 +954,7 @@ cycles                              = auto
 cycleup                             = 10
 cycledown                           = 20
 cycle emulation percentage adjust   = 0
-#DOSBOX-X-ADV:use dynamic core with paging on     = true
+use dynamic core with paging on     = true
 #DOSBOX-X-ADV:ignore opcode 63                    = true
 apmbios                             = true
 #DOSBOX-X-ADV:apmbios pnp                         = false

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -276,6 +276,9 @@ vsyncrate = 75
 #                           cycleup: Amount of cycles to decrease/increase with keycombos.(CTRL-F11/CTRL-F12)
 #                         cycledown: Setting it lower than 100 will be a percentage.
 # cycle emulation percentage adjust: The percentage adjustment for use with the "Emulate CPU speed" feature. Default is 0 (no adjustment), but you can adjust it (between -25% and 25%) if necessary.
+#   use dynamic core with paging on: Allow dynamic cores (dynamic_x86 and dynamic_rec) to be used with 386 paging enabled.
+#                                      If the dynamic_x86 core is set, this allows Windows 9x/ME to run properly, but may somewhat decrease the performance.
+#                                      If the dynamic_rec core is set, this disables the dynamic core if the 386 paging functions are currently enabled.
 #                           apmbios: Emulate Advanced Power Management BIOS calls
 core                              = auto
 fpu                               = true
@@ -284,6 +287,7 @@ cycles                            = auto
 cycleup                           = 10
 cycledown                         = 20
 cycle emulation percentage adjust = 0
+use dynamic core with paging on   = true
 apmbios                           = true
 
 [keyboard]

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -913,9 +913,9 @@ vsyncrate = 75
 #                             cycleup: Amount of cycles to decrease/increase with keycombos.(CTRL-F11/CTRL-F12)
 #                           cycledown: Setting it lower than 100 will be a percentage.
 #   cycle emulation percentage adjust: The percentage adjustment for use with the "Emulate CPU speed" feature. Default is 0 (no adjustment), but you can adjust it (between -25% and 25%) if necessary.
-#     use dynamic core with paging on: Allow dynamic core with 386 paging enabled. This is generally OK for DOS games and Windows 3.1.
-#                                        If the game becomes unstable, turn off this option.
-#                                        WARNING: Do NOT use this option with preemptive multitasking OSes including Windows 95 and Windows NT.
+#     use dynamic core with paging on: Allow dynamic cores (dynamic_x86 and dynamic_rec) to be used with 386 paging enabled.
+#                                        If the dynamic_x86 core is set, this allows Windows 9x/ME to run properly, but may somewhat decrease the performance.
+#                                        If the dynamic_rec core is set, this disables the dynamic core if the 386 paging functions are currently enabled.
 #                    ignore opcode 63: When debugging, do not report illegal opcode 0x63.
 #                                        Enable this option to ignore spurious errors while debugging from within Windows 3.1/9x/ME
 #                             apmbios: Emulate Advanced Power Management BIOS calls

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -2061,6 +2061,10 @@ void POD_Save_DOS_Files( std::ostream& stream )
                     oalloc.total_clusters=odp->allocation.total_clusters;
                     oalloc.free_clusters=odp->allocation.free_clusters;
                     oalloc.mediaid=odp->allocation.mediaid;
+                } else {
+                    physfsDrive *pdp = dynamic_cast<physfsDrive*>(Drives[lcv]);
+                    if (pdp && pdp->getOverlaydir())
+                        strcpy(overlaydir,pdp->getOverlaydir());
                 }
             } else if (!strncmp(dinfo,"fatDrive ",9)) {
                 fatDrive *fdp = dynamic_cast<fatDrive*>(Drives[lcv]);
@@ -2268,6 +2272,7 @@ void POD_Load_DOS_Files( std::istream& stream )
                         str=str.substr(0,found);
                     Drives[lcv]=new physfsDrive('A'+lcv,(":"+str+"\\").c_str(),lalloc.bytes_sector,lalloc.sectors_cluster,lalloc.total_clusters,lalloc.free_clusters,lalloc.mediaid,error,options);
                     if (Drives[lcv]) {
+                        if (strlen(overlaydir)) dynamic_cast<physfsDrive*>(Drives[lcv])->setOverlaydir(overlaydir);
                         DOS_EnableDriveMenu('A'+lcv);
                         mem_writeb(Real2Phys(dos.tables.mediaid)+lcv*dos.tables.dpb_size,lalloc.mediaid);
                     } else

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1201,10 +1201,18 @@ public:
                       if (!quiet) WriteOut(MSG_Get("PROGRAM_MOUNT_OVERLAY_NO_BASE"));
                       return;
                   }
+                  physfsDrive* pdp = dynamic_cast<physfsDrive*>(Drives[drive-'A']);
+                  physfscdromDrive* pcdp = dynamic_cast<physfscdromDrive*>(Drives[drive-'A']);
+                  if (pdp && !pcdp) {
+                      if (pdp->setOverlaydir(temp_line.c_str()))
+                          WriteOut(MSG_Get("PROGRAM_MOUNT_OVERLAY_STATUS"),(temp_line+(temp_line.size()&&temp_line.back()!=CROSS_FILESPLIT?std::string(1, CROSS_FILESPLIT):"")+std::string(1, drive)+"_DRIVE").c_str(),drive);
+                      else
+                          WriteOut(MSG_Get("PROGRAM_MOUNT_OVERLAY_ERROR"));
+                      return;
+                  }
                   localDrive* ldp = dynamic_cast<localDrive*>(Drives[drive-'A']);
                   cdromDrive* cdp = dynamic_cast<cdromDrive*>(Drives[drive-'A']);
-                  physfsDrive* pdp = dynamic_cast<physfsDrive*>(Drives[drive-'A']);
-                  if (!ldp || cdp || pdp) {
+                  if (!ldp || cdp || pcdp) {
 					  if (!quiet) WriteOut(MSG_Get("PROGRAM_MOUNT_OVERLAY_INCOMPAT_BASE"));
                       return;
                   }
@@ -1217,7 +1225,7 @@ public:
                           if (quiet) {delete newdrive;return;}
                           if (o_error == 1) WriteOut("No mixing of relative and absolute paths. Overlay failed.\n");
                           else if (o_error == 2) WriteOut("Overlay directory cannot be the same as underlying filesystem.\n");
-                          else WriteOut("An error occurred when trying to create an overlay drive.\n");
+                          else WriteOut(MSG_Get("PROGRAM_MOUNT_OVERLAY_ERROR"));
                           delete newdrive;
                           return;
                       } else {
@@ -6813,6 +6821,7 @@ void DOS_SetupPrograms(void) {
 	MSG_Add("PROGRAM_MOUNT_OVERLAY_NO_BASE","Please MOUNT a normal directory first before adding an overlay on top.\n");
 	MSG_Add("PROGRAM_MOUNT_OVERLAY_INCOMPAT_BASE","The overlay is NOT compatible with the drive that is specified.\n");
 	MSG_Add("PROGRAM_MOUNT_OVERLAY_STATUS","Overlay %s on drive %c mounted.\n");
+	MSG_Add("PROGRAM_MOUNT_OVERLAY_ERROR","An error occurred when trying to create an overlay drive.\n");
 
     MSG_Add("PROGRAM_LOADFIX_ALLOC","%d kb allocated.\n");
     MSG_Add("PROGRAM_LOADFIX_DEALLOC","%d kb freed.\n");

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -2521,8 +2521,18 @@ bool physfsDrive::Rename(const char * oldname,const char * newname) {
 	CROSS_FILENAME(newnew);
 	dirCache.ExpandName(newnew);
 	normalize(newnew,basedir);
-	/* yuck. physfs doesn't have "rename". */
-	LOG_MSG("PHYSFS TODO: rename not yet implemented (%s -> %s)",newold,newnew);
+    const char *dir=PHYSFS_getRealDir(newold);
+    if (dir && !strcmp(getOverlaydir(), dir)) {
+        char fullold[CROSS_LEN], fullnew[CROSS_LEN];
+        strcpy(fullold, dir);
+        strcat(fullold, newold);
+        strcpy(fullnew, dir);
+        strcat(fullnew, newnew);
+        if (rename(fullold, fullnew)==0) {
+            dirCache.EmptyCache();
+            return true;
+        }
+    } else LOG_MSG("PHYSFS: rename not supported (%s -> %s)",newold,newnew); // yuck. physfs doesn't have "rename".
 	return false;
 }
 

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -150,6 +150,8 @@ public:
 	virtual bool read_directory_first(void *handle, char* entry_name, char* entry_sname, bool& is_directory);
 	virtual bool read_directory_next(void *handle, char* entry_name, char* entry_sname, bool& is_directory);
 	virtual const char *GetInfo(void);
+	virtual const char *getOverlaydir(void);
+	virtual bool setOverlaydir(const char * name);
 	Bits UnMount();
 	virtual ~physfsDrive(void);
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2572,9 +2572,10 @@ void DOSBOX_SetupConfigSections(void) {
     Pint->SetBasic(true);
 
     Pbool = secprop->Add_bool("use dynamic core with paging on",Property::Changeable::Always,true);
-    Pbool->Set_help("Allow dynamic core with 386 paging enabled. This is generally OK for DOS games and Windows 3.1.\n"
-                    "If the game becomes unstable, turn off this option.\n"
-                    "WARNING: Do NOT use this option with preemptive multitasking OSes including Windows 95 and Windows NT.");
+    Pbool->Set_help("Allow dynamic cores (dynamic_x86 and dynamic_rec) to be used with 386 paging enabled.\n"
+                    "If the dynamic_x86 core is set, this allows Windows 9x/ME to run properly, but may somewhat decrease the performance.\n"
+                    "If the dynamic_rec core is set, this disables the dynamic core if the 386 paging functions are currently enabled.");
+    Pbool->SetBasic(true);
             
     Pbool = secprop->Add_bool("ignore opcode 63",Property::Changeable::Always,true);
     Pbool->Set_help("When debugging, do not report illegal opcode 0x63.\n"

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1801,6 +1801,22 @@ public:
                         }
                     }
                     swappos=DriveManager::GetDrivePosition(statusdrive);
+                } else if (!strncmp(info, "PhysFS directory ", 17)) {
+                    type="PhysFS directory";
+                    path=info+17;
+                    readonly=true;
+                    physfsDrive *pdp = dynamic_cast<physfsDrive*>(Drives[statusdrive]);
+                    if (pdp!=NULL) {
+                        const char *wdir = pdp->getOverlaydir();
+                        if (wdir!=NULL&&strlen(wdir)) {
+                            readonly=false;
+                            overlay=std::string(wdir)+(wdir[strlen(wdir)-1]!=CROSS_FILESPLIT?std::string(1, CROSS_FILESPLIT):"")+std::string(1, 'A'+statusdrive)+"_DRIVE";
+                        }
+                    }
+                } else if (!strncmp(info, "PhysFS CDRom ", 13)) {
+                    type="PhysFS CDRom";
+                    path=info+13;
+                    readonly=true;
                 } else if (!strncmp(info, "local directory ", 16)) {
                     type="local directory";
                     path=info+16;


### PR DESCRIPTION
Currently PhysFS drives are strictly read-only. This will allow such drives to be writable. The original patch used a different method, but I made it work by using overlay mounts instead, in a way similar to overlay mounts for local drives. Both ZIP and 7Z archives are supported by this feature.

Also updated the description for the "use dynamic core with paging on" config option to reflect how it currently works after the recent dynamic core patch.