### PR TITLE
macOS menu Unicode support etc

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -43,7 +43,7 @@
     a DOS code page with "country" option in [config]
     section of the config file. The Windows SDL1 menu
     and the macOS menu are now also compatible with
-    Unicode language files. (Wengier)
+    Unicode language files and characters. (Wengier)
   - Cleaned up some messages that involve box-drawing
     characters (such as the welcome banner) for easier
     translations to certain languages. (Wengier)
@@ -86,8 +86,11 @@
   - Added menu options "Generate NMI interrupt" & "Hook
     INT 2Fh calls" ("Help" => "Debugging options") for
     more debugging options. (Wengier)
-  - Fixed mouse not automatically captured as DOSBox-X
-    starts with the setting fullscreen=true. (Wengier)
+  - Fixed the mouse not automatically captured when
+    DOSBox-X starts with the settings fullscreen=true
+    and autolock=true. (Wengier)
+  - Fixed keys may not work after loading a saved state
+    for the game Buck Rogers. (Wengier)
   - Fixed issues related to screen dimensions in TTF
     output in CGA/EGA modes since 0.83.12. (Wengier)
   - Integrated SVN commits (Allofich)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -41,7 +41,9 @@
     between DBCS and SBCS modes temporarily. (Wengier)
   - Support for UTF-8 encoded language files. Specify
     a DOS code page with "country" option in [config]
-    section of the config file. (Wengier)
+    section of the config file. The Windows SDL1 menu
+    and the macOS menu are now also compatible with
+    Unicode language files. (Wengier)
   - Cleaned up some messages that involve box-drawing
     characters (such as the welcome banner) for easier
     translations to certain languages. (Wengier)
@@ -51,6 +53,9 @@
     config file will use the default IRQ number for the
     sound card type. Also fixed "irq=-1", "dma=-1" and
     "hdma=-1" not working as desired. (Wengier)
+  - Option "dpi aware=auto" now defaults to "true" when
+    full-screen mode is requested when DOSBox-X starts
+    in Windows SDL1 builds. (Wengier)
   - The return value of AL in Int21/AX=0Eh is no longer
     fixed. The game Jurassic Park may run after moving
     Z drive to a different letter (e.g. E:). (Wengier)

--- a/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
+++ b/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
@@ -10,7 +10,7 @@
     <category>Emulation</category>
   </categories>
   <releases>
-          <release version="@PACKAGE_VERSION@" date="2021-5-14"/>
+          <release version="@PACKAGE_VERSION@" date="2021-5-17"/>
   </releases>
   <screenshots>
 	  <screenshot type="default">

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -173,7 +173,8 @@ logfile     =
 debuggerrun = debugger
 
 [dosbox]
-#                                        language: Select another language file.
+#                                        language: Select a language file for DOSBox-X to use. Encoded with either UTF-8 or DOS code page.
+#                                                    Set the code page with the "country" setting in [config] section, e.g. country=34,858
 #                                           title: Additional text to place in the title bar of the window.
 #                                    fastbioslogo: If set, DOSBox-X will skip the BIOS screen by activating fast BIOS logo mode (without 1-second pause).
 #DOSBOX-X-ADV:#                        disable graphical splash: If set, DOSBox-X will always display text-mode BIOS splash screen instead of the graphical one.
@@ -2318,7 +2319,7 @@ rem = This section is the 4DOS.INI file, if you use 4DOS as the command shell
 #       dos: Reports whether DOS occupies HMA and allocates UMB memory (if available).
 #      fcbs: Number of FCB handles available to DOS programs (1-255).
 #     files: Number of file handles available to DOS programs (8-255).
-#   country: The country code for date/time formats and optionally the code page for TTF output.
+#   country: The country code for date/time formats and code page for TTF output and language files.
 # lastdrive: The maximum drive letter that can be accessed by programs.
 #              Possible values: a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z.
 rem         = This section is DOS's CONFIG.SYS file, not all CONFIG.SYS options supported

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -88,7 +88,8 @@ logfile     =
 debuggerrun = debugger
 
 [dosbox]
-#                  language: Select another language file.
+#                  language: Select a language file for DOSBox-X to use. Encoded with either UTF-8 or DOS code page.
+#                              Set the code page with the "country" setting in [config] section, e.g. country=34,858
 #                     title: Additional text to place in the title bar of the window.
 #              fastbioslogo: If set, DOSBox-X will skip the BIOS screen by activating fast BIOS logo mode (without 1-second pause).
 #               startbanner: If set (default), DOSBox-X will display the welcome banner when it starts.
@@ -955,7 +956,7 @@ rem = This section is the 4DOS.INI file, if you use 4DOS as the command shell
 #       dos: Reports whether DOS occupies HMA and allocates UMB memory (if available).
 #      fcbs: Number of FCB handles available to DOS programs (1-255).
 #     files: Number of file handles available to DOS programs (8-255).
-#   country: The country code for date/time formats and optionally the code page for TTF output.
+#   country: The country code for date/time formats and code page for TTF output and language files.
 # lastdrive: The maximum drive letter that can be accessed by programs.
 #              Possible values: a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z.
 rem         = This section is DOS's CONFIG.SYS file, not all CONFIG.SYS options supported

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -173,7 +173,8 @@ fileio      = false
 debuggerrun = debugger
 
 [dosbox]
-#                                        language: Select another language file.
+#                                        language: Select a language file for DOSBox-X to use. Encoded with either UTF-8 or DOS code page.
+#                                                    Set the code page with the "country" setting in [config] section, e.g. country=34,858
 #                                           title: Additional text to place in the title bar of the window.
 #                                    fastbioslogo: If set, DOSBox-X will skip the BIOS screen by activating fast BIOS logo mode (without 1-second pause).
 #                        disable graphical splash: If set, DOSBox-X will always display text-mode BIOS splash screen instead of the graphical one.
@@ -2318,7 +2319,7 @@ rem = This section is the 4DOS.INI file, if you use 4DOS as the command shell
 #       dos: Reports whether DOS occupies HMA and allocates UMB memory (if available).
 #      fcbs: Number of FCB handles available to DOS programs (1-255).
 #     files: Number of file handles available to DOS programs (8-255).
-#   country: The country code for date/time formats and optionally the code page for TTF output.
+#   country: The country code for date/time formats and code page for TTF output and language files.
 # lastdrive: The maximum drive letter that can be accessed by programs.
 #              Possible values: a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z.
 rem         = This section is DOS's CONFIG.SYS file, not all CONFIG.SYS options supported

--- a/include/build_timestamp.h
+++ b/include/build_timestamp.h
@@ -1,4 +1,4 @@
 /*auto-generated*/
-#define UPDATED_STR "May 14, 2021 3:37:54am"
-#define GIT_COMMIT_HASH "e40a064"
+#define UPDATED_STR "May 17, 2021 3:41:09pm"
+#define GIT_COMMIT_HASH "47da8f5"
 #define COPYRIGHT_END_YEAR "2021"

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1252,7 +1252,8 @@ void DOSBOX_SetupConfigSections(void) {
 
     secprop=control->AddSection_prop("dosbox",&Null_Init);
     Pstring = secprop->Add_path("language",Property::Changeable::Always,"");
-    Pstring->Set_help("Select another language file.");
+    Pstring->Set_help("Select a language file for DOSBox-X to use. Encoded with either UTF-8 or DOS code page.\n"
+                      "Set the code page with the \"country\" setting in [config] section, e.g. country=34,858");
     Pstring->SetBasic(true);
 
     Pstring = secprop->Add_path("title",Property::Changeable::Always,"");
@@ -4261,7 +4262,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pint->Set_help("Number of file handles available to DOS programs (8-255).");
     Pint->SetBasic(true);
     Pstring = secprop->Add_string("country",Property::Changeable::OnlyAtStart,"");
-    Pstring->Set_help("The country code for date/time formats and optionally the code page for TTF output.");
+    Pstring->Set_help("The country code for date/time formats and code page for TTF output and language files.");
     Pstring->SetBasic(true);
     Pstring = secprop->Add_string("lastdrive",Property::Changeable::OnlyAtStart,"a");
 	Pstring->Set_help("The maximum drive letter that can be accessed by programs.");

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -1704,9 +1704,9 @@ void DOSBox_SetMenu(DOSBoxMenu &altMenu) {
 #endif
 #if DOSBOXMENU_TYPE == DOSBOXMENU_NSMENU /* TODO: Move to menu.cpp DOSBox_SetMenu() and add setmenu(NULL) to DOSBox_NoMenu() @emendelson request showmenu=false */
     void sdl_hax_macosx_setmenu(void *nsMenu);
-    void menu_osx_set_menuobj(DOSBoxMenu *altMenu);
+    void menu_macosx_set_menuobj(DOSBoxMenu *altMenu);
     sdl_hax_macosx_setmenu(altMenu.getNsMenu());
-    menu_osx_set_menuobj(&altMenu);
+    menu_macosx_set_menuobj(&altMenu);
 #endif
 #if DOSBOXMENU_TYPE == DOSBOXMENU_HMENU
     if(!menu.gui) return;

--- a/src/gui/menu_macos.mm
+++ b/src/gui/menu_macos.mm
@@ -25,6 +25,10 @@ extern "C" void sdl1_hax_stock_osx_menu_additem(NSMenu *modme);
 extern "C" NSWindow *sdl1_hax_get_window(void);
 #endif
 
+char tempstr[4096];
+void InitCodePage();
+bool CodePageGuestToHostUTF8(char *d/*CROSS_LEN*/,const char *s/*CROSS_LEN*/);
+
 void GetClipboard(std::string* result) {
 	NSPasteboard* pb = [NSPasteboard generalPasteboard];
 	NSString* text = [pb stringForType:NSPasteboardTypeString];
@@ -62,7 +66,14 @@ void sdl_hax_nsMenuItemUpdateFromItem(void *nsMenuItem, DOSBoxMenu::item &item) 
 		}
 
 		{
-			NSString *title = [[NSString alloc] initWithUTF8String:ft.c_str()];
+			NSString *title;
+            int cp = dos.loaded_codepage;
+            if (!dos.loaded_codepage) InitCodePage();
+            if (CodePageGuestToHostUTF8(tempstr,ft.c_str()))
+                title = [[NSString alloc] initWithUTF8String:tempstr];
+            else
+                title = [[NSString alloc] initWithString:[NSString stringWithFormat:@"%s",ft.c_str()]];
+            dos.loaded_codepage = cp;
 			[ns_item setTitle:title];
 			[title release];
 		}
@@ -72,7 +83,14 @@ void sdl_hax_nsMenuItemUpdateFromItem(void *nsMenuItem, DOSBoxMenu::item &item) 
 }
 
 void* sdl_hax_nsMenuAlloc(const char *initWithText) {
-	NSString *title = [[NSString alloc] initWithUTF8String:initWithText];
+	NSString *title;
+    int cp = dos.loaded_codepage;
+    if (!dos.loaded_codepage) InitCodePage();
+    if (CodePageGuestToHostUTF8(tempstr,initWithText))
+        title = [[NSString alloc] initWithUTF8String:tempstr];
+    else
+        title = [[NSString alloc] initWithString:[NSString stringWithFormat:@"%s",initWithText]];
+    dos.loaded_codepage = cp;
 	NSMenu *menu = [[NSMenu alloc] initWithTitle: title];
 	[title release];
 	[menu setAutoenablesItems:NO];
@@ -105,7 +123,14 @@ void sdl_hax_nsMenuItemSetSubmenu(void *nsMenuItem,void *nsMenu) {
 }
 
 void* sdl_hax_nsMenuItemAlloc(const char *initWithText) {
-	NSString *title = [[NSString alloc] initWithUTF8String:initWithText];
+	NSString *title;
+    int cp = dos.loaded_codepage;
+    if (!dos.loaded_codepage) InitCodePage();
+    if (CodePageGuestToHostUTF8(tempstr,initWithText))
+        title = [[NSString alloc] initWithUTF8String:tempstr];
+    else
+        title = [[NSString alloc] initWithString:[NSString stringWithFormat:@"%s",initWithText]];
+    dos.loaded_codepage = cp;
 	NSMenuItem *item = [[NSMenuItem alloc] initWithTitle: title action:@selector(DOSBoxXMenuAction:) keyEquivalent:@""];
 	[title release];
 	return (void*)item;

--- a/src/gui/menu_macos.mm
+++ b/src/gui/menu_macos.mm
@@ -20,8 +20,8 @@
 @end
 
 #if !defined(C_SDL2)
-extern "C" void* sdl1_hax_stock_osx_menu(void);
-extern "C" void sdl1_hax_stock_osx_menu_additem(NSMenu *modme);
+extern "C" void* sdl1_hax_stock_macosx_menu(void);
+extern "C" void sdl1_hax_stock_macosx_menu_additem(NSMenu *modme);
 extern "C" NSWindow *sdl1_hax_get_window(void);
 #endif
 
@@ -109,7 +109,7 @@ void sdl_hax_macosx_setmenu(void *nsMenu) {
 	else {
 #if !defined(C_SDL2)
 		/* switch back to the menu SDL 1.x made */
-		[NSApp setMainMenu:((NSMenu*)sdl1_hax_stock_osx_menu())];
+		[NSApp setMainMenu:((NSMenu*)sdl1_hax_stock_macosx_menu())];
 #endif
 	}
 }
@@ -165,7 +165,7 @@ void sdl_hax_nsMenuAddApplicationMenu(void *nsMenu) {
 	[appMenu release];
 #else
     /* Re-use the application menu from SDL1 */
-    sdl1_hax_stock_osx_menu_additem((NSMenu*)nsMenu);
+    sdl1_hax_stock_macosx_menu_additem((NSMenu*)nsMenu);
 #endif
 }
 
@@ -177,7 +177,7 @@ extern bool GUI_IsRunning(void);
 
 static DOSBoxMenu *altMenu = NULL;
 
-void menu_osx_set_menuobj(DOSBoxMenu *new_altMenu) {
+void menu_macosx_set_menuobj(DOSBoxMenu *new_altMenu) {
     if (new_altMenu != NULL && new_altMenu != &mainMenu)
         altMenu = new_altMenu;
     else
@@ -241,7 +241,7 @@ void menu_osx_set_menuobj(DOSBoxMenu *new_altMenu) {
 
 bool has_touch_bar_support = false;
 
-bool osx_detect_nstouchbar(void) {
+bool macosx_detect_nstouchbar(void) {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 101202/* touch bar interface appeared in 10.12.2+ according to Apple */
     return (has_touch_bar_support = (NSClassFromString(@"NSTouchBar") != nil));
 #else
@@ -358,7 +358,7 @@ extern void ext_signal_host_key(bool enable);
 @end
 #endif
 
-void osx_reload_touchbar(void) {
+void macosx_reload_touchbar(void) {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 101202/* touch bar interface appeared in 10.12.2+ according to Apple */
     NSWindow *wnd = nil;
 
@@ -373,7 +373,7 @@ void osx_reload_touchbar(void) {
 }
 
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 101202/* touch bar interface appeared in 10.12.2+ according to Apple */
-NSTouchBar* osx_on_make_touch_bar(NSWindow *wnd) {
+NSTouchBar* macosx_on_make_touch_bar(NSWindow *wnd) {
     (void)wnd;
 
     NSTouchBar* touchBar = [[NSTouchBar alloc] init];
@@ -423,11 +423,11 @@ NSTouchBar* osx_on_make_touch_bar(NSWindow *wnd) {
 }
 #endif
 
-void osx_init_touchbar(void) {
+void macosx_init_touchbar(void) {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 101202/* touch bar interface appeared in 10.12.2+ according to Apple */
 # if !defined(C_SDL2)
     if (has_touch_bar_support)
-        sdl1_hax_make_touch_bar_set_callback(osx_on_make_touch_bar);
+        sdl1_hax_make_touch_bar_set_callback(macosx_on_make_touch_bar);
 # endif
 #endif
 }
@@ -436,7 +436,7 @@ void osx_init_touchbar(void) {
 extern "C" void sdl1_hax_set_dock_menu(NSMenu *menu);
 #endif
 
-void osx_init_dock_menu(void) {
+void macosx_init_dock_menu(void) {
 #if !defined(C_SDL2)
     NSMenu *menu = [[NSMenu alloc] initWithTitle:@""];
 

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -110,6 +110,10 @@ void                        WindowsTaskbarUpdatePreviewRegion(void);
 void                        WindowsTaskbarResetPreviewRegion(void);
 #endif
 
+#if defined(MACOSX)
+void                        macosx_reload_touchbar(void);
+#endif
+
 const char *aboutmsg = "DOSBox-X version " VERSION " (" SDL_STRING ", "
 #if defined(_M_X64) || defined (_M_AMD64) || defined (_M_ARM64) || defined (_M_IA64) || defined(__ia64__) || defined(__LP64__) || defined(_WIN64) || defined(__x86_64__) || defined(__aarch64__) || defined(__powerpc64__)
 	"64"
@@ -448,8 +452,7 @@ static GUI::ScreenSDL *UI_Startup(GUI::ScreenSDL *screen) {
     running = true;
 
 #if defined(MACOSX)
-    void osx_reload_touchbar(void);
-    osx_reload_touchbar();
+    macosx_reload_touchbar();
 #endif
 
     return screen;
@@ -465,8 +468,7 @@ static void UI_Shutdown(GUI::ScreenSDL *screen) {
 #endif
 
 #if defined(MACOSX)
-    void osx_reload_touchbar(void);
-    osx_reload_touchbar();
+    macosx_reload_touchbar();
 #endif
 
 #if defined(C_SDL2)

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -298,6 +298,10 @@ void                                            WindowsTaskbarUpdatePreviewRegio
 void                                            WindowsTaskbarResetPreviewRegion(void); // external
 #endif
 
+#if defined(MACOSX)
+void                        macosx_reload_touchbar(void);
+#endif
+
 //! \brief Base CEvent class for mapper events
 class CEvent {
 public:
@@ -4645,8 +4649,7 @@ void MAPPER_RunInternal() {
 #endif
 
 #if defined(MACOSX)
-    void osx_reload_touchbar(void);
-    osx_reload_touchbar();
+    macosx_reload_touchbar();
 #endif
 
     /* Go in the event loop */
@@ -4743,8 +4746,7 @@ void MAPPER_RunInternal() {
     mapper.running = false;
 
 #if defined(MACOSX)
-    void osx_reload_touchbar(void);
-    osx_reload_touchbar();
+    macosx_reload_touchbar();
 #endif
 
 #ifdef DOSBOXMENU_EXTERNALLY_MANAGED

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -12862,6 +12862,10 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 				dpi_aware_enable = false;
 #elif defined(WIN32) && !defined(HX_DOS)
 				dpi_aware_enable = true;
+#if !defined(C_SDL2)
+                if (!control->opt_fullscreen && !static_cast<Section_prop *>(control->GetSection("sdl"))->Get_bool("fullscreen"))
+#endif
+                {
 				UINT dpi=0;
 				HMODULE __user32 = GetModuleHandle("USER32.DLL");
 				if (__user32) {
@@ -12880,6 +12884,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 					}
 				}
 				if (dpi&&dpi/96>1) dpi_aware_enable = false;
+                }
 #else
 				dpi_aware_enable = true;
 #endif
@@ -13587,7 +13592,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
                 if (!sdl.desktop.fullscreen) GFX_SwitchFullScreen();
 
                 /* Setup Mouse correctly if fullscreen */
-                if(sdl.desktop.fullscreen) GFX_CaptureMouse();
+                if(sdl.desktop.fullscreen&&sdl.mouse.autoenable) GFX_CaptureMouse();
             }
 
             // Shows menu bar (window)

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -257,8 +257,8 @@ extern PFNGLVERTEXATTRIBPOINTERPROC glVertexAttribPointer;
 #ifdef MACOSX
 #include <CoreGraphics/CoreGraphics.h>
 extern bool has_touch_bar_support;
-bool osx_detect_nstouchbar(void);
-void osx_init_touchbar(void);
+bool macosx_detect_nstouchbar(void);
+void macosx_init_touchbar(void);
 void GetClipboard(std::string* result);
 bool SetClipboard(std::string value);
 #endif
@@ -12905,14 +12905,14 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 #endif
 
 #ifdef MACOSX
-        osx_detect_nstouchbar();/*assigns to has_touch_bar_support*/
+        macosx_detect_nstouchbar();/*assigns to has_touch_bar_support*/
         if (has_touch_bar_support) {
             LOG_MSG("macOS: NSTouchBar support detected in system");
-            osx_init_touchbar();
+            macosx_init_touchbar();
         }
 
-        extern void osx_init_dock_menu(void);
-        osx_init_dock_menu();
+        extern void macosx_init_dock_menu(void);
+        macosx_init_dock_menu();
 
         void qz_set_match_monitor_cb(void);
         qz_set_match_monitor_cb();

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -68,6 +68,18 @@ void MSG_Replace(const char * _name, const char* _val) {
 	Lang.push_back(MessageBlock(_name,_val));
 }
 
+void InitCodePage() {
+    if (IS_PC98_ARCH)
+        dos.loaded_codepage=932;
+    else if (!dos.loaded_codepage) {
+        Section_prop *section = static_cast<Section_prop *>(control->GetSection("config"));
+        if (!dos.loaded_codepage && !IS_PC98_ARCH && section!=NULL) {
+            char *countrystr = (char *)section->Get_string("country"), *r=strchr(countrystr, ',');
+            if (r!=NULL && *(r+1)) dos.loaded_codepage = atoi(trim(r+1));
+        }
+    }
+}
+
 void LoadMessageFile(const char * fname) {
 	if (!fname) return;
 	if(*fname=='\0') return;//empty string=no languagefile
@@ -89,13 +101,7 @@ void LoadMessageFile(const char * fname) {
 	/* Start out with empty strings */
 	name[0]=0;string[0]=0;
     int cp=dos.loaded_codepage;
-    if (!dos.loaded_codepage) {
-        Section_prop *section = static_cast<Section_prop *>(control->GetSection("config"));
-        if (!dos.loaded_codepage && !IS_PC98_ARCH && section!=NULL) {
-            char *countrystr = (char *)section->Get_string("country"), *r=strchr(countrystr, ',');
-            if (r!=NULL && *(r+1)) dos.loaded_codepage = atoi(trim(r+1));
-        }
-    }
+    if (!dos.loaded_codepage) InitCodePage();
 	while(fgets(linein, LINE_IN_MAXLEN, mfile)!=0) {
 		/* Parse the read line */
 		/* First remove characters 10 and 13 from the line */

--- a/src/misc/savestates.cpp
+++ b/src/misc/savestates.cpp
@@ -46,7 +46,7 @@ bool noremark_save_state = false;
 bool force_load_state = false;
 std::string saveloaderr="";
 void refresh_slots(void);
-void GFX_LosingFocus(void), MAPPER_ReleaseAllKeys(void), resetFontSize(void);
+void GFX_LosingFocus(void), GFX_ReleaseMouse(void), MAPPER_ReleaseAllKeys(void), resetFontSize(void);
 bool systemmessagebox(char const * aTitle, char const * aMessage, char const * aDialogType, char const * aIconType, int aDefaultButton);
 namespace
 {
@@ -186,7 +186,7 @@ void LoadGameState(bool pressed) {
 //        LOG_MSG("[%s]: State %d is empty!", getTime().c_str(), currentSlot + 1);
 //        return;
 //    }
-    GFX_LosingFocus();
+    if (!GFX_IsFullscreen()&&render.aspect) GFX_LosingFocus();
     try
     {
         LOG_MSG("Loading state from slot: %d", (int)currentSlot + 1);
@@ -1133,7 +1133,15 @@ void SaveState::save(size_t slot) { //throw (Error)
          *      has been changed to const char* and the return value of tinyfd_inputBox() is given to
          *      a local temporary char* string where the modification can be made, and *then* assigned
          *      to the const char* string for the rest of this function. */
+        bool fs=GFX_IsFullscreen();
+        if (fs) GFX_SwitchFullScreen();
+        MAPPER_ReleaseAllKeys();
+        GFX_LosingFocus();
+        GFX_ReleaseMouse();
         char *new_remark = tinyfd_inputBox("Save state", "Please enter remark for the state (optional; 30 characters maximum). Click the Cancel button to cancel the saving.", " ");
+        MAPPER_ReleaseAllKeys();
+        GFX_LosingFocus();
+        if (fs&&!GFX_IsFullscreen()) GFX_SwitchFullScreen();
         if (new_remark==NULL) return;
         new_remark=trim(new_remark);
         if (strlen(new_remark)>30) new_remark[30]=0;

--- a/vs2015/sdl/src/main/macosx/SDLMain.m
+++ b/vs2015/sdl/src/main/macosx/SDLMain.m
@@ -188,7 +188,7 @@ static void setApplicationMenu(NSMenu *modme)
     [menuItem release];
 }
 
-void sdl1_hax_stock_osx_menu_additem(NSMenu *modme) {
+void sdl1_hax_stock_macosx_menu_additem(NSMenu *modme) {
     setApplicationMenu(modme);
 }
 
@@ -221,7 +221,7 @@ static void setupWindowMenu(void)
 
 static NSMenu *stock_menu = NULL;
 
-void* sdl1_hax_stock_osx_menu(void) {
+void* sdl1_hax_stock_macosx_menu(void) {
 	return stock_menu;
 }
 


### PR DESCRIPTION
Unicode support was added to the Windows SDL1 menu previously. This will add Unicode support for macOS menu too, along with some other cleanups. Tested with both SDL1 and SDL2 builds in macOS.