### PR TITLE
Add cross-platform support and more options for DOSBox-X working directory

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,11 @@
 0.83.13
+  - Added config options "working directory option" and
+    "working directory default" in [dosbox] section of
+    the config file to provide various options for the
+    users to control DOSBox-X's working directory. For
+    example, DOSBox-X can use the primary config file
+    directory or the DOSBox-X program directory as its
+    working directory. (Wengier)
   - Mac OS X builds will prompt the user to select a
     folder at startup if run from the Finder (or from
     the root directory). The folder selected will then

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -185,16 +185,16 @@ logfile     =
 #                                                    If set to autofile, DOSBox-X will warn if there are open file handles or a guest system is currently running.
 #                                                    Possible values: true, false, 1, 0, auto, autofile.
 #                        working directory option: Select an option for DOSBox-X's working directory when it runs.
-#                                                    prompt: DOSBox-X will ask the user to select a working directory when it runs.
-#                                                    promptifroot: DOSBox-X will ask for a working directory if run from root (Linux/macOS).
-#                                                    custom: Specify a working directory via the "working directory default" option.
 #                                                    config: DOSBox-X will use the primary config file directory as the working directory.
-#                                                    program: DOSBox-X will use the DOSBox-X program directory as the working directory.
-#                                                    runtime: The directory DOSBox-X runs becomes the working directory (default for Windows).
+#                                                    custom: Specify a working directory via the "working directory default" option.
 #                                                    force: Similar to "custom", while overriding -defaultdir command-line option if used.
-#                                                    Possible values: prompt, promptifroot, custom, config, runtime, program, force.
+#                                                    program: DOSBox-X will use the DOSBox-X program directory as the working directory.
+#                                                    prompt: DOSBox-X will ask the user to select a working directory when it runs.
+#                                                    runtime: The directory DOSBox-X runs automatically becomes the working directory.
+#                                                    warnroot: DOSBox-X warns and asks for a different directory if run from the root.
+#                                                    Possible values: config, custom, force, runtime, program, prompt, warnroot.
 #                       working directory default: The default directory to act as DOSBox-X's working directory. See also the setting "working directory option".
-#                                                    For working directory option=prompt/promptifroot, the specified directory becomes the default directory for the selection.
+#                                                    For working directory option=prompt/warnroot, the specified directory becomes the default directory for the selection.
 #                           show advanced options: If set, the Configuration Tool will display all config options (including advanced ones) by default.
 #                                         hostkey: By default, DOSBox-X uses the mapper-defined host key, which defaults to F11 on Windows and F12 on other platforms.
 #                                                    You may alternatively specify a host key with this setting and bypass the host key as defined in the mapper.
@@ -390,7 +390,7 @@ startbanner                                     = true
 bannercolortheme                                = default
 dpi aware                                       = auto
 quit warning                                    = auto
-working directory option                        = promptifroot
+working directory option                        = warnroot
 working directory default                       = 
 show advanced options                           = false
 hostkey                                         = mapper

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -184,6 +184,17 @@ logfile     =
 #                                                    If set to auto (default), DOSBox-X will warn if a DOS program, game or a guest system is currently running.
 #                                                    If set to autofile, DOSBox-X will warn if there are open file handles or a guest system is currently running.
 #                                                    Possible values: true, false, 1, 0, auto, autofile.
+#                        working directory option: Select an option for DOSBox-X's working directory when it runs.
+#                                                    prompt: DOSBox-X will ask the user to select a working directory when it runs.
+#                                                    promptifroot: DOSBox-X will ask for a working directory if run from root (Linux/macOS).
+#                                                    custom: Specify a working directory via the "working directory default" option.
+#                                                    config: DOSBox-X will use the primary config file directory as the working directory.
+#                                                    program: DOSBox-X will use the DOSBox-X program directory as the working directory.
+#                                                    runtime: The directory DOSBox-X runs becomes the working directory (default for Windows).
+#                                                    force: Similar to "custom", while overriding -defaultdir command-line option if used.
+#                                                    Possible values: prompt, promptifroot, custom, config, runtime, program, force.
+#                       working directory default: The default directory to act as DOSBox-X's working directory. See also the setting "working directory option".
+#                                                    For working directory option=prompt/promptifroot, the specified directory becomes the default directory for the selection.
 #                           show advanced options: If set, the Configuration Tool will display all config options (including advanced ones) by default.
 #                                         hostkey: By default, DOSBox-X uses the mapper-defined host key, which defaults to F11 on Windows and F12 on other platforms.
 #                                                    You may alternatively specify a host key with this setting and bypass the host key as defined in the mapper.
@@ -379,6 +390,8 @@ startbanner                                     = true
 bannercolortheme                                = default
 dpi aware                                       = auto
 quit warning                                    = auto
+working directory option                        = promptifroot
+working directory default                       = 
 show advanced options                           = false
 hostkey                                         = mapper
 mapper send key                                 = ctrlaltdel
@@ -837,7 +850,7 @@ pc-98 force ibm keyboard layout          = false
 #DOSBOX-X-ADV:#                            The original DOS colors (0-15): #000000 #0000aa #00aa00 #00aaaa #aa0000 #aa00aa #aa5500 #aaaaaa #555555 #5555ff #55ff55 #55ffff #ff5555 #ff55ff #ffff55 #ffffff
 #DOSBOX-X-ADV:#                            gray scaled color scheme: (0,0,0)  #0e0e0e  (75,75,75) (89,89,89) (38,38,38) (52,52,52) #717171 #c0c0c0 #808080 (28,28,28) (150,150,150) (178,178,178) (76,76,76) (104,104,104) (226,226,226) (255,255,255)
 #        ttf.outputswitch: Specifies the output that DOSBox-X should switch to from the TTF output when a graphical mode is requiested, or auto for automatic selection.
-#                            Possible values: auto, surface, opengl, openglnb, openglhq, openglpp.
+#                            Possible values: auto, surface, opengl, openglnb, openglhq, openglpp, direct3d.
 #             ttf.winperc: Specifies the window percentage for the TTF output (100 = full screen). Ignored if the ttf.ptsize setting is specified.
 #              ttf.ptsize: Specifies the font point size for the TTF output. If specified (minimum: 9), it will override the ttf.winperc setting.
 #                ttf.lins: Specifies the number of rows on the screen for the TTF output (0 = default).

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -83,69 +83,82 @@ showmenu          = true
 logfile = 
 
 [dosbox]
-#              language: Select another language file.
-#                 title: Additional text to place in the title bar of the window.
-#          fastbioslogo: If set, DOSBox-X will skip the BIOS screen by activating fast BIOS logo mode (without 1-second pause).
-#           startbanner: If set (default), DOSBox-X will display the welcome banner when it starts.
-#      bannercolortheme: You can specify a different background color theme for the welcome banner from the default one.
-#                          Possible values: default, black, red, green, yellow, blue, magenta, cyan, white.
-#             dpi aware: Set this option (auto by default) to indicate to your OS that DOSBox-X is DPI aware.
-#                          If it is not set, Windows Vista/7/8/10 and higher may upscale the DOSBox-X window
-#                          on higher resolution monitors which is probably not what you want.
-#                          Possible values: true, false, 1, 0, auto.
-#          quit warning: Set this option to indicate whether DOSBox-X should show a warning message when the user tries to close its window.
-#                          If set to auto (default), DOSBox-X will warn if a DOS program, game or a guest system is currently running.
-#                          If set to autofile, DOSBox-X will warn if there are open file handles or a guest system is currently running.
-#                          Possible values: true, false, 1, 0, auto, autofile.
-# show advanced options: If set, the Configuration Tool will display all config options (including advanced ones) by default.
-#               hostkey: By default, DOSBox-X uses the mapper-defined host key, which defaults to F11 on Windows and F12 on other platforms.
-#                          You may alternatively specify a host key with this setting and bypass the host key as defined in the mapper.
-#                          This can also be done from the menu ("Main" => "Select host key").
-#                          Possible values: ctrlalt, ctrlshift, altshift, mapper.
-#       mapper send key: Select the key the mapper SendKey function will send.
-#                          Possible values: winlogo, winmenu, alttab, ctrlesc, ctrlbreak, ctrlaltdel.
-#      synchronize time: If set, DOSBox-X will try to automatically synchronize time with the host, unless you decide to change the date/time manually.
-#               machine: The type of machine DOSBox-X tries to emulate.
-#                          Possible values: hercules, cga, cga_mono, cga_rgb, cga_composite, cga_composite2, tandy, pcjr, ega, vgaonly, svga_s3, svga_s386c928, svga_s3vision864, svga_s3vision868, svga_s3trio32, svga_s3trio64, svga_s3trio64v+, svga_s3virge, svga_s3virgevx, svga_et3000, svga_et4000, svga_paradise, vesa_nolfb, vesa_oldvbe, amstrad, pc98, pc9801, pc9821, fm_towns, mcga, mda.
-#              captures: Directory where things like wave, midi, screenshot get captured.
-#              autosave: Enable the auto-save state feature. Specify a time interval in seconds, and optionally a save slot or start and end save slots.
-#                          For example, "autosave=10 11-20" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.
-#                          You can additionally specify up to 9 programs for this feature, e.g. "autosave=10 11-20 EDIT:21-30 EDITOR:35" for "EDIT" and "EDITOR".
-#                          Putting a minus sign (-) before the time interval causes the auto-saving function to not be activated at start.
-#              saveslot: Select the default save slot (1-100) to save/load states.
-#              savefile: Select the default save file to save/load states. If specified it will be used instead of the save slot.
-#            saveremark: If set, the save state feature will ask users to enter remarks when saving a state.
-#        forceloadstate: If set, DOSBox-X will load a saved state even if it finds there is a mismatch in the DOSBox-X version, machine type, program name and/or the memory size.
-#               memsize: Amount of memory DOSBox-X has in megabytes.
-#                          This value is best left at its default to avoid problems with some games,
-#                          although other games and applications may require a higher value.
-#                          Programs that use 286 protected mode like Windows 3.0 in Standard Mode may crash with more than 15MB.
-#            nocachedir: If set, MOUNT commands will mount with -nocachedir (disable directory caching) by default.
-#           freesizecap: If set to "cap" (="true"), the value of MOUNT -freesize will apply only if the actual free size is greater than the specified value.
-#                          If set to "relative", the value of MOUNT -freesize will change relative to the specified value.
-#                          If set to "fixed" (="false"), the value of MOUNT -freesize will be a fixed one to be reported all the time.
-#                          Possible values: true, false, fixed, relative, cap, 2, 1, 0.
-language              = 
-title                 = 
-fastbioslogo          = false
-startbanner           = true
-bannercolortheme      = default
-dpi aware             = auto
-quit warning          = auto
-show advanced options = false
-hostkey               = mapper
-mapper send key       = ctrlaltdel
-synchronize time      = false
-machine               = svga_s3
-captures              = capture
-autosave              = 
-saveslot              = 1
-savefile              = 
-saveremark            = true
-forceloadstate        = false
-memsize               = 16
-nocachedir            = false
-freesizecap           = cap
+#                  language: Select another language file.
+#                     title: Additional text to place in the title bar of the window.
+#              fastbioslogo: If set, DOSBox-X will skip the BIOS screen by activating fast BIOS logo mode (without 1-second pause).
+#               startbanner: If set (default), DOSBox-X will display the welcome banner when it starts.
+#          bannercolortheme: You can specify a different background color theme for the welcome banner from the default one.
+#                              Possible values: default, black, red, green, yellow, blue, magenta, cyan, white.
+#                 dpi aware: Set this option (auto by default) to indicate to your OS that DOSBox-X is DPI aware.
+#                              If it is not set, Windows Vista/7/8/10 and higher may upscale the DOSBox-X window
+#                              on higher resolution monitors which is probably not what you want.
+#                              Possible values: true, false, 1, 0, auto.
+#              quit warning: Set this option to indicate whether DOSBox-X should show a warning message when the user tries to close its window.
+#                              If set to auto (default), DOSBox-X will warn if a DOS program, game or a guest system is currently running.
+#                              If set to autofile, DOSBox-X will warn if there are open file handles or a guest system is currently running.
+#                              Possible values: true, false, 1, 0, auto, autofile.
+#  working directory option: Select an option for DOSBox-X's working directory when it runs.
+#                              prompt: DOSBox-X will ask the user to select a working directory when it runs.
+#                              promptifroot: DOSBox-X will ask for a working directory if run from root (Linux/macOS).
+#                              custom: Specify a working directory via the "working directory default" option.
+#                              config: DOSBox-X will use the primary config file directory as the working directory.
+#                              program: DOSBox-X will use the DOSBox-X program directory as the working directory.
+#                              runtime: The directory DOSBox-X runs becomes the working directory (default for Windows).
+#                              force: Similar to "custom", while overriding -defaultdir command-line option if used.
+#                              Possible values: prompt, promptifroot, custom, config, runtime, program, force.
+# working directory default: The default directory to act as DOSBox-X's working directory. See also the setting "working directory option".
+#                              For working directory option=prompt/promptifroot, the specified directory becomes the default directory for the selection.
+#     show advanced options: If set, the Configuration Tool will display all config options (including advanced ones) by default.
+#                   hostkey: By default, DOSBox-X uses the mapper-defined host key, which defaults to F11 on Windows and F12 on other platforms.
+#                              You may alternatively specify a host key with this setting and bypass the host key as defined in the mapper.
+#                              This can also be done from the menu ("Main" => "Select host key").
+#                              Possible values: ctrlalt, ctrlshift, altshift, mapper.
+#           mapper send key: Select the key the mapper SendKey function will send.
+#                              Possible values: winlogo, winmenu, alttab, ctrlesc, ctrlbreak, ctrlaltdel.
+#          synchronize time: If set, DOSBox-X will try to automatically synchronize time with the host, unless you decide to change the date/time manually.
+#                   machine: The type of machine DOSBox-X tries to emulate.
+#                              Possible values: hercules, cga, cga_mono, cga_rgb, cga_composite, cga_composite2, tandy, pcjr, ega, vgaonly, svga_s3, svga_s386c928, svga_s3vision864, svga_s3vision868, svga_s3trio32, svga_s3trio64, svga_s3trio64v+, svga_s3virge, svga_s3virgevx, svga_et3000, svga_et4000, svga_paradise, vesa_nolfb, vesa_oldvbe, amstrad, pc98, pc9801, pc9821, fm_towns, mcga, mda.
+#                  captures: Directory where things like wave, midi, screenshot get captured.
+#                  autosave: Enable the auto-save state feature. Specify a time interval in seconds, and optionally a save slot or start and end save slots.
+#                              For example, "autosave=10 11-20" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.
+#                              You can additionally specify up to 9 programs for this feature, e.g. "autosave=10 11-20 EDIT:21-30 EDITOR:35" for "EDIT" and "EDITOR".
+#                              Putting a minus sign (-) before the time interval causes the auto-saving function to not be activated at start.
+#                  saveslot: Select the default save slot (1-100) to save/load states.
+#                  savefile: Select the default save file to save/load states. If specified it will be used instead of the save slot.
+#                saveremark: If set, the save state feature will ask users to enter remarks when saving a state.
+#            forceloadstate: If set, DOSBox-X will load a saved state even if it finds there is a mismatch in the DOSBox-X version, machine type, program name and/or the memory size.
+#                   memsize: Amount of memory DOSBox-X has in megabytes.
+#                              This value is best left at its default to avoid problems with some games,
+#                              although other games and applications may require a higher value.
+#                              Programs that use 286 protected mode like Windows 3.0 in Standard Mode may crash with more than 15MB.
+#                nocachedir: If set, MOUNT commands will mount with -nocachedir (disable directory caching) by default.
+#               freesizecap: If set to "cap" (="true"), the value of MOUNT -freesize will apply only if the actual free size is greater than the specified value.
+#                              If set to "relative", the value of MOUNT -freesize will change relative to the specified value.
+#                              If set to "fixed" (="false"), the value of MOUNT -freesize will be a fixed one to be reported all the time.
+#                              Possible values: true, false, fixed, relative, cap, 2, 1, 0.
+language                  = 
+title                     = 
+fastbioslogo              = false
+startbanner               = true
+bannercolortheme          = default
+dpi aware                 = auto
+quit warning              = auto
+working directory option  = promptifroot
+working directory default = 
+show advanced options     = false
+hostkey                   = mapper
+mapper send key           = ctrlaltdel
+synchronize time          = false
+machine                   = svga_s3
+captures                  = capture
+autosave                  = 
+saveslot                  = 1
+savefile                  = 
+saveremark                = true
+forceloadstate            = false
+memsize                   = 16
+nocachedir                = false
+freesizecap               = cap
 
 [video]
 #                vmemsize: Amount of video memory in megabytes.
@@ -233,7 +246,7 @@ pc-98 force ibm keyboard layout = false
 #                     For a font name or relative path, directories such as the working directory and default system font directory will be searched.
 #                     For example, setting it to "consola" or "consola.ttf" will use the Consola font; similar for other TTF fonts.
 # ttf.outputswitch: Specifies the output that DOSBox-X should switch to from the TTF output when a graphical mode is requiested, or auto for automatic selection.
-#                     Possible values: auto, surface, opengl, openglnb, openglhq, openglpp.
+#                     Possible values: auto, surface, opengl, openglnb, openglhq, openglpp, direct3d.
 #      ttf.winperc: Specifies the window percentage for the TTF output (100 = full screen). Ignored if the ttf.ptsize setting is specified.
 #       ttf.ptsize: Specifies the font point size for the TTF output. If specified (minimum: 9), it will override the ttf.winperc setting.
 #         ttf.lins: Specifies the number of rows on the screen for the TTF output (0 = default).

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -98,16 +98,16 @@ logfile =
 #                              If set to autofile, DOSBox-X will warn if there are open file handles or a guest system is currently running.
 #                              Possible values: true, false, 1, 0, auto, autofile.
 #  working directory option: Select an option for DOSBox-X's working directory when it runs.
-#                              prompt: DOSBox-X will ask the user to select a working directory when it runs.
-#                              promptifroot: DOSBox-X will ask for a working directory if run from root (Linux/macOS).
-#                              custom: Specify a working directory via the "working directory default" option.
 #                              config: DOSBox-X will use the primary config file directory as the working directory.
-#                              program: DOSBox-X will use the DOSBox-X program directory as the working directory.
-#                              runtime: The directory DOSBox-X runs becomes the working directory (default for Windows).
+#                              custom: Specify a working directory via the "working directory default" option.
 #                              force: Similar to "custom", while overriding -defaultdir command-line option if used.
-#                              Possible values: prompt, promptifroot, custom, config, runtime, program, force.
+#                              program: DOSBox-X will use the DOSBox-X program directory as the working directory.
+#                              prompt: DOSBox-X will ask the user to select a working directory when it runs.
+#                              runtime: The directory DOSBox-X runs automatically becomes the working directory.
+#                              warnroot: DOSBox-X warns and asks for a different directory if run from the root.
+#                              Possible values: config, custom, force, runtime, program, prompt, warnroot.
 # working directory default: The default directory to act as DOSBox-X's working directory. See also the setting "working directory option".
-#                              For working directory option=prompt/promptifroot, the specified directory becomes the default directory for the selection.
+#                              For working directory option=prompt/warnroot, the specified directory becomes the default directory for the selection.
 #     show advanced options: If set, the Configuration Tool will display all config options (including advanced ones) by default.
 #                   hostkey: By default, DOSBox-X uses the mapper-defined host key, which defaults to F11 on Windows and F12 on other platforms.
 #                              You may alternatively specify a host key with this setting and bypass the host key as defined in the mapper.
@@ -143,7 +143,7 @@ startbanner               = true
 bannercolortheme          = default
 dpi aware                 = auto
 quit warning              = auto
-working directory option  = promptifroot
+working directory option  = warnroot
 working directory default = 
 show advanced options     = false
 hostkey                   = mapper

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -185,16 +185,16 @@ fileio      = false
 #                                                    If set to autofile, DOSBox-X will warn if there are open file handles or a guest system is currently running.
 #                                                    Possible values: true, false, 1, 0, auto, autofile.
 #                        working directory option: Select an option for DOSBox-X's working directory when it runs.
-#                                                    prompt: DOSBox-X will ask the user to select a working directory when it runs.
-#                                                    promptifroot: DOSBox-X will ask for a working directory if run from root (Linux/macOS).
-#                                                    custom: Specify a working directory via the "working directory default" option.
 #                                                    config: DOSBox-X will use the primary config file directory as the working directory.
-#                                                    program: DOSBox-X will use the DOSBox-X program directory as the working directory.
-#                                                    runtime: The directory DOSBox-X runs becomes the working directory (default for Windows).
+#                                                    custom: Specify a working directory via the "working directory default" option.
 #                                                    force: Similar to "custom", while overriding -defaultdir command-line option if used.
-#                                                    Possible values: prompt, promptifroot, custom, config, runtime, program, force.
+#                                                    program: DOSBox-X will use the DOSBox-X program directory as the working directory.
+#                                                    prompt: DOSBox-X will ask the user to select a working directory when it runs.
+#                                                    runtime: The directory DOSBox-X runs automatically becomes the working directory.
+#                                                    warnroot: DOSBox-X warns and asks for a different directory if run from the root.
+#                                                    Possible values: config, custom, force, runtime, program, prompt, warnroot.
 #                       working directory default: The default directory to act as DOSBox-X's working directory. See also the setting "working directory option".
-#                                                    For working directory option=prompt/promptifroot, the specified directory becomes the default directory for the selection.
+#                                                    For working directory option=prompt/warnroot, the specified directory becomes the default directory for the selection.
 #                           show advanced options: If set, the Configuration Tool will display all config options (including advanced ones) by default.
 #                                         hostkey: By default, DOSBox-X uses the mapper-defined host key, which defaults to F11 on Windows and F12 on other platforms.
 #                                                    You may alternatively specify a host key with this setting and bypass the host key as defined in the mapper.
@@ -390,7 +390,7 @@ startbanner                                     = true
 bannercolortheme                                = default
 dpi aware                                       = auto
 quit warning                                    = auto
-working directory option                        = promptifroot
+working directory option                        = warnroot
 working directory default                       = 
 show advanced options                           = false
 hostkey                                         = mapper

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -184,6 +184,17 @@ fileio      = false
 #                                                    If set to auto (default), DOSBox-X will warn if a DOS program, game or a guest system is currently running.
 #                                                    If set to autofile, DOSBox-X will warn if there are open file handles or a guest system is currently running.
 #                                                    Possible values: true, false, 1, 0, auto, autofile.
+#                        working directory option: Select an option for DOSBox-X's working directory when it runs.
+#                                                    prompt: DOSBox-X will ask the user to select a working directory when it runs.
+#                                                    promptifroot: DOSBox-X will ask for a working directory if run from root (Linux/macOS).
+#                                                    custom: Specify a working directory via the "working directory default" option.
+#                                                    config: DOSBox-X will use the primary config file directory as the working directory.
+#                                                    program: DOSBox-X will use the DOSBox-X program directory as the working directory.
+#                                                    runtime: The directory DOSBox-X runs becomes the working directory (default for Windows).
+#                                                    force: Similar to "custom", while overriding -defaultdir command-line option if used.
+#                                                    Possible values: prompt, promptifroot, custom, config, runtime, program, force.
+#                       working directory default: The default directory to act as DOSBox-X's working directory. See also the setting "working directory option".
+#                                                    For working directory option=prompt/promptifroot, the specified directory becomes the default directory for the selection.
 #                           show advanced options: If set, the Configuration Tool will display all config options (including advanced ones) by default.
 #                                         hostkey: By default, DOSBox-X uses the mapper-defined host key, which defaults to F11 on Windows and F12 on other platforms.
 #                                                    You may alternatively specify a host key with this setting and bypass the host key as defined in the mapper.
@@ -379,6 +390,8 @@ startbanner                                     = true
 bannercolortheme                                = default
 dpi aware                                       = auto
 quit warning                                    = auto
+working directory option                        = promptifroot
+working directory default                       = 
 show advanced options                           = false
 hostkey                                         = mapper
 mapper send key                                 = ctrlaltdel
@@ -837,7 +850,7 @@ pc-98 show graphics layer on initialize  = true
 #                            The original DOS colors (0-15): #000000 #0000aa #00aa00 #00aaaa #aa0000 #aa00aa #aa5500 #aaaaaa #555555 #5555ff #55ff55 #55ffff #ff5555 #ff55ff #ffff55 #ffffff
 #                            gray scaled color scheme: (0,0,0)  #0e0e0e  (75,75,75) (89,89,89) (38,38,38) (52,52,52) #717171 #c0c0c0 #808080 (28,28,28) (150,150,150) (178,178,178) (76,76,76) (104,104,104) (226,226,226) (255,255,255)
 #        ttf.outputswitch: Specifies the output that DOSBox-X should switch to from the TTF output when a graphical mode is requiested, or auto for automatic selection.
-#                            Possible values: auto, surface, opengl, openglnb, openglhq, openglpp.
+#                            Possible values: auto, surface, opengl, openglnb, openglhq, openglpp, direct3d.
 #             ttf.winperc: Specifies the window percentage for the TTF output (100 = full screen). Ignored if the ttf.ptsize setting is specified.
 #              ttf.ptsize: Specifies the font point size for the TTF output. If specified (minimum: 9), it will override the ttf.winperc setting.
 #                ttf.lins: Specifies the number of rows on the screen for the TTF output (0 = default).

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1196,7 +1196,7 @@ void DOSBOX_SetupConfigSections(void) {
         0 };
 
     const char* workdiropts[] = {
-        "prompt", "promptifroot", "custom", "config", "runtime", "program", "force",
+        "config", "custom", "force", "runtime", "program", "prompt", "warnroot",
         0 };
 
     const char* switchoutputs[] = {
@@ -1285,21 +1285,21 @@ void DOSBOX_SetupConfigSections(void) {
             "If set to autofile, DOSBox-X will warn if there are open file handles or a guest system is currently running.");
     Pstring->SetBasic(true);
 
-    Pstring = secprop->Add_string("working directory option",Property::Changeable::OnlyAtStart,"promptifroot");
+    Pstring = secprop->Add_string("working directory option",Property::Changeable::OnlyAtStart,"warnroot");
     Pstring->Set_values(workdiropts);
     Pstring->Set_help("Select an option for DOSBox-X's working directory when it runs.\n"
-            "prompt: DOSBox-X will ask the user to select a working directory when it runs.\n"
-            "promptifroot: DOSBox-X will ask for a working directory if run from root (Linux/macOS).\n"
-            "custom: Specify a working directory via the \"working directory default\" option.\n"
             "config: DOSBox-X will use the primary config file directory as the working directory.\n"
+            "custom: Specify a working directory via the \"working directory default\" option.\n"
+            "force: Similar to \"custom\", while overriding -defaultdir command-line option if used.\n"
             "program: DOSBox-X will use the DOSBox-X program directory as the working directory.\n"
-            "runtime: The directory DOSBox-X runs becomes the working directory (default for Windows).\n"
-            "force: Similar to \"custom\", while overriding -defaultdir command-line option if used.");
+            "prompt: DOSBox-X will ask the user to select a working directory when it runs.\n"
+            "runtime: The directory DOSBox-X runs automatically becomes the working directory.\n"
+            "warnroot: DOSBox-X warns and asks for a different directory if run from the root.");
     Pstring->SetBasic(true);
 
     Pstring = secprop->Add_path("working directory default",Property::Changeable::OnlyAtStart,"");
     Pstring->Set_help("The default directory to act as DOSBox-X's working directory. See also the setting \"working directory option\".\n"
-            "For working directory option=prompt/promptifroot, the specified directory becomes the default directory for the selection.");
+            "For working directory option=prompt/warnroot, the specified directory becomes the default directory for the selection.");
     Pstring->SetBasic(true);
 
     Pbool = secprop->Add_bool("show advanced options", Property::Changeable::Always, false);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1195,14 +1195,16 @@ void DOSBOX_SetupConfigSections(void) {
 
         0 };
 
+    const char* workdiropts[] = {
+        "prompt", "promptifroot", "custom", "config", "runtime", "program", "force",
+        0 };
+
     const char* switchoutputs[] = {
         "auto", "surface",
 #if C_OPENGL
         "opengl", "openglnb", "openglhq", "openglpp",
 #endif
-#if C_DIRECT3D
         "direct3d",
-#endif
         0 };
 
     const char* scalers[] = {
@@ -1281,6 +1283,23 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring->Set_help("Set this option to indicate whether DOSBox-X should show a warning message when the user tries to close its window.\n"
             "If set to auto (default), DOSBox-X will warn if a DOS program, game or a guest system is currently running.\n"
             "If set to autofile, DOSBox-X will warn if there are open file handles or a guest system is currently running.");
+    Pstring->SetBasic(true);
+
+    Pstring = secprop->Add_string("working directory option",Property::Changeable::OnlyAtStart,"promptifroot");
+    Pstring->Set_values(workdiropts);
+    Pstring->Set_help("Select an option for DOSBox-X's working directory when it runs.\n"
+            "prompt: DOSBox-X will ask the user to select a working directory when it runs.\n"
+            "promptifroot: DOSBox-X will ask for a working directory if run from root (Linux/macOS).\n"
+            "custom: Specify a working directory via the \"working directory default\" option.\n"
+            "config: DOSBox-X will use the primary config file directory as the working directory.\n"
+            "program: DOSBox-X will use the DOSBox-X program directory as the working directory.\n"
+            "runtime: The directory DOSBox-X runs becomes the working directory (default for Windows).\n"
+            "force: Similar to \"custom\", while overriding -defaultdir command-line option if used.");
+    Pstring->SetBasic(true);
+
+    Pstring = secprop->Add_path("working directory default",Property::Changeable::OnlyAtStart,"");
+    Pstring->Set_help("The default directory to act as DOSBox-X's working directory. See also the setting \"working directory option\".\n"
+            "For working directory option=prompt/promptifroot, the specified directory becomes the default directory for the selection.");
     Pstring->SetBasic(true);
 
     Pbool = secprop->Add_bool("show advanced options", Property::Changeable::Always, false);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -12013,6 +12013,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
                that we were started by the Finder */
             /* FIXME: Is there a better way to detect whether we were started by the Finder
                       or any other part of the macOS desktop? */
+            /* Wengier: This function has been extended to other platforms (Windows/Linux). */
 #if defined(WIN32)
             if (workdiropt == "prompt")
 #else
@@ -12069,9 +12070,10 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
             }
         } else
 #endif
-        if (((workdiropt == "custom" && !usecustomdir) || workdiropt == "force") && workdirdef.size()) {
+        if (((workdiropt == "custom" && !usecustomdir && !usecfgdir) || workdiropt == "force") && workdirdef.size()) {
             chdir(workdirdef.c_str());
             usecustomdir = true;
+            usecfgdir = false;
         } else if (workdiropt == "program") {
             std::string exepath=GetDOSBoxXPath();
             if (exepath.size()) chdir(exepath.c_str());


### PR DESCRIPTION
With the recent code DOSBox-X shows a dialog box that asks the user to select a folder if current directory is the root directory and the operating system is macOS. It is definitely useful for macOS, but I think this function can be further extended - both to other platforms and with additional options for working directories (e.g. user can set the primary config file directory or the DOSBox-X program directory as its working directory in the config directly instead of perhaps having to select a folder every time). This PR adds two config options (namely "working directory option" and "working directory default" in [dosbox] section) for this.

For the setting "working directory option", the following options are available (it defaults to "promptifroot" for Linux and macOS):

prompt: DOSBox-X will (always) ask the user to select a working directory when it runs.
promptifroot: DOSBox-X will ask for a working directory if run from root (Linux/macOS).
custom: Specify a working directory via the "working directory default" option.
config: DOSBox-X will use the primary config file directory as the working directory.
program: DOSBox-X will use the DOSBox-X program directory as the working directory.
runtime: The directory DOSBox-X runs becomes the working directory (default for Windows).
force: Similar to "custom", while overriding -defaultdir command-line option if used.

The setting "working directory default" allows the user to specify a working directory directly if "working directory option" is set to "custom" or "force", and it will set the default directory for the folder selection dialog box if "working directory option" is set to "prompt" or "promptifroot".

Tested in Windows, Linux, and macOS platforms.