### PR TITLE
MSVC warning fixes

### DIFF
--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -358,7 +358,7 @@ restart_core:
 				block = CreateCacheBlock(chandler,ip_point,cache_size);
 			}
 		} else {
-			int32_t old_cycles=CPU_Cycles;
+			int32_t old_cycles=(int32_t)CPU_Cycles;
 			CPU_Cycles=1;
 			CPU_CycleLeft+=old_cycles;
 			// manually save
@@ -470,7 +470,7 @@ run_block:
 }
 
 Bits CPU_Core_Dyn_X86_Trap_Run(void) {
-	int32_t oldCycles = CPU_Cycles;
+	int32_t oldCycles = (int32_t)CPU_Cycles;
 	CPU_Cycles = 1;
 	cpu.trap_skip = false;
 

--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -89,7 +89,7 @@ public:
 		Bits index=1+(end>>DYN_HASH_SHIFT);
 		bool is_current_block=false;
 		uint32_t ip_point=SegPhys(cs)+reg_eip;
-		ip_point=(PAGING_GetPhysicalPage(ip_point)-(phys_page<<12))+(ip_point&0xfff);
+		ip_point=(uint32_t)((PAGING_GetPhysicalPage(ip_point)-(phys_page<<12))+(ip_point&0xfff));
 		while (index>=0) {
 			Bitu map=0;
 			for (Bitu count=start;count<=end;count++) map+=write_map[count];

--- a/src/cpu/core_dyn_x86/dyn_fpu_dh.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu_dh.h
@@ -154,7 +154,7 @@ static void dh_fpu_mem(uint8_t inst, Bitu reg=decode.modrm.reg, void* mem=&dyn_d
 	cache_addb(0x05|(reg<<3));
 	cache_addd((uint32_t)(mem));
 #else // X86_64
-	opcode(reg).setabsaddr(mem).Emit8(inst);
+	opcode((int)reg).setabsaddr(mem).Emit8(inst);
 #endif
 }
 
@@ -171,7 +171,7 @@ static void dh_fpu_esc0(){
 	dyn_get_modrm(); 
 	if (decode.modrm.val >= 0xc0) {
 		cache_addb(0xd8);
-		cache_addb(decode.modrm.val);
+		cache_addb((uint8_t)decode.modrm.val);
 	} else { 
 		dyn_fill_ea();
 		dyn_call_function_pagefault_check((void*)&FPU_FLD_32,"%Drd",DREG(EA));
@@ -183,7 +183,7 @@ static void dh_fpu_esc1(){
 	dyn_get_modrm();  
 	if (decode.modrm.val >= 0xc0) {
 		cache_addb(0xd9);
-		cache_addb(decode.modrm.val);
+		cache_addb((uint8_t)decode.modrm.val);
 	} else {
 		Bitu group=(decode.modrm.val >> 3) & 7;
 		Bitu sub=(decode.modrm.val & 7);
@@ -231,7 +231,7 @@ static void dh_fpu_esc2(){
 	dyn_get_modrm();  
 	if (decode.modrm.val >= 0xc0) { 
 		cache_addb(0xda);
-		cache_addb(decode.modrm.val);
+		cache_addb((uint8_t)decode.modrm.val);
 	} else {
 		dyn_fill_ea(); 
 		dyn_call_function_pagefault_check((void*)&FPU_FLD_32,"%Drd",DREG(EA)); 
@@ -253,12 +253,12 @@ static void dh_fpu_esc3(){
 				break;
 			case 0x02:				//FNCLEX FCLEX
 				cache_addb(0xdb);
-				cache_addb(decode.modrm.val);
+				cache_addb((uint8_t)decode.modrm.val);
 				break;
 			case 0x03:				//FNINIT FINIT
 				gen_call_function((void*)&FPU_FNINIT_DH,""); 
 				cache_addb(0xdb);
-				cache_addb(decode.modrm.val);
+				cache_addb((uint8_t)decode.modrm.val);
 				break;
 			case 0x04:				//FNSETPM
 			case 0x05:				//FRSTPM
@@ -313,7 +313,7 @@ static void dh_fpu_esc4(){
 	dyn_get_modrm();  
 	if (decode.modrm.val >= 0xc0) { 
 		cache_addb(0xdc);
-		cache_addb(decode.modrm.val);
+		cache_addb((uint8_t)decode.modrm.val);
 	} else { 
 		dyn_fill_ea(); 
 		dyn_call_function_pagefault_check((void*)&FPU_FLD_64,"%Drd",DREG(EA)); 
@@ -325,7 +325,7 @@ static void dh_fpu_esc5(){
 	dyn_get_modrm();  
 	if (decode.modrm.val >= 0xc0) { 
 		cache_addb(0xdd);
-		cache_addb(decode.modrm.val);
+		cache_addb((uint8_t)decode.modrm.val);
 	} else {
 		dyn_fill_ea(); 
 		Bitu group=(decode.modrm.val >> 3) & 7;
@@ -371,7 +371,7 @@ static void dh_fpu_esc6(){
 	dyn_get_modrm();  
 	if (decode.modrm.val >= 0xc0) { 
 		cache_addb(0xde);
-		cache_addb(decode.modrm.val);
+		cache_addb((uint8_t)decode.modrm.val);
 	} else {
 		dyn_fill_ea(); 
 		dyn_call_function_pagefault_check((void*)&FPU_FLD_16,"%Drd",DREG(EA)); 
@@ -387,16 +387,16 @@ static void dh_fpu_esc7(){
 		switch (group){
 		case 0x00: /* FFREEP STi*/
 			cache_addb(0xdf);
-			cache_addb(decode.modrm.val);
+			cache_addb((uint8_t)decode.modrm.val);
 			break;
 		case 0x01: /* FXCH STi*/
 			cache_addb(0xdf);
-			cache_addb(decode.modrm.val);
+			cache_addb((uint8_t)decode.modrm.val);
 			break;
 		case 0x02:  /* FSTP STi*/
 		case 0x03:  /* FSTP STi*/
 			cache_addb(0xdf);
-			cache_addb(decode.modrm.val);
+			cache_addb((uint8_t)decode.modrm.val);
 			break;
 		case 0x04:
 			switch(sub){

--- a/src/cpu/core_dyn_x86/dyn_mmx.h
+++ b/src/cpu/core_dyn_x86/dyn_mmx.h
@@ -23,7 +23,7 @@ static void MMX_STORE_64(PhysPt addr) {
 
 // add simple instruction (that operates only with mm regs)
 static void dyn_mmx_simple(Bitu op, uint8_t modrm) {
-	cache_addw(0x0F | (op << 8)); cache_addb(modrm);
+	cache_addw((uint16_t)(0x0F | (op << 8))); cache_addb(modrm);
 }
 
 // same but with imm8 also
@@ -37,7 +37,7 @@ static void dyn_mmx_mem(Bitu op, Bitu reg=decode.modrm.reg, void* mem=&mmxtmp) {
 	cache_addb(0x05|(reg<<3));
 	cache_addd((uint32_t)(mem));
 #else // X86_64
-	opcode(reg).setabsaddr(mem).Emit16(0x0F | (op << 8));
+	opcode((int)reg).setabsaddr(mem).Emit16((uint16_t)(0x0F | (op << 8)));
 #endif
 }
 
@@ -77,7 +77,7 @@ static void dyn_mmx_op(Bitu op) {
 	} else {
         //if ((op == 0x71) || (op == 0x72) || (op == 0x73)) decode_fetchb_imm(imm);
         //dyn_call_function_pagefault_check((void*)&gen_mmx_op, "%I%I%I", op, decode.modrm.val, imm);
-		dyn_mmx_simple(op, decode.modrm.val);
+		dyn_mmx_simple(op, (uint8_t)decode.modrm.val);
     }
 }
 
@@ -86,7 +86,7 @@ static void dyn_mmx_shift_imm8(uint8_t op) {
 	dyn_get_modrm();
 	Bitu imm; decode_fetchb_imm(imm);
 
-	dyn_mmx_simple_imm8(op, decode.modrm.val, imm);
+	dyn_mmx_simple_imm8(op, (uint8_t)decode.modrm.val, (uint8_t)imm);
 }
 
 // 0x6E - MOVD mm, r/m32
@@ -124,7 +124,7 @@ static void dyn_mmx_movq_pqqq() {
 	}
 	else {
 		// movq mm, mm
-		dyn_mmx_simple(0x6F, decode.modrm.val);
+		dyn_mmx_simple(0x6F, (uint8_t)decode.modrm.val);
 	}
 }
 
@@ -163,7 +163,7 @@ static void dyn_mmx_movq_qqpq() {
 	}
 	else {
 		// movq mm, mm
-		dyn_mmx_simple(0x7F, decode.modrm.val);
+		dyn_mmx_simple(0x7F, (uint8_t)decode.modrm.val);
 	}
 }
 

--- a/src/cpu/core_normal/prefix_0f_mmx.h
+++ b/src/cpu/core_normal/prefix_0f_mmx.h
@@ -225,7 +225,7 @@
 		if (CPU_ArchitectureType<CPU_ARCHTYPE_PMMXSLOW) goto illegal_opcode;
 		GetRM;
 		uint8_t op=(rm>>3)&7;
-		uint8_t shift=Fetchb();
+		uint8_t shift=(uint8_t)Fetchb();
 		MMX_reg* dest=reg_mmx[rm&7];
 		switch (op) {
 			case 0x06: 	/*PSLLW*/
@@ -338,7 +338,7 @@
 		if (CPU_ArchitectureType<CPU_ARCHTYPE_PMMXSLOW) goto illegal_opcode;
 		GetRM;
 		uint8_t op=(rm>>3)&7;
-		uint8_t shift=Fetchb();
+		uint8_t shift=(uint8_t)Fetchb();
 		MMX_reg* dest=reg_mmx[rm&7];
 		switch (op) {
 			case 0x06: 	/*PSLLD*/
@@ -409,7 +409,7 @@
 	{
 		if (CPU_ArchitectureType<CPU_ARCHTYPE_PMMXSLOW) goto illegal_opcode;
 		GetRM;
-		uint8_t shift=Fetchb();
+		uint8_t shift=(uint8_t)Fetchb();
 		MMX_reg* dest=reg_mmx[rm&7];
 		if (shift > 63) dest->q = 0;
 		else {

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -1019,7 +1019,7 @@ doexception:
 
 void CPU_DebugException(uint32_t triggers,Bitu oldeip) {
   cpu.drx[6] = (cpu.drx[6] & 0xFFFF1FF0) | triggers;
-  CPU_Interrupt(EXCEPTION_DB,CPU_INT_EXCEPTION,oldeip);
+  CPU_Interrupt(EXCEPTION_DB,CPU_INT_EXCEPTION,(uint32_t)oldeip);
 }
 
 #include <stack>

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -2940,7 +2940,7 @@ extern "C" INPUT_RECORD * _pdcurses_hax_inputrecord(void);
 int32_t DEBUG_Run(int32_t amount,bool quickexit) {
 	skipFirstInstruction = true;
 	CPU_Cycles = amount;
-	int32_t ret = (*cpudecoder)();
+	int32_t ret = (int32_t)(*cpudecoder)();
 	if (quickexit) SetCodeWinStart();
 	else {
 		// ensure all breakpoints are activated

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -240,7 +240,7 @@ bool CDROM_Interface_Image::AudioFile::seek(int64_t offset)
 
 	// Convert the byte-offset to a time offset (milliseconds)
 	const bool result = Sound_Seek(sample, lround(offset/176.4f));
-	audio_pos = result ? offset : UINT32_MAX;
+	audio_pos = result ? (uint32_t)offset : UINT32_MAX;
 
 	#ifdef DEBUG
 	const auto end = std::chrono::steady_clock::now();
@@ -372,21 +372,21 @@ bool CDROM_Interface_Image::CHDFile::read(uint8_t* buffer,int64_t offset, int co
         } else {
             // read new hunk
             bool error = true;
-            hunk_thread_func(this->chd, needed_hunk, this->hunk_buffer, &error);
+            hunk_thread_func(this->chd, (int)needed_hunk, this->hunk_buffer, &error);
             if (error) {
                 return false;
             }
         }
 #endif
 
-        this->hunk_buffer_index = needed_hunk;
+        this->hunk_buffer_index = (int)needed_hunk;
 
 #if !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
         // prefetch: let our thread decode the next hunk
         if (hunk_thread) delete this->hunk_thread;
         this->hunk_thread = new std::thread(
             [this, needed_hunk]() {
-                hunk_thread_func(this->chd, needed_hunk + 1, this->hunk_buffer_next, &this->hunk_thread_error);
+                hunk_thread_func(this->chd, (int)(needed_hunk + 1), this->hunk_buffer_next, &this->hunk_thread_error);
             }
         );
 #endif
@@ -954,7 +954,7 @@ bool CDROM_Interface_Image::LoadIsoFile(char* filename)
 		return false;
 	}
     int64_t len=track.file->getLength();
-	track.length = len / track.sectorSize;
+	track.length = (int)(len / track.sectorSize);
 	// LOG_MSG("LoadIsoFile: %s, track 1, 0x40, sectorSize=%d, mode2=%s", filename, track.sectorSize, track.mode2 ? "true":"false");
 
 	tracks.push_back(track);
@@ -1307,7 +1307,7 @@ bool CDROM_Interface_Image::AddTrack(Track &curr, int &shift, int prestart, int 
 	} else {
 		if (!prev.length) {
 			int64_t tmp = prev.file->getLength() - prev.skip;
-			prev.length = tmp / prev.sectorSize;
+			prev.length = (int)(tmp / prev.sectorSize);
 			if (tmp % prev.sectorSize != 0) prev.length++; // padding
 		}
 		curr.start += prev.start + prev.length + currPregap;

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1551,7 +1551,7 @@ static Bitu DOS_21Handler(void) {
             if (DOS_OpenFile(name1,reg_al,&reg_ax)) {
 #if defined(USE_TTF)
                 if (ttf.inUse&&wpType==1) {
-                    int len = strlen(name1);
+                    int len = (int)strlen(name1);
                     if (len > 10 && !strcmp(name1+len-11, "\\VGA512.CHM"))  // Test for VGA512.CHM
                         WPvga512CHMhandle = reg_ax;							// Save handle
                 }

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -58,6 +58,7 @@
 #include "../libs/tinyfiledialogs/tinyfiledialogs.c"
 #endif
 #if defined(WIN32)
+#include <VersionHelpers.h>
 # if defined(__MINGW32__)
 #  define ht_stat_t struct _stat
 #  define ht_stat(x,y) _wstat(x,y)
@@ -1208,11 +1209,7 @@ public:
                 } else {
 #if defined (WIN32)
                     // Check OS
-                    OSVERSIONINFO osi;
-                    osi.dwOSVersionInfoSize = sizeof(osi);
-                    GetVersionEx(&osi);
-                    if ((osi.dwPlatformId==VER_PLATFORM_WIN32_NT) && (osi.dwMajorVersion>5)) {
-                        // Vista/above
+                    if (IsWindowsVistaOrGreater()) {
                         MSCDEX_SetCDInterface(CDROM_USE_IOCTL_DX, num);
                     } else {
                         MSCDEX_SetCDInterface(CDROM_USE_IOCTL_DIO, num);

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -468,8 +468,8 @@ std::string GetNewStr(const char *str) {
     if (str&&dos.loaded_codepage!=437) {
         char *temp = NULL;
         wchar_t* wstr = NULL;
-        int reqsize = MultiByteToWideChar(CP_UTF8, 0, str, strlen(str)+1, NULL, 0);
-        if (reqsize>0 && (wstr = new wchar_t[reqsize]) && MultiByteToWideChar(CP_UTF8, 0, str, strlen(str)+1, wstr, reqsize)==reqsize) {
+        int reqsize = MultiByteToWideChar(CP_UTF8, 0, str, (int)(strlen(str)+1), NULL, 0);
+        if (reqsize>0 && (wstr = new wchar_t[reqsize]) && MultiByteToWideChar(CP_UTF8, 0, str, (int)(strlen(str)+1), wstr, reqsize)==reqsize) {
             reqsize = WideCharToMultiByte(dos.loaded_codepage==808?866:(dos.loaded_codepage==872?855:dos.loaded_codepage), WC_NO_BEST_FIT_CHARS, wstr, -1, NULL, 0, "\x07", NULL);
             if (reqsize > 1 && (temp = new char[reqsize]) && WideCharToMultiByte(dos.loaded_codepage==808?866:(dos.loaded_codepage==872?855:dos.loaded_codepage), WC_NO_BEST_FIT_CHARS, wstr, -1, (LPSTR)temp, reqsize, "\x07", NULL) == reqsize)
                 newstr = std::string(temp);
@@ -3730,7 +3730,7 @@ void LOADFIX::Run(void)
             /* EMS allocates in 16kb increments */
             kb = (kb + 15u) & (~15u);
 
-            err = EMM_AllocateMemory(kb/16u/*16KB pages*/,/*&*/handle,false);
+            err = EMM_AllocateMemory((uint16_t)(kb/16u)/*16KB pages*/,/*&*/handle,false);
             if (err == 0) {
                 WriteOut("EMS block allocated (%uKB)\n",kb);
                 LOADFIX_ems_handles.push_back(handle);
@@ -6963,7 +6963,7 @@ int flagged_restore(char* zip)
             uint16_t handle, size;
             if (DOS_CreateFile(("\""+std::string(g_flagged_files[i])+"\"").c_str(),0,&handle)) {
                 for (uint64_t i=0; i<=ceil(fileSize/UINT16_MAX); i++) {
-                    size=(uint64_t)fileSize-UINT16_MAX*i>UINT16_MAX?UINT16_MAX:((uint64_t)fileSize-UINT16_MAX*i);
+                    size=(uint64_t)fileSize-UINT16_MAX*i>UINT16_MAX?UINT16_MAX:(uint16_t)((uint64_t)fileSize-UINT16_MAX*i);
                     DOS_WriteFile(handle,(uint8_t *)str.substr(i*UINT16_MAX, size).c_str(),&size);
                 }
                 DOS_CloseFile(handle);

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -7002,7 +7002,7 @@ public:
         }
         else if (cmd->GetCount())
         {
-            for (int i=1; i<=cmd->GetCount(); i++) {
+            for (unsigned int i=1; i<=cmd->GetCount(); i++) {
                 cmd->FindCommand(i,temp_line);
                 uint8_t drive;
                 char fullname[DOS_PATHLENGTH], flagfile[CROSS_LEN];

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -1479,7 +1479,7 @@ bool localDrive::AllocationInfo(uint16_t * _bytes_sector,uint8_t * _sectors_clus
                         if (diff<0&&(-diff)>*_free_clusters)
                             *_free_clusters=0;
                         else
-                            *_free_clusters += diff;
+                            *_free_clusters += (uint16_t)diff;
                     }
 					if (*_total_clusters<*_free_clusters) {
 						if (*_free_clusters>65525)
@@ -2248,7 +2248,7 @@ PHYSFS_sint64 PHYSFS_fileLength(const char *name) {
 
 /* Need to strip "/.." components and transform '\\' to '/' for physfs */
 static char *normalize(char * name, const char *basedir) {
-	int last = strlen(name)-1;
+	int last = (int)(strlen(name)-1);
 	strreplace(name,'\\','/');
 	while (last >= 0 && name[last] == '/') name[last--] = 0;
 	if (last > 0 && name[last] == '.' && name[last-1] == '/') name[last-1] = 0;
@@ -2258,7 +2258,7 @@ static char *normalize(char * name, const char *basedir) {
 		if (slash) *slash = 0;
 	}
 	if (strlen(basedir) > strlen(name)) { strcpy(name,basedir); strreplace(name,'\\','/'); }
-	last = strlen(name)-1;
+	last = (int)(strlen(name)-1);
 	while (last >= 0 && name[last] == '/') name[last--] = 0;
 	if (name[0] == 0) name[0] = '/';
 	//LOG_MSG("File access: %s",name);
@@ -2468,7 +2468,7 @@ physfsDrive::physfsDrive(const char driveLetter, const char * startdir,uint16_t 
 		if((lastdir == newname) && !strchr(dir+(((dir[0]|0x20) >= 'a' && (dir[0]|0x20) <= 'z')?2:0),':')) {
 			// If the first parameter is a directory, the next one has to be the archive file,
 			// do not confuse it with basedir if trailing : is not there!
-			int tmp = strlen(dir)-1;
+			int tmp = (int)(strlen(dir)-1);
 			dir[tmp++] = ':';
 			dir[tmp++] = CROSS_FILESPLIT;
 			dir[tmp] = '\0';
@@ -2936,7 +2936,7 @@ bool physfsFile::prepareWrite() {
 		PHYSFS_sint64 size;
 		PHYSFS_seek(fhandle, 0);
 		while ((size = PHYSFS_read(fhandle,buffer,1,65536)) > 0) {
-			if (PHYSFS_write(whandle,buffer,1,size) != size) {
+			if (PHYSFS_write(whandle,buffer,1,(PHYSFS_uint32)size) != size) {
 				LOG_MSG("PHYSFS copy-on-write failed: %s.",PHYSFS_getLastError());
 				PHYSFS_close(whandle);
 				return false;

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -2861,8 +2861,12 @@ bool physfsFile::Write(const uint8_t * data,uint16_t * size) {
 	last_action=WRITE;
 	if (*size==0) {
 		if (PHYSFS_tell(fhandle) == 0) {
-			PHYSFS_close(PHYSFS_openWrite(pname));
-			//LOG_MSG("Truncate %s (%s)",name,PHYSFS_getLastError());
+            if (PHYSFS_close(PHYSFS_openWrite(pname))) {
+                //LOG_MSG("Truncate %s (%s)",name,PHYSFS_getLastError());
+                return true;
+            }
+            else
+                return false;
 		} else {
 			LOG_MSG("PHYSFS TODO: truncate not yet implemented (%s at %i)",pname,PHYSFS_tell(fhandle));
 			return false;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -403,6 +403,7 @@ static Bitu Normal_Loop(void) {
         dosbox_allow_nonrecursive_page_fault = saved_allow;
 	}
 	catch (const GuestGenFaultException& gpf) {
+        (void)gpf;//UNUSED
 		Bitu FillFlags(void);
 
 		ret = 0;

--- a/src/gui/sdl_ttf.c
+++ b/src/gui/sdl_ttf.c
@@ -1064,7 +1064,7 @@ int TTF_SizeText(TTF_Font *font, const char *text, int *w, int *h)
 	int status;
 
 	/* Copy the Latin-1 text to a UNICODE text buffer */
-	unicode_len = strlen(text);
+	unicode_len = (int)strlen(text);
 	unicode_text = (Uint16 *)ALLOCA((1+unicode_len+1)*(sizeof *unicode_text));
 	if ( unicode_text == NULL ) {
 		TTF_SetError("Out of memory");
@@ -1088,7 +1088,7 @@ int TTF_SizeUTF8(TTF_Font *font, const char *text, int *w, int *h)
 	int status;
 
 	/* Copy the UTF-8 text to a UNICODE text buffer */
-	unicode_len = strlen(text);
+	unicode_len = (int)strlen(text);
 	unicode_text = (Uint16 *)ALLOCA((1+unicode_len+1)*(sizeof *unicode_text));
 	if ( unicode_text == NULL ) {
 		TTF_SetError("Out of memory");
@@ -1251,7 +1251,7 @@ SDL_Surface *TTF_RenderText_Solid(TTF_Font *font,
 	int unicode_len;
 
 	/* Copy the Latin-1 text to a UNICODE text buffer */
-	unicode_len = strlen(text);
+	unicode_len = (int)strlen(text);
 	unicode_text = (Uint16 *)ALLOCA((1+unicode_len+1)*(sizeof *unicode_text));
 	if ( unicode_text == NULL ) {
 		TTF_SetError("Out of memory");
@@ -1278,7 +1278,7 @@ SDL_Surface *TTF_RenderUTF8_Solid(TTF_Font *font,
 	int unicode_len;
 
 	/* Copy the UTF-8 text to a UNICODE text buffer */
-	unicode_len = strlen(text);
+	unicode_len = (int)strlen(text);
 	unicode_text = (Uint16 *)ALLOCA((1+unicode_len+1)*(sizeof *unicode_text));
 	if ( unicode_text == NULL ) {
 		TTF_SetError("Out of memory");
@@ -1510,7 +1510,7 @@ SDL_Surface *TTF_RenderText_Shaded(TTF_Font *font,
 	int unicode_len;
 
 	/* Copy the Latin-1 text to a UNICODE text buffer */
-	unicode_len = strlen(text);
+	unicode_len = (int)strlen(text);
 	unicode_text = (Uint16 *)ALLOCA((1+unicode_len+1)*(sizeof *unicode_text));
 	if ( unicode_text == NULL ) {
 		TTF_SetError("Out of memory");
@@ -1537,7 +1537,7 @@ SDL_Surface *TTF_RenderUTF8_Shaded(TTF_Font *font,
 	int unicode_len;
 
 	/* Copy the UTF-8 text to a UNICODE text buffer */
-	unicode_len = strlen(text);
+	unicode_len = (int)strlen(text);
 	unicode_text = (Uint16 *)ALLOCA((1+unicode_len+1)*(sizeof *unicode_text));
 	if ( unicode_text == NULL ) {
 		TTF_SetError("Out of memory");
@@ -1787,7 +1787,7 @@ SDL_Surface *TTF_RenderText_Blended(TTF_Font *font,
 	int unicode_len;
 
 	/* Copy the Latin-1 text to a UNICODE text buffer */
-	unicode_len = strlen(text);
+	unicode_len = (int)strlen(text);
 	unicode_text = (Uint16 *)ALLOCA((1+unicode_len+1)*(sizeof *unicode_text));
 	if ( unicode_text == NULL ) {
 		TTF_SetError("Out of memory");
@@ -1814,7 +1814,7 @@ SDL_Surface *TTF_RenderUTF8_Blended(TTF_Font *font,
 	int unicode_len;
 
 	/* Copy the UTF-8 text to a UNICODE text buffer */
-	unicode_len = strlen(text);
+	unicode_len = (int)strlen(text);
 	unicode_text = (Uint16 *)ALLOCA((1+unicode_len+1)*(sizeof *unicode_text));
 	if ( unicode_text == NULL ) {
 		TTF_SetError("Out of memory");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4495,7 +4495,7 @@ void GFX_EndTextLines(bool force=false) {
     // NTS: Additional fix is needed for the cursor in PC-98 mode; also expect further cleanup
 	bcount++;
 	if (vga.draw.cursor.enabled && vga.draw.cursor.sline <= vga.draw.cursor.eline && vga.draw.cursor.sline < 16 && blinkCursor) {	// Draw cursor?
-		int newPos = vga.draw.cursor.address>>1;
+		int newPos = (int)(vga.draw.cursor.address>>1);
 		if (newPos >= 0 && newPos < ttf.cols*ttf.lins) {								// If on screen
 			int y = newPos/ttf.cols;
 			int x = newPos%ttf.cols;
@@ -8494,7 +8494,7 @@ void PasteClipboard(bool bPressed) {
 #if defined (WIN32)
 void CopyClipboard(int all) {
 	uint16_t len=0;
-	const char* text = (char *)(all==2?Mouse_GetSelected(0,0,currentWindowWidth-1-sdl.clip.x,currentWindowHeight-1-sdl.clip.y,(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len):(all==1?Mouse_GetSelected(selscol, selsrow, selecol, selerow, -1, -1, &len):Mouse_GetSelected(mouse_start_x-sdl.clip.x,mouse_start_y-sdl.clip.y,mouse_end_x-sdl.clip.x,mouse_end_y-sdl.clip.y,sdl.clip.w,sdl.clip.h, &len)));
+	const char* text = (char *)(all==2?Mouse_GetSelected(0,0,(int)(currentWindowWidth-1-sdl.clip.x),(int)(currentWindowHeight-1-sdl.clip.y),(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len):(all==1?Mouse_GetSelected(selscol, selsrow, selecol, selerow, -1, -1, &len):Mouse_GetSelected(mouse_start_x-sdl.clip.x,mouse_start_y-sdl.clip.y,mouse_end_x-sdl.clip.x,mouse_end_y-sdl.clip.y,sdl.clip.w,sdl.clip.h, &len)));
 	if (OpenClipboard(NULL)&&EmptyClipboard()) {
 		HGLOBAL clipbuffer = GlobalAlloc(GMEM_DDESHARE, (len+1)*2);
 		LPWSTR buffer = static_cast<LPWSTR>(GlobalLock(clipbuffer));

--- a/src/hardware/RetroWaveLib/RetroWave.c
+++ b/src/hardware/RetroWaveLib/RetroWave.c
@@ -31,7 +31,7 @@ void retrowave_deinit(RetroWaveContext *ctx) {
 void retrowave_io_init(RetroWaveContext *ctx) {
 	// Sync CS state
 	uint8_t empty_byte = 0;
-	ctx->callback_io(ctx->user_data, 1e6, &empty_byte, NULL, 1);
+	ctx->callback_io(ctx->user_data, (uint32_t)1e6, &empty_byte, NULL, 1);
 
 	uint8_t init_sequence_1[] = {
 		0x00,
@@ -57,9 +57,9 @@ void retrowave_io_init(RetroWaveContext *ctx) {
 		uint8_t addr = i << 1;
 
 		init_sequence_1[0] = init_sequence_2[0] = init_sequence_3[0] = addr;
-		ctx->callback_io(ctx->user_data, 1e6, init_sequence_1, NULL, sizeof(init_sequence_1));
-		ctx->callback_io(ctx->user_data, 1e6, init_sequence_2, NULL, sizeof(init_sequence_2));
-		ctx->callback_io(ctx->user_data, 1e6, init_sequence_3, NULL, sizeof(init_sequence_3));
+		ctx->callback_io(ctx->user_data, (uint32_t)1e6, init_sequence_1, NULL, sizeof(init_sequence_1));
+		ctx->callback_io(ctx->user_data, (uint32_t)1e6, init_sequence_2, NULL, sizeof(init_sequence_2));
+		ctx->callback_io(ctx->user_data, (uint32_t)1e6, init_sequence_3, NULL, sizeof(init_sequence_3));
 	}
 }
 

--- a/src/hardware/parport/parport.cpp
+++ b/src/hardware/parport/parport.cpp
@@ -360,9 +360,9 @@ public:
             }
 
             if(cmd.FindStringBegin("base:",str,true))
-				parallel_baseaddr[i] = strtol(str.c_str(), NULL, 16);
+				parallel_baseaddr[i] = (uint16_t)strtol(str.c_str(), NULL, 16);
             if(cmd.FindStringBegin("irq:",str,true))
-				defaultirq[i] = strtol(str.c_str(), NULL, 10);
+				defaultirq[i] = (uint8_t)strtol(str.c_str(), NULL, 10);
 			cmd.FindCommand(1,str);
 #if C_DIRECTLPT
 			if(str=="reallpt") {

--- a/src/hardware/parport/printer.cpp
+++ b/src/hardware/parport/printer.cpp
@@ -2291,7 +2291,7 @@ void PRINTER_Init()
             unsigned int devnum;
             if (1!=sscanf(device.c_str(),"%u",&devnum)) devnum=-2;
             prtlist = "Printer Device List\n-------------------------------------------------------------\n";
-            for (int i=1; i < dwReturned; i++) {
+            for (unsigned int i=1; i < dwReturned; i++) {
                 if(devnum>0&&i==devnum) device=pInfo[i].pName;
                 prtlist+=(i<10?"0":"")+std::to_string(i)+" "+pInfo[i].pName+"\n";
             }

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -1122,7 +1122,7 @@ CSerial::CSerial(Bitu id, CommandLine* cmd) {
 
 	std::string str;
 	uint16_t base = serial_baseaddr[id];
-	if(cmd->FindStringBegin("base:",str,true)) base = strtol(str.c_str(), NULL, 16);
+	if(cmd->FindStringBegin("base:",str,true)) base = (uint16_t)strtol(str.c_str(), NULL, 16);
 	irq = serial_defaultirq[id];
 	getBituSubstring("irq:",&irq, cmd);
 	if (irq < 2 || irq > 15) irq = serial_defaultirq[id];

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -329,7 +329,7 @@ static void PIT0_Event(Bitu /*val*/) {
 }
 
 uint32_t PIT0_GetAssignedCounter(void) {
-    return pit[0].cntr;
+    return (uint32_t)pit[0].cntr;
 }
 
 static bool counter_output(Bitu counter) {

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -3668,13 +3668,13 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
                     if (autosave_end[index]>autosave_last[index]&&autosave_last[index]>=autosave_start[index]) autosave_last[index]++;
                     else autosave_last[index]=autosave_start[index];
                 } else autosave_last[index]=autosave_start[index];
-                int state = GetGameState_Run();
+                int state = (int)GetGameState_Run();
                 SetGameState_Run(autosave_last[index]-1);
                 SaveGameState_Run();
                 SetGameState_Run(state);
             } else if (!autosave_start[index]) {
                 SaveGameState_Run();
-                autosave_last[index]=GetGameState_Run()+1;
+                autosave_last[index]=(int)(GetGameState_Run()+1);
             }
             auto_save_state=false;
             ticksPrev=ticksNew;

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -3659,7 +3659,7 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
     // NTS: To be moved
     if (autosave_second>0&&enable_autosave) {
         uint32_t ticksNew=GetTicks();
-        if (ticksNew-ticksPrev>autosave_second*1000) {
+        if (ticksNew-ticksPrev>(unsigned int)autosave_second*1000) {
             auto_save_state=true;
             int index=0;
             for (int i=1; i<10&&i<=autosave_count; i++) if (autosave_name[i].size()&&!strcasecmp(RunningProgram, autosave_name[i].c_str())) index=i;

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -1358,8 +1358,8 @@ void XGA_Write(Bitu port, Bitu val, Bitu len) {
 				 * (initial output window before scaling - 1) is the lower 16 bits.
 				 *
 				 * K2 is signed 2's complement */
-				vga.s3.streams.ssctl_k1_hscale = val & regmask;
-				vga.s3.streams.ssctl_k2_hscale = (val >> 16u) & regmask;
+				vga.s3.streams.ssctl_k1_hscale = (uint16_t)(val & regmask);
+				vga.s3.streams.ssctl_k2_hscale = (uint16_t)((val >> 16u) & regmask);
 				if (vga.s3.streams.ssctl_k2_hscale &  ((regmask+1u)>>1u))   /* (0x7FF+1)>>1 = 0x400 */
 					vga.s3.streams.ssctl_k2_hscale -= (regmask+1u);         /* (0x7FF+1)    = 0x800 */
 			}

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -6970,7 +6970,7 @@ static void BIOS_Int10RightJustifiedPrint(const int x,int &y,const char *msg, bo
 }
 
 char *getSetupLine(const char *capt, const char *cont) {
-    unsigned int pad1=25-strlen(capt), pad2=41-strlen(cont);
+    unsigned int pad1=(unsigned int)(25-strlen(capt)), pad2=(unsigned int)(41-strlen(cont));
     static char line[90];
     sprintf(line, "º%*c%s%*c%s%*cº", 12, ' ', capt, pad1, ' ', cont, pad2, ' ');
     return line;

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -791,8 +791,8 @@ static void FinishSetMode(bool clearmem) {
 #if defined(USE_TTF)
     if (TTF_using() && CurMode->type==M_TEXT) {
         if (ttf.inUse) {
-            ttf.cols = CurMode->twidth;
-            ttf.lins = CurMode->theight;
+            ttf.cols = (int)CurMode->twidth;
+            ttf.lins = (int)CurMode->theight;
         } else if (ttf.lins && ttf.cols && !IS_PC98_ARCH && !IS_VGA_ARCH && CurMode->mode == 3) {
             CurMode->twidth = ttf.cols;
             CurMode->theight = ttf.lins;

--- a/src/output/output_opengl.cpp
+++ b/src/output/output_opengl.cpp
@@ -108,8 +108,8 @@ static void PPScale (
     int    sx, sy, orig_w, orig_h, min_w, min_h;
     double par, par_sq;
 
-    orig_w = min_w = render.src.width;
-    orig_h = min_h = render.src.height;
+    orig_w = min_w = (int)render.src.width;
+    orig_h = min_h = (int)render.src.height;
 
     par = ( double) orig_w / orig_h * 3 / 4;
     /* HACK: because RENDER_SetSize() does not set dblw and dblh correctly: */

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1266,7 +1266,7 @@ void DOS_Shell::CMD_PUSHD(char * args) {
             WriteOut(MSG_Get("SHELL_CMD_CHDIR_ERROR"),args);
         }
     } else {
-        for (int i=olddrives.size()-1; i>=0; i--)
+        for (int i=(int)(olddrives.size()-1); i>=0; i--)
             if (olddrives.at(i)>='A'&&olddrives.at(i)<='Z')
                 WriteOut("%c:\\%s\n",olddrives.at(i),olddirs.at(i).c_str());
     }


### PR DESCRIPTION
Fixes/silences all warnings in DOSBox-X files when building the 64-bit SDL1 solution. Warnings still are raised for the various library files used.

By the way, a warning is what allowed me to notice the issue fixed by my previous PR https://github.com/joncampbell123/dosbox-x/pull/2510.

Next I'm looking at fixing other warnings, such as those of GCC and Clang.