### PR TITLE
Fix for Win 3.x corrupt Group files in FAT image files #2381

### DIFF
--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -440,10 +440,9 @@ bool fatFile::Write(const uint8_t * data, uint16_t *size) {
 			if(loadedSector) myDrive->writeSector(currentSector, sectorBuffer);
 			loadedSector = false;
 
-			if (sizedec == 0) { curSectOff = 0; goto finalizeWrite; }
-
 			currentSector = myDrive->getAbsoluteSectFromBytePos(firstCluster, seekpos);
 			if(currentSector == 0) {
+			    if (sizedec == 0) goto finalizeWrite;
 				/* EOC reached before EOF - try to increase file allocation */
 				myDrive->appendCluster(firstCluster);
 				/* Try getting sector again */


### PR DESCRIPTION
This is a fix for #2381.
Month ago joncampbell fixed a FAT image problem: scandisk detected file length errors in some created files.
But this fix creates a problem with corrupted GRP files in windows 3.1x installations (see #1758).

With this new patch both problems are gone: no file size and no group file problems anymore.

The creation and extension of windows 3.1x group files is weird:
It's done with multiple position and write commands, some of them are writings of 1 or zero bytes at all.

# Description

_Summary of changes brought by this PR._


**Does this PR address some issue(s) ?**

_Add the issue(s) fixed, e.g. ```#2390 #1758```_


**Does this PR introduce new feature(s) ?**

No


**Are there any breaking changes ?**

Not really.


**Additional information**


