### PR TITLE
Allow to resolve environment variables in config option paths on Linux/macOS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 0.83.13
+  - DOSBox-X can now resolve file paths in its config
+    options that include environment variables on non-
+    Windows platforms (e.g. ${HOME}..) as well. (Wengier)
   - The error "Access Denied" is returned instead of
     "File not found" for files opened exclusively in
     another program on mounted local drives. (Wengier)


### PR DESCRIPTION
DOSBox-X can already resolve environment variables in config options that contain paths in Windows. This allows DOSBox-X to resolve environment variables in config options that contain paths in non-Windows systems as well (in addition to tildes), e.g.

``
[config]
``
``
SET TEST=${HOME}/${USER}
``

Tested in Linux and macOS.