### PR TITLE
SVN r4424

### DIFF
--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -31,7 +31,7 @@ public:
 		CodePageHandler * handler;		//Page containing this code
 	} page;
 	struct {
-		uint8_t * start;					//Where in the cache are we
+		const uint8_t * start;				//Where in the cache are we
 		uint8_t * xstart;					//Where in the cache are we
 		Bitu size;
 		CacheBlock * next;
@@ -58,7 +58,7 @@ static struct {
 		CacheBlock * free;
 		CacheBlock * running;
 	} block;
-	uint8_t * pos;
+	const uint8_t * pos;		// position in the cache block
 	CodePageHandler * free_pages;
 	CodePageHandler * used_pages;
 	CodePageHandler * last_page;
@@ -391,7 +391,7 @@ void CacheBlock::Clear(void) {
 	}
 }
 
-static INLINE void *cache_rwtox(void *x);
+static INLINE void *cache_rwtox(const void *x);
 
 static CacheBlock * cache_openblock(void) {
 	CacheBlock * block=cache.block.active;
@@ -455,38 +455,38 @@ static void cache_closeblock(void) {
 	}
 }
 
-static INLINE void cache_addb(uint8_t val,uint8_t *pos) {
-	*pos=val;
+static INLINE void cache_addb(uint8_t val,const uint8_t *pos) {
+	*(uint8_t*)pos = val;
 }
 static INLINE void cache_addb(uint8_t val) {
-	uint8_t *pos=cache.pos+1;
+	const uint8_t *pos=cache.pos+1;
 	cache_addb(val,cache.pos);
 	cache.pos=pos;
 }
 
-static INLINE void cache_addw(uint16_t val,uint8_t *pos) {
+static INLINE void cache_addw(uint16_t val,const uint8_t *pos) {
 	*(uint16_t*)pos=val;
 }
 static INLINE void cache_addw(uint16_t val) {
-	uint8_t *pos=cache.pos+2;
+	const uint8_t *pos=cache.pos+2;
 	cache_addw(val,cache.pos);
 	cache.pos=pos;
 }
 
-static INLINE void cache_addd(uint32_t val,uint8_t *pos) {
+static INLINE void cache_addd(uint32_t val,const uint8_t *pos) {
 	*(uint32_t*)pos=val;
 }
 static INLINE void cache_addd(uint32_t val) {
-	uint8_t *pos=cache.pos+4;
+	const uint8_t *pos=cache.pos+4;
 	cache_addd(val,cache.pos);
 	cache.pos=pos;
 }
 
-static INLINE void cache_addq(uint64_t val,uint8_t *pos) {
+static INLINE void cache_addq(uint64_t val,const uint8_t *pos) {
 	*(uint64_t*)pos=val;
 }
 static INLINE void cache_addq(uint64_t val) {
-	uint8_t *pos=cache.pos+8;
+	const uint8_t *pos=cache.pos+8;
 	cache_addq(val,cache.pos);
 	cache.pos=pos;
 }

--- a/src/cpu/core_dyn_x86/risc_x86.h
+++ b/src/cpu/core_dyn_x86/risc_x86.h
@@ -84,7 +84,7 @@ public:
 	}
 };
 
-static BlockReturn gen_runcode(uint8_t * code) {
+static BlockReturn gen_runcode(const uint8_t * code) {
 	BlockReturn retval;
 #if defined (_MSC_VER)
 	__asm {
@@ -978,40 +978,40 @@ static void gen_call_write(DynReg * dr,uint32_t val,Bitu write_size) {
 #endif
 }
 
-static uint8_t * gen_create_branch(BranchTypes type) {
+static const uint8_t * gen_create_branch(BranchTypes type) {
 	/* First free all registers */
 	cache_addw(0x70+type);
 	return (cache.pos-1);
 }
 
-static void gen_fill_branch(uint8_t * data,uint8_t * from=cache.pos) {
+static void gen_fill_branch(const uint8_t * data,const uint8_t * from=cache.pos) {
 #if C_DEBUG
 	Bits len=from-data;
 	if (len<0) len=-len;
 	if (len>126) LOG_MSG("Big jump %d",len);
 #endif
-	*data=(from-data-1);
+	cache_addb((uint8_t)(from-data-1),data);
 }
 
-static uint8_t * gen_create_branch_long(BranchTypes type) {
+static const uint8_t * gen_create_branch_long(BranchTypes type) {
 	cache_addw(0x800f+(type<<8));
 	cache_addd(0);
 	return (cache.pos-4);
 }
 
-static void gen_fill_branch_long(uint8_t * data,uint8_t * from=cache.pos) {
-	*(uint32_t*)data=(from-data-4);
+static void gen_fill_branch_long(const uint8_t * data,const uint8_t * from=cache.pos) {
+	cache_addd((uint32_t)(from-data-4),data);
 }
 
-static uint8_t * gen_create_jump(uint8_t * to=0) {
+static const uint8_t * gen_create_jump(const uint8_t * to=0) {
 	/* First free all registers */
 	cache_addb(0xe9);
 	cache_addd(to-(cache.pos+4));
 	return (cache.pos-4);
 }
 
-static void gen_fill_jump(uint8_t * data,uint8_t * to=cache.pos) {
-	*(uint32_t*)data=(to-data-4);
+static void gen_fill_jump(const uint8_t * data,const uint8_t * to=cache.pos) {
+	gen_fill_branch_long(data,to);
 }
 
 static uint8_t * gen_create_short_jump(void) {

--- a/src/cpu/core_dyn_x86/string.h
+++ b/src/cpu/core_dyn_x86/string.h
@@ -80,8 +80,8 @@ static void dyn_string(STRING_OP op) {
 	}
 	DynState rep_state, cmp_state;
 	dyn_savestate(&rep_state);
-	uint8_t * rep_start=cache.pos;
-	uint8_t * rep_ecx_jmp, * rep_cmp_jmp;
+	const uint8_t * rep_start=cache.pos;
+	const uint8_t * rep_ecx_jmp, * rep_cmp_jmp;
 	/* Check if ECX!=zero */
 	if (decode.rep) {
 		gen_dop_word(DOP_TEST,decode.big_addr,DREG(ECX),DREG(ECX));

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -127,7 +127,7 @@ static void IllegalOptionDynrec(const char* msg) {
 }
 
 static struct {
-	BlockReturn (*runcode)(uint8_t*);		// points to code that can start a block
+	BlockReturn (*runcode)(const uint8_t*);		// points to code that can start a block
 	Bitu callback;				// the occurred callback
 	Bitu readdata;				// spare space used when reading from memory
 	uint32_t protected_regs[8];	// space to save/restore register values

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -35,7 +35,7 @@ public:
 		CodePageHandlerDynRec * handler;			// page containing this code
 	} page;
 	struct {
-		uint8_t * start;			// where in the cache are we
+		const uint8_t * start;		// where in the cache are we
 		uint8_t * xstart;			// where in the cache are we, executable mapping (because so much of the risc generation points at this pointer!)
 		Bitu size;
 		CacheBlockDynRec * next;
@@ -64,7 +64,7 @@ static struct {
 		CacheBlockDynRec * free;		// pointer to the free list
 		CacheBlockDynRec * running;		// the last block that was entered for execution
 	} block;
-	uint8_t * pos;		// position in the cache block
+	const uint8_t * pos;		// position in the cache block
 	CodePageHandlerDynRec * free_pages;		// pointer to the free list
 	CodePageHandlerDynRec * used_pages;		// pointer to the list of used pages
 	CodePageHandlerDynRec * last_page;		// the last used page
@@ -486,7 +486,7 @@ void CacheBlockDynRec::Clear(void) {
 	}
 }
 
-static INLINE void *cache_rwtox(void *x);
+static INLINE void *cache_rwtox(const void *x);
 
 static CacheBlockDynRec * cache_openblock(void) {
 	CacheBlockDynRec * block=cache.block.active;
@@ -557,41 +557,41 @@ static void cache_closeblock(void) {
 
 
 // place an 8bit value into the cache
-static INLINE void cache_addb(uint8_t val,uint8_t *pos) {
-	*pos=val;
+static INLINE void cache_addb(uint8_t val,const uint8_t *pos) {
+	*(uint8_t*)pos = val;
 }
 static INLINE void cache_addb(uint8_t val) {
-	uint8_t *pos=cache.pos+1;
+	const uint8_t *pos=cache.pos+1;
 	cache_addb(val,cache.pos);
 	cache.pos=pos;
 }
 
 // place a 16bit value into the cache
-static INLINE void cache_addw(uint16_t val,uint8_t *pos) {
+static INLINE void cache_addw(uint16_t val,const uint8_t *pos) {
 	*(uint16_t*)pos=val;
 }
 static INLINE void cache_addw(uint16_t val) {
-	uint8_t *pos=cache.pos+2;
+	const uint8_t *pos=cache.pos+2;
 	cache_addw(val,cache.pos);
 	cache.pos=pos;
 }
 
 // place a 32bit value into the cache
-static INLINE void cache_addd(uint32_t val,uint8_t *pos) {
+static INLINE void cache_addd(uint32_t val,const uint8_t *pos) {
 	*(uint32_t*)pos=val;
 }
 static INLINE void cache_addd(uint32_t val) {
-	uint8_t *pos=cache.pos+4;
+	const uint8_t *pos=cache.pos+4;
 	cache_addd(val,cache.pos);
 	cache.pos=pos;
 }
 
 // place a 64bit value into the cache
-static INLINE void cache_addq(uint64_t val,uint8_t *pos) {
+static INLINE void cache_addq(uint64_t val,const uint8_t *pos) {
 	*(uint64_t*)pos=val;
 }
 static INLINE void cache_addq(uint64_t val) {
-	uint8_t *pos=cache.pos+8;
+	const uint8_t *pos=cache.pos+8;
 	cache_addq(val,cache.pos);
 	cache.pos=pos;
 }

--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -50,7 +50,7 @@ static CacheBlockDynRec * CreateCacheBlock(CodePageHandlerDynRec * codepage,Phys
 
 	// every codeblock that is run sets cache.block.running to itself
 	// so the block linking knows the last executed block
-	gen_mov_direct_ptr(&cache.block.running,(DRC_PTR_SIZE_IM)decode.block);
+	gen_mov_direct_ptr(&cache.block.running,(Bitu)decode.block);
 
 	// start with the cycles check
 	gen_mov_word_to_reg(FC_RETOP,&CPU_Cycles,true);

--- a/src/cpu/core_dynrec/decoder_basic.h
+++ b/src/cpu/core_dynrec/decoder_basic.h
@@ -394,10 +394,10 @@ static void INLINE dyn_get_modrm(void) {
 
 #ifdef DRC_USE_SEGS_ADDR
 
-#define MOV_SEG_VAL_TO_HOST_REG(host_reg, seg_index) gen_mov_seg16_to_reg(host_reg,(DRC_PTR_SIZE_IM)(DRCD_SEG_VAL(seg_index)) - (DRC_PTR_SIZE_IM)(&Segs))
+#define MOV_SEG_VAL_TO_HOST_REG(host_reg, seg_index) gen_mov_seg16_to_reg(host_reg,(Bitu)(DRCD_SEG_VAL(seg_index)) - (Bitu)(&Segs))
 
-#define MOV_SEG_PHYS_TO_HOST_REG(host_reg, seg_index) gen_mov_seg32_to_reg(host_reg,(DRC_PTR_SIZE_IM)(DRCD_SEG_PHYS(seg_index)) - (DRC_PTR_SIZE_IM)(&Segs))
-#define ADD_SEG_PHYS_TO_HOST_REG(host_reg, seg_index) gen_add_seg32_to_reg(host_reg,(DRC_PTR_SIZE_IM)(DRCD_SEG_PHYS(seg_index)) - (DRC_PTR_SIZE_IM)(&Segs))
+#define MOV_SEG_PHYS_TO_HOST_REG(host_reg, seg_index) gen_mov_seg32_to_reg(host_reg,(Bitu)(DRCD_SEG_PHYS(seg_index)) - (Bitu)(&Segs))
+#define ADD_SEG_PHYS_TO_HOST_REG(host_reg, seg_index) gen_add_seg32_to_reg(host_reg,(Bitu)(DRCD_SEG_PHYS(seg_index)) - (Bitu)(&Segs))
 
 #else
 
@@ -411,22 +411,22 @@ static void INLINE dyn_get_modrm(void) {
 
 #ifdef DRC_USE_REGS_ADDR
 
-#define MOV_REG_VAL_TO_HOST_REG(host_reg, reg_index) gen_mov_regval32_to_reg(host_reg,(DRC_PTR_SIZE_IM)(DRCD_REG_VAL(reg_index)) - (DRC_PTR_SIZE_IM)(&cpu_regs))
-#define ADD_REG_VAL_TO_HOST_REG(host_reg, reg_index) gen_add_regval32_to_reg(host_reg,(DRC_PTR_SIZE_IM)(DRCD_REG_VAL(reg_index)) - (DRC_PTR_SIZE_IM)(&cpu_regs))
+#define MOV_REG_VAL_TO_HOST_REG(host_reg, reg_index) gen_mov_regval32_to_reg(host_reg,(Bitu)(DRCD_REG_VAL(reg_index)) - (Bitu)(&cpu_regs))
+#define ADD_REG_VAL_TO_HOST_REG(host_reg, reg_index) gen_add_regval32_to_reg(host_reg,(Bitu)(DRCD_REG_VAL(reg_index)) - (Bitu)(&cpu_regs))
 
-#define MOV_REG_WORD16_TO_HOST_REG(host_reg, reg_index) gen_mov_regval16_to_reg(host_reg,(DRC_PTR_SIZE_IM)(DRCD_REG_WORD(reg_index,false)) - (DRC_PTR_SIZE_IM)(&cpu_regs))
-#define MOV_REG_WORD32_TO_HOST_REG(host_reg, reg_index) gen_mov_regval32_to_reg(host_reg,(DRC_PTR_SIZE_IM)(DRCD_REG_WORD(reg_index,true)) - (DRC_PTR_SIZE_IM)(&cpu_regs))
-#define MOV_REG_WORD_TO_HOST_REG(host_reg, reg_index, dword) gen_mov_regword_to_reg(host_reg,(DRC_PTR_SIZE_IM)(DRCD_REG_WORD(reg_index,dword)) - (DRC_PTR_SIZE_IM)(&cpu_regs), dword)
+#define MOV_REG_WORD16_TO_HOST_REG(host_reg, reg_index) gen_mov_regval16_to_reg(host_reg,(Bitu)(DRCD_REG_WORD(reg_index,false)) - (Bitu)(&cpu_regs))
+#define MOV_REG_WORD32_TO_HOST_REG(host_reg, reg_index) gen_mov_regval32_to_reg(host_reg,(Bitu)(DRCD_REG_WORD(reg_index,true)) - (Bitu)(&cpu_regs))
+#define MOV_REG_WORD_TO_HOST_REG(host_reg, reg_index, dword) gen_mov_regword_to_reg(host_reg,(Bitu)(DRCD_REG_WORD(reg_index,dword)) - (Bitu)(&cpu_regs), dword)
 
-#define MOV_REG_WORD16_FROM_HOST_REG(host_reg, reg_index) gen_mov_regval16_from_reg(host_reg,(DRC_PTR_SIZE_IM)(DRCD_REG_WORD(reg_index,false)) - (DRC_PTR_SIZE_IM)(&cpu_regs))
-#define MOV_REG_WORD32_FROM_HOST_REG(host_reg, reg_index) gen_mov_regval32_from_reg(host_reg,(DRC_PTR_SIZE_IM)(DRCD_REG_WORD(reg_index,true)) - (DRC_PTR_SIZE_IM)(&cpu_regs))
-#define MOV_REG_WORD_FROM_HOST_REG(host_reg, reg_index, dword) gen_mov_regword_from_reg(host_reg,(DRC_PTR_SIZE_IM)(DRCD_REG_WORD(reg_index,dword)) - (DRC_PTR_SIZE_IM)(&cpu_regs), dword)
+#define MOV_REG_WORD16_FROM_HOST_REG(host_reg, reg_index) gen_mov_regval16_from_reg(host_reg,(Bitu)(DRCD_REG_WORD(reg_index,false)) - (Bitu)(&cpu_regs))
+#define MOV_REG_WORD32_FROM_HOST_REG(host_reg, reg_index) gen_mov_regval32_from_reg(host_reg,(Bitu)(DRCD_REG_WORD(reg_index,true)) - (Bitu)(&cpu_regs))
+#define MOV_REG_WORD_FROM_HOST_REG(host_reg, reg_index, dword) gen_mov_regword_from_reg(host_reg,(Bitu)(DRCD_REG_WORD(reg_index,dword)) - (Bitu)(&cpu_regs), dword)
 
-#define MOV_REG_BYTE_TO_HOST_REG_LOW(host_reg, reg_index, high_byte) gen_mov_regbyte_to_reg_low(host_reg,(DRC_PTR_SIZE_IM)(DRCD_REG_BYTE(reg_index,high_byte)) - (DRC_PTR_SIZE_IM)(&cpu_regs))
-#define MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(host_reg, reg_index, high_byte) gen_mov_regbyte_to_reg_low_canuseword(host_reg,(DRC_PTR_SIZE_IM)(DRCD_REG_BYTE(reg_index,high_byte)) - (DRC_PTR_SIZE_IM)(&cpu_regs))
-#define MOV_REG_BYTE_FROM_HOST_REG_LOW(host_reg, reg_index, high_byte) gen_mov_regbyte_from_reg_low(host_reg,(DRC_PTR_SIZE_IM)(DRCD_REG_BYTE(reg_index,high_byte)) - (DRC_PTR_SIZE_IM)(&cpu_regs))
+#define MOV_REG_BYTE_TO_HOST_REG_LOW(host_reg, reg_index, high_byte) gen_mov_regbyte_to_reg_low(host_reg,(Bitu)(DRCD_REG_BYTE(reg_index,high_byte)) - (Bitu)(&cpu_regs))
+#define MOV_REG_BYTE_TO_HOST_REG_LOW_CANUSEWORD(host_reg, reg_index, high_byte) gen_mov_regbyte_to_reg_low_canuseword(host_reg, (Bitu)(DRCD_REG_BYTE(reg_index, high_byte)) - (Bitu)(&cpu_regs))
+#define MOV_REG_BYTE_FROM_HOST_REG_LOW(host_reg, reg_index, high_byte) gen_mov_regbyte_from_reg_low(host_reg, (Bitu)(DRCD_REG_BYTE(reg_index, high_byte)) - (Bitu)(&cpu_regs))
 
-#define MOV_FLAGS_TO_HOST_REG(host_reg) gen_mov_regval32_to_reg(host_reg,(DRC_PTR_SIZE_IM)(DRCD_REG_FLAGS) - (DRC_PTR_SIZE_IM)(&cpu_regs))
+#define MOV_FLAGS_TO_HOST_REG(host_reg) gen_mov_regval32_to_reg(host_reg,(Bitu)(DRCD_REG_FLAGS) - (Bitu)(&cpu_regs))
 
 #else
 
@@ -520,72 +520,72 @@ static INLINE void dyn_set_eip_end(HostReg reg,uint32_t imm=0) {
 // is architecture dependent
 // R=host register; I=32bit immediate value; A=address value; m=memory
 
-template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_R(const T func,Bitu op) {
+template <typename T> static INLINE const uint8_t* gen_call_function_R(const T func,Bitu op) {
     gen_load_param_reg(op,0);
     return gen_call_function_setup(func, 1);
 }
 
-template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_R3(const T func,Bitu op) {
+template <typename T> static INLINE const uint8_t* gen_call_function_R3(const T func,Bitu op) {
     gen_load_param_reg(op,2);
     return gen_call_function_setup(func, 3, true);
 }
 
-template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_RI(const T func,Bitu op1,Bitu op2) {
+template <typename T> static INLINE const uint8_t* gen_call_function_RI(const T func,Bitu op1,Bitu op2) {
     gen_load_param_imm(op2,1);
     gen_load_param_reg(op1,0);
     return gen_call_function_setup(func, 2);
 }
 
-template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_RA(const T func,Bitu op1,DRC_PTR_SIZE_IM op2) {
+template <typename T> static INLINE const uint8_t* gen_call_function_RA(const T func,Bitu op1,Bitu op2) {
     gen_load_param_addr(op2,1);
     gen_load_param_reg(op1,0);
     return gen_call_function_setup(func, 2);
 }
 
-template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_RR(const T func,Bitu op1,Bitu op2) {
+template <typename T> static INLINE const uint8_t* gen_call_function_RR(const T func,Bitu op1,Bitu op2) {
     gen_load_param_reg(op2,1);
     gen_load_param_reg(op1,0);
     return gen_call_function_setup(func, 2);
 }
 
-template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_IR(const T func,Bitu op1,Bitu op2) {
+template <typename T> static INLINE const uint8_t* gen_call_function_IR(const T func,Bitu op1,Bitu op2) {
     gen_load_param_reg(op2,1);
     gen_load_param_imm(op1,0);
     return gen_call_function_setup(func, 2);
 }
 
-template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_I(const T func,Bitu op) {
+template <typename T> static INLINE const uint8_t* gen_call_function_I(const T func,Bitu op) {
     gen_load_param_imm(op,0);
     return gen_call_function_setup(func, 1);
 }
 
-template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_II(const T func,Bitu op1,Bitu op2) {
+template <typename T> static INLINE const uint8_t* gen_call_function_II(const T func,Bitu op1,Bitu op2) {
     gen_load_param_imm(op2,1);
     gen_load_param_imm(op1,0);
     return gen_call_function_setup(func, 2);
 }
 
-template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_III(const T func,Bitu op1,Bitu op2,Bitu op3) {
+template <typename T> static INLINE const uint8_t* gen_call_function_III(const T func,Bitu op1,Bitu op2,Bitu op3) {
     gen_load_param_imm(op3,2);
     gen_load_param_imm(op2,1);
     gen_load_param_imm(op1,0);
     return gen_call_function_setup(func, 3);
 }
 
-template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_IA(const T func,Bitu op1,DRC_PTR_SIZE_IM op2) {
+template <typename T> static INLINE const uint8_t* gen_call_function_IA(const T func,Bitu op1,Bitu op2) {
     gen_load_param_addr(op2,1);
     gen_load_param_imm(op1,0);
     return gen_call_function_setup(func, 2);
 }
 
-template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_IIR(const T func,Bitu op1,Bitu op2,Bitu op3) {
+template <typename T> static INLINE const uint8_t* gen_call_function_IIR(const T func,Bitu op1,Bitu op2,Bitu op3) {
     gen_load_param_reg(op3,2);
     gen_load_param_imm(op2,1);
     gen_load_param_imm(op1,0);
     return gen_call_function_setup(func, 3);
 }
 
-template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_IIIR(const T func,Bitu op1,Bitu op2,Bitu op3,Bitu op4) {
+template <typename T> static INLINE const uint8_t* gen_call_function_IIIR(const T func,Bitu op1,Bitu op2,Bitu op3,Bitu op4) {
     gen_load_param_reg(op4,3);
     gen_load_param_imm(op3,2);
     gen_load_param_imm(op2,1);
@@ -593,7 +593,7 @@ template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_IIIR(const
     return gen_call_function_setup(func, 4);
 }
 
-template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_IRRR(const T func,Bitu op1,Bitu op2,Bitu op3,Bitu op4) {
+template <typename T> static INLINE const uint8_t* gen_call_function_IRRR(const T func,Bitu op1,Bitu op2,Bitu op3,Bitu op4) {
     gen_load_param_reg(op4,3);
     gen_load_param_reg(op3,2);
     gen_load_param_reg(op2,1);
@@ -601,12 +601,12 @@ template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_IRRR(const
     return gen_call_function_setup(func, 4);
 }
 
-template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_m(const T func,Bitu op) {
+template <typename T> static INLINE const uint8_t* gen_call_function_m(const T func,Bitu op) {
     gen_load_param_mem(op,2);
     return gen_call_function_setup(func, 3, true);
 }
 
-template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_mm(const T func,Bitu op1,Bitu op2) {
+template <typename T> static INLINE const uint8_t* gen_call_function_mm(const T func,Bitu op1,Bitu op2) {
     gen_load_param_mem(op2,3);
 	gen_load_param_mem(op1,2);
 	return gen_call_function_setup(func, 4, true);
@@ -631,7 +631,7 @@ static BlockReturn DynRunException(uint32_t eip_add,uint32_t cycle_sub) {
 // end of a cache block because it is rarely reached (like exceptions)
 static struct {
 	save_info_type type;
-	DRC_PTR_SIZE_IM branch_pos;
+	const uint8_t* branch_pos;
 	uint32_t eip_change;
 	Bitu cycles;
 } save_info_dynrec[512];
@@ -1212,7 +1212,7 @@ static void gen_restore_reg(HostReg reg,HostReg dest_reg) {
 
 static Bitu mf_functions_num=0;
 static struct {
-	uint8_t* pos;
+	const uint8_t* pos;
 	void* fct_ptr;
 	Bitu ftype;
 } mf_functions[64];
@@ -1263,9 +1263,9 @@ template <typename T> static void InvalidateFlagsPartially(const T current_simpl
 // enqueue this instruction, if later an instruction is encountered that
 // destroys all condition flags and the flags weren't needed in-between
 // this function can be replaced by a simpler one as well
-template <typename T> static void InvalidateFlagsPartially(const T current_simple_function,DRC_PTR_SIZE_IM cpos,Bitu flags_type) {
+template <typename T> static void InvalidateFlagsPartially(const T current_simple_function,const uint8_t* cpos,Bitu flags_type) {
 #ifdef DRC_FLAGS_INVALIDATION
-	mf_functions[mf_functions_num].pos=(uint8_t*)cpos;
+	mf_functions[mf_functions_num].pos=cpos;
 	mf_functions[mf_functions_num].fct_ptr=reinterpret_cast<void*>((uintptr_t)current_simple_function);
 	mf_functions[mf_functions_num].ftype=flags_type;
 	mf_functions_num++;

--- a/src/cpu/core_dynrec/decoder_opcodes.h
+++ b/src/cpu/core_dynrec/decoder_opcodes.h
@@ -459,7 +459,7 @@ static void dyn_pop_ev(void) {
 		if (decode.big_op) gen_call_function_raw(mem_writed_checked_drc);
 		else gen_call_function_raw(mem_writew_checked_drc);
 		gen_extend_byte(false,FC_RETOP); // bool -> dword
-		DRC_PTR_SIZE_IM no_fault = gen_create_branch_on_zero(FC_RETOP, true);
+		const uint8_t* no_fault = gen_create_branch_on_zero(FC_RETOP, true);
 		// restore original ESP
 		gen_restore_reg(FC_OP2);
 		MOV_REG_WORD32_FROM_HOST_REG(FC_OP2,DRC_REG_ESP);
@@ -1040,7 +1040,7 @@ static void dyn_larlsl(bool is_lar) {
 	gen_extend_word(false,FC_RETOP);
 	if (is_lar) gen_call_function((void*)CPU_LAR,"%R%A",FC_RETOP,(DRC_PTR_SIZE_IM)&core_dynrec.readdata);
 	else gen_call_function((void*)CPU_LSL,"%R%A",FC_RETOP,(DRC_PTR_SIZE_IM)&core_dynrec.readdata);
-	DRC_PTR_SIZE_IM brnz=gen_create_branch_on_nonzero(FC_RETOP,true);
+	const uint8_t* brnz=gen_create_branch_on_nonzero(FC_RETOP,true);
 	gen_mov_word_to_reg(FC_OP2,&core_dynrec.readdata,true);
 	MOV_REG_WORD_FROM_HOST_REG(FC_OP2,decode.modrm.reg,decode.big_op);
 	gen_fill_branch(brnz);
@@ -1050,7 +1050,7 @@ static void dyn_larlsl(bool is_lar) {
 
 static void dyn_mov_from_crx(void) {
 	dyn_get_modrm();
-	gen_call_function_IA(CPU_READ_CRX,decode.modrm.reg,(DRC_PTR_SIZE_IM)&core_dynrec.readdata);
+	gen_call_function_IA(CPU_READ_CRX,decode.modrm.reg,(Bitu)&core_dynrec.readdata);
 	dyn_check_exception(FC_RETOP);
 	gen_mov_word_to_reg(FC_OP2,&core_dynrec.readdata,true);
 	MOV_REG_WORD32_FROM_HOST_REG(FC_OP2,decode.modrm.rm);
@@ -1111,7 +1111,7 @@ static void dyn_branched_exit(BranchTypes btype,int32_t eip_add) {
 	dyn_reduce_cycles();
 
 	dyn_branchflag_to_reg(btype);
-	DRC_PTR_SIZE_IM data=gen_create_branch_on_nonzero(FC_RETOP,true);
+	const uint8_t* data=gen_create_branch_on_nonzero(FC_RETOP,true);
 
  	// Branch not taken
 	gen_add_direct_word(&reg_eip,eip_base,decode.big_op);
@@ -1142,8 +1142,8 @@ static void dyn_loop(LoopTypes type) {
 	dyn_reduce_cycles();
 	int8_t eip_add=(int8_t)decode_fetchb();
 	uint32_t eip_base=decode.code-decode.code_start;
-	DRC_PTR_SIZE_IM branch1=0;
-	DRC_PTR_SIZE_IM branch2=0;
+	const uint8_t* branch1=0;
+	const uint8_t* branch2=0;
 	switch (type) {
 	case LOOP_E:
 		dyn_branchflag_to_reg(BR_NZ);

--- a/src/cpu/core_dynrec/operators.h
+++ b/src/cpu/core_dynrec/operators.h
@@ -1310,20 +1310,20 @@ static uint32_t DRC_CALL_CONV dynrec_dshr_dword_simple(uint32_t op1,uint32_t op2
 
 static void dyn_dpshift_word_gencall(bool left) {
 	if (left) {
-		DRC_PTR_SIZE_IM proc_addr=gen_call_function_R3(dynrec_dshl_word,FC_OP3);
+		const uint8_t* proc_addr=gen_call_function_R3(dynrec_dshl_word,FC_OP3);
 		InvalidateFlagsPartially(dynrec_dshl_word_simple,proc_addr,t_DSHLw);
 	} else {
-		DRC_PTR_SIZE_IM proc_addr=gen_call_function_R3(dynrec_dshr_word,FC_OP3);
+		const uint8_t* proc_addr=gen_call_function_R3(dynrec_dshr_word,FC_OP3);
 		InvalidateFlagsPartially(dynrec_dshr_word_simple,proc_addr,t_DSHRw);
 	}
 }
 
 static void dyn_dpshift_dword_gencall(bool left) {
 	if (left) {
-		DRC_PTR_SIZE_IM proc_addr=gen_call_function_R3(dynrec_dshl_dword,FC_OP3);
+		const uint8_t* proc_addr=gen_call_function_R3(dynrec_dshl_dword,FC_OP3);
 		InvalidateFlagsPartially(dynrec_dshl_dword_simple,proc_addr,t_DSHLd);
 	} else {
-		DRC_PTR_SIZE_IM proc_addr=gen_call_function_R3(dynrec_dshr_dword,FC_OP3);
+		const uint8_t* proc_addr=gen_call_function_R3(dynrec_dshr_dword,FC_OP3);
 		InvalidateFlagsPartially(dynrec_dshr_dword_simple,proc_addr,t_DSHRd);
 	}
 }

--- a/src/cpu/core_dynrec/risc_armv4le-common.h
+++ b/src/cpu/core_dynrec/risc_armv4le-common.h
@@ -32,9 +32,6 @@
 // try to replace _simple functions by code
 #define DRC_FLAGS_INVALIDATION_DCODE
 
-// type with the same size as a pointer
-#define DRC_PTR_SIZE_IM uint32_t
-
 // calling convention modifier
 #define DRC_CALL_CONV	/* nothing */
 #define DRC_FC			/* nothing */
@@ -87,7 +84,7 @@ typedef uint8_t HostReg;
 #define HOST_pc HOST_r15
 
 
-static void cache_block_closing(uint8_t* block_start,Bitu block_size) {
+static void cache_block_closing(const uint8_t* block_start,Bitu block_size) {
 #ifdef _MSC_VER
     //flush cache - Win32 API for MSVC
     FlushInstructionCache(GetCurrentProcess(), block_start, block_size);

--- a/src/cpu/core_dynrec/risc_armv4le-thumb-niw.h
+++ b/src/cpu/core_dynrec/risc_armv4le-thumb-niw.h
@@ -181,13 +181,13 @@
 #define CACHE_DATA_MAX	 (288)
 
 // data pool variables
-static uint8_t * cache_datapos = NULL;	// position of data pool in the cache block
+static const uint8_t * cache_datapos = NULL;	// position of data pool in the cache block
 static uint32_t cache_datasize = 0;		// total size of data pool
 static uint32_t cache_dataindex = 0;		// used size of data pool = index of free data item (in bytes) in data pool
 
 
 // forwarded function
-static void INLINE gen_create_branch_short(void * func);
+static void INLINE gen_create_branch_short(const uint8_t * func);
 
 // function to check distance to data pool
 // if too close, then generate jump after data pool
@@ -204,7 +204,7 @@ static void cache_checkinstr(uint32_t size) {
 	if (cache.pos + size + CACHE_DATA_JUMP <= cache_datapos) return;
 
 	{
-		register uint8_t * newcachepos;
+		register const uint8_t * newcachepos;
 
 		newcachepos = cache_datapos + cache_datasize;
 		gen_create_branch_short(newcachepos);
@@ -214,7 +214,7 @@ static void cache_checkinstr(uint32_t size) {
 	if (cache.pos + CACHE_DATA_MAX + CACHE_DATA_ALIGN >= cache.block.active->cache.start + cache.block.active->cache.size &&
 		cache.pos + CACHE_DATA_MIN + CACHE_DATA_ALIGN + (CACHE_DATA_ALIGN - CACHE_ALIGN) < cache.block.active->cache.start + cache.block.active->cache.size)
 	{
-		cache_datapos = (uint8_t *) (((Bitu)cache.block.active->cache.start + cache.block.active->cache.size - CACHE_DATA_ALIGN) & ~(CACHE_DATA_ALIGN - 1));
+		cache_datapos = (const uint8_t *) (((Bitu)cache.block.active->cache.start + cache.block.active->cache.size - CACHE_DATA_ALIGN) & ~(CACHE_DATA_ALIGN - 1));
 	} else {
 		register uint32_t cachemodsize;
 
@@ -223,9 +223,9 @@ static void cache_checkinstr(uint32_t size) {
 		if (cachemodsize + CACHE_DATA_MAX + CACHE_DATA_ALIGN <= CACHE_MAXSIZE ||
 			cachemodsize + CACHE_DATA_MIN + CACHE_DATA_ALIGN + (CACHE_DATA_ALIGN - CACHE_ALIGN) > CACHE_MAXSIZE)
 		{
-			cache_datapos = (uint8_t *) (((Bitu)cache.pos + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
+			cache_datapos = (const uint8_t *) (((Bitu)cache.pos + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
 		} else {
-			cache_datapos = (uint8_t *) (((Bitu)cache.pos + (CACHE_MAXSIZE - CACHE_DATA_ALIGN) - cachemodsize) & ~(CACHE_DATA_ALIGN - 1));
+			cache_datapos = (const uint8_t *) (((Bitu)cache.pos + (CACHE_MAXSIZE - CACHE_DATA_ALIGN) - cachemodsize) & ~(CACHE_DATA_ALIGN - 1));
 		}
 	}
 
@@ -235,11 +235,11 @@ static void cache_checkinstr(uint32_t size) {
 
 // function to reserve item in data pool
 // returns address of item
-static uint8_t * cache_reservedata(void) {
+static const uint8_t * cache_reservedata(void) {
 	// if data pool not yet initialized, then initialize data pool
 	if (GCC_UNLIKELY(cache_datapos == NULL)) {
 		if (cache.pos + CACHE_DATA_MIN + CACHE_DATA_ALIGN < cache.block.active->cache.start + CACHE_DATA_MAX) {
-			cache_datapos = (uint8_t *) (((Bitu)cache.block.active->cache.start + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
+			cache_datapos = (const uint8_t *) (((Bitu)cache.block.active->cache.start + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
 		}
 	}
 
@@ -250,7 +250,7 @@ static uint8_t * cache_reservedata(void) {
 			if (cache.pos + CACHE_DATA_MAX + CACHE_DATA_ALIGN >= cache.block.active->cache.start + cache.block.active->cache.size &&
 				cache.pos + CACHE_DATA_MIN + CACHE_DATA_ALIGN + (CACHE_DATA_ALIGN - CACHE_ALIGN) < cache.block.active->cache.start + cache.block.active->cache.size)
 			{
-				cache_datapos = (uint8_t *) (((Bitu)cache.block.active->cache.start + cache.block.active->cache.size - CACHE_DATA_ALIGN) & ~(CACHE_DATA_ALIGN - 1));
+				cache_datapos = (const uint8_t *) (((Bitu)cache.block.active->cache.start + cache.block.active->cache.size - CACHE_DATA_ALIGN) & ~(CACHE_DATA_ALIGN - 1));
 			} else {
 				register uint32_t cachemodsize;
 
@@ -259,9 +259,9 @@ static uint8_t * cache_reservedata(void) {
 				if (cachemodsize + CACHE_DATA_MAX + CACHE_DATA_ALIGN <= CACHE_MAXSIZE ||
 					cachemodsize + CACHE_DATA_MIN + CACHE_DATA_ALIGN + (CACHE_DATA_ALIGN - CACHE_ALIGN) > CACHE_MAXSIZE)
 				{
-					cache_datapos = (uint8_t *) (((Bitu)cache.pos + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
+					cache_datapos = (const uint8_t *) (((Bitu)cache.pos + CACHE_DATA_MAX) & ~(CACHE_DATA_ALIGN - 1));
 				} else {
-					cache_datapos = (uint8_t *) (((Bitu)cache.pos + (CACHE_MAXSIZE - CACHE_DATA_ALIGN) - cachemodsize) & ~(CACHE_DATA_ALIGN - 1));
+					cache_datapos = (const uint8_t *) (((Bitu)cache.pos + (CACHE_MAXSIZE - CACHE_DATA_ALIGN) - cachemodsize) & ~(CACHE_DATA_ALIGN - 1));
 				}
 			}
 		}
@@ -350,10 +350,10 @@ static void gen_mov_dword_to_reg_imm(HostReg dest_reg,uint32_t imm) {
 				cache_addw( ADD_LO_PC_IMM(dest_reg, (diff - 2) >> 2) );      // add dest_reg, pc, #((diff - 2) >> 2)
 			}
 		} else {
-			uint8_t *datapos;
+			const uint8_t *datapos;
 
 			datapos = cache_reservedata();
-			*(uint32_t*)datapos=imm;
+			cache_addd(imm,datapos);
 
 			if (((uint32_t)cache.pos & 0x03) == 0) {
 				cache_addw( LDR_PC_IMM(dest_reg, datapos - (cache.pos + 4)) );      // ldr dest_reg, [pc, datapos]
@@ -726,8 +726,8 @@ static void gen_mov_direct_dword(void* dest,uint32_t imm) {
 }
 
 // move an address into memory
-static void INLINE gen_mov_direct_ptr(void* dest,DRC_PTR_SIZE_IM imm) {
-	gen_mov_direct_dword(dest,(uint32_t)imm);
+static void INLINE gen_mov_direct_ptr(void* dest,uint32_t imm) {
+	gen_mov_direct_dword(dest,imm);
 }
 
 // add a 32bit (dword==true) or 16bit (dword==false) constant value to a memory value
@@ -823,10 +823,10 @@ static INLINE void gen_lea(HostReg dest_reg,Bitu scale,Bits imm) {
 
 // helper function for gen_call_function_raw and gen_call_function_setup
 template <typename T> static void gen_call_function_helper(const T func) {
-    uint8_t *datapos;
+    const uint8_t* datapos;
 
     datapos = cache_reservedata();
-    *(uint32_t*)datapos=(uint32_t)func;
+    cache_addd((uint32_t)func, datapos);
 
     if (((uint32_t)cache.pos & 0x03) == 0) {
         cache_addw( LDR_PC_IMM(templo1, datapos - (cache.pos + 4)) );      // ldr templo1, [pc, datapos]
@@ -858,9 +858,9 @@ template <typename T> static void INLINE gen_call_function_raw(const T func) {
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-template <typename T> static uint32_t INLINE gen_call_function_setup(const T func,Bitu paramcount,bool fastcall=false) {
+template <typename T> static INLINE const uint8_t* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
 	cache_checkinstr(18);
-	uint32_t proc_addr = (uint32_t)cache.pos;
+	const uint8_t* proc_addr = cache.pos;
 	gen_call_function_helper(func);
 	return proc_addr;
 	// if proc_addr is on word  boundary ((proc_addr & 0x03) == 0)
@@ -936,7 +936,7 @@ static void gen_jmp_ptr(void * ptr,Bits imm=0) {
 
 // short conditional jump (+-127 bytes) if register is zero
 // the destination is set by gen_fill_branch() later
-static uint32_t gen_create_branch_on_zero(HostReg reg,bool dword) {
+static const uint8_t* gen_create_branch_on_zero(HostReg reg,bool dword) {
 	cache_checkinstr(4);
 	if (dword) {
 		cache_addw( CMP_IMM(reg, 0) );      // cmp reg, #0
@@ -944,12 +944,12 @@ static uint32_t gen_create_branch_on_zero(HostReg reg,bool dword) {
 		cache_addw( LSL_IMM(templo1, reg, 16) );      // lsl templo1, reg, #16
 	}
 	cache_addw( BEQ_FWD(0) );      // beq j
-	return ((uint32_t)cache.pos-2);
+	return (cache.pos-2);
 }
 
 // short conditional jump (+-127 bytes) if register is nonzero
 // the destination is set by gen_fill_branch() later
-static uint32_t gen_create_branch_on_nonzero(HostReg reg,bool dword) {
+static const uint8_t* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 	cache_checkinstr(4);
 	if (dword) {
 		cache_addw( CMP_IMM(reg, 0) );      // cmp reg, #0
@@ -957,25 +957,25 @@ static uint32_t gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 		cache_addw( LSL_IMM(templo1, reg, 16) );      // lsl templo1, reg, #16
 	}
 	cache_addw( BNE_FWD(0) );      // bne j
-	return ((uint32_t)cache.pos-2);
+	return (cache.pos-2);
 }
 
 // calculate relative offset and fill it into the location pointed to by data
-static void INLINE gen_fill_branch(DRC_PTR_SIZE_IM data) {
+static void INLINE gen_fill_branch(const uint8_t* data) {
 #if C_DEBUG
-	Bits len=(uint32_t)cache.pos-(data+4);
+	Bits len=cache.pos-(data+4);
 	if (len<0) len=-len;
 	if (len>252) LOG_MSG("Big jump %d",len);
 #endif
-	*(uint8_t*)data=(uint8_t)( ((uint32_t)cache.pos-(data+4)) >> 1 );
+	cache_addb((uint8_t)((cache.pos-(data+4)) >> 1 ),data);
 }
 
 
 // conditional jump if register is nonzero
 // for isdword==true the 32bit of the register are tested
 // for isdword==false the lowest 8bit of the register are tested
-static uint32_t gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
-	uint8_t *datapos;
+static const uint8_t* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
+	const uint8_t *datapos;
 
 	cache_checkinstr(8);
 	datapos = cache_reservedata();
@@ -993,12 +993,12 @@ static uint32_t gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 	}
 	cache_addw( BX(templo1) );      // bx templo1
 	// nobranch:
-	return ((uint32_t)datapos);
+	return (datapos);
 }
 
 // compare 32bit-register against zero and jump if value less/equal than zero
-static uint32_t gen_create_branch_long_leqzero(HostReg reg) {
-	uint8_t *datapos;
+static const uint8_t* gen_create_branch_long_leqzero(HostReg reg) {
+	const uint8_t *datapos;
 
 	cache_checkinstr(8);
 	datapos = cache_reservedata();
@@ -1012,17 +1012,17 @@ static uint32_t gen_create_branch_long_leqzero(HostReg reg) {
 	}
 	cache_addw( BX(templo1) );      // bx templo1
 	// nobranch:
-	return ((uint32_t)datapos);
+	return (datapos);
 }
 
 // calculate long relative offset and fill it into the location pointed to by data
-static void INLINE gen_fill_branch_long(uint32_t data) {
+static void INLINE gen_fill_branch_long(const uint8_t* data) {
 	// this is an absolute branch
-	*(uint32_t*)data=((uint32_t)cache.pos) + 1; // add 1 to keep processor in thumb state
+	cache_addd((uint32_t)cache.pos + 1,data); // add 1 to keep processor in thumb state
 }
 
 static void gen_run_code(void) {
-	uint8_t *pos1, *pos2, *pos3;
+	const uint8_t *pos1, *pos2, *pos3;
 
 #if (__ARM_EABI__)
 	// 8-byte stack alignment
@@ -1056,13 +1056,13 @@ static void gen_run_code(void) {
 		cache.pos = cache.pos + (32 - (((Bitu)cache.pos) & 0x1f));
 	}
 
-	*(uint32_t*)pos1 = ARM_LDR_IMM(FC_SEGS_ADDR, HOST_pc, cache.pos - (pos1 + 8));      // ldr FC_SEGS_ADDR, [pc, #(&Segs)]
+	cache_addd(ARM_LDR_IMM(FC_SEGS_ADDR, HOST_pc, cache.pos - (pos1 + 8)),pos1);;      // ldr FC_SEGS_ADDR, [pc, #(&Segs)]
 	cache_addd((uint32_t)&Segs);      // address of "Segs"
 
-	*(uint32_t*)pos2 = ARM_LDR_IMM(FC_REGS_ADDR, HOST_pc, cache.pos - (pos2 + 8));      // ldr FC_REGS_ADDR, [pc, #(&cpu_regs)]
+	cache_addd(ARM_LDR_IMM(FC_REGS_ADDR, HOST_pc, cache.pos - (pos2 + 8)),pos2);      // ldr FC_REGS_ADDR, [pc, #(&cpu_regs)]
 	cache_addd((uint32_t)&cpu_regs);  // address of "cpu_regs"
 
-	*(uint32_t*)pos3 = ARM_LDR_IMM(readdata_addr, HOST_pc, cache.pos - (pos3 + 8));      // ldr readdata_addr, [pc, #(&core_dynrec.readdata)]
+	cache_addd(ARM_LDR_IMM(readdata_addr, HOST_pc, cache.pos - (pos3 + 8)),pos3);      // ldr readdata_addr, [pc, #(&core_dynrec.readdata)]
 	cache_addd((uint32_t)&core_dynrec.readdata);  // address of "core_dynrec.readdata"
 
 	// align cache.pos to 32 bytes
@@ -1081,8 +1081,8 @@ static void gen_return_function(void) {
 
 // short unconditional jump (over data pool)
 // must emit at most CACHE_DATA_JUMP bytes
-static void INLINE gen_create_branch_short(void * func) {
-	cache_addw( B_FWD((uint32_t)func - ((uint32_t)cache.pos + 4)) );      // b func
+static void INLINE gen_create_branch_short(const uint8_t * func) {
+	cache_addw( B_FWD(func - (cache.pos + 4)) );      // b func
 }
 
 
@@ -1090,12 +1090,12 @@ static void INLINE gen_create_branch_short(void * func) {
 
 // called when a call to a function can be replaced by a
 // call to a simpler function
-static void gen_fill_function_ptr(uint8_t * pos,void* fct_ptr,Bitu flags_type) {
+static void gen_fill_function_ptr(const uint8_t* pos, void* fct_ptr, Bitu flags_type) {
 	if ((*(uint16_t*)pos & 0xf000) == 0xe000) {
 		if ((*(uint16_t*)pos & 0x0fff) >= ((CACHE_DATA_ALIGN / 2) - 1) &&
 			(*(uint16_t*)pos & 0x0fff) < 0x0800)
 		{
-			pos = (uint8_t *) ( ( ( (uint32_t)(*(uint16_t*)pos & 0x0fff) ) << 1 ) + ((uint32_t)pos + 4) );
+			pos = (const uint8_t *) ( ( ( (uint32_t)(*(uint16_t*)pos & 0x0fff) ) << 1 ) + ((uint32_t)pos + 4) );
 		}
 	}
 
@@ -1107,32 +1107,32 @@ static void gen_fill_function_ptr(uint8_t * pos,void* fct_ptr,Bitu flags_type) {
 			case t_ADDb:
 			case t_ADDw:
 			case t_ADDd:
-				*(uint16_t*)pos=ADD_REG(HOST_a1, HOST_a1, HOST_a2);	// add a1, a1, a2
-				*(uint16_t*)(pos+2)=B_FWD(10);						// b after_call (pc+10)
+				cache_addw(ADD_REG(HOST_a1, HOST_a1, HOST_a2),pos+0);	// add a1, a1, a2
+				cache_addw(B_FWD(10),pos+2);						// b after_call (pc+10)
 				break;
 			case t_ORb:
 			case t_ORw:
 			case t_ORd:
-				*(uint16_t*)pos=ORR(HOST_a1, HOST_a2);				// orr a1, a2
-				*(uint16_t*)(pos+2)=B_FWD(10);						// b after_call (pc+10)
+				cache_addw(ORR(HOST_a1, HOST_a2),pos+0);				// orr a1, a2
+				cache_addw(B_FWD(10),pos+2);						// b after_call (pc+10)
 				break;
 			case t_ANDb:
 			case t_ANDw:
 			case t_ANDd:
-				*(uint16_t*)pos=AND(HOST_a1, HOST_a2);				// and a1, a2
-				*(uint16_t*)(pos+2)=B_FWD(10);						// b after_call (pc+10)
+				cache_addw(AND(HOST_a1, HOST_a2),pos+0);				// and a1, a2
+				cache_addw(B_FWD(10),pos+2);						// b after_call (pc+10)
 				break;
 			case t_SUBb:
 			case t_SUBw:
 			case t_SUBd:
-				*(uint16_t*)pos=SUB_REG(HOST_a1, HOST_a1, HOST_a2);	// sub a1, a1, a2
-				*(uint16_t*)(pos+2)=B_FWD(10);						// b after_call (pc+10)
+				cache_addw(SUB_REG(HOST_a1, HOST_a1, HOST_a2),pos+0);	// sub a1, a1, a2
+				cache_addw(B_FWD(10),pos+2);						// b after_call (pc+10)
 				break;
 			case t_XORb:
 			case t_XORw:
 			case t_XORd:
-				*(uint16_t*)pos=EOR(HOST_a1, HOST_a2);				// eor a1, a2
-				*(uint16_t*)(pos+2)=B_FWD(10);						// b after_call (pc+10)
+				cache_addw(EOR(HOST_a1, HOST_a2),pos+0);				// eor a1, a2
+				cache_addw(B_FWD(10),pos+2);						// b after_call (pc+10)
 				break;
 			case t_CMPb:
 			case t_CMPw:
@@ -1140,113 +1140,113 @@ static void gen_fill_function_ptr(uint8_t * pos,void* fct_ptr,Bitu flags_type) {
 			case t_TESTb:
 			case t_TESTw:
 			case t_TESTd:
-				*(uint16_t*)pos=B_FWD(12);							// b after_call (pc+12)
+				cache_addw(B_FWD(12),pos+0);							// b after_call (pc+12)
 				break;
 			case t_INCb:
 			case t_INCw:
 			case t_INCd:
-				*(uint16_t*)pos=ADD_IMM3(HOST_a1, HOST_a1, 1);		// add a1, a1, #1
-				*(uint16_t*)(pos+2)=B_FWD(10);						// b after_call (pc+10)
+				cache_addw(ADD_IMM3(HOST_a1, HOST_a1, 1),pos+0);		// add a1, a1, #1
+				cache_addw(B_FWD(10),pos+2);						// b after_call (pc+10)
 				break;
 			case t_DECb:
 			case t_DECw:
 			case t_DECd:
-				*(uint16_t*)pos=SUB_IMM3(HOST_a1, HOST_a1, 1);		// sub a1, a1, #1
-				*(uint16_t*)(pos+2)=B_FWD(10);						// b after_call (pc+10)
+				cache_addw(SUB_IMM3(HOST_a1, HOST_a1, 1),pos+0);		// sub a1, a1, #1
+				cache_addw(B_FWD(10),pos+2);						// b after_call (pc+10)
 				break;
 			case t_SHLb:
 			case t_SHLw:
 			case t_SHLd:
-				*(uint16_t*)pos=LSL_REG(HOST_a1, HOST_a2);			// lsl a1, a2
-				*(uint16_t*)(pos+2)=B_FWD(10);						// b after_call (pc+10)
+				cache_addw(LSL_REG(HOST_a1, HOST_a2),pos+0);			// lsl a1, a2
+				cache_addw(B_FWD(10),pos+2);						// b after_call (pc+10)
 				break;
 			case t_SHRb:
-				*(uint16_t*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(uint16_t*)(pos+2)=LSR_IMM(HOST_a1, HOST_a1, 24);	// lsr a1, a1, #24
-				*(uint16_t*)(pos+4)=LSR_REG(HOST_a1, HOST_a2);		// lsr a1, a2
-				*(uint16_t*)(pos+6)=B_FWD(6);							// b after_call (pc+6)
+				cache_addw(LSL_IMM(HOST_a1, HOST_a1, 24),pos+0);		// lsl a1, a1, #24
+				cache_addw(LSR_IMM(HOST_a1, HOST_a1, 24),pos+2);	// lsr a1, a1, #24
+				cache_addw(LSR_REG(HOST_a1, HOST_a2),pos+4);		// lsr a1, a2
+				cache_addw(B_FWD(6),pos+6);							// b after_call (pc+6)
 				break;
 			case t_SHRw:
-				*(uint16_t*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(uint16_t*)(pos+2)=LSR_IMM(HOST_a1, HOST_a1, 16);	// lsr a1, a1, #16
-				*(uint16_t*)(pos+4)=LSR_REG(HOST_a1, HOST_a2);		// lsr a1, a2
-				*(uint16_t*)(pos+6)=B_FWD(6);							// b after_call (pc+6)
+				cache_addw(LSL_IMM(HOST_a1, HOST_a1, 16),pos+0);		// lsl a1, a1, #16
+				cache_addw(LSR_IMM(HOST_a1, HOST_a1, 16),pos+2);	// lsr a1, a1, #16
+				cache_addw(LSR_REG(HOST_a1, HOST_a2),pos+4);		// lsr a1, a2
+				cache_addw(B_FWD(6),pos+6);							// b after_call (pc+6)
 				break;
 			case t_SHRd:
-				*(uint16_t*)pos=LSR_REG(HOST_a1, HOST_a2);			// lsr a1, a2
-				*(uint16_t*)(pos+2)=B_FWD(10);						// b after_call (pc+10)
+				cache_addw(LSR_REG(HOST_a1, HOST_a2),pos+0);			// lsr a1, a2
+				cache_addw(B_FWD(10),pos+2);						// b after_call (pc+10)
 				break;
 			case t_SARb:
-				*(uint16_t*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(uint16_t*)(pos+2)=ASR_IMM(HOST_a1, HOST_a1, 24);	// asr a1, a1, #24
-				*(uint16_t*)(pos+4)=ASR_REG(HOST_a1, HOST_a2);		// asr a1, a2
-				*(uint16_t*)(pos+6)=B_FWD(6);							// b after_call (pc+6)
+				cache_addw(LSL_IMM(HOST_a1, HOST_a1, 24),pos+0);		// lsl a1, a1, #24
+				cache_addw(ASR_IMM(HOST_a1, HOST_a1, 24),pos+2);	// asr a1, a1, #24
+				cache_addw(ASR_REG(HOST_a1, HOST_a2),pos+4);		// asr a1, a2
+				cache_addw(B_FWD(6),pos+6);							// b after_call (pc+6)
 				break;
 			case t_SARw:
-				*(uint16_t*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(uint16_t*)(pos+2)=ASR_IMM(HOST_a1, HOST_a1, 16);	// asr a1, a1, #16
-				*(uint16_t*)(pos+4)=ASR_REG(HOST_a1, HOST_a2);		// asr a1, a2
-				*(uint16_t*)(pos+6)=B_FWD(6);							// b after_call (pc+6)
+				cache_addw(LSL_IMM(HOST_a1, HOST_a1, 16),pos+0);		// lsl a1, a1, #16
+				cache_addw(ASR_IMM(HOST_a1, HOST_a1, 16),pos+2);	// asr a1, a1, #16
+				cache_addw(ASR_REG(HOST_a1, HOST_a2),pos+4);		// asr a1, a2
+				cache_addw(B_FWD(6),pos+6);							// b after_call (pc+6)
 				break;
 			case t_SARd:
-				*(uint16_t*)pos=ASR_REG(HOST_a1, HOST_a2);			// asr a1, a2
-				*(uint16_t*)(pos+2)=B_FWD(10);						// b after_call (pc+10)
+				cache_addw(ASR_REG(HOST_a1, HOST_a2),pos+0);			// asr a1, a2
+				cache_addw(B_FWD(10),pos+2);						// b after_call (pc+10)
 				break;
 			case t_RORb:
-				*(uint16_t*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(uint16_t*)(pos+2)=LSR_IMM(templo1, HOST_a1, 8);		// lsr templo1, a1, #8
-				*(uint16_t*)(pos+4)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(uint16_t*)(pos+6)=NOP;								// nop
-				*(uint16_t*)(pos+8)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(uint16_t*)(pos+10)=NOP;								// nop
-				*(uint16_t*)(pos+12)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(uint16_t*)(pos+14)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
+				cache_addw(LSL_IMM(HOST_a1, HOST_a1, 24),pos+0);		// lsl a1, a1, #24
+				cache_addw(LSR_IMM(templo1, HOST_a1, 8),pos+2);		// lsr templo1, a1, #8
+				cache_addw(ORR(HOST_a1, templo1),pos+4);			// orr a1, templo1
+				cache_addw(NOP,pos+6);								// nop
+				cache_addw(LSR_IMM(templo1, HOST_a1, 16),pos+8);	// lsr templo1, a1, #16
+				cache_addw(NOP,pos+10);								// nop
+				cache_addw(ORR(HOST_a1, templo1),pos+12);			// orr a1, templo1
+				cache_addw(ROR_REG(HOST_a1, HOST_a2),pos+14);		// ror a1, a2
 				break;
 			case t_RORw:
-				*(uint16_t*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(uint16_t*)(pos+2)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(uint16_t*)(pos+4)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(uint16_t*)(pos+6)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
-				*(uint16_t*)(pos+8)=B_FWD(4);							// b after_call (pc+4)
+				cache_addw(LSL_IMM(HOST_a1, HOST_a1, 16),pos+0);		// lsl a1, a1, #16
+				cache_addw(LSR_IMM(templo1, HOST_a1, 16),pos+2);	// lsr templo1, a1, #16
+				cache_addw(ORR(HOST_a1, templo1),pos+4);			// orr a1, templo1
+				cache_addw(ROR_REG(HOST_a1, HOST_a2),pos+6);		// ror a1, a2
+				cache_addw(B_FWD(4),pos+8);							// b after_call (pc+4)
 				break;
 			case t_RORd:
-				*(uint16_t*)pos=ROR_REG(HOST_a1, HOST_a2);			// ror a1, a2
-				*(uint16_t*)(pos+2)=B_FWD(10);						// b after_call (pc+10)
+				cache_addw(ROR_REG(HOST_a1, HOST_a2),pos+0);			// ror a1, a2
+				cache_addw(B_FWD(10),pos+2);						// b after_call (pc+10)
 				break;
 			case t_ROLb:
-				*(uint16_t*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(uint16_t*)(pos+2)=NEG(HOST_a2, HOST_a2);			// neg a2, a2
-				*(uint16_t*)(pos+4)=LSR_IMM(templo1, HOST_a1, 8);		// lsr templo1, a1, #8
-				*(uint16_t*)(pos+6)=ADD_IMM8(HOST_a2, 32);			// add a2, #32
-				*(uint16_t*)(pos+8)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(uint16_t*)(pos+10)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(uint16_t*)(pos+12)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(uint16_t*)(pos+14)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
+				cache_addw(LSL_IMM(HOST_a1, HOST_a1, 24),pos+0);		// lsl a1, a1, #24
+				cache_addw(NEG(HOST_a2, HOST_a2),pos+2);			// neg a2, a2
+				cache_addw(LSR_IMM(templo1, HOST_a1, 8),pos+4);		// lsr templo1, a1, #8
+				cache_addw(ADD_IMM8(HOST_a2, 32),pos+6);			// add a2, #32
+				cache_addw(ORR(HOST_a1, templo1),pos+8);			// orr a1, templo1
+				cache_addw(LSR_IMM(templo1, HOST_a1, 16),pos+10);	// lsr templo1, a1, #16
+				cache_addw(ORR(HOST_a1, templo1),pos+12);			// orr a1, templo1
+				cache_addw(ROR_REG(HOST_a1, HOST_a2),pos+14);		// ror a1, a2
 				break;
 			case t_ROLw:
-				*(uint16_t*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(uint16_t*)(pos+2)=NEG(HOST_a2, HOST_a2);			// neg a2, a2
-				*(uint16_t*)(pos+4)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(uint16_t*)(pos+6)=ADD_IMM8(HOST_a2, 32);			// add a2, #32
-				*(uint16_t*)(pos+8)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(uint16_t*)(pos+10)=NOP;								// nop
-				*(uint16_t*)(pos+12)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
-				*(uint16_t*)(pos+14)=NOP;								// nop
+				cache_addw(LSL_IMM(HOST_a1, HOST_a1, 16),pos+0);		// lsl a1, a1, #16
+				cache_addw(NEG(HOST_a2, HOST_a2),pos+2);			// neg a2, a2
+				cache_addw(LSR_IMM(templo1, HOST_a1, 16),pos+4);	// lsr templo1, a1, #16
+				cache_addw(ADD_IMM8(HOST_a2, 32),pos+6);			// add a2, #32
+				cache_addw(ORR(HOST_a1, templo1),pos+8);			// orr a1, templo1
+				cache_addw(NOP,pos+10);								// nop
+				cache_addw(ROR_REG(HOST_a1, HOST_a2),pos+12);		// ror a1, a2
+				cache_addw(NOP,pos+14);								// nop
 				break;
 			case t_ROLd:
-				*(uint16_t*)pos=NEG(HOST_a2, HOST_a2);				// neg a2, a2
-				*(uint16_t*)(pos+2)=ADD_IMM8(HOST_a2, 32);			// add a2, #32
-				*(uint16_t*)(pos+4)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
-				*(uint16_t*)(pos+6)=B_FWD(6);							// b after_call (pc+6)
+				cache_addw(NEG(HOST_a2, HOST_a2),pos+0);				// neg a2, a2
+				cache_addw(ADD_IMM8(HOST_a2, 32),pos+2);			// add a2, #32
+				cache_addw(ROR_REG(HOST_a1, HOST_a2),pos+4);		// ror a1, a2
+				cache_addw(B_FWD(6),pos+6);							// b after_call (pc+6)
 				break;
 			case t_NEGb:
 			case t_NEGw:
 			case t_NEGd:
-				*(uint16_t*)pos=NEG(HOST_a1, HOST_a1);				// neg a1, a1
-				*(uint16_t*)(pos+2)=B_FWD(10);						// b after_call (pc+10)
+				cache_addw(NEG(HOST_a1, HOST_a1),pos+0);				// neg a1, a1
+				cache_addw(B_FWD(10),pos+2);						// b after_call (pc+10)
 				break;
 			default:
-				*(uint32_t*)( ( ((uint32_t) (*pos)) << 2 ) + ((uint32_t)pos + 4) ) = (uint32_t)fct_ptr;		// simple_func
+				cache_addd((uint32_t)fct_ptr,pos+4+pos[0]*4); // simple_func
 				break;
 		}
 	}
@@ -1257,32 +1257,32 @@ static void gen_fill_function_ptr(uint8_t * pos,void* fct_ptr,Bitu flags_type) {
 			case t_ADDb:
 			case t_ADDw:
 			case t_ADDd:
-				*(uint16_t*)pos=ADD_REG(HOST_a1, HOST_a1, HOST_a2);	// add a1, a1, a2
-				*(uint16_t*)(pos+2)=B_FWD(12);						// b after_call (pc+12)
+				cache_addw(ADD_REG(HOST_a1, HOST_a1, HOST_a2),pos+0);	// add a1, a1, a2
+				cache_addw(B_FWD(12),pos+2);						// b after_call (pc+12)
 				break;
 			case t_ORb:
 			case t_ORw:
 			case t_ORd:
-				*(uint16_t*)pos=ORR(HOST_a1, HOST_a2);				// orr a1, a2
-				*(uint16_t*)(pos+2)=B_FWD(12);						// b after_call (pc+12)
+				cache_addw(ORR(HOST_a1, HOST_a2),pos+0);				// orr a1, a2
+				cache_addw(B_FWD(12),pos+2);						// b after_call (pc+12)
 				break;
 			case t_ANDb:
 			case t_ANDw:
 			case t_ANDd:
-				*(uint16_t*)pos=AND(HOST_a1, HOST_a2);				// and a1, a2
-				*(uint16_t*)(pos+2)=B_FWD(12);						// b after_call (pc+12)
+				cache_addw(AND(HOST_a1, HOST_a2),pos+0);				// and a1, a2
+				cache_addw(B_FWD(12),pos+2);						// b after_call (pc+12)
 				break;
 			case t_SUBb:
 			case t_SUBw:
 			case t_SUBd:
-				*(uint16_t*)pos=SUB_REG(HOST_a1, HOST_a1, HOST_a2);	// sub a1, a1, a2
-				*(uint16_t*)(pos+2)=B_FWD(12);						// b after_call (pc+12)
+				cache_addw(SUB_REG(HOST_a1, HOST_a1, HOST_a2),pos+0);	// sub a1, a1, a2
+				cache_addw(B_FWD(12),pos+2);						// b after_call (pc+12)
 				break;
 			case t_XORb:
 			case t_XORw:
 			case t_XORd:
-				*(uint16_t*)pos=EOR(HOST_a1, HOST_a2);				// eor a1, a2
-				*(uint16_t*)(pos+2)=B_FWD(12);						// b after_call (pc+12)
+				cache_addw(EOR(HOST_a1, HOST_a2),pos+0);				// eor a1, a2
+				cache_addw(B_FWD(12),pos+2);						// b after_call (pc+12)
 				break;
 			case t_CMPb:
 			case t_CMPw:
@@ -1290,116 +1290,116 @@ static void gen_fill_function_ptr(uint8_t * pos,void* fct_ptr,Bitu flags_type) {
 			case t_TESTb:
 			case t_TESTw:
 			case t_TESTd:
-				*(uint16_t*)pos=B_FWD(14);							// b after_call (pc+14)
+				cache_addw(B_FWD(14),pos+0);							// b after_call (pc+14)
 				break;
 			case t_INCb:
 			case t_INCw:
 			case t_INCd:
-				*(uint16_t*)pos=ADD_IMM3(HOST_a1, HOST_a1, 1);		// add a1, a1, #1
-				*(uint16_t*)(pos+2)=B_FWD(12);						// b after_call (pc+12)
+				cache_addw(ADD_IMM3(HOST_a1, HOST_a1, 1),pos+0);		// add a1, a1, #1
+				cache_addw(B_FWD(12),pos+2);						// b after_call (pc+12)
 				break;
 			case t_DECb:
 			case t_DECw:
 			case t_DECd:
-				*(uint16_t*)pos=SUB_IMM3(HOST_a1, HOST_a1, 1);		// sub a1, a1, #1
-				*(uint16_t*)(pos+2)=B_FWD(12);						// b after_call (pc+12)
+				cache_addw(SUB_IMM3(HOST_a1, HOST_a1, 1),pos+0);		// sub a1, a1, #1
+				cache_addw(B_FWD(12),pos+2);						// b after_call (pc+12)
 				break;
 			case t_SHLb:
 			case t_SHLw:
 			case t_SHLd:
-				*(uint16_t*)pos=LSL_REG(HOST_a1, HOST_a2);			// lsl a1, a2
-				*(uint16_t*)(pos+2)=B_FWD(12);						// b after_call (pc+12)
+				cache_addw(LSL_REG(HOST_a1, HOST_a2),pos+0);			// lsl a1, a2
+				cache_addw(B_FWD(12),pos+2);						// b after_call (pc+12)
 				break;
 			case t_SHRb:
-				*(uint16_t*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(uint16_t*)(pos+2)=LSR_IMM(HOST_a1, HOST_a1, 24);	// lsr a1, a1, #24
-				*(uint16_t*)(pos+4)=LSR_REG(HOST_a1, HOST_a2);		// lsr a1, a2
-				*(uint16_t*)(pos+6)=B_FWD(8);							// b after_call (pc+8)
+				cache_addw(LSL_IMM(HOST_a1, HOST_a1, 24),pos+0);		// lsl a1, a1, #24
+				cache_addw(LSR_IMM(HOST_a1, HOST_a1, 24),pos+2);	// lsr a1, a1, #24
+				cache_addw(LSR_REG(HOST_a1, HOST_a2),pos+4);		// lsr a1, a2
+				cache_addw(B_FWD(8),pos+6);							// b after_call (pc+8)
 				break;
 			case t_SHRw:
-				*(uint16_t*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(uint16_t*)(pos+2)=LSR_IMM(HOST_a1, HOST_a1, 16);	// lsr a1, a1, #16
-				*(uint16_t*)(pos+4)=LSR_REG(HOST_a1, HOST_a2);		// lsr a1, a2
-				*(uint16_t*)(pos+6)=B_FWD(8);							// b after_call (pc+8)
+				cache_addw(LSL_IMM(HOST_a1, HOST_a1, 16),pos+0);		// lsl a1, a1, #16
+				cache_addw(LSR_IMM(HOST_a1, HOST_a1, 16),pos+2);	// lsr a1, a1, #16
+				cache_addw(LSR_REG(HOST_a1, HOST_a2),pos+4);		// lsr a1, a2
+				cache_addw(B_FWD(8),pos+6);							// b after_call (pc+8)
 				break;
 			case t_SHRd:
-				*(uint16_t*)pos=LSR_REG(HOST_a1, HOST_a2);			// lsr a1, a2
-				*(uint16_t*)(pos+2)=B_FWD(12);						// b after_call (pc+12)
+				cache_addw(LSR_REG(HOST_a1, HOST_a2),pos+0);			// lsr a1, a2
+				cache_addw(B_FWD(12),pos+2);						// b after_call (pc+12)
 				break;
 			case t_SARb:
-				*(uint16_t*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(uint16_t*)(pos+2)=ASR_IMM(HOST_a1, HOST_a1, 24);	// asr a1, a1, #24
-				*(uint16_t*)(pos+4)=ASR_REG(HOST_a1, HOST_a2);		// asr a1, a2
-				*(uint16_t*)(pos+6)=B_FWD(8);							// b after_call (pc+8)
+				cache_addw(LSL_IMM(HOST_a1, HOST_a1, 24),pos+0);		// lsl a1, a1, #24
+				cache_addw(ASR_IMM(HOST_a1, HOST_a1, 24),pos+2);	// asr a1, a1, #24
+				cache_addw(ASR_REG(HOST_a1, HOST_a2),pos+4);		// asr a1, a2
+				cache_addw(B_FWD(8),pos+6);							// b after_call (pc+8)
 				break;
 			case t_SARw:
-				*(uint16_t*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(uint16_t*)(pos+2)=ASR_IMM(HOST_a1, HOST_a1, 16);	// asr a1, a1, #16
-				*(uint16_t*)(pos+4)=ASR_REG(HOST_a1, HOST_a2);		// asr a1, a2
-				*(uint16_t*)(pos+6)=B_FWD(8);							// b after_call (pc+8)
+				cache_addw(LSL_IMM(HOST_a1, HOST_a1, 16),pos+0);		// lsl a1, a1, #16
+				cache_addw(ASR_IMM(HOST_a1, HOST_a1, 16),pos+2);	// asr a1, a1, #16
+				cache_addw(ASR_REG(HOST_a1, HOST_a2),pos+4);		// asr a1, a2
+				cache_addw(B_FWD(8),pos+6);							// b after_call (pc+8)
 				break;
 			case t_SARd:
-				*(uint16_t*)pos=ASR_REG(HOST_a1, HOST_a2);			// asr a1, a2
-				*(uint16_t*)(pos+2)=B_FWD(12);						// b after_call (pc+12)
+				cache_addw(ASR_REG(HOST_a1, HOST_a2),pos+0);			// asr a1, a2
+				cache_addw(B_FWD(12),pos+2);						// b after_call (pc+12)
 				break;
 			case t_RORb:
-				*(uint16_t*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(uint16_t*)(pos+2)=LSR_IMM(templo1, HOST_a1, 8);		// lsr templo1, a1, #8
-				*(uint16_t*)(pos+4)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(uint16_t*)(pos+6)=NOP;								// nop
-				*(uint16_t*)(pos+8)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(uint16_t*)(pos+10)=NOP;								// nop
-				*(uint16_t*)(pos+12)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(uint16_t*)(pos+14)=NOP;								// nop
-				*(uint16_t*)(pos+16)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
+				cache_addw(LSL_IMM(HOST_a1, HOST_a1, 24),pos+0);		// lsl a1, a1, #24
+				cache_addw(LSR_IMM(templo1, HOST_a1, 8),pos+2);		// lsr templo1, a1, #8
+				cache_addw(ORR(HOST_a1, templo1),pos+4);			// orr a1, templo1
+				cache_addw(NOP,pos+6);								// nop
+				cache_addw(LSR_IMM(templo1, HOST_a1, 16),pos+8);	// lsr templo1, a1, #16
+				cache_addw(NOP,pos+10);								// nop
+				cache_addw(ORR(HOST_a1, templo1),pos+12);			// orr a1, templo1
+				cache_addw(NOP,pos+14);								// nop
+				cache_addw(ROR_REG(HOST_a1, HOST_a2),pos+16);		// ror a1, a2
 				break;
 			case t_RORw:
-				*(uint16_t*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(uint16_t*)(pos+2)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(uint16_t*)(pos+4)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(uint16_t*)(pos+6)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
-				*(uint16_t*)(pos+8)=B_FWD(6);							// b after_call (pc+6)
+				cache_addw(LSL_IMM(HOST_a1, HOST_a1, 16),pos+0);		// lsl a1, a1, #16
+				cache_addw(LSR_IMM(templo1, HOST_a1, 16),pos+2);	// lsr templo1, a1, #16
+				cache_addw(ORR(HOST_a1, templo1),pos+4);			// orr a1, templo1
+				cache_addw(ROR_REG(HOST_a1, HOST_a2),pos+6);		// ror a1, a2
+				cache_addw(B_FWD(6),pos+8);							// b after_call (pc+6)
 				break;
 			case t_RORd:
-				*(uint16_t*)pos=ROR_REG(HOST_a1, HOST_a2);			// ror a1, a2
-				*(uint16_t*)(pos+2)=B_FWD(12);						// b after_call (pc+12)
+				cache_addw(ROR_REG(HOST_a1, HOST_a2),pos+0);			// ror a1, a2
+				cache_addw(B_FWD(12),pos+2);						// b after_call (pc+12)
 				break;
 			case t_ROLb:
-				*(uint16_t*)pos=LSL_IMM(HOST_a1, HOST_a1, 24);		// lsl a1, a1, #24
-				*(uint16_t*)(pos+2)=NEG(HOST_a2, HOST_a2);			// neg a2, a2
-				*(uint16_t*)(pos+4)=LSR_IMM(templo1, HOST_a1, 8);		// lsr templo1, a1, #8
-				*(uint16_t*)(pos+6)=ADD_IMM8(HOST_a2, 32);			// add a2, #32
-				*(uint16_t*)(pos+8)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(uint16_t*)(pos+10)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(uint16_t*)(pos+12)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(uint16_t*)(pos+14)=NOP;								// nop
-				*(uint16_t*)(pos+16)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
+				cache_addw(LSL_IMM(HOST_a1, HOST_a1, 24),pos+0);		// lsl a1, a1, #24
+				cache_addw(NEG(HOST_a2, HOST_a2),pos+2);			// neg a2, a2
+				cache_addw(LSR_IMM(templo1, HOST_a1, 8),pos+4);		// lsr templo1, a1, #8
+				cache_addw(ADD_IMM8(HOST_a2, 32),pos+6);			// add a2, #32
+				cache_addw(ORR(HOST_a1, templo1),pos+8);			// orr a1, templo1
+				cache_addw(LSR_IMM(templo1, HOST_a1, 16),pos+10);	// lsr templo1, a1, #16
+				cache_addw(ORR(HOST_a1, templo1),pos+12);			// orr a1, templo1
+				cache_addw(NOP,pos+14);								// nop
+				cache_addw(ROR_REG(HOST_a1, HOST_a2),pos+16);		// ror a1, a2
 				break;
 			case t_ROLw:
-				*(uint16_t*)pos=LSL_IMM(HOST_a1, HOST_a1, 16);		// lsl a1, a1, #16
-				*(uint16_t*)(pos+2)=NEG(HOST_a2, HOST_a2);			// neg a2, a2
-				*(uint16_t*)(pos+4)=LSR_IMM(templo1, HOST_a1, 16);	// lsr templo1, a1, #16
-				*(uint16_t*)(pos+6)=ADD_IMM8(HOST_a2, 32);			// add a2, #32
-				*(uint16_t*)(pos+8)=ORR(HOST_a1, templo1);			// orr a1, templo1
-				*(uint16_t*)(pos+10)=NOP;								// nop
-				*(uint16_t*)(pos+12)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
-				*(uint16_t*)(pos+14)=NOP;								// nop
-				*(uint16_t*)(pos+16)=NOP;								// nop
+				cache_addw(LSL_IMM(HOST_a1, HOST_a1, 16),pos+0);		// lsl a1, a1, #16
+				cache_addw(NEG(HOST_a2, HOST_a2),pos+2);			// neg a2, a2
+				cache_addw(LSR_IMM(templo1, HOST_a1, 16),pos+4);	// lsr templo1, a1, #16
+				cache_addw(ADD_IMM8(HOST_a2, 32),pos+6);			// add a2, #32
+				cache_addw(ORR(HOST_a1, templo1),pos+8);			// orr a1, templo1
+				cache_addw(NOP,pos+10);								// nop
+				cache_addw(ROR_REG(HOST_a1, HOST_a2),pos+12);		// ror a1, a2
+				cache_addw(NOP,pos+14);								// nop
+				cache_addw(NOP,pos+16);								// nop
 				break;
 			case t_ROLd:
-				*(uint16_t*)pos=NEG(HOST_a2, HOST_a2);				// neg a2, a2
-				*(uint16_t*)(pos+2)=ADD_IMM8(HOST_a2, 32);			// add a2, #32
-				*(uint16_t*)(pos+4)=ROR_REG(HOST_a1, HOST_a2);		// ror a1, a2
-				*(uint16_t*)(pos+6)=B_FWD(8);							// b after_call (pc+8)
+				cache_addw(NEG(HOST_a2, HOST_a2),pos+0);				// neg a2, a2
+				cache_addw(ADD_IMM8(HOST_a2, 32),pos+2);			// add a2, #32
+				cache_addw(ROR_REG(HOST_a1, HOST_a2),pos+4);		// ror a1, a2
+				cache_addw(B_FWD(8),pos+6);							// b after_call (pc+8)
 				break;
 			case t_NEGb:
 			case t_NEGw:
 			case t_NEGd:
-				*(uint16_t*)pos=NEG(HOST_a1, HOST_a1);				// neg a1, a1
-				*(uint16_t*)(pos+2)=B_FWD(12);						// b after_call (pc+12)
+				cache_addw(NEG(HOST_a1, HOST_a1),pos+0);				// neg a1, a1
+				cache_addw(B_FWD(12),pos+2);						// b after_call (pc+12)
 				break;
 			default:
-				*(uint32_t*)( ( ((uint32_t) (*pos)) << 2 ) + ((uint32_t)pos + 2) ) = (uint32_t)fct_ptr;		// simple_func
+				cache_addd((uint32_t)fct_ptr,pos+2+pos[0]*4); // simple_func
 				break;
 		}
 
@@ -1407,11 +1407,11 @@ static void gen_fill_function_ptr(uint8_t * pos,void* fct_ptr,Bitu flags_type) {
 #else
 	if (((uint32_t)pos & 0x03) == 0)
 	{
-		*(uint32_t*)( ( ((uint32_t) (*pos)) << 2 ) + ((uint32_t)pos + 4) ) = (uint32_t)fct_ptr;		// simple_func
+		cache_addd((uint32_t)fct_ptr,pos+4+pos[0]*4); // simple_func
 	}
 	else
 	{
-		*(uint32_t*)( ( ((uint32_t) (*pos)) << 2 ) + ((uint32_t)pos + 2) ) = (uint32_t)fct_ptr;		// simple_func
+		cache_addd((uint32_t)fct_ptr,pos+2+pos[0]*4); // simple_func
 	}
 #endif
 }

--- a/src/cpu/core_dynrec/risc_armv8le.h
+++ b/src/cpu/core_dynrec/risc_armv8le.h
@@ -32,9 +32,6 @@
 // try to replace _simple functions by code
 #define DRC_FLAGS_INVALIDATION_DCODE
 
-// type with the same size as a pointer
-#define DRC_PTR_SIZE_IM uint64_t
-
 // calling convention modifier
 #define DRC_CALL_CONV	/* nothing */
 #define DRC_FC			/* nothing */
@@ -670,7 +667,7 @@ static void gen_mov_direct_dword(void* dest,uint32_t imm) {
 }
 
 // move an address into memory
-static void INLINE gen_mov_direct_ptr(void* dest,DRC_PTR_SIZE_IM imm) {
+static void INLINE gen_mov_direct_ptr(void* dest,Bitu imm) {
 	gen_mov_qword_to_reg_imm(temp3, imm);
 	if (!gen_mov_memval_from_reg(temp3, dest, 8)) {
 		gen_mov_qword_to_reg_imm(temp1, (uint64_t)dest);
@@ -768,8 +765,8 @@ template <typename T> static void INLINE gen_call_function_raw(const T func) {
 // generate a call to a function with paramcount parameters
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
-template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_setup(const T func,Bitu paramcount,bool fastcall=false) {
-    DRC_PTR_SIZE_IM proc_addr = (DRC_PTR_SIZE_IM)cache.pos;
+template <typename T> static INLINE const uint8_t* gen_call_function_setup(void * func,Bitu paramcount,bool fastcall=false) {
+	const uint8_t* proc_addr = cache.pos;
 	gen_call_function_raw(func);
 	return proc_addr;
 }
@@ -780,7 +777,7 @@ static void INLINE gen_load_param_imm(Bitu imm,Bitu param) {
 }
 
 // load an address as param'th function parameter
-static void INLINE gen_load_param_addr(DRC_PTR_SIZE_IM addr,Bitu param) {
+static void INLINE gen_load_param_addr(Bitu addr,Bitu param) {
 	gen_mov_qword_to_reg_imm(param, addr);
 }
 
@@ -815,42 +812,44 @@ static void gen_jmp_ptr(void * ptr,Bits imm=0) {
 
 // short conditional jump (+-127 bytes) if register is zero
 // the destination is set by gen_fill_branch() later
-static DRC_PTR_SIZE_IM gen_create_branch_on_zero(HostReg reg,bool dword) {
+static const uint8_t* gen_create_branch_on_zero(HostReg reg,bool dword) {
 	if (dword) {
 		cache_addd( CBZ_FWD(reg, 0) );      // cbz reg, j
 	} else {
 		cache_addd( UXTH(temp1, reg) );     // uxth temp1, reg
 		cache_addd( CBZ_FWD(temp1, 0) );    // cbz temp1, j
 	}
-	return ((DRC_PTR_SIZE_IM)cache.pos-4);
+	return (cache.pos-4);
 }
 
 // short conditional jump (+-127 bytes) if register is nonzero
 // the destination is set by gen_fill_branch() later
-static DRC_PTR_SIZE_IM gen_create_branch_on_nonzero(HostReg reg,bool dword) {
+static const uint8_t* gen_create_branch_on_nonzero(HostReg reg,bool dword) {
 	if (dword) {
 		cache_addd( CBNZ_FWD(reg, 0) );     // cbnz reg, j
 	} else {
 		cache_addd( UXTH(temp1, reg) );     // uxth temp1, reg
 		cache_addd( CBNZ_FWD(temp1, 0) );   // cbnz temp1, j
 	}
-	return ((DRC_PTR_SIZE_IM)cache.pos-4);
+	return (cache.pos-4);
 }
 
 // calculate relative offset and fill it into the location pointed to by data
-static void INLINE gen_fill_branch(DRC_PTR_SIZE_IM data) {
+static void INLINE gen_fill_branch(const uint8_t* data) {
 #if C_DEBUG
-	Bits len=(uint64_t)cache.pos-data;
+	Bits len=cache.pos-data;
 	if (len<0) len=-len;
 	if (len>=0x00100000) LOG_MSG("Big jump %d",len);
 #endif
-	*(uint32_t*)data=( (*(uint32_t*)data) & 0xff00001f ) | ( ( ((uint64_t)cache.pos - data) << 3 ) & 0x00ffffe0 );
+	uint32_t offset = (uint32_t)(cache.pos-data) << 3;
+	cache_addw(((uint16_t)offset&~0x1f)|(data[0]&0x1f),data);
+	cache_addb((uint8_t)(offset>>16),data+2);
 }
 
 // conditional jump if register is nonzero
 // for isdword==true the 32bit of the register are tested
 // for isdword==false the lowest 8bit of the register are tested
-static DRC_PTR_SIZE_IM gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
+static const uint8_t* gen_create_branch_long_nonzero(HostReg reg,bool isdword) {
 	if (isdword) {
 		cache_addd( CBZ_FWD(reg, 8) );      // cbz reg, pc+8    // skip next instruction
 	} else {
@@ -858,25 +857,26 @@ static DRC_PTR_SIZE_IM gen_create_branch_long_nonzero(HostReg reg,bool isdword) 
 		cache_addd( CBZ_FWD(temp1, 8) );    // cbz temp1, pc+8  // skip next instruction
 	}
 	cache_addd( B_FWD(0) );         // b j
-	return ((DRC_PTR_SIZE_IM)cache.pos-4);
+	return (cache.pos-4);
 }
 
 // compare 32bit-register against zero and jump if value less/equal than zero
-static DRC_PTR_SIZE_IM gen_create_branch_long_leqzero(HostReg reg) {
+static const uint8_t* gen_create_branch_long_leqzero(HostReg reg) {
 	cache_addd( CMP_IMM(reg, 0, 0) );       // cmp reg, #0
 	cache_addd( BGT_FWD(8) );               // bgt pc+8 // skip next instruction
 	cache_addd( B_FWD(0) );                 // b j
-	return ((DRC_PTR_SIZE_IM)cache.pos-4);
+	return (cache.pos-4);
 }
 
 // calculate long relative offset and fill it into the location pointed to by data
-static void INLINE gen_fill_branch_long(DRC_PTR_SIZE_IM data) {
+static void INLINE gen_fill_branch_long(const uint8_t* data) {
 	// optimize for shorter branches ?
-	*(uint32_t*)data=( (*(uint32_t*)data) & 0xfc000000 ) | ( ( ((uint64_t)cache.pos - data) >> 2 ) & 0x03ffffff );
+	uint32_t offset = (uint32_t)(cache.pos-data) >> 2;
+	cache_addd(((data[3]<<24)&~0x03ffffff)|(offset&0x03ffffff),data);
 }
 
 static void gen_run_code(void) {
-	uint8_t *pos1, *pos2, *pos3;
+	const uint8_t *pos1, *pos2, *pos3;
 
 	cache_addd( 0xa9bd7bfd );                                           // stp fp, lr, [sp, #-48]!
 	cache_addd( 0x910003fd );                                           // mov fp, sp
@@ -897,13 +897,13 @@ static void gen_run_code(void) {
 		cache.pos = cache.pos + (32 - (((Bitu)cache.pos) & 0x1f));
 	}
 
-	*(uint32_t *)pos1 = LDR64_PC(FC_SEGS_ADDR, cache.pos - pos1);   // ldr FC_SEGS_ADDR, [pc, #(&Segs)]
+	cache_addd(LDR64_PC(FC_SEGS_ADDR, cache.pos - pos1),pos1);   // ldr FC_SEGS_ADDR, [pc, #(&Segs)]
 	cache_addq((uint64_t)&Segs);                      // address of "Segs"
 
-	*(uint32_t *)pos2 = LDR64_PC(FC_REGS_ADDR, cache.pos - pos2);   // ldr FC_REGS_ADDR, [pc, #(&cpu_regs)]
+	cache_addd(LDR64_PC(FC_REGS_ADDR, cache.pos - pos2),pos2);   // ldr FC_REGS_ADDR, [pc, #(&cpu_regs)]
 	cache_addq((uint64_t)&cpu_regs);                  // address of "cpu_regs"
 
-	*(uint32_t *)pos3 = LDR64_PC(readdata_addr, cache.pos - pos3);  // ldr readdata_addr, [pc, #(&core_dynrec.readdata)]
+	cache_addd(LDR64_PC(readdata_addr, cache.pos - pos3),pos3);  // ldr readdata_addr, [pc, #(&core_dynrec.readdata)]
 	cache_addq((uint64_t)&core_dynrec.readdata);      // address of "core_dynrec.readdata"
 
 	// align cache.pos to 32 bytes
@@ -924,54 +924,54 @@ static void gen_return_function(void) {
 
 // called when a call to a function can be replaced by a
 // call to a simpler function
-static void gen_fill_function_ptr(uint8_t * pos,void* fct_ptr,Bitu flags_type) {
+static void gen_fill_function_ptr(const uint8_t * pos,void* fct_ptr,Bitu flags_type) {
 #ifdef DRC_FLAGS_INVALIDATION_DCODE
 	// try to avoid function calls but rather directly fill in code
 	switch (flags_type) {
 		case t_ADDb:
 		case t_ADDw:
 		case t_ADDd:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=NOP;				// nop
-			*(uint32_t*)(pos+8)=ADD_REG_LSL_IMM(FC_RETOP, HOST_w0, HOST_w1, 0);	// add FC_RETOP, w0, w1
-			*(uint32_t*)(pos+12)=NOP;				// nop
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(NOP,pos+4);				// nop
+			cache_addd(ADD_REG_LSL_IMM(FC_RETOP, HOST_w0, HOST_w1, 0),pos+8);	// add FC_RETOP, w0, w1
+			cache_addd(NOP,pos+12);				// nop
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_ORb:
 		case t_ORw:
 		case t_ORd:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=NOP;				// nop
-			*(uint32_t*)(pos+8)=ORR_REG_LSL_IMM(FC_RETOP, HOST_w0, HOST_w1, 0);	// orr FC_RETOP, w0, w1
-			*(uint32_t*)(pos+12)=NOP;				// nop
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(NOP,pos+4);				// nop
+			cache_addd(ORR_REG_LSL_IMM(FC_RETOP, HOST_w0, HOST_w1, 0),pos+8);	// orr FC_RETOP, w0, w1
+			cache_addd(NOP,pos+12);				// nop
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_ANDb:
 		case t_ANDw:
 		case t_ANDd:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=NOP;				// nop
-			*(uint32_t*)(pos+8)=AND_REG_LSL_IMM(FC_RETOP, HOST_w0, HOST_w1, 0);	// and FC_RETOP, w0, w1
-			*(uint32_t*)(pos+12)=NOP;				// nop
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(NOP,pos+4);				// nop
+			cache_addd(AND_REG_LSL_IMM(FC_RETOP, HOST_w0, HOST_w1, 0),pos+8);	// and FC_RETOP, w0, w1
+			cache_addd(NOP,pos+12);				// nop
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_SUBb:
 		case t_SUBw:
 		case t_SUBd:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=NOP;				// nop
-			*(uint32_t*)(pos+8)=SUB_REG_LSL_IMM(FC_RETOP, HOST_w0, HOST_w1, 0);	// sub FC_RETOP, w0, w1
-			*(uint32_t*)(pos+12)=NOP;				// nop
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(NOP,pos+4);				// nop
+			cache_addd(SUB_REG_LSL_IMM(FC_RETOP, HOST_w0, HOST_w1, 0),pos+8);	// sub FC_RETOP, w0, w1
+			cache_addd(NOP,pos+12);				// nop
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_XORb:
 		case t_XORw:
 		case t_XORd:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=NOP;				// nop
-			*(uint32_t*)(pos+8)=EOR_REG_LSL_IMM(FC_RETOP, HOST_w0, HOST_w1, 0);	// eor FC_RETOP, w0, w1
-			*(uint32_t*)(pos+12)=NOP;				// nop
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(NOP,pos+4);				// nop
+			cache_addd(EOR_REG_LSL_IMM(FC_RETOP, HOST_w0, HOST_w1, 0),pos+8);	// eor FC_RETOP, w0, w1
+			cache_addd(NOP,pos+12);				// nop
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_CMPb:
 		case t_CMPw:
@@ -979,164 +979,164 @@ static void gen_fill_function_ptr(uint8_t * pos,void* fct_ptr,Bitu flags_type) {
 		case t_TESTb:
 		case t_TESTw:
 		case t_TESTd:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=NOP;				// nop
-			*(uint32_t*)(pos+8)=NOP;				// nop
-			*(uint32_t*)(pos+12)=NOP;				// nop
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(NOP,pos+4);				// nop
+			cache_addd(NOP,pos+8);				// nop
+			cache_addd(NOP,pos+12);				// nop
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_INCb:
 		case t_INCw:
 		case t_INCd:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=NOP;				// nop
-			*(uint32_t*)(pos+8)=ADD_IMM(FC_RETOP, HOST_w0, 1, 0);	// add FC_RETOP, w0, #1
-			*(uint32_t*)(pos+12)=NOP;				// nop
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(NOP,pos+4);				// nop
+			cache_addd(ADD_IMM(FC_RETOP, HOST_w0, 1, 0),pos+8);	// add FC_RETOP, w0, #1
+			cache_addd(NOP,pos+12);				// nop
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_DECb:
 		case t_DECw:
 		case t_DECd:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=NOP;				// nop
-			*(uint32_t*)(pos+8)=SUB_IMM(FC_RETOP, HOST_w0, 1, 0);	// sub FC_RETOP, w0, #1
-			*(uint32_t*)(pos+12)=NOP;				// nop
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(NOP,pos+4);				// nop
+			cache_addd(SUB_IMM(FC_RETOP, HOST_w0, 1, 0),pos+8);	// sub FC_RETOP, w0, #1
+			cache_addd(NOP,pos+12);				// nop
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_SHLb:
 		case t_SHLw:
 		case t_SHLd:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=NOP;				// nop
-			*(uint32_t*)(pos+8)=LSLV(FC_RETOP, HOST_w0, HOST_w1);	// lslv FC_RETOP, w0, w1
-			*(uint32_t*)(pos+12)=NOP;				// nop
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(NOP,pos+4);				// nop
+			cache_addd(LSLV(FC_RETOP, HOST_w0, HOST_w1),pos+8);	// lslv FC_RETOP, w0, w1
+			cache_addd(NOP,pos+12);				// nop
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_SHRb:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=UXTB(FC_RETOP, HOST_w0);				// uxtb FC_RETOP, w0
-			*(uint32_t*)(pos+8)=NOP;				// nop
-			*(uint32_t*)(pos+12)=LSRV(FC_RETOP, FC_RETOP, HOST_w1);	// lsrv FC_RETOP, FC_RETOP, w1
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(UXTB(FC_RETOP, HOST_w0),pos+4);				// uxtb FC_RETOP, w0
+			cache_addd(NOP,pos+8);				// nop
+			cache_addd(LSRV(FC_RETOP, FC_RETOP, HOST_w1),pos+12);	// lsrv FC_RETOP, FC_RETOP, w1
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_SHRw:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=UXTH(FC_RETOP, HOST_w0);				// uxth FC_RETOP, w0
-			*(uint32_t*)(pos+8)=NOP;				// nop
-			*(uint32_t*)(pos+12)=LSRV(FC_RETOP, FC_RETOP, HOST_w1);	// lsrv FC_RETOP, FC_RETOP, w1
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(UXTH(FC_RETOP, HOST_w0),pos+4);				// uxth FC_RETOP, w0
+			cache_addd(NOP,pos+8);				// nop
+			cache_addd(LSRV(FC_RETOP, FC_RETOP, HOST_w1),pos+12);	// lsrv FC_RETOP, FC_RETOP, w1
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_SHRd:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=NOP;				// nop
-			*(uint32_t*)(pos+8)=LSRV(FC_RETOP, HOST_w0, HOST_w1);	// lsrv FC_RETOP, w0, w1
-			*(uint32_t*)(pos+12)=NOP;				// nop
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(NOP,pos+4);				// nop
+			cache_addd(LSRV(FC_RETOP, HOST_w0, HOST_w1),pos+8);	// lsrv FC_RETOP, w0, w1
+			cache_addd(NOP,pos+12);				// nop
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_SARb:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=SXTB(FC_RETOP, HOST_w0);				// sxtb FC_RETOP, w0
-			*(uint32_t*)(pos+8)=NOP;				// nop
-			*(uint32_t*)(pos+12)=ASRV(FC_RETOP, FC_RETOP, HOST_w1);	// asrv FC_RETOP, FC_RETOP, w1
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(SXTB(FC_RETOP, HOST_w0),pos+4);				// sxtb FC_RETOP, w0
+			cache_addd(NOP,pos+8);				// nop
+			cache_addd(ASRV(FC_RETOP, FC_RETOP, HOST_w1),pos+12);	// asrv FC_RETOP, FC_RETOP, w1
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_SARw:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=SXTH(FC_RETOP, HOST_w0);				// sxth FC_RETOP, w0
-			*(uint32_t*)(pos+8)=NOP;				// nop
-			*(uint32_t*)(pos+12)=ASRV(FC_RETOP, FC_RETOP, HOST_w1);	// asrv FC_RETOP, FC_RETOP, w1
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(SXTH(FC_RETOP, HOST_w0),pos+4);				// sxth FC_RETOP, w0
+			cache_addd(NOP,pos+8);				// nop
+			cache_addd(ASRV(FC_RETOP, FC_RETOP, HOST_w1),pos+12);	// asrv FC_RETOP, FC_RETOP, w1
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_SARd:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=NOP;				// nop
-			*(uint32_t*)(pos+8)=ASRV(FC_RETOP, HOST_w0, HOST_w1);	// asrv FC_RETOP, w0, w1
-			*(uint32_t*)(pos+12)=NOP;				// nop
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(NOP,pos+4);				// nop
+			cache_addd(ASRV(FC_RETOP, HOST_w0, HOST_w1),pos+8);	// asrv FC_RETOP, w0, w1
+			cache_addd(NOP,pos+12);				// nop
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_RORb:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=BFI(HOST_w0, HOST_w0, 8, 8);			// bfi w0, w0, 8, 8
-			*(uint32_t*)(pos+8)=BFI(HOST_w0, HOST_w0, 16, 16);		// bfi w0, w0, 16, 16
-			*(uint32_t*)(pos+12)=RORV(FC_RETOP, HOST_w0, HOST_w1);	// rorv FC_RETOP, w0, w1
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(BFI(HOST_w0, HOST_w0, 8, 8),pos+4);			// bfi w0, w0, 8, 8
+			cache_addd(BFI(HOST_w0, HOST_w0, 16, 16),pos+8);		// bfi w0, w0, 16, 16
+			cache_addd(RORV(FC_RETOP, HOST_w0, HOST_w1),pos+12);	// rorv FC_RETOP, w0, w1
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_RORw:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=BFI(HOST_w0, HOST_w0, 16, 16);		// bfi w0, w0, 16, 16
-			*(uint32_t*)(pos+8)=NOP;				// nop
-			*(uint32_t*)(pos+12)=RORV(FC_RETOP, HOST_w0, HOST_w1);	// rorv FC_RETOP, w0, w1
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(BFI(HOST_w0, HOST_w0, 16, 16),pos+4);		// bfi w0, w0, 16, 16
+			cache_addd(NOP,pos+8);				// nop
+			cache_addd(RORV(FC_RETOP, HOST_w0, HOST_w1),pos+12);	// rorv FC_RETOP, w0, w1
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_RORd:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=NOP;				// nop
-			*(uint32_t*)(pos+8)=RORV(FC_RETOP, HOST_w0, HOST_w1);	// rorv FC_RETOP, w0, w1
-			*(uint32_t*)(pos+12)=NOP;				// nop
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(NOP,pos+4);				// nop
+			cache_addd(RORV(FC_RETOP, HOST_w0, HOST_w1),pos+8);	// rorv FC_RETOP, w0, w1
+			cache_addd(NOP,pos+12);				// nop
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_ROLb:
-			*(uint32_t*)pos=MOVZ(HOST_w2, 32, 0);									// movz w2, #32
-			*(uint32_t*)(pos+4)=BFI(HOST_w0, HOST_w0, 8, 8);						// bfi w0, w0, 8, 8
-			*(uint32_t*)(pos+8)=SUB_REG_LSL_IMM(HOST_w2, HOST_w2, HOST_w1, 0);	// sub w2, w2, w1
-			*(uint32_t*)(pos+12)=BFI(HOST_w0, HOST_w0, 16, 16);					// bfi w0, w0, 16, 16
-			*(uint32_t*)(pos+16)=RORV(FC_RETOP, HOST_w0, HOST_w2);				// rorv FC_RETOP, w0, w2
+			cache_addd(MOVZ(HOST_w2, 32, 0),pos+0);									// movz w2, #32
+			cache_addd(BFI(HOST_w0, HOST_w0, 8, 8),pos+4);						// bfi w0, w0, 8, 8
+			cache_addd(SUB_REG_LSL_IMM(HOST_w2, HOST_w2, HOST_w1, 0),pos+8);	// sub w2, w2, w1
+			cache_addd(BFI(HOST_w0, HOST_w0, 16, 16),pos+12);					// bfi w0, w0, 16, 16
+			cache_addd(RORV(FC_RETOP, HOST_w0, HOST_w2),pos+16);				// rorv FC_RETOP, w0, w2
 			break;
 		case t_ROLw:
-			*(uint32_t*)pos=MOVZ(HOST_w2, 32, 0);									// movz w2, #32
-			*(uint32_t*)(pos+4)=BFI(HOST_w0, HOST_w0, 16, 16);					// bfi w0, w0, 16, 16
-			*(uint32_t*)(pos+8)=SUB_REG_LSL_IMM(HOST_w2, HOST_w2, HOST_w1, 0);	// sub w2, w2, w1
-			*(uint32_t*)(pos+12)=NOP;				// nop
-			*(uint32_t*)(pos+16)=RORV(FC_RETOP, HOST_w0, HOST_w2);				// rorv FC_RETOP, w0, w2
+			cache_addd(MOVZ(HOST_w2, 32, 0),pos+0);									// movz w2, #32
+			cache_addd(BFI(HOST_w0, HOST_w0, 16, 16),pos+4);					// bfi w0, w0, 16, 16
+			cache_addd(SUB_REG_LSL_IMM(HOST_w2, HOST_w2, HOST_w1, 0),pos+8);	// sub w2, w2, w1
+			cache_addd(NOP,pos+12);				// nop
+			cache_addd(RORV(FC_RETOP, HOST_w0, HOST_w2),pos+16);				// rorv FC_RETOP, w0, w2
 			break;
 		case t_ROLd:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=MOVZ(HOST_w2, 32, 0);								// movz w2, #32
-			*(uint32_t*)(pos+8)=SUB_REG_LSL_IMM(HOST_w2, HOST_w2, HOST_w1, 0);	// sub w2, w2, w1
-			*(uint32_t*)(pos+12)=RORV(FC_RETOP, HOST_w0, HOST_w2);				// rorv FC_RETOP, w0, w2
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(MOVZ(HOST_w2, 32, 0),pos+4);								// movz w2, #32
+			cache_addd(SUB_REG_LSL_IMM(HOST_w2, HOST_w2, HOST_w1, 0),pos+8);	// sub w2, w2, w1
+			cache_addd(RORV(FC_RETOP, HOST_w0, HOST_w2),pos+12);				// rorv FC_RETOP, w0, w2
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_NEGb:
 		case t_NEGw:
 		case t_NEGd:
-			*(uint32_t*)pos=NOP;					// nop
-			*(uint32_t*)(pos+4)=NOP;				// nop
-			*(uint32_t*)(pos+8)=SUB_REG_LSL_IMM(FC_RETOP, HOST_wzr, HOST_w0, 0);	// sub FC_RETOP, wzr, w0
-			*(uint32_t*)(pos+12)=NOP;				// nop
-			*(uint32_t*)(pos+16)=NOP;				// nop
+			cache_addd(NOP,pos+0);					// nop
+			cache_addd(NOP,pos+4);				// nop
+			cache_addd(SUB_REG_LSL_IMM(FC_RETOP, HOST_wzr, HOST_w0, 0),pos+8);	// sub FC_RETOP, wzr, w0
+			cache_addd(NOP,pos+12);				// nop
+			cache_addd(NOP,pos+16);				// nop
 			break;
 		case t_DSHLd:
-			*(uint32_t*)pos=MOVZ64(HOST_x3, 0x1f, 0);								// movz x3, #0x1f
-			*(uint32_t*)(pos+4)=BFI64(HOST_x1, HOST_x0, 32, 32);					// bfi x1, x0, 32, 32
-			*(uint32_t*)(pos+8)=AND64_REG_LSL_IMM(HOST_x2, HOST_x2, HOST_x3, 0);	// and x2, x2, x3
-			*(uint32_t*)(pos+12)=LSLV64(FC_RETOP, HOST_x1, HOST_x2);				// lslv FC_RETOP, x1, x2
-			*(uint32_t*)(pos+16)=LSR64_IMM(FC_RETOP, FC_RETOP, 32);				// lsr FC_RETOP, FC_RETOP, #32
+			cache_addd(MOVZ64(HOST_x3, 0x1f, 0),pos+0);								// movz x3, #0x1f
+			cache_addd(BFI64(HOST_x1, HOST_x0, 32, 32),pos+4);					// bfi x1, x0, 32, 32
+			cache_addd(AND64_REG_LSL_IMM(HOST_x2, HOST_x2, HOST_x3, 0),pos+8);	// and x2, x2, x3
+			cache_addd(LSLV64(FC_RETOP, HOST_x1, HOST_x2),pos+12);				// lslv FC_RETOP, x1, x2
+			cache_addd(LSR64_IMM(FC_RETOP, FC_RETOP, 32),pos+16);				// lsr FC_RETOP, FC_RETOP, #32
 			break;
 		case t_DSHRd:
-			*(uint32_t*)pos=MOVZ64(HOST_x3, 0x1f, 0);								// movz x3, #0x1f
-			*(uint32_t*)(pos+4)=BFI64(HOST_x0, HOST_x1, 32, 32);					// bfi x0, x1, 32, 32
-			*(uint32_t*)(pos+8)=AND64_REG_LSL_IMM(HOST_x2, HOST_x2, HOST_x3, 0);	// and x2, x2, x3
-			*(uint32_t*)(pos+12)=NOP;												// nop
-			*(uint32_t*)(pos+16)=LSRV64(FC_RETOP, HOST_x0, HOST_x2);				// lsrv FC_RETOP, x0, x2
+			cache_addd(MOVZ64(HOST_x3, 0x1f, 0),pos+0);								// movz x3, #0x1f
+			cache_addd(BFI64(HOST_x0, HOST_x1, 32, 32),pos+4);					// bfi x0, x1, 32, 32
+			cache_addd(AND64_REG_LSL_IMM(HOST_x2, HOST_x2, HOST_x3, 0),pos+8);	// and x2, x2, x3
+			cache_addd(NOP,pos+12);												// nop
+			cache_addd(LSRV64(FC_RETOP, HOST_x0, HOST_x2),pos+16);				// lsrv FC_RETOP, x0, x2
 			break;
 		default:
-			*(uint32_t*)pos=MOVZ64(temp1, ((uint64_t)fct_ptr) & 0xffff, 0);                 // movz temp1, #(fct_ptr & 0xffff)
-			*(uint32_t*)(pos+4)=MOVK64(temp1, (((uint64_t)fct_ptr) >> 16) & 0xffff, 16);    // movk temp1, #((fct_ptr >> 16) & 0xffff), lsl #16
-			*(uint32_t*)(pos+8)=MOVK64(temp1, (((uint64_t)fct_ptr) >> 32) & 0xffff, 32);    // movk temp1, #((fct_ptr >> 32) & 0xffff), lsl #32
-			*(uint32_t*)(pos+12)=MOVK64(temp1, (((uint64_t)fct_ptr) >> 48) & 0xffff, 48);   // movk temp1, #((fct_ptr >> 48) & 0xffff), lsl #48
+			cache_addd(MOVZ64(temp1, ((uint64_t)fct_ptr) & 0xffff, 0),pos+0);                 // movz temp1, #(fct_ptr & 0xffff)
+			cache_addd(MOVK64(temp1, (((uint64_t)fct_ptr) >> 16) & 0xffff, 16),pos+4);    // movk temp1, #((fct_ptr >> 16) & 0xffff), lsl #16
+			cache_addd(MOVK64(temp1, (((uint64_t)fct_ptr) >> 32) & 0xffff, 32),pos+8);    // movk temp1, #((fct_ptr >> 32) & 0xffff), lsl #32
+			cache_addd(MOVK64(temp1, (((uint64_t)fct_ptr) >> 48) & 0xffff, 48),pos+12);   // movk temp1, #((fct_ptr >> 48) & 0xffff), lsl #48
 			break;
 
 	}
 #else
-	*(uint32_t*)pos=MOVZ64(temp1, ((uint64_t)fct_ptr) & 0xffff, 0);                 // movz temp1, #(fct_ptr & 0xffff)
-	*(uint32_t*)(pos+4)=MOVK64(temp1, (((uint64_t)fct_ptr) >> 16) & 0xffff, 16);    // movk temp1, #((fct_ptr >> 16) & 0xffff), lsl #16
-	*(uint32_t*)(pos+8)=MOVK64(temp1, (((uint64_t)fct_ptr) >> 32) & 0xffff, 32);    // movk temp1, #((fct_ptr >> 32) & 0xffff), lsl #32
-	*(uint32_t*)(pos+12)=MOVK64(temp1, (((uint64_t)fct_ptr) >> 48) & 0xffff, 48);   // movk temp1, #((fct_ptr >> 48) & 0xffff), lsl #48
+	cache_addd(MOVZ64(temp1, ((uint64_t)fct_ptr) & 0xffff, 0),pos+0);                 // movz temp1, #(fct_ptr & 0xffff)
+	cache_addd(MOVK64(temp1, (((uint64_t)fct_ptr) >> 16) & 0xffff, 16),pos+4);    // movk temp1, #((fct_ptr >> 16) & 0xffff), lsl #16
+	cache_addd(MOVK64(temp1, (((uint64_t)fct_ptr) >> 32) & 0xffff, 32),pos+8);    // movk temp1, #((fct_ptr >> 32) & 0xffff), lsl #32
+	cache_addd(MOVK64(temp1, (((uint64_t)fct_ptr) >> 48) & 0xffff, 48),pos+12);   // movk temp1, #((fct_ptr >> 48) & 0xffff), lsl #48
 #endif
 }
 #endif
 
-static void cache_block_closing(uint8_t* block_start,Bitu block_size) {
+static void cache_block_closing(const uint8_t* block_start,Bitu block_size) {
 #ifdef _MSC_VER
     //flush cache - Win32 API for MSVC
     FlushInstructionCache(GetCurrentProcess(), block_start, block_size);

--- a/src/cpu/dynamic_alloc_common.h
+++ b/src/cpu/dynamic_alloc_common.h
@@ -21,7 +21,7 @@ static uint8_t *cache_code_init = NULL; // NTS: Because dynamic code modifies ca
 static uint8_t *cache_exec_ptr = NULL;
 static Bitu cache_map_size = 0;
 
-static INLINE void *cache_rwtox(void *x) {
+static INLINE void *cache_rwtox(const void *x) {
     return (void*)((uintptr_t)((char*)x) + (uintptr_t)((char*)cache_exec_ptr) - (uintptr_t)((char*)cache_code_init));
 }
 


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/4424

"Make all references to cache const, use cache_adds instead of direct access."

Modified slightly to work with DOSBox-X. (I had to change `cache_rwtox` to take a const pointer because it is passed pointers that were made const by this commit.)

I'm OK with waiting until after the end-of-month release (that I assume is coming) before merging, if necessary.