### PR TITLE
Improve virtual drive Z: file system to support directories

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
 0.83.14
+  - Added support for directories on the Z drive, so
+    there is no need to put all files/programs on the
+    root directory of Z drive any more. Only one-level
+    directories are currently supported. (WEngier)
   - Added "Refresh rate..." menu option (under "Video")
     to set the video refresh rate. (Wengier)
   - Added "Enable A20 gate" menu option (under "DOS")
@@ -10,7 +14,9 @@
     to set the run mode when DOSBox-X Debugger starts.
     You can now also switch them from the menu ("Help"
     => "Debugging options" => "Debugger option: ..."),
-    including "debugger", "normal" & "watch". (Wengier)
+    including "debugger", "normal" & "watch". Also, the
+    built-in DEBUGBOX command without a parameter will
+    start the DOSBox-X debugger. (Wengier)
   - Added menu options "Generate NMI interrupt" & "Hook
     INT 2Fh calls" ("Help" => "Debugging options") for
     more debugging options. (Wengier)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,6 +28,8 @@ Windows installers for the previous DOSBox-X versions are also available from:
 * [dosbox-x-windows-0.83.12-setup.exe](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.12/dosbox-x-windows-0.83.12-setup.exe) (version 0.83.12)
 * [dosbox-x-windows-0.83.11-setup.exe](https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v0.83.11/dosbox-x-windows-0.83.11-setup.exe) (version 0.83.11)
 
+If you see the message "Windows Defender SmartScreen prevented an unrecognized app from starting", you can solve it by clicking "More info" and then "Run anyway".
+
 You can easily upgrade from a previous version of DOSBox-X to the new version with the Windows installer. The Windows installer in fact offers an option to automatically upgrade the config file (dosbox-x.conf) to the new version format while keeping all the user-customized settings already made. When you select this (recommended), the config file will include all options of the latest DOSBox-X version and also will keep all the changes already done previously by the user.
 
 Apart from the Windows installers, you can find six zip packages (three before 0.83.13) for each DOSBox-X version for the Windows platform in the Releases page as an alternative way to install DOSBox-X. These zip files are portable packages containing binaries built with Visual Studio 2019 (Win32, Win64, ARM32, ARM64 respectively), MinGW (Win32 and Win64 respectively). For the current DOSBox-X version 0.83.13, these portable builds are separately available from:

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -1808,8 +1808,8 @@ timeout     = 0
 #DOSBOX-X-ADV:#                                                     Set this option to true to prevent SCANDISK.EXE from attempting scan and repair drive Z:
 #DOSBOX-X-ADV:#                                                     which is impossible since Z: is a virtual drive not backed by a disk filesystem.
 #DOSBOX-X-ADV:#                                                     Possible values: true, false, 1, 0, auto.
-#DOSBOX-X-ADV:#                               drive z hide files: The files listed here (separated by space) will be either hidden or removed from the Z drive.
-#DOSBOX-X-ADV:#                                                     Files with leading forward slashs (e.g. "/4HELP.EXE") will be hidden files (DIR /A will list them).
+#DOSBOX-X-ADV:#                               drive z hide files: The files or directories listed here (separated by space) will be either hidden or removed from the Z drive.
+#DOSBOX-X-ADV:#                                                     Files with leading forward slashs (e.g. "/4HELP.EXE") will become hidden files (DIR /A will list them).
 #DOSBOX-X-ADV:#                           hma minimum allocation: Minimum allocation size for HMA in bytes (equivalent to /HMAMIN= parameter).
 #                                         ansi.sys: If set (by default), ANSI.SYS emulation is on. If clear, ANSI.SYS is not emulated and will not appear to be installed.
 #                                                     NOTE: This option has no effect in PC-98 mode where MS-DOS systems integrate ANSI.SYS into the DOS kernel.

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -1,4 +1,4 @@
-# This is the configuration file for DOSBox-X 0.83.13. (Please use the latest version of DOSBox-X)
+# This is the configuration file for DOSBox-X 0.83.14. (Please use the latest version of DOSBox-X)
 # Lines starting with a # are comment lines and are ignored by DOSBox-X.
 # They are used to (briefly) document the effect of each option.
 # To write out ALL options, use command 'config -all' with -wc or -writeconf options.
@@ -91,8 +91,6 @@ showmenu          = true
 
 [log]
 #     logfile: file where the log messages will be saved to
-# debuggerrun: The run mode when the DOSBox-X Debugger starts.
-#                Possible values: debugger, normal, watch.
 #DOSBOX-X-ADV:#         vga: Enable/Disable logging of this type.
 #DOSBOX-X-ADV:#                Possible values: true, false, debug, normal, warn, error, fatal, never.
 #DOSBOX-X-ADV:#      vgagfx: Enable/Disable logging of this type.
@@ -143,8 +141,9 @@ showmenu          = true
 #DOSBOX-X-ADV:#                Possible values: true, false, debug, normal, warn, error, fatal, never.
 #DOSBOX-X-ADV:#       int21: Log all INT 21h calls
 #DOSBOX-X-ADV:#      fileio: Log file I/O through INT 21h
+# debuggerrun: The run mode when the DOSBox-X Debugger starts.
+#                Possible values: debugger, normal, watch.
 logfile     = 
-debuggerrun = debugger
 #DOSBOX-X-ADV:vga         = false
 #DOSBOX-X-ADV:vgagfx      = false
 #DOSBOX-X-ADV:vgamisc     = false
@@ -171,6 +170,7 @@ debuggerrun = debugger
 #DOSBOX-X-ADV:sst         = false
 #DOSBOX-X-ADV:int21       = false
 #DOSBOX-X-ADV:fileio      = false
+debuggerrun = debugger
 
 [dosbox]
 #                                        language: Select another language file.
@@ -1809,7 +1809,7 @@ timeout     = 0
 #DOSBOX-X-ADV:#                                                     which is impossible since Z: is a virtual drive not backed by a disk filesystem.
 #DOSBOX-X-ADV:#                                                     Possible values: true, false, 1, 0, auto.
 #DOSBOX-X-ADV:#                               drive z hide files: The files listed here (separated by space) will be either hidden or removed from the Z drive.
-#DOSBOX-X-ADV:#                                                     Files with leading forward slashs (e.g. "/A20GATE.COM") will be hidden files (DIR /A will list them).
+#DOSBOX-X-ADV:#                                                     Files with leading forward slashs (e.g. "/4HELP.EXE") will be hidden files (DIR /A will list them).
 #DOSBOX-X-ADV:#                           hma minimum allocation: Minimum allocation size for HMA in bytes (equivalent to /HMAMIN= parameter).
 #                                         ansi.sys: If set (by default), ANSI.SYS emulation is on. If clear, ANSI.SYS is not emulated and will not appear to be installed.
 #                                                     NOTE: This option has no effect in PC-98 mode where MS-DOS systems integrate ANSI.SYS into the DOS kernel.
@@ -1984,7 +1984,7 @@ hma                                              = true
 #DOSBOX-X-ADV:hma allow reservation                            = true
 hard drive data rate limit                       = -1
 #DOSBOX-X-ADV:drive z is remote                                = auto
-#DOSBOX-X-ADV:drive z hide files                               = /A20GATE.COM /BIOSTEST.COM /DSXMENU.EXE /HEXMEM16.EXE /HEXMEM32.EXE /INT2FDBG.COM /LOADROM.COM /NMITEST.COM /VESAMOED.COM /VFRCRATE.COM
+#DOSBOX-X-ADV:drive z hide files                               = /BIN\25.COM /BIN\28.COM /BIN\50.COM
 #DOSBOX-X-ADV:hma minimum allocation                           = 0
 ansi.sys                                         = true
 #DOSBOX-X-ADV:log console                                      = false
@@ -2323,7 +2323,7 @@ fcbs        = 100
 files       = 200
 country     = 
 lastdrive   = a
-set path    = Z:\
+set path    = Z:\;Z:\SYSTEM;Z:\DOS;Z:\BIN
 set prompt  = $P$G
 set temp    = 
 install     = 

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1,4 +1,4 @@
-# This is the configuration file for DOSBox-X 0.83.13. (Please use the latest version of DOSBox-X)
+# This is the configuration file for DOSBox-X 0.83.14. (Please use the latest version of DOSBox-X)
 # Lines starting with a # are comment lines and are ignored by DOSBox-X.
 # They are used to (briefly) document the effect of each option.
 # To write out ALL options, use command 'config -all' with -wc or -writeconf options.
@@ -963,7 +963,7 @@ fcbs        = 100
 files       = 200
 country     = 
 lastdrive   = a
-set path    = Z:\
+set path    = Z:\;Z:\SYSTEM;Z:\DOS;Z:\BIN
 set prompt  = $P$G
 set temp    = 
 install     = 

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -1808,8 +1808,8 @@ timeout     = 0
 #                                                     Set this option to true to prevent SCANDISK.EXE from attempting scan and repair drive Z:
 #                                                     which is impossible since Z: is a virtual drive not backed by a disk filesystem.
 #                                                     Possible values: true, false, 1, 0, auto.
-#                               drive z hide files: The files listed here (separated by space) will be either hidden or removed from the Z drive.
-#                                                     Files with leading forward slashs (e.g. "/4HELP.EXE") will be hidden files (DIR /A will list them).
+#                               drive z hide files: The files or directories listed here (separated by space) will be either hidden or removed from the Z drive.
+#                                                     Files with leading forward slashs (e.g. "/4HELP.EXE") will become hidden files (DIR /A will list them).
 #                           hma minimum allocation: Minimum allocation size for HMA in bytes (equivalent to /HMAMIN= parameter).
 #                                         ansi.sys: If set (by default), ANSI.SYS emulation is on. If clear, ANSI.SYS is not emulated and will not appear to be installed.
 #                                                     NOTE: This option has no effect in PC-98 mode where MS-DOS systems integrate ANSI.SYS into the DOS kernel.

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -1,4 +1,4 @@
-# This is the configuration file for DOSBox-X 0.83.13. (Please use the latest version of DOSBox-X)
+# This is the configuration file for DOSBox-X 0.83.14. (Please use the latest version of DOSBox-X)
 # Lines starting with a # are comment lines and are ignored by DOSBox-X.
 # They are used to (briefly) document the effect of each option.
 # To write out ALL options, use command 'config -all' with -wc or -writeconf options.
@@ -91,8 +91,6 @@ showmenu          = true
 
 [log]
 #     logfile: file where the log messages will be saved to
-# debuggerrun: The run mode when the DOSBox-X Debugger starts.
-#                Possible values: debugger, normal, watch.
 #         vga: Enable/Disable logging of this type.
 #                Possible values: true, false, debug, normal, warn, error, fatal, never.
 #      vgagfx: Enable/Disable logging of this type.
@@ -143,8 +141,9 @@ showmenu          = true
 #                Possible values: true, false, debug, normal, warn, error, fatal, never.
 #       int21: Log all INT 21h calls
 #      fileio: Log file I/O through INT 21h
+# debuggerrun: The run mode when the DOSBox-X Debugger starts.
+#                Possible values: debugger, normal, watch.
 logfile     = 
-debuggerrun = debugger
 vga         = false
 vgagfx      = false
 vgamisc     = false
@@ -171,6 +170,7 @@ pci         = false
 sst         = false
 int21       = false
 fileio      = false
+debuggerrun = debugger
 
 [dosbox]
 #                                        language: Select another language file.
@@ -1809,7 +1809,7 @@ timeout     = 0
 #                                                     which is impossible since Z: is a virtual drive not backed by a disk filesystem.
 #                                                     Possible values: true, false, 1, 0, auto.
 #                               drive z hide files: The files listed here (separated by space) will be either hidden or removed from the Z drive.
-#                                                     Files with leading forward slashs (e.g. "/A20GATE.COM") will be hidden files (DIR /A will list them).
+#                                                     Files with leading forward slashs (e.g. "/4HELP.EXE") will be hidden files (DIR /A will list them).
 #                           hma minimum allocation: Minimum allocation size for HMA in bytes (equivalent to /HMAMIN= parameter).
 #                                         ansi.sys: If set (by default), ANSI.SYS emulation is on. If clear, ANSI.SYS is not emulated and will not appear to be installed.
 #                                                     NOTE: This option has no effect in PC-98 mode where MS-DOS systems integrate ANSI.SYS into the DOS kernel.
@@ -1984,7 +1984,7 @@ hma                                              = true
 hma allow reservation                            = true
 hard drive data rate limit                       = -1
 drive z is remote                                = auto
-drive z hide files                               = /A20GATE.COM /BIOSTEST.COM /DSXMENU.EXE /HEXMEM16.EXE /HEXMEM32.EXE /INT2FDBG.COM /LOADROM.COM /NMITEST.COM /VESAMOED.COM /VFRCRATE.COM
+drive z hide files                               = /BIN\25.COM /BIN\28.COM /BIN\50.COM
 hma minimum allocation                           = 0
 ansi.sys                                         = true
 log console                                      = false
@@ -2323,7 +2323,7 @@ fcbs        = 100
 files       = 200
 country     = 
 lastdrive   = a
-set path    = Z:\
+set path    = Z:\;Z:\SYSTEM;Z:\DOS;Z:\BIN
 set prompt  = $P$G
 set temp    = 
 install     = 

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -343,6 +343,6 @@ void DOS_AddDevice(DOS_Device * adddev);
 /* DelDevice destroys the device that is pointed to. */
 void DOS_DelDevice(DOS_Device * dev);
 
-void VFILE_Register(const char * name,uint8_t * data,uint32_t size);
-void VFILE_RegisterBuiltinFileBlob(const struct BuiltinFileBlob &b);
+void VFILE_Register(const char * name,uint8_t * data,uint32_t size,const char *dir = "");
+void VFILE_RegisterBuiltinFileBlob(const struct BuiltinFileBlob &b,const char *dir = "");
 #endif

--- a/include/programs.h
+++ b/include/programs.h
@@ -125,6 +125,6 @@ public:
 };
 
 typedef void (PROGRAMS_Main)(Program * * make);
-void PROGRAMS_MakeFile(char const * const name,PROGRAMS_Main * SDL_main);
+void PROGRAMS_MakeFile(char const * const name,PROGRAMS_Main * SDL_main,const char *dir="");
 
 #endif

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -307,7 +307,11 @@ Virtual_Drive::Virtual_Drive() {
 
 
 bool Virtual_Drive::FileOpen(DOS_File * * file,const char * name,uint32_t flags) {
-/* Scan through the internal list of files */
+	if (*name == 0) {
+		DOS_SetError(DOSERR_ACCESS_DENIED);
+		return false;
+	}
+    /* Scan through the internal list of files */
     const VFILE_Block* cur_file = first_file;
 	while (cur_file) {
 		unsigned int onpos=cur_file->onpos;
@@ -334,7 +338,11 @@ bool Virtual_Drive::FileCreate(DOS_File * * file,const char * name,uint16_t attr
 }
 
 bool Virtual_Drive::FileUnlink(const char * name) {
-    const VFILE_Block* cur_file = first_file;
+	if (*name == 0) {
+		DOS_SetError(DOSERR_ACCESS_DENIED);
+		return false;
+	}
+	const VFILE_Block* cur_file = first_file;
 	while (cur_file) {
 		unsigned int onpos=cur_file->onpos;
 		if (strcasecmp(name,(std::string(onpos?vfsnames[onpos]+std::string(1, '\\'):"")+cur_file->name).c_str())==0||(uselfn&&
@@ -470,7 +478,11 @@ bool Virtual_Drive::FindNext(DOS_DTA & dta) {
 }
 
 bool Virtual_Drive::SetFileAttr(const char * name,uint16_t attr) {
-    const VFILE_Block* cur_file = first_file;
+	if (*name == 0) {
+		DOS_SetError(DOSERR_ACCESS_DENIED);
+		return true;
+	}
+	const VFILE_Block* cur_file = first_file;
 	while (cur_file) {
 		unsigned int onpos=cur_file->onpos;
 		if (strcasecmp(name,(std::string(onpos?vfsnames[onpos]+std::string(1, '\\'):"")+cur_file->name).c_str())==0||(uselfn&&
@@ -487,7 +499,11 @@ bool Virtual_Drive::SetFileAttr(const char * name,uint16_t attr) {
 }
 
 bool Virtual_Drive::GetFileAttr(const char * name,uint16_t * attr) {
-    const VFILE_Block* cur_file = first_file;
+	if (*name == 0) {
+		*attr=DOS_ATTR_DIRECTORY;
+		return true;
+	}
+	const VFILE_Block* cur_file = first_file;
 	while (cur_file) {
 		unsigned int onpos=cur_file->onpos;
 		if (strcasecmp(name,(std::string(onpos?vfsnames[onpos]+std::string(1, '\\'):"")+cur_file->name).c_str())==0||(uselfn&&
@@ -522,7 +538,10 @@ HANDLE Virtual_Drive::CreateOpenFile(const char* name) {
 #endif
 
 bool Virtual_Drive::Rename(const char * oldname,const char * newname) {
-    (void)newname;//UNUSED
+	if (*oldname == 0 || *newname == 0) {
+		DOS_SetError(DOSERR_ACCESS_DENIED);
+		return false;
+	}
     const VFILE_Block* cur_file = first_file;
 	while (cur_file) {
 		unsigned int onpos=cur_file->onpos;

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -153,6 +153,7 @@ void VFILE_RegisterBuiltinFileBlob(const struct BuiltinFileBlob &b, const char *
 	VFILE_Register(b.recommended_file_name, (uint8_t*)b.data, (uint32_t)b.length, dir);
 }
 
+uint16_t fztime=0, fzdate=0;
 void VFILE_Register(const char * name,uint8_t * data,uint32_t size,const char *dir) {
     if (vfpos>=MAX_VFILES) return;
     std::istringstream in(hidefiles);
@@ -204,8 +205,8 @@ void VFILE_Register(const char * name,uint8_t * data,uint32_t size,const char *d
     vfpos++;
 	new_file->data=data;
 	new_file->size=size;
-	new_file->date=DOS_PackDate(2002,10,1);
-	new_file->time=DOS_PackTime(12,34,56);
+	new_file->date=fztime||fzdate?fzdate:DOS_PackDate(2002,10,1);
+	new_file->time=fztime||fzdate?fztime:DOS_PackTime(12,34,56);
 	new_file->onpos=onpos;
 	new_file->isdir=isdir;
 	new_file->hidden=hidden;

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -353,8 +353,12 @@ bool Virtual_Drive::MakeDir(const char * dir) {
 }
 
 bool Virtual_Drive::TestDir(const char * dir) {
-	if (!dir[0]) return true;		//only valid dir is the empty dir
-    for (unsigned int i=1; i<vfpos; i++) if (!strcasecmp(vfsnames[i], dir)||!strcasecmp(vfnames[i], dir)) return true;
+	if (!dir[0]) return true;		//root directory
+	const VFILE_Block* cur_file = first_file;
+	while (cur_file) {
+		if (cur_file->isdir&&(!strcasecmp(cur_file->name, dir)||!strcasecmp(cur_file->lname, dir))) return true;
+		cur_file=cur_file->next;
+	}
 	return false;
 }
 

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3649,9 +3649,9 @@ void DOSBOX_SetupConfigSections(void) {
                       "Set this option to true to prevent SCANDISK.EXE from attempting scan and repair drive Z:\n"
                       "which is impossible since Z: is a virtual drive not backed by a disk filesystem.");
 
-    Pstring = secprop->Add_string("drive z hide files",Property::Changeable::OnlyAtStart,"/A20GATE.COM /BIOSTEST.COM /DSXMENU.EXE /HEXMEM16.EXE /HEXMEM32.EXE /INT2FDBG.COM /LOADROM.COM /NMITEST.COM /VESAMOED.COM /VFRCRATE.COM");
+    Pstring = secprop->Add_string("drive z hide files",Property::Changeable::OnlyAtStart,"/BIN\\25.COM /BIN\\28.COM /BIN\\50.COM");
     Pstring->Set_help("The files listed here (separated by space) will be either hidden or removed from the Z drive.\n"
-                      "Files with leading forward slashs (e.g. \"/A20GATE.COM\") will be hidden files (DIR /A will list them).");
+                      "Files with leading forward slashs (e.g. \"/4HELP.EXE\") will be hidden files (DIR /A will list them).");
 
     Pint = secprop->Add_int("hma minimum allocation",Property::Changeable::WhenIdle,0);
     Pint->Set_help("Minimum allocation size for HMA in bytes (equivalent to /HMAMIN= parameter).");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3650,8 +3650,8 @@ void DOSBOX_SetupConfigSections(void) {
                       "which is impossible since Z: is a virtual drive not backed by a disk filesystem.");
 
     Pstring = secprop->Add_string("drive z hide files",Property::Changeable::OnlyAtStart,"/BIN\\25.COM /BIN\\28.COM /BIN\\50.COM");
-    Pstring->Set_help("The files listed here (separated by space) will be either hidden or removed from the Z drive.\n"
-                      "Files with leading forward slashs (e.g. \"/4HELP.EXE\") will be hidden files (DIR /A will list them).");
+    Pstring->Set_help("The files or directories listed here (separated by space) will be either hidden or removed from the Z drive.\n"
+                      "Files with leading forward slashs (e.g. \"/4HELP.EXE\") will become hidden files (DIR /A will list them).");
 
     Pint = secprop->Add_int("hma minimum allocation",Property::Changeable::WhenIdle,0);
     Pint->Set_help("Minimum allocation size for HMA in bytes (equivalent to /HMAMIN= parameter).");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -9382,12 +9382,12 @@ bool VM_Boot_DOSBox_Kernel() {
         /* Most MS-DOS installations run MSCDEX.EXE from somewhere in AUTOEXEC.BAT. We do the same here, in a fashion. */
         /* TODO: Can we make this an OPTION if the user doesn't want to make MSCDEX.EXE resident? */
         /* TODO: When we emulate executing AUTOEXEC.BAT between INIT_SHELL_READY and AUTOEXEC_BAT_DONE, can we make a fake MSCDEX.EXE within drive Z:\
-         *       and auto-add a Z:\MSCDEX.EXE to the top of AUTOEXEC.BAT, command line switches and all. if the user has not already added it? */
+         *       and auto-add a Z:\DOS\MSCDEX.EXE to the top of AUTOEXEC.BAT, command line switches and all. if the user has not already added it? */
         void MSCDEX_Startup(Section* sec);
         MSCDEX_Startup(NULL);
 
         /* Some installations load the MOUSE.COM driver from AUTOEXEC.BAT as well */
-        /* TODO: Can we make this an option? Can we add a fake MOUSE.COM to the Z:\ drive as well? */
+        /* TODO: Can we make this an option? Can we add a fake MOUSE.COM to the Z: drive as well? */
         void MOUSE_Startup(Section *sec);
         MOUSE_Startup(NULL);
 

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1159,7 +1159,7 @@ void MIXER_Controls_Init() {
 }
 
 void MIXER_DOS_Boot(Section *) {
-    PROGRAMS_MakeFile("MIXER.COM",MIXER_ProgramStart);
+    PROGRAMS_MakeFile("MIXER.COM",MIXER_ProgramStart,"/SYSTEM/");
 }
 
 void MIXER_Init() {

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -195,7 +195,6 @@ extern egc_quad                     pc98_gdc_tiles;
 extern uint8_t                      pc98_egc_srcmask[2]; /* host given (Neko: egc.srcmask) */
 extern uint8_t                      pc98_egc_maskef[2]; /* effective (Neko: egc.mask2) */
 extern uint8_t                      pc98_egc_mask[2]; /* host given (Neko: egc.mask) */
-extern std::string                  hidefiles;
 
 uint32_t S3_LFB_BASE =              S3_LFB_BASE_DEFAULT;
 
@@ -545,7 +544,7 @@ public:
     }
 };
 
-static void VFRCRATE_ProgramStart(Program * * make) {
+void VFRCRATE_ProgramStart(Program * * make) {
     *make=new VFRCRATE;
 }
 
@@ -583,7 +582,7 @@ public:
     }
 };
 
-static void CGASNOW_ProgramStart(Program * * make) {
+void CGASNOW_ProgramStart(Program * * make) {
     *make=new CGASNOW;
 }
 
@@ -1057,13 +1056,6 @@ void VGA_Reset(Section*) {
     }
 
     vsync.period = (1000.0F)/vsyncrate;
-
-    // TODO: Code to remove programs added by PROGRAMS_MakeFile
-
-    const Section_prop * dos_section=static_cast<Section_prop *>(control->GetSection("dos"));
-    hidefiles = dos_section->Get_string("drive z hide files");
-    if (machine == MCH_CGA) PROGRAMS_MakeFile("CGASNOW.COM",CGASNOW_ProgramStart);
-    PROGRAMS_MakeFile("VFRCRATE.COM",VFRCRATE_ProgramStart);
 
     if (IS_PC98_ARCH) {
         void VGA_OnEnterPC98(Section *sec);

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -102,7 +102,7 @@ void PROGRAMS_Shutdown(void) {
 	internal_progs.clear();
 }
 
-void PROGRAMS_MakeFile(char const * const name,PROGRAMS_Main * main) {
+void PROGRAMS_MakeFile(char const * const name,PROGRAMS_Main * main,const char *dir) {
 	uint32_t size=sizeof(exe_block)+sizeof(uint8_t);
 	InternalProgramEntry *ipe;
 	uint8_t *comdata;
@@ -124,7 +124,7 @@ void PROGRAMS_MakeFile(char const * const name,PROGRAMS_Main * main) {
 	ipe->comsize = size;
 	ipe->comdata = comdata;
 	internal_progs.push_back(ipe);
-	VFILE_Register(name,ipe->comdata,ipe->comsize);
+	VFILE_Register(name,ipe->comdata,ipe->comsize,dir);
 }
 
 static Bitu PROGRAMS_Handler(void) {
@@ -1499,7 +1499,7 @@ static void CONFIG_ProgramStart(Program * * make) {
 }
 
 void PROGRAMS_DOS_Boot(Section *) {
-	PROGRAMS_MakeFile("CONFIG.COM",CONFIG_ProgramStart);
+	PROGRAMS_MakeFile("CONFIG.COM",CONFIG_ProgramStart,"/SYSTEM/");
 }
 
 /* FIXME: Rename the function to clarify it does not init programs, it inits the callback mechanism

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -913,7 +913,7 @@ bool Config::PrintConfig(char const * const configfilename,int everything,bool n
 			}
 			if (!strcmp(temp, "config")) {
 				if (everything&&!used1) {
-					fprintf(outfile, "%-11s = %s\n", "set path", "Z:\\;Z:\\SYSTEM;Z:\\DOS;Z:\\BIN");
+					fprintf(outfile, "%-11s = %s\n", "set path", "Z:\\;Z:\\SYSTEM;Z:\\DOS;Z:\\BIN;Z:\\DEBUG");
 					fprintf(outfile, "%-11s = %s\n", "set prompt", "$P$G");
 					fprintf(outfile, "%-11s = %s\n", "set temp", "");
 				}

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -913,7 +913,7 @@ bool Config::PrintConfig(char const * const configfilename,int everything,bool n
 			}
 			if (!strcmp(temp, "config")) {
 				if (everything&&!used1) {
-					fprintf(outfile, "%-11s = %s\n", "set path", "Z:\\");
+					fprintf(outfile, "%-11s = %s\n", "set path", "Z:\\;Z:\\SYSTEM;Z:\\DOS;Z:\\BIN");
 					fprintf(outfile, "%-11s = %s\n", "set prompt", "$P$G");
 					fprintf(outfile, "%-11s = %s\n", "set temp", "");
 				}

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1005,7 +1005,7 @@ static Bitu INT2E_Handler(void) {
 }
 
 extern unsigned int dosbox_shell_env_size;
-
+extern uint16_t fztime, fzdate;
 void drivezRegister(std::string path, std::string dir) {
     char exePath[CROSS_LEN];
     std::vector<std::string> names;
@@ -1054,7 +1054,14 @@ void drivezRegister(std::string path, std::string dir) {
         f_size = 0;
         f_data = NULL;
 
-        if(f != NULL) {
+        if (f != NULL) {
+            struct stat temp_stat;
+            fstat(fileno(f),&temp_stat);
+            const struct tm* ltime;
+            if((ltime=localtime(&temp_stat.st_mtime))!=0) {
+                fztime=DOS_PackTime((uint16_t)ltime->tm_hour,(uint16_t)ltime->tm_min,(uint16_t)ltime->tm_sec);
+                fzdate=DOS_PackDate((uint16_t)(ltime->tm_year+1900),(uint16_t)(ltime->tm_mon+1),(uint16_t)ltime->tm_mday);
+            }
             fseek(f, 0, SEEK_END);
             f_size=ftell(f);
             f_data=(uint8_t*)malloc(f_size);
@@ -1062,8 +1069,8 @@ void drivezRegister(std::string path, std::string dir) {
             fread(f_data, sizeof(char), f_size, f);
             fclose(f);
         }
-
-        if(f_data) VFILE_Register(name.c_str(), f_data, f_size, dir=="/"?"":dir.c_str());
+        if (f_data) VFILE_Register(name.c_str(), f_data, f_size, dir=="/"?"":dir.c_str());
+        fztime = fzdate = 0;
     }
 }
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1114,6 +1114,7 @@ void SHELL_Init() {
 									"  time:       New time to set\n"\
 									"  /T:         Display simple time\n"\
 									"  /H:         Synchronize with host\n");
+	MSG_Add("SHELL_CMD_MKDIR_EXIST","Directory already exists - %s\n");
 	MSG_Add("SHELL_CMD_MKDIR_ERROR","Unable to create directory - %s\n");
 	MSG_Add("SHELL_CMD_RMDIR_ERROR","Invalid path, not directory, or directory not empty - %s\n");
     MSG_Add("SHELL_CMD_RENAME_ERROR","Unable to rename - %s\n");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1036,12 +1036,22 @@ void drivezRegister(std::string path, std::string dir) {
         }
 #endif
     }
+    int res;
     long f_size;
     uint8_t *f_data;
+    struct stat temp_stat;
+    const struct tm* ltime;
     for (std::string name: names) {
         if (!name.size()) continue;
         if (name.back()=='/' && dir=="/") {
+            res=stat((path+CROSS_FILESPLIT+name).c_str(),&temp_stat);
+            if (res) res=stat((GetDOSBoxXPath()+path+CROSS_FILESPLIT+name).c_str(),&temp_stat);
+            if (res==0&&(ltime=localtime(&temp_stat.st_mtime))!=0) {
+                fztime=DOS_PackTime((uint16_t)ltime->tm_hour,(uint16_t)ltime->tm_min,(uint16_t)ltime->tm_sec);
+                fzdate=DOS_PackDate((uint16_t)(ltime->tm_year+1900),(uint16_t)(ltime->tm_mon+1),(uint16_t)ltime->tm_mday);
+            }
             VFILE_Register(name.substr(0, name.size()-1).c_str(), 0, 0, dir.c_str());
+            fztime = fzdate = 0;
             drivezRegister(path+CROSS_FILESPLIT+name.substr(0, name.size()-1), dir+name);
             continue;
         }
@@ -1055,10 +1065,8 @@ void drivezRegister(std::string path, std::string dir) {
         f_data = NULL;
 
         if (f != NULL) {
-            struct stat temp_stat;
-            fstat(fileno(f),&temp_stat);
-            const struct tm* ltime;
-            if((ltime=localtime(&temp_stat.st_mtime))!=0) {
+            res=fstat(fileno(f),&temp_stat);
+            if (res==0&&(ltime=localtime(&temp_stat.st_mtime))!=0) {
                 fztime=DOS_PackTime((uint16_t)ltime->tm_hour,(uint16_t)ltime->tm_min,(uint16_t)ltime->tm_sec);
                 fzdate=DOS_PackDate((uint16_t)(ltime->tm_year+1900),(uint16_t)(ltime->tm_mon+1),(uint16_t)ltime->tm_mday);
             }

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -520,7 +520,7 @@ const char *ParseMsg(const char *msg) {
         return str_replace(str_replace(str_replace((char *)msg, (char*)"\xBA\033[0m", (char*)"\xBA\033[0m\n"), (char*)"\xBB\033[0m", (char*)"\xBB\033[0m\n"), (char*)"\xBC\033[0m", (char*)"\xBC\033[0m\n");
 }
 
-static char const * const path_string="PATH=Z:\\;Z:\\SYSTEM;Z:\\DOS;Z:\\BIN";
+static char const * const path_string="PATH=Z:\\;Z:\\SYSTEM;Z:\\DOS;Z:\\BIN;Z:\\DEBUG";
 static char const * const comspec_string="COMSPEC=Z:\\COMMAND.COM";
 static char const * const prompt_string="PROMPT=$P$G";
 static char const * const full_name="Z:\\COMMAND.COM";
@@ -644,6 +644,7 @@ void DOS_Shell::Run(void) {
 						}
 						if (!strncasecmp(cmd, "set ", 4)) {
 							vstr=std::string(val);
+							if (!strcmp(cmd, "set path")&&vstr=="Z:\\") vstr=path_string+5;
 							ResolvePath(vstr);
 							DoCommand((char *)(std::string(cmd)+"="+vstr).c_str());
 						} else if (!strcasecmp(cmd, "install")||!strcasecmp(cmd, "installhigh")||!strcasecmp(cmd, "device")||!strcasecmp(cmd, "devicehigh")) {
@@ -652,7 +653,7 @@ void DOS_Shell::Run(void) {
 							strcpy(tmp, vstr.c_str());
 							char *name=StripArg(tmp);
 							if (!*name) continue;
-							if (!DOS_FileExists(name)) {
+							if (!DOS_FileExists(name)&&!DOS_FileExists((std::string("Z:\\SYSTEM\\")+name).c_str())&&!DOS_FileExists((std::string("Z:\\DOS\\")+name).c_str())&&!DOS_FileExists((std::string("Z:\\BIN\\")+name).c_str())&&!DOS_FileExists((std::string("Z:\\DEBUG\\")+name).c_str())) {
 								WriteOut("The following file is missing or corrupted: %s\n", name);
 								continue;
 							}
@@ -674,7 +675,6 @@ void DOS_Shell::Run(void) {
 		}
         std::string line;
         GetEnvStr("PATH",line);
-		if (line=="PATH=Z:\\") DoCommand((char *)("SET "+std::string(path_string)).c_str());
 		if (!strlen(config_data)) {
 			strcat(config_data, "rem=");
 			strcat(config_data, (char *)section->Get_string("rem"));
@@ -871,7 +871,7 @@ public:
 			if (test.st_mode & S_IFDIR) {
 				autoexec[12].Install(std::string("MOUNT C \"") + buffer + "\"");
 				autoexec[13].Install("C:");
-				if(secure) autoexec[14].Install("z:\\config.com -securemode");
+				if(secure) autoexec[14].Install("z:\\system\\config.com -securemode");
 				command_found = true;
 			} else {
 				char* name = strrchr(buffer,CROSS_FILESPLIT);
@@ -893,7 +893,7 @@ public:
 				strcpy(orig,name);
 				upcase(name);
 				if(strstr(name,".BAT") != 0) {
-					if(secure) autoexec[14].Install("z:\\config.com -securemode");
+					if(secure) autoexec[14].Install("z:\\system\\config.com -securemode");
 					/* BATch files are called else exit will not work */
 					autoexec[15].Install(std::string("CALL ") + name);
 					if(addexit) autoexec[16].Install("exit");
@@ -906,10 +906,10 @@ public:
 					/* securemode gets a different number from the previous branches! */
 					autoexec[14].Install(std::string("IMGMOUNT D \"") + orig + std::string("\" -t iso"));
 					//autoexec[16].Install("D:");
-					if(secure) autoexec[15].Install("z:\\config.com -securemode");
+					if(secure) autoexec[15].Install("z:\\system\\config.com -securemode");
 					/* Makes no sense to exit here */
 				} else {
-					if(secure) autoexec[14].Install("z:\\config.com -securemode");
+					if(secure) autoexec[14].Install("z:\\system\\config.com -securemode");
 					autoexec[15].Install(name);
 					if(addexit) autoexec[16].Install("exit");
 				}
@@ -919,10 +919,10 @@ public:
 
 		/* Combining -securemode, noautoexec and no parameters leaves you with a lovely Z:\. */
 		if ( !command_found ) { 
-			if ( secure ) autoexec[12].Install("z:\\config.com -securemode");
+			if ( secure ) autoexec[12].Install("z:\\system\\config.com -securemode");
 		}
 #else
-		if (secure) autoexec[i++].Install("z:\\config.com -securemode");
+		if (secure) autoexec[i++].Install("z:\\system\\config.com -securemode");
 #endif
 
 		if (addexit) autoexec[i++].Install("exit");

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1358,7 +1358,7 @@ void DOS_Shell::CMD_MKDIR(char * args) {
 		return;
 	}
 	if (!DOS_MakeDir(args)) {
-		WriteOut(MSG_Get("SHELL_CMD_MKDIR_ERROR"),args);
+		WriteOut(MSG_Get(dos.errorcode==DOSERR_ACCESS_DENIED?"SHELL_CMD_MKDIR_EXIST":"SHELL_CMD_MKDIR_ERROR"),args);
 	}
 }
 

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -67,7 +67,7 @@ SHELL_Cmd cmd_list[]={
 {	"CTTY",			1,		&DOS_Shell::CMD_CTTY,		"SHELL_CMD_CTTY_HELP"},
 {	"DATE",			0,		&DOS_Shell::CMD_DATE,		"SHELL_CMD_DATE_HELP"},
 {	"DEL",			0,		&DOS_Shell::CMD_DELETE,		"SHELL_CMD_DELETE_HELP"},
-//{	"DELTREE",		1,		&DOS_Shell::CMD_DELTREE,	"SHELL_CMD_DELTREE_HELP"}, // DELTREE as a program (Z:\DELTREE.EXE) instead of shell command
+//{	"DELTREE",		1,		&DOS_Shell::CMD_DELTREE,	"SHELL_CMD_DELTREE_HELP"}, // DELTREE as a program (Z:\DOS\DELTREE.EXE) instead of shell command
 {	"ECHO",			0,		&DOS_Shell::CMD_ECHO,		"SHELL_CMD_ECHO_HELP"},
 {	"ERASE",		1,		&DOS_Shell::CMD_DELETE,		"SHELL_CMD_DELETE_HELP"},
 {	"EXIT",			0,		&DOS_Shell::CMD_EXIT,		"SHELL_CMD_EXIT_HELP"},
@@ -78,7 +78,7 @@ SHELL_Cmd cmd_list[]={
 {	"LFNFOR",		1,		&DOS_Shell::CMD_LFNFOR,		"SHELL_CMD_LFNFOR_HELP"},
 {	"LH",			1,		&DOS_Shell::CMD_LOADHIGH,	"SHELL_CMD_LOADHIGH_HELP"},
 {	"LOADHIGH",		1,		&DOS_Shell::CMD_LOADHIGH,	"SHELL_CMD_LOADHIGH_HELP"},
-//{   "LS",			1,		&DOS_Shell::CMD_LS,			"SHELL_CMD_LS_HELP"}, // LS as a program (Z:\LS.COM) instead of shell command
+//{   "LS",			1,		&DOS_Shell::CMD_LS,			"SHELL_CMD_LS_HELP"}, // LS as a program (Z:\BIN\LS.COM) instead of shell command
 {	"MD",			0,		&DOS_Shell::CMD_MKDIR,		"SHELL_CMD_MKDIR_HELP"},
 {	"MKDIR",		1,		&DOS_Shell::CMD_MKDIR,		"SHELL_CMD_MKDIR_HELP"},
 {	"MORE",			1,		&DOS_Shell::CMD_MORE,		"SHELL_CMD_MORE_HELP"},
@@ -104,10 +104,10 @@ SHELL_Cmd cmd_list[]={
 #if C_DEBUG
 // Additional commands for debugging purposes in DOSBox-X
 {	"DEBUGBOX",		1,		&DOS_Shell::CMD_DEBUGBOX,	"SHELL_CMD_DEBUGBOX_HELP"},
-//{	"INT2FDBG",		1,		&DOS_Shell::CMD_INT2FDBG,	"SHELL_CMD_INT2FDBG_HELP"}, // INT2FDBG as a program (Z:\INT2FDBG.COM) instead of shell command
+//{	"INT2FDBG",		1,		&DOS_Shell::CMD_INT2FDBG,	"SHELL_CMD_INT2FDBG_HELP"}, // INT2FDBG as a program (Z:\DEBUG\INT2FDBG.COM) instead of shell command
 #endif
 // Advanced commands specific to DOSBox-X
-//{	"ADDKEY",		1,		&DOS_Shell::CMD_ADDKEY,		"SHELL_CMD_ADDKEY_HELP"}, // ADDKEY as a program (Z:\ADDKEY.COM) instead of shell command
+//{	"ADDKEY",		1,		&DOS_Shell::CMD_ADDKEY,		"SHELL_CMD_ADDKEY_HELP"}, // ADDKEY as a program (Z:\BIN\ADDKEY.COM) instead of shell command
 {	"DX-CAPTURE",	1,		&DOS_Shell::CMD_DXCAPTURE,  "SHELL_CMD_DXCAPTURE_HELP"},
 {0,0,0,0}
 };
@@ -163,7 +163,7 @@ bool DOS_Shell::CheckConfig(char* cmd_in,char*line) {
 		if(val != NO_SUCH_PROPERTY) WriteOut("%s\n",val.c_str());
 		return true;
 	}
-	char newcom[1024]; newcom[0] = 0; strcpy(newcom,"z:\\config -set ");
+	char newcom[1024]; newcom[0] = 0; strcpy(newcom,"z:\\system\\config -set ");
 	if (line != NULL) {
 		line=trim(line);
 		if (*line=='=') line=trim(++line);


### PR DESCRIPTION
The Z: drive is the internal virtual drive, but it only supports files and not directories, unlike real DOS systems. There have been a lot of additional files in DOSBox-X's Z drive which makes it somewhat messy. This PR adds support for directories on the Z drive, inspirited by Issue #2505. Directory support on Z drive is still relatively basic in that only one-level directories are supported, but I think this should solve most problems already. By default there are 4 directories in Z:\:

```\SYSTEM```
For DOSBox-X's system files (MOUNT.COM, CONFIG.COM, etc)
```\DOS```
For various DOS commands (EDIT.COM, MEM.EXE, etc)
```\BIN```
For additional DOS programs (DOS4GW.EXE, CWSDPMI.EXE, etc)
```\DEBUG```
For debugging-related commands (A20GATE.COM, BIOSTEST.COM, etc)

You can add your own files (or replace existing files) to the Z drive by putting files/directories on the drivez folder, as before, but now one-level directories are supported in addition to files.