### PR TITLE
SVN r4444

### DIFF
--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -130,7 +130,7 @@ private:
         col=CURSOR_POS_COL(page) ;
         row=CURSOR_POS_ROW(page) ;
         if (!IS_PC98_ARCH)
-            ansi.nrows = real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS) + 1;
+            ansi.nrows = IS_EGAVGA_ARCH ? (real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS) + 1) : 25;
         tempdata = (ansi.data[0]? ansi.data[0] : 1);
         if(tempdata + static_cast<Bitu>(row) >= ansi.nrows)
         { row = ansi.nrows - 1;}
@@ -184,7 +184,7 @@ private:
 
         if (!IS_PC98_ARCH) {
             ansi.ncols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-            ansi.nrows = real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS) + 1;
+            ansi.nrows = IS_EGAVGA_ARCH ? (real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS) + 1) : 25;
         }
         /* Turn them into positions that are on the screen */
         if(ansi.data[0] >= ansi.nrows) ansi.data[0] = (uint8_t)ansi.nrows - 1;
@@ -1021,7 +1021,7 @@ bool device_CON::Write(const uint8_t * data,uint16_t * size) {
                     }
                     if (!IS_PC98_ARCH) {
                         ansi.ncols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-                        ansi.nrows = real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS) + 1;
+                        ansi.nrows = IS_EGAVGA_ARCH ? (real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS) + 1) : 25;
                     }
                     /* Turn them into positions that are on the screen */
                     if(ansi.data[0] == 0) ansi.data[0] = 1;
@@ -1083,7 +1083,7 @@ bool device_CON::Write(const uint8_t * data,uint16_t * size) {
                     row = CURSOR_POS_ROW(page);
                     if (!IS_PC98_ARCH) {
                         ansi.ncols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-                        ansi.nrows = real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS) + 1;
+                        ansi.nrows = IS_EGAVGA_ARCH ? (real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS) + 1) : 25;
                     }
 					INT10_ScrollWindow(row,0,ansi.nrows-1,ansi.ncols-1,ansi.data[0]? -ansi.data[0] : -1,ansi.attr,0xFF);
                     ClearAnsi();

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -819,6 +819,8 @@ static void INT10_Seg40Init(void) {
 		real_writeb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL,0x60);
 		real_writeb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT,16);
 		real_writeb(BIOSMEM_SEG,BIOSMEM_SWITCHES,0xF9);
+		// Set the pointer to video save pointer table
+		real_writed(BIOSMEM_SEG, BIOSMEM_VS_POINTER, int10.rom.video_save_pointers);
 	}
 	else {
 		real_writeb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL,0x00);
@@ -833,11 +835,11 @@ static void INT10_Seg40Init(void) {
 		real_writeb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL,0x10|(DISP2_Active()?0:1));
     else
 #endif
+	if (IS_EGAVGA_ARCH) {
 		real_writeb(BIOSMEM_SEG,BIOSMEM_MODESET_CTL,0x51); // why is display switching enabled (bit 6) ?
-	// Set the  default MSR
+	}
+	// Set the default MSR
 	real_writeb(BIOSMEM_SEG,BIOSMEM_CURRENT_MSR,0x09);
-	// Set the pointer to video save pointer table
-	real_writed(BIOSMEM_SEG, BIOSMEM_VS_POINTER, int10.rom.video_save_pointers);
 }
 
 static void INT10_InitVGA(void) {

--- a/src/ints/int10.h
+++ b/src/ints/int10.h
@@ -95,7 +95,8 @@ extern uint32_t S3_LFB_BASE;
 
 /* FIXME: Wait, what?? What the hell kind of preprocessor macro is this??? Kill these macros! --J.C. */
 #define BIOS_NCOLS uint16_t ncols=IS_PC98_ARCH ? 80 : real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-#define BIOS_NROWS uint16_t nrows=IS_PC98_ARCH ? (uint16_t)(real_readb(0x60,0x112)+1u) : (uint16_t)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1u;
+#define BIOS_NROWS uint16_t nrows=IS_PC98_ARCH ? (uint16_t)(real_readb(0x60,0x112)+1u) : IS_EGAVGA_ARCH?((uint16_t)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1):25;
+#define BIOS_CHEIGHT uint8_t cheight=IS_EGAVGA_ARCH?real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT):8;
 
 extern uint8_t int10_font_08[256 * 8];
 extern uint8_t int10_font_14[256 * 14];

--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -35,7 +35,7 @@ uint8_t DefaultANSIAttr();
 #endif
 
 static void MCGA2_CopyRow(uint8_t cleft,uint8_t cright,uint8_t rold,uint8_t rnew,PhysPt base) {
-    uint8_t cheight = real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
+    BIOS_CHEIGHT;
     PhysPt dest=base+((CurMode->twidth*rnew)*cheight+cleft);
     PhysPt src=base+((CurMode->twidth*rold)*cheight+cleft);
     Bitu copy=(Bitu)(cright-cleft);
@@ -47,7 +47,7 @@ static void MCGA2_CopyRow(uint8_t cleft,uint8_t cright,uint8_t rold,uint8_t rnew
 }
 
 static void CGA2_CopyRow(uint8_t cleft,uint8_t cright,uint8_t rold,uint8_t rnew,PhysPt base) {
-    uint8_t cheight = real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
+    BIOS_CHEIGHT;
     PhysPt dest=base+((CurMode->twidth*rnew)*(cheight/2)+cleft);
     PhysPt src=base+((CurMode->twidth*rold)*(cheight/2)+cleft);
     Bitu copy=(Bitu)(cright-cleft);
@@ -60,7 +60,7 @@ static void CGA2_CopyRow(uint8_t cleft,uint8_t cright,uint8_t rold,uint8_t rnew,
 }
 
 static void CGA4_CopyRow(uint8_t cleft,uint8_t cright,uint8_t rold,uint8_t rnew,PhysPt base) {
-    uint8_t cheight = real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
+    BIOS_CHEIGHT;
     PhysPt dest=base+((CurMode->twidth*rnew)*(cheight/2)+cleft)*2;
     PhysPt src=base+((CurMode->twidth*rold)*(cheight/2)+cleft)*2;   
     Bitu copy=(Bitu)(cright-cleft)*2u;Bitu nextline=(Bitu)CurMode->twidth*2u;
@@ -72,7 +72,7 @@ static void CGA4_CopyRow(uint8_t cleft,uint8_t cright,uint8_t rold,uint8_t rnew,
 }
 
 static void TANDY16_CopyRow(uint8_t cleft,uint8_t cright,uint8_t rold,uint8_t rnew,PhysPt base) {
-    uint8_t cheight = real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
+    BIOS_CHEIGHT;
     uint8_t banks=CurMode->twidth/10;
     PhysPt dest=base+((CurMode->twidth*rnew)*(cheight/banks)+cleft)*4;
     PhysPt src=base+((CurMode->twidth*rold)*(cheight/banks)+cleft)*4;
@@ -85,7 +85,7 @@ static void TANDY16_CopyRow(uint8_t cleft,uint8_t cright,uint8_t rold,uint8_t rn
 
 static void EGA16_CopyRow(uint8_t cleft,uint8_t cright,uint8_t rold,uint8_t rnew,PhysPt base) {
     PhysPt src,dest;Bitu copy;
-    uint8_t cheight = real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
+    BIOS_CHEIGHT;
     dest=base+(CurMode->twidth*rnew)*cheight+cleft;
     src=base+(CurMode->twidth*rold)*cheight+cleft;
     Bitu nextline=(Bitu)CurMode->twidth;
@@ -105,7 +105,7 @@ static void EGA16_CopyRow(uint8_t cleft,uint8_t cright,uint8_t rold,uint8_t rnew
 
 static void VGA_CopyRow(uint8_t cleft,uint8_t cright,uint8_t rold,uint8_t rnew,PhysPt base) {
     PhysPt src,dest;Bitu copy;
-    uint8_t cheight = real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
+    BIOS_CHEIGHT;
     dest=base+8u*((CurMode->twidth*rnew)*cheight+cleft);
     src=base+8u*((CurMode->twidth*rold)*cheight+cleft);
     Bitu nextline=8u*(Bitu)CurMode->twidth;
@@ -137,7 +137,7 @@ static void PC98_CopyRow(uint8_t cleft,uint8_t cright,uint8_t rold,uint8_t rnew,
 }
 
 static void MCGA2_FillRow(uint8_t cleft,uint8_t cright,uint8_t row,PhysPt base,uint8_t attr) {
-    uint8_t cheight = real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
+    BIOS_CHEIGHT;
     PhysPt dest=base+((CurMode->twidth*row)*cheight+cleft);
     Bitu copy=(Bitu)(cright-cleft);
     Bitu nextline=CurMode->twidth;
@@ -151,7 +151,7 @@ static void MCGA2_FillRow(uint8_t cleft,uint8_t cright,uint8_t row,PhysPt base,u
 }
 
 static void CGA2_FillRow(uint8_t cleft,uint8_t cright,uint8_t row,PhysPt base,uint8_t attr) {
-    uint8_t cheight = real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
+    BIOS_CHEIGHT;
     PhysPt dest=base+((CurMode->twidth*row)*(cheight/2)+cleft);
     Bitu copy=(Bitu)(cright-cleft);
     Bitu nextline=CurMode->twidth;
@@ -166,7 +166,7 @@ static void CGA2_FillRow(uint8_t cleft,uint8_t cright,uint8_t row,PhysPt base,ui
 }
 
 static void CGA4_FillRow(uint8_t cleft,uint8_t cright,uint8_t row,PhysPt base,uint8_t attr) {
-    uint8_t cheight = real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
+    BIOS_CHEIGHT;
     PhysPt dest=base+((CurMode->twidth*row)*(cheight/2)+cleft)*2;
     Bitu copy=(Bitu)(cright-cleft)*2u;Bitu nextline=CurMode->twidth*2;
     attr=(attr & 0x3) | ((attr & 0x3) << 2) | ((attr & 0x3) << 4) | ((attr & 0x3) << 6);
@@ -180,7 +180,7 @@ static void CGA4_FillRow(uint8_t cleft,uint8_t cright,uint8_t row,PhysPt base,ui
 }
 
 static void TANDY16_FillRow(uint8_t cleft,uint8_t cright,uint8_t row,PhysPt base,uint8_t attr) {
-    uint8_t cheight = real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
+    BIOS_CHEIGHT;
     uint8_t banks=CurMode->twidth/10;
     PhysPt dest=base+((CurMode->twidth*row)*(cheight/banks)+cleft)*4;
     Bitu copy=(Bitu)(cright-cleft)*4u;Bitu nextline=CurMode->twidth*4;
@@ -201,7 +201,7 @@ static void EGA16_FillRow(uint8_t cleft,uint8_t cright,uint8_t row,PhysPt base,u
     /* Enable all Write planes */
     IO_Write(0x3c4,2);IO_Write(0x3c5,0xf);
     /* Write some bytes */
-    uint8_t cheight = real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
+    BIOS_CHEIGHT;
     PhysPt dest=base+(CurMode->twidth*row)*cheight+cleft;   
     Bitu nextline=CurMode->twidth;
     Bitu copy = cheight;Bitu rowsize=(Bitu)(cright-cleft);
@@ -214,7 +214,7 @@ static void EGA16_FillRow(uint8_t cleft,uint8_t cright,uint8_t row,PhysPt base,u
 
 static void VGA_FillRow(uint8_t cleft,uint8_t cright,uint8_t row,PhysPt base,uint8_t attr) {
     /* Write some bytes */
-    uint8_t cheight = real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
+    BIOS_CHEIGHT;
     PhysPt dest=base+8*((CurMode->twidth*row)*cheight+cleft);
     Bitu nextline=8*CurMode->twidth;
     Bitu copy = cheight;Bitu rowsize=8u*(Bitu)(cright-cleft);
@@ -399,8 +399,7 @@ void INT10_SetActivePage(uint8_t page) {
 extern const char* RunningProgram;
 void INT10_SetCursorShape(uint8_t first,uint8_t last) {
     real_writew(BIOSMEM_SEG,BIOSMEM_CURSOR_TYPE,last|(first<<8u));
-    if (machine==MCH_CGA || machine==MCH_MCGA || machine==MCH_AMSTRAD) goto dowrite;
-    if (IS_TANDY_ARCH) goto dowrite;
+    if (!IS_EGAVGA_ARCH) goto dowrite;
     /* Skip CGA cursor emulation if EGA/VGA system is active */
     if (!(real_readb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL) & 0x8)) { /* if video subsystem is ACTIVE (bit is cleared) [https://www.stanislavs.org/helppc/bios_data_area.html] */
         /* Check for CGA type 01, invisible */
@@ -512,7 +511,7 @@ void ReadCharAttr(uint16_t col,uint16_t row,uint8_t page,uint16_t * result) {
     /* Externally used by the mouse routine */
     RealPt fontdata;
     uint16_t cols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-    uint8_t cheight = real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
+    BIOS_CHEIGHT;
     bool split_chr = false;
     switch (CurMode->type) {
     case M_TEXT:

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -801,38 +801,42 @@ static void FinishSetMode(bool clearmem) {
 	real_writew(BIOSMEM_SEG,BIOSMEM_NB_COLS,(uint16_t)CurMode->twidth);
 	real_writew(BIOSMEM_SEG,BIOSMEM_PAGE_SIZE,(uint16_t)CurMode->plength);
 	real_writew(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS,((CurMode->mode==7 )|| (CurMode->mode==0x0f)) ? 0x3b4 : 0x3d4);
-	real_writeb(BIOSMEM_SEG,BIOSMEM_NB_ROWS,(uint8_t)(CurMode->theight-1));
+
 	if (IS_EGAVGA_ARCH) {
+		real_writeb(BIOSMEM_SEG,BIOSMEM_NB_ROWS,(uint8_t)(CurMode->theight-1));
 		real_writew(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT,(uint16_t)CurMode->cheight);
 		real_writeb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL,(0x60|(clearmem?0:0x80)));
 		real_writeb(BIOSMEM_SEG,BIOSMEM_SWITCHES,0x09);
-	}
-
-	// this is an index into the dcc table:
+		// this is an index into the dcc table:
 #if C_DEBUG
-	if (IS_VGA_ARCH) real_writeb(BIOSMEM_SEG,BIOSMEM_DCC_INDEX,DISP2_Active()?0x0c:0x0b);
+		if(IS_VGA_ARCH) real_writeb(BIOSMEM_SEG,BIOSMEM_DCC_INDEX,DISP2_Active()?0x0c:0x0b);
 #else
-	if (IS_VGA_ARCH) real_writeb(BIOSMEM_SEG,BIOSMEM_DCC_INDEX,0x0b);
+		if(IS_VGA_ARCH) real_writeb(BIOSMEM_SEG,BIOSMEM_DCC_INDEX,0x0b);
 #endif
+
+		/* Set font pointer */
+		if (CurMode->mode<=3 || CurMode->mode==7)
+			RealSetVec(0x43,int10.rom.font_8_first);
+		else {
+			switch (CurMode->cheight) {
+			case 8:RealSetVec(0x43,int10.rom.font_8_first);break;
+			case 14:RealSetVec(0x43,int10.rom.font_14);break;
+			case 16:RealSetVec(0x43,int10.rom.font_16);break;
+			}
+		}
+	}
 
 	// Set cursor shape
 	if (CurMode->type==M_TEXT) {
-		INT10_SetCursorShape(CURSOR_SCAN_LINE_NORMAL, CURSOR_SCAN_LINE_END);
+		if (machine==MCH_HERC)
+			INT10_SetCursorShape(0x0c,0x0d);
+		else
+			INT10_SetCursorShape(CURSOR_SCAN_LINE_NORMAL, CURSOR_SCAN_LINE_END);
 	}
 	// Set cursor pos for page 0..7
 	for (uint8_t ct=0;ct<8;ct++) INT10_SetCursorPos(0,0,ct);
 	// Set active page 0
 	INT10_SetActivePage(0);
-	/* Set some interrupt vectors */
-	if (CurMode->mode<=3 || CurMode->mode==7) {
-		RealSetVec(0x43,int10.rom.font_8_first);
-	} else {
-		switch (CurMode->cheight) {
-		case 8:RealSetVec(0x43,int10.rom.font_8_first);break;
-		case 14:RealSetVec(0x43,int10.rom.font_14);break;
-		case 16:RealSetVec(0x43,int10.rom.font_16);break;
-		}
-	}
 	/* FIXME */
 	VGA_DAC_UpdateColorPalette();
 }

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -637,7 +637,7 @@ void Mouse_CursorMoved(float xrel,float yrel,float x,float y,bool emulate) {
     } else if (CurMode != NULL) {
         if (CurMode->type == M_TEXT) {
             mouse.x = x*real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS)*8;
-            mouse.y = y*(real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1)*8;
+            mouse.y = y*(IS_EGAVGA_ARCH?(real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1):25)*8;
         /* NTS: DeluxePaint II enhanced sets a large range (5112x3832) for VGA mode 0x12 640x480 16-color */
         } else {
             if ((mouse.max_x > 0) && (mouse.max_y > 0)) {
@@ -1044,7 +1044,7 @@ void Mouse_AfterNewVideoMode(bool setmode) {
             mouse.max_y = 400 - 1;
         }
         else {
-            Bitu rows = real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS);
+            Bitu rows = IS_EGAVGA_ARCH?real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS):24;
             if ((rows == 0) || (rows > 250)) rows = 25 - 1;
             mouse.max_y = 8*(rows+1) - 1;
         }


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/4444/

Modified as needed to make it work with DOSBox-X.

The original SVN commit changes
`#define BIOS_DEFAULT_RESET_LOCATION		(RealMake(0xf000,0xe05b))`
to
`#define BIOS_DEFAULT_RESET_LOCATION		(RealMake(0xf000,(machine==MCH_PCJR)?0x0043:0xe05b))`

but DOSBox-X instead uses

`Bitu BIOS_DEFAULT_RESET_LOCATION = ~0u;`
and
`BIOS_DEFAULT_RESET_LOCATION = PhysToReal416(ROMBIOS_GetMemory(64/*several callbacks*/,"BIOS default reset location",/*align*/4));`

so this part of the SVN commit is omitted.

The original commit claims to fix the CGA versions of Robomaze III and Road Runner, and I can confirm that in SVN, before this commit these two programs in CGA mode would not work correctly, with the screen stuck showing the DOS prompt, but at r4444  Road Runner CGA mode works and Robomaze III stops showing the DOS prompt (although for me it has a black screen).

In DOSBox-X, though, Road Runner already works in CGA mode before this commit, and Robomaze III also already behaves like current SVN (gets out of the DOS prompt but to a black screen). These two games seem to work the same also after this commit. This means that I'm not aware of this PR fixing anything, it just brings in as much of the code updates as I could from r4444.

This PR could cause problems with PC-98 mode, since SVN doesn't have PC-98 and so it's not accounted for in the changes.

