### PR TITLE
Fix oversights in porting SVN r4330

### DIFF
--- a/include/mem.h
+++ b/include/mem.h
@@ -81,16 +81,16 @@ static INLINE uint16_t host_readw(ConstHostPt off) {
 static INLINE uint32_t host_readd(ConstHostPt off) {
     return __builtin_bswap32(*(uint32_t *)off);
 }
-static INLINE void host_writew(HostPt off, const uint16_t val) {
+static INLINE void host_writew(HostPt const off, const uint16_t val) {
     *(uint16_t *)off = __builtin_bswap16(val);
 }
-static INLINE void host_writed(HostPt off, const uint32_t val) {
+static INLINE void host_writed(HostPt const off, const uint32_t val) {
     *(uint32_t *)off = __builtin_bswap32(val);
 }
-static INLINE void host_writeq(HostPt off, const uint64_t val) {
+static INLINE void host_writeq(HostPt const off, const uint64_t val) {
     *(uint64_t *)off = __builtin_bswap64(val);
 }
-#elif defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)
+#elif !defined(C_UNALIGNED_MEMORY)
 /* !defined(C_UNALIGNED_MEMORY) meaning: we're probably being compiled for a processor that doesn't like unaligned WORD access,
         on such processors typecasting memory as uint16_t and higher can cause a fault if the
         address is not aligned to that datatype when we read/write through it. */

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1666,6 +1666,7 @@ void fatDrive::fatDriveInit(const char *sysFilename, uint32_t bytesector, uint32
         bootbuffer.bpb.v.BPB_NumHeads = var_read(&bootbuffer.bpb.v.BPB_NumHeads);
         bootbuffer.bpb.v.BPB_HiddSec = var_read(&bootbuffer.bpb.v.BPB_HiddSec);
         bootbuffer.bpb.v.BPB_TotSec32 = var_read(&bootbuffer.bpb.v.BPB_TotSec32);
+        bootbuffer.bpb.v.BPB_VolID = var_read(&bootbuffer.bpb.v.BPB_VolID);
 
         if (!is_hdd) {
             /* Identify floppy format */


### PR DESCRIPTION
When I reviewed https://github.com/joncampbell123/dosbox-x/commit/6e3e4845a35db15e96daaf03dc9291e064da2a4a, which is a port of https://sourceforge.net/p/dosbox/code-0/4330, looking for any mistakes that might be causing https://github.com/joncampbell123/dosbox-x/issues/2336. I did notice a few places where I had not adapted the SVN code to existing DOSBox-X code.

These are just minor things that weren't the cause of that issue, but I'm going ahead and sending in this PR for them.

Changes:
1. Unlike the SVN code, all the `host_write` functions in `mem.h` in DOSBox-X have `const` before the first parameter. The new `host_write` functions of SVN r4330 now also have this.
2. Unlike the SVN code, in `mem.h` in DOSBox-X, the `host_write` and `host_read` functions at the top were within only `#if !defined(C_UNALIGNED_MEMORY)`, not `#if defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)`. The `#elif defined(WORDS_BIGENDIAN) || !defined(C_UNALIGNED_MEMORY)` of SVN r3440 now just has `!defined(C_UNALIGNED_MEMORY)` to match what had been in DOSBox-X before I ported the commit. (Looks like you removed `#if defined(WORDS_BIGENDIAN)` in a commit some years ago: https://github.com/joncampbell123/dosbox-x/commit/8cb3c035f82cec27f0bf3e54c9d04d58a239e659.)
3. In `drive_fat.cpp`, SVN r4330 includes a part where `bootbuffer.bpb.v` gets its values assigned the return value of passing in all the `bootbuffer.bpb.v` members that are 2 or more bytes to `var_read`. In DOSBox-X, `bootbuffer.bpb.v` here is a `FAT_BPB_MSDOS`, a typedef for `FAT_BPB_MSDOS40`. `FAT_BPB_MSDOS40` has one more member that is 2 or more bytes here that is not present in SVN: `BPB_VolID`. This is now also assigned with `var_read`.