### PR TITLE
OPL3Duo MinGW fix

### DIFF
--- a/src/hardware/opl3duoboard/opl3duoboard.cpp
+++ b/src/hardware/opl3duoboard/opl3duoboard.cpp
@@ -36,6 +36,8 @@ void Opl3DuoBoard::disconnect() {
         stopOPL3DuoThread = true;
         thread.join();
     }
+#else
+    reset();
 #endif
 
     // Once buffer thread has stopped close the port.
@@ -76,10 +78,16 @@ void Opl3DuoBoard::write(uint32_t reg, uint8_t val) {
 			printf("OPL3 Duo! Board: Write %d --> %d\n", val, reg);
 		#endif
 
+#if !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
 		sendBuffer[bufferWrPos] = (reg >> 6) | 0x80;
 		sendBuffer[bufferWrPos + 1] = ((reg & 0x3f) << 1) | (val >> 7);
 		sendBuffer[bufferWrPos + 2] = (val & 0x7f);
         bufferWrPos = (bufferWrPos + 3) % OPL3_DUO_BUFFER_SIZE;
+#else
+        SERIAL_sendchar(comport, (reg >> 6) | 0x80);
+        SERIAL_sendchar(comport, ((reg & 0x3f) << 1) | (val >> 7));
+        SERIAL_sendchar(comport, val & 0x7f);
+#endif
 	}
 }
 


### PR DESCRIPTION
# Description

This fixes an issue where if MinGW is used no data will be sent to the OPL3Duo board because there is no buffer thread.

**Does this PR address some issue(s) ?**

* It fixes the case where builds using MinGW are not sending any data, introduced in #2171


**Does this PR introduce new feature(s) ?**

No


**Are there any breaking changes ?**

No


**Additional information**

