### PR TITLE
Fix Issue #2230 etc

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,8 @@
 0.83.10
   - The Window key(s) in Windows and the Command key(s)
-    in macOS will be displayed as "Windows" & "Command"
-    keys instead of "super" & "meta" keys. (Wengier)
+    in macOS will now be displayed as the "Windows" and
+    "Command" keys instead of the "super" and "meta"
+    keys in SDL1 builds just like SDL2 builds. (Wengier)
   - Cursor blinking rate for TrueType font (TTF) output
     can now be customized with the ttf.blinkc option.
     Set an integer between 1 (fastest) and 7 (slowest)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -133,7 +133,8 @@
     the word processor for TTF dynamically using CONFIG
     command, e.g. "config -set ttf.font=test", "config
     -set ttf.lins=30", "config -set ttf.cols=100" and
-    "config -set ttf.wp=wp". (Wengier)
+    "config -set ttf.wp=wp". The limits for the options
+    ttf.cols and ttf.lins are increased too. (Wengier)
   - Implemented the DOS network redirector functions so
     that the host name can be reported to DOS programs,
     unless the secure mode is enabled. You may need to

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,10 +26,10 @@
     dynamic core with paging on" in [cpu] section to
     "false"; the default value of this option has been
     changed to "auto" which will enable/disable itself
-    based on whether the 386 paging has been enabled.
-    Also fixed incorrect behavior for handling trap
-    flags in the dynamic core and updated the MMX code
-    for improved performance. (koolkdev)
+    based on whether the 386 paging and a guest system
+    has been enabled. Also fixed incorrect behavior for
+    handling trap flags in the dynamic core and updated
+    the MMX code for improved performance. (koolkdev)
   - Added support for Direct3D output on Windows SDL2
     builds just like Windows SDL1 builds to become the
     default output in all Windows builds. (Wengier)
@@ -156,9 +156,9 @@
   - Updated the Tiny File Dialog library to the latest
     version v3.8.5, which fixes issues such as the
     compatibility problem with Windows XP. (Wengier)
-  - Updated FLAC and WAV CD-DA decoder libraries to the
-    latest versions (0.12.26 and 0.12.18 respectively;
-    per David Reid). (Wengier)
+  - Updated FLAC, MP3, and WAV CD-DA decoder libraries
+    to the latest versions (0.12.28, 0.6.26 and 0.12.18
+    respectively; per David Reid). (Wengier)
   - Integrated SVN commits (Allofich & Wengier)
     - r4426: Emulate debug register 6 during trap flag
     emulation (and normal int 1). Fixes 544 (jmarsh)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 0.83.10
+  - The Window key(s) in Windows and the Command key(s)
+    in macOS will be displayed as "Windows" & "Command"
+    keys instead of "super" & "meta" keys. (Wengier)
   - Cursor blinking rate for TrueType font (TTF) output
     can now be customized with the ttf.blinkc option.
     Set an integer between 1 (fastest) and 7 (slowest)

--- a/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
+++ b/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
@@ -10,7 +10,7 @@
     <category>Emulation</category>
   </categories>
   <releases>
-          <release version="@PACKAGE_VERSION@" date="2021-1-24"/>
+          <release version="@PACKAGE_VERSION@" date="2021-1-30"/>
   </releases>
   <screenshots>
 	  <screenshot type="default">

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -915,30 +915,30 @@ vsyncrate = 75
 #                                        Possible values: auto, fixed, max.
 #                             cycleup: Amount of cycles to decrease/increase with the mapped keyboard shortcut.
 #                           cycledown: Setting it lower than 100 will be a percentage.
-#   cycle emulation percentage adjust: The percentage adjustment for use with the "Emulate CPU speed" feature. Default is 0 (no adjustment), but you can adjust it (between -25% and 25%) if necessary.
-#     use dynamic core with paging on: Allow dynamic cores (dynamic_x86 and dynamic_rec) to be used with 386 paging enabled.
-#                                        If the dynamic_x86 core is set, this allows Windows 9x/ME to run properly, but may somewhat decrease the performance.
-#                                        If the dynamic_rec core is set, this disables the dynamic core if the 386 paging functions are currently enabled.
-#                                        If set to auto, this option will be enabled depending on if the 386 paging and a guest system is currently active.
-#                                        Possible values: true, false, 1, 0, auto.
+#DOSBOX-X-ADV:#   cycle emulation percentage adjust: The percentage adjustment for use with the "Emulate CPU speed" feature. Default is 0 (no adjustment), but you can adjust it (between -25% and 25%) if necessary.
+#DOSBOX-X-ADV:#     use dynamic core with paging on: Allow dynamic cores (dynamic_x86 and dynamic_rec) to be used with 386 paging enabled.
+#DOSBOX-X-ADV:#                                        If the dynamic_x86 core is set, this allows Windows 9x/ME to run properly, but may somewhat decrease the performance.
+#DOSBOX-X-ADV:#                                        If the dynamic_rec core is set, this disables the dynamic core if the 386 paging functions are currently enabled.
+#DOSBOX-X-ADV:#                                        If set to auto, this option will be enabled depending on if the 386 paging and a guest system are currently active.
+#DOSBOX-X-ADV:#                                        Possible values: true, false, 1, 0, auto.
 #DOSBOX-X-ADV:#                    ignore opcode 63: When debugging, do not report illegal opcode 0x63.
-#DOSBOX-X-ADV:#                                        Enable this option to ignore spurious errors while debugging from within Windows 3.1/9x/ME
-#                             apmbios: Emulate Advanced Power Management BIOS calls
+#DOSBOX-X-ADV:#                                        Enable this option to ignore spurious errors while debugging from within Windows 3.1/9x/ME.
+#                             apmbios: Emulate Advanced Power Management (APM) BIOS calls.
 #DOSBOX-X-ADV:#                         apmbios pnp: If emulating ISA PnP BIOS, announce APM BIOS in PnP enumeration.
 #DOSBOX-X-ADV:#                                        Warning: this can cause Windows 95 OSR2 and later to enumerate the APM BIOS twice and cause problems.
 #DOSBOX-X-ADV:#                     apmbios version: What version of the APM BIOS specification to emulate.
-#DOSBOX-X-ADV:#                                        You will need at least APM BIOS v1.1 for emulation to work with Windows 95/98/ME
+#DOSBOX-X-ADV:#                                        You will need at least APM BIOS v1.1 for emulation to work with Windows 95/98/ME.
 #DOSBOX-X-ADV:#                                        Possible values: auto, 1.0, 1.1, 1.2.
 #DOSBOX-X-ADV:#              apmbios allow realmode: Allow guest OS to connect from real mode.
 #DOSBOX-X-ADV:# apmbios allow 16-bit protected mode: Allow guest OS to connect from 16-bit protected mode.
 #DOSBOX-X-ADV:# apmbios allow 32-bit protected mode: Allow guest OS to connect from 32-bit protected mode.
 #DOSBOX-X-ADV:#                                        If you want power management in Windows 95/98/ME (beyond using the APM to shutdown the computer) you MUST enable this option.
 #DOSBOX-X-ADV:#                                        Windows 95/98/ME does not support the 16-bit real and protected mode APM BIOS entry points.
-#DOSBOX-X-ADV:#                                        Please note at this time that 32-bit APM is unstable under Windows ME
+#DOSBOX-X-ADV:#                                        Please note at this time that 32-bit APM is unstable under Windows ME.
 #DOSBOX-X-ADV:#                  integration device: Enable DOSBox-X integration I/O device. This can be used by the guest OS to match mouse pointer position, for example. EXPERIMENTAL!
 #DOSBOX-X-ADV:#              integration device pnp: List DOSBox-X integration I/O device as part of ISA PnP enumeration. This has no purpose yet.
-#DOSBOX-X-ADV:#                          isapnpbios: Emulate ISA Plug & Play BIOS. Enable if using DOSBox-X to run a PnP aware DOS program or if booting Windows 9x.
-#DOSBOX-X-ADV:#                                        Do not disable if Windows 9x is configured around PnP devices, you will likely confuse it.
+#                          isapnpbios: Emulate ISA Plug & Play BIOS. Enable if using DOSBox-X to run a PnP aware DOS program or if booting Windows 9x.
+#                                        Do not disable if Windows 9x is configured around PnP devices, you will likely confuse it.
 #DOSBOX-X-ADV:#                           realbig16: Allow the B (big) bit in real mode. If set, allow the DOS program to set the B bit,
 #DOSBOX-X-ADV:#                                        then jump to realmode with B still set (aka Huge Unreal mode). Needed for Project Angel.
 core                                = auto
@@ -958,8 +958,8 @@ cputype                             = auto
 cycles                              = auto
 cycleup                             = 10
 cycledown                           = 20
-cycle emulation percentage adjust   = 0
-use dynamic core with paging on     = auto
+#DOSBOX-X-ADV:cycle emulation percentage adjust   = 0
+#DOSBOX-X-ADV:use dynamic core with paging on     = auto
 #DOSBOX-X-ADV:ignore opcode 63                    = true
 apmbios                             = true
 #DOSBOX-X-ADV:apmbios pnp                         = false
@@ -969,7 +969,7 @@ apmbios                             = true
 #DOSBOX-X-ADV:apmbios allow 32-bit protected mode = true
 #DOSBOX-X-ADV:integration device                  = false
 #DOSBOX-X-ADV:integration device pnp              = false
-#DOSBOX-X-ADV:isapnpbios                          = true
+isapnpbios                          = true
 #DOSBOX-X-ADV:realbig16                           = false
 
 [keyboard]

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -913,13 +913,14 @@ vsyncrate = 75
 #                                          'max'           will allocate as much cycles as your computer is able to
 #                                                          handle.
 #                                        Possible values: auto, fixed, max.
-#                             cycleup: Amount of cycles to decrease/increase with keycombos.(CTRL-F11/CTRL-F12)
+#                             cycleup: Amount of cycles to decrease/increase with the mapped keyboard shortcut.
 #                           cycledown: Setting it lower than 100 will be a percentage.
 #   cycle emulation percentage adjust: The percentage adjustment for use with the "Emulate CPU speed" feature. Default is 0 (no adjustment), but you can adjust it (between -25% and 25%) if necessary.
 #     use dynamic core with paging on: Allow dynamic cores (dynamic_x86 and dynamic_rec) to be used with 386 paging enabled.
 #                                        If the dynamic_x86 core is set, this allows Windows 9x/ME to run properly, but may somewhat decrease the performance.
 #                                        If the dynamic_rec core is set, this disables the dynamic core if the 386 paging functions are currently enabled.
-#                                        If set to auto, this option will be enabled when 386 paging is enabled.
+#                                        If set to auto, this option will be enabled depending on if the 386 paging and a guest system is currently active.
+#                                        Possible values: true, false, 1, 0, auto.
 #DOSBOX-X-ADV:#                    ignore opcode 63: When debugging, do not report illegal opcode 0x63.
 #DOSBOX-X-ADV:#                                        Enable this option to ignore spurious errors while debugging from within Windows 3.1/9x/ME
 #                             apmbios: Emulate Advanced Power Management BIOS calls

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -1811,7 +1811,7 @@ timeout     = 0
 #DOSBOX-X-ADV:#                          unmask timer on disk io: If set, INT 21h emulation will unmask IRQ 0 (timer interrupt) when the application opens/closes/reads/writes files.
 #DOSBOX-X-ADV:#                           zero int 67h if no ems: If ems=false, leave interrupt vector 67h zeroed out (default true).
 #DOSBOX-X-ADV:#                                                     This is a workaround for games or demos that try to detect EMS by whether or not INT 67h is 0000:0000 rather than a proper test.
-#DOSBOX-X-ADV:#                                                     This option also affects whether INT 67h is zeroed when booting a guest OS
+#DOSBOX-X-ADV:#                                                     This option also affects whether INT 67h is zeroed when booting a guest OS.
 #DOSBOX-X-ADV:#                              zero unused int 68h: Leave INT 68h zero at startup.
 #DOSBOX-X-ADV:#                                                     Set this to true for certain games that use INT 68h in unusual ways that require a zero value.
 #DOSBOX-X-ADV:#                                                     Note that the vector is left at zero anyway when machine=cga.
@@ -1823,7 +1823,7 @@ timeout     = 0
 #DOSBOX-X-ADV:#                                                     DOS actually does, but if set, can help certain DOS games and demos cope with problems
 #DOSBOX-X-ADV:#                                                     related to uninitialized variables in expanded memory. When enabled this option may
 #DOSBOX-X-ADV:#                                                     incur a slight to moderate performance penalty.
-#DOSBOX-X-ADV:#                    ems system handle memory size: Amount of memory associated with system handle, in KB
+#DOSBOX-X-ADV:#                    ems system handle memory size: Amount of memory associated with system handle, in KB.
 #DOSBOX-X-ADV:#               ems system handle on even megabyte: If set, try to allocate the EMM system handle on an even megabyte.
 #DOSBOX-X-ADV:#                                                     If the DOS game or demo fiddles with the A20 gate while using EMM386.EXE emulation in virtual 8086 mode, setting this option may help prevent crashes.
 #DOSBOX-X-ADV:#                                                     However, forcing allocation on an even megabyte will also cause some extended memory fragmentation and reduce the
@@ -1838,7 +1838,7 @@ timeout     = 0
 #DOSBOX-X-ADV:#                        keep private area on boot: If set, keep the DOSBox-X private area around after boot (Mainline DOSBox behavior). If clear, unmap and discard the private area when you boot an operating system.
 #DOSBOX-X-ADV:#                              private area in umb: If set, keep private DOS segment in upper memory block, usually segment 0xC800 (Mainline DOSBox behavior)
 #DOSBOX-X-ADV:#                                                     If clear, place private DOS segment at the base of system memory (just below the MCB)
-#                                     quick reboot: If set, the DOS restart call will reboot the emulated DOS (integrated DOS or guest DOS) instead of the virtual machine
+#                                     quick reboot: If set, the DOS restart call will reboot the emulated DOS (integrated DOS or guest DOS) instead of the virtual machine.
 #                                                     
 #                                              ver: Set DOS version. Specify as major.minor format. A single number is treated as the major version (compatible with LFN support). Common settings are:
 #                                                     auto (or unset)                  Pick a DOS kernel version automatically

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -276,13 +276,14 @@ vsyncrate = 75
 #                                        'max'           will allocate as much cycles as your computer is able to
 #                                                        handle.
 #                                      Possible values: auto, fixed, max.
-#                           cycleup: Amount of cycles to decrease/increase with keycombos.(CTRL-F11/CTRL-F12)
+#                           cycleup: Amount of cycles to decrease/increase with the mapped keyboard shortcut.
 #                         cycledown: Setting it lower than 100 will be a percentage.
 # cycle emulation percentage adjust: The percentage adjustment for use with the "Emulate CPU speed" feature. Default is 0 (no adjustment), but you can adjust it (between -25% and 25%) if necessary.
 #   use dynamic core with paging on: Allow dynamic cores (dynamic_x86 and dynamic_rec) to be used with 386 paging enabled.
 #                                      If the dynamic_x86 core is set, this allows Windows 9x/ME to run properly, but may somewhat decrease the performance.
 #                                      If the dynamic_rec core is set, this disables the dynamic core if the 386 paging functions are currently enabled.
-#                                      If set to auto, this option will be enabled when 386 paging is enabled.
+#                                      If set to auto, this option will be enabled depending on if the 386 paging and a guest system is currently active.
+#                                      Possible values: true, false, 1, 0, auto.
 #                           apmbios: Emulate Advanced Power Management BIOS calls
 core                              = auto
 fpu                               = true

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -259,41 +259,36 @@ vsyncmode = off
 vsyncrate = 75
 
 [cpu]
-#                              core: CPU Core used in emulation. auto will switch to dynamic if available and appropriate.
-#                                      For the dynamic core, both dynamic_x86 and dynamic_rec are supported (dynamic_x86 is preferred).
-#                                      Windows 95 or other preemptive multitasking OSes will not work with the dynamic_rec core.
-#                                      Possible values: auto, dynamic, dynamic_x86, dynamic_nodhfpu, dynamic, dynamic_rec, normal, full, simple.
-#                               fpu: Enable FPU emulation
-#                           cputype: CPU Type used in emulation. auto emulates a 486 which tolerates Pentium instructions.
-#                                      Possible values: auto, 8086, 8086_prefetch, 80186, 80186_prefetch, 286, 286_prefetch, 386, 386_prefetch, 486old, 486old_prefetch, 486, 486_prefetch, pentium, pentium_mmx, ppro_slow.
-#                            cycles: Amount of instructions DOSBox-X tries to emulate each millisecond.
-#                                      Setting this value too high results in sound dropouts and lags.
-#                                      Cycles can be set in 3 ways:
-#                                        'auto'          tries to guess what a game needs.
-#                                                        It usually works, but can fail for certain games.
-#                                        'fixed #number' will set a fixed amount of cycles. This is what you usually
-#                                                        need if 'auto' fails (Example: fixed 4000).
-#                                        'max'           will allocate as much cycles as your computer is able to
-#                                                        handle.
-#                                      Possible values: auto, fixed, max.
-#                           cycleup: Amount of cycles to decrease/increase with the mapped keyboard shortcut.
-#                         cycledown: Setting it lower than 100 will be a percentage.
-# cycle emulation percentage adjust: The percentage adjustment for use with the "Emulate CPU speed" feature. Default is 0 (no adjustment), but you can adjust it (between -25% and 25%) if necessary.
-#   use dynamic core with paging on: Allow dynamic cores (dynamic_x86 and dynamic_rec) to be used with 386 paging enabled.
-#                                      If the dynamic_x86 core is set, this allows Windows 9x/ME to run properly, but may somewhat decrease the performance.
-#                                      If the dynamic_rec core is set, this disables the dynamic core if the 386 paging functions are currently enabled.
-#                                      If set to auto, this option will be enabled depending on if the 386 paging and a guest system is currently active.
-#                                      Possible values: true, false, 1, 0, auto.
-#                           apmbios: Emulate Advanced Power Management BIOS calls
-core                              = auto
-fpu                               = true
-cputype                           = auto
-cycles                            = auto
-cycleup                           = 10
-cycledown                         = 20
-cycle emulation percentage adjust = 0
-use dynamic core with paging on   = auto
-apmbios                           = true
+#       core: CPU Core used in emulation. auto will switch to dynamic if available and appropriate.
+#               For the dynamic core, both dynamic_x86 and dynamic_rec are supported (dynamic_x86 is preferred).
+#               Windows 95 or other preemptive multitasking OSes will not work with the dynamic_rec core.
+#               Possible values: auto, dynamic, dynamic_x86, dynamic_nodhfpu, dynamic, dynamic_rec, normal, full, simple.
+#        fpu: Enable FPU emulation
+#    cputype: CPU Type used in emulation. auto emulates a 486 which tolerates Pentium instructions.
+#               Possible values: auto, 8086, 8086_prefetch, 80186, 80186_prefetch, 286, 286_prefetch, 386, 386_prefetch, 486old, 486old_prefetch, 486, 486_prefetch, pentium, pentium_mmx, ppro_slow.
+#     cycles: Amount of instructions DOSBox-X tries to emulate each millisecond.
+#               Setting this value too high results in sound dropouts and lags.
+#               Cycles can be set in 3 ways:
+#                 'auto'          tries to guess what a game needs.
+#                                 It usually works, but can fail for certain games.
+#                 'fixed #number' will set a fixed amount of cycles. This is what you usually
+#                                 need if 'auto' fails (Example: fixed 4000).
+#                 'max'           will allocate as much cycles as your computer is able to
+#                                 handle.
+#               Possible values: auto, fixed, max.
+#    cycleup: Amount of cycles to decrease/increase with the mapped keyboard shortcut.
+#  cycledown: Setting it lower than 100 will be a percentage.
+#    apmbios: Emulate Advanced Power Management (APM) BIOS calls.
+# isapnpbios: Emulate ISA Plug & Play BIOS. Enable if using DOSBox-X to run a PnP aware DOS program or if booting Windows 9x.
+#               Do not disable if Windows 9x is configured around PnP devices, you will likely confuse it.
+core       = auto
+fpu        = true
+cputype    = auto
+cycles     = auto
+cycleup    = 10
+cycledown  = 20
+apmbios    = true
+isapnpbios = true
 
 [keyboard]
 #            aux: Enable emulation of the 8042 auxiliary port. PS/2 mouse emulation requires this to be enabled.

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -738,7 +738,7 @@ timeout     = 0
 #                                    to work at all.
 #                                    Possible values: true, emsboard, emm386, false, 1, 0.
 #                             umb: Enable UMB support.
-#                    quick reboot: If set, the DOS restart call will reboot the emulated DOS (integrated DOS or guest DOS) instead of the virtual machine
+#                    quick reboot: If set, the DOS restart call will reboot the emulated DOS (integrated DOS or guest DOS) instead of the virtual machine.
 #                                    
 #                             ver: Set DOS version. Specify as major.minor format. A single number is treated as the major version (compatible with LFN support). Common settings are:
 #                                    auto (or unset)                  Pick a DOS kernel version automatically

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -913,13 +913,14 @@ vsyncrate = 75
 #                                          'max'           will allocate as much cycles as your computer is able to
 #                                                          handle.
 #                                        Possible values: auto, fixed, max.
-#                             cycleup: Amount of cycles to decrease/increase with keycombos.(CTRL-F11/CTRL-F12)
+#                             cycleup: Amount of cycles to decrease/increase with the mapped keyboard shortcut.
 #                           cycledown: Setting it lower than 100 will be a percentage.
 #   cycle emulation percentage adjust: The percentage adjustment for use with the "Emulate CPU speed" feature. Default is 0 (no adjustment), but you can adjust it (between -25% and 25%) if necessary.
 #     use dynamic core with paging on: Allow dynamic cores (dynamic_x86 and dynamic_rec) to be used with 386 paging enabled.
 #                                        If the dynamic_x86 core is set, this allows Windows 9x/ME to run properly, but may somewhat decrease the performance.
 #                                        If the dynamic_rec core is set, this disables the dynamic core if the 386 paging functions are currently enabled.
-#                                        If set to auto, this option will be enabled when 386 paging is enabled.
+#                                        If set to auto, this option will be enabled depending on if the 386 paging and a guest system is currently active.
+#                                        Possible values: true, false, 1, 0, auto.
 #                    ignore opcode 63: When debugging, do not report illegal opcode 0x63.
 #                                        Enable this option to ignore spurious errors while debugging from within Windows 3.1/9x/ME
 #                             apmbios: Emulate Advanced Power Management BIOS calls

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -919,22 +919,22 @@ vsyncrate = 75
 #     use dynamic core with paging on: Allow dynamic cores (dynamic_x86 and dynamic_rec) to be used with 386 paging enabled.
 #                                        If the dynamic_x86 core is set, this allows Windows 9x/ME to run properly, but may somewhat decrease the performance.
 #                                        If the dynamic_rec core is set, this disables the dynamic core if the 386 paging functions are currently enabled.
-#                                        If set to auto, this option will be enabled depending on if the 386 paging and a guest system is currently active.
+#                                        If set to auto, this option will be enabled depending on if the 386 paging and a guest system are currently active.
 #                                        Possible values: true, false, 1, 0, auto.
 #                    ignore opcode 63: When debugging, do not report illegal opcode 0x63.
-#                                        Enable this option to ignore spurious errors while debugging from within Windows 3.1/9x/ME
-#                             apmbios: Emulate Advanced Power Management BIOS calls
+#                                        Enable this option to ignore spurious errors while debugging from within Windows 3.1/9x/ME.
+#                             apmbios: Emulate Advanced Power Management (APM) BIOS calls.
 #                         apmbios pnp: If emulating ISA PnP BIOS, announce APM BIOS in PnP enumeration.
 #                                        Warning: this can cause Windows 95 OSR2 and later to enumerate the APM BIOS twice and cause problems.
 #                     apmbios version: What version of the APM BIOS specification to emulate.
-#                                        You will need at least APM BIOS v1.1 for emulation to work with Windows 95/98/ME
+#                                        You will need at least APM BIOS v1.1 for emulation to work with Windows 95/98/ME.
 #                                        Possible values: auto, 1.0, 1.1, 1.2.
 #              apmbios allow realmode: Allow guest OS to connect from real mode.
 # apmbios allow 16-bit protected mode: Allow guest OS to connect from 16-bit protected mode.
 # apmbios allow 32-bit protected mode: Allow guest OS to connect from 32-bit protected mode.
 #                                        If you want power management in Windows 95/98/ME (beyond using the APM to shutdown the computer) you MUST enable this option.
 #                                        Windows 95/98/ME does not support the 16-bit real and protected mode APM BIOS entry points.
-#                                        Please note at this time that 32-bit APM is unstable under Windows ME
+#                                        Please note at this time that 32-bit APM is unstable under Windows ME.
 #                  integration device: Enable DOSBox-X integration I/O device. This can be used by the guest OS to match mouse pointer position, for example. EXPERIMENTAL!
 #              integration device pnp: List DOSBox-X integration I/O device as part of ISA PnP enumeration. This has no purpose yet.
 #                          isapnpbios: Emulate ISA Plug & Play BIOS. Enable if using DOSBox-X to run a PnP aware DOS program or if booting Windows 9x.

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -1811,7 +1811,7 @@ timeout     = 0
 #                          unmask timer on disk io: If set, INT 21h emulation will unmask IRQ 0 (timer interrupt) when the application opens/closes/reads/writes files.
 #                           zero int 67h if no ems: If ems=false, leave interrupt vector 67h zeroed out (default true).
 #                                                     This is a workaround for games or demos that try to detect EMS by whether or not INT 67h is 0000:0000 rather than a proper test.
-#                                                     This option also affects whether INT 67h is zeroed when booting a guest OS
+#                                                     This option also affects whether INT 67h is zeroed when booting a guest OS.
 #                              zero unused int 68h: Leave INT 68h zero at startup.
 #                                                     Set this to true for certain games that use INT 68h in unusual ways that require a zero value.
 #                                                     Note that the vector is left at zero anyway when machine=cga.
@@ -1823,7 +1823,7 @@ timeout     = 0
 #                                                     DOS actually does, but if set, can help certain DOS games and demos cope with problems
 #                                                     related to uninitialized variables in expanded memory. When enabled this option may
 #                                                     incur a slight to moderate performance penalty.
-#                    ems system handle memory size: Amount of memory associated with system handle, in KB
+#                    ems system handle memory size: Amount of memory associated with system handle, in KB.
 #               ems system handle on even megabyte: If set, try to allocate the EMM system handle on an even megabyte.
 #                                                     If the DOS game or demo fiddles with the A20 gate while using EMM386.EXE emulation in virtual 8086 mode, setting this option may help prevent crashes.
 #                                                     However, forcing allocation on an even megabyte will also cause some extended memory fragmentation and reduce the
@@ -1838,7 +1838,7 @@ timeout     = 0
 #                        keep private area on boot: If set, keep the DOSBox-X private area around after boot (Mainline DOSBox behavior). If clear, unmap and discard the private area when you boot an operating system.
 #                              private area in umb: If set, keep private DOS segment in upper memory block, usually segment 0xC800 (Mainline DOSBox behavior)
 #                                                     If clear, place private DOS segment at the base of system memory (just below the MCB)
-#                                     quick reboot: If set, the DOS restart call will reboot the emulated DOS (integrated DOS or guest DOS) instead of the virtual machine
+#                                     quick reboot: If set, the DOS restart call will reboot the emulated DOS (integrated DOS or guest DOS) instead of the virtual machine.
 #                                                     
 #                                              ver: Set DOS version. Specify as major.minor format. A single number is treated as the major version (compatible with LFN support). Common settings are:
 #                                                     auto (or unset)                  Pick a DOS kernel version automatically

--- a/include/build_timestamp.h
+++ b/include/build_timestamp.h
@@ -1,4 +1,4 @@
 /*auto-generated*/
-#define UPDATED_STR "Jan 24, 2021 2:26:23am"
-#define GIT_COMMIT_HASH "16a26bc"
+#define UPDATED_STR "Jan 30, 2021 9:13:43pm"
+#define GIT_COMMIT_HASH "c952f5a"
 #define COPYRIGHT_END_YEAR "2021"

--- a/include/render.h
+++ b/include/render.h
@@ -117,8 +117,8 @@ typedef struct Render_t {
 
 #if defined(USE_TTF)
 #include "SDL_ttf.h"
-#define txtMaxCols 160
-#define txtMaxLins 60
+#define txtMaxCols 240
+#define txtMaxLins 90
 typedef struct {
 	bool	inUse;
 	TTF_Font *SDL_font;

--- a/include/render.h
+++ b/include/render.h
@@ -117,8 +117,8 @@ typedef struct Render_t {
 
 #if defined(USE_TTF)
 #include "SDL_ttf.h"
-#define txtMaxCols 240
-#define txtMaxLins 90
+#define txtMaxCols 255
+#define txtMaxLins 88
 typedef struct {
 	bool	inUse;
 	TTF_Font *SDL_font;

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -191,7 +191,17 @@ void CPU_Core_Dynrec_Cache_Close(void);
 void CPU_Core_Dynrec_Cache_Reset(void);
 #endif
 
-bool CPU_IsDynamicCore(void);
+int CPU_IsDynamicCore(void) {
+#if (C_DYNAMIC_X86)
+    if (cpudecoder == &CPU_Core_Dyn_X86_Run)
+        return 1;
+#endif
+#if (C_DYNREC)
+    if (cpudecoder == &CPU_Core_Dynrec_Run)
+        return 2;
+#endif
+    return 0;
+}
 
 void menu_update_cputype(void) {
     bool allow_prefetch = false;
@@ -2312,18 +2322,6 @@ void CPU_Snap_Back_Restore() {
 
 void CPU_Snap_Back_Forget() {
 	snap_cpu_snapped = false;
-}
-
-bool CPU_IsDynamicCore(void) {
-#if (C_DYNAMIC_X86)
-    if (cpudecoder == &CPU_Core_Dyn_X86_Run)
-        return true;
-#endif
-#if (C_DYNREC)
-    if (cpudecoder == &CPU_Core_Dynrec_Run)
-        return true;
-#endif
-    return false;
 }
 
 static bool printed_cycles_auto_info = false;

--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -30,6 +30,7 @@
 #include "debug.h"
 #include "setup.h"
 
+extern bool dos_kernel_disabled;
 PagingBlock paging;
 
 // Pagehandler implementation
@@ -1435,12 +1436,16 @@ void PAGING_SetWP(bool wp) {
 		PAGING_ClearTLB();
 }
 
+int CPU_IsDynamicCore(void);
+
 void PAGING_Enable(bool enabled) {
 	/* If paging is disabled, we work from a default paging table */
 	if (paging.enabled==enabled) return;
 	paging.enabled=enabled;
-	if (auto_determine_dynamic_core_paging)
-		use_dynamic_core_with_paging = enabled;
+	if (auto_determine_dynamic_core_paging) {
+        int coretype=CPU_IsDynamicCore();
+		use_dynamic_core_with_paging = coretype==1?enabled&&dos_kernel_disabled:(coretype==2?enabled&&!dos_kernel_disabled:enabled);
+    }
 	if (enabled) {
 //		LOG(LOG_PAGING,LOG_NORMAL)("Enabled");
 		PAGING_SetDirBase(paging.cr3);

--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -1443,9 +1443,9 @@ void PAGING_Enable(bool enabled) {
 	if (paging.enabled==enabled) return;
 	paging.enabled=enabled;
 	if (auto_determine_dynamic_core_paging) {
-        int coretype=CPU_IsDynamicCore();
+		int coretype=CPU_IsDynamicCore();
 		use_dynamic_core_with_paging = coretype==1?enabled&&dos_kernel_disabled:(coretype==2?enabled&&!dos_kernel_disabled:enabled);
-    }
+	}
 	if (enabled) {
 //		LOG(LOG_PAGING,LOG_NORMAL)("Enabled");
 		PAGING_SetDirBase(paging.cr3);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1079,7 +1079,6 @@ void DOSBOX_SetupConfigSections(void) {
     const char* pc98videomodeopt[] = { "", "24khz", "31khz", "15khz", 0};
     const char* aspectmodes[] = { "false", "true", "0", "1", "yes", "no", "nearest", "bilinear", 0};
     const char *vga_ac_mapping_settings[] = { "", "auto", "4x4", "4low", "first16", 0 };
-    const char* dynamic_core_with_paging_settings[] = { "auto", "true", "false", 0 };
 
     const char* hostkeys[] = {
         "ctrlalt", "ctrlshift", "altshift", "mapper", 0 };
@@ -2305,7 +2304,7 @@ void DOSBOX_SetupConfigSections(void) {
 
     Pint = secprop->Add_int("cycleup",Property::Changeable::Always,10);
     Pint->SetMinMax(1,1000000);
-    Pint->Set_help("Amount of cycles to decrease/increase with keycombos.(CTRL-F11/CTRL-F12)");
+    Pint->Set_help("Amount of cycles to decrease/increase with the mapped keyboard shortcut.");
     Pint->SetBasic(true);
 
     Pint = secprop->Add_int("cycledown",Property::Changeable::Always,20);
@@ -2319,11 +2318,11 @@ void DOSBOX_SetupConfigSections(void) {
     Pint->SetBasic(true);
 
     Pstring = secprop->Add_string("use dynamic core with paging on",Property::Changeable::Always,"auto");
-    Pstring->Set_values(dynamic_core_with_paging_settings);
+    Pstring->Set_values(truefalseautoopt);
     Pstring->Set_help("Allow dynamic cores (dynamic_x86 and dynamic_rec) to be used with 386 paging enabled.\n"
                     "If the dynamic_x86 core is set, this allows Windows 9x/ME to run properly, but may somewhat decrease the performance.\n"
                     "If the dynamic_rec core is set, this disables the dynamic core if the 386 paging functions are currently enabled.\n"
-                    "If set to auto, this option will be enabled when 386 paging is enabled.");
+                    "If set to auto, this option will be enabled depending on if the 386 paging and a guest system is currently active.");
     Pstring->SetBasic(true);
             
     Pbool = secprop->Add_bool("ignore opcode 63",Property::Changeable::Always,true);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2315,22 +2315,20 @@ void DOSBOX_SetupConfigSections(void) {
     Pint = secprop->Add_int("cycle emulation percentage adjust",Property::Changeable::Always,0);
     Pint->SetMinMax(-50,50);
     Pint->Set_help("The percentage adjustment for use with the \"Emulate CPU speed\" feature. Default is 0 (no adjustment), but you can adjust it (between -25% and 25%) if necessary.");
-    Pint->SetBasic(true);
 
     Pstring = secprop->Add_string("use dynamic core with paging on",Property::Changeable::Always,"auto");
     Pstring->Set_values(truefalseautoopt);
     Pstring->Set_help("Allow dynamic cores (dynamic_x86 and dynamic_rec) to be used with 386 paging enabled.\n"
                     "If the dynamic_x86 core is set, this allows Windows 9x/ME to run properly, but may somewhat decrease the performance.\n"
                     "If the dynamic_rec core is set, this disables the dynamic core if the 386 paging functions are currently enabled.\n"
-                    "If set to auto, this option will be enabled depending on if the 386 paging and a guest system is currently active.");
-    Pstring->SetBasic(true);
+                    "If set to auto, this option will be enabled depending on if the 386 paging and a guest system are currently active.");
             
     Pbool = secprop->Add_bool("ignore opcode 63",Property::Changeable::Always,true);
     Pbool->Set_help("When debugging, do not report illegal opcode 0x63.\n"
-            "Enable this option to ignore spurious errors while debugging from within Windows 3.1/9x/ME");
+            "Enable this option to ignore spurious errors while debugging from within Windows 3.1/9x/ME.");
 
     Pbool = secprop->Add_bool("apmbios",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("Emulate Advanced Power Management BIOS calls");
+    Pbool->Set_help("Emulate Advanced Power Management (APM) BIOS calls.");
     Pbool->SetBasic(true);
 
     Pbool = secprop->Add_bool("apmbios pnp",Property::Changeable::WhenIdle,false);
@@ -2340,7 +2338,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring = secprop->Add_string("apmbios version",Property::Changeable::WhenIdle,"auto");
     Pstring->Set_values(apmbiosversions);
     Pstring->Set_help("What version of the APM BIOS specification to emulate.\n"
-            "You will need at least APM BIOS v1.1 for emulation to work with Windows 95/98/ME");
+            "You will need at least APM BIOS v1.1 for emulation to work with Windows 95/98/ME.");
 
     Pbool = secprop->Add_bool("apmbios allow realmode",Property::Changeable::WhenIdle,true);
     Pbool->Set_help("Allow guest OS to connect from real mode.");
@@ -2352,7 +2350,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pbool->Set_help("Allow guest OS to connect from 32-bit protected mode.\n"
             "If you want power management in Windows 95/98/ME (beyond using the APM to shutdown the computer) you MUST enable this option.\n"
             "Windows 95/98/ME does not support the 16-bit real and protected mode APM BIOS entry points.\n"
-            "Please note at this time that 32-bit APM is unstable under Windows ME");
+            "Please note at this time that 32-bit APM is unstable under Windows ME.");
 
     Pbool = secprop->Add_bool("integration device",Property::Changeable::WhenIdle,false);
     Pbool->Set_help("Enable DOSBox-X integration I/O device. This can be used by the guest OS to match mouse pointer position, for example. EXPERIMENTAL!");
@@ -2363,6 +2361,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pbool = secprop->Add_bool("isapnpbios",Property::Changeable::WhenIdle,true);
     Pbool->Set_help("Emulate ISA Plug & Play BIOS. Enable if using DOSBox-X to run a PnP aware DOS program or if booting Windows 9x.\n"
             "Do not disable if Windows 9x is configured around PnP devices, you will likely confuse it.");
+    Pbool->SetBasic(true);
 
     Pbool = secprop->Add_bool("realbig16",Property::Changeable::WhenIdle,false);
     Pbool->Set_help("Allow the B (big) bit in real mode. If set, allow the DOS program to set the B bit,\n"

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3598,7 +3598,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pbool = secprop->Add_bool("zero int 67h if no ems",Property::Changeable::OnlyAtStart,true);
     Pbool->Set_help("If ems=false, leave interrupt vector 67h zeroed out (default true).\n"
             "This is a workaround for games or demos that try to detect EMS by whether or not INT 67h is 0000:0000 rather than a proper test.\n"
-            "This option also affects whether INT 67h is zeroed when booting a guest OS");
+            "This option also affects whether INT 67h is zeroed when booting a guest OS.");
 
     Pbool = secprop->Add_bool("zero unused int 68h",Property::Changeable::OnlyAtStart,false);
     Pbool->Set_help("Leave INT 68h zero at startup.\n"
@@ -3619,7 +3619,7 @@ void DOSBOX_SetupConfigSections(void) {
             "incur a slight to moderate performance penalty.");
 
     Pint = secprop->Add_int("ems system handle memory size",Property::Changeable::WhenIdle,384);
-    Pint->Set_help("Amount of memory associated with system handle, in KB");
+    Pint->Set_help("Amount of memory associated with system handle, in KB.");
 
     Pbool = secprop->Add_bool("ems system handle on even megabyte",Property::Changeable::WhenIdle,false);
     Pbool->Set_help("If set, try to allocate the EMM system handle on an even megabyte.\n"
@@ -3653,7 +3653,7 @@ void DOSBOX_SetupConfigSections(void) {
             "If clear, place private DOS segment at the base of system memory (just below the MCB)");
 
     Pbool = secprop->Add_bool("quick reboot",Property::Changeable::WhenIdle,false);
-    Pbool->Set_help("If set, the DOS restart call will reboot the emulated DOS (integrated DOS or guest DOS) instead of the virtual machine\n");
+    Pbool->Set_help("If set, the DOS restart call will reboot the emulated DOS (integrated DOS or guest DOS) instead of the virtual machine.\n");
     Pbool->SetBasic(true);
 
     Pstring = secprop->Add_string("ver",Property::Changeable::WhenIdle,"");

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1038,7 +1038,12 @@ public:
 #if defined(C_SDL2)
         sprintf(buf,"Key %s",SDL_GetScancodeName(key));
 #else
-        sprintf(buf,"Key %s",SDL_GetKeyName(MapSDLCode((Bitu)key)));
+        const char *r=SDL_GetKeyName(MapSDLCode((Bitu)key));
+        if (!strcmp(r, "left super")) r = "left Windows";
+        else if (!strcmp(r, "right super")) r = "right Windows";
+        else if (!strcmp(r, "left meta")) r = "left Command";
+        else if (!strcmp(r, "right meta")) r = "right Command";
+        sprintf(buf,"Key %s",r);
 #endif
     }
     virtual void ConfigName(char * buf) override {
@@ -1065,6 +1070,10 @@ public:
 				if (c==NULL) c=(char *)strstr(r.c_str(), " alt");
 				if (c==NULL) c=(char *)strstr(r.c_str(), " shift");
 				if (c!=NULL) *(c+1)=toupper(*(c+1));
+                else if (r=="Left super") r = "Left Windows";
+                else if (r=="Right super") r = "Right Windows";
+                else if (r=="Left meta") r = "Left Command";
+                else if (r=="Right meta") r = "Right Command";
 			}
 		}
 #endif

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1107,12 +1107,14 @@ std::string CEvent::GetBindMenuText(void) {
             first=false;
             r += t;
         }
-        if (t!="Right Ctrl"&&t!="Left Ctrl"&&t!="Right Alt"&&t!="Left Alt"&&t!="Right Shift"&&t!="Left Shift") break;
+        if (t!="Right Windows"&&t!="Left Windows"&&t!="Right Command"&&t!="Left Command"&&t!="Right Ctrl"&&t!="Left Ctrl"&&t!="Right Alt"&&t!="Left Alt"&&t!="Right Shift"&&t!="Left Shift") break;
         s += t;
     }
-    if (s=="Right CtrlLeft Ctrl"||s=="Left CtrlRight Ctrl") r="Ctrl";
-    if (s=="Right AltLeft Alt"||s=="Left AltRight Alt") r="Alt";
-    if (s=="Right ShiftLeft Shift"||s=="Left ShiftRight Shift") r="Shift";
+    if (s=="Right WindowsLeft Windows"||s=="Left WindowsRight Windows") r="Windows";
+    else if (s=="Right CommandLeft Command"||s=="Left CommandRight Command") r="Command";
+    else if (s=="Right CtrlLeft Ctrl"||s=="Left CtrlRight Ctrl") r="Ctrl";
+    else if (s=="Right AltLeft Alt"||s=="Left AltRight Alt") r="Alt";
+    else if (s=="Right ShiftLeft Shift"||s=="Left ShiftRight Shift") r="Shift";
 
     return r;
 }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3576,6 +3576,10 @@ void OUTPUT_TTF_Select(int fsize=-1) {
             if (ttf.lins<1) ttf.lins=25;
             ttf.lins = MAX(24, MIN(txtMaxLins, ttf.lins));
             ttf.cols = MAX(40, MIN(txtMaxCols, ttf.cols));
+            if (ttf.cols*ttf.lins>16384) {
+                ttf.lins = 25;
+                ttf.cols = 80;
+            }
         } else if (firstset) {
             bool alter_vmode=false;
             uint16_t c=0, r=0;
@@ -3602,6 +3606,10 @@ void OUTPUT_TTF_Select(int fsize=-1) {
             } else {
                 ttf.lins = MAX(24, MIN(txtMaxLins, ttf.lins));
                 ttf.cols = MAX(40, MIN(txtMaxCols, ttf.cols));
+                if (ttf.cols*ttf.lins>16384) {
+                    ttf.lins = 25;
+                    ttf.cols = 80;
+                }
                 if (ttf.cols != c || ttf.lins != r) alter_vmode = true;
             }
             if (alter_vmode) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3469,6 +3469,24 @@ void SetBlinkRate(Section_prop* section) {
     else blinkCursor = IS_PC98_ARCH?6:4; // default cursor blinking is slower on PC-98 systems
 }
 
+int lastset=0;
+void CheckTTFLimit() {
+    ttf.lins = MAX(24, MIN(IS_VGA_ARCH?txtMaxLins:60, ttf.lins));
+    ttf.cols = MAX(40, MIN(IS_VGA_ARCH?txtMaxCols:160, ttf.cols));
+    if (ttf.cols*ttf.lins>16384) {
+        if (lastset==1) {
+            ttf.lins=16384/ttf.cols;
+            SetVal("render", "ttf.lins", std::to_string(ttf.lins));
+        } else if (lastset==2) {
+            ttf.cols=16384/ttf.lins;
+            SetVal("render", "ttf.cols", std::to_string(ttf.cols));
+        } else {
+            ttf.lins = 25;
+            ttf.cols = 80;
+        }
+    }
+}
+
 bool firstset=true;
 void OUTPUT_TTF_Select(int fsize=-1) {
     if (!initttf&&TTF_Init()) {											// Init SDL-TTF
@@ -3574,12 +3592,7 @@ void OUTPUT_TTF_Select(int fsize=-1) {
         if ((!CurMode||CurMode->type!=M_TEXT)&&!IS_PC98_ARCH) {
             if (ttf.cols<1) ttf.cols=80;
             if (ttf.lins<1) ttf.lins=25;
-            ttf.lins = MAX(24, MIN(txtMaxLins, ttf.lins));
-            ttf.cols = MAX(40, MIN(txtMaxCols, ttf.cols));
-            if (ttf.cols*ttf.lins>16384) {
-                ttf.lins = 25;
-                ttf.cols = 80;
-            }
+            CheckTTFLimit();
         } else if (firstset) {
             bool alter_vmode=false;
             uint16_t c=0, r=0;
@@ -3604,12 +3617,7 @@ void OUTPUT_TTF_Select(int fsize=-1) {
                     if (ttf.lins != r) alter_vmode = true;
                 }
             } else {
-                ttf.lins = MAX(24, MIN(txtMaxLins, ttf.lins));
-                ttf.cols = MAX(40, MIN(txtMaxCols, ttf.cols));
-                if (ttf.cols*ttf.lins>16384) {
-                    ttf.lins = 25;
-                    ttf.cols = 80;
-                }
+                CheckTTFLimit();
                 if (ttf.cols != c || ttf.lins != r) alter_vmode = true;
             }
             if (alter_vmode) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8712,7 +8712,7 @@ bool DOSBOX_parse_argv() {
 #endif
             fprintf(stderr,"  -lang <message file>                    Use specific message file instead of language= setting\n");
             fprintf(stderr,"  -nodpiaware                             Ignore (do not signal) Windows DPI awareness\n");
-            fprintf(stderr,"  -securemode                             Enable secure mode\n");
+            fprintf(stderr,"  -securemode                             Enable secure mode (no drive mounting etc)\n");
 #if defined(WIN32) && !defined(HX_DOS)
             fprintf(stderr,"  -winrun                                 Enable START command and CLIP$ device (Windows version only)\n");
             fprintf(stderr,"                                          Windows programs can be launched directly to run on the host.\n");

--- a/src/libs/decoders/dr_flac.h
+++ b/src/libs/decoders/dr_flac.h
@@ -1,6 +1,6 @@
 /*
 FLAC audio decoder. Choice of public domain or MIT-0. See license statements at the end of this file.
-dr_flac - v0.12.26 - 2021-01-17
+dr_flac - v0.12.27 - 2021-01-31
 
 David Reid - mackron@gmail.com
 
@@ -232,7 +232,7 @@ extern "C" {
 
 #define DRFLAC_VERSION_MAJOR     0
 #define DRFLAC_VERSION_MINOR     12
-#define DRFLAC_VERSION_REVISION  26
+#define DRFLAC_VERSION_REVISION  27
 #define DRFLAC_VERSION_STRING    DRFLAC_XSTRINGIFY(DRFLAC_VERSION_MAJOR) "." DRFLAC_XSTRINGIFY(DRFLAC_VERSION_MINOR) "." DRFLAC_XSTRINGIFY(DRFLAC_VERSION_REVISION)
 
 #include <stddef.h> /* For size_t. */
@@ -11806,6 +11806,9 @@ DRFLAC_API drflac_bool32 drflac_next_cuesheet_track(drflac_cuesheet_track_iterat
 /*
 REVISION HISTORY
 ================
+v0.12.27 - 2021-01-31
+  - Fix a static analysis warning.
+
 v0.12.26 - 2021-01-17
   - Fix a compilation warning due to _BSD_SOURCE being deprecated.
 

--- a/src/libs/decoders/dr_mp3.h
+++ b/src/libs/decoders/dr_mp3.h
@@ -1,6 +1,6 @@
 /*
 MP3 audio decoder. Choice of public domain or MIT-0. See license statements at the end of this file.
-dr_mp3 - v0.6.24 - 2020-12-07
+dr_mp3 - v0.6.26 - 2021-01-31
 
 David Reid - mackron@gmail.com
 
@@ -95,7 +95,7 @@ extern "C" {
 
 #define DRMP3_VERSION_MAJOR     0
 #define DRMP3_VERSION_MINOR     6
-#define DRMP3_VERSION_REVISION  23
+#define DRMP3_VERSION_REVISION  26
 #define DRMP3_VERSION_STRING    DRMP3_XSTRINGIFY(DRMP3_VERSION_MAJOR) "." DRMP3_XSTRINGIFY(DRMP3_VERSION_MINOR) "." DRMP3_XSTRINGIFY(DRMP3_VERSION_REVISION)
 
 #include <stddef.h> /* For size_t. */
@@ -281,14 +281,6 @@ DRMP3_API void drmp3dec_f32_to_s16(const float *in, drmp3_int16 *out, size_t num
 Main API (Pull API)
 ===================
 */
-#ifndef DRMP3_DEFAULT_CHANNELS
-#define DRMP3_DEFAULT_CHANNELS      2
-#endif
-#ifndef DRMP3_DEFAULT_SAMPLE_RATE
-#define DRMP3_DEFAULT_SAMPLE_RATE   44100
-#endif
-
-
 typedef enum
 {
     drmp3_seek_origin_start,
@@ -1870,7 +1862,7 @@ static void drmp3d_DCT_II(float *grbuf, int n)
     } else
 #endif
 #ifdef DR_MP3_ONLY_SIMD
-    {} /* for HAVE_SIMD=1, MINIMP3_ONLY_SIMD=1 case we do not need tail "else" branch */
+    {} /* for HAVE_SIMD=1, MINIMP3_ONLY_SIMD=1 case we do not need non-intrinsic "else" branch */
 #else
     for (; k < n; k++)
     {
@@ -2103,7 +2095,7 @@ static void drmp3d_synth(float *xl, drmp3d_sample_t *dstl, int nch, float *lins)
     } else
 #endif
 #ifdef DR_MP3_ONLY_SIMD
-    {}
+    {} /* for HAVE_SIMD=1, MINIMP3_ONLY_SIMD=1 case we do not need non-intrinsic "else" branch */
 #else
     for (i = 14; i >= 0; i--)
     {
@@ -4458,6 +4450,12 @@ counts rather than sample counts.
 /*
 REVISION HISTORY
 ================
+v0.6.26 - 2021-01-31
+  - Bring up to date with minimp3.
+
+v0.6.25 - 2020-12-26
+  - Remove DRMP3_DEFAULT_CHANNELS and DRMP3_DEFAULT_SAMPLE_RATE which are leftovers from some removed APIs.
+
 v0.6.24 - 2020-12-07
   - Fix a typo in version date for 0.6.23.
 

--- a/src/libs/decoders/dr_wav.h
+++ b/src/libs/decoders/dr_wav.h
@@ -1,6 +1,6 @@
 /*
 WAV audio loader and writer. Choice of public domain or MIT-0. See license statements at the end of this file.
-dr_wav - v0.12.18 - TBD
+dr_wav - v0.12.18 - 2021-01-31
 
 David Reid - mackron@gmail.com
 
@@ -6022,7 +6022,7 @@ two different ways to initialize a drwav object.
 /*
 REVISION HISTORY
 ================
-v0.12.18 - TBD
+v0.12.18 - 2021-01-31
   - Clean up some static analysis warnings.
 
 v0.12.17 - 2021-01-17

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -931,45 +931,55 @@ void CONFIG::Run(void) {
                         if (!strcasecmp(pvars[0].c_str(), "screenwidth")) {
                             GetMaxWidthHeight(&maxWidth, &maxHeight);
                             WriteOut("%d\n",maxWidth);
+                            first_shell->SetEnv("CONFIG",std::to_string(maxWidth).c_str());
                         } else if (!strcasecmp(pvars[0].c_str(), "screenheight")) {
                             GetMaxWidthHeight(&maxWidth, &maxHeight);
                             WriteOut("%d\n",maxHeight);
+                            first_shell->SetEnv("CONFIG",std::to_string(maxHeight).c_str());
                         } else if (!strcasecmp(pvars[0].c_str(), "drawwidth")) {
                             GetDrawWidthHeight(&maxWidth, &maxHeight);
                             WriteOut("%d\n",maxWidth);
+                            first_shell->SetEnv("CONFIG",std::to_string(maxWidth).c_str());
                         } else if (!strcasecmp(pvars[0].c_str(), "drawheight")) {
                             GetDrawWidthHeight(&maxWidth, &maxHeight);
                             WriteOut("%d\n",maxHeight);
+                            first_shell->SetEnv("CONFIG",std::to_string(maxHeight).c_str());
 #if defined(C_SDL2)
                         } else if (!strcasecmp(pvars[0].c_str(), "clientwidth")) {
                             int w = 640,h = 480;
                             SDL_Window* GFX_GetSDLWindow(void);
                             SDL_GetWindowSize(GFX_GetSDLWindow(), &w, &h);
                             WriteOut("%d\n",w);
+                            first_shell->SetEnv("CONFIG",std::to_string(w).c_str());
                         } else if (!strcasecmp(pvars[0].c_str(), "clientheight")) {
                             int w = 640,h = 480;
                             SDL_Window* GFX_GetSDLWindow(void);
                             SDL_GetWindowSize(GFX_GetSDLWindow(), &w, &h);
                             WriteOut("%d\n",h);
+                            first_shell->SetEnv("CONFIG",std::to_string(h).c_str());
 #elif defined(WIN32)
                         } else if (!strcasecmp(pvars[0].c_str(), "clientwidth")) {
                             RECT rect;
                             GetClientRect(GetHWND(), &rect);
                             WriteOut("%d\n",rect.right-rect.left);
+                            first_shell->SetEnv("CONFIG",std::to_string(rect.right-rect.left).c_str());
                         } else if (!strcasecmp(pvars[0].c_str(), "clientheight")) {
                             RECT rect;
                             GetClientRect(GetHWND(), &rect);
                             WriteOut("%d\n",rect.bottom-rect.top);
+                            first_shell->SetEnv("CONFIG",std::to_string(rect.bottom-rect.top).c_str());
 #endif
 #if defined(WIN32)
                         } else if (!strcasecmp(pvars[0].c_str(), "windowwidth")) {
                             RECT rect;
                             GetWindowRect(GetHWND(), &rect);
                             WriteOut("%d\n",rect.right-rect.left);
+                            first_shell->SetEnv("CONFIG",std::to_string(rect.right-rect.left).c_str());
                         } else if (!strcasecmp(pvars[0].c_str(), "windowheight")) {
                             RECT rect;
                             GetWindowRect(GetHWND(), &rect);
                             WriteOut("%d\n",rect.bottom-rect.top);
+                            first_shell->SetEnv("CONFIG",std::to_string(rect.bottom-rect.top).c_str());
 #endif
                         } else
                             WriteOut(MSG_Get("PROGRAM_CONFIG_PROPERTY_ERROR"));

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -46,7 +46,7 @@ typedef struct {
 
 Bitu call_program;
 extern const char *modifier;
-extern int enablelfn, paste_speed, wheel_key, freesizecap, wpType, wpVersion;
+extern int enablelfn, paste_speed, wheel_key, freesizecap, wpType, wpVersion, lastset;
 extern bool dos_kernel_disabled, force_nocachedir, wpcolon, lockmount, enable_config_as_shell_commands, load, winrun, winautorun, startwait, startquiet, mountwarning, wheel_guest, clipboard_dosapi, noremark_save_state, force_load_state, sync_time, manualtime;
 
 /* This registers a file on the virtual drive and creates the correct structure for it*/
@@ -1342,7 +1342,8 @@ void CONFIG::Run(void) {
 #endif
 							} else if (!strcasecmp(inputline.substr(0, 9).c_str(), "ttf.lins=")||!strcasecmp(inputline.substr(0, 9).c_str(), "ttf.cols=")) {
 #if defined(USE_TTF)
-                                if (!strcasecmp(inputline.substr(0, 9).c_str(), "ttf.cols=")&&IS_PC98_ARCH)
+                                bool iscol=!strcasecmp(inputline.substr(0, 9).c_str(), "ttf.cols=");
+                                if (iscol&&IS_PC98_ARCH)
                                     SetVal("render", "ttf.cols", "80");
                                 else if (!CurMode)
                                     ;
@@ -1352,7 +1353,9 @@ void CONFIG::Run(void) {
                                     reg_ax=(uint16_t)CurMode->mode;
                                     CALLBACK_RunRealInt(0x10);
                                 }
+                                lastset=iscol?2:1;
                                 ttf_setlines(0, 0);
+                                lastset=0;
 #endif
 							} else if (!strcasecmp(inputline.substr(0, 7).c_str(), "ttf.wp=")) {
 #if defined(USE_TTF)


### PR DESCRIPTION
This addresses Issue #2230, so that the Window key(s) in Windows and the Command key(s) in macOS will be displayed as the "Windows" and "Command" keys instead of the "super" and "meta" keys in SDL1 builds just like SDL2 builds. Also allows the games such as "Command & Conquer Convert Operations" to run in the default setting along with small decoder updates.