### PR TITLE
Warning fixes + cleanup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -54,7 +54,7 @@
   - Integrated SVN commits (Allofich)
     - r4443: Improve detection of Paradise SVGA in some
     installers with additional signature.
-    - Improve bittest instructions to wrap more
+    - r4453: Improve bittest instructions to wrap more
     correctly. 
     - r4454: Enable A20 routines in BIOS.
 0.83.13

--- a/src/dos/dos_memory.cpp
+++ b/src/dos/dos_memory.cpp
@@ -541,7 +541,7 @@ void DOS_SetupMemory(void) {
 	if (enable_dummy_device_mcb) {
 		// Create a dummy device MCB with PSPSeg=0x0008
         LOG_MSG("Dummy device MCB at segment 0x%x",DOS_MEM_START+mcb_sizes);
-		DOS_MCB mcb_devicedummy((uint16_t)DOS_MEM_START+mcb_sizes);
+		DOS_MCB mcb_devicedummy(DOS_MEM_START+mcb_sizes);
 		mcb_devicedummy.SetPSPSeg(MCB_DOS);	// Devices
 		mcb_devicedummy.SetSize(16);
 		mcb_devicedummy.SetType(0x4d);		// More blocks will follow
@@ -553,7 +553,7 @@ void DOS_SetupMemory(void) {
 //		mcb_devicedummy.SetFileName("SD      ");
 	}
 
-	DOS_MCB mcb((uint16_t)DOS_MEM_START+mcb_sizes);
+	DOS_MCB mcb(DOS_MEM_START+mcb_sizes);
 	mcb.SetPSPSeg(MCB_FREE);						//Free
 	mcb.SetType(0x5a);								//Last Block
 	if (machine==MCH_TANDY) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -7813,7 +7813,7 @@ void GFX_Events() {
 
     static Bitu iPasteTicker = 0;
     if (paste_speed && (iPasteTicker++ % paste_speed) == 0) { // emendelson: was 20 - good for WP51; Wengier: changed to 30 for better compatibility
-        int len = strPasteBuffer.length();
+        int len = (int)strPasteBuffer.length();
         PasteClipboardNext();   // end added emendelson from dbDOS; improved by Wengier
 #if defined(USE_TTF)
         bool isDBCSCP();

--- a/src/hardware/RetroWaveLib/Protocol/Serial.c
+++ b/src/hardware/RetroWaveLib/Protocol/Serial.c
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 uint32_t retrowave_protocol_serial_packed_length(uint32_t len_in) {
-	return ceil((double)len_in * 8 / 7) + 2;
+	return (uint32_t)(ceil((double)len_in * 8 / 7) + 2);
 }
 
 uint32_t retrowave_protocol_serial_pack(const void *_buf_in, uint32_t len_in, void *_buf_out) {

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -1148,7 +1148,7 @@ bool mem_unalignedreadw_checked(PhysPt address, uint16_t * val) {
     uint8_t rval1,rval2;
     if (mem_readb_checked(address+0, &rval1)) return true;
     if (mem_readb_checked(address+1, &rval2)) return true;
-    *val=(uint16_t)(((uint8_t)rval1) | (((uint8_t)rval2) << 8));
+    *val=(uint16_t)(rval1 | (rval2 << 8));
     return false;
 }
 
@@ -1158,7 +1158,7 @@ bool mem_unalignedreadd_checked(PhysPt address, uint32_t * val) {
     if (mem_readb_checked(address+1, &rval2)) return true;
     if (mem_readb_checked(address+2, &rval3)) return true;
     if (mem_readb_checked(address+3, &rval4)) return true;
-    *val=(uint32_t)(((uint8_t)rval1) | (((uint8_t)rval2) << 8) | (((uint8_t)rval3) << 16) | (((uint8_t)rval4) << 24));
+    *val=(uint32_t)(rval1 | (rval2 << 8) | (rval3 << 16) | (rval4 << 24));
     return false;
 }
 

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -219,7 +219,6 @@ struct PIT_Block {
                 if (new_mode) return false;
                 if (res.cycle != 0u/*index > delay*/) return true;
                 else return false;
-                break;
             case 2:
                 if (new_mode) return true;
                 return res.counter != 0;


### PR DESCRIPTION
Fixes for -Wdeprecated-declarations warnings in Clang about deprecated PHYSFS functions.

I silenced the warnings by replacing them with the contents of the deprecated functions, which would already call the recommended replacement functions. While doing so I removed a few unnecessary calculations, etc. that would have been done by the old functions (dividing a value by another value that in these cases will always be 1, etc.)

I was careful to keep the original code's logic but I'm not sure how to test to be sure that everything works. I tried running a game, loading a saved game in it, saving a game and then loading, and that all worked fine. Creating/removing a directory, creating, editing/saving/deleting a file, listing directory contents, and changing directory from the DOS prompt all worked fine.

Also removed some more redundant casts, parentheses and a break statement, as identified by static analysis, a couple type conversion warnings, and I added the SVN commit number from my previous PR that I left out of the CHANGELOG file.