### PR TITLE
Implement BIOS Setup Utility

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,10 @@
   - Improved handling for file- and record-locking
     for non-Windows platforms. Portions of the code
     are adopted from DOSEmu. (Wengier)
+  - Added a simple BIOS Setup Utlity, which will show
+    a summary of the current system configuration and
+    allow users to change the date and time. Press Del
+    key at the BIOS boot screen to enter. (Wengier)
   - Added experimental option to load a VGA BIOS ROM
     image and execute it, instead of our own INT 10h
     emulation. If enabled, it will load the specific

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -283,6 +283,41 @@ void menu_update_cputype(void) {
         refresh_item(mainMenu);
 }
 
+const char *GetCPUType() {
+    if (CPU_ArchitectureType == CPU_ARCHTYPE_8086 && (cpudecoder != &CPU_Core8086_Prefetch_Run))
+        return "8086";
+    else if (CPU_ArchitectureType == CPU_ARCHTYPE_8086 && (cpudecoder == &CPU_Core8086_Prefetch_Run))
+        return "8086 Prefetch";
+    else if (CPU_ArchitectureType == CPU_ARCHTYPE_80186 && (cpudecoder != &CPU_Core286_Prefetch_Run))
+        return "80186";
+    else if (CPU_ArchitectureType == CPU_ARCHTYPE_80186 && (cpudecoder == &CPU_Core286_Prefetch_Run))
+        return "80186 Prefetch";
+    else if (CPU_ArchitectureType == CPU_ARCHTYPE_286 && (cpudecoder != &CPU_Core286_Prefetch_Run))
+        return "80286";
+    else if (CPU_ArchitectureType == CPU_ARCHTYPE_286 && (cpudecoder == &CPU_Core286_Prefetch_Run))
+        return "80286 Prefetch";
+    else if (CPU_ArchitectureType == CPU_ARCHTYPE_386 && (cpudecoder != &CPU_Core_Prefetch_Run))
+        return "80386";
+    else if (CPU_ArchitectureType == CPU_ARCHTYPE_386 && (cpudecoder == &CPU_Core_Prefetch_Run))
+        return "80386 prefetch";
+    else if (CPU_ArchitectureType == CPU_ARCHTYPE_486OLD && (cpudecoder != &CPU_Core_Prefetch_Run))
+        return "80486 (old)";
+    else if (CPU_ArchitectureType == CPU_ARCHTYPE_486OLD && (cpudecoder == &CPU_Core_Prefetch_Run))
+        return "80486 (old) prefetch";
+    else if (CPU_ArchitectureType == CPU_ARCHTYPE_486NEW && (cpudecoder != &CPU_Core_Prefetch_Run))
+        return "80486";
+    else if (CPU_ArchitectureType == CPU_ARCHTYPE_486NEW && (cpudecoder == &CPU_Core_Prefetch_Run))
+        return "80486 Prefetch";
+    else if (CPU_ArchitectureType == CPU_ARCHTYPE_PENTIUM)
+        return "Pentium";
+    else if (CPU_ArchitectureType == CPU_ARCHTYPE_PMMXSLOW)
+        return "Pentium MMX";
+    else if (CPU_ArchitectureType == CPU_ARCHTYPE_PPROSLOW)
+        return "Pentium Pro";
+    else
+        return "Mixed/other x86";
+}
+
 int GetDynamicType() {
     const Section_prop * section=static_cast<Section_prop *>(control->GetSection("cpu"));
     std::string core(section->Get_string("core"));

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -84,6 +84,7 @@ extern bool pc98_40col_text;
 extern bool en_bios_ps2mouse;
 extern bool rom_bios_8x8_cga_font;
 extern bool pcibus_enable;
+extern bool enable_fpu;
 
 uint32_t Keyb_ig_status();
 bool VM_Boot_DOSBox_Kernel();
@@ -133,7 +134,7 @@ unsigned int APM_BIOS_connected_minor_version = 0;// what version the OS connect
 unsigned int APM_BIOS_minor_version = 2;    // what version to emulate e.g to emulate 1.2 set this to 2
 
 /* default bios type/version/date strings */
-const char* const bios_type_string = "IBM COMPATIBLE 486 BIOS for DOSBox-X";
+const char* const bios_type_string = "IBM COMPATIBLE BIOS for DOSBox-X";
 const char* const bios_version_string = "DOSBox-X BIOS v1.0";
 const char* const bios_date_string = "01/01/92";
 
@@ -6928,6 +6929,84 @@ static void BIOS_Int10RightJustifiedPrint(const int x,int &y,const char *msg) {
     }
 }
 
+char *getSetupLine(const char *capt, const char *cont) {
+    unsigned int pad1=25-strlen(capt), pad2=41-strlen(cont);
+    static char line[90];
+    sprintf(line, "บ%*c%s%*c%s%*cบ", 12, ' ', capt, pad1, ' ', cont, pad2, ' ');
+    return line;
+}
+
+void showDateTime(uint32_t value, int x, int y)
+{
+    char datestr[30], timestr[30];
+    sprintf(datestr, "%04u-%02u-%02u",dos.date.year,dos.date.month,dos.date.day);
+    BIOS_Int10RightJustifiedPrint(x,y,getSetupLine("System date:", datestr));
+    Bitu time=(Bitu)((100.0/((double)PIT_TICK_RATE/65536.0)) * (double)value)/100;
+    unsigned int sec=(uint8_t)((Bitu)time % 60);
+    time/=60;
+    unsigned int min=(uint8_t)((Bitu)time % 60);
+    time/=60;
+    unsigned int hour=(uint8_t)((Bitu)time % 24);
+    sprintf(timestr, "%02u:%02u:%02u",hour,min,sec);
+    BIOS_Int10RightJustifiedPrint(x,y,getSetupLine("System time:", timestr));
+}
+
+void showBIOSSetup(const char* card, int x, int y) {
+    reg_eax = 3;        // 80x25 text
+    CALLBACK_RunRealInt(0x10);
+    reg_eax = 0x0200u;
+    reg_ebx = 0x0000u;
+    reg_edx = 0x0000u;
+    CALLBACK_RunRealInt(0x10);
+    reg_eax = 0x0600u;
+    reg_ebx = 0x1e00u;
+    reg_ecx = 0x0000u;
+    reg_edx = 0x184Fu;
+    CALLBACK_RunRealInt(0x10);
+    BIOS_Int10RightJustifiedPrint(x,y,"                               BIOS Setup Utility                               ");
+    BIOS_Int10RightJustifiedPrint(x,y,"ษออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออป");
+    BIOS_Int10RightJustifiedPrint(x,y,"บ                                                                              บ");
+    showDateTime(BIOS_HostTimeSync(0),x,y);
+    BIOS_Int10RightJustifiedPrint(x,y,getSetupLine("Installed OS:", "DOS"));
+    BIOS_Int10RightJustifiedPrint(x,y,"บ                                                                              บ");
+#define DOSNAMEBUF 256
+    char pcname[DOSNAMEBUF];
+#if defined(WIN32)
+    DWORD size = DOSNAMEBUF;
+    GetComputerName(pcname, &size);
+    if (!size)
+#else
+    int result = gethostname(pcname, DOSNAMEBUF);
+    if (result)
+#endif
+        strcpy(pcname, "N/A");
+    BIOS_Int10RightJustifiedPrint(x,y,getSetupLine("Computer name:", pcname));
+    BIOS_Int10RightJustifiedPrint(x,y,getSetupLine("Product name:", ("DOSBox-X "+std::string(VERSION)).c_str()));
+    BIOS_Int10RightJustifiedPrint(x,y,getSetupLine("Product updated:", UPDATED_STR));
+    BIOS_Int10RightJustifiedPrint(x,y,"บ                                                                              บ");
+    BIOS_Int10RightJustifiedPrint(x,y,getSetupLine("BIOS description:", bios_type_string));
+    BIOS_Int10RightJustifiedPrint(x,y,getSetupLine("BIOS version:", bios_version_string));
+    uint32_t year,month,day;
+    if (sscanf(bios_date_string,"%u/%u/%u",&month,&day,&year)==3) {
+        char datestr[30];
+        sprintf(datestr, "%04u-%02u-%02u",year<80?2000+year:(year<100?1900+year:year),month,day);
+        BIOS_Int10RightJustifiedPrint(x,y,getSetupLine("BIOS date:", datestr));
+    } else
+        BIOS_Int10RightJustifiedPrint(x,y,getSetupLine("BIOS date:", bios_date_string));
+    BIOS_Int10RightJustifiedPrint(x,y,"บ                                                                              บ");
+    const char *GetCPUType();
+    BIOS_Int10RightJustifiedPrint(x,y,getSetupLine("Processor type:", GetCPUType()));
+    BIOS_Int10RightJustifiedPrint(x,y,getSetupLine("Processor speed:", (std::to_string(CPU_CycleAutoAdjust?CPU_CyclePercUsed:CPU_CycleMax)+" cycles/ms").c_str()));
+    BIOS_Int10RightJustifiedPrint(x,y,getSetupLine("Coprocessor:", enable_fpu?"Yes":"No"));
+    BIOS_Int10RightJustifiedPrint(x,y,"บ                                                                              บ");
+    BIOS_Int10RightJustifiedPrint(x,y,getSetupLine("Video card:", card));
+    BIOS_Int10RightJustifiedPrint(x,y,getSetupLine("Video memory:", (std::to_string(vga.mem.memsize/1024)+"K").c_str()));
+    BIOS_Int10RightJustifiedPrint(x,y,getSetupLine("Total memory:", (std::to_string(MEM_TotalPages()*4096/1024)+"K").c_str()));
+    BIOS_Int10RightJustifiedPrint(x,y,"บ                                                                              บ");
+    BIOS_Int10RightJustifiedPrint(x,y,"ศออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออออผ");
+    BIOS_Int10RightJustifiedPrint(x,y,"                                   ESC = Exit                                  ");
+}
+
 static Bitu ulimit = 0;
 static Bitu t_conv = 0;
 static bool bios_first_init=true;
@@ -8301,6 +8380,9 @@ private:
 #endif
             return CBRET_NONE;
         }
+        extern const char* RunningProgram;
+        RunningProgram = "DOSBOX-X";
+        GFX_SetTitle(-1,-1,-1,false);
         const char *msg = "DOSBox-X (C) 2011-" COPYRIGHT_END_YEAR " The DOSBox-X Team\nDOSBox-X project maintainer: joncampbell123\nDOSBox-X project homepage: https://dosbox-x.com\n\n";
         int logo_x,logo_y,x,y,rowheight=8;
 
@@ -8427,62 +8509,62 @@ private:
             BIOS_Int10RightJustifiedPrint(x,y,tmp);
         }
 
+        const char *card = "Unknown Graphics Adapter";
+
+        switch (machine) {
+            case MCH_CGA:
+                card = "IBM Color Graphics Adapter";
+                break;
+            case MCH_MCGA:
+                card = "IBM Multi Color Graphics Adapter";
+                break;
+            case MCH_MDA:
+                card = "IBM Monochrome Display Adapter";
+                break;
+            case MCH_HERC:
+                card = "IBM Monochrome Display Adapter (Hercules)";
+                break;
+            case MCH_EGA:
+                card = "IBM Enhanced Graphics Adapter";
+                break;
+            case MCH_PCJR:
+                card = "PCjr Graphics Adapter";
+                break;
+            case MCH_TANDY:
+                card = "Tandy Graphics Adapter";
+                break;
+            case MCH_VGA:
+                switch (svgaCard) {
+                    case SVGA_TsengET4K:
+                        card = "Tseng ET4000 SVGA";
+                        break;
+                    case SVGA_TsengET3K:
+                        card = "Tseng ET3000 SVGA";
+                        break;
+                    case SVGA_ParadisePVGA1A:
+                        card = "Paradise SVGA";
+                        break;
+                    case SVGA_S3Trio:
+                        card = "S3 Trio SVGA";
+                        break;
+                    default:
+                        card = "Standard VGA";
+                        break;
+                }
+
+                break;
+            case MCH_PC98:
+                card = "PC98 graphics";
+                break;
+            case MCH_AMSTRAD:
+                card = "Amstrad graphics";
+                break;
+            default:
+                abort(); // should not happen
+        }
+
         {
             char tmp[512];
-            const char *card = "?";
-
-            switch (machine) {
-                case MCH_CGA:
-                    card = "IBM Color Graphics Adapter";
-                    break;
-                case MCH_MCGA:
-                    card = "IBM Multi Color Graphics Adapter";
-                    break;
-                case MCH_MDA:
-                    card = "IBM Monochrome Display Adapter";
-                    break;
-                case MCH_HERC:
-                    card = "IBM Monochrome Display Adapter (Hercules)";
-                    break;
-                case MCH_EGA:
-                    card = "IBM Enhanced Graphics Adapter";
-                    break;
-                case MCH_PCJR:
-                    card = "PCjr graohics adapter";
-                    break;
-                case MCH_TANDY:
-                    card = "Tandy graohics adapter";
-                    break;
-                case MCH_VGA:
-                    switch (svgaCard) {
-                        case SVGA_TsengET4K:
-                            card = "Tseng ET4000 SVGA";
-                            break;
-                        case SVGA_TsengET3K:
-                            card = "Tseng ET3000 SVGA";
-                            break;
-                        case SVGA_ParadisePVGA1A:
-                            card = "Paradise SVGA";
-                            break;
-                        case SVGA_S3Trio:
-                            card = "S3 Trio SVGA";
-                            break;
-                        default:
-                            card = "Standard VGA";
-                            break;
-                    }
-
-                    break;
-                case MCH_PC98:
-                    card = "PC98 graphics";
-                    break;
-                case MCH_AMSTRAD:
-                    card = "Amstrad graphics";
-                    break;
-                default:
-                    abort(); // should not happen
-            }
-
             sprintf(tmp,"Video card is %s\n",card);
             BIOS_Int10RightJustifiedPrint(x,y,tmp);
         }
@@ -8516,6 +8598,9 @@ private:
                 case CPU_ARCHTYPE_PMMXSLOW:
                     cpuType = "Pentium MMX";
                     break;
+                case CPU_ARCHTYPE_PPROSLOW:
+                    cpuType = "Pentium Pro";
+                    break;
                 case CPU_ARCHTYPE_MIXED:
                     cpuType = "Auto (mixed)";
                     break;
@@ -8539,6 +8624,7 @@ private:
 
 #if !defined(C_EMSCRIPTEN)
         BIOS_Int10RightJustifiedPrint(x,y,"\nHit SPACEBAR to pause at this screen\n");
+        if (machine != MCH_PC98) BIOS_Int10RightJustifiedPrint(x,y,"\nPress DEL to enter BIOS setup screen\n");
         y--; /* next message should overprint */
         if (machine != MCH_PC98) {
             reg_eax = 0x0200;   // set cursor pos
@@ -8557,7 +8643,7 @@ private:
         // TODO: Then at this screen, we can print messages demonstrating the detection of
         //       IDE devices, floppy, ISA PnP initialization, anything of importance.
         //       I also envision adding the ability to hit DEL or F2 at this point to enter
-        //       a "BIOS setup" screen where all DOSBox configuration options can be
+        //       a "BIOS setup" screen where all DOSBox-X configuration options can be
         //       modified, with the same look and feel of an old BIOS.
 
 #if C_EMSCRIPTEN
@@ -8570,7 +8656,7 @@ private:
 #else
         bool fastbioslogo=static_cast<Section_prop *>(control->GetSection("dosbox"))->Get_bool("fastbioslogo")||control->opt_fastbioslogo||control->opt_fastlaunch;
         if (!fastbioslogo&&!bootguest&&!bootfast&&(bootvm||!use_quick_reboot)) {
-            bool wait_for_user = false;
+            bool wait_for_user = false, bios_setup = false;
             uint32_t lasttick=GetTicks();
             while ((GetTicks()-lasttick)<1000) {
                 if (machine == MCH_PC98) {
@@ -8595,7 +8681,14 @@ private:
 
                     if (reg_al == 32) { // user hit space
                         BIOS_Int10RightJustifiedPrint(x,y,"Hit ENTER or ESC to continue                    \n"); // overprint
+                        if (machine != MCH_PC98) BIOS_Int10RightJustifiedPrint(x,y,"\nPress DEL to enter BIOS setup screen\n");
                         wait_for_user = true;
+                        break;
+                    }
+
+                    if (machine != MCH_PC98 && reg_ax == 0x5300) { // user hit Del
+                        bios_setup = true;
+                        showBIOSSetup(card, x, y);
                         break;
                     }
                 }
@@ -8611,8 +8704,52 @@ private:
                     CALLBACK_RunRealInt(0x16);
                 }
 
+                if (machine != MCH_PC98 && reg_ax == 0x5300/*DEL*/) {
+                    bios_setup = true;
+                    showBIOSSetup(card, x, y);
+                    break;
+                }
+
                 if (reg_al == 27/*ESC*/ || reg_al == 13/*ENTER*/)
                     break;
+            }
+
+            lasttick=GetTicks();
+            while (bios_setup) {
+                if (GetTicks()-lasttick>=1000) {
+                    lasttick=GetTicks();
+                    reg_eax = 0x0200u;
+                    reg_ebx = 0x0000u;
+                    reg_edx = 0x0300u;
+                    CALLBACK_RunRealInt(0x10);
+                    showDateTime(BIOS_HostTimeSync(0),x,y);
+                    reg_eax = 0x0200u;
+                    reg_ebx = 0x0000u;
+                    reg_edx = 0x1823u;
+                    CALLBACK_RunRealInt(0x10);
+                }
+                if (machine == MCH_PC98) {
+                    reg_eax = 0x0100;   // sense key
+                    CALLBACK_RunRealInt(0x18);
+                    SETFLAGBIT(ZF,reg_bh == 0);
+                }
+                else {
+                    reg_eax = 0x0100;
+                    CALLBACK_RunRealInt(0x16);
+                }
+
+                if (!GETFLAG(ZF)) {
+                    if (machine == MCH_PC98) {
+                        reg_eax = 0x0000;   // read key
+                        CALLBACK_RunRealInt(0x18);
+                    }
+                    else {
+                        reg_eax = 0x0000;
+                        CALLBACK_RunRealInt(0x16);
+                    }
+                    if (reg_al == 27/*ESC*/)
+                        throw int(3);
+                }
             }
 #if defined(USE_TTF)
         } else if (TTF_using() && machine != MCH_PC98) {


### PR DESCRIPTION
There is currently a BIOS screen when DOSBox-X starts, but as mentioned in Issue #2255 it did not actually provide useful functions. This PR adds a simple BIOS Setup Utility which can be entered by pressing the Del key at the BIOS screen. The BIOS Setup Utility will show a summary of the current system configuration, although for now users can only change the date and time using this utility. Also fixed Issue #2284.