### PR TITLE
Solve Issues #2306, #2307, #2309 etc

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,9 @@
     a summary of the current system configuration and
     allow users to change the date and time. Press Del
     key at the BIOS boot screen to enter. (Wengier)
+  - Added config option "showbasic" in [sdl] section
+    which when set to false will hide DOSBox-X version
+    number and running speed in the titlebar. (Wengier)
   - Added experimental option to load a VGA BIOS ROM
     image and execute it, instead of our own INT 10h
     emulation. If enabled, it will load the specific

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -103,6 +103,8 @@
     Also fixed the messages in the welcome banner for
     these machine types to inform users the new default
     shortcuts (Ctrl(+Shift)+[F7/F8]). (Wengier)
+  - Fixed the screen messup of the welcome banner when
+    the config option "ansi.sys" is disabled. (Wengier)
   - Fixed DOS Int21/AH=0x5a "Create temporary file"
     function not generating unique files. (Wengier)
   - Fixed that the current drive goes back to Z drive

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,8 +28,10 @@
   - Improved handling for file- and record-locking
     for non-Windows platforms. Portions of the code
     are adopted from DOSEmu. (Wengier)
-  - Fixed PC-98 keyboard handling of CTRL+A through
-    CTRL+Z. CTRL+C now works correctly in PC-98 mode.
+  - Improved handling for the setting "ansi.sys=false",
+    such as fixing the welcome screen messup in this
+    case and allowing the use of a custom ANSI TSR
+    (such as NNANSI.COM) instead. (Wengier & stu)
   - You can now press Ctrl+C or Ctrl+Break to break
     from long outputs from commands like COPY, TYPE,
     DIR /S, and ATTRIB /S. (Wengier)
@@ -103,12 +105,12 @@
     Also fixed the messages in the welcome banner for
     these machine types to inform users the new default
     shortcuts (Ctrl(+Shift)+[F7/F8]). (Wengier)
-  - Fixed the screen messup of the welcome banner when
-    the config option "ansi.sys" is disabled. (Wengier)
   - Fixed DOS Int21/AH=0x5a "Create temporary file"
     function not generating unique files. (Wengier)
   - Fixed that the current drive goes back to Z drive
     when combined unmounts & mounts are used. (Wengier)
+  - Fixed PC-98 keyboard handling of CTRL+A through
+    CTRL+Z. CTRL+C now works correctly in PC-98 mode.
   - Fixed crash of Free Pascal compiler with dynamic
     core and setting "use dynamic core with paging on =
     auto" introduced in the previous version. (Wengier)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -95,11 +95,14 @@
   - The command "KEYB US" will return the DOS codepage
     to 437 if current codepage is different. (Wengier)
   - The setting "output=default" will enable the OpenGL
-    output for the Linux platform if possible. (Wengier)
+    output for Linux systems if possible. (Wengier)
   - Fixed the CGA/MCGA/MDA/Hercules-specfic shortcut
     function buttons in Mapper Editor, and the screen
     colors after exiting from Mapper Editor when using
-    these machine types in Direct3D output. (Wengier)
+    these machine types in Direct3D output (SDL1 build).
+    Also fixed the messages in the welcome banner for
+    these machine types to inform users the new default
+    shortcuts (Ctrl(+Shift)+[F7/F8]). (Wengier)
   - Fixed DOS Int21/AH=0x5a "Create temporary file"
     function not generating unique files. (Wengier)
   - Fixed that the current drive goes back to Z drive

--- a/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
+++ b/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
@@ -10,7 +10,7 @@
     <category>Emulation</category>
   </categories>
   <releases>
-          <release version="@PACKAGE_VERSION@" date="2021-2-21"/>
+          <release version="@PACKAGE_VERSION@" date="2021-2-25"/>
   </releases>
   <screenshots>
 	  <screenshot type="default">

--- a/contrib/windows/installer/DOSBox-X-setup.iss
+++ b/contrib/windows/installer/DOSBox-X-setup.iss
@@ -241,7 +241,7 @@ begin
     else
       PageBuild.Values[4] := True;
     CreateHelpButton(ScaleX(20), WizardForm.CancelButton.Top, WizardForm.CancelButton.Width, WizardForm.CancelButton.Height);
-    msg:='DOSBox-X supports different video output systems for different purposes.' #13#13 'By default it uses the Direct3D output, but you may want to select the OpenGL pixel-perfect scaling output for improved image quality (not available if you had selected an ARM build). Also, if you use text-mode DOS applications you probably want to select the TrueType font (TTF) output to make the text screen look much better.' #13#13 'This setting can be later modified in the DOSBox-X''s configuration file (dosbox-x.conf), or from DOSBox-X''s Video menu.';
+    msg:='DOSBox-X supports different video output systems for different purposes.' #13#13 'By default it uses the Direct3D output, but you may want to select the OpenGL pixel-perfect scaling output for improved image quality (not available if you had selected an ARM build). Also, if you use text-mode DOS applications you probably want to select the TrueType font (TTF) output to make the text screen look much better by using scalable TrueType fonts.' #13#13 'This setting can be later modified in the DOSBox-X''s configuration file (dosbox-x.conf), or from DOSBox-X''s Video menu.';
     PageOutput:=CreateInputOptionPage(100, 'Video output for DOSBox-X', 'Specify the DOSBox-X video output system', msg, True, False);
     PageOutput.Add('Default output (Direct3D)');
     PageOutput.Add('OpenGL with pixel-perfect scaling');
@@ -250,7 +250,7 @@ begin
     msg:='You can specify a default DOS version for DOSBox-X to report to itself and DOS programs. This can sometimes change the feature sets of DOSBox-X. For example, selecting 7.10 as the reported DOS version will enable support for Windows-style long filenames (LFN) and FAT32 disk images (>2GB disk images) by default.' #13#13 'If you are not sure about which DOS version to report, you can also leave this unselected, then a preset DOS version will be reported (usually 5.00).' #13#13 'This setting can be later modified in the DOSBox-X''s configuration file (dosbox-x.conf).';
     PageVer:=CreateInputOptionPage(101, 'Reported DOS version', 'Specify the default DOS version to report', msg, True, False);
     PageVer.Add('DOS version 3.30');
-    PageVer.Add('DOS version 5.00');
+    PageVer.Add('DOS version 5.00 (reported by default)');
     PageVer.Add('DOS version 6.22');
     PageVer.Add('DOS version 7.10 (for LFN and FAT32 support)');
 end;

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -53,6 +53,7 @@
 #                      Possible values: true, false, auto.
 #DOSBOX-X-ADV:#          overscan: Width of overscan border (0 to 10). (works only if output=surface)
 #          titlebar: Change the string displayed in the DOSBox-X title bar.
+#         showbasic: If set, DOSBox-X will show basic information including the DOSBox-X version number and current running speed in the title bar.
 #       showdetails: If set, DOSBox-X will show the cycles count (FPS) and emulation speed relative to realtime in the title bar.
 #          showmenu: Whether to show the menu bar (if supported). Default true.
 fullscreen        = false
@@ -78,6 +79,7 @@ mapperfile        = mapper-dosbox-x.map
 usescancodes      = auto
 #DOSBOX-X-ADV:overscan          = 0
 titlebar          = 
+showbasic         = true
 showdetails       = false
 showmenu          = true
 

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -48,6 +48,7 @@
 #                      If set to "auto" (default), it is enabled for SDL1 and non-US keyboards.
 #                      Possible values: true, false, auto.
 #          titlebar: Change the string displayed in the DOSBox-X title bar.
+#         showbasic: If set, DOSBox-X will show basic information including the DOSBox-X version number and current running speed in the title bar.
 #       showdetails: If set, DOSBox-X will show the cycles count (FPS) and emulation speed relative to realtime in the title bar.
 #          showmenu: Whether to show the menu bar (if supported). Default true.
 fullscreen        = false
@@ -69,6 +70,7 @@ priority          = higher,normal
 mapperfile        = mapper-dosbox-x.map
 usescancodes      = auto
 titlebar          = 
+showbasic         = true
 showdetails       = false
 showmenu          = true
 

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -53,6 +53,7 @@
 #                      Possible values: true, false, auto.
 #          overscan: Width of overscan border (0 to 10). (works only if output=surface)
 #          titlebar: Change the string displayed in the DOSBox-X title bar.
+#         showbasic: If set, DOSBox-X will show basic information including the DOSBox-X version number and current running speed in the title bar.
 #       showdetails: If set, DOSBox-X will show the cycles count (FPS) and emulation speed relative to realtime in the title bar.
 #          showmenu: Whether to show the menu bar (if supported). Default true.
 fullscreen        = false
@@ -78,6 +79,7 @@ mapperfile_sdl2   =
 usescancodes      = auto
 overscan          = 0
 titlebar          = 
+showbasic         = true
 showdetails       = false
 showmenu          = true
 

--- a/include/build_timestamp.h
+++ b/include/build_timestamp.h
@@ -1,4 +1,4 @@
 /*auto-generated*/
-#define UPDATED_STR "Feb 21, 2021 6:36:34pm"
-#define GIT_COMMIT_HASH "ea8c6f5"
+#define UPDATED_STR "Feb 25, 2021 12:45:55am"
+#define GIT_COMMIT_HASH "d345ff3"
 #define COPYRIGHT_END_YEAR "2021"

--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -1255,7 +1255,13 @@ void device_CON::ClearAnsi(void){
 }
 
 void device_CON::Output(uint8_t chr) {
-	if (dos.internal_output || ansi.enabled) {
+	if (!ANSI_SYS_installed() && !IS_PC98_ARCH) {
+		uint16_t oldax;
+		oldax=reg_ax;
+		reg_ax=chr;
+		CALLBACK_RunRealInt(0x29);
+		reg_ax=oldax;
+	} else if (dos.internal_output || ansi.enabled) {
 		if (CurMode->type==M_TEXT) {
 			uint8_t page=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
 			uint8_t col=CURSOR_POS_COL(page);

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -1814,7 +1814,8 @@ bool localFile::Write(const uint8_t * data,uint16_t * size) {
 bool toLock(int fd, bool is_lock, uint32_t pos, uint16_t size) {
     struct flock larg;
     unsigned long mask = 0xC0000000;
-    larg.l_type = is_lock ? (fcntl(fd, F_GETFL) == O_RDONLY ? F_RDLCK : F_WRLCK) : F_UNLCK;
+    int flag = fcntl(fd, F_GETFL);
+    larg.l_type = is_lock ? (flag & O_RDWR || flag & O_WRONLY ? F_WRLCK : F_RDLCK) : F_UNLCK;
     larg.l_start = pos;
     larg.l_len = size;
     larg.l_len &= ~mask;

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -1235,21 +1235,21 @@ void RENDER_Init() {
 
 	if (machine==MCH_HERC || machine==MCH_MDA) {
 		void HercBlend(bool pressed), CycleHercPal(bool pressed);
-		MAPPER_AddHandler(HercBlend,MK_nothing,0,"hercblend","Hercules Blending");
-		MAPPER_AddHandler(CycleHercPal,MK_nothing,0,"hercpal","Hercules Palette");
+		MAPPER_AddHandler(CycleHercPal,MK_f7,MMOD1,"hercpal","Hercules Palette");
+		MAPPER_AddHandler(HercBlend,MK_f8,MMOD1,"hercblend","Hercules Blending");
 	}
 
 	if (machine==MCH_CGA || machine==MCH_MCGA || machine==MCH_AMSTRAD) {
 		if(!mono_cga) {
             void IncreaseHue(bool pressed), DecreaseHue(bool pressed), CGAModel(bool pressed), Composite(bool pressed);
-            MAPPER_AddHandler(IncreaseHue,MK_nothing,0,"inchue","Increase Hue");
-            MAPPER_AddHandler(DecreaseHue,MK_nothing,0,"dechue","Decrease Hue");
-            MAPPER_AddHandler(CGAModel,MK_nothing,0,"cgamodel","Early/Late CGA");
-            MAPPER_AddHandler(Composite,MK_nothing,0,"cgacomp","CGA Composite");
+            MAPPER_AddHandler(DecreaseHue,MK_f7,MMOD1|MMOD3,"dechue","Decrease Hue");
+            MAPPER_AddHandler(IncreaseHue,MK_f8,MMOD1|MMOD3,"inchue","Increase Hue");
+            MAPPER_AddHandler(CGAModel,MK_f7,MMOD1,"cgamodel","Early/Late CGA");
+            MAPPER_AddHandler(Composite,MK_f8,MMOD1,"cgacomp","CGA Composite");
         } else {
             void CycleMonoCGAPal(bool pressed), CycleMonoCGABright(bool pressed);
-            MAPPER_AddHandler(CycleMonoCGAPal,MK_nothing,0,"monocgapal","Mono CGA Palette");
-            MAPPER_AddHandler(CycleMonoCGABright,MK_nothing,0,"monocgabri","Mono CGA Brightness");
+            MAPPER_AddHandler(CycleMonoCGAPal,MK_f7,MMOD1,"monocgapal","Mono CGA Palette");
+            MAPPER_AddHandler(CycleMonoCGABright,MK_f8,MMOD1,"monocgabri","Mono CGA Brightness");
         }
 	}
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1366,16 +1366,20 @@ void GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused) {
 //  if (timing != -1) internal_timing = timing;
 //  if (frameskip != -1) internal_frameskip = frameskip;
 
-    if (CPU_CycleAutoAdjust) {
-        sprintf(title,"%s%sDOSBox-X %s, %d%%",
-            dosbox_title.c_str(),dosbox_title.empty()?"":": ",
-            VERSION,(int)internal_cycles);
-    }
-    else {
-        sprintf(title,"%s%sDOSBox-X %s, %d cycles/ms",
-            dosbox_title.c_str(),dosbox_title.empty()?"":": ",
-            VERSION,(int)internal_cycles);
-    }
+    bool showbasic = section->Get_bool("showbasic");
+    if (showbasic) {
+        if (CPU_CycleAutoAdjust) {
+            sprintf(title,"%s%sDOSBox-X %s: %d%%",
+                dosbox_title.c_str(),dosbox_title.empty()?"":" - ",
+                VERSION,(int)internal_cycles);
+        }
+        else {
+            sprintf(title,"%s%sDOSBox-X %s: %d cycles/ms",
+                dosbox_title.c_str(),dosbox_title.empty()?"":" - ",
+                VERSION,(int)internal_cycles);
+        }
+    } else
+        sprintf(title,"%s%sDOSBox-X", dosbox_title.c_str(),dosbox_title.empty()?"":" - ");
 
     {
         const char *what = (titlebar != NULL && *titlebar != 0) ? titlebar : RunningProgram;
@@ -1383,7 +1387,7 @@ void GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused) {
         if (what != NULL && *what != 0) {
             char *p = title + strlen(title); // append to end of string
 
-            sprintf(p,", %s",what);
+            sprintf(p,"%c %s",showbasic?',':':', what);
         }
     }
 
@@ -7767,6 +7771,14 @@ void SDL_SetupConfigSection() {
     Pstring = sdl_sec->Add_string("titlebar", Property::Changeable::Always, "");
     Pstring->Set_help("Change the string displayed in the DOSBox-X title bar.");
     Pstring->SetBasic(true);
+
+    Pbool = sdl_sec->Add_bool("showbasic", Property::Changeable::Always, true);
+    Pbool->Set_help("If set, DOSBox-X will show basic information including the DOSBox-X version number and current running speed in the title bar.");
+    Pbool->SetBasic(true);
+
+    Pbool = sdl_sec->Add_bool("showdetails", Property::Changeable::Always, false);
+    Pbool->Set_help("If set, DOSBox-X will show the cycles count (FPS) and emulation speed relative to realtime in the title bar.");
+    Pbool->SetBasic(true);
 
     Pbool = sdl_sec->Add_bool("showdetails", Property::Changeable::Always, false);
     Pbool->Set_help("If set, DOSBox-X will show the cycles count (FPS) and emulation speed relative to realtime in the title bar.");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -7780,10 +7780,6 @@ void SDL_SetupConfigSection() {
     Pbool->Set_help("If set, DOSBox-X will show the cycles count (FPS) and emulation speed relative to realtime in the title bar.");
     Pbool->SetBasic(true);
 
-    Pbool = sdl_sec->Add_bool("showdetails", Property::Changeable::Always, false);
-    Pbool->Set_help("If set, DOSBox-X will show the cycles count (FPS) and emulation speed relative to realtime in the title bar.");
-    Pbool->SetBasic(true);
-
     Pbool = sdl_sec->Add_bool("showmenu", Property::Changeable::Always, true);
     Pbool->Set_help("Whether to show the menu bar (if supported). Default true.");
     Pbool->SetBasic(true);

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1172,20 +1172,20 @@ void SHELL_Init() {
                );
         if (!mono_cga) {
             MSG_Add("SHELL_STARTUP_CGA","\033[44;1m\xBA DOSBox-X supports Composite CGA mode.                                        \xBA\033[0m"
-                    "\033[44;1m\xBA Use \033[31mF12\033[37m to set composite output ON, OFF, or AUTO (default).                  \xBA\033[0m"
-                    "\033[44;1m\xBA \033[31m(Alt+)F11\033[37m changes hue; \033[31mCtrl+Alt+F11\033[37m selects early/late CGA model.            \xBA\033[0m"
+                    "\033[44;1m\xBA Use \033[31mCtrl+F8\033[37m to set composite output ON, OFF, or AUTO (default).              \xBA\033[0m"
+                    "\033[44;1m\xBA \033[31mCtrl+Shift+[F7/F8]\033[37m changes hue; \033[31mCtrl+F7\033[37m selects early/late CGA model.        \xBA\033[0m"
                     "\033[44;1m\xBA                                                                              \xBA\033[0m"
                    );
         } else {
-            MSG_Add("SHELL_STARTUP_CGA","\033[44;1m\xBA Use \033[31mF11\033[37m to cycle through green, amber, and white monochrome color,           \xBA\033[0m"
-                    "\033[44;1m\xBA and \033[31mAlt+F11\033[37m to change contrast/brightness settings.                          \xBA\033[0m"
+            MSG_Add("SHELL_STARTUP_CGA","\033[44;1m\xBA Use \033[31mCtrl+F7\033[37m to cycle through green, amber, and white monochrome color,       \xBA\033[0m"
+                   "\033[44;1m\xBA and \033[31mCtrl+F8\033[37m to change contrast/brightness settings.                          \xBA\033[0m"
                     "\033[44;1m\xBA                                                                              \xBA\033[0m"
                    );
         }
         MSG_Add("SHELL_STARTUP_PC98","\xBA DOSBox-X is now running in NEC PC-98 emulation mode.               \xBA\n"
                 "\xBA \033[31mPC-98 emulation is INCOMPLETE and CURRENTLY IN DEVELOPMENT.\033[37m        \xBA\n");
-        MSG_Add("SHELL_STARTUP_HERC","\033[44;1m\xBA Use F11 to cycle through white, amber, and green monochrome color.           \xBA\033[0m"
-                "\033[44;1m\xBA Use Alt+F11 to toggle horizontal blending (only in graphics mode).           \xBA\033[0m"
+        MSG_Add("SHELL_STARTUP_HERC","\033[44;1m\xBA Use Ctrl+F7 to cycle through white, amber, and green monochrome color.       \xBA\033[0m"
+                "\033[44;1m\xBA Use Ctrl+F8 to toggle horizontal blending (only in graphics mode).           \xBA\033[0m"
                 "\033[44;1m\xBA                                                                              \xBA\033[0m"
                );
         MSG_Add("SHELL_STARTUP_DEBUG",

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -479,11 +479,21 @@ void DOS_Shell::RunInternal(void) {
 
 char *str_replace(char *orig, char *rep, char *with);
 std::string GetPlatform(bool save);
+bool ANSI_SYS_installed();
 const char *ParseMsg(const char *msg) {
     char str[13];
     strncpy(str, UPDATED_STR, 12);
     str[12]=0;
     if (machine != MCH_PC98) {
+        if (!ANSI_SYS_installed()) {
+            msg = str_replace(str_replace((char *)msg, "\033[0m", ""), "\033[1m", "");
+            for (int i=1; i<8; i++) {
+                sprintf(str, "\033[3%dm", i);
+                msg = str_replace((char *)msg, str, "");
+                sprintf(str, "\033[4%d;1m", i);
+                msg = str_replace((char *)msg, str, "");
+            }
+        }
         Section_prop *section = static_cast<Section_prop *>(control->GetSection("dosbox"));
         std::string theme = section->Get_string("bannercolortheme");
         if (theme == "black")


### PR DESCRIPTION
This PR solves issues #2306, #2307, and #2309, and also fixed the messages in the welcome banner for CGA/MCGA/MDA/Hercules machine types to inform users the correct new default shortcuts (instead of invalid ones).