### PR TITLE
SVN r4447

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -92,6 +92,10 @@
     version 2.5.0. (Wengier)
   - Updated FLAC decoder library to the latest version
     (0.12.29 by David Reid). (Wengier)
+  - Integrated SVN commits (Allofich)
+    - r4447: Attribute Controller port alias on EGA
+    machine. Fixes EGA display of older Super Pac-Man
+    release.
 0.83.12
   - Tandy graphics emulation fixed to accept 8 bits
     for vertical total and vertical display CRTC

--- a/src/hardware/vga_attr.cpp
+++ b/src/hardware/vga_attr.cpp
@@ -345,6 +345,8 @@ Bitu read_p3c1(Bitu /*port*/,Bitu iolen) {
 void VGA_SetupAttr(void) {
 	if (IS_EGAVGA_ARCH) {
 		IO_RegisterWriteHandler(0x3c0,write_p3c0,IO_MB);
+		if (machine==MCH_EGA)
+			IO_RegisterWriteHandler(0x3c1,write_p3c0,IO_MB); // alias on EGA
 		if (IS_VGA_ARCH) {
 			IO_RegisterReadHandler(0x3c0,read_p3c0,IO_MB);
 			IO_RegisterReadHandler(0x3c1,read_p3c1,IO_MB);


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/4447/

The original commit message is

"Attribute Controller port alias on EGA machine. Fixes EGA display of older Super Pac-Man release."

I can confirm that Super Pac-Man is fixed.

Before this PR (game runs but screen is black):

![egaspac_000](https://user-images.githubusercontent.com/19624336/115272827-cb5e4600-a179-11eb-95fe-53bdea268da7.png)

After this PR:

![egaspac_000](https://user-images.githubusercontent.com/19624336/115272887-dc0ebc00-a179-11eb-9ef1-eef6a4ec9b8c.png)

