### PR TITLE
SVN commits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -142,6 +142,8 @@
   - Updated FLAC decoder library to the latest version
     (0.12.29 by David Reid). (Wengier)
   - Integrated SVN commits (Allofich)
+    - r4436, r4437: Rewrite store integer instructions
+    to check if the result fits.(vogons 78127)
     - r4447: Attribute Controller port alias on EGA
     machine. Fixes EGA display of older Super Pac-Man
     release.

--- a/configure.ac
+++ b/configure.ac
@@ -386,18 +386,26 @@ AC_CHECK_CXXFLAGS([ -Wno-address-of-packed-member ])
 dnl Clang/LLVM warning: don't care about int to void*, since void* is either same size or larger
 AC_CHECK_CXXFLAGS([ -Wno-int-to-void-pointer-cast ])
 
-dnl Some stuff for the icon.
+dnl Some stuff for the icon and other makefile platform stuff.
+dnl Slightly double with the above, but that deals more with compiled features.
 case "$host" in
     *-*-cygwin* | *-*-mingw32*)
        dnl Some stuff for the ico
        AC_CHECK_TOOL(WINDRES, windres, :)
        LDFLAGS="-static -static-libgcc -static-libstdc++ $LDFLAGS"
+       DBPLATFORM="win"
+    ;;
+    *-*-darwin*)
+       WINDRES=":"
+       DBPLATFORM="mac"
     ;;
     *)
        WINDRES=":"
+       DBPLATFORM="other"
     ;;
 esac
        AM_CONDITIONAL(HAVE_WINDRES, test "x$WINDRES" != "x:")
+       AM_CONDITIONAL(MACOSX, test "x$DBPLATFORM" = "xmac")
        AC_SUBST(WINDRES)
 
 dnl LIBRARY TEST: SDL 2.x

--- a/patch-integration/Skipped SVN commits.txt
+++ b/patch-integration/Skipped SVN commits.txt
@@ -73,3 +73,4 @@ Commit#:	Reason for skipping:
 4415		Conflict
 4417		No function definition in DOSBox-X, so unnecessary.
 4418		No C_SRECORD in DOSBox-X
+4429		Conflict

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -542,6 +542,9 @@ private:
 	bool		once;
 
 	static std::list<CBreakpoint*>	BPoints;
+#if C_HEAVY_DEBUG
+	friend bool DEBUG_HeavyIsBreakpoint(void);
+#endif
 };
 
 CBreakpoint::CBreakpoint(void):type(BKPNT_UNKNOWN),location(0),
@@ -4598,7 +4601,7 @@ bool DEBUG_HeavyIsBreakpoint(void) {
 		skipFirstInstruction = false;
 		return false;
 	}
-	if (CBreakpoint::CheckBreakpoint(SegValue(cs),reg_eip)) {
+	if (!CBreakpoint::BPoints.empty() && CBreakpoint::CheckBreakpoint(SegValue(cs),reg_eip)) {
 		return true;
 	}
 	return false;

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -3243,7 +3243,7 @@ uint32_t DEBUG_CheckKeys(void) {
 					break;
 				}
 				// If we aren't stepping over something, do a normal step.
-				// NB: Fall-through
+				/* FALLTHROUGH */
 		case KEY_F(11):	// trace into
                 DrawRegistersUpdateOld();
 				exitLoop = false;

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -263,11 +263,13 @@ static void FPU_FST_F80(PhysPt addr) {
 }
 
 static void FPU_FST_I16(PhysPt addr) {
-	mem_writew(addr,(uint16_t)static_cast<int16_t>(FROUND(fpu.regs[TOP].d)));
+	double val = FROUND(fpu.regs[TOP].d);
+	mem_writew(addr,(val < 32768.0 && val >= -32768.0)?static_cast<int16_t>(val):0x8000);
 }
 
 static void FPU_FST_I32(PhysPt addr) {
-	mem_writed(addr,(uint32_t)static_cast<int32_t>(FROUND(fpu.regs[TOP].d)));
+	double val = FROUND(fpu.regs[TOP].d);
+	mem_writed(addr,(val < 2147483648.0 && val >= -2147483648.0)?static_cast<int32_t>(val):0x80000000);
 }
 
 static void FPU_FST_I64(PhysPt addr) {
@@ -280,7 +282,9 @@ static void FPU_FST_I64(PhysPt addr) {
 		mem_writed(addr+4,(uint32_t)(fpu.regs_80[TOP].raw.l >> (uint64_t)32));
 	}
 	else {
-		blah.ll = static_cast<int64_t>(FROUND(fpu.regs[TOP].d));
+		double val = FROUND(fpu.regs[TOP].d);
+		blah.ll = (val < 9223372036854775808.0 && val >= -9223372036854775808.0)?static_cast<int64_t>(val):LONGTYPE(0x8000000000000000);
+
 		mem_writed(addr,(uint32_t)blah.l.lower);
 		mem_writed(addr+4,(uint32_t)blah.l.upper);
 	}

--- a/src/hardware/vga_crtc.cpp
+++ b/src/hardware/vga_crtc.cpp
@@ -126,12 +126,12 @@ void vga_write_p3d5(Bitu port,Bitu val,Bitu iolen) {
 			5-6	Number of character clocks to delay start of display after Horizontal
 				Retrace.
 			7	bit 5 of the End Horizontal Blanking count (See 3d4h index 3 bit 0-4)
-		*/	
+		*/
 		break;
 	case 0x06: /* Vertical Total Register */
 		if (crtc(read_only)) break;
 		if (val != crtc(vertical_total)) {
-			crtc(vertical_total)=(uint8_t)val;	
+			crtc(vertical_total)=(uint8_t)val;
 			VGA_StartResize();
 		}
 		/*	0-7	Lower 8 bits of the Vertical Total. Bit 8 is found in 3d4h index 7
@@ -254,7 +254,7 @@ void vga_write_p3d5(Bitu port,Bitu val,Bitu iolen) {
 		break;
 	case 0x10:	/* Vertical Retrace Start Register */
 		crtc(vertical_retrace_start)=(uint8_t)val;
-		/*	
+		/*
 			0-7	Lower 8 bits of Vertical Retrace Start. Vertical Retrace starts when
 			the line counter reaches this value. Bit 8 is found in 3d4h index 7
 			bit 2. Bit 9 is found in 3d4h index 7 bit 7.
@@ -262,7 +262,7 @@ void vga_write_p3d5(Bitu port,Bitu val,Bitu iolen) {
 		break;
 	case 0x11:	/* Vertical Retrace End Register */
 		crtc(vertical_retrace_end)=(uint8_t)val;
-		
+
 		if (IS_EGAVGA_ARCH && !(val & 0x10)) {
 			vga.draw.vret_triggered=false;
 			if (GCC_UNLIKELY(machine==MCH_EGA)) PIC_DeActivateIRQ(9);
@@ -325,7 +325,7 @@ void vga_write_p3d5(Bitu port,Bitu val,Bitu iolen) {
 			crtc(start_vertical_blanking)=(uint8_t)val;
 			VGA_StartResize();
 		}
-		/* 
+		/*
 			0-7	Lower 8 bits of Vertical Blank Start. Vertical blanking starts when
 				the line counter reaches this value. Bit 8 is found in 3d4h index 7
 				bit 3.
@@ -420,7 +420,7 @@ Bitu vga_read_p3d5x(Bitu port,Bitu iolen) {
 	case 0x05:	/* End Horizontal Retrace Register */
 		return crtc(end_horizontal_retrace);
 	case 0x06: /* Vertical Total Register */
-		return crtc(vertical_total);	
+		return crtc(vertical_total);
 	case 0x07:	/* Overflow Register */
 		return crtc(overflow);
 	case 0x08:	/* Preset Row Scan Register */

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -786,8 +786,10 @@ string Section_line::GetPropValue(string const& /* _property*/) const {
     return NO_SUCH_PROPERTY;
 }
 
+#define HELPLINE_SIZE 256
 bool Config::PrintConfig(char const * const configfilename,int everything,bool norem) const {
-    char temp[50];char helpline[256];
+    char temp[50];
+    char helpline[HELPLINE_SIZE] = { 0 };
     FILE* outfile = fopen(configfilename,"w+t");
     if (outfile == NULL) return false;
 
@@ -867,7 +869,7 @@ bool Config::PrintConfig(char const * const configfilename,int everything,bool n
                 const char * helpstr = MSG_Get(temp);
                 const char * linestart = helpstr;
                 char * helpwrite = helpline;
-                while (*helpstr && helpstr - linestart < sizeof(helpline)) {
+                while (*helpstr && helpstr - linestart < HELPLINE_SIZE - 2) {
                     *helpwrite++ = *helpstr;
                     if (*helpstr == '\n') {
                         *helpwrite = 0;


### PR DESCRIPTION
Continuing on from https://github.com/joncampbell123/dosbox-x/pull/2482.

https://sourceforge.net/p/dosbox/code-0/4425/ - Skipped, as the unused parameters are already handled (through casting to void) in DOSBox-X and I don't know if the minor spacing changes are wanted for DOSBox-X.
https://sourceforge.net/p/dosbox/code-0/4426/ - Already in DOSBox-X.
https://sourceforge.net/p/dosbox/code-0/4427/ - The removal of trailing whitespace part is in this PR. Otherwise skipped, as it's another `Bitfs` commit (assuming that DOSBox's "Bit" types are unwanted since we're using `uint32_t`, etc. now) and unused parameters/spacing format commit.
https://sourceforge.net/p/dosbox/code-0/4428/ - Skipped, as unused parameters are already handled in DOSBox-X.
https://sourceforge.net/p/dosbox/code-0/4429/ - Skipped due to code conflict, as is basically always the case with SVN changes to `sdlmain.cpp`
https://sourceforge.net/p/dosbox/code-0/4430/ - In this PR. By the way, DOSBox-X has an extra line here:

```LDFLAGS="-static -static-libgcc -static-libstdc++ $LDFLAGS"```

I did not copy this line into the new "mac" and "other" cases added by r4430, but I don't know if I should have or not.

https://sourceforge.net/p/dosbox/code-0/4431/ - In this PR.
https://sourceforge.net/p/dosbox/code-0/4432/ - Everything but the fallthrough comment change was already in DOSBox-X, so just changed the fallthrough comment.
https://sourceforge.net/p/dosbox/code-0/4433/ - Skipped, sBitfs commit.
https://sourceforge.net/p/dosbox/code-0/4434/ - In this PR
https://sourceforge.net/p/dosbox/code-0/4435/ - Skipped. This commit supposedly adds a Mac icon.
https://sourceforge.net/p/dosbox/code-0/4436/ - In this PR (mostly overwritten by 4437, so combined them here)
https://sourceforge.net/p/dosbox/code-0/4437/ - In this PR, combined with 4436 into a single commit.