### PR TITLE
Add option to specify "auto" for "use dynamic core with paging on"

### DIFF
--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -919,6 +919,7 @@ vsyncrate = 75
 #     use dynamic core with paging on: Allow dynamic cores (dynamic_x86 and dynamic_rec) to be used with 386 paging enabled.
 #                                        If the dynamic_x86 core is set, this allows Windows 9x/ME to run properly, but may somewhat decrease the performance.
 #                                        If the dynamic_rec core is set, this disables the dynamic core if the 386 paging functions are currently enabled.
+#                                        If set to auto, this option will be enabled when 386 paging is enabled.
 #DOSBOX-X-ADV:#                    ignore opcode 63: When debugging, do not report illegal opcode 0x63.
 #DOSBOX-X-ADV:#                                        Enable this option to ignore spurious errors while debugging from within Windows 3.1/9x/ME
 #                             apmbios: Emulate Advanced Power Management BIOS calls
@@ -957,7 +958,7 @@ cycles                              = auto
 cycleup                             = 10
 cycledown                           = 20
 cycle emulation percentage adjust   = 0
-use dynamic core with paging on     = true
+use dynamic core with paging on     = auto
 #DOSBOX-X-ADV:ignore opcode 63                    = true
 apmbios                             = true
 #DOSBOX-X-ADV:apmbios pnp                         = false

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -282,6 +282,7 @@ vsyncrate = 75
 #   use dynamic core with paging on: Allow dynamic cores (dynamic_x86 and dynamic_rec) to be used with 386 paging enabled.
 #                                      If the dynamic_x86 core is set, this allows Windows 9x/ME to run properly, but may somewhat decrease the performance.
 #                                      If the dynamic_rec core is set, this disables the dynamic core if the 386 paging functions are currently enabled.
+#                                      If set to auto, this option will be enabled when 386 paging is enabled.
 #                           apmbios: Emulate Advanced Power Management BIOS calls
 core                              = auto
 fpu                               = true
@@ -290,7 +291,7 @@ cycles                            = auto
 cycleup                           = 10
 cycledown                         = 20
 cycle emulation percentage adjust = 0
-use dynamic core with paging on   = true
+use dynamic core with paging on   = auto
 apmbios                           = true
 
 [keyboard]

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -919,6 +919,7 @@ vsyncrate = 75
 #     use dynamic core with paging on: Allow dynamic cores (dynamic_x86 and dynamic_rec) to be used with 386 paging enabled.
 #                                        If the dynamic_x86 core is set, this allows Windows 9x/ME to run properly, but may somewhat decrease the performance.
 #                                        If the dynamic_rec core is set, this disables the dynamic core if the 386 paging functions are currently enabled.
+#                                        If set to auto, this option will be enabled when 386 paging is enabled.
 #                    ignore opcode 63: When debugging, do not report illegal opcode 0x63.
 #                                        Enable this option to ignore spurious errors while debugging from within Windows 3.1/9x/ME
 #                             apmbios: Emulate Advanced Power Management BIOS calls
@@ -957,7 +958,7 @@ cycles                              = auto
 cycleup                             = 10
 cycledown                           = 20
 cycle emulation percentage adjust   = 0
-use dynamic core with paging on     = true
+use dynamic core with paging on     = auto
 ignore opcode 63                    = true
 apmbios                             = true
 apmbios pnp                         = false

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -78,6 +78,7 @@ bool report_fdiv_bug = false;
 extern bool ignore_opcode_63;
 
 extern bool use_dynamic_core_with_paging;
+extern bool auto_determine_dynamic_core_paging;
 
 bool cpu_double_fault_enable;
 bool cpu_triple_fault_reset;
@@ -3286,10 +3287,17 @@ public:
 
 		report_fdiv_bug = section->Get_bool("report fdiv bug");
 		ignore_opcode_63 = section->Get_bool("ignore opcode 63");
-		use_dynamic_core_with_paging = section->Get_bool("use dynamic core with paging on");
 		cpu_double_fault_enable = section->Get_bool("double fault");
 		cpu_triple_fault_reset = section->Get_bool("reset on triple fault");
 		cpu_allow_big16 = section->Get_bool("realbig16");
+
+		std::string dynamic_core_paging = section->Get_string("use dynamic core with paging on");
+		auto_determine_dynamic_core_paging = dynamic_core_paging == "auto";
+		if (auto_determine_dynamic_core_paging) {
+			use_dynamic_core_with_paging = PAGING_Enabled();
+		} else {
+			use_dynamic_core_with_paging = dynamic_core_paging == "true";
+		}
 
         if (cpu_allow_big16) {
             /* FIXME: GCC 4.8: How is this an empty body? Explain. */

--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -267,6 +267,7 @@ void PrintPageInfo(const char* string, PhysPt lin_addr, bool writing, bool prepa
 */
 
 bool use_dynamic_core_with_paging = false; /* allow dynamic core even with paging (AT YOUR OWN RISK!!!!) */
+bool auto_determine_dynamic_core_paging = false; /* enable use_dynamic_core_with_paging when paging is enabled */
 bool dosbox_allow_nonrecursive_page_fault = false;	/* when set, do nonrecursive mode (when executing instruction) */
 
 void PAGING_PageFault(PhysPt lin_addr,Bitu page_addr,Bitu faultcode) {
@@ -1438,6 +1439,8 @@ void PAGING_Enable(bool enabled) {
 	/* If paging is disabled, we work from a default paging table */
 	if (paging.enabled==enabled) return;
 	paging.enabled=enabled;
+	if (auto_determine_dynamic_core_paging)
+		use_dynamic_core_with_paging = enabled;
 	if (enabled) {
 //		LOG(LOG_PAGING,LOG_NORMAL)("Enabled");
 		PAGING_SetDirBase(paging.cr3);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1079,6 +1079,7 @@ void DOSBOX_SetupConfigSections(void) {
     const char* pc98videomodeopt[] = { "", "24khz", "31khz", "15khz", 0};
     const char* aspectmodes[] = { "false", "true", "0", "1", "yes", "no", "nearest", "bilinear", 0};
     const char *vga_ac_mapping_settings[] = { "", "auto", "4x4", "4low", "first16", 0 };
+    const char* dynamic_core_with_paging_settings[] = { "auto", "true", "false", 0 };
 
     const char* hostkeys[] = {
         "ctrlalt", "ctrlshift", "altshift", "mapper", 0 };
@@ -2317,11 +2318,13 @@ void DOSBOX_SetupConfigSections(void) {
     Pint->Set_help("The percentage adjustment for use with the \"Emulate CPU speed\" feature. Default is 0 (no adjustment), but you can adjust it (between -25% and 25%) if necessary.");
     Pint->SetBasic(true);
 
-    Pbool = secprop->Add_bool("use dynamic core with paging on",Property::Changeable::Always,true);
-    Pbool->Set_help("Allow dynamic cores (dynamic_x86 and dynamic_rec) to be used with 386 paging enabled.\n"
+    Pstring = secprop->Add_string("use dynamic core with paging on",Property::Changeable::Always,"auto");
+    Pstring->Set_values(dynamic_core_with_paging_settings);
+    Pstring->Set_help("Allow dynamic cores (dynamic_x86 and dynamic_rec) to be used with 386 paging enabled.\n"
                     "If the dynamic_x86 core is set, this allows Windows 9x/ME to run properly, but may somewhat decrease the performance.\n"
-                    "If the dynamic_rec core is set, this disables the dynamic core if the 386 paging functions are currently enabled.");
-    Pbool->SetBasic(true);
+                    "If the dynamic_rec core is set, this disables the dynamic core if the 386 paging functions are currently enabled.\n"
+                    "If set to auto, this option will be enabled when 386 paging is enabled.");
+    Pstring->SetBasic(true);
             
     Pbool = secprop->Add_bool("ignore opcode 63",Property::Changeable::Always,true);
     Pbool->Set_help("When debugging, do not report illegal opcode 0x63.\n"


### PR DESCRIPTION
Which turns on this option when 386 paging is used. Change default to "auto".
As discussed here:
https://github.com/joncampbell123/dosbox-x/pull/2182#issuecomment-767393316
The risk that I can think of is if a code would be generated without the ability to handle exceptions when paging is off, but will run from the cache with exceptions enabled after enabling paging. Should I reset the dynamic cache on change? I don't think that it should happen since "MOV CR" isn't implemented in the dynamic core, and any code that ran before enabling paging shouldn't run after it since the addresses are different, no?