### PR TITLE
Some fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,8 +24,8 @@
     if the start is not a multiple of the ratio of
     logical to physical sector size. This allows the
     HDI image of Dragon Knight 4 to mount.
-  - Fixed Windows 9x installation failures caused by
-    FAT driver changes in the previous version.
+  - Fixed Windows 95/98 installation failures caused by
+    FAT driver and DOS API changes in previous version.
   - Fixed well-intended but erroneous fall through case
     in the INT15 handler that prevented 3rd party mouse
     drivers from detecting the PS/2 mouse.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,8 @@
     not working (but "ttf.wp=xy" did work). (Wengier)
   - Fixed preview function in WordStar not working for
     TrueType font output in previous version. (Wengier)
+  - Increased upper limit of "prebuffer" config option
+    (in [mixer] section) from 100 to 250. (Wengier)
   - Integrated SVN commits (Allofich)
     - r4416: Added ability to start and stop avi
     recording, and to start keymapper, from config.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@
   - CD-ROM image emulation now supports ISO images
     that are 2GB or larger, 32-bit integer size limit
     has been lifted.
+  - Increased upper limit of "prebuffer" config option
+    (in [mixer] section) from 100 to 250. (Wengier)
   - Added scrollbar buttons to the Configuration Tool,
     so that the scrollbars better resemble the style of
     the Windows 3.1 scrollbars.
@@ -29,12 +31,12 @@
   - Fixed well-intended but erroneous fall through case
     in the INT15 handler that prevented 3rd party mouse
     drivers from detecting the PS/2 mouse.
+  - Fixed the color issue with the Configuration Tool
+    in the macOS SDL1 build. (ant_222)
   - Fixed setting option "ttf.wp=xy3" or "ttf.wp=xy4"
     not working (but "ttf.wp=xy" did work). (Wengier)
   - Fixed preview function in WordStar not working for
     TrueType font output in previous version. (Wengier)
-  - Increased upper limit of "prebuffer" config option
-    (in [mixer] section) from 100 to 250. (Wengier)
   - Integrated SVN commits (Allofich)
     - r4416: Added ability to start and stop avi
     recording, and to start keymapper, from config.

--- a/src/cpu/core_dyn_x86/dyn_mmx.h
+++ b/src/cpu/core_dyn_x86/dyn_mmx.h
@@ -40,5 +40,5 @@ static void dyn_mmx_op(Bitu op) {
 }
 
 static void dyn_mmx_emms() {
-	dyn_call_function_pagefault_check((void*)&setFPUTagEmpty, "");
+	gen_call_function((void*)&setFPUTagEmpty, "");
 }

--- a/src/cpu/core_dyn_x86/dyn_mmx.h
+++ b/src/cpu/core_dyn_x86/dyn_mmx.h
@@ -30,15 +30,15 @@ static void dyn_mmx_op(Bitu op) {
 
 	if (decode.modrm.mod < 3) {
 		dyn_fill_ea();
-		gen_call_function((void*)&gen_mmx_op, "%I%I%I%Ddr", op, decode.modrm.val, imm, DREG(EA));
+		dyn_call_function_pagefault_check((void*)&gen_mmx_op, "%I%I%I%Ddr", op, decode.modrm.val, imm, DREG(EA));
 	}
 	else {
 		if ((op == 0x71) || (op == 0x72) || (op == 0x73))
 			decode_fetchb_imm(imm);
-		gen_call_function((void*)&gen_mmx_op, "%I%I%I", op, decode.modrm.val, imm);
+		dyn_call_function_pagefault_check((void*)&gen_mmx_op, "%I%I%I", op, decode.modrm.val, imm);
 	}
 }
 
 static void dyn_mmx_emms() {
-	gen_call_function((void*)&setFPUTagEmpty, "");
+	dyn_call_function_pagefault_check((void*)&setFPUTagEmpty, "");
 }

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -4150,24 +4150,33 @@ void DOS_Int21_71a8(char* name1, const char* name2) {
 			MEM_StrCopy(SegPhys(ds)+reg_si,name1,DOSNAMEBUF);
 			int i,j=0,o=0;
             char c[13];
-            const char* s = strrchr(name1, '.');
-			for (i=0;i<8;j++) {
-					if (name1[j] == 0 || s-name1 <= j) break;
-					if (name1[j] == '.') continue;
-					c[o++] = toupper(name1[j]);
-					i++;
-			}
-			if (s != NULL) {
-					s++;
-					if (s != 0 && reg_dh == 1) c[o++] = '.';
-					for (i=0;i<3;i++) {
-							if (*(s+i) == 0) break;
-							c[o++] = toupper(*(s+i));
-					}
-			}
-			assert(o <= 12);
-			c[o] = 0;
-			MEM_BlockWrite(SegPhys(es)+reg_di,c,strlen(c)+1);
+            if (reg_dh == 0) memset(c, 0, sizeof(c));
+            if (strcmp(name1, ".") && strcmp(name1, "..")) {
+                const char* s = strrchr(name1, '.');
+                for (i=0;i<8;j++) {
+                        if (name1[j] == 0 || (s==NULL?8:s-name1) <= j) {
+                            if (reg_dh == 0 && s != NULL) for (int j=0; j<8-i; j++) c[o++] = ' ';
+                            break;
+                        }
+                        while (name1[j]&&name1[j]<=32||name1[j]==127||name1[j]=='"'||name1[j]=='+'||name1[j]=='='||name1[j]=='.'||name1[j]==','||name1[j]==';'||name1[j]==':'||name1[j]=='<'||name1[j]=='>'||name1[j]=='['||name1[j]==']'||name1[j]=='|'||name1[j]=='?'||name1[j]=='*') j++;
+                        c[o++] = toupper(name1[j]);
+                        i++;
+                }
+                if (s != NULL) {
+                        s++;
+                        if (s != 0 && reg_dh == 1) c[o++] = '.';
+                        j=0;
+                        for (i=0;i<3;i++) {
+                                if (*(s+i+j) == 0) break;
+                                while (*(s+i+j)&&*(s+i+j)<=32||*(s+i+j)==127||*(s+i+j)=='"'||*(s+i+j)=='+'||*(s+i+j)=='='||*(s+i+j)==','||*(s+i+j)==';'||*(s+i+j)==':'||*(s+i+j)=='<'||*(s+i+j)=='>'||*(s+i+j)=='['||*(s+i+j)==']'||*(s+i+j)=='|'||*(s+i+j)=='?'||*(s+i+j)=='*') j++;
+                                c[o++] = toupper(*(s+i+j));
+                        }
+                }
+                assert(o <= 12);
+                c[o] = 0;
+            } else
+                strcpy(c, name1);
+			MEM_BlockWrite(SegPhys(es)+reg_di,c,reg_dh==1?strlen(c)+1:11);
 			reg_ax=0;
 			CALLBACK_SCF(false);
 	} else {

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -1204,8 +1204,8 @@ bool DOS_CreateTempFile(char * const name,uint16_t * entry) {
 		for (i=0;i<8;i++) {
 			tempname[i]=(rand()%26)+'A';
 		}
-		tempname[8]=0;
-		if (DOS_FileExists(name)) {cont=true;continue;}
+		tempname[8]='.';tempname[9]='T';tempname[10]='M';tempname[11]='P';tempname[12]=0;
+		//if (DOS_FileExists(name)) {cont=true;continue;} // FIXME: Check name uniqueness
 	} while (cont || (!DOS_CreateFile(name,0,entry) && dos.errorcode==DOSERR_FILE_ALREADY_EXISTS));
 	if (dos.errorcode) return false;
 	return true;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2537,7 +2537,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pint->SetBasic(true);
 
     Pint = secprop->Add_int("prebuffer",Property::Changeable::OnlyAtStart,25);
-    Pint->SetMinMax(0,100);
+    Pint->SetMinMax(0,250);
     Pint->Set_help("How many milliseconds of data to keep on top of the blocksize.");
 
     secprop=control->AddSection_prop("midi",&Null_Init,true);//done


### PR DESCRIPTION
This fixes the "Message SU991016" issue when installing Windows 98, along with code changes such as replacing gen_call_function with dyn_call_function_pagefault_check (as suggested by @koolkdev) and @ant-222's fix of issue #2322.