### PR TITLE
Use "emplace_back" and "emplace_front", and other cleanup (via static analysis)

### DIFF
--- a/include/control.h
+++ b/include/control.h
@@ -67,7 +67,7 @@ public:
     std::vector<std::string> startup_params;
     std::vector<std::string> configfiles;
     Config(CommandLine * cmd):cmdline(cmd),secure_mode(false) {
-        startup_params.push_back(cmdline->GetFileName());
+        startup_params.emplace_back(cmdline->GetFileName());
         cmdline->FillVector(startup_params);
         opt_exit = false;
         opt_debug = false;

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -495,7 +495,7 @@ public:
 	CBreakpoint(void);
 	void					SetAddress		(uint16_t seg, uint32_t off)	{ location = (PhysPt)GetAddress(seg,off); type = BKPNT_PHYSICAL; segment = seg; offset = off; };
 	void					SetAddress		(PhysPt adr)				{ location = adr; type = BKPNT_PHYSICAL; };
-	void					SetInt			(uint8_t _intNr, uint16_t ah, uint16_t al)	{ intNr = _intNr, ahValue = ah; alValue = al; type = BKPNT_INTERRUPT; };
+	void					SetInt			(uint8_t _intNr, uint16_t ah, uint16_t al)	{ intNr = _intNr; ahValue = ah; alValue = al; type = BKPNT_INTERRUPT; };
 	void					SetOnce			(bool _once)				{ once = _once; };
 	void					SetType			(EBreakpoint _type)			{ type = _type; };
 	void					SetValue		(uint8_t value)				{ ahValue = value; };

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -3881,12 +3881,12 @@ void LogPages(char* selname) {
 		Bitu sel = GetHexValue(selname,selname);
 		if ((sel==0x00) && ((*selname==0) || (*selname=='*'))) {
 			for (unsigned int i=0; i<0xfffff; i++) {
-				Bitu table_addr=((Bitu)paging.base.page<<12u)+(i >> 10u)*(Bitu)4u;
+				Bitu table_addr=(paging.base.page<<12u)+(i >> 10u)*(Bitu)4u;
 				X86PageEntry table;
 				table.load=phys_readd((PhysPt)table_addr);
 				if (table.block.p) {
 					X86PageEntry entry;
-                    PhysPt entry_addr=((PhysPt)table.block.base<<12u)+(i & 0x3ffu)* 4u;
+                    PhysPt entry_addr=(table.block.base<<12u)+(i & 0x3ffu)* 4u;
 					entry.load=phys_readd(entry_addr);
 					if (entry.block.p) {
 						sprintf(out1,"page %05Xxxx -> %04Xxxx  flags [uw] %x:%x::%x:%x [d=%x|a=%x]",

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -1216,7 +1216,7 @@ static void DrawCode(void) {
 		return;
 
 	uint32_t disEIP = codeViewData.useEIP;
-	char dline[200];Bitu size;Bitu c;
+	char dline[200];Bitu size;
 	static char line20[21] = "                    ";
     int w,h;
 
@@ -1276,7 +1276,7 @@ static void DrawCode(void) {
 		if (drawsize>10) { toolarge = true; drawsize = 9; }
  
         if (start != mem_no_address) {
-            for (c=0;c<drawsize;c++) {
+            for (Bitu c=0;c<drawsize;c++) {
                 uint8_t value;
                 if (!mem_readb_checked((PhysPt)(start+c),&value)) {
                     wattrset (dbg.win_code,0);

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -3273,7 +3273,7 @@ uint32_t DEBUG_CheckKeys(void) {
                     if(ParseCommand(codeViewData.inputStr)) {
                         char* cmd = ltrim(codeViewData.inputStr);
                         if (histBuff.empty() || *--histBuff.end()!=cmd)
-                            histBuff.push_back(cmd);
+                            histBuff.emplace_back(cmd);
                         if (histBuff.size() > MAX_HIST_BUFFER) histBuff.pop_front();
                         histBuffPos = histBuff.end();
                         ClearInputLine();

--- a/src/debug/debug_disasm.cpp
+++ b/src/debug/debug_disasm.cpp
@@ -608,11 +608,11 @@ static void outhex(char subtype, int extend, int optional, int defsize, int sign
       } else
         signchar = '+';
       if (delta || !optional)
-		uprintf("%c%0*lX", (char)signchar, (int)(extend), (long)delta);
+		uprintf("%c%0*lX", signchar, (extend), (long)delta);
     } else {
       if (extend==2)
         delta = (UINT16)delta;
-	  uprintf("%0.*lX", (int)(2*extend), (long)delta );
+	  uprintf("%0.*lX", (2*extend), (long)delta );
     }
     return;
   }
@@ -629,7 +629,7 @@ static void outhex(char subtype, int extend, int optional, int defsize, int sign
        } else
          signchar = '+';
        if (sign)
-		 uprintf("%c%02lX", (char)signchar, delta & 0xFFL);
+		 uprintf("%c%02lX", signchar, delta & 0xFFL);
        else
 		 uprintf("%02lX", delta & 0xFFL);
        break;
@@ -641,7 +641,7 @@ static void outhex(char subtype, int extend, int optional, int defsize, int sign
        } else
          signchar = '+';
        if (sign)
-		 uprintf("%c%04lX", (char)signchar, delta & 0xFFFFL);
+		 uprintf("%c%04lX", signchar, delta & 0xFFFFL);
        else
 		 uprintf("%04lX", delta & 0xFFFFL);
        break;
@@ -653,7 +653,7 @@ static void outhex(char subtype, int extend, int optional, int defsize, int sign
        } else
          signchar = '+';
        if (sign)
-		 uprintf("%c%08lX", (char)signchar, (unsigned long)delta & 0xFFFFFFFFL);
+		 uprintf("%c%08lX", signchar, (unsigned long)delta & 0xFFFFFFFFL);
        else
 		 uprintf("%08lX", (unsigned long)delta & 0xFFFFFFFFL);
        break;
@@ -873,13 +873,13 @@ static void percent(char type, char subtype)
        switch (bytes(subtype)) {              /* sizeof offset value */
        case 1:
             vofs = (INT8)getbyte();
-			name = addr_to_hex((UINT32)vofs+(UINT32)instruction_offset+(UINT32)INSTRUCTION_SIZE,0);
+			name = addr_to_hex((UINT32)vofs+instruction_offset+(UINT32)INSTRUCTION_SIZE,0);
             break;
        case 2:
             vofs  = (INT32)((UINT32)getbyte());
             vofs |= (INT32)((UINT32)getbyte() << 8);
             vofs  = (INT16)vofs;
-			name  = addr_to_hex((UINT32)vofs+(UINT32)instruction_offset+(UINT32)INSTRUCTION_SIZE,0);
+			name  = addr_to_hex((UINT32)vofs+instruction_offset+(UINT32)INSTRUCTION_SIZE,0);
             break;
 			/* i386 */
        case 4:
@@ -887,7 +887,7 @@ static void percent(char type, char subtype)
             vofs |= (INT32)((UINT32)getbyte() << 8);
             vofs |= (INT32)((UINT32)getbyte() << 16);
             vofs |= (INT32)((UINT32)getbyte() << 24);
-			name = addr_to_hex((UINT32)vofs+(UINT32)instruction_offset+(UINT32)INSTRUCTION_SIZE,(addrsize == 32)?0:1);
+			name = addr_to_hex((UINT32)vofs+instruction_offset+(UINT32)INSTRUCTION_SIZE,(addrsize == 32)?0:1);
             break;
        }
 	   if (vofs<0)

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -695,7 +695,7 @@ void DEBUG_ShowMsg(char const* format,...) {
 		logBuffPos=logBuff.end();
 		DEBUG_RefreshPage(0);
 	}
-	logBuff.push_back(buf);
+	logBuff.emplace_back(buf);
 	if (logBuff.size() > MAX_LOG_BUFFER) {
         logBuffHasDiscarded = true;
         if (logBuffPos == logBuff.begin()) ++logBuffPos; /* keep the iterator valid */

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -492,7 +492,7 @@ static void MakeSubWindows(void) {
 
             /* add height to the window */
             yheight[wndi] += (unsigned int)expand_by;
-            outy += (int)expand_by;
+            outy += expand_by;
             wndi++;
 
             /* move the others down */

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -917,7 +917,7 @@ bool DOS_UnlinkFile(char const * const name) {
 				strcpy(temp, dir);
 				if (strlen(temp)&&temp[strlen(temp)-1]!='\\') strcat(temp, "\\");
 				strcat(temp, find_name);
-				cdirs.push_back(std::string(temp));
+				cdirs.emplace_back(std::string(temp));
 			}
 		} while ((ret=DOS_FindNext())==true);
 		lfn_filefind_handle=fbak;

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -548,7 +548,7 @@ void MenuBrowseFDImage(char drive, int num, int type) {
     if (lTheOpenFileName) {
         uint8_t mediaid = 0xF0;
         std::vector<std::string> options;
-        if (mountiro[drive-'A']) options.push_back("readonly");
+        if (mountiro[drive-'A']) options.emplace_back("readonly");
         fatDrive *newDrive = new fatDrive(lTheOpenFileName, 0, 0, 0, 0, options);
         if (!newDrive->created_successfully) {
             tinyfd_messageBox("Error","Could not mount the selected floppy disk image.","ok","error", 1);

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -4091,25 +4091,25 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 		char dir_name[CROSS_LEN], dir_sname[CROSS_LEN];
 		bool is_directory;
 		if (read_directory_first(dirp, dir_name, dir_sname, is_directory)) {
-			if ((strlen(dir_name) > prefix_lengh+5) && strncmp(dir_name,special_prefix.c_str(),prefix_lengh) == 0) specials.push_back(dir_name);
+			if ((strlen(dir_name) > prefix_lengh+5) && strncmp(dir_name,special_prefix.c_str(),prefix_lengh) == 0) specials.emplace_back(dir_name);
 			else if (is_directory) {
-				dirnames.push_back(dir_name);
+				dirnames.emplace_back(dir_name);
 				if (!strlen(dir_sname)) {
 					strcpy(dir_sname, dir_name);
 					upcase(dir_sname);
 				}
-				dirnames.push_back(dir_sname);
-			} else filenames.push_back(dir_name);
+				dirnames.emplace_back(dir_sname);
+			} else filenames.emplace_back(dir_name);
 			while (read_directory_next(dirp, dir_name, dir_sname, is_directory)) {
-				if ((strlen(dir_name) > prefix_lengh+5) && strncmp(dir_name,special_prefix.c_str(),prefix_lengh) == 0) specials.push_back(dir_name);
+				if ((strlen(dir_name) > prefix_lengh+5) && strncmp(dir_name,special_prefix.c_str(),prefix_lengh) == 0) specials.emplace_back(dir_name);
 				else if (is_directory) {
-					dirnames.push_back(dir_name);
+					dirnames.emplace_back(dir_name);
 					if (!strlen(dir_sname)) {
 						strcpy(dir_sname, dir_name);
 						upcase(dir_sname);
 					}
-					dirnames.push_back(dir_sname);
-				} else filenames.push_back(dir_name);
+					dirnames.emplace_back(dir_sname);
+				} else filenames.emplace_back(dir_name);
 			}
 		}
 		closedir(dirp);
@@ -4199,7 +4199,7 @@ void Overlay_Drive::update_cache(bool read_directory_contents) {
 			//upcase(dosname);  //Should not be really needed, as uppercase in the overlay is a requirement...
 			CROSS_DOSFILENAME(dosname);
 			if (logoverlay) LOG_MSG("update cache add dosname %s",dosname);
-			DOSnames_cache.push_back(dosname);
+			DOSnames_cache.emplace_back(dosname);
 		}
 	}
 
@@ -4709,7 +4709,7 @@ void Overlay_Drive::add_deleted_file(const char* name,bool create_on_disk) {
 	else
 		strcat(tname,temp_name);
 	if (!is_deleted_file(tname)) {
-		deleted_files_in_base.push_back(tname);
+		deleted_files_in_base.emplace_back(tname);
 		if (create_on_disk) add_special_file_to_disk(tname, "DEL");
 	}
 }
@@ -4836,8 +4836,8 @@ void Overlay_Drive::add_DOSdir_to_cache(const char* name, const char *sname) {
 	if (!name || !*name ) return; //Skip empty file.
 	if (logoverlay) LOG_MSG("Adding name to overlay_only_dir_cache %s",name);
 	if (!is_dir_only_in_overlay(name)) {
-		DOSdirs_cache.push_back(name);
-		DOSdirs_cache.push_back(sname);
+		DOSdirs_cache.emplace_back(name);
+		DOSdirs_cache.emplace_back(sname);
 	}
 }
 
@@ -4889,7 +4889,7 @@ void Overlay_Drive::remove_deleted_file(const char* name,bool create_on_disk) {
 void Overlay_Drive::add_deleted_path(const char* name, bool create_on_disk) {
 	if (!name || !*name ) return; //Skip empty file.
 	if (!is_deleted_path(name)) {
-		deleted_paths_in_base.push_back(name);
+		deleted_paths_in_base.emplace_back(name);
 		//Add it to deleted files as well, so it gets skipped in FindNext. 
 		//Maybe revise that.
 		if (create_on_disk) add_special_file_to_disk(name,"RMD");

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -927,7 +927,7 @@ bool INT10_SetVideoMode_OTHER(uint16_t mode,bool clearmem) {
 	else if(CurMode->hdispend==80) syncwidth = 0xc;
 	else syncwidth = 0x6;
 	
-	IO_WriteW(crtc_base,(uint16_t)(0x03 | (syncwidth) << 8));
+	IO_WriteW(crtc_base,(uint16_t)(0x03 | syncwidth << 8));
 	////Vertical total
 	IO_WriteW(crtc_base,(uint16_t)(0x04 | (CurMode->vtotal) << 8));
 	//Vertical total adjust, 6 for cga,hercules,tandy
@@ -1052,7 +1052,7 @@ bool INT10_SetVideoMode_OTHER(uint16_t mode,bool clearmem) {
             if (CurMode->mode == 2 || CurMode->mode == 3)
                 mcga_mode |= 0x80;
 
-            IO_WriteW(crtc_base,0x10 | (mcga_mode) << 8);
+            IO_WriteW(crtc_base,0x10 | mcga_mode << 8);
         }
 		break;
 	case MCH_TANDY:

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -53,7 +53,7 @@ void MSG_Add(const char * _name, const char* _val) {
 		}
 	}
 	/* if the message doesn't exist add it */
-	Lang.push_back(MessageBlock(_name,_val));
+	Lang.emplace_back(MessageBlock(_name,_val));
 }
 
 void MSG_Replace(const char * _name, const char* _val) {
@@ -65,7 +65,7 @@ void MSG_Replace(const char * _name, const char* _val) {
 		}
 	}
 	/* Even if the message doesn't exist add it */
-	Lang.push_back(MessageBlock(_name,_val));
+	Lang.emplace_back(MessageBlock(_name,_val));
 }
 
 void InitCodePage() {

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -970,14 +970,14 @@ void Null_Init(Section *sec);
 
 void AddExitFunction(SectionFunction func,const char *name,bool canchange) {
     /* NTS: Add functions so that iterating front to back executes them in First In Last Out order. */
-    exitfunctions.push_front(Function_wrapper(func,canchange,name));
+    exitfunctions.emplace_front(Function_wrapper(func,canchange,name));
 }
 
 void AddVMEventFunction(enum vm_event event,SectionFunction func,const char *name,bool canchange) {
     assert(event < VM_EVENT_MAX);
 
     /* NTS: First In First Out order */
-    vm_event_functions[event].push_back(Function_wrapper(func,canchange,name));
+    vm_event_functions[event].emplace_back(Function_wrapper(func,canchange,name));
 }
 
 const char *VM_EVENT_string[VM_EVENT_MAX] = {
@@ -1073,7 +1073,7 @@ bool Config::ParseConfigFile(char const * const configfilename) {
     if (!in) return false;
     const char * settings_type;
     settings_type = (configfiles.size() == 0)? "primary":"additional";
-    configfiles.push_back(configfilename);
+    configfiles.emplace_back(configfilename);
 
     LOG(LOG_MISC,LOG_NORMAL)("Loading %s settings from config file %s", settings_type,configfilename);
 
@@ -1527,7 +1527,7 @@ CommandLine::CommandLine(int argc,char const * const argv[],enum opt_style opt) 
         if (!raw_cmdline.empty()) raw_cmdline += " ";
         raw_cmdline += argv[i];
 
-        cmds.push_back(argv[i]);
+        cmds.emplace_back(argv[i]);
         i++;
     }
 }

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1072,7 +1072,7 @@ void drivezRegister(std::string path, std::string dir) {
         if(hFind != INVALID_HANDLE_VALUE) {
             do {
                 if(!(fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
-                    names.push_back(fd.cFileName);
+                    names.emplace_back(fd.cFileName);
                 else if (strcmp(fd.cFileName, ".") && strcmp(fd.cFileName, ".."))
                     names.push_back(std::string(fd.cFileName)+"/");
             } while(::FindNextFile(hFind, &fd));

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -701,7 +701,7 @@ static bool doDeltree(DOS_Shell * shell, char * args, DOS_DTA dta, bool optY, bo
                         fdir=true;
                         strcat(spath, name);
                         strcat(spath, "\\*.*");
-                        cdirs.push_back(std::string(spath));
+                        cdirs.emplace_back(std::string(spath));
                     }
                 } else {
                     if (!optY&&first) {
@@ -780,7 +780,7 @@ void DOS_Shell::CMD_DELTREE(char * args) {
 	dos.dta(dos.tables.tempdta);
 	DOS_DTA dta(dos.dta());
 	tdirs.clear();
-	tdirs.push_back(std::string(args));
+	tdirs.emplace_back(std::string(args));
 	bool first=true, found=false;
     ctrlbrk=false;
     inshell=true;
@@ -880,7 +880,7 @@ static bool doTree(DOS_Shell * shell, char * args, DOS_DTA dta, bool optA, bool 
                     if (strcmp(name, ".")&&strcmp(name, "..")) {
                         strcat(spath, name);
                         strcat(spath, "\\*.*");
-                        cdirs.push_back(std::string(spath));
+                        cdirs.emplace_back(std::string(spath));
                         found=true;
                     }
                 } else if (optF) {
@@ -942,7 +942,7 @@ void DOS_Shell::CMD_TREE(char * args) {
     ctrlbrk=false;
     inshell=true;
 	tdirs.clear();
-	tdirs.push_back(std::string(buffer));
+	tdirs.emplace_back(std::string(buffer));
 	while (!tdirs.empty()) {
 		if (!doTree(this, (char *)tdirs.begin()->c_str(), dta, optA, optF)) break;
 		tdirs.erase(tdirs.begin());
@@ -1190,9 +1190,9 @@ void DOS_Shell::CMD_RENAME(char * args){
 				strcpy(targs, dir_source);
 				if (uselfn) removeChar(targs, '\"');
 				strcat(targs, arg2);
-				sources.push_back(uselfn?((sargs[0]!='"'?"\"":"")+std::string(sargs)+(sargs[strlen(sargs)-1]!='"'?"\"":"")).c_str():sargs);
-				sources.push_back(uselfn?((targs[0]!='"'?"\"":"")+std::string(targs)+(targs[strlen(targs)-1]!='"'?"\"":"")).c_str():targs);
-				sources.push_back(strlen(sargs)>2&&sargs[0]=='.'&&sargs[1]=='\\'?sargs+2:sargs);
+				sources.emplace_back(uselfn?((sargs[0]!='"'?"\"":"")+std::string(sargs)+(sargs[strlen(sargs)-1]!='"'?"\"":"")).c_str():sargs);
+				sources.emplace_back(uselfn?((targs[0]!='"'?"\"":"")+std::string(targs)+(targs[strlen(targs)-1]!='"'?"\"":"")).c_str():targs);
+				sources.emplace_back(strlen(sargs)>2&&sargs[0]=='.'&&sargs[1]=='\\'?sargs+2:sargs);
 			}
 			lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
 		} while ( DOS_FindNext() );
@@ -1270,7 +1270,7 @@ void DOS_Shell::CMD_PUSHD(char * args) {
         if (strlen(args)>1 && args[1]==':') DOS_SetDefaultDrive(toupper(args[0])-'A');
         if (DOS_ChangeDir(sargs)) {
             olddrives.push_back(drive);
-            olddirs.push_back(std::string(dir));
+            olddirs.emplace_back(std::string(dir));
         } else {
             if (strlen(args)>1 && args[1]==':') DOS_SetDefaultDrive(drive-'A');
             WriteOut(MSG_Get("SHELL_CMD_CHDIR_ERROR"),args);
@@ -1854,7 +1854,7 @@ void DOS_Shell::CMD_DIR(char * args) {
 	dos.dta(dos.tables.tempdta);
 	DOS_DTA dta(dos.dta());
 	dirs.clear();
-	dirs.push_back(std::string(args));
+	dirs.emplace_back(std::string(args));
 	inshell=true;
 	while (!dirs.empty()) {
 		ctrlbrk=false;
@@ -3252,7 +3252,7 @@ void DOS_Shell::CMD_ATTRIB(char *args){
 	dos.dta(dos.tables.tempdta);
 	DOS_DTA dta(dos.dta());
 	adirs.clear();
-	adirs.push_back(std::string(args));
+	adirs.emplace_back(std::string(args));
 	bool found=false;
 	inshell=true;
 	while (!adirs.empty()) {

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -274,14 +274,14 @@ bool DOS_Shell::BuildCompletions(char * line, uint16_t str_len) {
 
         if (strcmp(name, ".") && strcmp(name, "..")) {
             if (dir_only) { //Handle the dir only case different (line starts with cd)
-                if(att & DOS_ATTR_DIRECTORY) l_completion.push_back(qlname);
+                if(att & DOS_ATTR_DIRECTORY) l_completion.emplace_back(qlname);
             } else {
                 const char *ext = strrchr(name, '.'); // file extension
                 if (ext && (strcmp(ext, ".BAT") == 0 || strcmp(ext, ".COM") == 0 || strcmp(ext, ".EXE") == 0))
-                    // we add executables to the a seperate list and place that list infront of the normal files
-                    executable.push_front(qlname);
+                    // we add executables to a separate list and place that list in front of the normal files
+                    executable.emplace_front(qlname);
                 else
-                    l_completion.push_back(qlname);
+                    l_completion.emplace_back(qlname);
             }
         }
         res=DOS_FindNext();
@@ -534,7 +534,7 @@ void DOS_Shell::InputCommand(char * line) {
                 // store current command in history if we are at beginning
                 if (it_history == l_history.begin() && !current_hist) {
                     current_hist=true;
-                    l_history.push_front(line);
+                    l_history.emplace_front(line);
                 }
 
                 // ensure we're at end to handle all cases
@@ -836,7 +836,7 @@ void DOS_Shell::InputCommand(char * line) {
 
 	// add command line to history. Win95 behavior with DOSKey suggests
 	// that the original string is preserved, not the expanded string.
-	l_history.push_front(line); it_history = l_history.begin();
+	l_history.emplace_front(line); it_history = l_history.begin();
 	if (l_completion.size()) l_completion.clear();
 
 	/* DOS %variable% substitution */


### PR DESCRIPTION
Mainly this is the replacement of various calls to `push_back` and `push_front` with `emplace_back` and `emplace_front`, which appear as recommendations when using the static analyzer Sonic Lint. Here is their page on this recommendation: https://rules.sonarsource.com/cpp/RSPEC-6003

The page says it only creates the recommendations "when an insertion function on a supported container leads to the construction of a large temporary object that can be avoided by using the provided emplacement member function."

I checked a bare-bones example based on the replacement recommendation that appeared for `debug_gui.cpp` using this site:
https://godbolt.org/z/x5hMq8r9n

and replacing `push_back` with `emplace_back` did shorten the generated assembly (for each of GCC, Clang and MSVC).

I couldn't find it now, but I thought I remembered seeing somewhere that DOSBox-X aims to be buildable on C++11? Not sure if that's correct, but the emplace functions were introduced in C++11, so I think this should be OK in that regard.

https://en.cppreference.com/w/cpp/container/vector/emplace_back
https://en.cppreference.com/w/cpp/container/list/emplace_front

Also a few other minor cleanups like redundant casts, what looks like a comma typo in place of a semicolon, etc. as found with the static analyzer.