### PR TITLE
SVN commits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -106,6 +106,13 @@
   - Fixed that the "Save" button in Configuration Tool
     did not save config file in last version. (Wengier)
   - Integrated SVN commits (Allofich)
+    - r4346: Fix a long-standing crash that occurred
+    when disconnecting a second joystick after
+    partially mapping it.
+    - r4344: Add F8 to toggle printable characters on
+    and off in the debugger.
+    - r4340: Fix behavior when main memory allocation
+    fails.
     - r4336: Correct an oversight of r4186 when floppy
     disks are mounted.
     - r4330: some big endian improvements and drive_fat

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -314,6 +314,7 @@ struct SCodeViewData {
 static uint16_t  dataSeg;
 static uint32_t  dataOfs;
 static bool    showExtend = true;
+static bool    showPrintable = true;
 
 static void ClearInputLine(void) {
 	codeViewData.inputStr[0] = 0;
@@ -960,8 +961,10 @@ static void DrawData(void) {
 
                 wattrset (dbg.win_data,0);
                 mvwprintw (dbg.win_data,y,14+3*x,"%02X",ch);
-                if (ch<32 || !isprint(*reinterpret_cast<unsigned char*>(&ch))) ch='.';
-                mvwprintw (dbg.win_data,y,63+x,"%c",ch);
+                if(showPrintable) {
+                    if (ch<32 || !isprint(*reinterpret_cast<unsigned char*>(&ch))) ch='.';
+                    mvwprintw (dbg.win_data,y,63+x,"%c",ch);
+                } else mvwaddch(dbg.win_data,y,63+x,ch);
 
                 add++;
             }
@@ -977,8 +980,10 @@ static void DrawData(void) {
                     if (!mem_readb_checked((PhysPt)address,&ch)) {
                         wattrset (dbg.win_data,0);
                         mvwprintw (dbg.win_data,y,14+3*x,"%02X",ch);
-                        if (ch<32 || !isprint(*reinterpret_cast<unsigned char*>(&ch))) ch='.';
-                        mvwprintw (dbg.win_data,y,63+x,"%c",ch);
+                        if(showPrintable) {
+                            if (ch<32 || !isprint(*reinterpret_cast<unsigned char*>(&ch))) ch='.';
+                            mvwprintw (dbg.win_data,y,63+x,"%c",ch);
+                        } else mvwaddch(dbg.win_data,y,63+x,ch);
                     }
                     else {
                         wattrset (dbg.win_data, COLOR_PAIR(PAIR_BYELLOW_BLACK));
@@ -2663,6 +2668,7 @@ bool ParseCommand(char* str) {
 		DEBUG_ShowMsg("F3/F6                     - Previous command in history.\n");
 		DEBUG_ShowMsg("F4/F7                     - Next command in history.\n");
 		DEBUG_ShowMsg("F5                        - Run.\n");
+		DEBUG_ShowMsg("F8                        - Toggle printable characters.\n");
 		DEBUG_ShowMsg("F9                        - Set/Remove breakpoint.\n");
 		DEBUG_ShowMsg("F10/F11                   - Step over / trace into instruction.\n");
 		DEBUG_ShowMsg("ALT + D/E/S/X/B           - Set data view to DS:SI/ES:DI/SS:SP/DS:DX/ES:BX.\n");
@@ -3203,6 +3209,9 @@ uint32_t DEBUG_CheckKeys(void) {
 
 				DOSBOX_SetNormalLoop();
 				break;
+		case KEY_F(8):	// Toggle printable characters
+				showPrintable = !showPrintable;
+				break;
 		case KEY_F(9):	// Set/Remove Breakpoint
 				if (CBreakpoint::IsBreakpoint(codeViewData.cursorSeg, codeViewData.cursorOfs)) {
 					if (CBreakpoint::DeleteBreakpoint(codeViewData.cursorSeg, codeViewData.cursorOfs))
@@ -3733,8 +3742,7 @@ static void LogDOSKernMem(void) {
 }
 
 // Display the content of all Memory Control Blocks.
-static void LogMCBS(void)
-{
+static void LogMCBS(void) {
     if (dos_kernel_disabled) {
         if (boothax == BOOTHAX_MSDOS) {
             if (guest_msdos_LoL == 0 || guest_msdos_mcb_chain == 0) {
@@ -3777,8 +3785,7 @@ static void LogMCBS(void)
     DEBUG_EndPagedContent();
 }
 
-static void LogGDT(void)
-{
+static void LogGDT(void) {
 	char out1[512];
 	Descriptor desc;
 	Bitu length = cpu.gdt.GetLimit();

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1626,6 +1626,7 @@ private:
         return NULL;
     }
     CBind * CreateHatBind(Bitu hat,uint8_t value) {
+        if (hat < hats_cap) return NULL;
         Bitu hat_dir;
         if (value&SDL_HAT_UP) hat_dir=0;
         else if (value&SDL_HAT_RIGHT) hat_dir=1;

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -1825,7 +1825,7 @@ void Init_RAM() {
 
     /* Allocate the RAM. We alloc as a large unsigned char array. new[] does not initialize the array,
      * so we then must zero the buffer. */
-    MemBase = new uint8_t[memory.pages*4096];
+    MemBase = new(std::nothrow) uint8_t[memory.pages*4096];
     if (!MemBase) E_Exit("Can't allocate main memory of %d KB",(int)memsizekb);
     /* Clear the memory, as new doesn't always give zeroed memory
      * (Visual C debug mode). We want zeroed memory though. */


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/4337 - Already in DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4338 - Already in DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4339 - Skipped. Web site-related.
https://sourceforge.net/p/dosbox/code-0/4340 - In this PR.
https://sourceforge.net/p/dosbox/code-0/4341 - Already in DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4342 - Already in DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4343 - Already in DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4344 - In this PR
https://sourceforge.net/p/dosbox/code-0/4345 - Skipped. Not needed.
https://sourceforge.net/p/dosbox/code-0/4346 - In this PR

sBitfs(x) changes in the implemented commits were skipped since the commit implementing that function was already skipped, since DOSBox-X seems to be moving away from using Bitu and Bits. Also the LOG calls sBitfs(x) is being used with in SVN already have their parameters cast to the expected sizes in DOSBox-X.