### PR TITLE
Allow TTF cursor blinking rate customization and update comments

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,19 @@
 0.83.10
+  - Cursor blinking rate for TrueType font (TTF) output
+    can now be customized with the ttf.blinkc option.
+    Set an integer between 1 (slowest) and 6 (fastest)
+    to change TTF cursor blinking rate, or setting it to
+    0 for no cursor (or false for non-blinking cursor as
+    in previous versions), with the default value being
+    6 on PC-98 systems and 4 elsewhere. (Wengier)
   - Fixed parallel port emulation to allow MDA port 3BCh
     to work properly.
   - Enhanced the printer function on Windows platforms
     to allow printer names to be specified in [printer]
     section via the "device" option for direct printing
-    to the selected device. If it is left empty, then
-    Windows Print dialog will be shown, or specifying
-    "-" will only cause it to show once (unless the user
+    to the selected device. If left empty, then Windows
+    Print dialog will always be shown, or specifying "-"
+    will cause it to show only once (unless the user
     clicks "Cancel"). Under "Help" menu there is now a
     menu option "List Printer Devices" to list printer
     devices on Windows, and the parallel port LPT1 now
@@ -28,8 +35,13 @@
     section of the config file to enable this output.
     Alternatively, the output can be selected from the
     menu ("Video" => "Output" => "OpenGL perfect") at
-    run-time. This feature was implemented by ant_222
-    with some code cleanups by Wengier.
+    run-time. It is recommended to set config options
+    "doublescan=false" and "aspect=true" for openglpp
+    output. Also, with high DPI displays (e.g. on Win
+    7+ with DPI scaling enabled) it works better with
+    full-screen mode and the setting "dpi aware=true".
+    The feature was implemented by ant_222 (author of
+    the patch) with some code cleanups by Wengier.
   - Updated the Windows installer to add a page for
     new users to select a video system output to use -
     the default output (Direct3D), OpenGL with pixel-

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 0.83.10
   - Cursor blinking rate for TrueType font (TTF) output
     can now be customized with the ttf.blinkc option.
-    Set an integer between 1 (slowest) and 6 (fastest)
+    Set an integer between 1 (fastest) and 7 (slowest)
     to change TTF cursor blinking rate, or setting it to
     0 for no cursor (or false for non-blinking cursor as
     in previous versions), with the default value being
@@ -36,12 +36,13 @@
     Alternatively, the output can be selected from the
     menu ("Video" => "Output" => "OpenGL perfect") at
     run-time. It is recommended to set config options
-    "doublescan=false" and "aspect=true" for openglpp
-    output. Also, with high DPI displays (e.g. on Win
-    7+ with DPI scaling enabled) it works better with
-    full-screen mode and the setting "dpi aware=true".
-    The feature was implemented by ant_222 (author of
-    the patch) with some code cleanups by Wengier.
+    and "aspect=true" (whenever the emulated display
+    has an aspect ratio of 4:3) and "doublescan=false"
+    for openglpp output. Also, with high DPI displays
+    (e.g. on Windows 7+ with DPI scaling enabled) it
+    works better with full-screen mode and the setting
+    "dpi aware=true". It was implemented by ant_222
+    (patch author) with some code cleanups by Wengier.
   - Updated the Windows installer to add a page for
     new users to select a video system output to use -
     the default output (Direct3D), OpenGL with pixel-

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -756,6 +756,7 @@ pc-98 force ibm keyboard layout          = false
 #                                  'direct3d'/opengl outputs: uses output driver functions to scale / pad image with black bars, correcting output to proportional 4:3 image
 #                                      In most cases image degradation should not be noticeable (it all depends on the video adapter and how much the image is upscaled).
 #                                      Should have none to negligible impact on performance, mostly being done in hardware
+#                                      For the pixel-perfect scaling (output=openglpp), it is recommended to set this to true
 #                                  'surface' output: inherits old DOSBox aspect ratio correction method (adjusting rendered image line count to correct output to 4:3 ratio)
 #                                      Due to source image manipulation this mode does not mix well with scalers, i.e. multiline scalers like hq2x/hq3x will work poorly
 #                                      Slightly degrades visual image quality. Has a tiny impact on performance
@@ -768,6 +769,7 @@ pc-98 force ibm keyboard layout          = false
 #                            same manner as the actual VGA output (320x200 is rendered as 640x400 for example).
 #                            If clear, doublescanned output is rendered at the native source resolution (320x200 as 320x200).
 #                            This affects the raster PRIOR to the software or hardware scalers. Choose wisely.
+#                            For pixel-perfect scaling (output=openglpp), it is recommended to turn this option off.
 #                  scaler: Scaler used to enlarge/enhance low resolution modes. If 'forced' is appended,
 #                            then the scaler will be used even if the result might not be desired.
 #                            To fit a scaler in the resolution used at full screen may require a border or side bars.
@@ -822,7 +824,8 @@ pc-98 force ibm keyboard layout          = false
 #DOSBOX-X-ADV:#           ttf.underline: If set, DOSBox-X will display underlined text visually (requires a word processor be set) for the TTF output.
 #DOSBOX-X-ADV:#           ttf.strikeout: If set, DOSBox-X will display strikeout text visually (requires a word processor be set) for the TTF output.
 #DOSBOX-X-ADV:#             ttf.char512: If set, DOSBox-X will display the 512-character font if possible (requires a word processor be set) for the TTF output.
-#              ttf.blinkc: If set, the cursor will blink for the TTF output.
+#              ttf.blinkc: If set to true, the cursor blinks for the TTF output; setting it to false will turn the blinking off.
+#                            You can also change the blinking rate by setting an interger between 1 (fastest) and 6 (slowest), or 0 for no cursor.
 frameskip               = 0
 #DOSBOX-X-ADV:alt render              = false
 aspect                  = false
@@ -1695,7 +1698,7 @@ dongle    = false
 #                  bmp     : Creates BMP images (very huge files, not recommended)
 #                  printer : Send to an actual printer in Windows (specify a printer, or Print dialog will appear)
 #   multipage: Adds all pages to one PostScript file or printer job until CTRL-F2 is pressed.
-#      device: Specify the Windows printer device to use. You can see the list of devices from the
+#      device: Specify the Windows printer device to use. You can see the list of devices from the Help
 #                  menu ('List printer devices') or the Status Window. Then make your choice and put either
 #                  the printer device number (e.g. 2) or your printer name (e.g. Microsoft Print to PDF).
 #                  Leaving it empty will show the Windows Print dialog (or '-' for showing once).
@@ -1992,10 +1995,10 @@ ipx = false
 #DOSBOX-X-ADV:#                private use, so modify the last three number blocks.
 #DOSBOX-X-ADV:#                I.e. AC:DE:48:88:99:AB.
 #     realnic: Specifies which of your network interfaces is used.
-#                Write 'list' here to see the list of devices in the
-#                Status Window. Then make your choice and put either the
-#                interface number (2 or something) or a part of your adapters
-#                name, e.g. VIA here.
+#                Write 'list' here to see the list of devices from the Help
+#                menu ('List network interfaces') or from the Status Window.
+#                Then make your choice and put either the interface number
+#                (e.g. 2) or a part of your adapters name (e.g. VIA here).
 #DOSBOX-X-ADV:# pcaptimeout: Specifies the read timeout for the device in milliseconds for the pcap backend, or the default value will be used.
 ne2000      = false
 nicbase     = 300

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -825,7 +825,7 @@ pc-98 force ibm keyboard layout          = false
 #DOSBOX-X-ADV:#           ttf.strikeout: If set, DOSBox-X will display strikeout text visually (requires a word processor be set) for the TTF output.
 #DOSBOX-X-ADV:#             ttf.char512: If set, DOSBox-X will display the 512-character font if possible (requires a word processor be set) for the TTF output.
 #              ttf.blinkc: If set to true, the cursor blinks for the TTF output; setting it to false will turn the blinking off.
-#                            You can also change the blinking rate by setting an interger between 1 (fastest) and 6 (slowest), or 0 for no cursor.
+#                            You can also change the blinking rate by setting an interger between 1 (fastest) and 7 (slowest), or 0 for no cursor.
 frameskip               = 0
 #DOSBOX-X-ADV:alt render              = false
 aspect                  = false

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -186,6 +186,7 @@ pc-98 force ibm keyboard layout = false
 #                           'direct3d'/opengl outputs: uses output driver functions to scale / pad image with black bars, correcting output to proportional 4:3 image
 #                               In most cases image degradation should not be noticeable (it all depends on the video adapter and how much the image is upscaled).
 #                               Should have none to negligible impact on performance, mostly being done in hardware
+#                               For the pixel-perfect scaling (output=openglpp), it is recommended to set this to true
 #                           'surface' output: inherits old DOSBox aspect ratio correction method (adjusting rendered image line count to correct output to 4:3 ratio)
 #                               Due to source image manipulation this mode does not mix well with scalers, i.e. multiline scalers like hq2x/hq3x will work poorly
 #                               Slightly degrades visual image quality. Has a tiny impact on performance
@@ -197,6 +198,7 @@ pc-98 force ibm keyboard layout = false
 #                     same manner as the actual VGA output (320x200 is rendered as 640x400 for example).
 #                     If clear, doublescanned output is rendered at the native source resolution (320x200 as 320x200).
 #                     This affects the raster PRIOR to the software or hardware scalers. Choose wisely.
+#                     For pixel-perfect scaling (output=openglpp), it is recommended to turn this option off.
 #           scaler: Scaler used to enlarge/enhance low resolution modes. If 'forced' is appended,
 #                     then the scaler will be used even if the result might not be desired.
 #                     To fit a scaler in the resolution used at full screen may require a border or side bars.
@@ -228,7 +230,8 @@ pc-98 force ibm keyboard layout = false
 #           ttf.wp: You can specify a word processor for the TTF output (WP=WordPerfect, WS=WordStar, XY=XyWrite) and optionally also a version number.
 #                     For example, WP6 will set the word processor as WordPerfect 6, and XY4 will set the word processor as XyWrite 4.
 #                     Word processor-specific features like on-screen text styles and 512-character font will be enabled based on this.
-#       ttf.blinkc: If set, the cursor will blink for the TTF output.
+#       ttf.blinkc: If set to true, the cursor blinks for the TTF output; setting it to false will turn the blinking off.
+#                     You can also change the blinking rate by setting an interger between 1 (fastest) and 6 (slowest), or 0 for no cursor.
 frameskip        = 0
 aspect           = false
 euro             = -1
@@ -677,7 +680,7 @@ dongle    = false
 #                  bmp     : Creates BMP images (very huge files, not recommended)
 #                  printer : Send to an actual printer in Windows (specify a printer, or Print dialog will appear)
 #   multipage: Adds all pages to one PostScript file or printer job until CTRL-F2 is pressed.
-#      device: Specify the Windows printer device to use. You can see the list of devices from the
+#      device: Specify the Windows printer device to use. You can see the list of devices from the Help
 #                  menu ('List printer devices') or the Status Window. Then make your choice and put either
 #                  the printer device number (e.g. 2) or your printer name (e.g. Microsoft Print to PDF).
 #                  Leaving it empty will show the Windows Print dialog (or '-' for showing once).
@@ -805,10 +808,10 @@ ipx = false
 # nicbase: The base address of the NE2000 board.
 #  nicirq: The interrupt it uses. Note serial2 uses IRQ3 as default.
 # realnic: Specifies which of your network interfaces is used.
-#            Write 'list' here to see the list of devices in the
-#            Status Window. Then make your choice and put either the
-#            interface number (2 or something) or a part of your adapters
-#            name, e.g. VIA here.
+#            Write 'list' here to see the list of devices from the Help
+#            menu ('List network interfaces') or from the Status Window.
+#            Then make your choice and put either the interface number
+#            (e.g. 2) or a part of your adapters name (e.g. VIA here).
 ne2000  = false
 nicbase = 300
 nicirq  = 3

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -231,7 +231,7 @@ pc-98 force ibm keyboard layout = false
 #                     For example, WP6 will set the word processor as WordPerfect 6, and XY4 will set the word processor as XyWrite 4.
 #                     Word processor-specific features like on-screen text styles and 512-character font will be enabled based on this.
 #       ttf.blinkc: If set to true, the cursor blinks for the TTF output; setting it to false will turn the blinking off.
-#                     You can also change the blinking rate by setting an interger between 1 (fastest) and 6 (slowest), or 0 for no cursor.
+#                     You can also change the blinking rate by setting an interger between 1 (fastest) and 7 (slowest), or 0 for no cursor.
 frameskip        = 0
 aspect           = false
 euro             = -1

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -756,6 +756,7 @@ pc-98 show graphics layer on initialize  = true
 #                                  'direct3d'/opengl outputs: uses output driver functions to scale / pad image with black bars, correcting output to proportional 4:3 image
 #                                      In most cases image degradation should not be noticeable (it all depends on the video adapter and how much the image is upscaled).
 #                                      Should have none to negligible impact on performance, mostly being done in hardware
+#                                      For the pixel-perfect scaling (output=openglpp), it is recommended to set this to true
 #                                  'surface' output: inherits old DOSBox aspect ratio correction method (adjusting rendered image line count to correct output to 4:3 ratio)
 #                                      Due to source image manipulation this mode does not mix well with scalers, i.e. multiline scalers like hq2x/hq3x will work poorly
 #                                      Slightly degrades visual image quality. Has a tiny impact on performance
@@ -768,6 +769,7 @@ pc-98 show graphics layer on initialize  = true
 #                            same manner as the actual VGA output (320x200 is rendered as 640x400 for example).
 #                            If clear, doublescanned output is rendered at the native source resolution (320x200 as 320x200).
 #                            This affects the raster PRIOR to the software or hardware scalers. Choose wisely.
+#                            For pixel-perfect scaling (output=openglpp), it is recommended to turn this option off.
 #                  scaler: Scaler used to enlarge/enhance low resolution modes. If 'forced' is appended,
 #                            then the scaler will be used even if the result might not be desired.
 #                            To fit a scaler in the resolution used at full screen may require a border or side bars.
@@ -822,7 +824,8 @@ pc-98 show graphics layer on initialize  = true
 #           ttf.underline: If set, DOSBox-X will display underlined text visually (requires a word processor be set) for the TTF output.
 #           ttf.strikeout: If set, DOSBox-X will display strikeout text visually (requires a word processor be set) for the TTF output.
 #             ttf.char512: If set, DOSBox-X will display the 512-character font if possible (requires a word processor be set) for the TTF output.
-#              ttf.blinkc: If set, the cursor will blink for the TTF output.
+#              ttf.blinkc: If set to true, the cursor blinks for the TTF output; setting it to false will turn the blinking off.
+#                            You can also change the blinking rate by setting an interger between 1 (fastest) and 6 (slowest), or 0 for no cursor.
 frameskip               = 0
 alt render              = false
 aspect                  = false
@@ -1695,7 +1698,7 @@ dongle    = false
 #                  bmp     : Creates BMP images (very huge files, not recommended)
 #                  printer : Send to an actual printer in Windows (specify a printer, or Print dialog will appear)
 #   multipage: Adds all pages to one PostScript file or printer job until CTRL-F2 is pressed.
-#      device: Specify the Windows printer device to use. You can see the list of devices from the
+#      device: Specify the Windows printer device to use. You can see the list of devices from the Help
 #                  menu ('List printer devices') or the Status Window. Then make your choice and put either
 #                  the printer device number (e.g. 2) or your printer name (e.g. Microsoft Print to PDF).
 #                  Leaving it empty will show the Windows Print dialog (or '-' for showing once).
@@ -1992,10 +1995,10 @@ ipx = false
 #                private use, so modify the last three number blocks.
 #                I.e. AC:DE:48:88:99:AB.
 #     realnic: Specifies which of your network interfaces is used.
-#                Write 'list' here to see the list of devices in the
-#                Status Window. Then make your choice and put either the
-#                interface number (2 or something) or a part of your adapters
-#                name, e.g. VIA here.
+#                Write 'list' here to see the list of devices from the Help
+#                menu ('List network interfaces') or from the Status Window.
+#                Then make your choice and put either the interface number
+#                (e.g. 2) or a part of your adapters name (e.g. VIA here).
 # pcaptimeout: Specifies the read timeout for the device in milliseconds for the pcap backend, or the default value will be used.
 ne2000      = false
 nicbase     = 300

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -825,7 +825,7 @@ pc-98 show graphics layer on initialize  = true
 #           ttf.strikeout: If set, DOSBox-X will display strikeout text visually (requires a word processor be set) for the TTF output.
 #             ttf.char512: If set, DOSBox-X will display the 512-character font if possible (requires a word processor be set) for the TTF output.
 #              ttf.blinkc: If set to true, the cursor blinks for the TTF output; setting it to false will turn the blinking off.
-#                            You can also change the blinking rate by setting an interger between 1 (fastest) and 6 (slowest), or 0 for no cursor.
+#                            You can also change the blinking rate by setting an interger between 1 (fastest) and 7 (slowest), or 0 for no cursor.
 frameskip               = 0
 alt render              = false
 aspect                  = false

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2010,6 +2010,7 @@ void DOSBOX_SetupConfigSections(void) {
         "      'direct3d'/opengl outputs: uses output driver functions to scale / pad image with black bars, correcting output to proportional 4:3 image\n"
         "          In most cases image degradation should not be noticeable (it all depends on the video adapter and how much the image is upscaled).\n"
         "          Should have none to negligible impact on performance, mostly being done in hardware\n"
+        "          For the pixel-perfect scaling (output=openglpp), it is recommended to set this to true\n"
         "      'surface' output: inherits old DOSBox aspect ratio correction method (adjusting rendered image line count to correct output to 4:3 ratio)\n"
         "          Due to source image manipulation this mode does not mix well with scalers, i.e. multiline scalers like hq2x/hq3x will work poorly\n"
         "          Slightly degrades visual image quality. Has a tiny impact on performance"
@@ -2053,7 +2054,8 @@ void DOSBOX_SetupConfigSections(void) {
     Pbool->Set_help("If set, doublescanned output emits two scanlines for each source line, in the\n"
             "same manner as the actual VGA output (320x200 is rendered as 640x400 for example).\n"
             "If clear, doublescanned output is rendered at the native source resolution (320x200 as 320x200).\n"
-            "This affects the raster PRIOR to the software or hardware scalers. Choose wisely.");
+            "This affects the raster PRIOR to the software or hardware scalers. Choose wisely.\n"
+            "For pixel-perfect scaling (output=openglpp), it is recommended to turn this option off.");
     Pbool->SetBasic(true);
 
     Pmulti = secprop->Add_multi("scaler",Property::Changeable::Always," ");
@@ -2195,9 +2197,10 @@ void DOSBOX_SetupConfigSections(void) {
 	Pbool = secprop->Add_bool("ttf.char512", Property::Changeable::Always, true);
     Pbool->Set_help("If set, DOSBox-X will display the 512-character font if possible (requires a word processor be set) for the TTF output.");
 
-	Pbool = secprop->Add_bool("ttf.blinkc", Property::Changeable::Always, true);
-    Pbool->Set_help("If set, the cursor will blink for the TTF output.");
-    Pbool->SetBasic(true);
+	Pstring = secprop->Add_string("ttf.blinkc", Property::Changeable::Always, "true");
+    Pstring->Set_help("If set to true, the cursor blinks for the TTF output; setting it to false will turn the blinking off.\n"
+                      "You can also change the blinking rate by setting an interger between 1 (fastest) and 6 (slowest), or 0 for no cursor.");
+    Pstring->SetBasic(true);
 
     secprop=control->AddSection_prop("vsync",&Null_Init,true);//done
 
@@ -3399,7 +3402,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pbool->SetBasic(true);
 
     Pstring = secprop->Add_string("device", Property::Changeable::WhenIdle, "-");
-    Pstring->Set_help("Specify the Windows printer device to use. You can see the list of devices from the\n"
+    Pstring->Set_help("Specify the Windows printer device to use. You can see the list of devices from the Help\n"
         "  menu (\'List printer devices\') or the Status Window. Then make your choice and put either\n"
         "  the printer device number (e.g. 2) or your printer name (e.g. Microsoft Print to PDF).\n"
         "  Leaving it empty will show the Windows Print dialog (or \'-\' for showing once).");
@@ -3802,12 +3805,12 @@ void DOSBOX_SetupConfigSections(void) {
     secprop=control->AddSection_prop("ne2000",&Null_Init,true);
     MSG_Add("NE2000_CONFIGFILE_HELP",
         "macaddr -- The physical address the emulator will use on your network.\n"
-        "           If you have multiple DOSBoxes running on your network,\n"
+        "           If you have multiple DOSBox-Xes running on your network,\n"
         "           this has to be changed. Modify the last three number blocks.\n"
         "           I.e. AC:DE:48:88:99:AB.\n"
         "realnic -- Specifies which of your network interfaces is used.\n"
-        "           Write \'list\' here to see the list of devices from the\n"
-        "           menu (\'List network interfaces\') or the Status Window.\n"
+        "           Write \'list\' here to see the list of devices from the Help\n"
+        "           menu (\'List network interfaces\') or from the Status Window.\n"
         "           Then make your choice and put either the interface number\n"
         "           (e.g. 2) or a part of your adapters name (e.g. VIA here)."
     );
@@ -3837,10 +3840,10 @@ void DOSBOX_SetupConfigSections(void) {
      *       can then compile NE2000 support with and without libpcap/winpcap support. */
     Pstring = secprop->Add_string("realnic", Property::Changeable::WhenIdle,"list");
     Pstring->Set_help("Specifies which of your network interfaces is used.\n"
-        "Write \'list\' here to see the list of devices in the\n"
-        "Status Window. Then make your choice and put either the\n"
-        "interface number (2 or something) or a part of your adapters\n"
-        "name, e.g. VIA here.");
+        "Write \'list\' here to see the list of devices from the Help\n"
+        "menu (\'List network interfaces\') or from the Status Window.\n"
+        "Then make your choice and put either the interface number\n"
+        "(e.g. 2) or a part of your adapters name (e.g. VIA here).");
     Pstring->SetBasic(true);
 
     Pstring = secprop->Add_string("pcaptimeout", Property::Changeable::WhenIdle,"default");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2199,7 +2199,7 @@ void DOSBOX_SetupConfigSections(void) {
 
 	Pstring = secprop->Add_string("ttf.blinkc", Property::Changeable::Always, "true");
     Pstring->Set_help("If set to true, the cursor blinks for the TTF output; setting it to false will turn the blinking off.\n"
-                      "You can also change the blinking rate by setting an interger between 1 (fastest) and 6 (slowest), or 0 for no cursor.");
+                      "You can also change the blinking rate by setting an interger between 1 (fastest) and 7 (slowest), or 0 for no cursor.");
     Pstring->SetBasic(true);
 
     secprop=control->AddSection_prop("vsync",&Null_Init,true);//done

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3465,7 +3465,7 @@ void SetBlinkRate(Section_prop* section) {
     const char * blinkCstr = section->Get_string("ttf.blinkc");
     unsigned int num=-1;
     if (!strcasecmp(blinkCstr, "false")) blinkCursor = -1;
-    else if (1==sscanf(blinkCstr,"%u",&num)&&num>=0&&num<=6) blinkCursor = num;
+    else if (1==sscanf(blinkCstr,"%u",&num)&&num>=0&&num<=7) blinkCursor = num;
     else blinkCursor = IS_PC98_ARCH?6:4; // default cursor blinking is slower on PC-98 systems
 }
 
@@ -4386,7 +4386,7 @@ void GFX_EndTextLines(bool force=false) {
     if (!force) justChanged = false;
     // NTS: Additional fix is needed for the cursor in PC-98 mode; also expect further cleanup
 	bcount++;
-	if (vga.draw.cursor.enabled && vga.draw.cursor.sline <= vga.draw.cursor.eline && vga.draw.cursor.sline < 16) {		// Draw cursor?
+	if (vga.draw.cursor.enabled && vga.draw.cursor.sline <= vga.draw.cursor.eline && vga.draw.cursor.sline < 16 && blinkCursor) {	// Draw cursor?
 		int newPos = vga.draw.cursor.address>>1;
 		if (newPos >= 0 && newPos < ttf.cols*ttf.lins) {								// If on screen
 			int y = newPos/ttf.cols;
@@ -4394,7 +4394,7 @@ void GFX_EndTextLines(bool force=false) {
 			vga.draw.cursor.count++;
 
 			if (blinkCursor>-1)
-				vga.draw.cursor.blinkon = (vga.draw.cursor.count & (int)pow(2.0,blinkCursor)) ? true : false;
+				vga.draw.cursor.blinkon = (vga.draw.cursor.count & 1<<blinkCursor) ? true : false;
 
 			if (ttf.cursor != newPos || vga.draw.cursor.sline != prev_sline || ((blinkstate != vga.draw.cursor.blinkon) && blinkCursor>-1)) {				// If new position or shape changed, forse draw
 				if (blinkCursor>-1 && blinkstate == vga.draw.cursor.blinkon) {

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -45,8 +45,8 @@ typedef struct {
 #endif
 
 Bitu call_program;
-extern int enablelfn, paste_speed, wheel_key, freesizecap;
 extern const char *modifier;
+extern int enablelfn, paste_speed, wheel_key, freesizecap, wpType, wpVersion;
 extern bool dos_kernel_disabled, force_nocachedir, wpcolon, lockmount, enable_config_as_shell_commands, load, winrun, winautorun, startwait, startquiet, mountwarning, wheel_guest, clipboard_dosapi, noremark_save_state, force_load_state, sync_time, manualtime;
 
 /* This registers a file on the virtual drive and creates the correct structure for it*/
@@ -1335,7 +1335,7 @@ void CONFIG::Run(void) {
 #endif
                             }
 						} else if (!strcasecmp(pvars[0].c_str(), "render")) {
-                            void GFX_ForceRedrawScreen(void), ttf_reset(void), ttf_setlines(int cols, int lins);
+                            void GFX_ForceRedrawScreen(void), ttf_reset(void), ttf_setlines(int cols, int lins), SetBlinkRate(Section_prop* section);
 							if (!strcasecmp(inputline.substr(0, 9).c_str(), "ttf.font=")) {
 #if defined(USE_TTF)
                                 ttf_reset();
@@ -1353,6 +1353,26 @@ void CONFIG::Run(void) {
                                     CALLBACK_RunRealInt(0x10);
                                 }
                                 ttf_setlines(0, 0);
+#endif
+							} else if (!strcasecmp(inputline.substr(0, 7).c_str(), "ttf.wp=")) {
+#if defined(USE_TTF)
+                                const char *wpstr=section->Get_string("ttf.wp");
+                                wpType=wpVersion=0;
+                                if (strlen(wpstr)>1) {
+                                    if (!strncasecmp(wpstr, "WP", 2)) wpType=1;
+                                    else if (!strncasecmp(wpstr, "WS", 2)) wpType=2;
+                                    else if (!strncasecmp(wpstr, "XY", 3)) wpType=3;
+                                    if (strlen(wpstr)>2&&wpstr[2]>='1'&&wpstr[2]<='9') wpVersion=wpstr[2]-'0';
+                                }
+                                mainMenu.get_item("ttf_wpno").check(!wpType).refresh_item(mainMenu);
+                                mainMenu.get_item("ttf_wpwp").check(wpType==1).refresh_item(mainMenu);
+                                mainMenu.get_item("ttf_wpws").check(wpType==2).refresh_item(mainMenu);
+                                mainMenu.get_item("ttf_wpxy").check(wpType==3).refresh_item(mainMenu);
+                                resetFontSize();
+#endif
+							} else if (!strcasecmp(inputline.substr(0, 11).c_str(), "ttf.blinkc=")) {
+#if defined(USE_TTF)
+                                SetBlinkRate(section);
 #endif
 							} else if (!strcasecmp(inputline.substr(0, 9).c_str(), "glshader=")) {
 #if C_OPENGL

--- a/src/output/output_opengl.cpp
+++ b/src/output/output_opengl.cpp
@@ -97,6 +97,10 @@ int Voodoo_OGL_GetWidth();
 int Voodoo_OGL_GetHeight();
 bool Voodoo_OGL_Active();
 
+// NTS: With high DPI displays (e.g. on Windows 7+ with DPI scaling enabled)
+//      this works better with maximized window or full-screen mode and the
+//      setting "dpi aware=true".
+
 static void PPScale (
     uint16_t  fixed_w , uint16_t  fixed_h,
     uint16_t* window_w, uint16_t* window_h )

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -108,9 +108,8 @@ SHELL_Cmd cmd_list[]={
 {0,0,0,0}
 };
 
-extern int enablelfn, lfn_filefind_handle;
-extern bool date_host_forced, usecon, rsize;
-extern bool sync_time, manualtime;
+extern int enablelfn, lfn_filefind_handle, file_access_tries;
+extern bool date_host_forced, usecon, rsize, sync_time, manualtime;
 extern unsigned long freec;
 extern uint16_t countryNo;
 void DOS_SetCountry(uint16_t countryNo);
@@ -2198,6 +2197,9 @@ void DOS_Shell::CMD_COPY(char * args) {
 									}
 							} while (cont);
 							if (!DOS_CloseFile(sourceHandle)) failed=true;
+#if defined(WIN32)
+							if (file_access_tries>0 && DOS_FindDevice(name) == DOS_DEVICES) DOS_SetFileDate(targetHandle, ftime, fdate);
+#endif
 							if (!DOS_CloseFile(targetHandle)) failed=true;
 							if (failed)
                                 WriteOut(MSG_Get("SHELL_CMD_COPY_ERROR"),uselfn?lname:name);


### PR DESCRIPTION
The current cursor blink rate is fixed according to the platform (PC-98 or elsewhere). This will make it possible to customize the cursor blink rate, but the current value will be kept as the default value. Also updated some other comments in the config file.