### PR TITLE
SVN commits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,9 @@
   - Integrated SVN commits (Allofich)
     - r4443: Improve detection of Paradise SVGA in some
     installers with additional signature.
+    - Improve bittest instructions to wrap more
+    correctly. 
+    - r4454: Enable A20 routines in BIOS.
 0.83.13
   - DOSBox-X can now resolve file paths in its config
     options that include environment variables on non-

--- a/src/cpu/core_normal/helpers.h
+++ b/src/cpu/core_normal/helpers.h
@@ -168,3 +168,13 @@
 #define CASE_0F_B(_WHICH)						\
 	CASE_0F_W(_WHICH)							\
 	CASE_0F_D(_WHICH)
+
+#define FixEA16 do {							\
+		switch (rm & 7) {						\
+			case 6:	if (rm < 0x40) break;		\
+			case 2:								\
+			case 3:								\
+				BaseDS=BaseSS;					\
+		}										\
+		eaa=BaseDS+(uint16_t)(eaa-BaseDS);        \
+	} while(0)

--- a/src/cpu/core_normal/prefix_0f.h
+++ b/src/cpu/core_normal/prefix_0f.h
@@ -400,6 +400,7 @@
 				SETFLAGBIT(CF,(*earw & mask));
 			} else {
 				GetEAa;eaa+=(PhysPt)((((int16_t)*rmrw)>>4)*2);
+				if (!TEST_PREFIX_ADDR) FixEA16;
 				uint16_t old=LoadMw(eaa);
 				SETFLAGBIT(CF,(old & mask));
 			}
@@ -431,6 +432,7 @@
 				*earw|=mask;
 			} else {
 				GetEAa;eaa+=(PhysPt)((((int16_t)*rmrw)>>4)*2);
+				if (!TEST_PREFIX_ADDR) FixEA16;
 				uint16_t old=LoadMw(eaa);
 				SETFLAGBIT(CF,(old & mask));
 				SaveMw(eaa,old | mask);
@@ -526,6 +528,7 @@
 				*earw&= ~mask;
 			} else {
 				GetEAa;eaa+=(PhysPt)((((int16_t)*rmrw)>>4)*2);
+				if (!TEST_PREFIX_ADDR) FixEA16;
 				uint16_t old=LoadMw(eaa);
 				SETFLAGBIT(CF,(old & mask));
 				SaveMw(eaa,old & ~mask);
@@ -625,6 +628,7 @@
 				*earw^=mask;
 			} else {
 				GetEAa;eaa+=(PhysPt)((((int16_t)*rmrw)>>4)*2);
+				if (!TEST_PREFIX_ADDR) FixEA16;
 				uint16_t old=LoadMw(eaa);
 				SETFLAGBIT(CF,(old & mask));
 				SaveMw(eaa,old ^ mask);

--- a/src/cpu/core_normal/prefix_66_0f.h
+++ b/src/cpu/core_normal/prefix_66_0f.h
@@ -242,6 +242,7 @@
 				SETFLAGBIT(CF,(*eard & mask));
 			} else {
 				GetEAa;eaa+=(PhysPt)((((int32_t)*rmrd)>>5)*4);
+				if (!TEST_PREFIX_ADDR) FixEA16;
 				uint32_t old=LoadMd(eaa);
 				SETFLAGBIT(CF,(old & mask));
 			}
@@ -268,6 +269,7 @@
 				*eard|=mask;
 			} else {
 				GetEAa;eaa+=(PhysPt)((((int32_t)*rmrd)>>5)*4);
+				if (!TEST_PREFIX_ADDR) FixEA16;
 				uint32_t old=LoadMd(eaa);
 				SETFLAGBIT(CF,(old & mask));
 				SaveMd(eaa,old | mask);
@@ -333,6 +335,7 @@
 				*eard&= ~mask;
 			} else {
 				GetEAa;eaa+=(PhysPt)((((int32_t)*rmrd)>>5)*4);
+				if (!TEST_PREFIX_ADDR) FixEA16;
 				uint32_t old=LoadMd(eaa);
 				SETFLAGBIT(CF,(old & mask));
 				SaveMd(eaa,old & ~mask);
@@ -428,6 +431,7 @@
 				*eard^=mask;
 			} else {
 				GetEAa;eaa+=(PhysPt)((((int32_t)*rmrd)>>5)*4);
+				if (!TEST_PREFIX_ADDR) FixEA16;
 				uint32_t old=LoadMd(eaa);
 				SETFLAGBIT(CF,(old & mask));
 				SaveMd(eaa,old ^ mask);

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -5751,7 +5751,33 @@ static Bitu INT15_Handler(void) {
     }
     switch (reg_ah) {
     case 0x06:
-        LOG(LOG_BIOS,LOG_NORMAL)("INT15 Unkown Function 6 (Amstrad?)");
+        LOG(LOG_BIOS,LOG_NORMAL)("INT15 Unknown Function 6 (Amstrad?)");
+        break;
+    case 0x24:      //A20 stuff
+        switch (reg_al) {
+        case 0: //Disable a20
+            MEM_A20_Enable(false);
+            reg_ah = 0;                   //call successful
+            CALLBACK_SCF(false);             //clear on success
+            break;
+        case 1: //Enable a20
+            MEM_A20_Enable( true );
+            reg_ah = 0;                   //call successful
+            CALLBACK_SCF(false);             //clear on success
+            break;
+        case 2: //Query a20
+            reg_al = MEM_A20_Enabled() ? 0x1 : 0x0;
+            reg_ah = 0;                   //call successful
+            CALLBACK_SCF(false);
+            break;
+        case 3: //Get a20 support
+            reg_bx = 0x3;       //Bitmask, keyboard and 0x92
+            reg_ah = 0;         //call successful
+            CALLBACK_SCF(false);
+            break;
+        default:
+            goto unhandled;
+        }
         break;
     case 0xC0:  /* Get Configuration*/
         CPU_SetSegGeneral(es,biosConfigSeg);
@@ -6550,6 +6576,7 @@ static Bitu INT15_Handler(void) {
                 }
                 break;
             default:
+            unhandled:
                 LOG(LOG_BIOS,LOG_ERROR)("INT15:Unknown call ah=E8, al=%2X",reg_al);
                 reg_ah=0x86;
                 CALLBACK_SCF(true);


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/4453/ - In this PR
https://sourceforge.net/p/dosbox/code-0/4454/ - In this PR

@joncampbell123 (and maybe @Wengier), I imagine 4454 may be of interest to you, as it deals with the A20 gate that DOSBox-X has various options for. DOSBox-X's `INT15_Handler` function didn't have a case 0x24, which this commit adds, so it seems like a positive addition, but I don't know if it might interfere in some way with existing A20 related code or options in DOSBox-X.