### PR TITLE
Fix building DOSBox-X RPMs for 32-bit ARM, PPC and s390x

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -869,6 +869,7 @@ AC_ARG_ENABLE(dynrec,AC_HELP_STRING([--disable-dynrec],[Disable recompiling cpu 
 AC_MSG_CHECKING(whether recompiling cpu core will be enabled) 
 if test x$enable_dynrec = xno -o x$enable_dynamic_core = xno; then 
    AC_MSG_RESULT(no)
+# test for MIPS32 is missing from this Dynamic Recompiler whitelist
 elif test x$c_targetcpu = xx86 -o x$c_targetcpu = xx86_64 -o x$c_targetcpu = arm; then
    AC_DEFINE(C_DYNREC,1)
    AC_MSG_RESULT(yes)

--- a/configure.ac
+++ b/configure.ac
@@ -536,7 +536,7 @@ case "$host_cpu" in
     c_targetcpu="m68k"
     c_unalignedmemory=yes
     ;;
-   armv7l)
+   armv7*)
     AC_DEFINE(C_TARGETCPU,ARMV7LE)
     AC_MSG_RESULT(ARMv7 Little Endian)
     c_targetcpu="arm"
@@ -854,11 +854,13 @@ dnl FEATURE: Whether to enable x86 dynamic core
 AH_TEMPLATE(C_DYNAMIC_X86,[Define to 1 to use x86/x64 dynamic cpu core])
 AC_ARG_ENABLE(dynamic-x86,AC_HELP_STRING([--disable-dynamic-x86],[Disable x86/x64 dynamic cpu core]),,enable_dynamic_x86=yes)
 AC_MSG_CHECKING(whether x86 dynamic cpu core will be enabled)
-if test x$enable_dynamic_x86 = xno -o x$enable_dynamic_core = xno -o x$c_targetcpu = xarm; then
+if test x$enable_dynamic_x86 = xno -o x$enable_dynamic_core = xno; then
    AC_MSG_RESULT(no)
-else
+elif test x$c_targetcpu = xx86 -o x$c_targetcpu = xx86_64; then
    AC_DEFINE(C_DYNAMIC_X86,1)
    AC_MSG_RESULT(yes)
+else
+   AC_MSG_RESULT(no)
 fi
 
 dnl FEATURE: Whether to enable recompiling dynamic core
@@ -867,9 +869,11 @@ AC_ARG_ENABLE(dynrec,AC_HELP_STRING([--disable-dynrec],[Disable recompiling cpu 
 AC_MSG_CHECKING(whether recompiling cpu core will be enabled) 
 if test x$enable_dynrec = xno -o x$enable_dynamic_core = xno; then 
    AC_MSG_RESULT(no)
-else
+elif test x$c_targetcpu = xx86 -o x$c_targetcpu = xx86_64 -o x$c_targetcpu = arm; then
    AC_DEFINE(C_DYNREC,1)
    AC_MSG_RESULT(yes)
+else
+   AC_MSG_RESULT(no)
 fi
 
 dnl FEATURE: Whether to emulate the floating point unit

--- a/contrib/linux/dosbox-x.spec.in
+++ b/contrib/linux/dosbox-x.spec.in
@@ -1,4 +1,4 @@
-Name:          dosbox-x
+Name:          @PACKAGE_NAME@
 Version:       @PACKAGE_VERSION@
 Release:       1%{?dist}
 Summary:       DOS emulator for running DOS games and applications including Windows 3.x/9x
@@ -27,9 +27,6 @@ BuildRequires: zlib-devel
 
 Requires:      fluid-soundfont-gm
 
-# Dynamic recompiler only supports x86 and arm
-ExclusiveArch: %{ix86} %{arm} x86_64 aarch64
-
 %description
 DOSBox-X is an open-source DOS emulator for running DOS games and applications.
 DOS-based Windows such as Windows 3.x and Windows 9x are officially supported.
@@ -52,11 +49,11 @@ DOSBox-X emulates a legacy IBM PC and DOS environment, and has many emulation
 options and features.
 
 %prep
-%autosetup -n dosbox-x
+%autosetup -n %{name}
 
 %build
 ./autogen.sh
-./configure --enable-core-inline --enable-debug=heavy --prefix=/usr --enable-sdl2
+%configure --enable-core-inline --enable-debug=heavy --enable-sdl2
 %make_build
 
 %install


### PR DESCRIPTION
# Description

As part of trying to get DOSBox-X approved for Fedora packaging, I ran into
some issues with 32-bit ARM, PPC and s390x. This PR fixes those issues
and now all the architectures that Fedora Koji builds on (above + i686,
x86_64 and Aarch64) are able to build successfully.

There is still the issue that DYNREC should apparently also compile for
MIPS32 (see src/cpu/core_dynrec/risc_mipsel32.h), but I'm not sure
how to add that to the CPU detect routine in configure.ac such that
it can be whitelisted for DYNREC. And I have no way of testing if it would
even work.

**Does this PR address some issue(s) ?**

https://github.com/joncampbell123/dosbox-x/issues/2236
