### PR TITLE
Enhanced auto-saving states (including GUI)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -41,6 +41,8 @@
     to 437 if current codepage is different. (Wengier)
   - The setting "output=default" will enable the OpenGL
     output for the Linux platform if possible. (Wengier)
+  - Fixed that the "Save" button in Configuration Tool
+    did not save config file in last version. (Wengier)
   - Integrated SVN commits (Allofich)
     - r4320: Report Q-Channel track number in BCD,
     meaning it is not converted to binary by the

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,13 +30,15 @@
   - The Configuration Tool windows are now scalable, so
     that they will no longer look very small in e.g.
     full-screen or High DPI modes. (ant_222)
-  - If the -defaultdir option is the last command-line
-    option and no paramter is specified, then directory
-    of the primary config file (if any) will become the
-    default directory for DOSBox-X. (Wengier)
+  - If the -defaultdir option is the only or the last
+    command-line option and no parameter is specified,
+    then directory of the primary config file (if any)
+    becomes the DOSBox-X default directory. (Wengier)
   - You can now change the current output dynamically
     with CONFIG command, e.g. "CONFIG -set output=ttf"
     and "CONFIG -set output=default". (Wengier)
+  - The command "KEYB US" will return the DOS codepage
+    to 437 if current codepage is different. (Wengier)
   - The setting "output=default" will enable the OpenGL
     output for the Linux platform if possible. (Wengier)
   - Integrated SVN commits (Allofich)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,21 +5,28 @@
     852, 853, 855, 857, 858, 860, 861, 862, 863, 864,
     865, 866, 869, 872, and 874. (Wengier)
   - Added function to automatically save states in the
-    specified interval (in seconds). You can optionally
+    specified time interval (in seconds). You can also
     specify a save slot or start and end save slots to
-    be used. For example, "autosave=10 11 20" will set
+    be used. For example, "autosave=10 11-20" will set
     a 10-second time interval for auto-saving, and the
     save slots used will be between 11 and 20. If no
     save slot is specified, then the current save slot
     will be used for auto-saving. Putting a minus sign
     before time interval causes the auto-saving function
-    to not be activated at start. A menu option "Enable-
-    auto-saving state" is added to "Save/load options"
-    menu group under "Capture" to toggle the auto-saving
-    when the function is enabled. Likewise, menu option
-    "Select last auto-saved slot" is added to "Select
-    save slot" menu group (under "Capture") to switch to
-    the last auto-saved slot. (Wengier)
+    to not be activated at start. You can optionally
+    also specify up to 9 program names for this feature,
+    e.g. "autosave=10 11-20 EDIT:21-30 EDITOR:35" will
+    cause program "EDIT" to use save slots 21-30, and
+    "EDITOR" to use save slot 35, and other programs to
+    use save slots 11-20. Added a menu option "Auto-save
+    settings..." to manage the auto-saving feature at
+    run-time. A menu option "Enable auto-saving state"
+    is added to the "Save/load options" menu group under
+    "Capture" to toggle auto-saving when the function is
+    enabled. Likewise, a menu option "Select last auto-
+    saved slot" is added to the "Select save slot" menu
+    group (also under "Capture") to switch to the last
+    auto-saved slot (if any). (Wengier)
   - The Configuration Tool windows are now scalable, so
     that they will no longer look very small in e.g.
     full-screen or High DPI modes. (ant_222)

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -192,6 +192,7 @@ logfile     =
 #                                        captures: Directory where things like wave, midi, screenshot get captured.
 #                                        autosave: Enable auto-save state feature. Specify a time interval in seconds, and optionally a save slot or start and end save slots.
 #                                                    For example, "autosave=10 11 20" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.
+#                                                    You can additionally specify up to 9 programs for this feature, e.g. "autosave=10 11-20 EDIT:21-30 EDITOR:35" for "EDIT" and "EDITOR".
 #                                        saveslot: Select the default save slot (1-100) to save/load states.
 #                                        savefile: Select the default save file to save/load states. If specified it will be used instead of the save slot.
 #                                      saveremark: If set, the save state feature will ask users to enter remarks when saving a state.

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -190,9 +190,10 @@ logfile     =
 #                                         machine: The type of machine DOSBox-X tries to emulate.
 #                                                    Possible values: hercules, cga, cga_mono, cga_rgb, cga_composite, cga_composite2, tandy, pcjr, ega, vgaonly, svga_s3, svga_et3000, svga_et4000, svga_paradise, vesa_nolfb, vesa_oldvbe, amstrad, pc98, pc9801, pc9821, fm_towns, mcga, mda.
 #                                        captures: Directory where things like wave, midi, screenshot get captured.
-#                                        autosave: Enable auto-save state feature. Specify a time interval in seconds, and optionally a save slot or start and end save slots.
-#                                                    For example, "autosave=10 11 20" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.
+#                                        autosave: Enable the auto-save state feature. Specify a time interval in seconds, and optionally a save slot or start and end save slots.
+#                                                    For example, "autosave=10 11-20" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.
 #                                                    You can additionally specify up to 9 programs for this feature, e.g. "autosave=10 11-20 EDIT:21-30 EDITOR:35" for "EDIT" and "EDITOR".
+#                                                    Putting a minus sign (-) before the time interval causes the auto-saving function to not be activated at start.
 #                                        saveslot: Select the default save slot (1-100) to save/load states.
 #                                        savefile: Select the default save file to save/load states. If specified it will be used instead of the save slot.
 #                                      saveremark: If set, the save state feature will ask users to enter remarks when saving a state.

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -102,9 +102,10 @@ logfile =
 #               machine: The type of machine DOSBox-X tries to emulate.
 #                          Possible values: hercules, cga, cga_mono, cga_rgb, cga_composite, cga_composite2, tandy, pcjr, ega, vgaonly, svga_s3, svga_et3000, svga_et4000, svga_paradise, vesa_nolfb, vesa_oldvbe, amstrad, pc98, pc9801, pc9821, fm_towns, mcga, mda.
 #              captures: Directory where things like wave, midi, screenshot get captured.
-#              autosave: Enable auto-save state feature. Specify a time interval in seconds, and optionally a save slot or start and end save slots.
-#                          For example, "autosave=10 11 20" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.
+#              autosave: Enable the auto-save state feature. Specify a time interval in seconds, and optionally a save slot or start and end save slots.
+#                          For example, "autosave=10 11-20" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.
 #                          You can additionally specify up to 9 programs for this feature, e.g. "autosave=10 11-20 EDIT:21-30 EDITOR:35" for "EDIT" and "EDITOR".
+#                          Putting a minus sign (-) before the time interval causes the auto-saving function to not be activated at start.
 #              saveslot: Select the default save slot (1-100) to save/load states.
 #              savefile: Select the default save file to save/load states. If specified it will be used instead of the save slot.
 #            saveremark: If set, the save state feature will ask users to enter remarks when saving a state.

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -104,6 +104,7 @@ logfile =
 #              captures: Directory where things like wave, midi, screenshot get captured.
 #              autosave: Enable auto-save state feature. Specify a time interval in seconds, and optionally a save slot or start and end save slots.
 #                          For example, "autosave=10 11 20" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.
+#                          You can additionally specify up to 9 programs for this feature, e.g. "autosave=10 11-20 EDIT:21-30 EDITOR:35" for "EDIT" and "EDITOR".
 #              saveslot: Select the default save slot (1-100) to save/load states.
 #              savefile: Select the default save file to save/load states. If specified it will be used instead of the save slot.
 #            saveremark: If set, the save state feature will ask users to enter remarks when saving a state.

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -190,9 +190,10 @@ fileio      = false
 #                                         machine: The type of machine DOSBox-X tries to emulate.
 #                                                    Possible values: hercules, cga, cga_mono, cga_rgb, cga_composite, cga_composite2, tandy, pcjr, ega, vgaonly, svga_s3, svga_et3000, svga_et4000, svga_paradise, vesa_nolfb, vesa_oldvbe, amstrad, pc98, pc9801, pc9821, fm_towns, mcga, mda.
 #                                        captures: Directory where things like wave, midi, screenshot get captured.
-#                                        autosave: Enable auto-save state feature. Specify a time interval in seconds, and optionally a save slot or start and end save slots.
-#                                                    For example, "autosave=10 11 20" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.
+#                                        autosave: Enable the auto-save state feature. Specify a time interval in seconds, and optionally a save slot or start and end save slots.
+#                                                    For example, "autosave=10 11-20" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.
 #                                                    You can additionally specify up to 9 programs for this feature, e.g. "autosave=10 11-20 EDIT:21-30 EDITOR:35" for "EDIT" and "EDITOR".
+#                                                    Putting a minus sign (-) before the time interval causes the auto-saving function to not be activated at start.
 #                                        saveslot: Select the default save slot (1-100) to save/load states.
 #                                        savefile: Select the default save file to save/load states. If specified it will be used instead of the save slot.
 #                                      saveremark: If set, the save state feature will ask users to enter remarks when saving a state.

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -192,6 +192,7 @@ fileio      = false
 #                                        captures: Directory where things like wave, midi, screenshot get captured.
 #                                        autosave: Enable auto-save state feature. Specify a time interval in seconds, and optionally a save slot or start and end save slots.
 #                                                    For example, "autosave=10 11 20" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.
+#                                                    You can additionally specify up to 9 programs for this feature, e.g. "autosave=10 11-20 EDIT:21-30 EDITOR:35" for "EDIT" and "EDITOR".
 #                                        saveslot: Select the default save slot (1-100) to save/load states.
 #                                        savefile: Select the default save file to save/load states. If specified it will be used instead of the save slot.
 #                                      saveremark: If set, the save state feature will ask users to enter remarks when saving a state.

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -1053,6 +1053,7 @@ Bitu keyboard_layout::switch_keyboard_layout(const char* new_layout, keyboard_la
 	} else if (this->use_foreign_layout) {
 		// switch to the US layout
 		this->use_foreign_layout=false;
+		if (tried_cp < 0) dos.loaded_codepage = 437;
 		diacritics_character=0;
 		LOG(LOG_BIOS,LOG_NORMAL)("Switched to US layout");
 	}

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1225,9 +1225,10 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring->SetBasic(true);
 
     Pmulti = secprop->Add_multi("autosave",Property::Changeable::Always," ");
-    Pmulti->Set_help("Enable auto-save state feature. Specify a time interval in seconds, and optionally a save slot or start and end save slots.\n"
-            "For example, \"autosave=10 11 20\" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.\n"
-            "You can additionally specify up to 9 programs for this feature, e.g. \"autosave=10 11-20 EDIT:21-30 EDITOR:35\" for \"EDIT\" and \"EDITOR\".");
+    Pmulti->Set_help("Enable the auto-save state feature. Specify a time interval in seconds, and optionally a save slot or start and end save slots.\n"
+            "For example, \"autosave=10 11-20\" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.\n"
+            "You can additionally specify up to 9 programs for this feature, e.g. \"autosave=10 11-20 EDIT:21-30 EDITOR:35\" for \"EDIT\" and \"EDITOR\".\n"
+            "Putting a minus sign (-) before the time interval causes the auto-saving function to not be activated at start.");
     Pmulti->SetBasic(true);
     Pstring = Pmulti->GetSection()->Add_string("second",Property::Changeable::WhenIdle,"");
     for (int i=0; i<10; i++) Pmulti->GetSection()->Add_string("arg"+std::to_string(i),Property::Changeable::WhenIdle,"");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1226,11 +1226,11 @@ void DOSBOX_SetupConfigSections(void) {
 
     Pmulti = secprop->Add_multi("autosave",Property::Changeable::Always," ");
     Pmulti->Set_help("Enable auto-save state feature. Specify a time interval in seconds, and optionally a save slot or start and end save slots.\n"
-            "For example, \"autosave=10 11 20\" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.");
+            "For example, \"autosave=10 11 20\" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.\n"
+            "You can additionally specify up to 9 programs for this feature, e.g. \"autosave=10 11-20 EDIT:21-30 EDITOR:35\" for \"EDIT\" and \"EDITOR\".");
     Pmulti->SetBasic(true);
     Pstring = Pmulti->GetSection()->Add_string("second",Property::Changeable::WhenIdle,"");
-    Pstring = Pmulti->GetSection()->Add_string("start",Property::Changeable::WhenIdle,"");
-    Pstring = Pmulti->GetSection()->Add_string("end",Property::Changeable::WhenIdle,"");
+    for (int i=0; i<10; i++) Pmulti->GetSection()->Add_string("arg"+std::to_string(i),Property::Changeable::WhenIdle,"");
 
     Pint = secprop->Add_int("saveslot", Property::Changeable::WhenIdle,1);
     Pint->SetMinMax(1,100);

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -609,6 +609,7 @@ static const char *def_menu_capture[] =
     "mapper_savestate",
     "mapper_loadstate",
     "saveslotmenu",
+    "autosavecfg",
     "browsesavefile",
     "mapper_showstate",
     NULL

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1538,29 +1538,30 @@ protected:
     GUI::Input *name[10], *start[10], *end[10];
 public:
     SetAutoSave(GUI::Screen *parent, int x, int y, const char *title) :
-        ToplevelWindow(parent, x, y, 630, 390, title) {
+        ToplevelWindow(parent, x, y, 630, 400, title) {
         new GUI::Label(this, 5, 15, "Time interval (secs)");
         name[0] = new GUI::Input(this, 175, 10, 80);
         name[0]->setText(std::to_string(autosave_second).c_str());
-        new GUI::Label(this, 265, 15, "Start slot");
-        start[0] = new GUI::Input(this, 350, 10, 35);
+        new GUI::Label(this, 270, 15, "Start slot");
+        start[0] = new GUI::Input(this, 360, 10, 35);
         start[0]->setText(std::to_string(autosave_start[0]).c_str());
-        new GUI::Label(this, 400, 15, "End slot (optional)");
-        end[0] = new GUI::Input(this, 570, 10, 35);
+        new GUI::Label(this, 410, 15, "End slot (optional)");
+        end[0] = new GUI::Input(this, 575, 10, 35);
         end[0]->setText(std::to_string(autosave_end[0]).c_str());
         for (int i=1; i<10; i++) {
             new GUI::Label(this, 5, 15+i*30, "Program "+std::to_string(i)+" (Optional)");
             name[i] = new GUI::Input(this, 175, 10+i*30, 80);
             name[i]->setText(autosave_name[i].c_str());
-            new GUI::Label(this, 265, 15+i*30, "Start slot");
-            start[i] = new GUI::Input(this, 350, 10+i*30, 35);
+            new GUI::Label(this, 270, 15+i*30, "Start slot");
+            start[i] = new GUI::Input(this, 360, 10+i*30, 35);
             start[i]->setText(std::to_string(autosave_start[i]).c_str());
-            new GUI::Label(this, 400, 15+i*30, "End slot (optional)");
-            end[i] = new GUI::Input(this, 570, 10+i*30, 35);
+            new GUI::Label(this, 410, 15+i*30, "End slot (optional)");
+            end[i] = new GUI::Input(this, 575, 10+i*30, 35);
             end[i]->setText(std::to_string(autosave_end[i]).c_str());
         }
-        (new GUI::Button(this, 250, 315, "OK", 70))->addActionHandler(this);
-        (new GUI::Button(this, 330, 315, "Cancel", 70))->addActionHandler(this);
+        new GUI::Label(this, 15, 315, "Note: 0 for start slot = use current slot; -1 for start slot = skip saving");
+        (new GUI::Button(this, 250, 335, "OK", 70))->addActionHandler(this);
+        (new GUI::Button(this, 330, 335, "Cancel", 70))->addActionHandler(this);
         move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1574,7 +1574,7 @@ public:
                 autosave_name[i] = (const char*)name[i]->getText();
                 if (autosave_name[i].size()) autosave_count=i;
                 autosave_start[i] = atoi(start[i]->getText());
-                if (autosave_start[i]<0) autosave_start[i]=0;
+                if (autosave_start[i]<-1) autosave_start[i]=-1;
                 autosave_end[i] = atoi(end[i]->getText());
                 if (autosave_end[i]<autosave_start[i]) autosave_end[i]=0;
                 if (autosave_start[i]>1&&autosave_start[i]<=100&&autosave_last[i]<autosave_start[i]||autosave_last[i]>(autosave_end[i]>=autosave_start[i]&&autosave_end[i]<=100?autosave_end[i]:autosave_start[i])) autosave_last[i]=-1;

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1428,7 +1428,7 @@ public:
             name->setText(fullpath);
             return;
         }
-        if (arg == "OK" || arg == "Save & Restart") control->PrintConfig(name->getText(), saveall->isChecked()?1:-1);
+        if (arg == "Save" || arg == "Save & Restart") control->PrintConfig(name->getText(), saveall->isChecked()?1:-1);
         if (arg == "Save & Restart") RebootConfig((const char*)name->getText(), true);
         close();
         if(shortcut) running=false;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -10827,6 +10827,20 @@ bool use_save_file_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * con
     return true;
 }
 
+bool auto_save_setting_menu_callback(DOSBoxMenu * const /*menu*/, DOSBoxMenu::item * const /*menuitem*/) {
+    MAPPER_ReleaseAllKeys();
+
+    GFX_LosingFocus();
+
+    GUI_Shortcut(29);
+
+    MAPPER_ReleaseAllKeys();
+
+    GFX_LosingFocus();
+
+    return true;
+}
+
 void refresh_slots() {
     std::string text=mainMenu.get_item("current_page").get_text();
     std::size_t found = text.find(":");
@@ -12468,6 +12482,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
             mainMenu.alloc_item(DOSBoxMenu::item_type_id,"refreshslot").set_text("Refresh display status").set_callback_function(refresh_slots_menu_callback);
             mainMenu.alloc_item(DOSBoxMenu::item_type_id,"lastautosaveslot").set_text("Select last auto-saved slot").set_callback_function(last_autosave_slot_menu_callback).enable(false);
             mainMenu.alloc_item(DOSBoxMenu::item_type_id, "usesavefile").set_text("Use save file instead of save slot").set_callback_function(use_save_file_menu_callback).check(use_save_file);
+            mainMenu.alloc_item(DOSBoxMenu::item_type_id, "autosavecfg").set_text("Auto-save settings...").set_callback_function(auto_save_setting_menu_callback);
             mainMenu.alloc_item(DOSBoxMenu::item_type_id, "browsesavefile").set_text("Browse save file...").set_callback_function(browse_save_file_menu_callback).enable(use_save_file);
             {
 				mainMenu.alloc_item(DOSBoxMenu::item_type_id,"current_page").set_text("Current page: 1/10").enable(false).set_callback_function(refresh_slots_menu_callback);

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -1826,8 +1826,46 @@ void CAPTURE_Destroy(Section *sec) {
 }
 
 bool enable_autosave = false;
-int autosave_second = 0, autosave_start, autosave_end, autosave_last = -1;
+int autosave_second = 0, autosave_count = 0, autosave_start[10], autosave_end[10], autosave_last[10];
+std::string autosave_name[10];
 void OPL_SaveRawEvent(bool pressed), SetGameState_Run(int value), ResolvePath(std::string& in);
+
+void ParseAutoSaveArg(std::string arg) {
+    if (arg.size()) {
+        size_t found=arg.find_last_of(":");
+        int start, end;
+        if (found==std::string::npos||found==0) {
+            found=arg.find_last_of("-");
+            if (found==std::string::npos) {
+                start=atoi(arg.c_str());
+                if (start>0) autosave_start[0]=start;
+            } else {
+                start=atoi(arg.substr(0, found).c_str());
+                end=atoi(arg.substr(found+1).c_str());
+                if (start>0) {
+                    autosave_start[0]=start;
+                    if (end>=start) autosave_end[0]=end;
+                }
+            }
+        } else if (autosave_count<9) {
+            autosave_name[++autosave_count]=arg.substr(0, found);
+            std::string remain=arg.substr(found+1);
+            found=remain.find_last_of("-");
+            if (found==std::string::npos) {
+                start=atoi(remain.c_str());
+                if (start>0) autosave_start[autosave_count]=start;
+            } else {
+                start=atoi(remain.substr(0, found).c_str());
+                end=atoi(remain.substr(found+1).c_str());
+                if (start>0) {
+                    autosave_start[autosave_count]=start;
+                    if (end>=start) autosave_end[autosave_count]=end;
+                }
+            }
+        }
+    }
+}
+
 void CAPTURE_Init() {
 	DOSBoxMenu::item *item;
 
@@ -1860,8 +1898,12 @@ void CAPTURE_Init() {
     }
     Prop_multival* prop = section->Get_multival("autosave");
     autosave_second = atoi(prop->GetSection()->Get_string("second"));
-    autosave_start = atoi(prop->GetSection()->Get_string("start"));
-    autosave_end = atoi(prop->GetSection()->Get_string("end"));
+    for (int i=0; i<10; i++) {
+        autosave_name[i] = "";
+        autosave_start[i] = autosave_end[i] = 0;
+        autosave_last[i] = -1;
+        ParseAutoSaveArg(prop->GetSection()->Get_string("arg"+std::to_string(i)));
+    }
     enable_autosave = autosave_second>0;
     if (autosave_second<0) autosave_second=-autosave_second;
     mainMenu.get_item("enable_autosave").check(enable_autosave).enable(autosave_second>0).refresh_item(mainMenu);

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -1836,31 +1836,33 @@ void ParseAutoSaveArg(std::string arg) {
         int start, end;
         if (found==std::string::npos||found==0) {
             found=arg.find_last_of("-");
-            if (found==std::string::npos) {
+            if (found==std::string::npos||found==0) {
                 start=atoi(arg.c_str());
                 if (start>0) autosave_start[0]=start;
+                else if (start<0) autosave_start[0]=-1;
             } else {
                 start=atoi(arg.substr(0, found).c_str());
                 end=atoi(arg.substr(found+1).c_str());
                 if (start>0) {
                     autosave_start[0]=start;
                     if (end>=start) autosave_end[0]=end;
-                }
+                } else if (start<0) autosave_start[0]=-1;
             }
         } else if (autosave_count<9) {
             autosave_name[++autosave_count]=arg.substr(0, found);
             std::string remain=arg.substr(found+1);
             found=remain.find_last_of("-");
-            if (found==std::string::npos) {
+            if (found==std::string::npos||found==0) {
                 start=atoi(remain.c_str());
                 if (start>0) autosave_start[autosave_count]=start;
+                else if (start<0) autosave_start[autosave_count]=-1;
             } else {
                 start=atoi(remain.substr(0, found).c_str());
                 end=atoi(remain.substr(found+1).c_str());
                 if (start>0) {
                     autosave_start[autosave_count]=start;
                     if (end>=start) autosave_end[autosave_count]=end;
-                }
+                } else if (start<0) autosave_start[autosave_count]=-1;
             }
         }
     }

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -3217,7 +3217,7 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
                 SetGameState_Run(autosave_last[index]-1);
                 SaveGameState_Run();
                 SetGameState_Run(state);
-            } else {
+            } else if (!autosave_start[index]) {
                 SaveGameState_Run();
                 autosave_last[index]=GetGameState_Run()+1;
             }

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -100,7 +100,8 @@ extern bool vga_double_buffered_line_compare;
 extern bool pc98_crt_mode;      // see port 6Ah command 40h/41h.
 extern bool pc98_31khz_mode;
 extern bool auto_save_state, enable_autosave;
-extern int autosave_second, autosave_start, autosave_end, autosave_last;
+extern int autosave_second, autosave_count, autosave_start[10], autosave_end[10], autosave_last[10];
+extern std::string autosave_name[10];
 void SetGameState_Run(int value), SaveGameState_Run(void);
 size_t GetGameState_Run(void);
 
@@ -2790,6 +2791,7 @@ void VGA_CaptureWriteScanline(const uint8_t *raw) {
 uint32_t ticksPrev = 0;
 bool sync_time, manualtime=false;
 bool CodePageGuestToHostUint16(uint16_t *d/*CROSS_LEN*/,const char *s/*CROSS_LEN*/);
+extern const char* RunningProgram;
 
 static void VGA_VerticalTimer(Bitu /*val*/) {
     double current_time = PIC_GetCurrentEventTime();
@@ -3204,18 +3206,20 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
         uint32_t ticksNew=GetTicks();
         if (ticksNew-ticksPrev>autosave_second*1000) {
             auto_save_state=true;
-            if (autosave_start>=1&&autosave_start<=100) {
-                if (autosave_end>=1&&autosave_end<=100&&autosave_end>autosave_start) {
-                    if (autosave_end>autosave_last&&autosave_last>=autosave_start) autosave_last++;
-                    else autosave_last=autosave_start;
-                } else autosave_last=autosave_start;
+            int index=0;
+            for (int i=1; i<10&&i<=autosave_count; i++) if (autosave_name[i].size()&&!strcasecmp(RunningProgram, autosave_name[i].c_str())) index=i;
+            if (autosave_start[index]>=1&&autosave_start[index]<=100) {
+                if (autosave_end[index]>=autosave_start[index]&&autosave_end[index]<=100&&autosave_end[index]>autosave_start[index]) {
+                    if (autosave_end[index]>autosave_last[index]&&autosave_last[index]>=autosave_start[index]) autosave_last[index]++;
+                    else autosave_last[index]=autosave_start[index];
+                } else autosave_last[index]=autosave_start[index];
                 int state = GetGameState_Run();
-                SetGameState_Run(autosave_last-1);
+                SetGameState_Run(autosave_last[index]-1);
                 SaveGameState_Run();
                 SetGameState_Run(state);
             } else {
                 SaveGameState_Run();
-                autosave_last=GetGameState_Run()+1;
+                autosave_last[index]=GetGameState_Run()+1;
             }
             auto_save_state=false;
             ticksPrev=ticksNew;

--- a/src/misc/savestates.cpp
+++ b/src/misc/savestates.cpp
@@ -35,9 +35,10 @@
 #endif
 
 extern unsigned int page;
-extern int autosave_last;
-extern std::string savefilename;
+extern int autosave_last[10], autosave_count;
+extern std::string autosave_name[10], savefilename;
 extern bool use_save_file, clearline, dos_kernel_disabled;
+extern const char* RunningProgram;
 bool auto_save_state=false;
 bool noremark_save_state = false;
 bool force_load_state = false;
@@ -227,12 +228,15 @@ void PreviousSaveSlot(bool pressed) {
 }
 
 void LastAutoSaveSlot(bool pressed) {
-    if (!pressed||autosave_last<1) return;
+    if (!pressed) return;
+    int index=0;
+    for (int i=1; i<10&&i<=autosave_count; i++) if (autosave_name[i].size()&&!strcasecmp(RunningProgram, autosave_name[i].c_str())) index=i;
+    if (autosave_last[index]<1) return;
 
 	char name[6]="slot0";
 	name[4]='0'+(char)(currentSlot%SaveState::SLOT_COUNT);
 	mainMenu.get_item(name).check(false).refresh_item(mainMenu);
-    currentSlot.set(autosave_last-1);
+    currentSlot.set(autosave_last[index]-1);
     if (page!=currentSlot/SaveState::SLOT_COUNT) {
         page=(unsigned int)(currentSlot/SaveState::SLOT_COUNT);
         refresh_slots();
@@ -1135,7 +1139,6 @@ void SaveState::save(size_t slot) { //throw (Error)
 	bool create_machinetype=false;
 	bool create_timestamp=false;
 	bool create_saveremark=false;
-	extern const char* RunningProgram;
 	std::string path;
 	bool Get_Custom_SaveDir(std::string& savedir);
 	if(Get_Custom_SaveDir(path)) {

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -3759,7 +3759,10 @@ void DOS_Shell::CMD_CHCP(char * args) {
         WriteOut("Changing code page is not supported for the PC98 system.\n");
         return;
     }
-    if (!ttf.inUse) {
+#if defined(USE_TTF)
+    if (!ttf.inUse)
+#endif
+    {
         WriteOut("Changing code page is only supported for the TrueType font output.\n");
         return;
     }

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -3706,13 +3706,13 @@ void DOS_Shell::CMD_CTTY(char * args) {
 
 	/* must be device */
 	if (DOS_FindDevice(args) == DOS_DEVICES) {
-		WriteOut("Invalid device");
+		WriteOut("Invalid device - %s\n", args);
 		return;
 	}
 
 	/* close STDIN/STDOUT/STDERR and replace with new handle */
 	if (!DOS_OpenFile(args,OPEN_READWRITE,&handle)) {
-		WriteOut("Unable to open device");
+		WriteOut("Unable to open device - %s\n", args);
 		return;
 	}
 
@@ -3733,7 +3733,7 @@ void DOS_Shell::CMD_COUNTRY(char * args) {
 	args = trim(args);
 	if (!*args)
 		{
-		WriteOut("Current country code: %d\r\n", countryNo);
+		WriteOut("Current country code: %d\n", countryNo);
 		return;
 		}
 	int newCC;
@@ -3744,7 +3744,7 @@ void DOS_Shell::CMD_COUNTRY(char * args) {
 		DOS_SetCountry(countryNo);
 		return;
 		}
-	WriteOut("Invalid country code\r\n");
+	WriteOut("Invalid country code - %s\n", StripArg(args));
 	return;
 }
 
@@ -3752,7 +3752,7 @@ void DOS_Shell::CMD_CHCP(char * args) {
 	HELP("CHCP");
 	args = trim(args);
 	if (!*args) {
-		WriteOut("Active code page: %d\r\n", dos.loaded_codepage);
+		WriteOut("Active code page: %d\n", dos.loaded_codepage);
 		return;
 	}
     if (IS_PC98_ARCH) {


### PR DESCRIPTION
@emendelson has suggested the option to turn on the auto-saving feature automatically when a specified program is running, possibly include two or more specified programs. I think this is actually a very good idea for automation of the feature, so I have implemented it in this PR. I also added a GUI ("Auto-save settings" under "Capture" menu) to setup or change the auto-saving settings instead of using the config file for usability.