### PR TITLE
Fix warnings

### DIFF
--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -3069,7 +3069,7 @@ bool physfsFile::Write(const uint8_t * data,uint16_t * size) {
 			return false;
 		}
 	} else {
-		PHYSFS_sint64 mysize = PHYSFS_write(fhandle,data,1,(PHYSFS_uint64)*size);
+		PHYSFS_sint64 mysize = PHYSFS_writeBytes(fhandle, data, *size);
 		//LOG_MSG("Wrote %i bytes (wanted %i) at %i of %s (%s)",(int)mysize,(int)*size,(int)PHYSFS_tell(fhandle),name,PHYSFS_getLastError());
 		*size = (uint16_t)mysize;
 		return true;

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1854,7 +1854,7 @@ protected:
 public:
     ShowMixerInfo(GUI::Screen *parent, int x, int y, const char *title) :
         ToplevelWindow(parent, x, y, 350, 270, title) {
-            std::string mixerinfo();
+            extern std::string mixerinfo();
             std::istringstream in(mixerinfo().c_str());
             int r=0;
             if (in)	for (std::string line; std::getline(in, line); ) {
@@ -1915,7 +1915,7 @@ public:
                 else if (name=="fluidsynth") name="FluidSynth";
                 else name[0]=toupper(name[0]);
             }
-            std::string getoplmode(), getoplemu();
+            extern std::string getoplmode(), getoplemu();
             std::string midiinfo = "MIDI available: "+std::string(midi.available?"Yes":"No")+"\nMIDI device: "+name+"\nMIDI soundfont file / ROM path:\n"+sffile+"\nOPL mode: "+getoplmode()+"\nOPL emulation: "+getoplemu();
             std::istringstream in(midiinfo.c_str());
             int r=0;
@@ -2082,7 +2082,7 @@ protected:
 public:
     ShowIDEInfo(GUI::Screen *parent, int x, int y, const char *title) :
         ToplevelWindow(parent, x, y, 300, 210, title) {
-            std::string GetIDEInfo();
+            extern std::string GetIDEInfo();
             std::istringstream in(GetIDEInfo().c_str());
             int r=0;
             if (in)	for (std::string line; std::getline(in, line); ) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -267,7 +267,8 @@ static bool PasteClipboardNext();
 #if C_DIRECT3D
 void d3d_init(void);
 #endif
-bool TTF_using(void), isDBCSCP();
+bool TTF_using(void);
+extern bool isDBCSCP();
 void ShutDownMemHandles(Section * sec);
 void resetFontSize(), decreaseFontSize();
 void MAPPER_ReleaseAllKeys(), GFX_ReleaseMouse();


### PR DESCRIPTION
Fixes Clang "vexing parse" warnings by marking the function calls `extern`, as is already done elsewhere for  `isDBCSCP()`, for example.

Also fixes a deprecated function warning for a `PHYSFS_write` call that was still there.