### PR TITLE
Move file in VS project to match actual directory

### DIFF
--- a/vs2015/dosbox-x.vcxproj.filters
+++ b/vs2015/dosbox-x.vcxproj.filters
@@ -1518,6 +1518,9 @@
     <ClCompile Include="..\src\libs\decoders\internal\opus\silk\debug_silk.c">
       <Filter>Sources\libs\decoder</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\misc\savestates.cpp">
+      <Filter>Sources\misc</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\aviwriter\avi.h">


### PR DESCRIPTION
In the Visual Studio solution, `savestates.cpp` appeared in the hierarchical view of the project as outside of any sub-folders of `src`. It's actually in the `misc` folder, so this PR moves it within the Visual Studio solution so that it matches the actual file location like the rest of the files.