### PR TITLE
Add RetroWave OPL3 board support

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1162,7 +1162,7 @@ void DOSBOX_SetupConfigSections(void) {
     const char* irqssb[] = { "7", "5", "3", "9", "10", "11", "12", 0 };
     const char* dmasgus[] = { "3", "0", "1", "5", "6", "7", 0 };
     const char* dmassb[] = { "1", "5", "0", "3", "6", "7", 0 };
-    const char* oplemus[] = { "default", "compat", "fast", "nuked", "mame", "opl2board","opl3duoboard" ,0 };
+    const char* oplemus[] = { "default", "compat", "fast", "nuked", "mame", "opl2board", "opl3duoboard", "retrowave_opl3", 0 };
     const char *qualityno[] = { "0", "1", "2", "3", 0 };
     const char* tandys[] = { "auto", "on", "off", 0};
     const char* ps1opt[] = { "on", "off", 0};
@@ -2964,6 +2964,18 @@ void DOSBOX_SetupConfigSections(void) {
 
     Pstring = secprop->Add_string("oplport", Property::Changeable::WhenIdle, "");
 	Pstring->Set_help("Serial port of the OPL2 Audio Board when oplemu=opl2board, opl2mode will become 'opl2' automatically.");
+    Pstring->SetBasic(true);
+
+    Pstring = secprop->Add_string("retrowave_bus", Property::Changeable::WhenIdle, "serial");
+    Pstring->Set_help("Bus of the Retrowave series board (serial/spi). SPI is only supported on Linux.");
+    Pstring->SetBasic(true);
+
+    Pstring = secprop->Add_string("retrowave_spi_cs", Property::Changeable::WhenIdle, "0,6");
+    Pstring->Set_help("SPI chip select pin of the Retrowave series board. Only supported on Linux.");
+    Pstring->SetBasic(true);
+
+    Pstring = secprop->Add_string("retrowave_port", Property::Changeable::WhenIdle, "");
+    Pstring->Set_help("Serial port of the Retrowave series board.");
     Pstring->SetBasic(true);
 
     Phex = secprop->Add_hex("hardwarebase",Property::Changeable::WhenIdle,0x220);

--- a/src/hardware/Makefile.am
+++ b/src/hardware/Makefile.am
@@ -18,5 +18,13 @@ libhardware_a_SOURCES = adlib.cpp dma.cpp gameblaster.cpp hardware.cpp iohandler
 			snd_pc98/common/parts.c snd_pc98/generic/keydisp.c snd_pc98/sound/adpcmc.c snd_pc98/sound/adpcmg.c \
 			snd_pc98/sound/rhythmc.c snd_pc98/sound/sound.c snd_pc98/sound/getsnd/getwave.c snd_pc98/sound/getsnd/getsmix.c \
 			snd_pc98/sound/getsnd/getsnd.c snd_pc98/x11/dosio.c snd_pc98/sound/fmboard.c snd_pc98/sound/soundrom.c \
-			snd_pc98/cbus/board86.c snd_pc98/sound/fmtimer.c snd_pc98/cbus/board26k.c 8255.cpp opl2board/opl2board.cpp opl3duoboard/opl3duoboard.cpp
+			snd_pc98/cbus/board86.c snd_pc98/sound/fmtimer.c snd_pc98/cbus/board26k.c 8255.cpp opl2board/opl2board.cpp opl3duoboard/opl3duoboard.cpp \
+						RetroWaveLib/Board/OPL3.c \
+						RetroWaveLib/Platform/Win32_SerialPort.c \
+            			RetroWaveLib/Platform/POSIX_SerialPort.c \
+            			RetroWaveLib/Platform/Linux_SPI.c \
+            			RetroWaveLib/Protocol/Serial.c \
+            			RetroWaveLib/RetroWave_DOSBoX.cpp \
+                        RetroWaveLib/RetroWave.c
+
 

--- a/src/hardware/RetroWaveLib/Board/MasterGear.c
+++ b/src/hardware/RetroWaveLib/Board/MasterGear.c
@@ -1,0 +1,131 @@
+/*
+    This file is part of RetroWave.
+
+    Copyright (C) 2021 ReimuNotMoe <reimu@sudomaker.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "MasterGear.h"
+
+static const int transfer_speed = 1e6;
+
+
+void retrowave_mastergear_queue_ym2413(RetroWaveContext *ctx, uint8_t reg, uint8_t val) {
+	retrowave_cmd_buffer_init(ctx, RetroWave_Board_MasterGear, 0x12);
+	ctx->transfer_speed_hint = transfer_speed;
+
+	ctx->cmd_buffer_used += 12;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 12] = 0xff;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 11] = reg;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 10] = 0xf1;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 9] = reg;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 8] = 0xff;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 7] = val;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 6] = 0xf9;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 5] = val;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 4] = 0xf7;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 3] = val;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 2] = 0xff;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 1] = val;
+}
+
+void retrowave_mastergear_reset_ym2413(RetroWaveContext *ctx) {
+	uint8_t buf[] = {RetroWave_Board_MasterGear, 0x12, 0xfe};
+	ctx->callback_io(ctx->user_data, transfer_speed / 10, buf, NULL, sizeof(buf));
+	buf[2] = 0xff;
+	ctx->callback_io(ctx->user_data, transfer_speed / 10, buf, NULL, sizeof(buf));
+}
+
+void retrowave_mastergear_queue_sn76489(RetroWaveContext *ctx, uint8_t val) {
+	retrowave_cmd_buffer_init(ctx, RetroWave_Board_MasterGear, 0x12);
+	ctx->transfer_speed_hint = transfer_speed;
+
+	ctx->cmd_buffer_used += 10;
+	// Set data only
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 10] = 0xff;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 9] = val;
+	// CS# on
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 8] = 0x5f;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 7] = val;
+	// CS#+WR# on
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 6] = 0x0f;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 5] = val;
+	// WR# on
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 4] = 0xaf;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 3] = val;
+	// ALL off
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 2] = 0xff;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 1] = 0x00;
+}
+
+void retrowave_mastergear_mute_sn76489(RetroWaveContext *ctx) {
+	uint8_t mute_tone1 = 0x9f;
+	uint8_t mute_tone2 = 0xdf;
+	uint8_t mute_tone3 = 0xbf;
+	uint8_t mute_noise = 0xff;
+
+	uint8_t buf[] = {RetroWave_Board_MasterGear, 0x12,
+			 0xff, mute_tone1, 0x5f, mute_tone1, 0x0f, mute_tone1, 0xaf, mute_tone1, 0xff, 0x00,
+			 0xff, mute_tone2, 0x5f, mute_tone2, 0x0f, mute_tone2, 0xaf, mute_tone2, 0xff, 0x00,
+			 0xff, mute_tone3, 0x5f, mute_tone3, 0x0f, mute_tone3, 0xaf, mute_tone3, 0xff, 0x00,
+			 0xff, mute_noise, 0x5f, mute_noise, 0x0f, mute_noise, 0xaf, mute_noise, 0xff, 0x00,
+	};
+
+	ctx->callback_io(ctx->user_data, transfer_speed / 10, buf, NULL, sizeof(buf));
+}
+
+void retrowave_mastergear_queue_sn76489_left(RetroWaveContext *ctx, uint8_t val) {
+	retrowave_cmd_buffer_init(ctx, RetroWave_Board_MasterGear, 0x12);
+	ctx->transfer_speed_hint = transfer_speed;
+
+	ctx->cmd_buffer_used += 10;
+	// Set data only
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 10] = 0xff;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 9] = val;
+	// CS# on
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 8] = 0xdf;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 7] = val;
+	// CS#+WR# on
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 6] = 0xcf;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 5] = val;
+	// WR# on
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 4] = 0xef;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 3] = val;
+	// ALL off
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 2] = 0xff;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 1] = 0x00;
+}
+
+void retrowave_mastergear_queue_sn76489_right(RetroWaveContext *ctx, uint8_t val) {
+	retrowave_cmd_buffer_init(ctx, RetroWave_Board_MasterGear, 0x12);
+	ctx->transfer_speed_hint = transfer_speed;
+
+	ctx->cmd_buffer_used += 10;
+	// Set data only
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 10] = 0xff;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 9] = val;
+	// CS# on
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 8] = 0x7f;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 7] = val;
+	// CS#+WR# on
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 6] = 0x3f;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 5] = val;
+	// WR# on
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 4] = 0xbf;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 3] = val;
+	// ALL off
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 2] = 0xff;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 1] = 0x00;
+}

--- a/src/hardware/RetroWaveLib/Board/MasterGear.h
+++ b/src/hardware/RetroWaveLib/Board/MasterGear.h
@@ -1,0 +1,40 @@
+/*
+    This file is part of RetroWave.
+
+    Copyright (C) 2021 ReimuNotMoe <reimu@sudomaker.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "../RetroWave.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern void retrowave_mastergear_queue_ym2413(RetroWaveContext *ctx, uint8_t reg, uint8_t val);
+
+extern void retrowave_mastergear_reset_ym2413(RetroWaveContext *ctx);
+
+extern void retrowave_mastergear_queue_sn76489(RetroWaveContext *ctx, uint8_t val);
+extern void retrowave_mastergear_queue_sn76489_left(RetroWaveContext *ctx, uint8_t val);
+extern void retrowave_mastergear_queue_sn76489_right(RetroWaveContext *ctx, uint8_t val);
+
+extern void retrowave_mastergear_mute_sn76489(RetroWaveContext *ctx);
+
+#ifdef __cplusplus
+};
+#endif

--- a/src/hardware/RetroWaveLib/Board/MiniBlaster.c
+++ b/src/hardware/RetroWaveLib/Board/MiniBlaster.c
@@ -1,0 +1,59 @@
+/*
+    This file is part of RetroWave.
+
+    Copyright (C) 2021 ReimuNotMoe <reimu@sudomaker.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "MiniBlaster.h"
+
+static const int transfer_speed = 0.8e6;
+
+void retrowave_miniblaster_queue(RetroWaveContext *ctx, uint8_t reg, uint8_t val) {
+	retrowave_cmd_buffer_init(ctx, RetroWave_Board_MiniBlaster, 0x12);
+	ctx->transfer_speed_hint = transfer_speed;
+
+	if (reg < 0x80) {
+		reg &= 0x7f;
+		ctx->cmd_buffer_used += 12;
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 12] = 0xfd;        // A0 = 1, CS# = 0, WR# = 1
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 11] = reg;
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 10] = 0xf9;        // A0 = 1, CS# = 0, WR# = 0
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 9] = reg;
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 8] = 0xff;        //
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 7] = val;
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 6] = 0xfc;        // A0 = 0, CS# = 0, WR# = 1
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 5] = val;
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 4] = 0xf8;        // A0 = 0, CS# = 0, WR# = 0
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 3] = val;
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 2] = 0xfe;        // A0 = 0
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 1] = val;
+	} else {
+		reg &= 0x7f;
+		ctx->cmd_buffer_used += 12;
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 12] = 0xdf;        // A0 = 1, CS# = 0, WR# = 1
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 11] = reg;
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 10] = 0x9f;        // A0 = 1, CS# = 0, WR# = 0
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 9] = reg;
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 8] = 0xff;        //
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 7] = val;
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 6] = 0xcf;        // A0 = 0, CS# = 0, WR# = 1
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 5] = val;
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 4] = 0x8f;        // A0 = 0, CS# = 0, WR# = 0
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 3] = val;
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 2] = 0xef;        // A0 = 0
+		ctx->cmd_buffer[ctx->cmd_buffer_used - 1] = val;
+	}
+}

--- a/src/hardware/RetroWaveLib/Board/MiniBlaster.h
+++ b/src/hardware/RetroWaveLib/Board/MiniBlaster.h
@@ -1,0 +1,32 @@
+/*
+    This file is part of RetroWave.
+
+    Copyright (C) 2021 ReimuNotMoe <reimu@sudomaker.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "../RetroWave.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern void retrowave_miniblaster_queue(RetroWaveContext *ctx, uint8_t reg, uint8_t val);
+
+#ifdef __cplusplus
+};
+#endif

--- a/src/hardware/RetroWaveLib/Board/OPL3.c
+++ b/src/hardware/RetroWaveLib/Board/OPL3.c
@@ -1,0 +1,72 @@
+/*
+    This file is part of RetroWave.
+
+    Copyright (C) 2021 ReimuNotMoe <reimu@sudomaker.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "OPL3.h"
+
+static const int transfer_speed = 2e6;
+
+void retrowave_opl3_queue_port0(RetroWaveContext *ctx, uint8_t reg, uint8_t val) {
+	retrowave_cmd_buffer_init(ctx, RetroWave_Board_OPL3, 0x12);
+	ctx->transfer_speed_hint = transfer_speed;
+
+	ctx->cmd_buffer_used += 6;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 6] = 0xe1;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 5] = reg;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 4] = 0xe3;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 3] = val;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 2] = 0xfb;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 1] = val;
+}
+
+void retrowave_opl3_queue_port1(RetroWaveContext *ctx, uint8_t reg, uint8_t val) {
+	retrowave_cmd_buffer_init(ctx, RetroWave_Board_OPL3, 0x12);
+	ctx->transfer_speed_hint = transfer_speed;
+
+	ctx->cmd_buffer_used += 6;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 6] = 0xe5;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 5] = reg;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 4] = 0xe7;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 3] = val;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 2] = 0xfb;
+	ctx->cmd_buffer[ctx->cmd_buffer_used - 1] = val;
+}
+
+void retrowave_opl3_emit_port0(RetroWaveContext *ctx, uint8_t reg, uint8_t val) {
+	uint8_t buf[] = {RetroWave_Board_OPL3, 0x12, 0xe1, reg, 0xe3, val, 0xfb, val};
+	ctx->callback_io(ctx->user_data, transfer_speed, buf, NULL, sizeof(buf));
+}
+
+void retrowave_opl3_emit_port1(RetroWaveContext *ctx, uint8_t reg, uint8_t val) {
+	uint8_t buf[] = {RetroWave_Board_OPL3, 0x12, 0xe5, reg, 0xe7, val, 0xfb, val};
+	ctx->callback_io(ctx->user_data, transfer_speed, buf, NULL, sizeof(buf));
+}
+
+void retrowave_opl3_reset(RetroWaveContext *ctx) {
+	uint8_t buf[] = {RetroWave_Board_OPL3, 0x12, 0xfe};
+	ctx->callback_io(ctx->user_data, transfer_speed / 10, buf, NULL, sizeof(buf));
+	buf[2] = 0xff;
+	ctx->callback_io(ctx->user_data, transfer_speed / 10, buf, NULL, sizeof(buf));
+}
+
+void retrowave_opl3_mute(RetroWaveContext *ctx) {
+	for (uint8_t i = 0x20; i <= 0xF5; i++) {
+		retrowave_opl3_emit_port0(ctx, i, i >= 0x40 && i <= 0x55 ? 0xFF : 0x00);
+		retrowave_opl3_emit_port1(ctx, i, i >= 0x40 && i <= 0x55 ? 0xFF : 0x00);
+	}
+}

--- a/src/hardware/RetroWaveLib/Board/OPL3.h
+++ b/src/hardware/RetroWaveLib/Board/OPL3.h
@@ -1,0 +1,38 @@
+/*
+    This file is part of RetroWave.
+
+    Copyright (C) 2021 ReimuNotMoe <reimu@sudomaker.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "../RetroWave.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern void retrowave_opl3_queue_port0(RetroWaveContext *ctx, uint8_t reg, uint8_t val);
+extern void retrowave_opl3_queue_port1(RetroWaveContext *ctx, uint8_t reg, uint8_t val);
+extern void retrowave_opl3_emit_port0(RetroWaveContext *ctx, uint8_t reg, uint8_t val);
+extern void retrowave_opl3_emit_port1(RetroWaveContext *ctx, uint8_t reg, uint8_t val);
+
+extern void retrowave_opl3_reset(RetroWaveContext *ctx);
+extern void retrowave_opl3_mute(RetroWaveContext *ctx);
+
+#ifdef __cplusplus
+};
+#endif

--- a/src/hardware/RetroWaveLib/Platform/Linux_SPI.c
+++ b/src/hardware/RetroWaveLib/Platform/Linux_SPI.c
@@ -1,0 +1,166 @@
+/*
+    This file is part of RetroWave.
+
+    Copyright (C) 2021 ReimuNotMoe <reimu@sudomaker.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "Linux_SPI.h"
+
+#ifdef __linux
+
+static const char log_tag[] = "retrowave platform linux_spi";
+
+
+static inline void __attribute__((always_inline)) set_cs(RetroWavePlatform_LinuxSPI *ctx, int value) {
+	struct gpiohandle_data gpio_data;
+
+	gpio_data.values[0] = value;
+
+	if (ioctl(ctx->fd_gpioline, GPIOHANDLE_SET_LINE_VALUES_IOCTL, &gpio_data)) {
+		fprintf(stderr, "%s: FATAL: failed to set GPIO value: %s\n", log_tag, strerror(errno));
+		abort();
+	}
+}
+
+static inline void set_device_lock(RetroWavePlatform_LinuxSPI *ctx, int value) {
+	errno = 0;
+
+	int rc_lock;
+
+	do {
+		rc_lock = flock(ctx->fd_spi, value ? LOCK_EX : LOCK_UN);
+	} while (errno == EINTR);
+
+	if (rc_lock < 0) {
+		fprintf(stderr, "%s: FATAL: failed to change lock state on SPI device node: %s\n", log_tag, strerror(errno));
+		abort();
+	}
+}
+
+static struct spi_ioc_transfer spi_tr = {0};
+
+static void io_callback(void *userp, uint32_t data_rate, const void *tx_buf, void *rx_buf, uint32_t len) {
+	RetroWavePlatform_LinuxSPI *ctx = userp;
+
+	spi_tr.tx_buf = (__u64)tx_buf;
+	spi_tr.rx_buf = (__u64)rx_buf;
+	spi_tr.len = len;
+	spi_tr.speed_hz = data_rate;
+//	spi_tr.bits_per_word = 8;
+
+//	set_device_lock(ctx, 1);
+
+	set_cs(ctx, 0);
+
+	if (ioctl(ctx->fd_spi, SPI_IOC_MESSAGE(1), &spi_tr) < 0) {
+		fprintf(stderr, "%s: FATAL: failed to do SPI transfer: %s\n", log_tag, strerror(errno));
+		abort();
+	}
+
+//	printf("SPI TX: ");
+//
+//	for (int i=0; i<len; i++) {
+//		printf("%02x ", ((uint8_t *)tx_buf)[i]);
+//	}
+//
+//	puts("");
+//
+//	printf("SPI RX: ");
+//
+//	for (int i=0; i<len; i++) {
+//		printf("%02x ", ((uint8_t *)rx_buf)[i]);
+//	}
+//
+//	puts("");
+
+	set_cs(ctx, 1);
+
+//	set_device_lock(ctx, 0);
+}
+
+int retrowave_init_linux_spi(RetroWaveContext *ctx, const char *spi_dev, int cs_gpio_chip, int cs_gpio_line) {
+	retrowave_init(ctx);
+
+	ctx->user_data = malloc(sizeof(RetroWavePlatform_LinuxSPI));
+
+	RetroWavePlatform_LinuxSPI *pctx = ctx->user_data;
+
+	// SPI Init
+	pctx->fd_spi = open(spi_dev, O_RDWR);
+	if (pctx->fd_spi < 0) {
+		fprintf(stderr, "%s: failed to open SPI device `%s': %s\n", log_tag, spi_dev, strerror(errno));
+		free(pctx);
+		return -1;
+	}
+
+	int spi_mode = SPI_NO_CS;
+	if (ioctl(pctx->fd_spi, SPI_IOC_WR_MODE32, &spi_mode) < 0) {
+		fprintf(stderr, "%s: failed to set SPI mode 0x%02x: %s\n", log_tag, spi_mode, strerror(errno));
+		free(pctx);
+		return -1;
+	}
+
+	int spi_speed = 1200000;
+	if (ioctl(pctx->fd_spi, SPI_IOC_WR_MAX_SPEED_HZ, &spi_speed) < 0) {
+		fprintf(stderr, "%s: failed to set SPI speed to %d: %s\n", log_tag, spi_speed, strerror(errno));
+		free(pctx);
+		return -1;
+	}
+
+	// GPIO Init
+	char pathbuf[24];
+	snprintf(pathbuf, sizeof(pathbuf)-1, "/dev/gpiochip%d", cs_gpio_chip);
+	pctx->fd_gpiochip = open(pathbuf, O_RDWR);
+	if (pctx->fd_gpiochip < 0) {
+		fprintf(stderr, "%s: failed to open GPIO device `%s': %s\n", log_tag, pathbuf, strerror(errno));
+		free(pctx);
+		return -1;
+	}
+
+	struct gpiohandle_request gl_req = {0};
+	gl_req.lineoffsets[0] = cs_gpio_line;
+	gl_req.default_values[0] = 1; // CS should be high if not used
+	gl_req.flags = GPIOHANDLE_REQUEST_OUTPUT;
+	gl_req.lines = 1;
+	strcpy(gl_req.consumer_label, "RetroWave SPI CS");
+
+retry_lock:
+	if (ioctl(pctx->fd_gpiochip, GPIO_GET_LINEHANDLE_IOCTL, &gl_req)) {
+		if (errno == EBUSY) {
+			goto retry_lock;
+		}
+		fprintf(stderr, "%s: failed to request GPIO line %d: %s\n", log_tag, cs_gpio_line, strerror(errno));
+		abort();
+	}
+
+	pctx->fd_gpioline = gl_req.fd;
+
+	ctx->callback_io = io_callback;
+
+	return 0;
+}
+
+void retrowave_deinit_linux_spi(RetroWaveContext *ctx) {
+	RetroWavePlatform_LinuxSPI *pctx = ctx->user_data;
+
+	close(pctx->fd_spi);
+	close(pctx->fd_gpioline);
+	close(pctx->fd_gpiochip);
+
+	free(pctx);
+}
+
+#endif

--- a/src/hardware/RetroWaveLib/Platform/Linux_SPI.h
+++ b/src/hardware/RetroWaveLib/Platform/Linux_SPI.h
@@ -1,0 +1,58 @@
+/*
+    This file is part of RetroWave.
+
+    Copyright (C) 2021 ReimuNotMoe <reimu@sudomaker.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#ifdef __linux
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <sys/file.h>
+#include <sys/mman.h>
+#include <linux/types.h>
+#include <linux/version.h>
+#include <linux/gpio.h>
+#include <linux/spi/spidev.h>
+
+#include "../RetroWave.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	int fd_spi, fd_gpiochip;
+	int fd_gpioline;
+} RetroWavePlatform_LinuxSPI;
+
+extern int retrowave_init_linux_spi(RetroWaveContext *ctx, const char *spi_dev, int cs_gpio_chip, int cs_gpio_line);
+extern void retrowave_deinit_linux_spi(RetroWaveContext *ctx);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/hardware/RetroWaveLib/Platform/POSIX_SerialPort.c
+++ b/src/hardware/RetroWaveLib/Platform/POSIX_SerialPort.c
@@ -1,0 +1,159 @@
+/*
+    This file is part of RetroWave.
+
+    Copyright (C) 2021 ReimuNotMoe <reimu@sudomaker.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "POSIX_SerialPort.h"
+#include "assert.h"
+
+#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+
+static const char log_tag[] = "retrowave platform posix_serialport";
+
+int set_tty(int fd) {
+	struct termios tio;
+
+#ifdef __linux__
+	if (ioctl(fd, TCGETS, &tio)) {
+#else
+	if (tcgetattr(fd, &tio)) {
+#endif
+		fprintf(stderr, "%s: FATAL: failed to get tty attributes: %s\n", log_tag, strerror(errno));
+		return -1;
+	}
+
+	tio.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
+	tio.c_oflag &= ~OPOST;
+	tio.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
+	tio.c_cflag &= ~(CSIZE | PARENB);
+	tio.c_cflag |= CS8;
+
+#if defined (__linux__) || defined (__CYGWIN__)
+	tio.c_cflag &= ~CBAUD;
+	tio.c_cflag |= B2000000;
+#endif
+
+#if defined (BSD) || defined(__FreeBSD__)
+	cfsetispeed(&tio, 2000000);
+        cfsetospeed(&tio, 2000000);
+#endif
+
+#ifdef __linux__
+	if (ioctl(fd, TCSETS, &tio)) {
+#else
+	if (tcsetattr(fd, 0, &tio)) {
+#endif
+		fprintf(stderr, "%s: FATAL: failed to set tty attributes: %s\n", log_tag, strerror(errno));
+		return -1;
+	}
+
+#ifdef __APPLE__
+	int speed = 2000000;
+
+	if (ioctl(fd, IOSSIOSPEED, &speed) == -1) {
+		fprintf(stderr, "%s: FATAL: failed to set MacOS specific tty attributes: %s", log_tag, strerror(errno));
+		return -1;
+	}
+#endif
+
+	return 0;
+}
+
+static inline void set_device_lock(RetroWavePlatform_POSIXSerialPort *ctx, int value) {
+	errno = 0;
+
+	int rc_lock;
+
+	do {
+		rc_lock = flock(ctx->fd_tty, value ? LOCK_EX : LOCK_UN);
+	} while (errno == EINTR);
+
+	if (rc_lock < 0) {
+		fprintf(stderr, "%s: FATAL: failed to change lock state on tty device node: %s\n", log_tag, strerror(errno));
+		abort();
+	}
+}
+
+static void io_callback(void *userp, uint32_t data_rate, const void *tx_buf, void *rx_buf, uint32_t len) {
+	RetroWavePlatform_POSIXSerialPort *ctx = userp;
+
+	set_device_lock(ctx, 1);
+
+	uint32_t packed_len = retrowave_protocol_serial_packed_length(len);
+
+	uint8_t *packed_data;
+
+	if (packed_len > 128)
+		packed_data = malloc(packed_len);
+	else
+		packed_data = alloca(packed_len);
+
+
+	assert(retrowave_protocol_serial_pack(tx_buf, len, packed_data) == packed_len);
+
+	size_t written = 0;
+
+	while (written < len) {
+		ssize_t rc = write(ctx->fd_tty, packed_data + written, packed_len - written);
+		if (rc > 0) {
+			written += rc;
+		} else {
+			fprintf(stderr, "%s: FATAL: failed to write to tty: %s\n", log_tag, strerror(errno));
+			abort();
+		}
+	}
+
+	if (packed_len > 128)
+		free(packed_data);
+
+	set_device_lock(ctx, 0);
+}
+
+int retrowave_init_posix_serialport(RetroWaveContext *ctx, const char *tty_path) {
+	retrowave_init(ctx);
+
+	ctx->user_data = malloc(sizeof(RetroWavePlatform_POSIXSerialPort));
+
+	RetroWavePlatform_POSIXSerialPort *pctx = ctx->user_data;
+
+	pctx->fd_tty = open(tty_path, O_RDWR);
+	if (pctx->fd_tty < 0) {
+		fprintf(stderr, "%s: failed to open tty device `%s': %s\n", log_tag, tty_path, strerror(errno));
+		free(pctx);
+		return -1;
+	}
+
+	if (set_tty(pctx->fd_tty)) {
+#ifdef __CYGWIN__
+		puts("Workaround activated: ignoring all termios errors on Cygwin.");
+#else
+		return -1;
+#endif
+	}
+
+	ctx->callback_io = io_callback;
+
+	return 0;
+}
+
+void retrowave_deinit_posix_serialport(RetroWaveContext *ctx) {
+	RetroWavePlatform_POSIXSerialPort *pctx = ctx->user_data;
+	close(pctx->fd_tty);
+	free(pctx);
+}
+
+#endif

--- a/src/hardware/RetroWaveLib/Platform/POSIX_SerialPort.h
+++ b/src/hardware/RetroWaveLib/Platform/POSIX_SerialPort.h
@@ -1,0 +1,59 @@
+/*
+    This file is part of RetroWave.
+
+    Copyright (C) 2021 ReimuNotMoe <reimu@sudomaker.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <termios.h>
+
+#include <sys/ioctl.h>
+#include <sys/file.h>
+
+#ifdef __APPLE__
+#include <IOKit/serial/ioss.h>
+#endif
+
+#include "../RetroWave.h"
+#include "../Protocol/Serial.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	int fd_tty;
+} RetroWavePlatform_POSIXSerialPort;
+
+extern int retrowave_init_posix_serialport(RetroWaveContext *ctx, const char *tty_path);
+extern void retrowave_deinit_posix_serialport(RetroWaveContext *ctx);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/hardware/RetroWaveLib/Platform/STM32_HAL_SPI.c
+++ b/src/hardware/RetroWaveLib/Platform/STM32_HAL_SPI.c
@@ -1,0 +1,55 @@
+/*
+    This file is part of RetroWave.
+
+    Copyright (C) 2021 ReimuNotMoe <reimu@sudomaker.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "STM32_HAL_SPI.h"
+
+extern void HAL_GPIO_WritePin(void *GPIOx, uint16_t GPIO_Pin, int PinState);
+extern int HAL_SPI_TransmitReceive(void *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size, uint32_t Timeout);
+
+static void io_callback(void *userp, uint32_t data_rate, const void *tx_buf, void *rx_buf, uint32_t len) {
+	RetroWavePlatform_STM32_HAL_SPI *ctx = userp;
+
+	HAL_GPIO_WritePin(ctx->cs_gpiox, ctx->cs_gpio_pin, 0);
+
+	HAL_SPI_TransmitReceive(ctx->hspi, (uint8_t *)tx_buf, rx_buf, len, 0x7ffffff);
+
+	HAL_GPIO_WritePin(ctx->cs_gpiox, ctx->cs_gpio_pin, 1);
+}
+
+int retrowave_init_stm32_hal_spi(RetroWaveContext *ctx, void *hspi, void *cs_gpiox, uint16_t cs_gpio_pin) {
+	retrowave_init(ctx);
+
+	ctx->user_data = malloc(sizeof(RetroWavePlatform_STM32_HAL_SPI));
+
+	RetroWavePlatform_STM32_HAL_SPI *pctx = ctx->user_data;
+
+	pctx->hspi = hspi;
+	pctx->cs_gpiox = cs_gpiox;
+	pctx->cs_gpio_pin = cs_gpio_pin;
+
+	ctx->callback_io = io_callback;
+
+	HAL_GPIO_WritePin(cs_gpiox, cs_gpio_pin, 1);
+
+	return 0;
+}
+
+void retrowave_deinit_stm32_hal_spi(RetroWaveContext *ctx) {
+	free(ctx->user_data);
+}

--- a/src/hardware/RetroWaveLib/Platform/STM32_HAL_SPI.h
+++ b/src/hardware/RetroWaveLib/Platform/STM32_HAL_SPI.h
@@ -1,0 +1,44 @@
+/*
+    This file is part of RetroWave.
+
+    Copyright (C) 2021 ReimuNotMoe <reimu@sudomaker.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "../RetroWave.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	void *hspi;
+	void *cs_gpiox;
+	uint16_t cs_gpio_pin;
+} RetroWavePlatform_STM32_HAL_SPI;
+
+extern int retrowave_init_stm32_hal_spi(RetroWaveContext *ctx, void *hspi, void *cs_gpiox, uint16_t cs_gpio_pin);
+extern void retrowave_deinit_stm32_hal_spi(RetroWaveContext *ctx);
+
+#ifdef __cplusplus
+};
+#endif

--- a/src/hardware/RetroWaveLib/Platform/Win32_SerialPort.c
+++ b/src/hardware/RetroWaveLib/Platform/Win32_SerialPort.c
@@ -1,0 +1,130 @@
+/*
+    This file is part of RetroWave.
+
+    Copyright (C) 2021 ReimuNotMoe <reimu@sudomaker.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "Win32_SerialPort.h"
+
+#ifdef _WIN32
+
+static const char log_tag[] = "retrowave platform win32_serialport";
+
+static void io_callback(void *userp, uint32_t data_rate, const void *tx_buf, void *rx_buf, uint32_t len) {
+	RetroWavePlatform_Win32SerialPort *ctx = userp;
+
+	uint32_t packed_len = retrowave_protocol_serial_packed_length(len);
+
+	uint8_t *packed_data;
+
+	if (packed_len > 128)
+		packed_data = malloc(packed_len);
+	else
+		packed_data = alloca(packed_len);
+
+	retrowave_protocol_serial_pack(tx_buf, len, packed_data);
+
+
+	DWORD bytesWritten;
+
+	WriteFile(ctx->porthandle, packed_data, packed_len, &bytesWritten, NULL);
+
+	if (packed_len > 128)
+		free(packed_data);
+}
+
+int retrowave_init_win32_serialport(RetroWaveContext *ctx, const char *com_path) {
+	retrowave_init(ctx);
+
+	ctx->user_data = malloc(sizeof(RetroWavePlatform_Win32SerialPort));
+
+	RetroWavePlatform_Win32SerialPort *pctx = ctx->user_data;
+
+	if (strlen(com_path) > 240) {
+		printf("%s: error: COM path too long!\n", log_tag);
+		SetLastError(ERROR_BUFFER_OVERFLOW);
+		free(ctx->user_data);
+		return -1;
+	}
+
+	char extended_portname[256];
+
+	snprintf(extended_portname, sizeof(extended_portname)-1, "\\\\.\\%s", com_path);
+
+	pctx->porthandle = CreateFile(extended_portname,
+				     GENERIC_READ | GENERIC_WRITE, 0,
+				     NULL,          // no security attributes
+				     OPEN_EXISTING, // must use OPEN_EXISTING
+				     0,             // non overlapped I/O
+				     NULL           // hTemplate must be NULL for comm devices
+	);
+
+	if (pctx->porthandle == INVALID_HANDLE_VALUE) {
+		printf("%s: CreateFile failed with error %d.\n", log_tag, GetLastError());
+		free(ctx->user_data);
+		return -1;
+	}
+
+	DCB dcb;
+	BOOL fSuccess;
+
+	//  Initialize the DCB structure.
+	SecureZeroMemory(&dcb, sizeof(DCB));
+	dcb.DCBlength = sizeof(DCB);
+
+	//  Build on the current configuration by first retrieving all current
+	//  settings.
+	fSuccess = GetCommState(pctx->porthandle, &dcb);
+
+	if (!fSuccess) {
+		// Handle the error.
+		printf("%s: GetCommState failed with error %d.\n", log_tag, GetLastError());
+		free(ctx->user_data);
+		return -1;
+	}
+
+	//  Fill in some DCB values and set the com state:
+	//  57,600 bps, 8 data bits, no parity, and 1 stop bit.
+	dcb.BaudRate = CBR_115200;     //  baud rate
+	dcb.ByteSize = 8;             //  data size, xmit and rcv
+	dcb.Parity   = NOPARITY;      //  parity bit
+	dcb.StopBits = ONESTOPBIT;    //  stop bit
+
+	fSuccess = SetCommState(pctx->porthandle, &dcb);
+
+	if (!fSuccess) {
+		//  Handle the error.
+		printf("%s: SetCommState failed with error %d.\n", log_tag, GetLastError());
+		free(ctx->user_data);
+		return -1;
+	}
+
+	ctx->callback_io = io_callback;
+
+	return 0;
+}
+
+void retrowave_deinit_win32_serialport(RetroWaveContext *ctx) {
+	RetroWavePlatform_Win32SerialPort *pctx = ctx->user_data;
+
+	if (pctx->porthandle != INVALID_HANDLE_VALUE) {
+		CloseHandle(pctx->porthandle);
+	}
+
+	free(pctx);
+}
+
+#endif

--- a/src/hardware/RetroWaveLib/Platform/Win32_SerialPort.h
+++ b/src/hardware/RetroWaveLib/Platform/Win32_SerialPort.h
@@ -1,0 +1,44 @@
+/*
+    This file is part of RetroWave.
+
+    Copyright (C) 2021 ReimuNotMoe <reimu@sudomaker.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "../RetroWave.h"
+#include "../Protocol/Serial.h"
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	HANDLE porthandle;
+} RetroWavePlatform_Win32SerialPort;
+
+extern int retrowave_init_win32_serialport(RetroWaveContext *ctx, const char *com_path);
+extern void retrowave_deinit_win32_serialport(RetroWaveContext *ctx);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/hardware/RetroWaveLib/Protocol/Serial.c
+++ b/src/hardware/RetroWaveLib/Protocol/Serial.c
@@ -1,0 +1,74 @@
+/*
+    This file is part of RetroWave.
+
+    Copyright (C) 2021 ReimuNotMoe <reimu@sudomaker.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "Serial.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint32_t retrowave_protocol_serial_packed_length(uint32_t len_in) {
+	return ceil((double)len_in * 8 / 7) + 2;
+}
+
+uint32_t retrowave_protocol_serial_pack(const void *_buf_in, uint32_t len_in, void *_buf_out) {
+	uint32_t in_cursor = 0;
+	uint32_t out_cursor = 0;
+
+	uint8_t* buf_in = (uint8_t*)_buf_in;
+	uint8_t* buf_out = (uint8_t*)_buf_out;
+
+	buf_out[out_cursor] = 0x00;
+	out_cursor += 1;
+
+	uint8_t shift_count = 0;
+
+	while(in_cursor < len_in) {
+		uint8_t cur_byte_out = buf_in[in_cursor] >> shift_count;
+		if (in_cursor > 0) {
+			cur_byte_out |= (buf_in[in_cursor - 1] << (8 - shift_count));
+		}
+
+		cur_byte_out |= 0x01;
+		buf_out[out_cursor] = cur_byte_out;
+
+		shift_count += 1;
+		in_cursor += 1;
+		out_cursor += 1;
+		if (shift_count > 7) {
+			shift_count = 0;
+			in_cursor -= 1;
+		}
+	}
+
+	if (shift_count) {
+		buf_out[out_cursor] = buf_in[in_cursor - 1] << (8 - shift_count);
+		buf_out[out_cursor] |= 0x01;
+		out_cursor += 1;
+	}
+
+	buf_out[out_cursor] = 0x02;
+	out_cursor += 1;
+
+	return out_cursor;
+}
+
+#ifdef __cplusplus
+};
+#endif

--- a/src/hardware/RetroWaveLib/Protocol/Serial.h
+++ b/src/hardware/RetroWaveLib/Protocol/Serial.h
@@ -1,0 +1,44 @@
+/*
+    This file is part of RetroWave.
+
+    Copyright (C) 2021 ReimuNotMoe <reimu@sudomaker.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <stdint.h>
+#include <math.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+	Retrowave_Serial_Transfer_End = 0,
+	Retrowave_Serial_Transfer_Start = 1,
+} RetroWaveProtocol_Serial_ControlFlags;
+
+typedef struct {
+	uint8_t data : 7;
+	uint8_t is_data : 1;
+} __attribute__((__packed__, gcc_struct)) RetroWaveProtocol_Serial_Byte;
+
+extern uint32_t retrowave_protocol_serial_packed_length(uint32_t len_in);
+extern uint32_t retrowave_protocol_serial_pack(const void *_buf_in, uint32_t len_in, void *_buf_out);
+
+#ifdef __cplusplus
+};
+#endif

--- a/src/hardware/RetroWaveLib/RetroWave.c
+++ b/src/hardware/RetroWaveLib/RetroWave.c
@@ -1,0 +1,103 @@
+/*
+    This file is part of RetroWave.
+
+    Copyright (C) 2021 ReimuNotMoe <reimu@sudomaker.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "RetroWave.h"
+
+void retrowave_init(RetroWaveContext *ctx) {
+	memset(ctx, 0, sizeof(RetroWaveContext));
+	ctx->cmd_buffer = malloc(8192);
+}
+
+void retrowave_deinit(RetroWaveContext *ctx) {
+	free(ctx->cmd_buffer);
+}
+
+void retrowave_io_init(RetroWaveContext *ctx) {
+	// Sync CS state
+	uint8_t empty_byte = 0;
+	ctx->callback_io(ctx->user_data, 1e6, &empty_byte, NULL, 1);
+
+	uint8_t init_sequence_1[] = {
+		0x00,
+		0x0a,	// IOCON register
+		0x28	// Enable: HAEN, SEQOP
+	};
+
+	uint8_t init_sequence_2[] = {
+		0x00,
+		0x00,	// IODIRA register
+		0x00,	// Set output
+		0x00	// Set output
+	};
+
+	uint8_t init_sequence_3[] = {
+		0x00,
+		0x12,	// GPIOA register
+		0xff,	// Set all HIGH
+		0xff	// Set all HIGH
+	};
+
+	for (uint8_t i=0x20; i<0x28; i++) {
+		uint8_t addr = i << 1;
+
+		init_sequence_1[0] = init_sequence_2[0] = init_sequence_3[0] = addr;
+		ctx->callback_io(ctx->user_data, 1e6, init_sequence_1, NULL, sizeof(init_sequence_1));
+		ctx->callback_io(ctx->user_data, 1e6, init_sequence_2, NULL, sizeof(init_sequence_2));
+		ctx->callback_io(ctx->user_data, 1e6, init_sequence_3, NULL, sizeof(init_sequence_3));
+	}
+}
+
+void retrowave_cmd_buffer_init(RetroWaveContext *ctx, RetroWaveBoardType board_type, uint8_t first_reg) {
+	if (ctx->cmd_buffer_used) {
+		if (ctx->cmd_buffer[0] != board_type) {
+			retrowave_flush(ctx);
+		}
+	}
+
+	if (!ctx->cmd_buffer_used) {
+		ctx->cmd_buffer[0] = board_type;
+		ctx->cmd_buffer[1] = first_reg;
+		ctx->cmd_buffer_used = 2;
+	}
+}
+
+static inline void cmd_buffer_deinit(RetroWaveContext *ctx) {
+	ctx->cmd_buffer_used = 0;
+}
+
+void retrowave_flush(RetroWaveContext *ctx) {
+	if (ctx->cmd_buffer_used) {
+//		puts("flush");
+
+		ctx->callback_io(ctx->user_data, ctx->transfer_speed_hint, ctx->cmd_buffer, NULL, ctx->cmd_buffer_used);
+
+		cmd_buffer_deinit(ctx);
+	}
+}
+
+uint8_t retrowave_invert_byte(uint8_t val) {
+	uint8_t ret;
+
+	for (uint8_t i=0; i<8; i++) {
+		uint8_t bit = (val >> i) & 1U;
+		ret ^= (-bit ^ ret) & (1UL << (7-i));
+	}
+
+	return ret;
+}

--- a/src/hardware/RetroWaveLib/RetroWave.h
+++ b/src/hardware/RetroWaveLib/RetroWave.h
@@ -1,0 +1,59 @@
+/*
+    This file is part of RetroWave.
+
+    Copyright (C) 2021 ReimuNotMoe <reimu@sudomaker.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+	RetroWave_Board_Unknown = 0,
+	RetroWave_Board_OPL3 = 0x21 << 1,
+	RetroWave_Board_MiniBlaster = 0x20 << 1,
+	RetroWave_Board_MasterGear = 0x24 << 1
+} RetroWaveBoardType;
+
+typedef struct {
+	void *user_data;
+	void (*callback_io)(void *, uint32_t, const void *, void *, uint32_t);
+	uint8_t *cmd_buffer;
+	uint32_t cmd_buffer_used, cmd_buffer_size;
+	uint32_t transfer_speed_hint;
+} RetroWaveContext;
+
+extern void retrowave_init(RetroWaveContext *ctx);
+extern void retrowave_deinit(RetroWaveContext *ctx);
+
+extern void retrowave_io_init(RetroWaveContext *ctx);
+
+extern void retrowave_cmd_buffer_init(RetroWaveContext *ctx, RetroWaveBoardType board_type, uint8_t first_reg);
+
+extern void retrowave_flush(RetroWaveContext *ctx);
+
+extern uint8_t retrowave_invert_byte(uint8_t val);
+
+#ifdef __cplusplus
+};
+#endif

--- a/src/hardware/RetroWaveLib/RetroWave_DOSBoX.cpp
+++ b/src/hardware/RetroWaveLib/RetroWave_DOSBoX.cpp
@@ -1,0 +1,73 @@
+//
+// Created by root on 4/16/21.
+//
+
+#include "RetroWave_DOSBoX.hpp"
+
+RetroWaveContext retrowave_global_context;
+int retrowave_global_context_inited = 0;
+
+static void retrowave_iocb_empty(void *userp, uint32_t data_rate, const void *tx_buf, void *rx_buf, uint32_t len) {
+
+}
+
+static std::vector<std::string> string_split(const std::string &s, char delim) {
+	std::vector<std::string> result;
+	std::stringstream ss (s);
+	std::string item;
+
+	while (getline(ss, item, delim)) {
+		result.push_back(item);
+	}
+
+	return result;
+}
+
+void retrowave_init_dosbox(const std::string& bus, const std::string& path, const std::string& spi_cs) {
+	if (retrowave_global_context_inited)
+		return;
+
+	int rc = -1;
+
+	if (bus == "serial") {
+#if defined (__linux__) || defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+		char buf[128];
+		snprintf(buf, sizeof(buf)-1, "/dev/%s", path.c_str());
+
+		rc = retrowave_init_posix_serialport(&retrowave_global_context, buf);
+#endif
+
+#ifdef _WIN32
+		rc = retrowave_init_win32_serialport(&retrowave_global_context, path.c_str());
+#endif
+	} else if (bus == "spi") {
+#if defined (__linux__)
+		auto scgs = string_split(spi_cs, ',');
+		int scg[2] = {0};
+
+		if (scgs.size() != 2) {
+			puts("error: bad GPIO specification. Please use the `gpiochip,line' format.");
+			exit(2);
+		}
+
+		scg[0] = strtol(scgs[0].c_str(), nullptr, 10);
+		scg[1] = strtol(scgs[1].c_str(), nullptr, 10);
+
+		printf("SPI CS: chip=%d, line=%d\n", scg[0], scg[1]);
+
+		rc = retrowave_init_linux_spi(&retrowave_global_context, path.c_str(), scg[0], scg[1]);
+#else
+		DEBUG_ShowMsg("RetroWave: error: SPI is not supported on your platform!");
+#endif
+	}
+
+	if (rc < 0) {
+		DEBUG_ShowMsg("RetroWave: Failed to init board! Please change configuration!");
+		retrowave_init(&retrowave_global_context);
+		retrowave_global_context.callback_io = retrowave_iocb_empty;
+	}
+
+	retrowave_io_init(&retrowave_global_context);
+
+	retrowave_global_context_inited = true;
+}

--- a/src/hardware/RetroWaveLib/RetroWave_DOSBoX.hpp
+++ b/src/hardware/RetroWaveLib/RetroWave_DOSBoX.hpp
@@ -1,0 +1,41 @@
+/*
+    This file is part of RetroWave.
+
+    Copyright (C) 2021 ReimuNotMoe <reimu@sudomaker.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <vector>
+#include <string>
+#include <sstream>
+
+#include "RetroWave.h"
+#include "Board/OPL3.h"
+#include "Protocol/Serial.h"
+#include "Platform/POSIX_SerialPort.h"
+#include "Platform/Win32_SerialPort.h"
+#include "Platform/Linux_SPI.h"
+
+#include "../serialport/libserial.h"
+
+extern void DEBUG_ShowMsg(char const* format,...);
+
+extern RetroWaveContext retrowave_global_context;
+extern int retrowave_global_context_inited;
+
+extern void retrowave_init_dosbox(const std::string& bus, const std::string& path, const std::string& spi_cs);
+


### PR DESCRIPTION
# Description

Add support for the upcoming RetroWave OPL3 hardware player.

**Does this PR address some issue(s) ?**

Nope.

**Does this PR introduce new feature(s) ?**

Add support for the upcoming RetroWave OPL3 hardware player.

Supports
1. USB adapter mode for PC/Macs.
1. SPI mode for Raspberry Pi.

**Are there any breaking changes ?**
No.

**Additional information**

RetroWave Lib: https://github.com/SudoMaker/RetroWave

Demo videos:

1. [Working on a Windows laptop](https://www.youtube.com/watch?v=YZkywpIIkiM)
2. [Working on a Linux laptop](https://youtu.be/zdS7gqn4DZU)
3. [Working on Raspberry Pi as a HAT](https://youtu.be/bB5FK8uXP50)

Additional configurations:

With USB adapter:
![Screenshot_20210420_004920](https://user-images.githubusercontent.com/10512422/115404703-277ba580-a220-11eb-904e-a5ee7999cf32.png)

With Raspberry Pi SPI
![EE4A0768](https://user-images.githubusercontent.com/10512422/115406297-9dccd780-a221-11eb-837b-ae8c12a138a6.jpg)

