### PR TITLE
Allow to save the folder selection to the global config file

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,7 +18,9 @@
     example, DOSBox-X can use the primary config file
     directory or the DOSBox-X program directory as its
     working directory. You can view the DOSBox-X'safe
-    working directory with CONFIG -L command. (Wengier)
+    working directory with CONFIG -L command. DOSBox-X
+    is also able to save the working directory that a
+    user selects to global config files. (Wengier)
   - Added new command-line options -promptfolder and
     -nopromptfolder which will cause the folder prompt
     dialogs to show or not to show at startup.

--- a/README.source-code-description
+++ b/README.source-code-description
@@ -150,6 +150,8 @@ and as of DOSBox-X 0.83.6 support for FluidSynth MIDI Synthesizer is also includ
 (set "mididevice=fluidsynth" in the [midi] section of DOSBox-X's configuration file
 (dosbox-x.conf) along with required soundfont file (e.g. FluidR3_GM.sf2) to use it).
 
+The slirp backend is only supported by MinGW builds but not Visual Studio builds.
+
 Build the source code for your platform (Win32, x64, ARM and ARM64 are supported).
 
 As of 2018/06/06, Visual Studio 2017 builds (32-bit and 64-bit) explicitly require
@@ -372,14 +374,14 @@ src/shell/shell_cmds.cpp    Shell internal command handling, shell commands:
                                 DIR         CD/CHDIR    ADDKEY      ALIAS
                                 ATTRIB      BREAK       CALL        CHOICE
                                 CLS         COPY        COUNTRY     CTTY
-                                DATE        DEL/ERASE   DELTREE     ECHO
-                                EXIT        FOR         GOTO        HELP
-                                IF          LFNFOR      LH/LOADHIGH MD/MKDIR
-                                MORE        PATH        PAUSE       PROMPT
+                                DATE        DEBUGBOX    DEL/ERASE   DELTREE
+                                DX-CAPTURE  ECHO        EXIT        FOR
+                                GOTO        HELP        IF          LFNFOR
+                                LH/LOADHIGH MD/MKDIR    MORE        PATH
+                                PAUSE       POPD        PROMPT      PUSHD
                                 RD/RMDIR    REM         REN/RENAME  SET
                                 SHIFT       SUBST       TIME        TYPE
                                 VER         VERIFY      VOL         TRUENAME
-                                DX-CAPTURE  DEBUGBOX    INT2FDBG
 
 src/shell/shell_misc.cpp    PROMPT generator, command line input interface,
                             shell execution, and command location via PATH
@@ -440,7 +442,7 @@ src/gui/render_scalers.cpp  Render scaler definitions and code. Note that
 src/gui/midi.cpp            MIDI output framework. Header files include
                             additional platform-specific code.
 
-src/gui/menu_osx.mm         macOS Objective C++ code to bridge Objective C
+src/gui/menu_macos.mm       macOS Objective C++ code to bridge Objective C
                             and C++ so that the menu manipulation code can
                             work correctly.
 

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -184,6 +184,18 @@ logfile     =
 #                                                    If set to auto (default), DOSBox-X will warn if a DOS program, game or a guest system is currently running.
 #                                                    If set to autofile, DOSBox-X will warn if there are open file handles or a guest system is currently running.
 #                                                    Possible values: true, false, 1, 0, auto, autofile.
+#                        working directory option: Select an option for DOSBox-X's working directory when it runs.
+#                                                    autoprompt: DOSBox-X will auto-decide whether to prompt for a working directory.
+#                                                    config: DOSBox-X will use the primary config file directory as the working directory.
+#                                                    custom: Specify a working directory via the "working directory default" option.
+#                                                    default: Similar to autoprompt, but DOSBox-X will ask whether to save the selected folder.
+#                                                    force: Similar to "custom", while overriding -defaultdir command-line option if used.
+#                                                    noprompt: DOSBox-X uses the current directory and never prompts for a working directory.
+#                                                    program: DOSBox-X will use the DOSBox-X program directory as the working directory.
+#                                                    prompt: DOSBox-X will ask the user to select a working directory when it runs.
+#                                                    Possible values: autoprompt, config, custom, default, force, noprompt, program, prompt.
+#                       working directory default: The default directory to act as DOSBox-X's working directory. See also the setting "working directory option".
+#                                                    For working directory option=prompt, the specified directory becomes the default directory for the folder selection.
 #                           show advanced options: If set, the Configuration Tool will display all config options (including advanced ones) by default.
 #                                         hostkey: By default, DOSBox-X uses the mapper-defined host key, which defaults to F11 on Windows and F12 on other platforms.
 #                                                    You may alternatively specify a host key with this setting and bypass the host key as defined in the mapper.
@@ -379,6 +391,8 @@ startbanner                                     = true
 bannercolortheme                                = default
 dpi aware                                       = auto
 quit warning                                    = auto
+working directory option                        = default
+working directory default                       = 
 show advanced options                           = false
 hostkey                                         = mapper
 mapper send key                                 = ctrlaltdel
@@ -837,7 +851,7 @@ pc-98 force ibm keyboard layout          = false
 #DOSBOX-X-ADV:#                            The original DOS colors (0-15): #000000 #0000aa #00aa00 #00aaaa #aa0000 #aa00aa #aa5500 #aaaaaa #555555 #5555ff #55ff55 #55ffff #ff5555 #ff55ff #ffff55 #ffffff
 #DOSBOX-X-ADV:#                            gray scaled color scheme: (0,0,0)  #0e0e0e  (75,75,75) (89,89,89) (38,38,38) (52,52,52) #717171 #c0c0c0 #808080 (28,28,28) (150,150,150) (178,178,178) (76,76,76) (104,104,104) (226,226,226) (255,255,255)
 #        ttf.outputswitch: Specifies the output that DOSBox-X should switch to from the TTF output when a graphical mode is requiested, or auto for automatic selection.
-#                            Possible values: auto, surface, opengl, openglnb, openglhq, openglpp.
+#                            Possible values: auto, surface, opengl, openglnb, openglhq, openglpp, direct3d.
 #             ttf.winperc: Specifies the window percentage for the TTF output (100 = full screen). Ignored if the ttf.ptsize setting is specified.
 #              ttf.ptsize: Specifies the font point size for the TTF output. If specified (minimum: 9), it will override the ttf.winperc setting.
 #                ttf.lins: Specifies the number of rows on the screen for the TTF output (0 = default).

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -83,69 +83,83 @@ showmenu          = true
 logfile = 
 
 [dosbox]
-#              language: Select another language file.
-#                 title: Additional text to place in the title bar of the window.
-#          fastbioslogo: If set, DOSBox-X will skip the BIOS screen by activating fast BIOS logo mode (without 1-second pause).
-#           startbanner: If set (default), DOSBox-X will display the welcome banner when it starts.
-#      bannercolortheme: You can specify a different background color theme for the welcome banner from the default one.
-#                          Possible values: default, black, red, green, yellow, blue, magenta, cyan, white.
-#             dpi aware: Set this option (auto by default) to indicate to your OS that DOSBox-X is DPI aware.
-#                          If it is not set, Windows Vista/7/8/10 and higher may upscale the DOSBox-X window
-#                          on higher resolution monitors which is probably not what you want.
-#                          Possible values: true, false, 1, 0, auto.
-#          quit warning: Set this option to indicate whether DOSBox-X should show a warning message when the user tries to close its window.
-#                          If set to auto (default), DOSBox-X will warn if a DOS program, game or a guest system is currently running.
-#                          If set to autofile, DOSBox-X will warn if there are open file handles or a guest system is currently running.
-#                          Possible values: true, false, 1, 0, auto, autofile.
-# show advanced options: If set, the Configuration Tool will display all config options (including advanced ones) by default.
-#               hostkey: By default, DOSBox-X uses the mapper-defined host key, which defaults to F11 on Windows and F12 on other platforms.
-#                          You may alternatively specify a host key with this setting and bypass the host key as defined in the mapper.
-#                          This can also be done from the menu ("Main" => "Select host key").
-#                          Possible values: ctrlalt, ctrlshift, altshift, mapper.
-#       mapper send key: Select the key the mapper SendKey function will send.
-#                          Possible values: winlogo, winmenu, alttab, ctrlesc, ctrlbreak, ctrlaltdel.
-#      synchronize time: If set, DOSBox-X will try to automatically synchronize time with the host, unless you decide to change the date/time manually.
-#               machine: The type of machine DOSBox-X tries to emulate.
-#                          Possible values: hercules, cga, cga_mono, cga_rgb, cga_composite, cga_composite2, tandy, pcjr, ega, vgaonly, svga_s3, svga_s386c928, svga_s3vision864, svga_s3vision868, svga_s3trio32, svga_s3trio64, svga_s3trio64v+, svga_s3virge, svga_s3virgevx, svga_et3000, svga_et4000, svga_paradise, vesa_nolfb, vesa_oldvbe, amstrad, pc98, pc9801, pc9821, fm_towns, mcga, mda.
-#              captures: Directory where things like wave, midi, screenshot get captured.
-#              autosave: Enable the auto-save state feature. Specify a time interval in seconds, and optionally a save slot or start and end save slots.
-#                          For example, "autosave=10 11-20" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.
-#                          You can additionally specify up to 9 programs for this feature, e.g. "autosave=10 11-20 EDIT:21-30 EDITOR:35" for "EDIT" and "EDITOR".
-#                          Putting a minus sign (-) before the time interval causes the auto-saving function to not be activated at start.
-#              saveslot: Select the default save slot (1-100) to save/load states.
-#              savefile: Select the default save file to save/load states. If specified it will be used instead of the save slot.
-#            saveremark: If set, the save state feature will ask users to enter remarks when saving a state.
-#        forceloadstate: If set, DOSBox-X will load a saved state even if it finds there is a mismatch in the DOSBox-X version, machine type, program name and/or the memory size.
-#               memsize: Amount of memory DOSBox-X has in megabytes.
-#                          This value is best left at its default to avoid problems with some games,
-#                          although other games and applications may require a higher value.
-#                          Programs that use 286 protected mode like Windows 3.0 in Standard Mode may crash with more than 15MB.
-#            nocachedir: If set, MOUNT commands will mount with -nocachedir (disable directory caching) by default.
-#           freesizecap: If set to "cap" (="true"), the value of MOUNT -freesize will apply only if the actual free size is greater than the specified value.
-#                          If set to "relative", the value of MOUNT -freesize will change relative to the specified value.
-#                          If set to "fixed" (="false"), the value of MOUNT -freesize will be a fixed one to be reported all the time.
-#                          Possible values: true, false, fixed, relative, cap, 2, 1, 0.
-language              = 
-title                 = 
-fastbioslogo          = false
-startbanner           = true
-bannercolortheme      = default
-dpi aware             = auto
-quit warning          = auto
-show advanced options = false
-hostkey               = mapper
-mapper send key       = ctrlaltdel
-synchronize time      = false
-machine               = svga_s3
-captures              = capture
-autosave              = 
-saveslot              = 1
-savefile              = 
-saveremark            = true
-forceloadstate        = false
-memsize               = 16
-nocachedir            = false
-freesizecap           = cap
+#                  language: Select another language file.
+#                     title: Additional text to place in the title bar of the window.
+#              fastbioslogo: If set, DOSBox-X will skip the BIOS screen by activating fast BIOS logo mode (without 1-second pause).
+#               startbanner: If set (default), DOSBox-X will display the welcome banner when it starts.
+#          bannercolortheme: You can specify a different background color theme for the welcome banner from the default one.
+#                              Possible values: default, black, red, green, yellow, blue, magenta, cyan, white.
+#                 dpi aware: Set this option (auto by default) to indicate to your OS that DOSBox-X is DPI aware.
+#                              If it is not set, Windows Vista/7/8/10 and higher may upscale the DOSBox-X window
+#                              on higher resolution monitors which is probably not what you want.
+#                              Possible values: true, false, 1, 0, auto.
+#              quit warning: Set this option to indicate whether DOSBox-X should show a warning message when the user tries to close its window.
+#                              If set to auto (default), DOSBox-X will warn if a DOS program, game or a guest system is currently running.
+#                              If set to autofile, DOSBox-X will warn if there are open file handles or a guest system is currently running.
+#                              Possible values: true, false, 1, 0, auto, autofile.
+#  working directory option: Select an option for DOSBox-X's working directory when it runs.
+#                              autoprompt: DOSBox-X will auto-decide whether to prompt for a working directory.
+#                              config: DOSBox-X will use the primary config file directory as the working directory.
+#                              custom: Specify a working directory via the "working directory default" option.
+#                              default: Similar to autoprompt, but DOSBox-X will ask whether to save the selected folder.
+#                              force: Similar to "custom", while overriding -defaultdir command-line option if used.
+#                              noprompt: DOSBox-X uses the current directory and never prompts for a working directory.
+#                              program: DOSBox-X will use the DOSBox-X program directory as the working directory.
+#                              prompt: DOSBox-X will ask the user to select a working directory when it runs.
+#                              Possible values: autoprompt, config, custom, default, force, noprompt, program, prompt.
+# working directory default: The default directory to act as DOSBox-X's working directory. See also the setting "working directory option".
+#                              For working directory option=prompt, the specified directory becomes the default directory for the folder selection.
+#     show advanced options: If set, the Configuration Tool will display all config options (including advanced ones) by default.
+#                   hostkey: By default, DOSBox-X uses the mapper-defined host key, which defaults to F11 on Windows and F12 on other platforms.
+#                              You may alternatively specify a host key with this setting and bypass the host key as defined in the mapper.
+#                              This can also be done from the menu ("Main" => "Select host key").
+#                              Possible values: ctrlalt, ctrlshift, altshift, mapper.
+#           mapper send key: Select the key the mapper SendKey function will send.
+#                              Possible values: winlogo, winmenu, alttab, ctrlesc, ctrlbreak, ctrlaltdel.
+#          synchronize time: If set, DOSBox-X will try to automatically synchronize time with the host, unless you decide to change the date/time manually.
+#                   machine: The type of machine DOSBox-X tries to emulate.
+#                              Possible values: hercules, cga, cga_mono, cga_rgb, cga_composite, cga_composite2, tandy, pcjr, ega, vgaonly, svga_s3, svga_s386c928, svga_s3vision864, svga_s3vision868, svga_s3trio32, svga_s3trio64, svga_s3trio64v+, svga_s3virge, svga_s3virgevx, svga_et3000, svga_et4000, svga_paradise, vesa_nolfb, vesa_oldvbe, amstrad, pc98, pc9801, pc9821, fm_towns, mcga, mda.
+#                  captures: Directory where things like wave, midi, screenshot get captured.
+#                  autosave: Enable the auto-save state feature. Specify a time interval in seconds, and optionally a save slot or start and end save slots.
+#                              For example, "autosave=10 11-20" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.
+#                              You can additionally specify up to 9 programs for this feature, e.g. "autosave=10 11-20 EDIT:21-30 EDITOR:35" for "EDIT" and "EDITOR".
+#                              Putting a minus sign (-) before the time interval causes the auto-saving function to not be activated at start.
+#                  saveslot: Select the default save slot (1-100) to save/load states.
+#                  savefile: Select the default save file to save/load states. If specified it will be used instead of the save slot.
+#                saveremark: If set, the save state feature will ask users to enter remarks when saving a state.
+#            forceloadstate: If set, DOSBox-X will load a saved state even if it finds there is a mismatch in the DOSBox-X version, machine type, program name and/or the memory size.
+#                   memsize: Amount of memory DOSBox-X has in megabytes.
+#                              This value is best left at its default to avoid problems with some games,
+#                              although other games and applications may require a higher value.
+#                              Programs that use 286 protected mode like Windows 3.0 in Standard Mode may crash with more than 15MB.
+#                nocachedir: If set, MOUNT commands will mount with -nocachedir (disable directory caching) by default.
+#               freesizecap: If set to "cap" (="true"), the value of MOUNT -freesize will apply only if the actual free size is greater than the specified value.
+#                              If set to "relative", the value of MOUNT -freesize will change relative to the specified value.
+#                              If set to "fixed" (="false"), the value of MOUNT -freesize will be a fixed one to be reported all the time.
+#                              Possible values: true, false, fixed, relative, cap, 2, 1, 0.
+language                  = 
+title                     = 
+fastbioslogo              = false
+startbanner               = true
+bannercolortheme          = default
+dpi aware                 = auto
+quit warning              = auto
+working directory option  = default
+working directory default = 
+show advanced options     = false
+hostkey                   = mapper
+mapper send key           = ctrlaltdel
+synchronize time          = false
+machine                   = svga_s3
+captures                  = capture
+autosave                  = 
+saveslot                  = 1
+savefile                  = 
+saveremark                = true
+forceloadstate            = false
+memsize                   = 16
+nocachedir                = false
+freesizecap               = cap
 
 [video]
 #                vmemsize: Amount of video memory in megabytes.
@@ -233,7 +247,7 @@ pc-98 force ibm keyboard layout = false
 #                     For a font name or relative path, directories such as the working directory and default system font directory will be searched.
 #                     For example, setting it to "consola" or "consola.ttf" will use the Consola font; similar for other TTF fonts.
 # ttf.outputswitch: Specifies the output that DOSBox-X should switch to from the TTF output when a graphical mode is requiested, or auto for automatic selection.
-#                     Possible values: auto, surface, opengl, openglnb, openglhq, openglpp.
+#                     Possible values: auto, surface, opengl, openglnb, openglhq, openglpp, direct3d.
 #      ttf.winperc: Specifies the window percentage for the TTF output (100 = full screen). Ignored if the ttf.ptsize setting is specified.
 #       ttf.ptsize: Specifies the font point size for the TTF output. If specified (minimum: 9), it will override the ttf.winperc setting.
 #         ttf.lins: Specifies the number of rows on the screen for the TTF output (0 = default).

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -184,6 +184,18 @@ fileio      = false
 #                                                    If set to auto (default), DOSBox-X will warn if a DOS program, game or a guest system is currently running.
 #                                                    If set to autofile, DOSBox-X will warn if there are open file handles or a guest system is currently running.
 #                                                    Possible values: true, false, 1, 0, auto, autofile.
+#                        working directory option: Select an option for DOSBox-X's working directory when it runs.
+#                                                    autoprompt: DOSBox-X will auto-decide whether to prompt for a working directory.
+#                                                    config: DOSBox-X will use the primary config file directory as the working directory.
+#                                                    custom: Specify a working directory via the "working directory default" option.
+#                                                    default: Similar to autoprompt, but DOSBox-X will ask whether to save the selected folder.
+#                                                    force: Similar to "custom", while overriding -defaultdir command-line option if used.
+#                                                    noprompt: DOSBox-X uses the current directory and never prompts for a working directory.
+#                                                    program: DOSBox-X will use the DOSBox-X program directory as the working directory.
+#                                                    prompt: DOSBox-X will ask the user to select a working directory when it runs.
+#                                                    Possible values: autoprompt, config, custom, default, force, noprompt, program, prompt.
+#                       working directory default: The default directory to act as DOSBox-X's working directory. See also the setting "working directory option".
+#                                                    For working directory option=prompt, the specified directory becomes the default directory for the folder selection.
 #                           show advanced options: If set, the Configuration Tool will display all config options (including advanced ones) by default.
 #                                         hostkey: By default, DOSBox-X uses the mapper-defined host key, which defaults to F11 on Windows and F12 on other platforms.
 #                                                    You may alternatively specify a host key with this setting and bypass the host key as defined in the mapper.
@@ -379,6 +391,8 @@ startbanner                                     = true
 bannercolortheme                                = default
 dpi aware                                       = auto
 quit warning                                    = auto
+working directory option                        = default
+working directory default                       = 
 show advanced options                           = false
 hostkey                                         = mapper
 mapper send key                                 = ctrlaltdel
@@ -837,7 +851,7 @@ pc-98 show graphics layer on initialize  = true
 #                            The original DOS colors (0-15): #000000 #0000aa #00aa00 #00aaaa #aa0000 #aa00aa #aa5500 #aaaaaa #555555 #5555ff #55ff55 #55ffff #ff5555 #ff55ff #ffff55 #ffffff
 #                            gray scaled color scheme: (0,0,0)  #0e0e0e  (75,75,75) (89,89,89) (38,38,38) (52,52,52) #717171 #c0c0c0 #808080 (28,28,28) (150,150,150) (178,178,178) (76,76,76) (104,104,104) (226,226,226) (255,255,255)
 #        ttf.outputswitch: Specifies the output that DOSBox-X should switch to from the TTF output when a graphical mode is requiested, or auto for automatic selection.
-#                            Possible values: auto, surface, opengl, openglnb, openglhq, openglpp.
+#                            Possible values: auto, surface, opengl, openglnb, openglhq, openglpp, direct3d.
 #             ttf.winperc: Specifies the window percentage for the TTF output (100 = full screen). Ignored if the ttf.ptsize setting is specified.
 #              ttf.ptsize: Specifies the font point size for the TTF output. If specified (minimum: 9), it will override the ttf.winperc setting.
 #                ttf.lins: Specifies the number of rows on the screen for the TTF output (0 = default).

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1196,7 +1196,7 @@ void DOSBOX_SetupConfigSections(void) {
         0 };
 
     const char* workdiropts[] = {
-        "config", "custom", "default", "force", "noprompt", "program", "prompt",
+        "autoprompt", "config", "custom", "default", "force", "noprompt", "program", "prompt",
         0 };
 
     const char* switchoutputs[] = {
@@ -1288,9 +1288,10 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring = secprop->Add_string("working directory option",Property::Changeable::OnlyAtStart,"default");
     Pstring->Set_values(workdiropts);
     Pstring->Set_help("Select an option for DOSBox-X's working directory when it runs.\n"
+            "autoprompt: DOSBox-X will auto-decide whether to prompt for a working directory.\n"
             "config: DOSBox-X will use the primary config file directory as the working directory.\n"
             "custom: Specify a working directory via the \"working directory default\" option.\n"
-            "default: DOSBox-X will decide whether to prompt for a working directory.\n"
+            "default: Similar to autoprompt, but DOSBox-X will ask whether to save the selected folder.\n"
             "force: Similar to \"custom\", while overriding -defaultdir command-line option if used.\n"
             "noprompt: DOSBox-X uses the current directory and never prompts for a working directory.\n"
             "program: DOSBox-X will use the DOSBox-X program directory as the working directory.\n"

--- a/src/gui/Makefile.am
+++ b/src/gui/Makefile.am
@@ -20,6 +20,6 @@ endif
 
 if MACOSX
 libgui_a_SOURCES += \
-	menu_osx.mm
+	menu_macos.mm
 endif
 

--- a/src/gui/menu_macos.mm
+++ b/src/gui/menu_macos.mm
@@ -603,3 +603,14 @@ void MacOSX_alert(const char *title, const char *message) {
     [alert setAlertStyle:NSInformationalAlertStyle];
     [alert runModal];
 }
+
+int MacOSX_yesnocancel(const char *title, const char *message) {
+    NSAlert *alert = [[NSAlert alloc] init];
+    [alert addButtonWithTitle:@"Yes"];
+    [alert addButtonWithTitle:@"No"];
+    [alert addButtonWithTitle:@"Cancel"];
+    [alert setMessageText:[NSString stringWithFormat:@"%s",title]];
+    [alert setInformativeText:[NSString stringWithFormat:@"%s",message]];
+    [alert setAlertStyle:NSInformationalAlertStyle];
+    return [alert runModal];
+}


### PR DESCRIPTION
DOSBox-X currently prompts for folder to set the working directory in some cases, and there are also options to set it in the config file. This PR allows DOSBox-X to ask whether to save the folder user has selected when the file selection dialog shows up for the first time. If the user selects Yes, DOSBox-X will save the folder selection to the global config file and will not prompt for a folder again, and if the user selects No, DOSBox-X will continue to prompt for a folder when it runs without asking this question (and if the user selects Cancel, DOSBox-X will prompt for folder and ask this question again next time it runs). Along with small fixups. Tested in Windows, Linux and macOS.