### PR TITLE
SVN commits

### DIFF
--- a/README.source-code-description
+++ b/README.source-code-description
@@ -170,42 +170,42 @@ SDL 1.2.x or SDL 2.0.x
     been modified from the original. You can find the changes in the
     source package of DOSBox-X (src/platform/sdl-win32.diff). If you
     want the patched source tree send us an email. (see README)
-    Licensed under LGPL
     Note that only version 1.2.x (SDL1 version) and version 2.0.x
     (SDL2 version) are currently supported.
+    License: LGPLv2+
 
 Curses (optional)
     If you want to enable the debugger you need a curses library.
     ncurses should be installed on just about every unix distro.
-    For win32 get pdcurses at https://pdcurses.sourceforge.net
-    License: Open source
+    For win32 get pdcurses at https://pdcurses.org/
+    License: Public Domain
 
 Libpng (optional)
     Needed for the screenshots.
     For win32 get libpng from https://gnuwin32.sourceforge.net/packages.html
     See http://www.libpng.org/pub/png/ for more details.
-    License: Open Source
+    License: zlib/libpng
 
 Zlib (optional)
     Needed by libpng.
     For win32 get libz (rename to zlib) from https://gnuwin32.sourceforge.net/packages.html
-    See http://www.zlib.net for more details.
-    License: Open Source
+    See https://www.zlib.net/ for more details.
+    License: zlib
 
 SDL_Net (optional)
-    For modem/ipx support. Get it from https://www.libsdl.org/projects/SDL_net/
-    Licensed under LGPL
+    For modem/ipx support.
+    Get it from https://www.libsdl.org/projects/SDL_net/release-1.2.html
+    License: LGPLv2+
 
-SDL_Sound 
-    For compressed audio on diskimages. (optional)
+SDL_Sound (optional)
+    For compressed audio on diskimages (cue sheets) support.
     This is for cue/bin CD-ROM images with compressed (MP3/OGG/FLAC) audio tracks.
     Get it from https://icculus.org/SDL_sound
-    Licenced under LGPL
+    Licence: LGPLv2+
 
-ALSA_Headers
-    (optional)
+ALSA_Headers (optional)
     for Alsa support under linux. Part of the linux kernel sources
-    Licensed under LGPL
+    License: LGPLv2+
 
 Configure script options
 ------------------------
@@ -254,8 +254,9 @@ The DOSBox-X configure script accepts the following switches, which you can use 
 
 --enable-debug 
         Enables the internal debugger. --enable-debug=heavy enables even more 
-        debug options. DOSBox-X should then be run from a xterm and when the sdl-
-        window is active press alt-pause to enter the debugger.
+        debug options. To use the debugger, DOSBox-X should be run from an xterm
+        and when the sdl-window is active press alt-pause to enter the
+        debugger.
 
 --disable-FEATURE
         Do not include FEATURE (same as --enable-FEATURE=no)
@@ -304,29 +305,30 @@ The DOSBox-X configure script accepts the following switches, which you can use 
         for a possible speed decrease.
 
 --disable-fpu
-        Disables the emulated FPU. Although the fpu emulation code isn't 
-        finished and isn't entirely accurate it's advised to leave it on. 
+        Disables the emulated FPU. Although the fpu emulation code isn't
+        finished and isn't entirely accurate, it's advised to leave it on.
 
 --disable-fpu-x86
 --disable-fpu-x64
-        Disables the assembly FPU core. Although relatively new, the x86/x64 fpu  
-        core has more accuracy then the regular fpu core. 
+        Disables the assembly FPU core. Although relatively new, the x86/x64
+        fpu core has more accuracy than the regular fpu core. 
 
 --disable-dynamic-x86
-        Disables the dynamic x86 specific CPU core. Although it might be 
-        be a bit unstable, it can greatly improve the speed of dosbox-x on x86 
-        hosts.
-        Please note that this option on x86 will result in a different
-        dynamic/recompiling CPU core being compiled then the default.
+        Disables the dynamic x86/x64 specific cpu core. Although it might be
+        a bit unstable, it can greatly improve the speed of dosbox-x on x86 
+        and x64 hosts.
+        Please note that this option on x86/x64 will result in a different
+        dynamic/recompiling CPU core being compiled than the default.
         For more information see the option --disable-dynrec
 
 --disable-dynrec
-        Disables the recompiling CPU core. Currently x86 and x86_64 only.
-        You can activate this core on x86 by disabling the dynamic-x86 core.
+        Disables the recompiling CPU core. Currently x86/x64 and arm only.
+        You can activate this core on x86/x64 by disabling the dynamic-x86
+        core.
 
 --disable-dynamic-core
-        Disables all dynamic cores. (same effect as 
-        --disable-dynamic-x86 --disable-dynrec)
+        Disables all dynamic cores. (same effect as --disable-dynamic-x86
+        or --disable-dynrec).
 
 --disable-opengl
         Disables OpenGL support (output mode that can be selected in the

--- a/README.source-code-description
+++ b/README.source-code-description
@@ -305,16 +305,16 @@ The DOSBox-X configure script accepts the following switches, which you can use 
         for a possible speed decrease.
 
 --disable-fpu
-        Disables the emulated FPU. Although the fpu emulation code isn't
+        Disables the emulated FPU. Although the FPU emulation code isn't
         finished and isn't entirely accurate, it's advised to leave it on.
 
 --disable-fpu-x86
 --disable-fpu-x64
         Disables the assembly FPU core. Although relatively new, the x86/x64
-        fpu core has more accuracy than the regular fpu core. 
+        FPU core has more accuracy than the regular FPU core. 
 
 --disable-dynamic-x86
-        Disables the dynamic x86/x64 specific cpu core. Although it might be
+        Disables the dynamic x86/x64 specific CPU core. Although it might be
         a bit unstable, it can greatly improve the speed of dosbox-x on x86 
         and x64 hosts.
         Please note that this option on x86/x64 will result in a different
@@ -908,7 +908,7 @@ Within each 1ms tick, a cycle count specified by the user
 is executed as CPU time.
 
 Setting cycles=3000 therefore, instructs DOSBox and DOSBox-X
-to execute 3000 cpu cycles per millisecond. That generally
+to execute 3000 CPU cycles per millisecond. That generally
 means (though not always) that 3000 instructions are executed
 per millisecond.
 

--- a/configure.ac
+++ b/configure.ac
@@ -851,8 +851,8 @@ dnl FEATURE: Whether to enable dynamic core
 AC_ARG_ENABLE(dynamic-core,AC_HELP_STRING([--disable-dynamic-core],[Disable all dynamic cores]),,enable_dynamic_core=yes)
 
 dnl FEATURE: Whether to enable x86 dynamic core
-AH_TEMPLATE(C_DYNAMIC_X86,[Define to 1 to use x86 dynamic cpu core])
-AC_ARG_ENABLE(dynamic-x86,AC_HELP_STRING([--disable-dynamic-x86],[Disable x86 dynamic cpu core]),,enable_dynamic_x86=yes)
+AH_TEMPLATE(C_DYNAMIC_X86,[Define to 1 to use x86/x64 dynamic cpu core])
+AC_ARG_ENABLE(dynamic-x86,AC_HELP_STRING([--disable-dynamic-x86],[Disable x86/x64 dynamic cpu core]),,enable_dynamic_x86=yes)
 AC_MSG_CHECKING(whether x86 dynamic cpu core will be enabled)
 if test x$enable_dynamic_x86 = xno -o x$enable_dynamic_core = xno -o x$c_targetcpu = xarm; then
    AC_MSG_RESULT(no)

--- a/patch-integration/Skipped SVN commits.txt
+++ b/patch-integration/Skipped SVN commits.txt
@@ -34,7 +34,11 @@ Commit#:	Reason for skipping:
 4270		Conflict
 4278		Conflict
 4281		Conflict
-4285		Website
+4291		Skipped because DOSBox-X may be phasing out Bitu and Bits
+4292		Skipped because DOSBox-X may be phasing out Bitu and Bits
+4298		Skipped the timing change. It makes the cursor blink too slow compared to footage of an actual machine.
+4303		DOSBox-X has its own handling for dpi awareness and preventing scaling.
+4306		Conflict
 
 (Commits in this interval are still TODO)
 

--- a/src/ints/int10_pal.cpp
+++ b/src/ints/int10_pal.cpp
@@ -350,8 +350,8 @@ void INT10_GetDACPage(uint8_t* mode,uint8_t* page) {
     /* the operations carried out here blanked the display because of the index (0x10/0x14) without bit 5,
      * write a dummy index with bit 5 to reenable the display. Bugfix for "Blue Force" MS-DOS game.
      *
-     * Note that DOSBox SVN has the same bug without this fix, but appears to work because the AC blanking
-     * doesn't work (2019/12/08). */
+     * Note that DOSBox SVN had the same bug without this fix, but appeared to work because the AC blanking
+     * didn't work. DOSBox SVN has a similar fix as of commit r4297. */
     IO_Write(VGAREG_ACTL_ADDRESS,0x10/*index*/ | 0x20/*display enable*/);
     /* read both, to avoid having to read 0x3CC or BIOS data area regs */
     IO_Read(0x3BA); /* reset flip flop */

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -215,8 +215,9 @@ void E_Exit(const char * format,...) {
 #endif
 	va_list msg;
 	va_start(msg,format);
-	vsprintf(buf,format,msg);
+	vsnprintf(buf,sizeof(buf),format,msg);
 	va_end(msg);
+	buf[sizeof(buf) - 1] = '\0';
 	strcat(buf,"\n");
 	LOG_MSG("E_Exit: %s\n",buf);
 #if defined(WIN32)


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/4286 - In this PR
https://sourceforge.net/p/dosbox/code-0/4287 - In this PR
https://sourceforge.net/p/dosbox/code-0/4288 - In this PR
https://sourceforge.net/p/dosbox/code-0/4289 - Already in DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4290 - In this PR
https://sourceforge.net/p/dosbox/code-0/4291 - Skipped since DOSBox-X is probably phasing out `Bitu` and `Bits` anyway.
https://sourceforge.net/p/dosbox/code-0/4292 - Same as above
https://sourceforge.net/p/dosbox/code-0/4293 - DOSBox-X uses `(void)type;` for this.
https://sourceforge.net/p/dosbox/code-0/4294 - Same as above
https://sourceforge.net/p/dosbox/code-0/4295 - Already in DOSBox-X.
https://sourceforge.net/p/dosbox/code-0/4296 - Mostly already in or irrelevant to DOSBox-X. Just `support.cpp` changes added, except for the part about leaving newline handling to the exception catcher, since as far as I could see DOSBox-X doesn't call `throw` there like SVN does.
https://sourceforge.net/p/dosbox/code-0/4297 - Already in DOSBox-X. Updated comment that said SVN doesn't have this fix.
https://sourceforge.net/p/dosbox/code-0/4298 - Timing change implemented in this PR. `vga.draw.cursor.count++` relocation part is already in DOSBox-X.
https://sourceforge.net/p/dosbox/code-0/4299 - Already in DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4300 - Irrelevant to DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4301 - Already in DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4302 - Already in DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4303 - Skipped because DOSBox-X has its own solution (the "dpi aware" .conf setting)
https://sourceforge.net/p/dosbox/code-0/4304 - Already in DOSBox-X (for 7 years!)
https://sourceforge.net/p/dosbox/code-0/4305 - Already in DOSBox-X (although log message is commented out in DOSBox-X)
https://sourceforge.net/p/dosbox/code-0/4306 - Skipped because of code being significantly different.

To summarize, mostly just skipped a bunch of commits that were either already implemented in DOSBox-X or irrelevant to it. Changes are updates to documentation, and a timing change in https://sourceforge.net/p/dosbox/code-0/4298. @joncampbell123, you may want to look at that timing change.

Also I updated the skipped commits file. I removed the "Website" entry I made for one commit earlier. @Wengier, I think you wanted me to put in the reason for _all_ skipped commits, which is why I added that "Website" entry, but I'd rather only include commits in this file that might possibly be relevant to DOSBox-X in the future. Lots of commits have already been separately implemented in DOSBox-X or are irrelevant, such as the website stuff, so I don't want to bother with those ones.