### PR TITLE
Add menu option to restart DOSBox-X with selected config file

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,8 @@
   - Added menu options "Generate NMI interrupt" & "Hook
     INT 2Fh calls" ("Help" => "Debugging options") for
     more debugging options. (Wengier)
+  - Fixed issues related to screen dimensions in TTF
+    output in CGA/EGA modes since 0.83.12. (Wengier)
   - Integrated SVN commits (Allofich)
     - r4443: Improve detection of Paradise SVGA in some
     installers with additional signature.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,8 @@
     that previously appeared on the root directory of
     Z drive are now categorized into directories, with
     addition of some files/programs, such as additional
-    4DOS files and TITLE command. (Wengier)
+    4DOS files, text utilties in TEXTUTIL directory and
+    TITLE command to change window title. (Wengier)
   - Added "Restart DOSBox-X with config file..." menu
     option to start DOSBox-X with the specified config
     file automatically from the menu. (Wengier)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,9 @@
     addition of some files/programs, such as additional
     4DOS files, text utilties in TEXTUTIL directory and
     TITLE command to change window title. (Wengier)
+  - The return value of AL in Int21/AX=0Eh is no longer
+    fixed. The game Jurassic Park may run after moving
+    Z drive to a different letter (e.g. E:). (Wengier)
   - Added "Restart DOSBox-X with config file..." menu
     option to start DOSBox-X with the specified config
     file automatically from the menu. (Wengier)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,11 @@
     4DOS, BIN, DEBUG, DOS, SYSTEM, TEXTUTIL. Most files
     that previously appeared on the root directory of
     Z drive are now categorized into directories, with
-    addition of some files/programs. (Wengier)
+    addition of some files/programs, such as additional
+    4DOS files and TITLE command. (Wengier)
+  - Added "Restart DOSBox-X with config file..." menu
+    option to start DOSBox-X with the specified config
+    file automatically from the menu. (Wengier)
   - Added "Refresh rate..." menu option (under "Video")
     to set the video refresh rate. (Wengier)
   - Added "Enable A20 gate" menu option (under "DOS")

--- a/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
+++ b/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
@@ -10,7 +10,7 @@
     <category>Emulation</category>
   </categories>
   <releases>
-          <release version="@PACKAGE_VERSION@" date="2021-5-7"/>
+          <release version="@PACKAGE_VERSION@" date="2021-5-9"/>
   </releases>
   <screenshots>
 	  <screenshot type="default">

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -536,7 +536,8 @@ freesizecap                                     = cap
 #DOSBOX-X-ADV:#                                                      This can be used to help diagnose whether or not the DOS game is page flipping properly according to vertical retrace if the display on-screen is flickering.
 #DOSBOX-X-ADV:#                  vertical retrace poll debug line: VGA debugging switch. If set, an inverse green dotted line will be drawn on the exact scanline that the CRTC status port (0x3DA) was read.
 #DOSBOX-X-ADV:#                                                      This can be used to help diagnose whether the DOS game is propertly waiting for vertical retrace.
-#DOSBOX-X-ADV:#                                           cgasnow: When machine=cga, determines whether or not to emulate CGA snow in 80x25 text mode
+#DOSBOX-X-ADV:#                                           cgasnow: When machine=cga, determines whether or not to emulate CGA snow in 80x25 text mode.
+#DOSBOX-X-ADV:#                                                      This parameter is also changeable from the builtin CGASNOW command in CGA mode.
 #DOSBOX-X-ADV:#                            vga 3da undefined bits: VGA status port 3BA/3DAh only defines bits 0 and 3. This setting allows you to assign a bit pattern to the undefined bits.
 #DOSBOX-X-ADV:#                                                      The purpose of this hack is to deal with demos that read and handle port 3DAh in ways that might crash if all are zero.
 #DOSBOX-X-ADV:#                             rom bios 8x8 CGA font: If set, or mainline DOSBox compatible BIOS mapping, a legacy 8x8 CGA font (first 128 characters) is stored at 0xF000:0xFA6E. DOS programs that do not use INT 10h to locate fonts might require that font to be located there.

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -536,7 +536,8 @@ enable pci bus                                  = true
 #                                                      This can be used to help diagnose whether or not the DOS game is page flipping properly according to vertical retrace if the display on-screen is flickering.
 #                  vertical retrace poll debug line: VGA debugging switch. If set, an inverse green dotted line will be drawn on the exact scanline that the CRTC status port (0x3DA) was read.
 #                                                      This can be used to help diagnose whether the DOS game is propertly waiting for vertical retrace.
-#                                           cgasnow: When machine=cga, determines whether or not to emulate CGA snow in 80x25 text mode
+#                                           cgasnow: When machine=cga, determines whether or not to emulate CGA snow in 80x25 text mode.
+#                                                      This parameter is also changeable from the builtin CGASNOW command in CGA mode.
 #                            vga 3da undefined bits: VGA status port 3BA/3DAh only defines bits 0 and 3. This setting allows you to assign a bit pattern to the undefined bits.
 #                                                      The purpose of this hack is to deal with demos that read and handle port 3DAh in ways that might crash if all are zero.
 #                             rom bios 8x8 CGA font: If set, or mainline DOSBox compatible BIOS mapping, a legacy 8x8 CGA font (first 128 characters) is stored at 0xF000:0xFA6E. DOS programs that do not use INT 10h to locate fonts might require that font to be located there.

--- a/include/build_timestamp.h
+++ b/include/build_timestamp.h
@@ -1,4 +1,4 @@
 /*auto-generated*/
-#define UPDATED_STR "May 7, 2021 4:03:25am"
-#define GIT_COMMIT_HASH "b13972f"
+#define UPDATED_STR "May 9, 2021 1:26:40am"
+#define GIT_COMMIT_HASH "b778192"
 #define COPYRIGHT_END_YEAR "2021"

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1008,7 +1008,11 @@ static Bitu DOS_21Handler(void) {
             break;  
         case 0x0e:      /* Select Default Drive */
             DOS_SetDefaultDrive(reg_dl);
-            reg_al=DOS_DRIVES;
+            {
+                int drive=maxdrive>=1&&maxdrive<=26?maxdrive:1;
+                for (uint16_t i=drive;i<DOS_DRIVES;i++) if (Drives[i]) drive=i+1;
+                reg_al=drive;
+            }
             break;
         case 0x0f:      /* Open File using FCB */
             if(DOS_FCBOpen(SegValue(ds),reg_dx)){

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -5860,7 +5860,7 @@ void MODE::Run(void) {
     else if (strcasecmp(temp_line.c_str(),"con")==0 || strcasecmp(temp_line.c_str(),"con:")==0) {
         if (IS_PC98_ARCH) return;
         int LINES = 25, COLS = 80;
-        LINES=real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
+        LINES=(IS_EGAVGA_ARCH?real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS):24)+1;
         COLS=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
         if (cmd->GetCount()<2) {
             WriteOut("Status for device CON:\n----------------------\nColumns=%d\nLines=%d\n\nCode page operation not supported on this device\n", COLS, LINES);

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -90,7 +90,7 @@ bool qmount = false;
 bool nowarn = false;
 extern bool mountfro[26], mountiro[26];
 
-void DOS_EnableDriveMenu(char drv);
+void DOS_EnableDriveMenu(char drv), GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused);
 void runBoot(const char *str), runMount(const char *str), runImgmount(const char *str), runRescan(const char *str);
 
 #if defined(OS2)

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -176,7 +176,7 @@ void DetachFromBios(imageDisk* image) {
     }
 }
 
-extern std::string hidefiles;
+extern std::string hidefiles, dosbox_title;
 extern int swapInDisksSpecificDrive;
 extern bool dos_kernel_disabled, clearline;
 void MSCDEX_SetCDInterface(int intNr, int forceCD);
@@ -6459,6 +6459,39 @@ static void TREE_ProgramStart(Program * * make) {
     *make=new TREE;
 }
 
+class TITLE : public Program {
+public:
+    void Run(void);
+private:
+	void PrintUsage() {
+        constexpr const char *msg =
+           "Sets the window title for the DOSBox-X window.\n\n"
+           "TITLE [string]\n\n"
+           "  string       Specifies the title for the DOSBox-X window.\n";
+        WriteOut(msg);
+	}
+};
+
+void TITLE::Run()
+{
+	// Hack To allow long commandlines
+	ChangeToLongCmd();
+
+	// Usage
+	if (cmd->FindExist("-?", false) || cmd->FindExist("/?", false)) {
+		PrintUsage();
+		return;
+	}
+	char *args=(char *)cmd->GetRawCmdline().c_str();
+    dosbox_title=trim(args);
+    SetVal("dosbox", "title", dosbox_title);
+    GFX_SetTitle(-1,-1,-1,false);
+}
+
+static void TITLE_ProgramStart(Program * * make) {
+    *make=new TITLE;
+}
+
 class COLOR : public Program {
 public:
     void Run(void);
@@ -7668,6 +7701,7 @@ void DOS_SetupPrograms(void) {
 	}
 
     PROGRAMS_MakeFile("COLOR.COM",COLOR_ProgramStart,"/BIN/");
+    PROGRAMS_MakeFile("TITLE.COM",TITLE_ProgramStart,"/BIN/");
     PROGRAMS_MakeFile("LS.COM",LS_ProgramStart,"/BIN/");
     PROGRAMS_MakeFile("ADDKEY.COM",ADDKEY_ProgramStart,"/BIN/");
     PROGRAMS_MakeFile("CFGTOOL.COM",CFGTOOL_ProgramStart,"/SYSTEM/");

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1814,7 +1814,8 @@ void DOSBOX_SetupConfigSections(void) {
             "This can be used to help diagnose whether the DOS game is propertly waiting for vertical retrace.");
 
     Pbool = secprop->Add_bool("cgasnow",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("When machine=cga, determines whether or not to emulate CGA snow in 80x25 text mode");
+    Pbool->Set_help("When machine=cga, determines whether or not to emulate CGA snow in 80x25 text mode.\n"
+                    "This parameter is also changeable from the builtin CGASNOW command in CGA mode.");
 
     /* Default changed to 0x04 for "Blues Brothers" at Allofich's request [https://github.com/joncampbell123/dosbox-x/issues/1273] */
     Phex = secprop->Add_hex("vga 3da undefined bits",Property::Changeable::WhenIdle,0x04);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1027,6 +1027,7 @@ void DOSBOX_RealInit() {
 
 #if defined(USE_TTF)
     if (IS_PC98_ARCH) ttf.cols = 80; // The number of columns on the screen is apparently fixed to 80 in PC-98 mode at this time
+    else if (!IS_EGAVGA_ARCH) ttf.lins = 25;
 #endif
 
     // TODO: should be parsed by motherboard emulation

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1027,7 +1027,6 @@ void DOSBOX_RealInit() {
 
 #if defined(USE_TTF)
     if (IS_PC98_ARCH) ttf.cols = 80; // The number of columns on the screen is apparently fixed to 80 in PC-98 mode at this time
-    else if (!IS_EGAVGA_ARCH) ttf.lins = 25;
 #endif
 
     // TODO: should be parsed by motherboard emulation

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -135,8 +135,7 @@ static const char *def_menu_main[] =
 #endif
 #if !defined(C_EMSCRIPTEN)//FIXME: Shutdown causes problems with Emscripten
     "--",
-#endif
-#if !defined(C_EMSCRIPTEN)//FIXME: Shutdown causes problems with Emscripten
+    "restartconf",
     "mapper_shutdown",
 #endif
     NULL

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -127,7 +127,7 @@ void RebootConfig(std::string filename, bool confirm=false) {
 #if defined(WIN32)
         ShellExecute(NULL, "open", exepath.c_str(), para.c_str(), NULL, SW_NORMAL);
 #else
-        system((exepath+" "+para).c_str());
+        system((exepath+" "+para+ " &").c_str());
 #endif
         throw(0);
     }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3683,7 +3683,7 @@ void OUTPUT_TTF_Select(int fsize=-1) {
                 r=real_readb(0x60,0x113) & 0x01 ? 25 : 20;
             } else {
                 c=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-                r=(uint16_t)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
+                r=(uint16_t)(IS_EGAVGA_ARCH?real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS):24)+1;
             }
             if (ttf.lins<1||ttf.cols<1)	{
                 if (ttf.cols<1)
@@ -3709,7 +3709,7 @@ void OUTPUT_TTF_Select(int fsize=-1) {
                 }
                 if (!IS_PC98_ARCH) {
                     real_writeb(BIOSMEM_SEG,BIOSMEM_NB_COLS,ttf.cols);
-                    real_writeb(BIOSMEM_SEG,BIOSMEM_NB_ROWS,ttf.lins-1);
+                    if (IS_EGAVGA_ARCH) real_writeb(BIOSMEM_SEG,BIOSMEM_NB_ROWS,ttf.lins-1);
                 }
             }
             firstset=false;
@@ -3720,7 +3720,7 @@ void OUTPUT_TTF_Select(int fsize=-1) {
                 r=real_readb(0x60,0x113) & 0x01 ? 25 : 20;
             } else {
                 c=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-                r=(uint16_t)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
+                r=(uint16_t)(IS_EGAVGA_ARCH?real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS):24)+1;
             }
             ttf.cols=c;
             ttf.lins=r;
@@ -6240,7 +6240,7 @@ void ClipKeySelect(int sym) {
         if (sym==SDLK_LEFT && (selmark?selecol:selscol)>0) (selmark?selecol:selscol)--;
         else if (sym==SDLK_RIGHT && (selmark?selecol:selscol)<(IS_PC98_ARCH?80:real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS))-1) (selmark?selecol:selscol)++;
         else if (sym==SDLK_UP && (selmark?selerow:selsrow)>0) (selmark?selerow:selsrow)--;
-        else if (sym==SDLK_DOWN && (selmark?selerow:selsrow)<(IS_PC98_ARCH?(real_readb(0x60,0x113)&0x01?25:20)-1:real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS))) (selmark?selerow:selsrow)++;
+        else if (sym==SDLK_DOWN && (selmark?selerow:selsrow)<(IS_PC98_ARCH?(real_readb(0x60,0x113)&0x01?25:20)-1:(IS_EGAVGA_ARCH?real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS):24))) (selmark?selerow:selsrow)++;
         Mouse_Select(selscol, selsrow, selmark?selecol:selscol, selmark?selerow:selsrow, -1, -1, true);
     }
 }
@@ -10555,7 +10555,7 @@ bool clear_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuit
     if (CurMode->mode>7&&CurMode->mode!=0x0019&&CurMode->mode!=0x0043&&CurMode->mode!=0x0054&&CurMode->mode!=0x0055&&CurMode->mode!=0x0064)
         return true;
     if (CurMode->type==M_TEXT || dos_kernel_disabled) {
-        const auto rows = real_readb(BIOSMEM_SEG, BIOSMEM_NB_ROWS);
+        const auto rows = (IS_EGAVGA_ARCH?real_readb(BIOSMEM_SEG, BIOSMEM_NB_ROWS):24);
         const auto cols = real_readw(BIOSMEM_SEG, BIOSMEM_NB_COLS);
         INT10_ScrollWindow(0, 0, rows, static_cast<uint8_t>(cols), -rows, 0x7, 0xff);
         INT10_SetCursorPos(0, 0, 0);
@@ -10661,7 +10661,7 @@ void ttf_setlines(int cols, int lins) {
     firstset=true;
     ttf_reset();
     real_writeb(BIOSMEM_SEG,BIOSMEM_NB_COLS,ttf.cols);
-    real_writeb(BIOSMEM_SEG,BIOSMEM_NB_ROWS,ttf.lins-1);
+    if (IS_EGAVGA_ARCH) real_writeb(BIOSMEM_SEG,BIOSMEM_NB_ROWS,ttf.lins-1);
     vga.draw.address_add = ttf.cols * 2;
 }
 #endif

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3440,18 +3440,6 @@ bool setColors(const char *colorArray, int n) {
 	return true;
 }
 
-bool readTTFStyle(unsigned long size, void* font, FILE * fh) {
-    size = ftell(fh);
-    if(size != -1L) {
-        font = malloc((size_t)size);
-        if(font && !fseek(fh, 0, SEEK_SET) && fread(font, 1, (size_t)size, fh) == (size_t)size) {
-            fclose(fh);
-            return true;
-        }
-    }
-    return false;
-}
-
 std::string failName="";
 bool readTTF(const char *fName, bool bold, bool ital) {
 	FILE * ttf_fh = NULL;
@@ -3535,28 +3523,17 @@ bool readTTF(const char *fName, bool bold, bool ital) {
             ttf_fh = fopen(ttfPath, "rb");
         }
     }
-    if(ttf_fh) {
-        if(!fseek(ttf_fh, 0, SEEK_END))
-        {
-            if(bold && ital) {
-                if(readTTFStyle(ttfSizebi, ttfFontbi, ttf_fh))
-                    return true;
-            }
-            else if(bold && !ital) {
-                if(readTTFStyle(ttfSizeb, ttfFontb, ttf_fh))
-                    return true;
-            }
-            else if(!bold && ital) {
-                if(readTTFStyle(ttfSizei, ttfFonti, ttf_fh))
-                    return true;
-            }
-            else {
-                if(readTTFStyle(ttfSize, ttfFont, ttf_fh))
-                    return true;
-            }
-        }
-        fclose(ttf_fh);
-    }
+    if (ttf_fh) {
+		if (!fseek(ttf_fh, 0, SEEK_END))
+			if (((bold&&ital?ttfSizebi:(bold&&!ital?ttfSizeb:(!bold&&ital?ttfSizei:ttfSize))) = ftell(ttf_fh)) != -1L)
+				if ((bold&&ital?ttfFontbi:(bold&&!ital?ttfFontb:(!bold&&ital?ttfFonti:ttfFont))) = malloc((size_t)(bold&&ital?ttfSizebi:(bold&&!ital?ttfSizeb:(!bold&&ital?ttfSizei:ttfSize)))))
+					if (!fseek(ttf_fh, 0, SEEK_SET))
+						if (fread((bold&&ital?ttfFontbi:(bold&&!ital?ttfFontb:(!bold&&ital?ttfFonti:ttfFont))), 1, (size_t)(bold&&ital?ttfSizebi:(bold&&!ital?ttfSizeb:(!bold&&ital?ttfSizei:ttfSize))), ttf_fh) == (size_t)(bold&&ital?ttfSizebi:(bold&&!ital?ttfSizeb:(!bold&&ital?ttfSizei:ttfSize)))) {
+							fclose(ttf_fh);
+							return true;
+						}
+		fclose(ttf_fh);
+	}
     if (!failName.size()||failName.compare(fName)) {
         failName=std::string(fName);
         std::string message="Could not load font file: "+std::string(fName)+(strlen(fName)<5||strcasecmp(fName+strlen(fName)-4, ".ttf")?".ttf":"");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3671,6 +3671,7 @@ void OUTPUT_TTF_Select(int fsize=-1) {
 
         ttf.lins = render_section->Get_int("ttf.lins");
         ttf.cols = render_section->Get_int("ttf.cols");
+        if (fsize&&!IS_PC98_ARCH&&!IS_EGAVGA_ARCH) ttf.lins = 25;
         if ((!CurMode||CurMode->type!=M_TEXT)&&!IS_PC98_ARCH) {
             if (ttf.cols<1) ttf.cols=80;
             if (ttf.lins<1) ttf.lins=25;

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -520,15 +520,16 @@ static void resetSize(Bitu /*val*/) {
 class VFRCRATE : public Program {
 public:
     void Run(void) {
-        WriteOut("Locks or unlocks the video refresh rate.\n\n");
         if (cmd->FindExist("/?", false)) {
+			WriteOut("Locks or unlocks the video refresh rate.\n\n");
 			WriteOut("VFRCRATE [SET [OFF|PAL|NTSC|rate]\n");
 			WriteOut("  SET OFF   Unlock the refresh rate\n");
 			WriteOut("  SET PAL   Lock to PAL frame rate\n");
 			WriteOut("  SET NTSC  Lock to NTSC frame rate\n");
 			WriteOut("  SET rate  Lock to integer frame rate, e.g. 15\n");
 			WriteOut("  SET rate  Lock to decimal frame rate, e.g. 29.97\n");
-			WriteOut("  SET rate  Lock to fractional frame rate, e.g. 60000/1001\n");
+			WriteOut("  SET rate  Lock to fractional frame rate, e.g. 60000/1001\n\n");
+			WriteOut("Type VFRCRATE without a parameter to show the current status.\n");
 			return;
 		}
         if (cmd->FindString("SET",temp_line,false))
@@ -538,7 +539,7 @@ public:
         if (TTF_using()) PIC_AddEvent(&resetSize, 1);
 #endif
         if (vga_force_refresh_rate > 0)
-            WriteOut("Video refresh rate is locked to %.3f fps\n",vga_force_refresh_rate);
+            WriteOut("Video refresh rate is locked to %.3f fps.\n",vga_force_refresh_rate);
         else
             WriteOut("Video refresh rate is unlocked.\n");
     }
@@ -559,8 +560,16 @@ public:
     /*! \brief      Program entry point, when the command is run
      */
     void Run(void) {
+        if (cmd->FindExist("/?", false)) {
+			WriteOut("Turns CGA snow emulation on or off.\n\n");
+			WriteOut("CGASNOW [ON|OFF]\n");
+			WriteOut("  ON   Turns on CGA snow emulation.\n");
+			WriteOut("  OFF  Turns off CGA snow emulation.\n\n");
+			WriteOut("Type CGASNOW without a parameter to show the current status.\n");
+			return;
+		}
         if(cmd->FindExist("ON")) {
-            WriteOut("CGA snow enabled\n");
+            WriteOut("CGA snow enabled.\n");
             enableCGASnow = 1;
             if (vga.mode == M_TEXT || vga.mode == M_TANDY_TEXT) {
                 VGA_SetupHandlers();
@@ -568,7 +577,7 @@ public:
             }
         }
         else if(cmd->FindExist("OFF")) {
-            WriteOut("CGA snow disabled\n");
+            WriteOut("CGA snow disabled.\n");
             enableCGASnow = 0;
             if (vga.mode == M_TEXT || vga.mode == M_TANDY_TEXT) {
                 VGA_SetupHandlers();
@@ -576,8 +585,7 @@ public:
             }
         }
         else {
-            WriteOut("CGA snow currently %s\n",
-                enableCGASnow ? "enabled" : "disabled");
+            WriteOut("CGA snow is currently %s.\n", enableCGASnow ? "enabled" : "disabled");
         }
     }
 };

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -7095,6 +7095,9 @@ int oldcols = 0, oldlins = 0;
 void showBIOSSetup(const char* card, int x, int y) {
     reg_eax = 3;        // 80x25 text
     CALLBACK_RunRealInt(0x10);
+#if defined(USE_TTF)
+    if (TTF_using() && (ttf.cols != 80 || ttf.lins != 25)) ttf_setlines(80, 25);
+#endif
     if (machine == MCH_PC98) {
         for (unsigned int i=0;i < (80*400);i++) {
             mem_writeb(0xA8000+i,0);        // B
@@ -8562,6 +8565,16 @@ private:
         GFX_SetTitle(-1,-1,-1,false);
         const char *msg = "DOSBox-X (C) 2011-" COPYRIGHT_END_YEAR " The DOSBox-X Team\nDOSBox-X project maintainer: joncampbell123\nDOSBox-X project homepage: https://dosbox-x.com\nDOSBox-X user guide: https://dosbox-x.com/wiki\n\n";
         bool textsplash = section->Get_bool("disable graphical splash");
+#if defined(USE_TTF)
+        if (TTF_using()) {
+            textsplash = true;
+            if (ttf.cols != 80 || ttf.lins != 25) {
+                oldcols = ttf.cols;
+                oldlins = ttf.lins;
+            } else
+                oldcols = oldlins = 0;
+        }
+#endif
         char logostr[8][30];
         strcpy(logostr[0], "+-------------------+");
         strcpy(logostr[1], "|    Welcome  To    |");
@@ -8577,17 +8590,6 @@ private:
         , SDL_STRING);
         sprintf(logostr[6], "|  Version %7s  |", VERSION);
         strcpy(logostr[7], "+-------------------+");
-#if defined(USE_TTF)
-        if (TTF_using()) {
-            textsplash = true;
-            if (ttf.cols != 80 || ttf.lins != 25) {
-                oldcols = ttf.cols;
-                oldlins = ttf.lins;
-                ttf_setlines(80, 25);
-            } else
-                oldcols = oldlins = 0;
-        }
-#endif
 startfunction:
         int logo_x,logo_y,x=2,y=2,rowheight=8;
         logo_y = 2;
@@ -8695,6 +8697,10 @@ startfunction:
             // TODO: For CGA, PCjr, and Tandy, we could render a 4-color CGA version of the same logo.
             //       And for MDA/Hercules, we could render a monochromatic ASCII art version.
         }
+
+#if defined(USE_TTF)
+        if (TTF_using() && (ttf.cols != 80 || ttf.lins != 25)) ttf_setlines(80, 25);
+#endif
 
         if (machine != MCH_PC98) {
             reg_eax = 0x0200;   // set cursor pos
@@ -9086,9 +9092,6 @@ startfunction:
         }
 #endif
 
-#if defined(USE_TTF)
-        if (TTF_using() && oldcols>0 && oldlins>0) ttf_setlines(oldcols, oldlins);
-#endif
         if (machine == MCH_PC98) {
             reg_eax = 0x4100;   // hide the graphics layer (PC-98)
             CALLBACK_RunRealInt(0x18);
@@ -9117,6 +9120,12 @@ startfunction:
             reg_eax = 3;
             CALLBACK_RunRealInt(0x10);
         }
+#if defined(USE_TTF)
+        if (TTF_using() && oldcols>0 && oldlins>0) {
+            ttf_setlines(oldcols, oldlins);
+            oldcols = oldlins = 0;
+        }
+#endif
 
         return CBRET_NONE;
     }

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -7095,9 +7095,6 @@ int oldcols = 0, oldlins = 0;
 void showBIOSSetup(const char* card, int x, int y) {
     reg_eax = 3;        // 80x25 text
     CALLBACK_RunRealInt(0x10);
-#if defined(USE_TTF)
-    if (TTF_using() && (ttf.cols != 80 || ttf.lins != 25)) ttf_setlines(80, 25);
-#endif
     if (machine == MCH_PC98) {
         for (unsigned int i=0;i < (80*400);i++) {
             mem_writeb(0xA8000+i,0);        // B
@@ -7121,9 +7118,16 @@ void showBIOSSetup(const char* card, int x, int y) {
         reg_eax = 0x0600u;
         reg_ebx = 0x1e00u;
         reg_ecx = 0x0000u;
-        reg_edx = 0x184Fu;
+        reg_edx =
+#if defined(USE_TTF)
+        TTF_using()?(ttf.lins-1)*0x100+(ttf.cols-1):
+#endif
+        0x184Fu;
         CALLBACK_RunRealInt(0x10);
     }
+#if defined(USE_TTF)
+    if (TTF_using() && (ttf.cols != 80 || ttf.lins != 25)) ttf_setlines(80, 25);
+#endif
     char title[]="                               BIOS Setup Utility                               ";
     char *p=machine == MCH_PC98?title+2:title;
     BIOS_Int10RightJustifiedPrint(x,y,p);

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -726,7 +726,7 @@ const char* Mouse_GetSelected(int x1, int y1, int x2, int y2, int w, int h, uint
 		r=real_readb(0x60,0x113) & 0x01 ? 25 : 20;
 	} else {
 		c=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-		r=(uint16_t)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
+		r=(uint16_t)(IS_EGAVGA_ARCH?real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS):24)+1;
 	}
     int c1=x1, r1=y1, c2=x2, r2=y2, t;
     if (w>0&&h>0) {
@@ -790,7 +790,7 @@ void Mouse_Select(int x1, int y1, int x2, int y2, int w, int h, bool select) {
         r=real_readb(0x60,0x113) & 0x01 ? 25 : 20;
     } else {
         c=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-        r=(uint16_t)real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
+        r=(uint16_t)(IS_EGAVGA_ARCH?real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS):24)+1;
     }
     if (w>0&&h>0) {
         c1=c*x1/w;

--- a/src/misc/savestates.cpp
+++ b/src/misc/savestates.cpp
@@ -9,6 +9,7 @@
 #include "menu.h"
 #include "shell.h"
 #include "cross.h"
+#include "render.h"
 #include "mapper.h"
 #include "control.h"
 #include "logging.h"
@@ -45,7 +46,7 @@ bool noremark_save_state = false;
 bool force_load_state = false;
 std::string saveloaderr="";
 void refresh_slots(void);
-void GFX_LosingFocus(void), MAPPER_ReleaseAllKeys(void);
+void GFX_LosingFocus(void), MAPPER_ReleaseAllKeys(void), resetFontSize(void);
 bool systemmessagebox(char const * aTitle, char const * aMessage, char const * aDialogType, char const * aIconType, int aDefaultButton);
 namespace
 {
@@ -190,6 +191,9 @@ void LoadGameState(bool pressed) {
     {
         LOG_MSG("Loading state from slot: %d", (int)currentSlot + 1);
         SaveState::instance().load(currentSlot);
+#if defined(USE_TTF)
+        if (ttf.inUse) resetFontSize();
+#endif
     }
     catch (const SaveState::Error& err)
     {

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -610,7 +610,7 @@ size_t GetPauseCount() {
 	if (IS_PC98_ARCH)
 		rows=real_readb(0x60,0x113) & 0x01 ? 25 : 20;
 	else
-		rows=real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
+		rows=(IS_EGAVGA_ARCH?real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS):24)+1;
 	return (rows > 3u) ? (rows - 3u) : 22u;
 }
 
@@ -2689,7 +2689,7 @@ void DOS_Shell::CMD_MORE(char * args) {
 		LINES=real_readb(0x60,0x113) & 0x01 ? 25 : 20;
 		COLS=80;
 	} else {
-		LINES=real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS)+1;
+		LINES=(IS_EGAVGA_ARCH?real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS):24)+1;
 		COLS=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
 	}
 	LINES--;


### PR DESCRIPTION
This PR adds the menu option in the "Main" menu to automatically restart DOSBox-X with the selected config file so that DOSBox-X will re-load itself with a new configuration file that may be completely different from the current one, similar to the ```config -bc``` command-line option I added previously. Also added/updated help messages for commands like CGASNOW and VFRCRATE, and a TITLE.COM program in Z:\BIN to change the DOSBox-X window title, along with smaller fixes.

P.S. I noticed that the fix in PR #2513 by @Allofich seems to break the readTTF function for different TTF styles. That PR was intended to reformat the code style, but unfortunately it did not work as expected for this function. So I reverted this to the previous code to make it work again.