### PR TITLE
Fixup for cache_addb

### DIFF
--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -455,23 +455,40 @@ static void cache_closeblock(void) {
 	}
 }
 
+static INLINE void cache_addb(uint8_t val,uint8_t *pos) {
+	*pos=val;
+}
 static INLINE void cache_addb(uint8_t val) {
-	*cache.pos++=val;
+	uint8_t *pos=cache.pos+1;
+	cache_addb(val,cache.pos);
+	cache.pos=pos;
 }
 
+static INLINE void cache_addw(uint16_t val,uint8_t *pos) {
+	*(uint16_t*)pos=val;
+}
 static INLINE void cache_addw(uint16_t val) {
-	*(uint16_t*)cache.pos=val;
-	cache.pos+=2;
+	uint8_t *pos=cache.pos+2;
+	cache_addw(val,cache.pos);
+	cache.pos=pos;
 }
 
+static INLINE void cache_addd(uint32_t val,uint8_t *pos) {
+	*(uint32_t*)pos=val;
+}
 static INLINE void cache_addd(uint32_t val) {
-	*(uint32_t*)cache.pos=val;
-	cache.pos+=4;
+	uint8_t *pos=cache.pos+4;
+	cache_addd(val,cache.pos);
+	cache.pos=pos;
 }
 
+static INLINE void cache_addq(uint64_t val,uint8_t *pos) {
+	*(uint64_t*)pos=val;
+}
 static INLINE void cache_addq(uint64_t val) {
-	*(uint64_t*)cache.pos=val;
-	cache.pos+=8;
+	uint8_t *pos=cache.pos+8;
+	cache_addq(val,cache.pos);
+	cache.pos=pos;
 }
 
 static void gen_return(BlockReturn retcode);

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -124,7 +124,7 @@ private:
 					else { // try 32-bit absolute address
 						if ((int32_t)offset != offset) IllegalOption("opcode::Emit: bad RIP address");
 						// change emitted modrm base from 5 to 4 (use sib)
-						cache.pos[-1] -= 1; // FIXME: Incoming code from SVN uses cache_addb(modrm-1,cache.pos-1), which suggests they changed or overloaded cache_addb?
+						cache_addb(modrm-1,cache.pos-1);
 						cache_addb(0x25); // sib: [none+1*none+simm32]
 					}
 				} else if ((modrm&7)!=4 || (sib&7)!=5)

--- a/vs2015/dosbox-x.vcxproj
+++ b/vs2015/dosbox-x.vcxproj
@@ -1473,6 +1473,15 @@ copy "$(SolutionDir)\..\contrib\windows\shaders\*.*" "$(OutputPath)\shaders\"</C
     <ClInclude Include="..\src\cpu\core_dynrec\risc_mipsel32.h" />
     <ClInclude Include="..\src\cpu\core_dynrec\risc_x64.h" />
     <ClInclude Include="..\src\cpu\core_dynrec\risc_x86.h" />
+    <ClInclude Include="..\src\cpu\core_dyn_x86\cache.h" />
+    <ClInclude Include="..\src\cpu\core_dyn_x86\decoder.h" />
+    <ClInclude Include="..\src\cpu\core_dyn_x86\dyn_fpu.h" />
+    <ClInclude Include="..\src\cpu\core_dyn_x86\dyn_fpu_dh.h" />
+    <ClInclude Include="..\src\cpu\core_dyn_x86\helpers.h" />
+    <ClInclude Include="..\src\cpu\core_dyn_x86\mmx_gen.h" />
+    <ClInclude Include="..\src\cpu\core_dyn_x86\risc_x64.h" />
+    <ClInclude Include="..\src\cpu\core_dyn_x86\risc_x86.h" />
+    <ClInclude Include="..\src\cpu\core_dyn_x86\string.h" />
     <ClInclude Include="..\src\cpu\core_full\ea_lookup.h" />
     <ClInclude Include="..\src\cpu\core_full\load.h" />
     <ClInclude Include="..\src\cpu\core_full\loadwrite.h" />

--- a/vs2015/dosbox-x.vcxproj.filters
+++ b/vs2015/dosbox-x.vcxproj.filters
@@ -121,6 +121,9 @@
     <Filter Include="Sources\libs\decoder">
       <UniqueIdentifier>{8c545daa-26e1-4aad-a8ee-48caa3730fab}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Sources\cpu\core_dyn_x86">
+      <UniqueIdentifier>{09ec76de-76b7-416f-9a14-f47a19aabc07}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\aviwriter\avi_rw_iobuf.cpp">
@@ -2344,6 +2347,33 @@
     </ClInclude>
     <ClInclude Include="..\src\libs\mt32\MidiStreamParser.h">
       <Filter>Sources\libs\mt32</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dyn_x86\cache.h">
+      <Filter>Sources\cpu\core_dyn_x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dyn_x86\decoder.h">
+      <Filter>Sources\cpu\core_dyn_x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dyn_x86\dyn_fpu.h">
+      <Filter>Sources\cpu\core_dyn_x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dyn_x86\dyn_fpu_dh.h">
+      <Filter>Sources\cpu\core_dyn_x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dyn_x86\helpers.h">
+      <Filter>Sources\cpu\core_dyn_x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dyn_x86\mmx_gen.h">
+      <Filter>Sources\cpu\core_dyn_x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dyn_x86\risc_x64.h">
+      <Filter>Sources\cpu\core_dyn_x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dyn_x86\risc_x86.h">
+      <Filter>Sources\cpu\core_dyn_x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\cpu\core_dyn_x86\string.h">
+      <Filter>Sources\cpu\core_dyn_x86</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
`cache_addb` with 2 parameters was added in https://sourceforge.net/p/dosbox/code-0/4398/. However, while in SVN it was only added to one cache.h file, because in https://sourceforge.net/p/dosbox/code-0/4396/, 2 cache.h files were merged, DOSBox-X still has 2 cache.h files because  I skipped 4396.

This duplicates the changes in the other cache.h file, allowing use of 2-parameter `cache_addb` in the file that had the compile error.

Also, I added the files in the core_dyn_x86 folder to the Visual Studio solution, as they were missing from it, which probably contributed to me overlooking this issue.

I confirmed that this builds successfully.

