### PR TITLE
SVN commits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,6 +32,12 @@
     and "CONFIG -set output=default". (Wengier)
   - The setting "output=default" will enable the OpenGL
     output for the Linux platform if possible. (Wengier)
+  - Integrated SVN commits (Allofich)
+    - r4320: Report Q-Channel track number in BCD,
+    meaning it is not converted to binary by the
+    CD-ROM device driver. Fixes the CD-Player feature
+    of DOS Navigator 1.51 when playing past track 15.
+    - r4318: Add LOGC debug command to log cs:ip only.
 0.83.10
   - The Windows key(s) in Windows and the Command key(s)
     in macOS will now be displayed as the "Windows" and

--- a/patch-integration/Skipped SVN commits.txt
+++ b/patch-integration/Skipped SVN commits.txt
@@ -39,6 +39,16 @@ Commit#:	Reason for skipping:
 4298		Skipped the timing change. It makes the cursor blink too slow compared to footage of an actual machine.
 4303		DOSBox-X has its own handling for dpi awareness and preventing scaling.
 4306		Conflict
+4311		Sets max scalers to 3, but DOSBox-X already has code involving higher scalers.
+4313		Conflict. DOSBox-X also has vga.dac.xlat32 statements here, should they also be rewritten to use var_write?
+4314		Conflict
+4315		Conflict
+4316		Conflict
+4322		Conflict
+4324		Conflict
+4325		Fix to 4065, which was skipped
+4326		Conflict
+4329		Conflict
 
 (Commits in this interval are still TODO)
 

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -1975,6 +1975,11 @@ bool ParseCommand(char* str) {
 		command = "logcode";
 	}
 
+	if (command == "LOGC") { // Create Cpu coverage log file
+		cpuLogType = 3;
+		command = "logcode";
+	}
+
 	if (command == "logcode") { //Shared code between all logs
 		DEBUG_ShowMsg("DEBUG: Starting log\n");
 		cpuLogFile.open("LOGCPU.TXT");
@@ -2620,8 +2625,8 @@ bool ParseCommand(char* str) {
 		DEBUG_ShowMsg("INT [nr] / INTT [nr]      - Execute / Trace into interrupt.\n");
 #if C_HEAVY_DEBUG
 		DEBUG_ShowMsg("LOG [num]                 - Write cpu log file.\n");
-		DEBUG_ShowMsg("LOGS/LOGL [num]           - Write short/long cpu log file.\n");
-		DEBUG_ShowMsg("HEAVYLOG                  - Enable/Disable automatic cpu log when dosbox exits.\n");
+		DEBUG_ShowMsg("LOGS/LOGL/LOGC [num]      - Write short/long/cs:ip-only cpu log file.\n");
+		DEBUG_ShowMsg("HEAVYLOG                  - Enable/Disable automatic cpu log when DOSBox-X exits.\n");
 		DEBUG_ShowMsg("ZEROPROTECT               - Enable/Disable zero code execution detection.\n");
 #endif
 		DEBUG_ShowMsg("SR [reg] [value]          - Set register value. Multiple pairs allowed.\n");
@@ -3962,6 +3967,11 @@ static void LogCPUInfo(void) {
 #if C_HEAVY_DEBUG
 static void LogInstruction(uint16_t segValue, uint32_t eipValue,  ofstream& out) {
 	static char empty[23] = { 32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,0 };
+
+	if (cpuLogType == 3) { //Log only cs:ip.
+		out << setw(4) << SegValue(cs) << ":" << setw(8) << reg_eip << endl;
+		return;
+	}
 
 	PhysPt start = (PhysPt)GetAddress(segValue,eipValue);
 	char dline[200];Bitu size;

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -987,7 +987,7 @@ static uint16_t MSCDEX_IOCTL_Input(PhysPt buffer,uint8_t drive_unit) {
 					TMSF abs,rel;
 					mscdex->GetSubChannelData(drive_unit,attr,track,index,rel,abs);
 					mem_writeb(buffer+1,attr);
-					mem_writeb(buffer+2,track);
+					mem_writeb(buffer+2,((track/10)<<4)|(track%10)); // track in BCD
 					mem_writeb(buffer+3,index);
 					mem_writeb(buffer+4,rel.min);
 					mem_writeb(buffer+5,rel.sec);


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/4311 - Skipped. Sets max scalers to 3, but DOSBox-X already has code involving higher scalers.
https://sourceforge.net/p/dosbox/code-0/4312 - Skipped because this is a correction to 4311.
https://sourceforge.net/p/dosbox/code-0/4313 - Skipped because DOSBox-X also has `vga.dac.xlat32` statements here. Should they also be rewritten to use `var_write`, as `vga.dac.xlat16` is by this commit?
https://sourceforge.net/p/dosbox/code-0/4314 - Skipped due to code conflict.
https://sourceforge.net/p/dosbox/code-0/4315 - Skipped due to code conflict.
https://sourceforge.net/p/dosbox/code-0/4316 - Skipped due to code conflict.
https://sourceforge.net/p/dosbox/code-0/4317 - Skipped because this adjusts 4311, setting the max to 4, which is still less than DOSBox-X.
https://sourceforge.net/p/dosbox/code-0/4318 - In this PR
https://sourceforge.net/p/dosbox/code-0/4319 - Already in DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4320 - In this PR
https://sourceforge.net/p/dosbox/code-0/4321 - Already in DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4322 - Skipped due to code conflict.
https://sourceforge.net/p/dosbox/code-0/4323 - Already in DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4324 - Skipped due to code conflict.
https://sourceforge.net/p/dosbox/code-0/4325 - Skipped because this is a fix to 4065, which was skipped due to potential conflict.
https://sourceforge.net/p/dosbox/code-0/4326 - Skipped due to code conflict.
https://sourceforge.net/p/dosbox/code-0/4327 - Skipped because the removed variable is not in DOSBox-X code.
https://sourceforge.net/p/dosbox/code-0/4328 - Already in DOSBox-X (as in the DOSBox-X code was already formatted like this)
https://sourceforge.net/p/dosbox/code-0/4329 - Skipped due to code conflict.

I could add 4313 if the question written above is answered.