### PR TITLE
Fix Issue #2261 and more

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -95,6 +95,9 @@
     directory has no 8.3 filename entry. (Wengier)
   - Fixed an issue in MinGW builds that no data will be
     sent to the OPL3Duo board. (DhrBaksteen)
+  - Fixed screen flickering when hovering over the menu
+    with Direct3D output in the Windows SDL2 build that
+    was introduced in the last version. (Wengier)
   - Fixed that the "Save" button in Configuration Tool
     did not save config file in last version. (Wengier)
   - Integrated SVN commits (Allofich)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,9 +2,10 @@
   - Improved handling for file- and record-locking
     for non-Windows platforms. Portions of the code
     are adopted from DOSEmu. (Wengier)
-  - With the option "startcmd=true" or -winrun, you can
-    now start Windows applications from within a DOS
-    program or the 4DOS shell. (Wengier)
+  - With the config option "startcmd=true" or command-
+    line option -winrun, you can now launch Windows
+    applications from within a DOS program or from the
+    4DOS shell in addition to built-in shell. (Wengier)
   - Added a simple BIOS Setup Utlity, which will show
     a summary of the current system configuration and
     allow users to change the date and time. Press Del

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,9 @@
   - Improved handling for file- and record-locking
     for non-Windows platforms. Portions of the code
     are adopted from DOSEmu. (Wengier)
+  - With the option "startcmd=true" or -winrun, you can
+    now start Windows applications from within a DOS
+    program or the 4DOS shell. (Wengier)
   - Added a simple BIOS Setup Utlity, which will show
     a summary of the current system configuration and
     allow users to change the date and time. Press Del

--- a/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
+++ b/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
@@ -10,7 +10,7 @@
     <category>Emulation</category>
   </categories>
   <releases>
-          <release version="@PACKAGE_VERSION@" date="2021-2-15"/>
+          <release version="@PACKAGE_VERSION@" date="2021-2-19"/>
   </releases>
   <screenshots>
 	  <screenshot type="default">

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -1220,7 +1220,7 @@ fluid.soundfont         =
 #DOSBOX-X-ADV:#                                                     such DOS applications may reduce audible popping and artifacts.
 #DOSBOX-X-ADV:#                                         irq hack: Specify a hack related to the Sound Blaster IRQ to avoid crashes in a handful of games and demos.
 #DOSBOX-X-ADV:#                                                         none                   Emulate IRQs normally
-#DOSBOX-X-ADV:#                                                         cs_equ_ds              Do not fire IRQ unless two CPU segment registers match: CS == DS. Read Dosbox-X Wiki or source code for details.
+#DOSBOX-X-ADV:#                                                         cs_equ_ds              Do not fire IRQ unless two CPU segment registers match: CS == DS. Read DOSBox-X Wiki or source code for details.
 #                                              dma: The DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the DMA unassigned
 #                                                     Possible values: 1, 5, 0, 3, 6, 7.
 #                                             hdma: The High DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the High DMA unassigned
@@ -1398,7 +1398,7 @@ blaster environment variable                     = true
 #                                       Possible values: 3, 0, 1, 5, 6, 7.
 #DOSBOX-X-ADV:#                           irq hack: Specify a hack related to the Gravis Ultrasound IRQ to avoid crashes in a handful of games and demos.
 #DOSBOX-X-ADV:#                                           none                   Emulate IRQs normally
-#DOSBOX-X-ADV:#                                           cs_equ_ds              Do not fire IRQ unless two CPU segment registers match: CS == DS. Read Dosbox-X Wiki or source code for details.
+#DOSBOX-X-ADV:#                                           cs_equ_ds              Do not fire IRQ unless two CPU segment registers match: CS == DS. Read DOSBox-X Wiki or source code for details.
 #                            gustype: Type of Gravis Ultrasound to emulate.
 #                                       classic             Original Gravis Ultrasound chipset
 #                                       classic37           Original Gravis Ultrasound with ICS Mixer (rev 3.7)
@@ -2233,7 +2233,7 @@ rem = This section is the 4DOS.INI file, if you use 4DOS as the command shell
 #       dos: Reports whether DOS occupies HMA and allocates UMB memory (if available).
 #      fcbs: Number of FCB handles available to DOS programs (1-255).
 #     files: Number of file handles available to DOS programs (8-255).
-#   country: Sets the country code for country-specific date/time formats.
+#   country: Sets the country code for country-specific date & time formats.
 # lastdrive: The maximum drive letter that can be accessed by programs.
 #              Possible values: a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z.
 rem         = This section is DOS's CONFIG.SYS file, not all CONFIG.SYS options supported

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -164,7 +164,7 @@ logfile     =
 [dosbox]
 #                                        language: Select another language file.
 #                                           title: Additional text to place in the title bar of the window.
-#                                    fastbioslogo: If set, DOSBox-X will enable fast BIOS logo mode (skip 1-second pause).
+#                                    fastbioslogo: If set, DOSBox-X will skip the BIOS screen by activating fast BIOS logo mode (without 1-second pause).
 #                                     startbanner: If set (default), DOSBox-X will display the welcome banner when it starts.
 #                                bannercolortheme: You can specify a different background color theme for the welcome banner from the default one.
 #                                                    Possible values: default, black, red, green, yellow, blue, magenta, cyan, white.
@@ -1879,9 +1879,9 @@ timeout     = 0
 #                                                     If set to false or none, DOSBox-X will not show such messages on the screen when the error occurred.
 #                                                     If set to "a20fix" or "loadfix", DOSBox-X will show the message for the a20fix or the loadfix only.
 #                                                     Possible values: true, false, 1, 0, both, a20fix, loadfix, none.
-#                                         startcmd: Allow starting commands to run on the Windows host including the use of START command.
-#                                        startwait: Specify whether DOSBox-X should wait for the Windows programs after they are started.
-#                                       startquiet: If set, DOSBox-X will not show information messages before launching Windows programs to run on the host.
+#                                         startcmd: Allow starting Windows programs or commands to run on the Windows host including the use of START command.
+#                                        startwait: Specify whether DOSBox-X should wait for the Windows applications after they are started.
+#                                       startquiet: If set, before launching Windows applications to run on the host DOSBox-X will not show messages like "Now run it as a Windows application".
 #DOSBOX-X-ADV:#                                       startincon: START command will start these commands (separated by space) in a console and wait for a key press before exiting.
 #                                            int33: Enable INT 33H for mouse support.
 #DOSBOX-X-ADV:#   int33 hide host cursor if interrupt subroutine: If set, the cursor on the host will be hidden if the DOS application provides it's own

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -879,7 +879,7 @@ rem = This section is the 4DOS.INI file, if you use 4DOS as the command shell
 #       dos: Reports whether DOS occupies HMA and allocates UMB memory (if available).
 #      fcbs: Number of FCB handles available to DOS programs (1-255).
 #     files: Number of file handles available to DOS programs (8-255).
-#   country: Sets the country code for country-specific date/time formats.
+#   country: Sets the country code for country-specific date & time formats.
 # lastdrive: The maximum drive letter that can be accessed by programs.
 #              Possible values: a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z.
 rem         = This section is DOS's CONFIG.SYS file, not all CONFIG.SYS options supported

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -79,7 +79,7 @@ logfile =
 [dosbox]
 #              language: Select another language file.
 #                 title: Additional text to place in the title bar of the window.
-#          fastbioslogo: If set, DOSBox-X will enable fast BIOS logo mode (skip 1-second pause).
+#          fastbioslogo: If set, DOSBox-X will skip the BIOS screen by activating fast BIOS logo mode (without 1-second pause).
 #           startbanner: If set (default), DOSBox-X will display the welcome banner when it starts.
 #      bannercolortheme: You can specify a different background color theme for the welcome banner from the default one.
 #                          Possible values: default, black, red, green, yellow, blue, magenta, cyan, white.
@@ -761,9 +761,9 @@ timeout     = 0
 #                                    If set to false or none, DOSBox-X will not show such messages on the screen when the error occurred.
 #                                    If set to "a20fix" or "loadfix", DOSBox-X will show the message for the a20fix or the loadfix only.
 #                                    Possible values: true, false, 1, 0, both, a20fix, loadfix, none.
-#                        startcmd: Allow starting commands to run on the Windows host including the use of START command.
-#                       startwait: Specify whether DOSBox-X should wait for the Windows programs after they are started.
-#                      startquiet: If set, DOSBox-X will not show information messages before launching Windows programs to run on the host.
+#                        startcmd: Allow starting Windows programs or commands to run on the Windows host including the use of START command.
+#                       startwait: Specify whether DOSBox-X should wait for the Windows applications after they are started.
+#                      startquiet: If set, before launching Windows applications to run on the host DOSBox-X will not show messages like "Now run it as a Windows application".
 #                           int33: Enable INT 33H for mouse support.
 #                  keyboardlayout: Language code of the keyboard layout (or none).
 #     dos clipboard device enable: If enabled, a DOS device will be added for bidirectional communications with the Windows clipboard.

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -1220,7 +1220,7 @@ fluid.chorus.type       = 0
 #                                                     such DOS applications may reduce audible popping and artifacts.
 #                                         irq hack: Specify a hack related to the Sound Blaster IRQ to avoid crashes in a handful of games and demos.
 #                                                         none                   Emulate IRQs normally
-#                                                         cs_equ_ds              Do not fire IRQ unless two CPU segment registers match: CS == DS. Read Dosbox-X Wiki or source code for details.
+#                                                         cs_equ_ds              Do not fire IRQ unless two CPU segment registers match: CS == DS. Read DOSBox-X Wiki or source code for details.
 #                                              dma: The DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the DMA unassigned
 #                                                     Possible values: 1, 5, 0, 3, 6, 7.
 #                                             hdma: The High DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the High DMA unassigned
@@ -1398,7 +1398,7 @@ io port aliasing                                 = true
 #                                       Possible values: 3, 0, 1, 5, 6, 7.
 #                           irq hack: Specify a hack related to the Gravis Ultrasound IRQ to avoid crashes in a handful of games and demos.
 #                                           none                   Emulate IRQs normally
-#                                           cs_equ_ds              Do not fire IRQ unless two CPU segment registers match: CS == DS. Read Dosbox-X Wiki or source code for details.
+#                                           cs_equ_ds              Do not fire IRQ unless two CPU segment registers match: CS == DS. Read DOSBox-X Wiki or source code for details.
 #                            gustype: Type of Gravis Ultrasound to emulate.
 #                                       classic             Original Gravis Ultrasound chipset
 #                                       classic37           Original Gravis Ultrasound with ICS Mixer (rev 3.7)
@@ -2233,7 +2233,7 @@ rem = This section is the 4DOS.INI file, if you use 4DOS as the command shell
 #       dos: Reports whether DOS occupies HMA and allocates UMB memory (if available).
 #      fcbs: Number of FCB handles available to DOS programs (1-255).
 #     files: Number of file handles available to DOS programs (8-255).
-#   country: Sets the country code for country-specific date/time formats.
+#   country: Sets the country code for country-specific date & time formats.
 # lastdrive: The maximum drive letter that can be accessed by programs.
 #              Possible values: a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z.
 rem         = This section is DOS's CONFIG.SYS file, not all CONFIG.SYS options supported

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -164,7 +164,7 @@ fileio      = false
 [dosbox]
 #                                        language: Select another language file.
 #                                           title: Additional text to place in the title bar of the window.
-#                                    fastbioslogo: If set, DOSBox-X will enable fast BIOS logo mode (skip 1-second pause).
+#                                    fastbioslogo: If set, DOSBox-X will skip the BIOS screen by activating fast BIOS logo mode (without 1-second pause).
 #                                     startbanner: If set (default), DOSBox-X will display the welcome banner when it starts.
 #                                bannercolortheme: You can specify a different background color theme for the welcome banner from the default one.
 #                                                    Possible values: default, black, red, green, yellow, blue, magenta, cyan, white.
@@ -1879,9 +1879,9 @@ timeout     = 0
 #                                                     If set to false or none, DOSBox-X will not show such messages on the screen when the error occurred.
 #                                                     If set to "a20fix" or "loadfix", DOSBox-X will show the message for the a20fix or the loadfix only.
 #                                                     Possible values: true, false, 1, 0, both, a20fix, loadfix, none.
-#                                         startcmd: Allow starting commands to run on the Windows host including the use of START command.
-#                                        startwait: Specify whether DOSBox-X should wait for the Windows programs after they are started.
-#                                       startquiet: If set, DOSBox-X will not show information messages before launching Windows programs to run on the host.
+#                                         startcmd: Allow starting Windows programs or commands to run on the Windows host including the use of START command.
+#                                        startwait: Specify whether DOSBox-X should wait for the Windows applications after they are started.
+#                                       startquiet: If set, before launching Windows applications to run on the host DOSBox-X will not show messages like "Now run it as a Windows application".
 #                                       startincon: START command will start these commands (separated by space) in a console and wait for a key press before exiting.
 #                                            int33: Enable INT 33H for mouse support.
 #   int33 hide host cursor if interrupt subroutine: If set, the cursor on the host will be hidden if the DOS application provides it's own

--- a/include/build_timestamp.h
+++ b/include/build_timestamp.h
@@ -1,4 +1,4 @@
 /*auto-generated*/
-#define UPDATED_STR "Feb 15, 2021 3:55:09pm"
-#define GIT_COMMIT_HASH "45fbbb9"
+#define UPDATED_STR "Feb 19, 2021 3:28:35pm"
+#define GIT_COMMIT_HASH "f562256"
 #define COPYRIGHT_END_YEAR "2021"

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -40,6 +40,9 @@
 #include "dos_network.h"
 #include "render.h"
 #if defined(WIN32)
+#include "../dos/cdrom.h"
+#include <shellapi.h>
+#include <shlwapi.h>
 #include <winsock.h>
 #else
 #include <unistd.h>
@@ -113,10 +116,10 @@ const char dos_clipboard_device_default[]="CLIP$";
 int maxfcb=100;
 int maxdrive=1;
 int enablelfn=-1;
-bool uselfn;
+bool uselfn, winautorun=false;
 extern int infix;
 extern bool int15_wait_force_unmask_irq, shellrun, i4dos;
-extern bool winrun, startcmd, startwait, startquiet, winautorun;
+extern bool winrun, startcmd, startwait, startquiet, ctrlbrk;
 extern bool startup_state_numlock, mountwarning, clipboard_dosapi;
 std::string startincon;
 
@@ -573,6 +576,148 @@ typedef struct {
 } ext_space_info_t;
 
 #define DOSNAMEBUF 256
+char appname[DOSNAMEBUF+2+DOS_NAMELENGTH_ASCII], appargs[CTBUF];
+
+#if defined (WIN32) && !defined(HX_DOS)
+intptr_t hret=0;
+void EndRunProcess() {
+    if(hret) {
+        DWORD exitCode;
+        GetExitCodeProcess((HANDLE)hret, &exitCode);
+        if (exitCode==STILL_ACTIVE)
+            TerminateProcess((HANDLE)hret, 0);
+    }
+    ctrlbrk=false;
+}
+
+void HostAppRun() {
+    char comline[256], *p=comline;
+    char winDirCur[512], winDirNew[512], winName[256], dir[CROSS_LEN+15];
+    char *fullname=appname;
+    uint8_t drive;
+    if (!DOS_MakeName(fullname, winDirNew, &drive)) return;
+    if (GetCurrentDirectory(512, winDirCur)&&(!strncmp(Drives[drive]->GetInfo(),"local ",6)||!strncmp(Drives[drive]->GetInfo(),"CDRom ",6))) {
+        bool useoverlay=false;
+        Overlay_Drive *odp = dynamic_cast<Overlay_Drive*>(Drives[drive]);
+        if (odp != NULL) {
+            strcpy(winName, odp->getOverlaydir());
+            strcat(winName, winDirNew);
+            struct stat tempstat;
+            if (stat(winName,&tempstat)==0 && (tempstat.st_mode & S_IFDIR)==0)
+                useoverlay=true;
+        }
+        if (!useoverlay) {
+            strcpy(winName, Drives[drive]->GetBaseDir());
+            strcat(winName, winDirNew);
+            if (!PathFileExists(winName)) {
+                bool olfn=uselfn;
+                uselfn=true;
+                if (DOS_GetSFNPath(fullname,dir,true)&&DOS_MakeName(("\""+std::string(dir)+"\"").c_str(), winDirNew, &drive)) {
+                    strcpy(winName, Drives[drive]->GetBaseDir());
+                    strcat(winName, winDirNew);
+                }
+                uselfn=olfn;
+            }
+        }
+        if (!strncmp(Drives[DOS_GetDefaultDrive()]->GetInfo(),"local ",6)||!strncmp(Drives[DOS_GetDefaultDrive()]->GetInfo(),"CDRom ",6)) {
+            Overlay_Drive *ddp = dynamic_cast<Overlay_Drive*>(Drives[DOS_GetDefaultDrive()]);
+            strcpy(winDirNew, ddp!=NULL?ddp->getOverlaydir():Drives[DOS_GetDefaultDrive()]->GetBaseDir());
+            strcat(winDirNew, Drives[DOS_GetDefaultDrive()]->curdir);
+            if (!PathFileExists(winDirNew)) {
+                bool olfn=uselfn;
+                uselfn=true;
+                if (DOS_GetCurrentDir(0,dir,true)) {
+                    strcpy(winDirNew, ddp!=NULL?ddp->getOverlaydir():Drives[DOS_GetDefaultDrive()]->GetBaseDir());
+                    strcat(winDirNew, dir);
+                }
+                uselfn=olfn;
+            }
+        } else {
+            strcpy(winDirNew, useoverlay?odp->getOverlaydir():Drives[drive]->GetBaseDir());
+            strcat(winDirNew, Drives[drive]->curdir);
+        }
+        if (SetCurrentDirectory(winDirNew)) {
+            SHELLEXECUTEINFO lpExecInfo;
+            strcpy(comline, appargs);
+            strcpy(comline, trim(p));
+            if (!startquiet) {
+                char msg[]="Now run it as a Windows application...\r\n";
+                uint16_t s = (uint16_t)strlen(msg);
+                DOS_WriteFile(STDOUT,(uint8_t*)msg,&s);
+            }
+            DWORD temp = (DWORD)SHGetFileInfo(winName,NULL,NULL,NULL,SHGFI_EXETYPE);
+            if (temp==0) temp = (DWORD)SHGetFileInfo((std::string(winDirNew)+"\\"+std::string(fullname)).c_str(),NULL,NULL,NULL,SHGFI_EXETYPE);
+            if (HIWORD(temp)==0 && LOWORD(temp)==0x4550) { // Console applications
+                lpExecInfo.cbSize  = sizeof(SHELLEXECUTEINFO);
+                lpExecInfo.fMask=SEE_MASK_DOENVSUBST|SEE_MASK_NOCLOSEPROCESS;
+                lpExecInfo.hwnd = NULL;
+                lpExecInfo.lpVerb = "open";
+                lpExecInfo.lpDirectory = NULL;
+                lpExecInfo.nShow = SW_SHOW;
+                lpExecInfo.hInstApp = (HINSTANCE) SE_ERR_DDEFAIL;
+                strcpy(dir, "/C \"");
+                strcat(dir, winName);
+                strcat(dir, " ");
+                strcat(dir, comline);
+                strcat(dir, " & echo( & echo The command execution is completed. & pause\"");
+                lpExecInfo.lpFile = "CMD.EXE";
+                lpExecInfo.lpParameters = dir;
+                ShellExecuteEx(&lpExecInfo);
+                hret = (intptr_t)lpExecInfo.hProcess;
+            } else {
+                char qwinName[258];
+                sprintf(qwinName,"\"%s\"",winName);
+                hret = _spawnl(P_NOWAIT, winName, qwinName, comline, NULL);
+            }
+            SetCurrentDirectory(winDirCur);
+            if (startwait && hret > 0) {
+                int count=0;
+                ctrlbrk=false;
+                DWORD exitCode = 0;
+                GetExitCodeProcess((HANDLE)hret, &exitCode);
+                while (GetExitCodeProcess((HANDLE)hret, &exitCode) && exitCode == STILL_ACTIVE) {
+                    CALLBACK_Idle();
+                    if (ctrlbrk) {
+                        uint8_t c;uint16_t n=1;
+                        DOS_ReadFile (STDIN,&c,&n);
+                        if (c == 3) {
+                            char msg[]="^C\r\n";
+                            uint16_t s = (uint16_t)strlen(msg);
+                            DOS_WriteFile(STDOUT,(uint8_t*)msg,&s);
+                        }
+                        EndRunProcess();
+                        exitCode=0;
+                        break;
+                    }
+                    if (++count==20000&&!startquiet) {
+                        char msg[]="(Press Ctrl+C to exit immediately)\r\n";
+                        uint16_t s = (uint16_t)strlen(msg);
+                        DOS_WriteFile(STDOUT,(uint8_t*)msg,&s);
+                    }
+                }
+                dos.return_code = exitCode&255;
+                dos.return_mode = 0;
+                hret = 0;
+            } else if (hret > 0)
+                hret = 0;
+            else
+                hret = errno;
+            DOS_SetError((uint16_t)hret);
+            hret=0;
+            return;
+        } else if (startquiet) {
+            char msg[]="This program cannot be run in DOS mode.\r\n";
+            uint16_t s = (uint16_t)strlen(msg);
+            DOS_WriteFile(STDERR,(uint8_t*)msg,&s);
+        }
+    } else if (startquiet) {
+        char msg[]="This program cannot be run in DOS mode.\r\n";
+        uint16_t s = (uint16_t)strlen(msg);
+        DOS_WriteFile(STDERR,(uint8_t*)msg,&s);
+    }
+}
+#endif
+
 static Bitu DOS_21Handler(void) {
     bool unmask_irq0 = false;
 
@@ -1688,7 +1833,15 @@ static Bitu DOS_21Handler(void) {
                 }
 
                 LOG(LOG_EXEC,LOG_NORMAL)("Execute %s %d",name1,reg_al);
-                if (!DOS_Execute(name1,SegPhys(es)+reg_bx,reg_al)) {
+                DOS_ParamBlock block(SegPhys(es)+reg_bx);
+                block.LoadData();
+                CommandTail ctail;
+                MEM_BlockRead(Real2Phys(block.exec.cmdtail),&ctail,CTBUF+1);
+                if (DOS_Execute(name1,SegPhys(es)+reg_bx,reg_al)) {
+                    strcpy(appname, name1);
+                    strncpy(appargs, ctail.buffer, ctail.count);
+                    appargs[ctail.count]=0;
+                } else {
                     reg_ax=dos.errorcode;
                     CALLBACK_SCF(true);
                 }
@@ -1699,7 +1852,14 @@ static Bitu DOS_21Handler(void) {
         case 0x4c:                  /* EXIT Terminate with return code */
             DOS_Terminate(dos.psp(),false,reg_al);
             if (DOS_BreakINT23InProgress) throw int(0); /* HACK: Ick */
+#if defined (WIN32) && !defined(HX_DOS)
+            if (winautorun&&reqwin&&*appname&&!control->SecureMode())
+                HostAppRun();
+            reqwin=false;
+#endif
             dos_program_running = false;
+            *appname=0;
+            *appargs=0;
             break;
         case 0x4d:                  /* Get Return code */
             reg_al=dos.return_code;/* Officially read from SDA and clear when read */
@@ -3271,12 +3431,14 @@ public:
 
             real_writeb(0x60,0x113,0x01); /* 25-line mode */
         }
+        *appname=0;
+        *appargs=0;
 	}
 	~DOS(){
 		infix=-1;
 #if defined(WIN32) && !defined(HX_DOS)
 		if (startwait) {
-			void EndStartProcess(), EndRunProcess();
+			void EndStartProcess();
 			EndStartProcess();
 			EndRunProcess();
 		}

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1205,7 +1205,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring->SetBasic(true);
 
     Pbool = secprop->Add_bool("fastbioslogo",Property::Changeable::OnlyAtStart,false);
-    Pbool->Set_help("If set, DOSBox-X will enable fast BIOS logo mode (skip 1-second pause).");
+    Pbool->Set_help("If set, DOSBox-X will skip the BIOS screen by activating fast BIOS logo mode (without 1-second pause).");
     Pbool->SetBasic(true);
 
     Pbool = secprop->Add_bool("startbanner",Property::Changeable::OnlyAtStart,true);
@@ -3771,15 +3771,15 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring->SetBasic(true);
 
     Pbool = secprop->Add_bool("startcmd",Property::Changeable::OnlyAtStart,false);
-    Pbool->Set_help("Allow starting commands to run on the Windows host including the use of START command.");
+    Pbool->Set_help("Allow starting Windows programs or commands to run on the Windows host including the use of START command.");
     Pbool->SetBasic(true);
 
     Pbool = secprop->Add_bool("startwait",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("Specify whether DOSBox-X should wait for the Windows programs after they are started.");
+    Pbool->Set_help("Specify whether DOSBox-X should wait for the Windows applications after they are started.");
     Pbool->SetBasic(true);
 
     Pbool = secprop->Add_bool("startquiet",Property::Changeable::WhenIdle,false);
-    Pbool->Set_help("If set, DOSBox-X will not show information messages before launching Windows programs to run on the host.");
+    Pbool->Set_help("If set, before launching Windows applications to run on the host DOSBox-X will not show messages like \"Now run it as a Windows application\".");
     Pbool->SetBasic(true);
 
     Pstring = secprop->Add_string("startincon",Property::Changeable::OnlyAtStart,"assoc attrib chcp copy dir echo for ftype help if set type ver vol xcopy");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2786,7 +2786,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring = secprop->Add_string("irq hack",Property::Changeable::WhenIdle,"none");
     Pstring->Set_help("Specify a hack related to the Sound Blaster IRQ to avoid crashes in a handful of games and demos.\n"
             "    none                   Emulate IRQs normally\n"
-            "    cs_equ_ds              Do not fire IRQ unless two CPU segment registers match: CS == DS. Read Dosbox-X Wiki or source code for details.");
+            "    cs_equ_ds              Do not fire IRQ unless two CPU segment registers match: CS == DS. Read DOSBox-X Wiki or source code for details.");
 
     Pint = secprop->Add_int("dma",Property::Changeable::WhenIdle,1);
     Pint->Set_values(dmassb);
@@ -3067,7 +3067,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring = secprop->Add_string("irq hack",Property::Changeable::WhenIdle,"none");
     Pstring->Set_help("Specify a hack related to the Gravis Ultrasound IRQ to avoid crashes in a handful of games and demos.\n"
             "    none                   Emulate IRQs normally\n"
-            "    cs_equ_ds              Do not fire IRQ unless two CPU segment registers match: CS == DS. Read Dosbox-X Wiki or source code for details.");
+            "    cs_equ_ds              Do not fire IRQ unless two CPU segment registers match: CS == DS. Read DOSBox-X Wiki or source code for details.");
 
     Pstring = secprop->Add_string("gustype",Property::Changeable::WhenIdle,"classic");
     Pstring->Set_values(gustypes);
@@ -4110,7 +4110,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pint->Set_help("Number of file handles available to DOS programs (8-255).");
     Pint->SetBasic(true);
     Pstring = secprop->Add_string("country",Property::Changeable::OnlyAtStart,"");
-    Pstring->Set_help("Sets the country code for country-specific date/time formats.");
+    Pstring->Set_help("Sets the country code for country-specific date & time formats.");
     Pstring->SetBasic(true);
     Pstring = secprop->Add_string("lastdrive",Property::Changeable::OnlyAtStart,"a");
 	Pstring->Set_help("The maximum drive letter that can be accessed by programs.");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5736,6 +5736,7 @@ DOSBoxMenu::item_handle_t DOSBoxMenu::displaylist::itemFromPoint(DOSBoxMenu &men
     return unassigned_item_handle;
 }
 
+bool skipdraw=false;
 void DOSBoxMenu::item::updateScreenFromItem(DOSBoxMenu &menu) {
     (void)menu;//UNUSED
     if (!OpenGL_using()) {
@@ -5744,6 +5745,7 @@ void DOSBoxMenu::item::updateScreenFromItem(DOSBoxMenu &menu) {
         SDL_rect_cliptoscreen(uprect);
 
 #if defined(C_SDL2)
+        if (!Direct3D_using() || !skipdraw)
         SDL_UpdateWindowSurfaceRects(sdl.window, &uprect, 1);
 #else
         SDL_UpdateRects( sdl.surface, 1, &uprect );
@@ -5893,7 +5895,9 @@ static void HandleMouseMotion(SDL_MouseMotionEvent * motion) {
         /* do NOT draw SDL menu in OpenGL mode when 3Dfx emulation is using OpenGL */
     }
     else if (!sdl.mouse.locked && !sdl.desktop.fullscreen && mainMenu.isVisible() && motion->y < mainMenu.menuBox.h && Mouse_GetButtonState() == 0) {
+        skipdraw=true;
         GFX_SDLMenuTrackHover(mainMenu,mainMenu.display_list.itemFromPoint(mainMenu,motion->x,motion->y));
+        skipdraw=false;
         SDL_ShowCursor(SDL_ENABLE);
 
         if (OpenGL_using() && mainMenu.needsRedraw()) {

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -8666,7 +8666,7 @@ startfunction:
                 card = "IBM Monochrome Display Adapter";
                 break;
             case MCH_HERC:
-                card = "IBM Monochrome Display Adapter (Hercules)";
+                card = "Hercules Monochrome Graphics Adapter";
                 break;
             case MCH_EGA:
                 card = "IBM Enhanced Graphics Adapter";

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -695,6 +695,7 @@ void DOS_Shell::Run(void) {
 				}
 			} else input_line[0]='\0';
 		} else {
+			if (optInit && control->opt_exit) break;
 			if (echo) ShowPrompt();
 			InputCommand(input_line);
 			if (echo && !input_eof) WriteOut("\n");

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -31,11 +31,6 @@
 #include "inout.h"
 #include "../ints/int10.h"
 #include "../dos/drives.h"
-#ifdef WIN32
-#include "../dos/cdrom.h"
-#include <shellapi.h>
-#include <shlwapi.h>
-#endif
 
 #ifdef _MSC_VER
 # if !defined(C_SDL2)
@@ -978,21 +973,8 @@ overflow:
 
 int infix=-1;
 std::string full_arguments = "";
-intptr_t hret=0;
 bool dos_a20_disable_on_exec=false;
-bool winautorun=false;
-extern bool packerr, reqwin, startwait, startquiet, ctrlbrk, mountwarning;
-#if defined (WIN32) && !defined(HX_DOS)
-void EndRunProcess() {
-    if(hret) {
-        DWORD exitCode;
-        GetExitCodeProcess((HANDLE)hret, &exitCode);
-        if (exitCode==STILL_ACTIVE)
-            TerminateProcess((HANDLE)hret, 0);
-    }
-    ctrlbrk=false;
-}
-#endif
+extern bool packerr, mountwarning;
 bool DOS_Shell::Execute(char* name, const char* args) {
 /* return true  => don't check for hardware changes in do_command 
  * return false =>       check for hardware changes in do_command */
@@ -1223,7 +1205,6 @@ continue_1:
 		reg_ip=RealOff(newcsip);
 #endif
 		packerr=false;
-		reqwin=false;
 		/* Start up a dos execute interrupt */
 		reg_ax=0x4b00;
 		//Filename pointer
@@ -1248,8 +1229,7 @@ continue_1:
 			Execute(name, args);
 			dos_a20_disable_on_exec=false;
 			infix=-1;
-		}
-		else if (packerr&&infix<1&&sec->Get_bool("autoloadfix")) {
+		} else if (packerr&&infix<1&&sec->Get_bool("autoloadfix")) {
 			uint16_t segment;
 			uint16_t blocks = (uint16_t)(1); /* start with one paragraph, resize up later. see if it comes up below the 64KB mark */
 			if (DOS_AllocateMemory(&segment,&blocks)) {
@@ -1268,118 +1248,8 @@ continue_1:
 			}
 		} else if (packerr&&infix<2&&!autofixwarn) {
             WriteOut("Packed file is corrupt");
-#if defined (WIN32) && !defined(HX_DOS)
-		} else if (winautorun&&reqwin&&!control->SecureMode()) {
-            char comline[256], *p=comline;
-            char winDirCur[512], winDirNew[512], winName[256], dir[CROSS_LEN+15];
-            uint8_t drive;
-            if (!DOS_MakeName(fullname, winDirNew, &drive)) return false;
-            if (GetCurrentDirectory(512, winDirCur)&&(!strncmp(Drives[drive]->GetInfo(),"local ",6)||!strncmp(Drives[drive]->GetInfo(),"CDRom ",6))) {
-                bool useoverlay=false;
-                Overlay_Drive *odp = dynamic_cast<Overlay_Drive*>(Drives[drive]);
-                if (odp != NULL) {
-                    strcpy(winName, odp->getOverlaydir());
-                    strcat(winName, winDirNew);
-                    struct stat tempstat;
-                    if (stat(winName,&tempstat)==0 && (tempstat.st_mode & S_IFDIR)==0)
-                        useoverlay=true;
-                }
-                if (!useoverlay) {
-                    strcpy(winName, Drives[drive]->GetBaseDir());
-                    strcat(winName, winDirNew);
-                    if (!PathFileExists(winName)) {
-                        bool olfn=uselfn;
-                        uselfn=true;
-                        if (DOS_GetSFNPath(fullname,dir,true)&&DOS_MakeName(("\""+std::string(dir)+"\"").c_str(), winDirNew, &drive)) {
-                            strcpy(winName, Drives[drive]->GetBaseDir());
-                            strcat(winName, winDirNew);
-                        }
-                        uselfn=olfn;
-                    }
-                }
-                if (!strncmp(Drives[DOS_GetDefaultDrive()]->GetInfo(),"local ",6)||!strncmp(Drives[DOS_GetDefaultDrive()]->GetInfo(),"CDRom ",6)) {
-                    Overlay_Drive *ddp = dynamic_cast<Overlay_Drive*>(Drives[DOS_GetDefaultDrive()]);
-                    strcpy(winDirNew, ddp!=NULL?ddp->getOverlaydir():Drives[DOS_GetDefaultDrive()]->GetBaseDir());
-                    strcat(winDirNew, Drives[DOS_GetDefaultDrive()]->curdir);
-                    if (!PathFileExists(winDirNew)) {
-                        bool olfn=uselfn;
-                        uselfn=true;
-                        if (DOS_GetCurrentDir(0,dir,true)) {
-                            strcpy(winDirNew, ddp!=NULL?ddp->getOverlaydir():Drives[DOS_GetDefaultDrive()]->GetBaseDir());
-                            strcat(winDirNew, dir);
-                        }
-                        uselfn=olfn;
-                    }
-                } else {
-                    strcpy(winDirNew, useoverlay?odp->getOverlaydir():Drives[drive]->GetBaseDir());
-                    strcat(winDirNew, Drives[drive]->curdir);
-                }
-                if (SetCurrentDirectory(winDirNew)) {
-                    SHELLEXECUTEINFO lpExecInfo;
-                    strcpy(comline, args);
-                    strcpy(comline, trim(p));
-                    if (!startquiet) WriteOut("Now run it as a Windows application...\r\n");
-                    DWORD temp = (DWORD)SHGetFileInfo(winName,NULL,NULL,NULL,SHGFI_EXETYPE);
-                    if (temp==0) temp = (DWORD)SHGetFileInfo((std::string(winDirNew)+"\\"+std::string(fullname)).c_str(),NULL,NULL,NULL,SHGFI_EXETYPE);
-                    if (HIWORD(temp)==0 && LOWORD(temp)==0x4550) { // Console applications
-                        lpExecInfo.cbSize  = sizeof(SHELLEXECUTEINFO);
-                        lpExecInfo.fMask=SEE_MASK_DOENVSUBST|SEE_MASK_NOCLOSEPROCESS;
-                        lpExecInfo.hwnd = NULL;
-                        lpExecInfo.lpVerb = "open";
-                        lpExecInfo.lpDirectory = NULL;
-                        lpExecInfo.nShow = SW_SHOW;
-                        lpExecInfo.hInstApp = (HINSTANCE) SE_ERR_DDEFAIL;
-                        strcpy(dir, "/C \"");
-                        strcat(dir, winName);
-                        strcat(dir, " ");
-                        strcat(dir, comline);
-                        strcat(dir, " & echo( & echo The command execution is completed. & pause\"");
-                        lpExecInfo.lpFile = "CMD.EXE";
-                        lpExecInfo.lpParameters = dir;
-                        ShellExecuteEx(&lpExecInfo);
-                        hret = (intptr_t)lpExecInfo.hProcess;
-                    } else {
-                        char qwinName[258];
-                        sprintf(qwinName,"\"%s\"",winName);
-                        hret = _spawnl(P_NOWAIT, winName, qwinName, comline, NULL);
-                    }
-                    SetCurrentDirectory(winDirCur);
-                    if (startwait && hret > 0) {
-                        int count=0;
-                        ctrlbrk=false;
-                        DWORD exitCode = 0;
-                        GetExitCodeProcess((HANDLE)hret, &exitCode);
-                        while (GetExitCodeProcess((HANDLE)hret, &exitCode) && exitCode == STILL_ACTIVE) {
-                            CALLBACK_Idle();
-                            if (ctrlbrk) {
-                                uint8_t c;uint16_t n=1;
-                                DOS_ReadFile (STDIN,&c,&n);
-                                if (c == 3) WriteOut("^C\n");
-                                EndRunProcess();
-                                exitCode=0;
-                                break;
-                            }
-                            if (++count==20000&&!startquiet) WriteOut("(Press Ctrl+C to exit immediately)\n");
-                        }
-                        dos.return_code = exitCode&255;
-                        dos.return_mode = 0;
-                        hret = 0;
-                    } else if (hret > 0)
-                        hret = 0;
-                    else
-                        hret = errno;
-                    DOS_SetError((uint16_t)hret);
-                    bool ret=hret == 0;
-                    hret=0;
-                    return ret;
-                } else if (startquiet)
-                    WriteOut("This program cannot be run in DOS mode.\n");
-            } else if (startquiet)
-                WriteOut("This program cannot be run in DOS mode.\n");
-#endif
         }
 		packerr=false;
-		reqwin=false;
 	}
 	return true; //Executable started
 }


### PR DESCRIPTION
As mentioned in issue #2261, the screen will flicker when hovering over the menu with Direct3D output in the Windows SDL2 build. This will hopefully fix the issue. Also addressed the issue with -winrun function as reported by another user.