### PR TITLE
Allow clipboard pasting in Windows SDL2 builds to work with Win3.x apps

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,9 @@
     for keyboard pasting" is added to "Shared clipboard
     functions" menu group (under "Main") to instead use
     the BIOS function for the clipboard pasting in both
-    Windows SDL1 and SDL2 builds. (Wengier)
+    Windows SDL1 and SDL2 builds. This setting can also
+    be changed with the "clip_paste_bios" config option
+    in [sdl] section of the configuration. (Wengier)
   - Added support for the clipboard device (CLIP$) and
     DOS clipboard API on non-Windows systems (they were
     previously only supported on the Windows platform).

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,13 +5,14 @@
     4DOS shell in addition to built-in shell. (Wengier)
   - Windows SDL2 builds now use same clipboard pasting
     method as Windows SDL1 builds by default instead of
-    the BIOS function. A menu option "Use BIOS function
-    for keyboard pasting" is added to "Shared clipboard
-    functions" menu group (under "Main") to instead use
-    the BIOS function for the clipboard pasting in both
-    Windows SDL1 and SDL2 builds. This setting can also
-    be changed with the "clip_paste_bios" config option
-    in [sdl] section of the configuration. (Wengier)
+    the BIOS function. The method is now also available
+    for Linux and macOS builds. A menu option "Use BIOS
+    function for keyboard pasting" is added to "Shared
+    clipboard functions" menu group (under "Main") to
+    use BIOS function for the clipboard pasting instead
+    of the keystroke method. This setting can also be
+    changed with the "clip_paste_bios" config option in
+    [sdl] section of the configuration. (Wengier)
   - Added support for the clipboard device (CLIP$) and
     DOS clipboard API on non-Windows systems (they were
     previously only supported on the Windows platform).

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
 0.83.11
+  - With setting "output=default", the TrueType font
+    (TTF) output will be used by default for PC-98 and
+    VGA+ machine types. A text-mode BIOS screen will be
+    enabled for the TTF output. (Wengier)
   - With the config option "startcmd=true" or command-
     line option -winrun, Windows applications can now
     be launched from within a DOS program or from the

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -43,8 +43,8 @@
     case and allowing the use of a custom ANSI TSR
     (such as NNANSI.COM) instead. (Wengier & stu)
   - You can now press Ctrl+C or Ctrl+Break to break
-    from long outputs from commands like COPY, TYPE,
-    DIR /S, and ATTRIB /S. (Wengier)
+    from long outputs from commands like TYPE, MORE,
+    COPY, DIR /S, and ATTRIB /S. (Wengier)
   - Renamed MEM.COM to MEM.EXE to match DOS. (Wengier)
   - Rewrote built-in TREE command instead of the one
     from FreeDOS to support long filenames. (Wengier)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,12 +3,22 @@
     line option -winrun, Windows applications can now
     be launched from within a DOS program or from the
     4DOS shell in addition to built-in shell. (Wengier)
+  - Windows SDL2 builds now use same clipboard pasting
+    method as Windows SDL1 builds by default instead of
+    the BIOS function. A menu option "Use BIOS function
+    for keyboard pasting" is added to "Shared clipboard
+    functions" menu group (under "Main") to instead use
+    the BIOS function for the clipboard pasting in both
+    Windows SDL1 and SDL2 builds. (Wengier)
   - Added support for the clipboard device (CLIP$) and
     DOS clipboard API on non-Windows systems (they were
     previously only supported on the Windows platform).
     In Linux/macOS SDL1 builds only the read access is
     supported whereas Linux/macOS SDL2 builds support
     both read and write accesses. (Wengier)
+  - Added "Paste Clipboard" button to the AUTOEXEC.BAT,
+    CONFIG.SYS and 4DOS.INI sections in Configuration
+    Tool for pasting clipboard contents. (Wengier)
   - Added a simple BIOS Setup Utlity, which will show
     a summary of the current system configuration and
     allow users to change the date and time. Press Del

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,9 +16,9 @@
   - Added support for the clipboard device (CLIP$) and
     DOS clipboard API on non-Windows systems (they were
     previously only supported on the Windows platform).
-    In Linux/macOS SDL1 builds only the read access is
-    supported whereas Linux/macOS SDL2 builds support
-    both read and write accesses. (Wengier)
+    In Linux SDL1 build only read access is supported
+    whereas both read and write access are supported in
+    all other builds. (Wengier)
   - Added "Paste Clipboard" button to the AUTOEXEC.BAT,
     CONFIG.SYS and 4DOS.INI sections in Configuration
     Tool for pasting clipboard contents. (Wengier)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,7 +18,9 @@
     previously only supported on the Windows platform).
     In Linux SDL1 build only read access is supported
     whereas both read and write access are supported in
-    all other builds. (Wengier)
+    all other builds. Also, selecting and copying text
+    to the host clipboard using a mouse button or arrow
+    key is now supported in macOS SDL1 build. (Wengier)
   - Added "Paste Clipboard" button to the AUTOEXEC.BAT,
     CONFIG.SYS and 4DOS.INI sections in Configuration
     Tool for pasting clipboard contents. (Wengier)

--- a/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
+++ b/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
@@ -10,7 +10,7 @@
     <category>Emulation</category>
   </categories>
   <releases>
-          <release version="@PACKAGE_VERSION@" date="2021-2-25"/>
+          <release version="@PACKAGE_VERSION@" date="2021-2-27"/>
   </releases>
   <screenshots>
 	  <screenshot type="default">

--- a/contrib/windows/installer/DOSBox-X-setup.iss
+++ b/contrib/windows/installer/DOSBox-X-setup.iss
@@ -241,11 +241,11 @@ begin
     else
       PageBuild.Values[4] := True;
     CreateHelpButton(ScaleX(20), WizardForm.CancelButton.Top, WizardForm.CancelButton.Width, WizardForm.CancelButton.Height);
-    msg:='DOSBox-X supports different video output systems for different purposes.' #13#13 'By default it uses the Direct3D output, but you may want to select the OpenGL pixel-perfect scaling output for improved image quality (not available if you had selected an ARM build). Also, if you use text-mode DOS applications you probably want to select the TrueType font (TTF) output to make the text screen look much better by using scalable TrueType fonts.' #13#13 'This setting can be later modified in the DOSBox-X''s configuration file (dosbox-x.conf), or from DOSBox-X''s Video menu.';
+    msg:='DOSBox-X supports different video output systems for different purposes.' #13#13 'By default it uses the TrueType font (TTF) output for text screens and the Direct3D output for graphical screens, but you can select the OpenGL pixel-perfect scaling ("OpenGL perfect") output if you desire the pixel-perfect scaling feature for scaling images without any edge blurring (not available if you had selected an ARM build), or use the Direct3D output for all DOS games and applications.' #13#13 'This setting can be later modified in the DOSBox-X''s configuration file (dosbox-x.conf), or from DOSBox-X''s Video menu.';
     PageOutput:=CreateInputOptionPage(100, 'Video output for DOSBox-X', 'Specify the DOSBox-X video output system', msg, True, False);
-    PageOutput.Add('Default output (Direct3D)');
+    PageOutput.Add('Default (TrueType font or Direct3D)');
     PageOutput.Add('OpenGL with pixel-perfect scaling');
-    PageOutput.Add('TrueType font output for text-mode applications');
+    PageOutput.Add('Direct3D for all games/applications');
     PageOutput.Values[0] := True;
     msg:='You can specify a default DOS version for DOSBox-X to report to itself and DOS programs. This can sometimes change the feature sets of DOSBox-X. For example, selecting 7.10 as the reported DOS version will enable support for Windows-style long filenames (LFN) and FAT32 disk images (>2GB disk images) by default.' #13#13 'If you are not sure about which DOS version to report, you can also leave this unselected, then a preset DOS version will be reported (usually 5.00).' #13#13 'This setting can be later modified in the DOSBox-X''s configuration file (dosbox-x.conf).';
     PageVer:=CreateInputOptionPage(101, 'Reported DOS version', 'Specify the default DOS version to report', msg, True, False);
@@ -321,11 +321,11 @@ begin
       begin
         Wizardform.ReadyMemo.Lines.Add('');
         Wizardform.ReadyMemo.Lines.Add('Video output for DOSBox-X:');
-        msg:='Default output (Direct3D)';
+        msg:='Default (TrueType font or Direct3D)';
         if (PageOutput.Values[1]) then
           msg:='OpenGL with pixel-perfect scaling';
         if (PageOutput.Values[2]) then
-          msg:='TrueType font output for text-mode applications';
+          msg:='Direct3D for all games/applications';
         Wizardform.ReadyMemo.Lines.Add('      '+msg);
       end
       if PageVer.Values[0] or PageVer.Values[1] or PageVer.Values[2] or PageVer.Values[3] then
@@ -418,7 +418,7 @@ begin
               if (PageOutput.Values[1]) then
                 FileLines[i] := linetmp+' openglpp';
               if (PageOutput.Values[2]) then
-                FileLines[i] := linetmp+' ttf';
+                FileLines[i] := linetmp+' direct3d';
               break;
             end
           end

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -25,6 +25,9 @@
 # clip_key_modifier: Change the keyboard modifier for the shared clipboard copy/paste function using a mouse button or arrow keys.
 #                      The default modifier is "shift" (both left and right shift keys). Set to "none" if no modifier is desired.
 #                      Possible values: none, ctrl, lctrl, rctrl, alt, lalt, ralt, shift, lshift, rshift, ctrlalt, ctrlshift, altshift, lctrlalt, lctrlshift, laltshift, rctrlalt, rctrlshift, raltshift.
+#   clip_paste_bios: Specify whether to use BIOS keyboard functions for clipboard pasting instead of the keystroke method.
+#                      For pasting clipboard text into Windows 3.x/9x applications, make sure to use the keystroke method.
+#                      Possible values: true, false, 1, 0, auto.
 #  clip_paste_speed: Set keyboard speed for pasting from the shared clipboard.
 #                      If the default setting of 30 causes lost keystrokes, increase the number.
 #                      Or experiment with decreasing the number for applications that accept keystrokes quickly.
@@ -50,7 +53,7 @@
 #DOSBOX-X-ADV:#   mapperfile_sdl2: File used to load/save the key/event mappings from DOSBox-X SDL2 builds. If set it will override "mapperfile" for SDL2 builds.
 #      usescancodes: Avoid usage of symkeys, might not work on all operating systems.
 #                      If set to "auto" (default), it is enabled for SDL1 and non-US keyboards.
-#                      Possible values: true, false, auto.
+#                      Possible values: true, false, 1, 0, auto.
 #DOSBOX-X-ADV:#          overscan: Width of overscan border (0 to 10). (works only if output=surface)
 #          titlebar: Change the string displayed in the DOSBox-X title bar.
 #         showbasic: If set, DOSBox-X will show basic information including the DOSBox-X version number and current running speed in the title bar.
@@ -67,6 +70,7 @@ autolock          = false
 #DOSBOX-X-ADV:autolock_feedback = beep
 clip_mouse_button = right
 clip_key_modifier = shift
+clip_paste_bios   = auto
 clip_paste_speed  = 30
 sensitivity       = 100
 mouse_emulation   = locked

--- a/contrib/windows/installer/readme.txt
+++ b/contrib/windows/installer/readme.txt
@@ -16,7 +16,7 @@ At the beginning you have got a Z:\> instead of a C:\> at the DOSBox-X prompt. S
 
 To change to the drive mounted like above, type "C:". If everything went fine, DOSBox-X will display the prompt "C:\>". You do not have to manually mount drives after DOSBox-X starts. Click the "Main" menu, and select "Configuration tool". Then select the "AUTOEXEC.BAT" setting group, where you can change its contents. The commands present here are run when DOSBox-X starts, so you can use this section for the mounting and other purposes, such as launching a specific program you want to use, or a game you want to play. You can also quickly launch a DOS program or game in DOSBox-X by clicking "Quick launch program..." under "DOS" menu.
 
-Hint: DOSBox-X supports different video output systems for different purposes. By default it uses the Direct3D output, but if you desire the pixel-perfect scaling feature for improved image quality you may want to select the openglpp output ("OpenGL perfect"). Also, if you use text-mode DOS applications and/or the DOS shell a lot you probably want to select the TrueType font (TTF) output to make the text screen look much better.
+Hint: DOSBox-X supports different video output systems for different purposes. By default it uses the TrueType font (TTF) output for text screens and the Direct3D output for graphical screens, but if you desire the pixel-perfect scaling feature for scaling images without any edge blurring you may want to select the openglpp output ("OpenGL perfect"), or you can select the Direct3D or standard OpenGL outputs for all DOS games and applications.
 
 Further Information
 ===================

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -23,6 +23,9 @@
 # clip_key_modifier: Change the keyboard modifier for the shared clipboard copy/paste function using a mouse button or arrow keys.
 #                      The default modifier is "shift" (both left and right shift keys). Set to "none" if no modifier is desired.
 #                      Possible values: none, ctrl, lctrl, rctrl, alt, lalt, ralt, shift, lshift, rshift, ctrlalt, ctrlshift, altshift, lctrlalt, lctrlshift, laltshift, rctrlalt, rctrlshift, raltshift.
+#   clip_paste_bios: Specify whether to use BIOS keyboard functions for clipboard pasting instead of the keystroke method.
+#                      For pasting clipboard text into Windows 3.x/9x applications, make sure to use the keystroke method.
+#                      Possible values: true, false, 1, 0, auto.
 #  clip_paste_speed: Set keyboard speed for pasting from the shared clipboard.
 #                      If the default setting of 30 causes lost keystrokes, increase the number.
 #                      Or experiment with decreasing the number for applications that accept keystrokes quickly.
@@ -46,7 +49,7 @@
 #        mapperfile: File used to load/save the key/event mappings from. Resetmapper only works with the default value.
 #      usescancodes: Avoid usage of symkeys, might not work on all operating systems.
 #                      If set to "auto" (default), it is enabled for SDL1 and non-US keyboards.
-#                      Possible values: true, false, auto.
+#                      Possible values: true, false, 1, 0, auto.
 #          titlebar: Change the string displayed in the DOSBox-X title bar.
 #         showbasic: If set, DOSBox-X will show basic information including the DOSBox-X version number and current running speed in the title bar.
 #       showdetails: If set, DOSBox-X will show the cycles count (FPS) and emulation speed relative to realtime in the title bar.
@@ -61,6 +64,7 @@ output            = default
 autolock          = false
 clip_mouse_button = right
 clip_key_modifier = shift
+clip_paste_bios   = auto
 clip_paste_speed  = 30
 sensitivity       = 100
 mouse_emulation   = locked

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -25,6 +25,9 @@
 # clip_key_modifier: Change the keyboard modifier for the shared clipboard copy/paste function using a mouse button or arrow keys.
 #                      The default modifier is "shift" (both left and right shift keys). Set to "none" if no modifier is desired.
 #                      Possible values: none, ctrl, lctrl, rctrl, alt, lalt, ralt, shift, lshift, rshift, ctrlalt, ctrlshift, altshift, lctrlalt, lctrlshift, laltshift, rctrlalt, rctrlshift, raltshift.
+#   clip_paste_bios: Specify whether to use BIOS keyboard functions for clipboard pasting instead of the keystroke method.
+#                      For pasting clipboard text into Windows 3.x/9x applications, make sure to use the keystroke method.
+#                      Possible values: true, false, 1, 0, auto.
 #  clip_paste_speed: Set keyboard speed for pasting from the shared clipboard.
 #                      If the default setting of 30 causes lost keystrokes, increase the number.
 #                      Or experiment with decreasing the number for applications that accept keystrokes quickly.
@@ -50,7 +53,7 @@
 #   mapperfile_sdl2: File used to load/save the key/event mappings from DOSBox-X SDL2 builds. If set it will override "mapperfile" for SDL2 builds.
 #      usescancodes: Avoid usage of symkeys, might not work on all operating systems.
 #                      If set to "auto" (default), it is enabled for SDL1 and non-US keyboards.
-#                      Possible values: true, false, auto.
+#                      Possible values: true, false, 1, 0, auto.
 #          overscan: Width of overscan border (0 to 10). (works only if output=surface)
 #          titlebar: Change the string displayed in the DOSBox-X title bar.
 #         showbasic: If set, DOSBox-X will show basic information including the DOSBox-X version number and current running speed in the title bar.
@@ -67,6 +70,7 @@ autolock          = false
 autolock_feedback = beep
 clip_mouse_button = right
 clip_key_modifier = shift
+clip_paste_bios   = auto
 clip_paste_speed  = 30
 sensitivity       = 100
 mouse_emulation   = locked

--- a/include/build_timestamp.h
+++ b/include/build_timestamp.h
@@ -1,4 +1,4 @@
 /*auto-generated*/
-#define UPDATED_STR "Feb 25, 2021 12:45:55am"
-#define GIT_COMMIT_HASH "d345ff3"
+#define UPDATED_STR "Feb 27, 2021 2:08:42am"
+#define GIT_COMMIT_HASH "294e2de"
 #define COPYRIGHT_END_YEAR "2021"

--- a/include/mouse.h
+++ b/include/mouse.h
@@ -35,7 +35,7 @@ void Mouse_ChangePS2Callback(uint16_t pseg, uint16_t pofs);
 
 
 void Mouse_CursorMoved(float xrel,float yrel,float x,float y,bool emulate);
-#if defined(WIN32) || defined(C_SDL2)
+#if defined(WIN32) || defined(MACOSX) || defined(C_SDL2)
 const char* Mouse_GetSelected(int x1, int y1, int x2, int y2, int w, int h, uint16_t *textlen);
 void Mouse_Select(int x1, int y1, int x2, int y2, int w, int h, bool select);
 #endif

--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -1256,8 +1256,7 @@ void device_CON::ClearAnsi(void){
 
 void device_CON::Output(uint8_t chr) {
 	if (!ANSI_SYS_installed() && !IS_PC98_ARCH) {
-		uint16_t oldax;
-		oldax=reg_ax;
+		uint16_t oldax=reg_ax;
 		reg_ax=chr;
 		CALLBACK_RunRealInt(0x29);
 		reg_ax=oldax;

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -283,7 +283,7 @@ private:
 				}
 			CloseClipboard();
 			}
-#elif defined(C_SDL2)
+#elif defined(C_SDL2) || defined(MACOSX)
             std::ifstream in(tmpAscii);
             std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
             std::string result="";
@@ -293,7 +293,12 @@ private:
                 result+=(uname!=NULL?std::string(uname):token)+std::string(1, 10);
             }
             if (result.size()&&result.back()==10) result.pop_back();
+#if defined(C_SDL2)
             SDL_SetClipboardText(result.c_str());
+#else
+            bool SetClipboard(std::string value);
+            SetClipboard(result);
+#endif
 #endif
 		fclose(fh);
 		remove(tmpAscii);

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -659,7 +659,7 @@ int lock_file_region(int fd, int cmd, struct flock *fl, long long start, unsigne
   if (cmd == F_SETLK64 || cmd == F_GETLK64) {
     struct flock64 fl64;
     int result;
-    //LOG_MSG("Large file locking start=%llx, len=%lx\n", start, len);
+    LOG(LOG_DOSMISC,LOG_DEBUG)("Large file locking start=%llx, len=%lx\n", start, len);
     fl64.l_type = fl->l_type;
     fl64.l_whence = fl->l_whence;
     fl64.l_pid = fl->l_pid;
@@ -729,7 +729,7 @@ bool share(int fd, int mode, uint32_t flags) {
     if ((flags & 0x8000) && (fl.l_type != F_WRLCK)) return true;
     /* else fall through */
   default:
-    LOG_MSG("internal SHARE: unknown sharing mode %x\n", share_mode);
+    LOG(LOG_DOSMISC,LOG_WARN)("internal SHARE: unknown sharing mode %x\n", share_mode);
     return false;
     break;
   }
@@ -738,7 +738,7 @@ bool share(int fd, int mode, uint32_t flags) {
   if ( ret == -1 && errno == EINVAL )
 #endif
     lock_file_region( fd, F_SETLK, &fl, 0x100000000LL, 1 );
-    LOG_MSG("internal SHARE: locking: fd %d, type %d whence %d pid %d\n", fd, fl.l_type, fl.l_whence, fl.l_pid);
+    LOG(LOG_DOSMISC,LOG_DEBUG)("internal SHARE: locking: fd %d, type %d whence %d pid %d\n", fd, fl.l_type, fl.l_whence, fl.l_pid);
 
     return true;
 }
@@ -803,12 +803,12 @@ bool localDrive::FileOpen(DOS_File * * file,const char * name,uint32_t flags) {
         if (handle == INVALID_HANDLE_VALUE) return false;
         int nHandle = _open_osfhandle((intptr_t)handle, _O_RDONLY);
         if (nHandle == -1) {CloseHandle(handle);return false;}
-        hand = _wfdopen(nHandle, type);
+        hand = _wfdopen(nHandle, (flags&0xf)==OPEN_WRITE?"wb":type);
 #else
         uint16_t unix_mode = (flags&0xf)==OPEN_READ||(flags&0xf)==OPEN_READ_NO_MOD?O_RDONLY:((flags&0xf)==OPEN_WRITE?O_WRONLY:O_RDWR);
         int fd = open(host_name, unix_mode);
         if (fd<0 || !share(fd, unix_mode & O_ACCMODE, flags)) {close(fd);return false;}
-        hand = fdopen(fd, type);
+        hand = fdopen(fd, (flags&0xf)==OPEN_WRITE?"wb":type);
 #endif
     } else {
 #ifdef host_cnv_use_wchar

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -803,12 +803,12 @@ bool localDrive::FileOpen(DOS_File * * file,const char * name,uint32_t flags) {
         if (handle == INVALID_HANDLE_VALUE) return false;
         int nHandle = _open_osfhandle((intptr_t)handle, _O_RDONLY);
         if (nHandle == -1) {CloseHandle(handle);return false;}
-        hand = _wfdopen(nHandle, (flags&0xf)==OPEN_WRITE?"wb":type);
+        hand = _wfdopen(nHandle, (flags&0xf)==OPEN_WRITE?_HT("wb"):type);
 #else
         uint16_t unix_mode = (flags&0xf)==OPEN_READ||(flags&0xf)==OPEN_READ_NO_MOD?O_RDONLY:((flags&0xf)==OPEN_WRITE?O_WRONLY:O_RDWR);
         int fd = open(host_name, unix_mode);
         if (fd<0 || !share(fd, unix_mode & O_ACCMODE, flags)) {close(fd);return false;}
-        hand = fdopen(fd, (flags&0xf)==OPEN_WRITE?"wb":type);
+        hand = fdopen(fd, (flags&0xf)==OPEN_WRITE?_HT("wb"):type);
 #endif
     } else {
 #ifdef host_cnv_use_wchar

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -659,7 +659,7 @@ int lock_file_region(int fd, int cmd, struct flock *fl, long long start, unsigne
   if (cmd == F_SETLK64 || cmd == F_GETLK64) {
     struct flock64 fl64;
     int result;
-    LOG_MSG("Large file locking start=%llx, len=%lx\n", start, len);
+    //LOG_MSG("Large file locking start=%llx, len=%lx\n", start, len);
     fl64.l_type = fl->l_type;
     fl64.l_whence = fl->l_whence;
     fl64.l_pid = fl->l_pid;

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -196,9 +196,7 @@ static const char *def_menu_main_clipboard[] =
 #endif
     "clipboard_device",
     "clipboard_dosapi",
-#if defined (WIN32) && !defined(__MINGW32__)
     "clipboard_biospaste",
-#endif
     "--",
 #if defined(WIN32) || defined(C_SDL2)
     "mapper_copyall",

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -1764,30 +1764,6 @@ void DOSBox_CheckOS(int &id, int &major, int &minor) {
 }
 #endif
 
-#if defined(WIN32)
-# if defined(HX_DOS) || !defined(C_SDL2)
-HWND GetHWND(void) {
-    SDL_SysWMinfo wmi;
-    SDL_VERSION(&wmi.version);
-
-    if(!SDL_GetWMInfo(&wmi)) {
-        return NULL;
-    }
-    return wmi.window;
-}
-
-HWND GetSurfaceHWND(void) {
-    SDL_SysWMinfo wmi;
-    SDL_VERSION(&wmi.version);
-
-    if (!SDL_GetWMInfo(&wmi)) {
-        return NULL;
-    }
-    return wmi.child_window;
-}
-# endif
-#endif
-
 void MSG_WM_COMMAND_handle(SDL_SysWMmsg &Message) {
 #if defined(WIN32) && !defined(HX_DOS)
     bool GFX_GetPreventFullscreen(void);

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -187,7 +187,7 @@ static const char *def_menu_main_wheelarrow[] =
 /* main -> shared clipboard menu ("SharedClipboard") */
 static const char *def_menu_main_clipboard[] =
 {
-#if defined(WIN32) || defined(C_SDL2)
+#if defined(WIN32) || defined(MACOSX) || defined(C_SDL2)
     "mapper_fastedit",
     "clipboard_right",
     "clipboard_middle",
@@ -198,7 +198,7 @@ static const char *def_menu_main_clipboard[] =
     "clipboard_dosapi",
     "clipboard_biospaste",
     "--",
-#if defined(WIN32) || defined(C_SDL2)
+#if defined(WIN32) || defined(MACOSX) || defined(C_SDL2)
     "mapper_copyall",
 #endif
     "mapper_paste",

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -196,7 +196,7 @@ static const char *def_menu_main_clipboard[] =
 #endif
     "clipboard_device",
     "clipboard_dosapi",
-#if defined(WIN32)
+#if defined (WIN32) && !defined(__MINGW32__)
     "clipboard_biospaste",
 #endif
     "--",

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -196,6 +196,9 @@ static const char *def_menu_main_clipboard[] =
 #endif
     "clipboard_device",
     "clipboard_dosapi",
+#if defined(WIN32)
+    "clipboard_biospaste",
+#endif
     "--",
 #if defined(WIN32) || defined(C_SDL2)
     "mapper_copyall",

--- a/src/gui/menu_osx.mm
+++ b/src/gui/menu_osx.mm
@@ -31,6 +31,13 @@ void GetClipboard(std::string* result) {
 	*result = std::string([text UTF8String]);
 }
 
+bool SetClipboard(std::string value) {
+	NSPasteboard* pb = [NSPasteboard generalPasteboard];
+	NSString* text = [NSString stringWithUTF8String:value.c_str()];
+	[pb clearContents];
+	return [pb setString:text forType:NSStringPboardType];
+}
+
 void *sdl_hax_nsMenuItemFromTag(void *nsMenu, unsigned int tag) {
 	NSMenuItem *ns_item = [((NSMenu*)nsMenu) itemWithTag: tag];
 	return (ns_item != nil) ? ns_item : NULL;

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1300,11 +1300,15 @@ public:
 			PasteClipboard(true);
 			swapad=true;
 			unsigned char head;
+            GUI::Key *key;
+            GUI::Key::Special ksym = (GUI::Key::Special)0;
 			while (strPasteBuffer.length()) {
+                key = NULL;
 				head = strPasteBuffer[0];
-				if (head == 9) for (int i=0; i<8; i++) content->keyDown(GUI::Key(' ', GUI::Key::None, false, false, false, false));
-				else if (head == 13) content->keyDown(GUI::Key(GUI::Key::None, GUI::Key::Enter, false, false, false, false));
-				else if (head > 31) content->keyDown(GUI::Key(head, GUI::Key::None, false, false, false, false));
+				if (head == 9) for (int i=0; i<8; i++) key = new GUI::Key(' ', ksym, false, false, false, false);
+				else if (head == 13) key = new GUI::Key(0, GUI::Key::Enter, false, false, false, false);
+				else if (head > 31) key = new GUI::Key(head, ksym, false, false, false, false);
+                if (key != NULL) content->keyDown(*key);
 				strPasteBuffer = strPasteBuffer.substr(1, strPasteBuffer.length());
 			}
             return;
@@ -1373,11 +1377,15 @@ public:
 			PasteClipboard(true);
 			swapad=true;
 			unsigned char head;
+            GUI::Key *key;
+            GUI::Key::Special ksym = (GUI::Key::Special)0;
 			while (strPasteBuffer.length()) {
+                key = NULL;
 				head = strPasteBuffer[0];
-				if (head == 9) for (int i=0; i<8; i++) content->keyDown(GUI::Key(' ', GUI::Key::None, false, false, false, false));
-				else if (head == 13) content->keyDown(GUI::Key(GUI::Key::None, GUI::Key::Enter, false, false, false, false));
-				else if (head > 31) content->keyDown(GUI::Key(head, GUI::Key::None, false, false, false, false));
+				if (head == 9) for (int i=0; i<8; i++) key = new GUI::Key(' ', ksym, false, false, false, false);
+				else if (head == 13) key = new GUI::Key(0, GUI::Key::Enter, false, false, false, false);
+				else if (head > 31) key = new GUI::Key(head, ksym, false, false, false, false);
+                if (key != NULL) content->keyDown(*key);
 				strPasteBuffer = strPasteBuffer.substr(1, strPasteBuffer.length());
 			}
 			return;

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -67,7 +67,7 @@ protected:
     std::istringstream      lines;
 };
 
-extern uint8_t                int10_font_14[256 * 14];
+extern uint8_t              int10_font_14[256 * 14];
 
 extern uint32_t             GFX_Rmask;
 extern unsigned char        GFX_Rshift;
@@ -77,9 +77,11 @@ extern uint32_t             GFX_Bmask;
 extern unsigned char        GFX_Bshift;
 
 extern int                  statusdrive, swapInDisksSpecificDrive;
-extern bool                 dos_kernel_disabled, confres;
+extern bool                 dos_kernel_disabled, confres, swapad;
 extern Bitu                 currentWindowWidth, currentWindowHeight;
+extern std::string          strPasteBuffer;
 
+extern void                 PasteClipboard(bool bPressed);
 extern bool                 MSG_Write(const char *);
 extern void                 LoadMessageFile(const char * fname);
 extern void                 GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused);
@@ -1169,7 +1171,7 @@ public:
         int button_row_y = first_row_y + scroll_h + 5;
         int button_w = 70;
         int button_pad_w = 10;
-        int button_row_w = ((button_pad_w + button_w) * 3) - button_pad_w;
+        int button_row_w = ((button_pad_w + button_w) * 4 + button_w) - button_pad_w;
         int button_row_cx = (((columns * column_width) - button_row_w) / 2) + 5;
 
         resize((columns * column_width) + border_left + border_right + 2/*wiw border*/ + wiw->vscroll_display_width/*scrollbar*/ + 10,
@@ -1182,14 +1184,17 @@ public:
         content = new GUI::Input(this, 5, button_row_y-height+20, 510 - border_left - border_right, height-25);
         content->setText(extra_data);
 
-        GUI::Button *b = new GUI::Button(this, button_row_cx, button_row_y, "Cancel", button_w);
+        GUI::Button *b = new GUI::Button(this, button_row_cx, button_row_y, "Paste Clipboard", button_w*2);
+        b->addActionHandler(this);
+
+        b = new GUI::Button(this, button_row_cx + button_w + (button_w + button_pad_w), button_row_y, "Help", button_w);
+        b->addActionHandler(this);
+
+        b = new GUI::Button(this, button_row_cx + button_w + (button_w + button_pad_w)*2, button_row_y, "Cancel", button_w);
         b->addActionHandler(this);
         closeButton = b;
 
-        b = new GUI::Button(this, button_row_cx + (button_w + button_pad_w), button_row_y, "Help", button_w);
-        b->addActionHandler(this);
-
-        b = new GUI::Button(this, button_row_cx + (button_w + button_pad_w)*2, button_row_y, "OK", button_w);
+        b = new GUI::Button(this, button_row_cx + button_w + (button_w + button_pad_w)*3, button_row_y, "OK", button_w);
 
         int i = 0;
         Property *prop;
@@ -1259,6 +1264,7 @@ public:
 
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
         if (arg == "OK") section->data = *(std::string*)content->getText();
+        std::string lines = *(std::string*)content->getText();
         if (arg == "OK" || arg == "Cancel" || arg == "Close") { close(); if(shortcut) running=false; }
         else if (arg == "Help") {
             std::vector<GUI::Char> new_cfg_sname;
@@ -1288,6 +1294,20 @@ public:
             else {
                 lookup->second->raise();
             }
+		} else if (arg == "Paste Clipboard") {
+			strPasteBuffer="";
+			swapad=false;
+			PasteClipboard(true);
+			swapad=true;
+			unsigned char head;
+			while (strPasteBuffer.length()) {
+				head = strPasteBuffer[0];
+				if (head == 9) for (int i=0; i<8; i++) content->keyDown(GUI::Key(' ', GUI::Key::None, false, false, false, false));
+				else if (head == 13) content->keyDown(GUI::Key(GUI::Key::None, GUI::Key::Enter, false, false, false, false));
+				else if (head > 31) content->keyDown(GUI::Key(head, GUI::Key::None, false, false, false, false));
+				strPasteBuffer = strPasteBuffer.substr(1, strPasteBuffer.length());
+			}
+            return;
         } else ToplevelWindow::actionExecuted(b, arg);
     }
 
@@ -1317,7 +1337,7 @@ public:
     std::vector<GUI::Char> cfg_sname;
 public:
     AutoexecEditor(GUI::Screen *parent, int x, int y, Section_line *section) :
-        ToplevelWindow(parent, x, y, 450, 260 + GUI::titlebar_y_stop, ""), section(section) {
+        ToplevelWindow(parent, x, y, 550, 260 + GUI::titlebar_y_stop, ""), section(section) {
         if (section == NULL) {
             LOG_MSG("BUG: AutoexecEditor constructor called with section == NULL\n");
             return;
@@ -1327,12 +1347,13 @@ public:
         title[0] = std::toupper(title[0]);
         setTitle("Edit "+title);
         new GUI::Label(this, 5, 10, "Content:");
-        content = new GUI::Input(this, 5, 30, 450 - 10 - border_left - border_right, 185);
+        content = new GUI::Input(this, 5, 30, 550 - 10 - border_left - border_right, 185);
         content->setText(section->data);
-        if (first_shell) (new GUI::Button(this, 5, 220, "Append History"))->addActionHandler(this);
-        if (shell_idle) (new GUI::Button(this, 180, 220, "Execute Now"))->addActionHandler(this);
-        (closeButton = new GUI::Button(this, 290, 220, "Cancel", 70))->addActionHandler(this);
-        (new GUI::Button(this, 360, 220, "OK", 70))->addActionHandler(this);
+        (new GUI::Button(this, 5, 220, "Paste Clipboard"))->addActionHandler(this);
+        if (first_shell) (new GUI::Button(this, 147, 220, "Append History"))->addActionHandler(this);
+        if (shell_idle) (new GUI::Button(this, 281, 220, "Execute Now"))->addActionHandler(this);
+        (closeButton = new GUI::Button(this, 391, 220, "Cancel", 70))->addActionHandler(this);
+        (new GUI::Button(this, 461, 220, "OK", 70))->addActionHandler(this);
         move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
@@ -1346,7 +1367,21 @@ public:
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) {
         if (arg == "OK") section->data = *(std::string*)content->getText();
         if (arg == "OK" || arg == "Cancel" || arg == "Close") { close(); if(shortcut) running=false; }
-        else if (arg == "Append History") {
+        else if (arg == "Paste Clipboard") {
+			strPasteBuffer="";
+			swapad=false;
+			PasteClipboard(true);
+			swapad=true;
+			unsigned char head;
+			while (strPasteBuffer.length()) {
+				head = strPasteBuffer[0];
+				if (head == 9) for (int i=0; i<8; i++) content->keyDown(GUI::Key(' ', GUI::Key::None, false, false, false, false));
+				else if (head == 13) content->keyDown(GUI::Key(GUI::Key::None, GUI::Key::Enter, false, false, false, false));
+				else if (head > 31) content->keyDown(GUI::Key(head, GUI::Key::None, false, false, false, false));
+				strPasteBuffer = strPasteBuffer.substr(1, strPasteBuffer.length());
+			}
+			return;
+		} else if (arg == "Append History") {
             std::list<std::string>::reverse_iterator i = first_shell->l_history.rbegin();
             std::string lines = *(std::string*)content->getText();
             while (i != first_shell->l_history.rend()) {
@@ -1508,6 +1543,7 @@ public:
         name->setText(cycles.c_str());
         (new GUI::Button(this, 120, 60, "Cancel", 70))->addActionHandler(this);
         (new GUI::Button(this, 210, 60, "OK", 70))->addActionHandler(this);
+        (new GUI::Button(this, 300, 60, "Paste", 70))->addActionHandler(this);
         move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
 
         name->raise(); /* make sure keyboard focus is on the text field, ready for the user */

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -912,9 +912,9 @@ static SDLKey sdlkey_map[MAX_SCANCODES]={SDLK_UNKNOWN,SDLK_ESCAPE,
 void setScanCode(Section_prop * section) {
 	usescancodes = -1;
 	const char *usesc = section->Get_string("usescancodes");
-	if (!strcasecmp(usesc, "true"))
+	if (!strcasecmp(usesc, "true")||!strcmp(usesc, "1"))
 		usescancodes = 1;
-	else if (!strcasecmp(usesc, "false"))
+	else if (!strcasecmp(usesc, "false")||!strcmp(usesc, "0"))
 		usescancodes = 0;
 }
 void loadScanCode();

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4985,7 +4985,9 @@ bool has_GUI_StartUp = false;
 
 std::string GetDefaultOutput() {
     static std::string output = "surface";
-#ifdef __WIN32__
+#if defined(USE_TTF)
+    output ="ttf";
+#elif defined(WIN32)
 # if defined(HX_DOS)
     output ="surface"; /* HX DOS should stick to surface */
 # elif defined(__MINGW32__) && !(C_DIRECT3D) && !defined(C_SDL2)

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -317,6 +317,7 @@ BOOL CALLBACK EnumDispProc(HMONITOR hMon, HDC dcMon, RECT* pRcMon, LPARAM lParam
 	curscreen++;
 	if (sdl.displayNumber==curscreen) monrect=*pRcMon;
 	return TRUE;
+
 }
 #endif
 extern int dos_clipboard_device_access;
@@ -8129,8 +8130,10 @@ static bool PasteClipboardNext() {
 			GenKBStroke(uiScanCodeAlt, true, sdlmMods);
 
 		uint8_t ansiVal = cKey;
+		unsigned int ct = 0;
 		for (int i = 100; i; i /= 10) {
 			int numKey = ansiVal/i;                                    // High digit of Alt+ASCII number combination
+			if (!numKey) ct++;
 			ansiVal %= i;
 #if defined(WIN32) && (!defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR))
 			UINT uiScanCode = MapVirtualKey(numKey+VK_NUMPAD0, MAPVK_VK_TO_VSC);
@@ -8139,8 +8142,19 @@ static bool PasteClipboardNext() {
 #endif
 			GenKBStroke(uiScanCode, true, sdlmMods);
 			GenKBStroke(uiScanCode, false, sdlmMods);
-			}
+		}
 		GenKBStroke(uiScanCodeAlt, false, sdlmMods);                // Alt up
+		if (ct%2) {
+			GenKBStroke(uiScanCodeAlt, true, sdlmMods);
+#if defined(WIN32) && (!defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR))
+			UINT uiScanCode = MapVirtualKey(0+VK_NUMPAD0, MAPVK_VK_TO_VSC);
+#else
+			UINT uiScanCode = 0+'0';
+#endif
+			GenKBStroke(uiScanCode, true, sdlmMods);
+			GenKBStroke(uiScanCode, false, sdlmMods);
+			GenKBStroke(uiScanCodeAlt, false, sdlmMods);
+		}
 		if (bModAltOn)                                                // Alt down if is was already down
 			GenKBStroke(uiScanCodeAlt, true, sdlmMods);
     }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5220,8 +5220,8 @@ static void GUI_StartUp() {
     else mbutton=0;
     modifier = section->Get_string("clip_key_modifier");
     const char *pastebios = section->Get_string("clip_paste_bios");
-    if (!strcmp(pastebios, "true") || !strcmp(pastebios, "1")) clipboard_biospaste = true;
-    else if (!strcmp(pastebios, "false") || !strcmp(pastebios, "0")) clipboard_biospaste = false;
+    if (!strcasecmp(pastebios, "true") || !strcmp(pastebios, "1")) clipboard_biospaste = true;
+    else if (!strcasecmp(pastebios, "false") || !strcmp(pastebios, "0")) clipboard_biospaste = false;
     paste_speed = (unsigned int)section->Get_int("clip_paste_speed");
     wheel_key = section->Get_int("mouse_wheel_key");
     wheel_guest=wheel_key>0;
@@ -7709,10 +7709,11 @@ void SDL_SetupConfigSection() {
 		"The default modifier is \"shift\" (both left and right shift keys). Set to \"none\" if no modifier is desired.");
     Pstring->SetBasic(true);
 
-	const char* truefalseautoopt[] = { "true", "false", "auto", 0};
+	const char* truefalseautoopt[] = { "true", "false", "1", "0", "auto", 0};
 	Pstring = sdl_sec->Add_string("clip_paste_bios",Property::Changeable::WhenIdle, "auto");
 	Pstring->Set_values(truefalseautoopt);
-	Pstring->Set_help("Specify whether to use BIOS functions for clipboard pasting instead of the keyboard stroke method.");
+	Pstring->Set_help("Specify whether to use BIOS keyboard functions for clipboard pasting instead of the keystroke method.\n"
+		"For pasting clipboard text into Windows 3.x/9x applications, make sure to use the keystroke method.");
     Pstring->SetBasic(true);
 
     Pint = sdl_sec->Add_int("clip_paste_speed", Property::Changeable::WhenIdle, 30);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -7789,7 +7789,7 @@ void SDL_SetupConfigSection() {
 //  Pint->Set_help("Value of overscan color.");
 }
 
-#if defined(WIN32)
+#if defined(WIN32) && !defined(__MINGW32__)
 #define DIRECTINPUT_VERSION 0x0800
 #include <dinput.h>
 #ifndef DIK_PAUSE
@@ -10735,6 +10735,7 @@ bool dos_clipboard_device_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::ite
     return true;
 }
 
+#if defined (WIN32) && !defined(__MINGW32__)
 bool clipboard_bios_paste_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
     (void)menuitem;//UNUSED
@@ -10742,6 +10743,7 @@ bool clipboard_bios_paste_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::ite
     mainMenu.get_item("clipboard_biospaste").check(clipboard_biospaste).refresh_item(mainMenu);
     return true;
 }
+#endif
 
 bool pc98_force_uskb_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
@@ -12806,9 +12808,11 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         if (control->SecureMode()) clipboard_dosapi = false;
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_device").set_text("Enable DOS clipboard device access").set_callback_function(dos_clipboard_device_menu_callback).check(dos_clipboard_device_access==4&&!control->SecureMode());
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_dosapi").set_text("Enable DOS clipboard API for applications").set_callback_function(dos_clipboard_api_menu_callback).check(clipboard_dosapi);
-#if defined (WIN32)
+#if defined (WIN32) && !defined(__MINGW32__)
         if (IS_PC98_ARCH) clipboard_biospaste = true;
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_biospaste").set_text("Use BIOS function for clipboard pasting").set_callback_function(clipboard_bios_paste_menu_callback).check(clipboard_biospaste);
+#else
+        clipboard_biospaste = true;
 #endif
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_winlogo").set_text("Send logo key").set_callback_function(sendkey_preset_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_winmenu").set_text("Send menu key").set_callback_function(sendkey_preset_menu_callback);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1220,7 +1220,7 @@ bool                        startup_state_numlock = false; // Global for keyboar
 bool                        startup_state_capslock = false; // Global for keyboard initialisation
 bool                        startup_state_scrlock = false; // Global for keyboard initialisation
 int mouse_start_x=-1, mouse_start_y=-1, mouse_end_x=-1, mouse_end_y=-1, fx=-1, fy=-1, paste_speed=20, wheel_key=0, mbutton=3;
-bool wheel_guest = false, clipboard_dosapi = true;
+bool wheel_guest = false, clipboard_dosapi = true, clipboard_biospaste = false;
 const char *modifier;
 
 #if defined(WIN32) && !defined(C_SDL2)
@@ -7789,7 +7789,7 @@ void SDL_SetupConfigSection() {
 //  Pint->Set_help("Value of overscan color.");
 }
 
-#if defined(WIN32) && !defined(C_SDL2)
+#if defined(WIN32)
 #define DIRECTINPUT_VERSION 0x0800
 #include <dinput.h>
 #ifndef DIK_PAUSE
@@ -7797,6 +7797,10 @@ void SDL_SetupConfigSection() {
 #endif
 #ifndef DIK_OEM_102
 #define DIK_OEM_102 0x56    /* < > | on UK/Germany keyboards */
+#endif
+#if defined(C_SDL2)
+#define SDLKey SDL_Keycode
+#define SDLMod SDL_Keymod
 #endif
 static SDLKey aryScanCodeToSDLKey[0xFF];
 static bool   bScanCodeMapInited = false;
@@ -7876,20 +7880,38 @@ static void PasteInitMapSCToSDLKey()
     aryScanCodeToSDLKey[DIK_F8] = SDLK_F8;
     aryScanCodeToSDLKey[DIK_F9] = SDLK_F9;
     aryScanCodeToSDLKey[DIK_F10] = SDLK_F10;
+#if defined(C_SDL2)
+    aryScanCodeToSDLKey[DIK_NUMLOCK] = SDLK_NUMLOCKCLEAR;
+    aryScanCodeToSDLKey[DIK_SCROLL] = SDLK_SCROLLLOCK;
+#else
     aryScanCodeToSDLKey[DIK_NUMLOCK] = SDLK_NUMLOCK;
     aryScanCodeToSDLKey[DIK_SCROLL] = SDLK_SCROLLOCK;
+#endif
+    aryScanCodeToSDLKey[DIK_SUBTRACT] = SDLK_KP_MINUS;
+    aryScanCodeToSDLKey[DIK_ADD] = SDLK_KP_PLUS;
+#if defined(C_SDL2)
+    aryScanCodeToSDLKey[DIK_NUMPAD7] = SDLK_KP_7;
+    aryScanCodeToSDLKey[DIK_NUMPAD8] = SDLK_KP_8;
+    aryScanCodeToSDLKey[DIK_NUMPAD9] = SDLK_KP_9;
+    aryScanCodeToSDLKey[DIK_NUMPAD4] = SDLK_KP_4;
+    aryScanCodeToSDLKey[DIK_NUMPAD5] = SDLK_KP_5;
+    aryScanCodeToSDLKey[DIK_NUMPAD6] = SDLK_KP_6;
+    aryScanCodeToSDLKey[DIK_NUMPAD1] = SDLK_KP_1;
+    aryScanCodeToSDLKey[DIK_NUMPAD2] = SDLK_KP_2;
+    aryScanCodeToSDLKey[DIK_NUMPAD3] = SDLK_KP_3;
+    aryScanCodeToSDLKey[DIK_NUMPAD0] = SDLK_KP_0;
+#else
     aryScanCodeToSDLKey[DIK_NUMPAD7] = SDLK_KP7;
     aryScanCodeToSDLKey[DIK_NUMPAD8] = SDLK_KP8;
     aryScanCodeToSDLKey[DIK_NUMPAD9] = SDLK_KP9;
-    aryScanCodeToSDLKey[DIK_SUBTRACT] = SDLK_KP_MINUS;
     aryScanCodeToSDLKey[DIK_NUMPAD4] = SDLK_KP4;
     aryScanCodeToSDLKey[DIK_NUMPAD5] = SDLK_KP5;
     aryScanCodeToSDLKey[DIK_NUMPAD6] = SDLK_KP6;
-    aryScanCodeToSDLKey[DIK_ADD] = SDLK_KP_PLUS;
     aryScanCodeToSDLKey[DIK_NUMPAD1] = SDLK_KP1;
     aryScanCodeToSDLKey[DIK_NUMPAD2] = SDLK_KP2;
     aryScanCodeToSDLKey[DIK_NUMPAD3] = SDLK_KP3;
     aryScanCodeToSDLKey[DIK_NUMPAD0] = SDLK_KP0;
+#endif
     aryScanCodeToSDLKey[DIK_DECIMAL] = SDLK_KP_PERIOD;
     aryScanCodeToSDLKey[DIK_F11] = SDLK_F11;
     aryScanCodeToSDLKey[DIK_F12] = SDLK_F12;
@@ -7902,7 +7924,11 @@ static void PasteInitMapSCToSDLKey()
     aryScanCodeToSDLKey[DIK_NUMPADENTER] = SDLK_KP_ENTER;
     aryScanCodeToSDLKey[DIK_RCONTROL] = SDLK_RCTRL;
     aryScanCodeToSDLKey[DIK_DIVIDE] = SDLK_KP_DIVIDE;
+#if defined(C_SDL2)
+    aryScanCodeToSDLKey[DIK_SYSRQ] = SDLK_PRINTSCREEN;
+#else
     aryScanCodeToSDLKey[DIK_SYSRQ] = SDLK_PRINT;
+#endif
     aryScanCodeToSDLKey[DIK_RMENU] = SDLK_RALT;
     aryScanCodeToSDLKey[DIK_PAUSE] = SDLK_PAUSE;
     aryScanCodeToSDLKey[DIK_HOME] = SDLK_HOME;
@@ -7915,8 +7941,13 @@ static void PasteInitMapSCToSDLKey()
     aryScanCodeToSDLKey[DIK_NEXT] = SDLK_PAGEDOWN;
     aryScanCodeToSDLKey[DIK_INSERT] = SDLK_INSERT;
     aryScanCodeToSDLKey[DIK_DELETE] = SDLK_DELETE;
+#if defined(C_SDL2)
+    aryScanCodeToSDLKey[DIK_LWIN] = SDLK_LGUI;
+    aryScanCodeToSDLKey[DIK_RWIN] = SDLK_RGUI;
+#else
     aryScanCodeToSDLKey[DIK_LWIN] = SDLK_LMETA;
     aryScanCodeToSDLKey[DIK_RWIN] = SDLK_RMETA;
+#endif
     aryScanCodeToSDLKey[DIK_APPS] = SDLK_MENU;
 
     bScanCodeMapInited = true;
@@ -7934,10 +7965,16 @@ static void GenKBStroke(const UINT uiScanCode, const bool bDepressed, const SDLM
 
     SDL_Event evntKeyStroke = { 0 };
     evntKeyStroke.type = bDepressed ? SDL_KEYDOWN : SDL_KEYUP;
+#if defined(C_SDL2)
+    evntKeyStroke.key.keysym.scancode = SDL_GetScancodeFromKey(sdlkey);
+#else
     evntKeyStroke.key.keysym.scancode = (unsigned char)LOBYTE(uiScanCode);
+#endif
     evntKeyStroke.key.keysym.sym = sdlkey;
     evntKeyStroke.key.keysym.mod = keymods;
+#if !defined(C_SDL2)
     evntKeyStroke.key.keysym.unicode = 0;
+#endif
     evntKeyStroke.key.state = bDepressed ? SDL_PRESSED : SDL_RELEASED;
     SDL_PushEvent(&evntKeyStroke);
 }
@@ -7945,7 +7982,7 @@ static void GenKBStroke(const UINT uiScanCode, const bool bDepressed, const SDLM
 static bool PasteClipboardNext() {
     if (strPasteBuffer.length() == 0)
         return false;
-	if (IS_PC98_ARCH) {
+	if (clipboard_biospaste) {
 		BIOS_AddKeyToBuffer(strPasteBuffer[0]);
 		strPasteBuffer = strPasteBuffer.substr(1, strPasteBuffer.length());
 		return true;
@@ -10698,6 +10735,14 @@ bool dos_clipboard_device_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::ite
     return true;
 }
 
+bool clipboard_bios_paste_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+    clipboard_biospaste = !clipboard_biospaste;
+    mainMenu.get_item("clipboard_biospaste").check(clipboard_biospaste).refresh_item(mainMenu);
+    return true;
+}
+
 bool pc98_force_uskb_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
     (void)menuitem;//UNUSED
@@ -12760,7 +12805,11 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 #endif
         if (control->SecureMode()) clipboard_dosapi = false;
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_device").set_text("Enable DOS clipboard device access").set_callback_function(dos_clipboard_device_menu_callback).check(dos_clipboard_device_access==4&&!control->SecureMode());
-       mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_dosapi").set_text("Enable DOS clipboard API for applications").set_callback_function(dos_clipboard_api_menu_callback).check(clipboard_dosapi);
+        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_dosapi").set_text("Enable DOS clipboard API for applications").set_callback_function(dos_clipboard_api_menu_callback).check(clipboard_dosapi);
+#if defined (WIN32)
+        if (IS_PC98_ARCH) clipboard_biospaste = true;
+        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_biospaste").set_text("Use BIOS function for clipboard pasting").set_callback_function(clipboard_bios_paste_menu_callback).check(clipboard_biospaste);
+#endif
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_winlogo").set_text("Send logo key").set_callback_function(sendkey_preset_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_winmenu").set_text("Send menu key").set_callback_function(sendkey_preset_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_alttab").set_text("Send Alt+Tab").set_callback_function(sendkey_preset_menu_callback);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5479,7 +5479,7 @@ static void GUI_StartUp() {
     MAPPER_AddHandler(SwitchFullScreen,MK_f,MMODHOST,"fullscr","Toggle fullscreen", &item);
     item->set_text("Toggle fullscreen");
 
-#if defined(C_SDL2) || defined(WIN32)
+#if defined(C_SDL2) || defined(WIN32) || defined(MACOSX)
     MAPPER_AddHandler(QuickEdit,MK_nothing, 0,"fastedit", "Quick edit mode", &item);
     item->set_text("Quick edit: copy on select and paste text");
 
@@ -10745,7 +10745,7 @@ bool autolock_mouse_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * co
     return true;
 }
 
-#if defined (WIN32) || defined(C_SDL2)
+#if defined (WIN32) || defined(MACOSX) || defined(C_SDL2)
 bool arrow_keys_clipboard_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
     (void)menuitem;//UNUSED
@@ -12881,7 +12881,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         std::string doubleBufString = std::string("desktop.doublebuf");
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"showdetails").set_text("Show FPS and RT speed in title bar").set_callback_function(showdetails_menu_callback).check(!menu.hidecycles && menu.showrt);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"auto_lock_mouse").set_text("Autolock mouse").set_callback_function(autolock_mouse_menu_callback).check(sdl.mouse.autoenable);
-#if defined (WIN32) || defined(C_SDL2)
+#if defined (WIN32) || defined(MACOSX) || defined(C_SDL2)
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_right").set_text("Via right mouse button").set_callback_function(right_mouse_clipboard_menu_callback).check(mbutton==3);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_middle").set_text("Via middle mouse button").set_callback_function(middle_mouse_clipboard_menu_callback).check(mbutton==2);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"clipboard_arrows").set_text("Via arrow keys (Home=start, End=end)").set_callback_function(arrow_keys_clipboard_menu_callback).check(mbutton==4);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3898,8 +3898,14 @@ void modeSwitched(bool full) {
     if ((full && !locked) || (!full && locked)) GFX_CaptureMouse();
 }
 
+bool toaddmenu = false;
 void GFX_SwitchFullScreen(void)
 {
+    if (sdl.desktop.fullscreen && toaddmenu && static_cast<Section_prop *>(control->GetSection("sdl"))->Get_bool("showmenu")) {
+        DOSBox_SetMenu();
+        toaddmenu = false;
+    }
+
 #if defined(USE_TTF)
     if (ttf.inUse) {
         if (ttf.fullScrn) {
@@ -12750,6 +12756,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 
             menu.showrt = control->opt_showrt||sdl_sec->Get_bool("showdetails");
             menu.hidecycles = (control->opt_showcycles||sdl_sec->Get_bool("showdetails") ? false : true);
+            toaddmenu = false;
         }
 
         /* Start up main machine */
@@ -13137,8 +13144,15 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
             bool cfg_want_menu = section->Get_bool("showmenu");
 
             /* -- -- decide whether to set menu */
-            if (menu_gui && !control->opt_nomenu && cfg_want_menu)
-                DOSBox_SetMenu();
+            if (menu_gui && !control->opt_nomenu && cfg_want_menu) {
+#if DOSBOXMENU_TYPE == DOSBOXMENU_HMENU
+                if (TTF_using() && sdl.desktop.fullscreen) {
+                    DOSBox_NoMenu();
+                    toaddmenu=true;
+                } else
+#endif
+                    DOSBox_SetMenu();
+            }
             else
                 DOSBox_NoMenu();
         }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2007,8 +2007,10 @@ void SDL_Prepare(void) {
 
     SDL_PumpEvents();
     DragAcceptFiles(GetHWND(), TRUE);
-    SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY, SDL_DEFAULT_REPEAT_INTERVAL);
 #endif
+#endif
+#if !defined(C_SDL2)
+    SDL_EnableKeyRepeat(SDL_DEFAULT_REPEAT_DELAY, SDL_DEFAULT_REPEAT_INTERVAL);
 #endif
 }
 
@@ -7604,7 +7606,9 @@ void GFX_Events() {
             // ignore tab events that arrive just after regaining focus. (likely the result of alt-tab)
             if ((event.key.keysym.sym == SDLK_TAB) && (GetTicks() - sdl.focus_ticks < 2)) break;
 #endif
-#if defined (MACOSX)            
+#if defined (MACOSX)
+            if (event.type == SDL_KEYDOWN && isModifierApplied())
+                ClipKeySelect(event.key.keysym.sym);
             /* On macs CMD-Q is the default key to close an application */
             if (event.key.keysym.sym == SDLK_q && (event.key.keysym.mod == KMOD_RMETA || event.key.keysym.mod == KMOD_LMETA) ) {
                 KillSwitch(true);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1252,25 +1252,39 @@ extern "C" void SDL1_hax_SetMenu(HMENU menu);
 # include <os2.h>
 #endif
 
-#if defined(C_SDL2)
-# if defined(WIN32)
-HWND GetHWND()
-{
+#if defined(WIN32)
+HWND GetHWND(void) {
     SDL_SysWMinfo wmi;
     SDL_VERSION(&wmi.version);
+# if defined(C_SDL2)
     if (sdl.window == NULL)
         return nullptr;
     if (!SDL_GetWindowWMInfo(sdl.window, &wmi))
         return nullptr;
     return wmi.info.win.window;
+#else
+    if(!SDL_GetWMInfo(&wmi)) {
+        return NULL;
+    }
+    return wmi.window;
+#endif
 }
 
-HWND GetSurfaceHWND()
-{
+HWND GetSurfaceHWND(void) {
+# if defined(C_SDL2)
     return GetHWND();
-}
+# else
+    SDL_SysWMinfo wmi;
+    SDL_VERSION(&wmi.version);
+
+    if (!SDL_GetWMInfo(&wmi)) {
+        return NULL;
+    }
+    return wmi.child_window;
 # endif
+}
 #endif
+
 void SDL_rect_cliptoscreen(SDL_Rect &r) {
     if (r.x < 0) {
         r.w += r.x;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4986,10 +4986,12 @@ bool has_GUI_StartUp = false;
 std::string GetDefaultOutput() {
     static std::string output = "surface";
 #if defined(USE_TTF)
-    output ="ttf";
+    std::string mtype(static_cast<Section_prop *>(control->GetSection("dosbox"))->Get_string("machine"));
+    if (mtype.substr(0, 3) == "vga" || mtype.substr(0, 4) == "svga" || mtype.substr(0, 4) == "vesa" || mtype.substr(0, 4) == "pc98")
+        return "ttf";
 #elif defined(WIN32)
 # if defined(HX_DOS)
-    output ="surface"; /* HX DOS should stick to surface */
+    output = "surface"; /* HX-DOS should stick to surface */
 # elif defined(__MINGW32__) && !(C_DIRECT3D) && !defined(C_SDL2)
     /* NTS: OpenGL output never seems to work in VirtualBox under Windows XP */
     output = isVirtualBox ? "surface" : "opengl"; /* MinGW builds do not yet have Direct3D */

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -8645,18 +8645,27 @@ startfunction:
         if (machine != MCH_PC98 && textsplash) {
             Bitu edx = reg_edx;
             int oldx = x, oldy = y;
-            const char *str[4];
-            str[0] = "+-------------------+";
-            str[1] = "|    Welcome  To    |";
-            str[2] = "| D O S B o x - X ! |";
-            str[3] = "+-------------------+";
-            for (unsigned int i=0; i<4; i++) {
+            char str[7][30];
+            strcpy(str[0], "+-------------------+");
+            strcpy(str[1], "|    Welcome  To    |");
+            strcpy(str[2], "| D O S B o x - X ! |");
+            strcpy(str[3], "|                   |");
+            sprintf(str[4], "|    %d-bit %s    |",
+#if defined(_M_X64) || defined (_M_AMD64) || defined (_M_ARM64) || defined (_M_IA64) || defined(__ia64__) || defined(__LP64__) || defined(_WIN64) || defined(__x86_64__) || defined(__aarch64__) || defined(__powerpc64__)^M
+            64
+#else^M
+            32
+#endif^M
+            , SDL_STRING);
+            sprintf(str[5], "|  Version %7s  |", VERSION);
+            strcpy(str[6], "+-------------------+");
+            for (unsigned int i=0; i<7; i++) {
                 for (unsigned int j=0; j<strlen(str[i]); j++) {
                     reg_eax = 0x0200u;
                     reg_ebx = 0x0000u;
                     reg_edx = 0x0236u + i*0x100 + j;
                     CALLBACK_RunRealInt(0x10);
-                    reg_eax = 0x0900u+(i==0&&j==0?0xDA:(i==0&&j==strlen(str[0])-1?0xBF:(i==3&&j==0?0xD3:(i==3&&j==strlen(str[3])-1?0xD9:(str[i][j]=='-'&&i!=2?0xC4:(str[i][j]=='|'?0xB3:str[i][j]%0xff))))));
+                    reg_eax = 0x0900u+(i==0&&j==0?0xDA:(i==0&&j==strlen(str[0])-1?0xBF:(i==6&&j==0?0xD3:(i==6&&j==strlen(str[6])-1?0xD9:(str[i][j]=='-'&&i!=2&&i!=4?0xC4:(str[i][j]=='|'?0xB3:str[i][j]%0xff))))));
                     reg_ebx = 0x002fu;
                     reg_ecx = 0x0001u;
                     CALLBACK_RunRealInt(0x10);

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -7055,14 +7055,6 @@ int oldcols = 0, oldlins = 0;
 void showBIOSSetup(const char* card, int x, int y) {
     reg_eax = 3;        // 80x25 text
     CALLBACK_RunRealInt(0x10);
-#if defined(USE_TTF)
-    if (TTF_using() && (ttf.cols != 80 || ttf.lins != 25)) {
-        oldcols = ttf.cols;
-        oldlins = ttf.lins;
-        ttf_setlines(80, 25);
-    } else
-        oldcols = oldlins = 0;
-#endif
     if (machine == MCH_PC98) {
         for (unsigned int i=0;i < (80*400);i++) {
             mem_writeb(0xA8000+i,0);        // B
@@ -8508,7 +8500,6 @@ private:
     }
     CALLBACK_HandlerObject cb_bios_startup_screen;
     static Bitu cb_bios_startup_screen__func(void) {
-startfunction:
         if (control->opt_fastlaunch && machine != MCH_PC98) {
 #if defined(USE_TTF)
             if (TTF_using()) {
@@ -8527,11 +8518,21 @@ startfunction:
         extern void GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused);
         RunningProgram = "DOSBOX-X";
         GFX_SetTitle(-1,-1,-1,false);
-        const char *msg = "DOSBox-X (C) 2011-" COPYRIGHT_END_YEAR " The DOSBox-X Team\nDOSBox-X project maintainer: joncampbell123\nDOSBox-X project homepage: https://dosbox-x.com\n\n";
-        int logo_x,logo_y,x,y,rowheight=8;
-
-        y = 2;
-        x = 2;
+        const char *msg = "DOSBox-X (C) 2011-" COPYRIGHT_END_YEAR " The DOSBox-X Team\nDOSBox-X project maintainer: joncampbell123\nDOSBox-X project homepage: https://dosbox-x.com\nDOSBox-X user guide: https://dosbox-x.com/wiki\n\n";
+        bool textsplash = false;
+#if defined(USE_TTF)
+        if (TTF_using()) {
+            textsplash = true;
+            if (ttf.cols != 80 || ttf.lins != 25) {
+                oldcols = ttf.cols;
+                oldlins = ttf.lins;
+                ttf_setlines(80, 25);
+            } else
+                oldcols = oldlins = 0;
+        }
+#endif
+startfunction:
+        int logo_x,logo_y,x=2,y=2,rowheight=8;
         logo_y = 2;
         logo_x = 80 - 2 - (224/8);
 
@@ -8539,14 +8540,14 @@ startfunction:
 
         // TODO: For those who would rather not use the VGA graphical modes, add a configuration option to "disable graphical splash".
         //       We would then revert to a plain text copyright and status message here (and maybe an ASCII art version of the DOSBox-X logo).
-        //       This option is especially useful for TrueType font (TTF) output which supports text-mode only
-        if (IS_VGA_ARCH) {
+        //       For TrueType font (TTF) output (which supports text-mode only) the text-mode splash will be used automatically.
+        if (IS_VGA_ARCH && !textsplash) {
             rowheight = 16;
             reg_eax = 18;       // 640x480 16-color
             CALLBACK_RunRealInt(0x10);
             DrawDOSBoxLogoVGA((unsigned int)logo_x*8u,(unsigned int)logo_y*(unsigned int)rowheight);
         }
-        else if (machine == MCH_EGA) {
+        else if (machine == MCH_EGA && !textsplash) {
             rowheight = 14;
             reg_eax = 16;       // 640x350 16-color
             CALLBACK_RunRealInt(0x10);
@@ -8560,7 +8561,7 @@ startfunction:
 
             DrawDOSBoxLogoVGA((unsigned int)logo_x*8u,(unsigned int)logo_y*(unsigned int)rowheight);
         }
-        else if (machine == MCH_CGA || machine == MCH_MCGA || machine == MCH_PCJR || machine == MCH_AMSTRAD || machine == MCH_TANDY) {
+        else if ((machine == MCH_CGA || machine == MCH_MCGA || machine == MCH_PCJR || machine == MCH_AMSTRAD || machine == MCH_TANDY) && !textsplash) {
             rowheight = 8;
             reg_eax = 6;        // 640x200 2-color
             CALLBACK_RunRealInt(0x10);
@@ -8618,10 +8619,11 @@ startfunction:
                 }
             }
 
-            if (!control->opt_fastlaunch) DrawDOSBoxLogoPC98((unsigned int)logo_x*8u,(unsigned int)logo_y*(unsigned int)rowheight);
-
-            reg_eax = 0x4000;   // show the graphics layer (PC-98) so we can render the DOSBox logo
-            CALLBACK_RunRealInt(0x18);
+            if (!textsplash) {
+                if (!control->opt_fastlaunch) DrawDOSBoxLogoPC98((unsigned int)logo_x*8u,(unsigned int)logo_y*(unsigned int)rowheight);
+                reg_eax = 0x4000;   // show the graphics layer (PC-98) so we can render the DOSBox-X logo
+                CALLBACK_RunRealInt(0x18);
+            }
         }
         else {
             reg_eax = 3;        // 80x25 text
@@ -8640,6 +8642,31 @@ startfunction:
         }
 
         BIOS_Int10RightJustifiedPrint(x,y,msg);
+        if (machine != MCH_PC98 && textsplash) {
+            Bitu edx = reg_edx;
+            int oldx = x, oldy = y;
+            const char *str[4];
+            str[0] = "+-------------------+";
+            str[1] = "|    Welcome  To    |";
+            str[2] = "| D O S B o x - X ! |";
+            str[3] = "+-------------------+";
+            for (unsigned int i=0; i<4; i++) {
+                for (unsigned int j=0; j<strlen(str[i]); j++) {
+                    reg_eax = 0x0200u;
+                    reg_ebx = 0x0000u;
+                    reg_edx = 0x0236u + i*0x100 + j;
+                    CALLBACK_RunRealInt(0x10);
+                    reg_eax = 0x0900u+(i==0&&j==0?0xDA:(i==0&&j==strlen(str[0])-1?0xBF:(i==3&&j==0?0xD3:(i==3&&j==strlen(str[3])-1?0xD9:(str[i][j]=='-'&&i!=2?0xC4:(str[i][j]=='|'?0xB3:str[i][j]%0xff))))));
+                    reg_ebx = 0x002fu;
+                    reg_ecx = 0x0001u;
+                    CALLBACK_RunRealInt(0x10);
+                }
+            }
+            reg_eax = 0x0200u;
+            reg_ebx = 0x0000u;
+            reg_edx = edx;
+            CALLBACK_RunRealInt(0x10);
+        }
 
         {
             uint64_t sz = (uint64_t)MEM_TotalPages() * (uint64_t)4096;
@@ -8887,9 +8914,6 @@ startfunction:
                     }
                     if (askexit) {
                         if (reg_al == 'Y' || reg_al == 'y') {
-#if defined(USE_TTF)
-                            if (TTF_using() && oldcols>0 && oldlins>0) ttf_setlines(oldcols, oldlins);
-#endif
                             goto startfunction;
                         } else {
                             reg_eax = 0x0200u;
@@ -8958,9 +8982,6 @@ startfunction:
                             reg_eax = 0x1600;
                             reg_edx = 0xE100;
                             CALLBACK_RunRealInt(0x18);
-#if defined(USE_TTF)
-                            if (TTF_using() && oldcols>0 && oldlins>0) ttf_setlines(oldcols, oldlins);
-#endif
                             goto startfunction;
                         }
                         reg_eax = 0x0200u;
@@ -8986,6 +9007,9 @@ startfunction:
         }
 #endif
 
+#if defined(USE_TTF)
+        if (TTF_using() && oldcols>0 && oldlins>0) ttf_setlines(oldcols, oldlins);
+#endif
         if (machine == MCH_PC98) {
             reg_eax = 0x4100;   // hide the graphics layer (PC-98)
             CALLBACK_RunRealInt(0x18);

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -29,6 +29,8 @@
 #include "programs.h"
 #include "render.h"
 #include "menu.h"
+#include "regs.h"
+#include "callback.h"
 
 #define SEQ_REGS 0x05
 #define GFX_REGS 0x09
@@ -1179,6 +1181,11 @@ void ttf_switch_off(bool ss=true) {
 
 void ttf_switch_on(bool ss=true) {
     if (ss&&ttfswitch||!ss&&switch_output_from_ttf) {
+        uint16_t oldax=reg_ax;
+        reg_ax=0x1600;
+        CALLBACK_RunRealInt(0x2F);
+        if (reg_al!=0&&reg_al!=0x80) {reg_ax=oldax;return;}
+        reg_ax=oldax;
         change_output(10);
         SetVal("sdl", "output", "ttf");
         void OutputSettingMenuUpdate(void);

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -709,7 +709,7 @@ uint8_t Mouse_GetButtonState(void) {
     return mouse.buttons;
 }
 
-#if defined(WIN32) || defined(C_SDL2)
+#if defined(WIN32) || defined(MACOSX) || defined(C_SDL2)
 #include "render.h"
 char text[5000];
 const char* Mouse_GetSelected(int x1, int y1, int x2, int y2, int w, int h, uint16_t *textlen) {

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -2740,6 +2740,7 @@ nextfile:
 		WriteOut(MSG_Get("SHELL_CMD_FILE_NOT_FOUND"),word);
 		return;
 	}
+	ctrlbrk=false;
 	do {
 		n=1;
 		DOS_ReadFile(handle,&c,&n);
@@ -2761,6 +2762,7 @@ nextfile:
 				nlines=0;
 			}
 		}
+        if (CheckBreak(this)) break;
 	} while (n);
 	DOS_CloseFile(handle);
 	if (*args) {


### PR DESCRIPTION
As mentioned in Issue #2310, in Windows SDL1 builds clipboard pasting work with Win3.x apps, but not in Windows SDL2 builds. This will make clipboard pasting in Windows SDL2 builds work the same way as Windows SDL1 builds by default. A menu option "Use BIOS function for keyboard pasting" is added to "Shared clipboard functions" menu group (under "Main") to use the BIOS method instead in both Windows SDL1 and SDL2 builds. There is also a "Paste Clipboard" button in certain sections of the Configuration Tool.