### PR TITLE
Remove casts that remove const qualification

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -122,7 +122,7 @@ public:
 	virtual uint8_t Read_AbsoluteSector(uint32_t sectnum, void * data);
 	virtual uint8_t Write_AbsoluteSector(uint32_t sectnum, const void * data);
 
-	imageDiskD88(FILE *imgFile, uint8_t *imgName, uint32_t imgSizeK, bool isHardDisk);
+	imageDiskD88(FILE *imgFile, const char *imgName, uint32_t imgSizeK, bool isHardDisk);
 	virtual ~imageDiskD88();
 
     unsigned char fd_type_major;
@@ -161,7 +161,7 @@ public:
 	virtual uint8_t Read_AbsoluteSector(uint32_t sectnum, void * data);
 	virtual uint8_t Write_AbsoluteSector(uint32_t sectnum, const void * data);
 
-	imageDiskNFD(FILE *imgFile, uint8_t *imgName, uint32_t imgSizeK, bool isHardDisk, unsigned int revision);
+	imageDiskNFD(FILE *imgFile, const char *imgName, uint32_t imgSizeK, bool isHardDisk, unsigned int revision);
 	virtual ~imageDiskNFD();
 
     struct vfdentry {
@@ -191,7 +191,7 @@ public:
 	virtual uint8_t Read_AbsoluteSector(uint32_t sectnum, void * data);
 	virtual uint8_t Write_AbsoluteSector(uint32_t sectnum, const void * data);
 
-	imageDiskVFD(FILE *imgFile, uint8_t *imgName, uint32_t imgSizeK, bool isHardDisk);
+	imageDiskVFD(FILE *imgFile, const char *imgName, uint32_t imgSizeK, bool isHardDisk);
 	virtual ~imageDiskVFD();
 
     struct vfdentry {

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -164,7 +164,7 @@ enum { HAND_NONE=0,HAND_FILE,HAND_DEVICE};
 /* Routines for File Class */
 void DOS_SetupFiles (void);
 bool DOS_ReadFile(uint16_t entry,uint8_t * data,uint16_t * amount, bool fcb = false);
-bool DOS_WriteFile(uint16_t entry,uint8_t * data,uint16_t * amount,bool fcb = false);
+bool DOS_WriteFile(uint16_t entry,const uint8_t * data,uint16_t * amount,bool fcb = false);
 bool DOS_SeekFile(uint16_t entry,uint32_t * pos,uint32_t type,bool fcb = false);
 /* ert, 20100711: Locking extensions */
 bool DOS_LockFile(uint16_t entry,uint8_t mode,uint32_t pos,uint32_t size);
@@ -181,7 +181,7 @@ bool DOS_OpenFileExtended(char const * name, uint16_t flags, uint16_t createAttr
 bool DOS_CreateFile(char const * name,uint16_t attributes,uint16_t * entry, bool fcb = false);
 bool DOS_UnlinkFile(char const * const name);
 bool DOS_GetSFNPath(char const * const path, char *SFNpath, bool LFN);
-bool DOS_FindFirst(char *search,uint16_t attr,bool fcb_findfirst=false);
+bool DOS_FindFirst(const char *search,uint16_t attr,bool fcb_findfirst=false);
 bool DOS_FindNext(void);
 bool DOS_Canonicalize(char const * const name,char * const big);
 bool DOS_CreateTempFile(char * const name,uint16_t * entry);

--- a/include/qcow2_disk.h
+++ b/include/qcow2_disk.h
@@ -58,7 +58,7 @@ public:
 	
 	uint8_t read_sector(uint32_t sectnum, uint8_t* data);
 
-	uint8_t write_sector(uint32_t sectnum, uint8_t* data);
+	uint8_t write_sector(uint32_t sectnum, const uint8_t* data);
 	
 private:
 
@@ -106,7 +106,7 @@ private:
 
 	uint8_t update_reference_count(uint64_t cluster_offset, uint8_t* cluster_buffer);
 
-	uint8_t write_data(uint64_t file_offset, uint8_t* data, uint64_t data_size);
+	uint8_t write_data(uint64_t file_offset, const uint8_t* data, uint64_t data_size);
 
 	uint8_t write_l1_table_entry(uint64_t address, uint64_t l2_table_offset);
 
@@ -123,7 +123,7 @@ class QCow2Disk : public imageDisk{
 
 public:
 	
-	QCow2Disk(QCow2Image::QCow2Header& qcow2Header, FILE *qcow2File, uint8_t *imgName, uint32_t imgSizeK, uint32_t sectorSizeBytes, bool isHardDisk);
+	QCow2Disk(QCow2Image::QCow2Header& qcow2Header, FILE *qcow2File, const char *imgName, uint32_t imgSizeK, uint32_t sectorSizeBytes, bool isHardDisk);
 
 	virtual ~QCow2Disk();
 	

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -447,7 +447,7 @@ void DOS_PrintCBreak() {
 	/* print ^C <newline> */
 	uint16_t n = 4;
 	const char *nl = "^C\r\n";
-	DOS_WriteFile(STDOUT,(uint8_t*)nl,&n);
+	DOS_WriteFile(STDOUT,(const uint8_t*)nl,&n);
 }
 
 bool DOS_BreakTest(bool print=true) {
@@ -2998,7 +2998,9 @@ public:
 			maxfcb = (int)config_section->Get_int("fcbs");
 			if (maxfcb<1) maxfcb=1;
 			else if (maxfcb>255) maxfcb=255;
-			char *dosopt = (char *)config_section->Get_string("dos"), *r=strchr(dosopt, ',');
+            char dosopt[50];
+            strcpy(dosopt, config_section->Get_string("dos"));
+			char *r=strchr(dosopt, ',');
 			if (r==NULL) {
 				if (!strcasecmp(trim(dosopt), "high")) dos_in_hma=true;
 				else if (!strcasecmp(trim(dosopt), "low")) dos_in_hma=false;
@@ -3012,16 +3014,16 @@ public:
 				if (!strcasecmp(trim(r+1), "umb")) dos_umb=true;
 				else if (!strcasecmp(trim(r+1), "noumb")) dos_umb=false;
 			}
-			char *lastdrive = (char *)config_section->Get_string("lastdrive");
+			const char *lastdrive = config_section->Get_string("lastdrive");
 			if (strlen(lastdrive)==1&&lastdrive[0]>='a'&&lastdrive[0]<='z')
 				maxdrive=lastdrive[0]-'a'+1;
-			char *dosbreak = (char *)config_section->Get_string("break");
+			const char *dosbreak = config_section->Get_string("break");
 			if (!strcasecmp(dosbreak, "on"))
 				dos.breakcheck=true;
 			else if (!strcasecmp(dosbreak, "off"))
 				dos.breakcheck=false;
 #if defined(WIN32)
-			char *numlock = (char *)config_section->Get_string("numlock");
+			const char *numlock = config_section->Get_string("numlock");
 			if ((!strcasecmp(numlock, "off")&&startup_state_numlock) || (!strcasecmp(numlock, "on")&&!startup_state_numlock))
 				SetNumLock();
 #endif
@@ -3058,9 +3060,10 @@ public:
         }
         startcmd = section->Get_bool("startcmd");
         startincon = section->Get_string("startincon");
-        char *dos_clipboard_device_enable = (char *)section->Get_string("dos clipboard device enable");
+        const char *dos_clipboard_device_enable = section->Get_string("dos clipboard device enable");
 		dos_clipboard_device_access = !strcasecmp(dos_clipboard_device_enable, "disabled")?0:(!strcasecmp(dos_clipboard_device_enable, "read")?2:(!strcasecmp(dos_clipboard_device_enable, "write")?3:(!strcasecmp(dos_clipboard_device_enable, "full")||!strcasecmp(dos_clipboard_device_enable, "true")?4:1)));
-		dos_clipboard_device_name = (char *)section->Get_string("dos clipboard device name");
+        char temp[9];
+		dos_clipboard_device_name = strcpy(temp, section->Get_string("dos clipboard device name"));
         clipboard_dosapi = section->Get_bool("dos clipboard api");
         if (control->SecureMode()) clipboard_dosapi = false;
         mainMenu.get_item("clipboard_dosapi").check(clipboard_dosapi).enable(true).refresh_item(mainMenu);
@@ -3075,7 +3078,7 @@ public:
 					break;
 				}
 			}
-			dos_clipboard_device_name=valid?upcase(dos_clipboard_device_name):(char *)dos_clipboard_device_default;
+			dos_clipboard_device_name=valid?upcase(dos_clipboard_device_name):strcpy(dos_clipboard_device_name,dos_clipboard_device_default);
 			LOG(LOG_DOSMISC,LOG_NORMAL)("DOS clipboard device (%s access) is enabled with the name %s\n", dos_clipboard_device_access==1?"dummy":(dos_clipboard_device_access==2?"read":(dos_clipboard_device_access==3?"write":"full")), dos_clipboard_device_name);
             std::string text=mainMenu.get_item("clipboard_device").get_text();
             std::size_t found = text.find(":");
@@ -3423,7 +3426,8 @@ public:
         mainMenu.get_item("dos_lfn_enable").check(enablelfn==1).enable(true).refresh_item(mainMenu);
         mainMenu.get_item("dos_lfn_disable").check(enablelfn==0).enable(true).refresh_item(mainMenu);
 
-		char *ver = (char *)section->Get_string("ver");
+        char ver[5];
+        strcpy(ver, section->Get_string("ver"));
 		if (*ver) {
 			if (set_ver(ver)) {
 				/* warn about unusual version numbers */

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -486,7 +486,7 @@ bool DOS_Rename(char const * const oldname,char const * const newname) {
 	return false;
 }
 
-bool DOS_FindFirst(char * search,uint16_t attr,bool fcb_findfirst) {
+bool DOS_FindFirst(const char * search,uint16_t attr,bool fcb_findfirst) {
 	LOG(LOG_FILES,LOG_NORMAL)("file search attributes %X name %s",attr,search);
 	DOS_DTA dta(dos.dta());
 	uint8_t drive;char fullsearch[DOS_PATHLENGTH];
@@ -583,7 +583,7 @@ bool DOS_ReadFile(uint16_t entry,uint8_t * data,uint16_t * amount,bool fcb) {
 	return ret;
 }
 
-bool DOS_WriteFile(uint16_t entry,uint8_t * data,uint16_t * amount,bool fcb) {
+bool DOS_WriteFile(uint16_t entry,const uint8_t * data,uint16_t * amount,bool fcb) {
 #if defined(WIN32) && !defined(__MINGW32__)
 	if(Network_IsActiveResource(entry))
 		return Network_WriteFile(entry,data,amount);
@@ -746,8 +746,8 @@ bool DOS_CreateFile(char const * name,uint16_t attributes,uint16_t * entry,bool 
 
 bool DOS_OpenFile(char const * name,uint8_t flags,uint16_t * entry,bool fcb) {
 #if defined(WIN32) && !defined(__MINGW32__)
-	if(Network_IsNetworkResource(const_cast<char *>(name)))
-		return Network_OpenFile(const_cast<char *>(name),flags,entry);
+	if(Network_IsNetworkResource(name))
+		return Network_OpenFile(name,flags,entry);
 #endif
 	/* First check for devices */
 	if (flags>2) LOG(LOG_FILES,LOG_NORMAL)("Special file open command %X file %s",flags,name); // FIXME: Why? Is there something about special opens DOSBox doesn't handle properly?
@@ -908,7 +908,7 @@ bool DOS_UnlinkFile(char const * const name) {
 		std::string pfull=std::string(spath)+std::string(pattern);
 		int fbak=lfn_filefind_handle;
 		lfn_filefind_handle=LFN_FILEFIND_INTERNAL;
-		bool ret=DOS_FindFirst((char *)((pfull.length()&&pfull[0]=='"'?"":"\"")+pfull+(pfull.length()&&pfull[pfull.length()-1]=='"'?"":"\"")).c_str(),0xffu & ~DOS_ATTR_VOLUME & ~DOS_ATTR_DIRECTORY);
+		bool ret=DOS_FindFirst(((pfull.length()&&pfull[0]=='"'?"":"\"")+pfull+(pfull.length()&&pfull[pfull.length()-1]=='"'?"":"\"")).c_str(),0xffu & ~DOS_ATTR_VOLUME & ~DOS_ATTR_DIRECTORY);
 		if (ret) do {
 			char find_name[DOS_NAMELENGTH_ASCII],lfind_name[LFN_NAMELENGTH];
 			uint16_t find_date,find_time;uint32_t find_size;uint8_t find_attr;

--- a/src/dos/dos_network2.h
+++ b/src/dos/dos_network2.h
@@ -33,7 +33,7 @@ August 8 2005		cyberwalker
 
 extern uint16_t	NetworkHandleList[127];	/*in dos_files.cpp*/
 
- bool	Network_IsNetworkResource(char * filename)
+ bool	Network_IsNetworkResource(const char * filename)
 {
 	if(strlen(filename)>1)
 			return (filename[0]=='\\' && filename[1]=='\\');
@@ -48,7 +48,7 @@ extern uint16_t	NetworkHandleList[127];	/*in dos_files.cpp*/
 }//bool	Network_IsNetworkFile(uint16_t entry)
 
 
- bool	Network_OpenFile(char * filename,uint8_t flags,uint16_t * entry)
+ bool	Network_OpenFile(const char * filename,uint8_t flags,uint16_t * entry)
 {
 	int oflag=_O_BINARY;
 	int shflag=0;
@@ -155,7 +155,7 @@ int _nhandle;
 }//bool Network_ReadFile(uint16_t entry,uint8_t * data,uint16_t * amount)
 
 
- bool	Network_WriteFile(uint16_t entry,uint8_t * data,uint16_t * amount)
+ bool	Network_WriteFile(uint16_t entry,const uint8_t * data,uint16_t * amount)
 {
 		uint16_t towrite=*amount;
 		uint32_t handle=RealHandle(entry);

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1646,7 +1646,7 @@ private:
 
         localDrive* ldp=0;
 		bool readonly=wpcolon&&strlen(filename)>1&&filename[0]==':';
-        if (!DOS_MakeName(const_cast<char*>(readonly?filename+1:filename),fullname,&drive)) return NULL;
+        if (!DOS_MakeName(readonly?filename+1:filename,fullname,&drive)) return NULL;
 
         try {       
             ldp=dynamic_cast<localDrive*>(Drives[drive]);
@@ -1985,16 +1985,16 @@ public:
                     const char *ext = strrchr(temp_line.c_str(),'.'), *fname=readonly?temp_line.c_str()+1:temp_line.c_str();
 
                     if (ext != NULL && !strcasecmp(ext, ".d88")) {
-                        newDiskSwap[i] = new imageDiskD88(usefile, (uint8_t *)fname, floppysize, false);
+                        newDiskSwap[i] = new imageDiskD88(usefile, fname, floppysize, false);
                     }
                     else if (!memcmp(tmp,"VFD1.",5)) { /* FDD files */
-                        newDiskSwap[i] = new imageDiskVFD(usefile, (uint8_t *)fname, floppysize, false);
+                        newDiskSwap[i] = new imageDiskVFD(usefile, fname, floppysize, false);
                     }
                     else if (!memcmp(tmp,"T98FDDIMAGE.R0\0\0",16)) {
-                        newDiskSwap[i] = new imageDiskNFD(usefile, (uint8_t *)fname, floppysize, false, 0);
+                        newDiskSwap[i] = new imageDiskNFD(usefile, fname, floppysize, false, 0);
                     }
                     else if (!memcmp(tmp,"T98FDDIMAGE.R1\0\0",16)) {
-                        newDiskSwap[i] = new imageDiskNFD(usefile, (uint8_t *)fname, floppysize, false, 1);
+                        newDiskSwap[i] = new imageDiskNFD(usefile, fname, floppysize, false, 1);
                     }
                     else {
                         newDiskSwap[i] = new imageDisk(usefile, fname, floppysize, false);
@@ -2624,7 +2624,7 @@ public:
         uint8_t drive;
         char fullname[DOS_PATHLENGTH];
         localDrive* ldp=0;
-        if (!DOS_MakeName((char *)temp_line.c_str(),fullname,&drive)) return;
+        if (!DOS_MakeName(temp_line.c_str(),fullname,&drive)) return;
 
         try {
             /* try to read ROM file into buffer */
@@ -2705,7 +2705,7 @@ public:
         uint8_t drive;
         char fullname[DOS_PATHLENGTH];
         localDrive* ldp = 0;
-        if (!DOS_MakeName((char*)temp_line.c_str(), fullname, &drive)) return;
+        if (!DOS_MakeName(temp_line.c_str(), fullname, &drive)) return;
 
         try {
             /* try to read ROM file into buffer */
@@ -4866,10 +4866,13 @@ private:
             if (commandLine.size()>4 && commandLine[0]=='\'' && toupper(commandLine[1])>='A' && toupper(commandLine[1])<='Z' && commandLine[2]==':' && (commandLine[3]=='/' || commandLine[3]=='\\') && commandLine.back()=='\'')
                 commandLine = commandLine.substr(1, commandLine.size()-2);
             else if (!paths.size() && commandLine.size()>3 && commandLine[0]=='\'' && toupper(commandLine[1])>='A' && toupper(commandLine[1])<='Z' && commandLine[2]==':' && (commandLine[3]=='/' || commandLine[3]=='\\')) {
-                std::string line=trim((char *)cmd->GetRawCmdline().c_str());
+                char temp[256];
+                strcpy(temp, cmd->GetRawCmdline().c_str());
+                std::string line=trim(temp);
                 std::size_t space=line.find(' ');
                 if (space!=std::string::npos) {
-                    line=trim((char *)line.substr(space).c_str());
+                    strcpy(temp, line.substr(space).c_str());
+                    line=trim(temp);
                     std::size_t found=line.back()=='\''?line.find_last_of('\''):line.rfind("' ");
                     if (found!=std::string::npos&&found>2) {
                         commandLine=line.substr(1, found-1);
@@ -5295,28 +5298,28 @@ private:
                                 break;
                             }
                             case imageDiskVHD::ERROR_OPENING: 
-                                errorMessage = (char*)MSG_Get("VHD_ERROR_OPENING"); break;
+                                errorMessage = MSG_Get("VHD_ERROR_OPENING"); break;
                             case imageDiskVHD::INVALID_DATA: 
-                                errorMessage = (char*)MSG_Get("VHD_INVALID_DATA"); break;
+                                errorMessage = MSG_Get("VHD_INVALID_DATA"); break;
                             case imageDiskVHD::UNSUPPORTED_TYPE: 
-                                errorMessage = (char*)MSG_Get("VHD_UNSUPPORTED_TYPE"); break;
+                                errorMessage = MSG_Get("VHD_UNSUPPORTED_TYPE"); break;
                             case imageDiskVHD::ERROR_OPENING_PARENT: 
-                                errorMessage = (char*)MSG_Get("VHD_ERROR_OPENING_PARENT"); break;
+                                errorMessage = MSG_Get("VHD_ERROR_OPENING_PARENT"); break;
                             case imageDiskVHD::PARENT_INVALID_DATA: 
-                                errorMessage = (char*)MSG_Get("VHD_PARENT_INVALID_DATA"); break;
+                                errorMessage = MSG_Get("VHD_PARENT_INVALID_DATA"); break;
                             case imageDiskVHD::PARENT_UNSUPPORTED_TYPE: 
-                                errorMessage = (char*)MSG_Get("VHD_PARENT_UNSUPPORTED_TYPE"); break;
+                                errorMessage = MSG_Get("VHD_PARENT_UNSUPPORTED_TYPE"); break;
                             case imageDiskVHD::PARENT_INVALID_MATCH: 
-                                errorMessage = (char*)MSG_Get("VHD_PARENT_INVALID_MATCH"); break;
+                                errorMessage = MSG_Get("VHD_PARENT_INVALID_MATCH"); break;
                             case imageDiskVHD::PARENT_INVALID_DATE: 
-                                errorMessage = (char*)MSG_Get("VHD_PARENT_INVALID_DATE"); break;
+                                errorMessage = MSG_Get("VHD_PARENT_INVALID_DATE"); break;
                             default: break;
                             }
                         }
                     }
                 }
                 if (!skipDetectGeometry && !DetectGeometry(NULL, paths[i].c_str(), sizes)) {
-                    errorMessage = (char*)("Unable to detect geometry\n");
+                    errorMessage = "Unable to detect geometry\n";
                 }
             }
 
@@ -5335,7 +5338,7 @@ private:
                 imgDisks.push_back(newDrive);
 				fatDrive* fdrive=dynamic_cast<fatDrive*>(newDrive);
                 if (!fdrive->created_successfully) {
-                    errorMessage = (char*)MSG_Get("PROGRAM_IMGMOUNT_CANT_CREATE");
+                    errorMessage = MSG_Get("PROGRAM_IMGMOUNT_CANT_CREATE");
 					if (fdrive->req_ver_major>0) {
 						static char ver_msg[150];
 						sprintf(ver_msg, "Mounting this image file requires a reported DOS version of %u.%u or higher.\n%s", fdrive->req_ver_major, fdrive->req_ver_minor, errorMessage);
@@ -5802,7 +5805,7 @@ private:
             sectors = (uint64_t)qcow2_header.size / (uint64_t)sizes[0];
             imagesize = (uint32_t)(qcow2_header.size / 1024L);
             setbuf(newDisk, NULL);
-            newImage = new QCow2Disk(qcow2_header, newDisk, (uint8_t *)fname, imagesize, (uint32_t)sizes[0], (imagesize > 2880));
+            newImage = new QCow2Disk(qcow2_header, newDisk, fname, imagesize, (uint32_t)sizes[0], (imagesize > 2880));
         }
         else {
             char tmp[256];
@@ -5821,28 +5824,28 @@ private:
                 sectors = (uint64_t)ftello64(newDisk) / (uint64_t)sizes[0];
                 imagesize = (uint32_t)(sectors / 2); /* orig. code wants it in KBs */
                 setbuf(newDisk, NULL);
-                newImage = new imageDiskD88(newDisk, (uint8_t *)fname, imagesize, (imagesize > 2880));
+                newImage = new imageDiskD88(newDisk, fname, imagesize, (imagesize > 2880));
             }
             else if (!memcmp(tmp, "VFD1.", 5)) { /* FDD files */
                 fseeko64(newDisk, 0L, SEEK_END);
                 sectors = (uint64_t)ftello64(newDisk) / (uint64_t)sizes[0];
                 imagesize = (uint32_t)(sectors / 2); /* orig. code wants it in KBs */
                 setbuf(newDisk, NULL);
-                newImage = new imageDiskVFD(newDisk, (uint8_t *)fname, imagesize, (imagesize > 2880));
+                newImage = new imageDiskVFD(newDisk, fname, imagesize, (imagesize > 2880));
             }
             else if (!memcmp(tmp,"T98FDDIMAGE.R0\0\0",16)) {
                 fseeko64(newDisk, 0L, SEEK_END);
                 sectors = (uint64_t)ftello64(newDisk) / (uint64_t)sizes[0];
                 imagesize = (uint32_t)(sectors / 2); /* orig. code wants it in KBs */
                 setbuf(newDisk, NULL);
-                newImage = new imageDiskNFD(newDisk, (uint8_t *)fname, imagesize, (imagesize > 2880), 0);
+                newImage = new imageDiskNFD(newDisk, fname, imagesize, (imagesize > 2880), 0);
             }
             else if (!memcmp(tmp,"T98FDDIMAGE.R1\0\0",16)) {
                 fseeko64(newDisk, 0L, SEEK_END);
                 sectors = (uint64_t)ftello64(newDisk) / (uint64_t)sizes[0];
                 imagesize = (uint32_t)(sectors / 2); /* orig. code wants it in KBs */
                 setbuf(newDisk, NULL);
-                newImage = new imageDiskNFD(newDisk, (uint8_t *)fname, imagesize, (imagesize > 2880), 1);
+                newImage = new imageDiskNFD(newDisk, fname, imagesize, (imagesize > 2880), 1);
             }
             else {
                 fseeko64(newDisk, 0L, SEEK_END);

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1252,7 +1252,7 @@ fatDrive::fatDrive(const char* sysFilename, uint32_t bytesector, uint32_t cylsec
 			return;
 		}
 		filesize = (uint32_t)(qcow2_header.size / 1024L);
-		loadedDisk = new QCow2Disk(qcow2_header, diskfile, (uint8_t *)fname, filesize, bytesector, (filesize > 2880));
+		loadedDisk = new QCow2Disk(qcow2_header, diskfile, fname, filesize, bytesector, (filesize > 2880));
 	}
 	else{
 		fseeko64(diskfile, 0L, SEEK_SET);
@@ -1268,22 +1268,22 @@ fatDrive::fatDrive(const char* sysFilename, uint32_t bytesector, uint32_t cylsec
         if (ext != NULL && !strcasecmp(ext, ".d88")) {
             fseeko64(diskfile, 0L, SEEK_END);
             filesize = (uint32_t)(ftello64(diskfile) / 1024L);
-            loadedDisk = new imageDiskD88(diskfile, (uint8_t *)fname, filesize, (filesize > 2880));
+            loadedDisk = new imageDiskD88(diskfile, fname, filesize, (filesize > 2880));
         }
         else if (!memcmp(bootcode,"VFD1.",5)) { /* FDD files */
             fseeko64(diskfile, 0L, SEEK_END);
             filesize = (uint32_t)(ftello64(diskfile) / 1024L);
-            loadedDisk = new imageDiskVFD(diskfile, (uint8_t *)fname, filesize, (filesize > 2880));
+            loadedDisk = new imageDiskVFD(diskfile, fname, filesize, (filesize > 2880));
         }
         else if (!memcmp(bootcode,"T98FDDIMAGE.R0\0\0",16)) {
             fseeko64(diskfile, 0L, SEEK_END);
             filesize = (uint32_t)(ftello64(diskfile) / 1024L);
-            loadedDisk = new imageDiskNFD(diskfile, (uint8_t *)fname, filesize, (filesize > 2880), 0);
+            loadedDisk = new imageDiskNFD(diskfile, fname, filesize, (filesize > 2880), 0);
         }
         else if (!memcmp(bootcode,"T98FDDIMAGE.R1\0\0",16)) {
             fseeko64(diskfile, 0L, SEEK_END);
             filesize = (uint32_t)(ftello64(diskfile) / 1024L);
-            loadedDisk = new imageDiskNFD(diskfile, (uint8_t *)fname, filesize, (filesize > 2880), 1);
+            loadedDisk = new imageDiskNFD(diskfile, fname, filesize, (filesize > 2880), 1);
         }
         else {
             fseeko64(diskfile, 0L, SEEK_END);

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -687,7 +687,7 @@ host_cnv_char_t *CodePageGuestToHost(const char *s) {
 
 char *CodePageHostToGuest(const host_cnv_char_t *s) {
 #if defined(host_cnv_use_wchar)
-    if (!CodePageHostToGuestUTF16((char *)cpcnv_temp,(uint16_t *)s))
+    if (!CodePageHostToGuestUTF16((char *)cpcnv_temp,(const uint16_t *)s))
 #else
     if (!CodePageHostToGuestUTF8((char *)cpcnv_temp,(char *)s))
 #endif
@@ -698,7 +698,7 @@ char *CodePageHostToGuest(const host_cnv_char_t *s) {
 
 char *CodePageHostToGuestL(const host_cnv_char_t *s) {
 #if defined(host_cnv_use_wchar)
-    if (!CodePageHostToGuestUTF16((char *)cpcnv_ltemp,(uint16_t *)s))
+    if (!CodePageHostToGuestUTF16((char *)cpcnv_ltemp,(const uint16_t *)s))
 #else
     if (!CodePageHostToGuestUTF8((char *)cpcnv_ltemp,(char *)s))
 #endif
@@ -3651,8 +3651,10 @@ FILE* Overlay_Drive::create_file_in_overlay(const char* dos_filename, char const
 	else {
 		f = fopen_wrap(newname,mode);
 	}
-	//Check if a directories are part of the name:
-	char* dir = strrchr((char *)dos_filename,'\\');
+	//Check if a directory is part of the name:
+    char temp[256];
+    strcpy(temp, dos_filename);
+	char* dir = strrchr(temp,'\\');
 	if (!f && dir && *dir) {
 		if (logoverlay) LOG_MSG("Overlay: warning creating a file inside a directory %s",dos_filename);
 		//ensure they exist, else make them in the overlay if they exist in the original....

--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -26,7 +26,7 @@
 #include "support.h"
 #include "control.h"
 
-bool wild_match(char *haystack, char *needle) {
+bool wild_match(const char *haystack, char *needle) {
 	size_t max, i;
     for (; *needle != '\0'; ++needle) {
         switch (*needle) {
@@ -100,7 +100,7 @@ bool WildFileCmp(const char * file, const char * wild)
 			if (!wild_match(file_name, wild_name)) return false;
 			goto checkext;
 		} else
-			return wild_match((char *)file, wild_name);
+			return wild_match(file, wild_name);
 	} else {
 		r=0;
 		while (r<8) {
@@ -179,7 +179,7 @@ bool LWildFileCmp(const char * file, const char * wild)
 			if (!wild_match(file_name, wild_name)) return false;
 			goto checkext;
 		} else
-			return wild_match((char *)file, wild_name);
+			return wild_match(file, wild_name);
 	} else {
 		r=0;
 		while (r<size) {

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -1436,7 +1436,7 @@ uint8_t imageDiskVFD::Write_AbsoluteSector(uint32_t sectnum,const void *data) {
     return Write_Sector(h,c,s,data);
 }
 
-imageDiskVFD::imageDiskVFD(FILE *imgFile, uint8_t *imgName, uint32_t imgSizeK, bool isHardDisk) : imageDisk(ID_VFD) {
+imageDiskVFD::imageDiskVFD(FILE *imgFile, const char *imgName, uint32_t imgSizeK, bool isHardDisk) : imageDisk(ID_VFD) {
     (void)isHardDisk;//UNUSED
     unsigned char tmp[16];
 
@@ -1451,7 +1451,7 @@ imageDiskVFD::imageDiskVFD(FILE *imgFile, uint8_t *imgName, uint32_t imgSizeK, b
     diskimg = imgFile;
 
     if (imgName != NULL)
-        diskname = (const char*)imgName;
+        diskname = imgName;
 
     // NOTES:
     // 
@@ -1759,7 +1759,7 @@ uint8_t imageDiskD88::Write_AbsoluteSector(uint32_t sectnum,const void *data) {
     return Write_Sector(h,c,s,data);
 }
 
-imageDiskD88::imageDiskD88(FILE *imgFile, uint8_t *imgName, uint32_t imgSizeK, bool isHardDisk) : imageDisk(ID_D88) {
+imageDiskD88::imageDiskD88(FILE *imgFile, const char *imgName, uint32_t imgSizeK, bool isHardDisk) : imageDisk(ID_D88) {
     (void)isHardDisk;//UNUSED
     D88HEAD head;
 
@@ -1780,7 +1780,7 @@ imageDiskD88::imageDiskD88(FILE *imgFile, uint8_t *imgName, uint32_t imgSizeK, b
     diskimg = imgFile;
 
     if (imgName != NULL)
-        diskname = (const char*)imgName;
+        diskname = imgName;
 
     // NOTES:
     // 
@@ -2055,7 +2055,7 @@ uint8_t imageDiskNFD::Write_AbsoluteSector(uint32_t sectnum,const void *data) {
     return Write_Sector(h,c,s,data);
 }
 
-imageDiskNFD::imageDiskNFD(FILE *imgFile, uint8_t *imgName, uint32_t imgSizeK, bool isHardDisk, unsigned int revision) : imageDisk(ID_NFD) {
+imageDiskNFD::imageDiskNFD(FILE *imgFile, const char *imgName, uint32_t imgSizeK, bool isHardDisk, unsigned int revision) : imageDisk(ID_NFD) {
     (void)isHardDisk;//UNUSED
     union {
         NFDHDR head;
@@ -2077,7 +2077,7 @@ imageDiskNFD::imageDiskNFD(FILE *imgFile, uint8_t *imgName, uint32_t imgSizeK, b
     diskimg = imgFile;
 
     if (imgName != NULL)
-        diskname = (const char*)imgName;
+        diskname = imgName;
 
     // NOTES:
     // 

--- a/src/ints/qcow2_disk.cpp
+++ b/src/ints/qcow2_disk.cpp
@@ -140,7 +140,7 @@ using namespace std;
 
 
 //Public function to a write a sector.
-	uint8_t QCow2Image::write_sector(uint32_t sectnum, uint8_t* data){
+	uint8_t QCow2Image::write_sector(uint32_t sectnum, const uint8_t* data){
 		const uint64_t address = (uint64_t)sectnum * sector_size;
 		if (address >= header.size){
 			return 0x05;
@@ -385,7 +385,7 @@ using namespace std;
 
 
 //Write data of arbitrary length to the image file.
-	uint8_t QCow2Image::write_data(uint64_t file_offset, uint8_t* data, uint64_t data_size){
+	uint8_t QCow2Image::write_data(uint64_t file_offset, const uint8_t* data, uint64_t data_size){
 		if (0 != fseeko64(file, (off_t)file_offset, SEEK_SET)){
 			return 0x05;
 		}
@@ -433,7 +433,7 @@ using namespace std;
 
 
 //Public Constructor.
-	QCow2Disk::QCow2Disk(QCow2Image::QCow2Header& qcow2Header, FILE *qcow2File, uint8_t *imgName, uint32_t imgSizeK, uint32_t sectorSizeBytes, bool isHardDisk) : imageDisk(qcow2File, (const char*)imgName, imgSizeK, isHardDisk), qcowImage(qcow2Header, qcow2File, (const char*) imgName, sectorSizeBytes){
+	QCow2Disk::QCow2Disk(QCow2Image::QCow2Header& qcow2Header, FILE *qcow2File, const char *imgName, uint32_t imgSizeK, uint32_t sectorSizeBytes, bool isHardDisk) : imageDisk(qcow2File, (const char*)imgName, imgSizeK, isHardDisk), qcowImage(qcow2Header, qcow2File, (const char*) imgName, sectorSizeBytes){
 	}
 
 
@@ -450,5 +450,5 @@ using namespace std;
 
 //Public function to a write a sector.
 	uint8_t QCow2Disk::Write_AbsoluteSector(uint32_t sectnum,const void* data){
-		return qcowImage.write_sector(sectnum, (uint8_t*)data);
+		return qcowImage.write_sector(sectnum, (const uint8_t*)data);
 	}

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -1346,7 +1346,8 @@ void CONFIG::Run(void) {
 								mainMenu.get_item("dos_lfn_disable").check(enablelfn==0).refresh_item(mainMenu);
 								uselfn = enablelfn==1 || ((enablelfn == -1 || enablelfn == -2) && (dos.version.major>6 || winrun));
 							} else if (!strcasecmp(inputline.substr(0, 4).c_str(), "ver=")) {
-								char *ver = (char *)section->Get_string("ver");
+                                char ver[5];
+                                strcpy(ver, section->Get_string("ver"));
 								if (!*ver) {
 									dos.version.minor=0;
 									dos.version.major=5;


### PR DESCRIPTION
Improves const-correctness by removing several casts of const values to non-const values (identified with a static analyzer).

The removed casts were of 2 cases.

Case 1: A const value was being cast to non-const to be used as a parameter in a function call. In some cases the function parameter was const, so I just removed the cast if I could, or if there was a type conversion happening with the cast but the const keyword was missing, I added the const keyword. In other cases the function parameter was non-const, but it could be changed to const without issue, so I did that and removed the cast to non-const.

Case 2: A string/const char pointer was being cast to non-const. In some cases the cast was just unnecessary, so I removed it. In the others, I used `strcpy` to copy the const char pointer contents to a non-const char array, which is then used in the following operations that need to modify it.