### PR TITLE
Warning fixes

### DIFF
--- a/include/mem.h
+++ b/include/mem.h
@@ -145,7 +145,7 @@ static INLINE void host_writeq(HostPt const off,const uint64_t val) {
 
 
 static INLINE void var_write(uint8_t * const var, const uint8_t val) {
-    host_writeb((HostPt)var, val);
+    host_writeb(var, val);
 }
 
 static INLINE void var_write(uint16_t * const var, const uint16_t val) {
@@ -219,32 +219,32 @@ void mem_strcpy(PhysPt dest,PhysPt src);
 /* The folowing functions are all shortcuts to the above functions using physical addressing */
 
 static inline constexpr PhysPt PhysMake(const uint16_t seg,const uint16_t off) {
-    return ((PhysPt)seg << (PhysPt)4U) + (PhysPt)off;
+    return ((PhysPt)seg << 4U) + (PhysPt)off;
 }
 
 static inline constexpr uint16_t RealSeg(const RealPt pt) {
-    return (uint16_t)((RealPt)pt >> (RealPt)16U);
+    return (uint16_t)(pt >> 16U);
 }
 
 static inline constexpr uint16_t RealOff(const RealPt pt) {
-    return (uint16_t)((RealPt)pt & (RealPt)0xffffu);
+    return (uint16_t)(pt & 0xffffu);
 }
 
 static inline constexpr PhysPt Real2Phys(const RealPt pt) {
-    return (PhysPt)(((PhysPt)RealSeg(pt) << (PhysPt)4U) + (PhysPt)RealOff(pt));
+    return (((PhysPt)RealSeg(pt) << 4U) + (PhysPt)RealOff(pt));
 }
 
 static inline constexpr RealPt RealMake(const uint16_t seg,const uint16_t off) {
-    return (RealPt)(((RealPt)seg << (RealPt)16U) + (RealPt)off);
+    return (((RealPt)seg << 16U) + (RealPt)off);
 }
 
 /* convert physical address to 4:16 real pointer (example: 0xABCDE -> 0xA000:0xBCDE) */
 static inline constexpr RealPt PhysToReal416(const PhysPt phys) {
-    return RealMake((uint16_t)(((PhysPt)phys >> (PhysPt)4U) & (PhysPt)0xF000U),(uint16_t)((PhysPt)phys & (PhysPt)0xFFFFU));
+    return RealMake((uint16_t)((phys >> 4U) & 0xF000U),(uint16_t)(phys & 0xFFFFU));
 }
 
 static inline constexpr PhysPt RealVecAddress(const uint8_t vec) {
-    return (PhysPt)((unsigned int)vec << 2U);
+    return ((unsigned int)vec << 2U);
 }
 
 
@@ -274,7 +274,7 @@ static INLINE RealPt RealGetVec(const uint8_t vec) {
 }
 
 static INLINE void RealSetVec(const uint8_t vec,const RealPt pt) {
-    mem_writed(RealVecAddress(vec),(uint32_t)pt);
+    mem_writed(RealVecAddress(vec),pt);
 }
 
 static INLINE void RealSetVec(const uint8_t vec,const RealPt pt,RealPt &old) {

--- a/src/dos/cdrom.cpp
+++ b/src/dos/cdrom.cpp
@@ -134,7 +134,6 @@ bool CDROM_Interface_SDL::GetAudioSub(unsigned char& attr, unsigned char& track,
 		FRAMES_TO_MSF((unsigned int)cd->cur_frame+cd->track[track].offset,&absPos.min,&absPos.sec,&absPos.fr);
 	}
 	return CD_INDRIVE(SDL_CDStatus(cd));		
-    return false;
 }
 
 bool CDROM_Interface_SDL::GetAudioStatus(bool& playing, bool& pause){

--- a/src/dos/cdrom.cpp
+++ b/src/dos/cdrom.cpp
@@ -107,7 +107,6 @@ bool CDROM_Interface_SDL::GetAudioTracks(int& stTrack, int& end, TMSF& leadOut) 
 		FRAMES_TO_MSF(cd->track[cd->numtracks].offset,&leadOut.min,&leadOut.sec,&leadOut.fr);
 	}
 	return CD_INDRIVE(SDL_CDStatus(cd));
-    return false;
 }
 
 bool CDROM_Interface_SDL::GetAudioTrackInfo(int track, TMSF& start, unsigned char& attr) {

--- a/src/dos/cdrom.cpp
+++ b/src/dos/cdrom.cpp
@@ -117,7 +117,7 @@ bool CDROM_Interface_SDL::GetAudioTrackInfo(int track, TMSF& start, unsigned cha
 		FRAMES_TO_MSF(cd->track[track-1].offset,&start.min,&start.sec,&start.fr);
 		attr	= cd->track[track-1].type<<4;//sdl uses 0 for audio and 4 for data. instead of 0x00 and 0x40
 	}
-	return CD_INDRIVE(SDL_CDStatus(cd));	
+	return CD_INDRIVE(SDL_CDStatus(cd));
 }
 
 bool CDROM_Interface_SDL::GetAudioSub(unsigned char& attr, unsigned char& track, unsigned char& index, TMSF& relPos, TMSF& absPos) {
@@ -133,7 +133,7 @@ bool CDROM_Interface_SDL::GetAudioSub(unsigned char& attr, unsigned char& track,
 		FRAMES_TO_MSF((unsigned int)cd->cur_frame,&relPos.min,&relPos.sec,&relPos.fr);
 		FRAMES_TO_MSF((unsigned int)cd->cur_frame+cd->track[track].offset,&absPos.min,&absPos.sec,&absPos.fr);
 	}
-	return CD_INDRIVE(SDL_CDStatus(cd));		
+	return CD_INDRIVE(SDL_CDStatus(cd));
 }
 
 bool CDROM_Interface_SDL::GetAudioStatus(bool& playing, bool& pause){

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1619,7 +1619,7 @@ static Bitu DOS_21Handler(void) {
                     MEM_BlockWrite(SegPhys(ds)+reg_dx,dos_copybuf,toread);
                     reg_ax=toread;
 #if defined(USE_TTF)
-                    if (ttf.inUse && reg_bx == WPvga512CHMhandle)
+                    if (ttf.inUse && reg_bx == WPvga512CHMhandle){
                         if (toread == 26 || toread == 2) {
                             if (toread == 2)
                                 WP5chars = *(uint16_t*)dos_copybuf;
@@ -1636,6 +1636,7 @@ static Bitu DOS_21Handler(void) {
                             WPvga512CHMhandle = -1;
                             WPvga512CHMcheck = false;
                         }
+                    }
 #endif
                     CALLBACK_SCF(false);
                 }

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -2512,7 +2512,7 @@ static Bitu DOS_21Handler(void) {
 					info->available_allocation_units = freec?freec:free_clusters;
 					info->total_allocation_units = totalc?totalc:total_clusters;
 					MEM_BlockWrite(SegPhys(es)+reg_di,info,sizeof(ext_space_info_t));
-					delete(info);
+					delete info;
 					reg_ax=0;
 					CALLBACK_SCF(false);
 				}

--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -113,7 +113,7 @@ void DOS_UpdatePSPName(void) {
 void DOS_Terminate(uint16_t pspseg,bool tsr,uint8_t exitcode) {
 
 	dos.return_code=exitcode;
-	dos.return_mode=(tsr)?(uint8_t)RETURN_TSR:(uint8_t)RETURN_EXIT;
+	dos.return_mode=tsr?(uint8_t)RETURN_TSR:(uint8_t)RETURN_EXIT;
 	
 	DOS_PSP curpsp(pspseg);
 	if (pspseg==curpsp.GetParent()) return;

--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -754,7 +754,6 @@ bool DOS_IOCTL(void) {
 				return false;
 			}
 		}
-		break;
 	case 0x0E:			/* Get Logical Drive Map */
 		if (drive < 2) {
 			if (Drives[drive]) reg_al=drive+1;

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -3278,7 +3278,6 @@ restart_int:
                     break;
                 default:
                     abort();
-                    break;
             }
 
             /* FAT32 increases reserved area to at least 7. Microsoft likes to use 32 */
@@ -3387,7 +3386,7 @@ restart_int:
                         case 12:    tmp_fatlimit = ((((vol_sectors / 20u) * (512u / fat_copies)) / 3u) * 2u) + 2u; break;
                         case 16:    tmp_fatlimit =  (((vol_sectors / 20u) * (512u / fat_copies)) / 2u)       + 2u; break;
                         case 32:    tmp_fatlimit =  (((vol_sectors / 20u) * (512u / fat_copies)) / 4u)       + 2u; break;
-                        default:    abort(); break;
+                        default:    abort();
                     }
 
                     while ((vol_sectors/sectors_per_cluster) >= (tmp_fatlimit - 2u) && sectors_per_cluster < 0x80u) sectors_per_cluster <<= 1;
@@ -7101,7 +7100,6 @@ public:
             }
             return;
         }
-        return;
     }
     void printHelp()
     {

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -2339,14 +2339,22 @@ uint8_t fatDrive::Write_AbsoluteSector_INT25(uint32_t sectnum, void * data) {
 
 static void copyDirEntry(const direntry *src, direntry *dst) {
 	memcpy(dst, src, 14); // single byte fields
-	var_write(&dst->crtTime, src->crtTime);
-	var_write(&dst->crtDate, src->crtDate);
-	var_write(&dst->accessDate, src->accessDate);
-	var_write(&dst->hiFirstClust, src->hiFirstClust);
-	var_write(&dst->modTime, src->modTime);
-	var_write(&dst->modDate, src->modDate);
-	var_write(&dst->loFirstClust, src->loFirstClust);
-	var_write(&dst->entrysize, src->entrysize);
+    void* var = &dst->crtTime;
+	var_write((uint16_t*)var, src->crtTime);
+    var = &dst->crtDate;
+	var_write((uint16_t*)var, src->crtDate);
+    var = &dst->accessDate;
+	var_write((uint16_t*)var, src->accessDate);
+    var = &dst->hiFirstClust;
+	var_write((uint16_t*)var, src->hiFirstClust);
+    var = &dst->modTime;
+	var_write((uint16_t*)var, src->modTime);
+    var = &dst->modDate;
+	var_write((uint16_t*)var, src->modDate);
+    var = &dst->loFirstClust;
+	var_write((uint16_t*)var, src->loFirstClust);
+    var = &dst->entrysize;
+	var_write((uint32_t*)var, src->entrysize);
 }
 
 bool fatDrive::FindNextInternal(uint32_t dirClustNumber, DOS_DTA &dta, direntry *foundEntry) {

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1668,16 +1668,26 @@ void fatDrive::fatDriveInit(const char *sysFilename, uint32_t bytesector, uint32
             }
         }
 
-        bootbuffer.bpb.v.BPB_BytsPerSec = var_read(&bootbuffer.bpb.v.BPB_BytsPerSec);
-        bootbuffer.bpb.v.BPB_RsvdSecCnt = var_read(&bootbuffer.bpb.v.BPB_RsvdSecCnt);
-        bootbuffer.bpb.v.BPB_RootEntCnt = var_read(&bootbuffer.bpb.v.BPB_RootEntCnt);
-        bootbuffer.bpb.v.BPB_TotSec16 = var_read(&bootbuffer.bpb.v.BPB_TotSec16);
-        bootbuffer.bpb.v.BPB_FATSz16 = var_read(&bootbuffer.bpb.v.BPB_FATSz16);
-        bootbuffer.bpb.v.BPB_SecPerTrk = var_read(&bootbuffer.bpb.v.BPB_SecPerTrk);
-        bootbuffer.bpb.v.BPB_NumHeads = var_read(&bootbuffer.bpb.v.BPB_NumHeads);
-        bootbuffer.bpb.v.BPB_HiddSec = var_read(&bootbuffer.bpb.v.BPB_HiddSec);
-        bootbuffer.bpb.v.BPB_TotSec32 = var_read(&bootbuffer.bpb.v.BPB_TotSec32);
-        bootbuffer.bpb.v.BPB_VolID = var_read(&bootbuffer.bpb.v.BPB_VolID);
+        void* var = &bootbuffer.bpb.v.BPB_BytsPerSec;
+        bootbuffer.bpb.v.BPB_BytsPerSec = var_read((uint16_t*)var);
+        var = &bootbuffer.bpb.v.BPB_RsvdSecCnt;
+        bootbuffer.bpb.v.BPB_RsvdSecCnt = var_read((uint16_t*)var);
+        var = &bootbuffer.bpb.v.BPB_RootEntCnt;
+        bootbuffer.bpb.v.BPB_RootEntCnt = var_read((uint16_t*)var);
+        var = &bootbuffer.bpb.v.BPB_TotSec16;
+        bootbuffer.bpb.v.BPB_TotSec16 = var_read((uint16_t*)var);
+        var = &bootbuffer.bpb.v.BPB_FATSz16;
+        bootbuffer.bpb.v.BPB_FATSz16 = var_read((uint16_t*)var);
+        var = &bootbuffer.bpb.v.BPB_SecPerTrk;
+        bootbuffer.bpb.v.BPB_SecPerTrk = var_read((uint16_t*)var);
+        var = &bootbuffer.bpb.v.BPB_NumHeads;
+        bootbuffer.bpb.v.BPB_NumHeads = var_read((uint16_t*)var);
+        var = &bootbuffer.bpb.v.BPB_HiddSec;
+        bootbuffer.bpb.v.BPB_HiddSec = var_read((uint32_t*)var);
+        var = &bootbuffer.bpb.v.BPB_TotSec32;
+        bootbuffer.bpb.v.BPB_TotSec32 = var_read((uint32_t*)var);
+        var = &bootbuffer.bpb.v.BPB_VolID;
+        bootbuffer.bpb.v.BPB_VolID = var_read((uint32_t*)var);
 
         if (!is_hdd) {
             /* Identify floppy format */

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1130,7 +1130,6 @@ uint32_t fatDrive::appendCluster(uint32_t startCluster) {
 			break;
 		default:
 			abort();
-			break;
 	}
 
 	while (1) {

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -423,8 +423,6 @@ bool CodePageHostToGuest(char *d/*CROSS_LEN*/,const host_cnv_char_t *s/*CROSS_LE
             }
             return String_HOST_TO_ASCII(d,s);
     }
-
-    return false;
 }
 
 bool CodePageGuestToHostUint16(uint16_t *d/*CROSS_LEN*/,const char *s/*CROSS_LEN*/) {
@@ -470,8 +468,6 @@ bool CodePageGuestToHostUint16(uint16_t *d/*CROSS_LEN*/,const char *s/*CROSS_LEN
         default: // Otherwise just use code page 437
             return String_SBCS_TO_HOST_uint16<uint16_t>(d,s,cp437_to_unicode,sizeof(cp437_to_unicode)/sizeof(cp437_to_unicode[0]));
     }
-
-    return false;
 }
 
 bool CodePageGuestToHost(host_cnv_char_t *d/*CROSS_LEN*/,const char *s/*CROSS_LEN*/) {
@@ -523,8 +519,6 @@ bool CodePageGuestToHost(host_cnv_char_t *d/*CROSS_LEN*/,const char *s/*CROSS_LE
             }
             return String_ASCII_TO_HOST(d,s);
     }
-
-    return false;
 }
 
 host_cnv_char_t *CodePageGuestToHost(const char *s) {

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -2485,7 +2485,7 @@ public:
             else if (helpcmd=="RD") helpcmd="RMDIR";
             else if (helpcmd=="REN") helpcmd="RENAME";
             std::string helpinfo=std::string(MSG_Get(("SHELL_CMD_"+helpcmd+"_HELP").c_str()))+"\n"+std::string(MSG_Get(("SHELL_CMD_"+helpcmd+"_HELP_LONG").c_str()));
-            std::istringstream in(str_replace(str_replace(str_replace(str_replace((char *)helpinfo.c_str(), "%%", "%"), "\033[0m", ""), "\033[33;1m", ""), "\033[37;1m", ""));
+            std::istringstream in(str_replace(str_replace(str_replace(str_replace((char *)helpinfo.c_str(), (char*)"%%", (char*)"%"), (char*)"\033[0m", (char*)""), (char*)"\033[33;1m", (char*)""), (char*)"\033[37;1m", (char*)""));
             int r=0;
             if (in)	for (std::string line; std::getline(in, line); ) {
                 r+=25;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5540,7 +5540,7 @@ static void GUI_StartUp() {
         SDL_putenv(pos);
 #endif
     } else
-        putenv("SDL_VIDEO_CENTERED=center");
+        putenv((char*)"SDL_VIDEO_CENTERED=center");
 #endif
 
 /* Initialize screen for first time */
@@ -10514,7 +10514,7 @@ bool toOutput(const char *what) {
 #endif
         }
 #if !defined(C_SDL2)
-        putenv("SDL_VIDEO_CENTERED=center");
+        putenv((char*)"SDL_VIDEO_CENTERED=center");
 #endif
         firstset=false;
         change_output(10);

--- a/src/hardware/RetroWaveLib/Board/OPL3.c
+++ b/src/hardware/RetroWaveLib/Board/OPL3.c
@@ -19,7 +19,7 @@
 
 #include "OPL3.h"
 
-static const int transfer_speed = 2e6;
+static const int transfer_speed = (const int)2e6;
 
 void retrowave_opl3_queue_port0(RetroWaveContext *ctx, uint8_t reg, uint8_t val) {
 	retrowave_cmd_buffer_init(ctx, RetroWave_Board_OPL3, 0x12);


### PR DESCRIPTION
Fixes for Clang warnings, one MSVC warning fix, and removal of some redundant casts, statements and parentheses (identified by a static analyzer).