### PR TITLE
SVN commits

### DIFF
--- a/patch-integration/Skipped SVN commits.txt
+++ b/patch-integration/Skipped SVN commits.txt
@@ -75,3 +75,6 @@ Commit#:	Reason for skipping:
 4418		No C_SRECORD in DOSBox-X
 4424		Declares const but then casts to non-const
 4429		Conflict
+4445		Conflict
+4446		Conflict
+4448		Additional parameters for DOSBox-X needed

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -2180,8 +2180,10 @@ bool fatDrive::FileCreate(DOS_File **file, const char *name, uint16_t attributes
 bool fatDrive::FileExists(const char *name) {
     direntry fileEntry = {};
 	uint32_t dummy1, dummy2;
-	if(!getFileDirEntry(name, &fileEntry, &dummy1, &dummy2)) return false;
-	return true;
+	uint16_t save_errorcode = dos.errorcode;
+	bool found = getFileDirEntry(name, &fileEntry, &dummy1, &dummy2);
+	dos.errorcode = save_errorcode;
+	return found;
 }
 
 bool fatDrive::FileOpen(DOS_File **file, const char *name, uint32_t flags) {

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2444,12 +2444,12 @@ void DOSBOX_SetupConfigSections(void) {
 
     Pmulti_remain = secprop->Add_multiremain("cycles",Property::Changeable::Always," ");
     Pmulti_remain->Set_help(
-        "Amount of instructions DOSBox-X tries to emulate each millisecond.\n"
+        "Number of instructions DOSBox-X tries to emulate each millisecond.\n"
         "Setting this value too high results in sound dropouts and lags.\n"
         "Cycles can be set in 3 ways:\n"
         "  'auto'          tries to guess what a game needs.\n"
         "                  It usually works, but can fail for certain games.\n"
-        "  'fixed #number' will set a fixed amount of cycles. This is what you usually\n"
+        "  'fixed #number' will set a fixed number of cycles. This is what you usually\n"
         "                  need if 'auto' fails (Example: fixed 4000).\n"
         "  'max'           will allocate as much cycles as your computer is able to\n"
         "                  handle.");


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/4444/ - Already in DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4445/ - Code conflict
https://sourceforge.net/p/dosbox/code-0/4446/ - Code conflict
https://sourceforge.net/p/dosbox/code-0/4447/ - Already in DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4448/ - Code conflict. DOSBox-X uses additional parameters for defining disk types not defined in the SVN commit. This could be easily added to DOSBox-X if the additional parameter values are known. @joncampbell123 or @Wengier, want to take a look?
https://sourceforge.net/p/dosbox/code-0/4449/ - Skipped. Code duplication here only existed in SVN, not DOSBox-X, so making it into a function is unnecessary.
https://sourceforge.net/p/dosbox/code-0/4450/ - In this PR. I don't know what the regression mentioned is or if it is present in DOSBox-X, so I refrained from putting it in the changelog. Similar code to preserve the error code is also already in another function, `fatDrive::FileCreate`.
https://sourceforge.net/p/dosbox/code-0/4451/ - Partially in this PR. The deleted file is not in DOSBox-X so just the help message changes are in this PR.
https://sourceforge.net/p/dosbox/code-0/4452/ - Skipped. File is not used in DOSBox-X (it's in `unused-source-files.zip` in the `src/libs/zmbv` folder.)
