### PR TITLE
SVN commits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -149,6 +149,8 @@
   - Integrated SVN commits (Allofich)
     - r4436, r4437: Rewrite store integer instructions
     to check if the result fits.(vogons 78127)
+    - r4443: Improve detection of Paradise SVGA in some
+    installers with additional signature.
     - r4447: Attribute Controller port alias on EGA
     machine. Fixes EGA display of older Super Pac-Man
     release.

--- a/patch-integration/Skipped SVN commits.txt
+++ b/patch-integration/Skipped SVN commits.txt
@@ -73,4 +73,5 @@ Commit#:	Reason for skipping:
 4415		Conflict
 4417		No function definition in DOSBox-X, so unnecessary.
 4418		No C_SRECORD in DOSBox-X
+4424		Declares const but then casts to non-const
 4429		Conflict

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -1207,7 +1207,8 @@ bool DOS_CreateTempFile(char * const name,uint16_t * entry) {
 		}
 		tempname[8]=0;
 		//if (DOS_FileExists(name)) {cont=true;continue;} // FIXME: Check name uniqueness
-	} while (cont || (!DOS_CreateFile(name,0,entry) && dos.errorcode==DOSERR_FILE_ALREADY_EXISTS));
+	} while (cont || DOS_FileExists(name));
+	DOS_CreateFile(name,0,entry);
 	if (dos.errorcode) return false;
 	return true;
 }

--- a/src/hardware/vga_paradise.cpp
+++ b/src/hardware/vga_paradise.cpp
@@ -232,13 +232,6 @@ void SVGA_Setup_ParadisePVGA1A(void) {
 		pvga1a.PR1 = 2<<6;
 	}
 
-	// Paradise ROM signature
-	PhysPt rom_base=PhysMake(0xc000,0);
-	phys_writeb(rom_base+0x007d,'V');
-	phys_writeb(rom_base+0x007e,'G');
-	phys_writeb(rom_base+0x007f,'A');
-	phys_writeb(rom_base+0x0080,'=');
-
 	IO_Write(0x3cf, 0x05); // Enable!
 }
 

--- a/src/hardware/vga_s3.cpp
+++ b/src/hardware/vga_s3.cpp
@@ -694,11 +694,6 @@ void SVGA_Setup_S3Trio(void) {
         vga.s3.reg_36 = 0x7a;       // 8mb fast page mode
     }
 
-    if (!VGA_BIOS_use_rom) {
-        // S3 ROM signature
-        phys_writes(PhysMake(0xc000,0)+0x003f, "S3 86C764", 10);
-    }
-
     PCI_AddSVGAS3_Device();
 }
 

--- a/src/hardware/vga_tseng.cpp
+++ b/src/hardware/vga_tseng.cpp
@@ -645,11 +645,6 @@ void SVGA_Setup_TsengET4K(void) {
         vga.mem.memsize = 512*1024;
     else
         vga.mem.memsize = 1024*1024;
-
-    if (!VGA_BIOS_use_rom) {
-        // Tseng ROM signature
-        phys_writes(PhysMake(0xc000,0)+0x0075, " Tseng ", 8);
-    }
 }
 
 

--- a/src/ints/int10_memory.cpp
+++ b/src/ints/int10_memory.cpp
@@ -184,6 +184,8 @@ void INT10_RemoveVGABIOS(void) { /* PC-98 does not have VGA BIOS */
 
 RealPt GetSystemBiosINT10Vector(void);
 
+extern bool VGA_BIOS_use_rom;
+
 void INT10_SetupRomMemory(void) {
 	/* if no space allocated for video BIOS (such as machine=cga) then return immediately */
 	if (VGA_BIOS_Size == 0) {
@@ -271,6 +273,40 @@ void INT10_SetupRomMemory(void) {
         // VGA BIOS copyright
 		if (IS_VGA_ARCH) phys_writes(rom_base+0x1e, "IBM compatible VGA BIOS", 24);
 		else phys_writes(rom_base+0x1e, "IBM compatible EGA BIOS", 24);
+
+		if (IS_VGA_ARCH) {
+			// SVGA card-specific ROM signatures
+			switch(svgaCard) {
+			case SVGA_S3Trio:
+                if(!VGA_BIOS_use_rom) {
+                    // S3 ROM signature
+                    phys_writes(rom_base+0x003f, "S3 86C764", 10);
+                }
+				break;
+			case SVGA_TsengET4K:
+			case SVGA_TsengET3K:
+                if(!VGA_BIOS_use_rom) {
+                    // Tseng ROM signature
+                    phys_writes(rom_base+0x0075, " Tseng ", 8);
+                }
+				break;
+			case SVGA_ParadisePVGA1A:
+				phys_writeb(rom_base+0x0048,' ');
+				phys_writeb(rom_base+0x0049,'W');
+				phys_writeb(rom_base+0x004a,'E');
+				phys_writeb(rom_base+0x004b,'S');
+				phys_writeb(rom_base+0x004c,'T');
+				phys_writeb(rom_base+0x004d,'E');
+				phys_writeb(rom_base+0x004e,'R');
+				phys_writeb(rom_base+0x004f,'N');
+				phys_writeb(rom_base+0x0050,' ');
+				phys_writeb(rom_base+0x007d,'V');
+				phys_writeb(rom_base+0x007e,'G');
+				phys_writeb(rom_base+0x007f,'A');
+				phys_writeb(rom_base+0x0080,'=');
+				break;
+			}
+		}
 
 		// JMP to INT 10h in the system BIOS.
 		//


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/4438/ - Skipped. This adds the folder created by skipped commit r4435 (the one that added a Mac icon) to the automake files.
https://sourceforge.net/p/dosbox/code-0/4439/ - Skipped. sBitfs commit.
https://sourceforge.net/p/dosbox/code-0/4440/ - Skipped. sBitfs commit.
https://sourceforge.net/p/dosbox/code-0/4441/ - In this PR.
https://sourceforge.net/p/dosbox/code-0/4442/ - In this PR. DOSBox-X already randomizes the temp files names differently each run, but the change to prevent overwriting files was not yet present in DOSBox-X, so that part is added in this PR.
https://sourceforge.net/p/dosbox/code-0/4443/ - In this PR.