### PR TITLE
Cleanup

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -357,7 +357,7 @@ public:
 		switch (size) {
 		case 1:mem_writeb(pt+addr,(uint8_t)val);break;
 		case 2:mem_writew(pt+addr,(uint16_t)val);break;
-		case 4:mem_writed(pt+addr,(uint32_t)val);break;
+		case 4:mem_writed(pt+addr,val);break;
 		}
 	}
     inline void SetPt(const uint16_t seg) { pt=PhysMake(seg,0);}
@@ -563,7 +563,7 @@ public:
 	void	SetDirID(uint16_t entry)			{ sSave(sDTA,dirID,entry); };
 	void	SetDirIDCluster(uint32_t entry)	{ sSave(sDTA,dirCluster,entry); };
 	uint16_t	GetDirID(void)				{ return (uint16_t)sGet(sDTA,dirID); };
-	uint32_t	GetDirIDCluster(void)		{ return (uint32_t)sGet(sDTA,dirCluster); };
+	uint32_t	GetDirIDCluster(void)		{ return sGet(sDTA,dirCluster); };
     uint8_t   GetAttr(void)               { return (uint8_t)sGet(sDTA,sattr); }
 private:
 	#ifdef _MSC_VER
@@ -684,7 +684,7 @@ public:
 	void SetPSP(uint16_t _psp) { sSave(sSDA,current_psp, _psp); }
 	uint8_t GetDrive(void) { return (uint8_t)sGet(sSDA,current_drive); }
 	uint16_t GetPSP(void) { return (uint16_t)sGet(sSDA,current_psp); }
-	uint32_t GetDTA(void) { return (uint32_t)sGet(sSDA,current_dta); }
+	uint32_t GetDTA(void) { return sGet(sSDA,current_dta); }
 	
 	
 private:

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -78,7 +78,7 @@ public:
     DOS_File() :flags(0) { name = 0; attr = 0; date = 0; drive = 0; refCtr = 0; open = false; time = 0; hdrive = 0xff; newtime = false; };
 	DOS_File(const DOS_File& orig);
 	DOS_File & operator= (const DOS_File & orig);
-	virtual	~DOS_File(){if(name) delete [] name;};
+	virtual ~DOS_File(){ delete [] name;};
 	virtual bool	Read(uint8_t * data,uint16_t * size)=0;
 	virtual bool	Write(const uint8_t * data,uint16_t * size)=0;
 	virtual bool	Seek(uint32_t * pos,uint32_t type)=0;
@@ -86,7 +86,7 @@ public:
 	/* ert, 20100711: Locking extensions */
 	virtual bool    LockFile(uint8_t mode, uint32_t pos, uint16_t size) { (void)mode; (void)pos; (void)size; return false; };
 	virtual uint16_t	GetInformation(void)=0;
-	virtual void	SetName(const char* _name)	{ if (name) delete[] name; name = new char[strlen(_name)+1]; strcpy(name,_name); }
+	virtual void	SetName(const char* _name)	{ delete[] name; name = new char[strlen(_name)+1]; strcpy(name,_name); }
 	virtual char*	GetName(void)				{ return name; };
 	virtual bool	IsOpen()					{ return open; };
 	virtual bool	IsName(const char* _name)	{ if (!name) return false; return strcasecmp(name,_name)==0; };

--- a/include/menu.h
+++ b/include/menu.h
@@ -36,7 +36,6 @@ void Mount_Img_HDD(char drive, std::string realpath);
 void DOSBox_SetMenu(void);
 void DOSBox_NoMenu(void);
 void DOSBox_RefreshMenu(void);
-void ToggleMenu(bool pressed);
 void DOSBox_CheckOS(int &id, int &major, int &minor);
 void MountDrive(char drive, const char drive2[DOS_PATHLENGTH]);
 void MountDrive_2(char drive, const char drive2[DOS_PATHLENGTH], std::string drive_type);

--- a/include/programs.h
+++ b/include/programs.h
@@ -101,8 +101,8 @@ class Program {
 public:
 	Program();                                          //! Constructor
 	virtual ~Program(){                                 //! Default destructor
-		if (cmd != NULL) delete cmd;
-		if (psp != NULL) delete psp;
+		delete cmd;
+		delete psp;
 	}
 
     /*! \brief      Exit status of the program

--- a/include/setup.h
+++ b/include/setup.h
@@ -412,7 +412,7 @@ public:
 	virtual bool SetValue(std::string const& input,bool init);
 	virtual bool SetValue(std::string const& input) { return SetValue(input,/*init*/false); };
 	virtual const std::vector<Value>& GetValues() const;
-	virtual ~Prop_multival() { if (section != NULL) { delete section; } }
+	virtual ~Prop_multival() { delete section; }
 }; //value bevat totale string. setvalue zet elk van de sub properties en checked die.
 
 class Prop_multival_remain:public Prop_multival{

--- a/include/video.h
+++ b/include/video.h
@@ -75,7 +75,6 @@ bool GFX_IsFullscreen(void);
 void GFX_SwitchLazyFullscreen(bool lazy);
 bool GFX_LazyFullscreenRequested(void);
 void GFX_SwitchFullscreenNoReset(void);
-void GFX_RestoreMode(void);
 void GFX_UpdateSDLCaptureState(void);
 
 #if defined (WIN32)

--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -394,6 +394,7 @@ bool DOS_Execute(const char* name, PhysPt block_pt, uint8_t flags) {
 			}
 			if (maxfree<minsize) {
 				DOS_CloseFile(fhandle);
+                delete[] loadbuf;
 				DOS_SetError(DOSERR_INSUFFICIENT_MEMORY);
 				DOS_FreeMemory(envseg);
 				return false;

--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -350,7 +350,7 @@ bool DOS_Execute(const char* name, PhysPt block_pt, uint8_t flags) {
 			if (imagesize+headersize<512u) imagesize = 512u-headersize;
 		}
 	}
-	uint8_t * loadbuf=(uint8_t *)new uint8_t[0x10000u];
+	uint8_t * loadbuf=new uint8_t[0x10000u];
 	if (flags!=OVERLAY) {
 		/* Create an environment block */
 		envseg=block.exec.envseg;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -285,10 +285,10 @@ unsigned long long update_clockdom_from_now(ClockDomain &dst) {
 
     /* PIC_Ticks (if I read the code correctly) is millisecond ticks, units of 1/1000 seconds.
      * PIC_TickIndexND() units of submillisecond time in units of 1/CPU_CycleMax. */
-    s  = (signed long long)((unsigned long long)PIC_Ticks * (unsigned long long)dst.freq);
-    s += (signed long long)(((unsigned long long)PIC_TickIndexND() * (unsigned long long)dst.freq) / (unsigned long long)CPU_CycleMax);
+    s  = (signed long long)((unsigned long long)PIC_Ticks * dst.freq);
+    s += (signed long long)(((unsigned long long)PIC_TickIndexND() * dst.freq) / (unsigned long long)CPU_CycleMax);
     /* convert down to frequency counts, not freq x 1000 */
-    s /= (signed long long)(1000ULL * (unsigned long long)dst.freq_div);
+    s /= (signed long long)(1000ULL * dst.freq_div);
 
     /* guard against time going backwards slightly (as PIC_TickIndexND() will do sometimes by tiny amounts) */
     if (dst.counter < (unsigned long long)s) dst.counter = (unsigned long long)s;
@@ -1078,8 +1078,8 @@ void DOSBOX_RealInit() {
     LOG_MSG("%s BCLK: %.3fHz (%llu/%llu)",
         IS_PC98_ARCH ? "C-BUS" : "ISA",
         (double)clockdom_ISA_BCLK.freq / clockdom_ISA_BCLK.freq_div,
-        (unsigned long long)clockdom_ISA_BCLK.freq,
-        (unsigned long long)clockdom_ISA_BCLK.freq_div);
+        clockdom_ISA_BCLK.freq,
+        clockdom_ISA_BCLK.freq_div);
 
     clockdom_ISA_OSC.set_name("ISA OSC");
     clockdom_ISA_BCLK.set_name("ISA BCLK");

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -3169,10 +3169,10 @@ void VGA_CaptureWriteScanline(const uint8_t *raw) {
         vga_capture_write_address < 0xFFFF0000ul &&
         (vga_capture_write_address + (vga_capture_current_rect.w*4ul)) <= MemMax) {
         switch (vga.draw.bpp) {
-            case 32:    VGA_CaptureWriteScanlineChecked<32>((uint32_t*)raw); break;
-            case 16:    VGA_CaptureWriteScanlineChecked<16>((uint16_t*)raw); break;
-            case 15:    VGA_CaptureWriteScanlineChecked<16>((uint16_t*)raw); break;
-            case 8:     VGA_CaptureWriteScanlineChecked< 8>((uint8_t *)raw); break;
+            case 32:    VGA_CaptureWriteScanlineChecked<32>((const uint32_t*)raw); break;
+            case 16:    VGA_CaptureWriteScanlineChecked<16>((const uint16_t*)raw); break;
+            case 15:    VGA_CaptureWriteScanlineChecked<16>((const uint16_t*)raw); break;
+            case 8:     VGA_CaptureWriteScanlineChecked< 8>(raw); break;
         }
     }
     else {

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -816,8 +816,6 @@ static uint8_t * VGA_Draw_Xlat32_Linear_Line(Bitu vidstart, Bitu /*line*/) {
     return TempLine;
 }
 
-extern uint32_t Expand16Table[4][16];
-
 template <const unsigned int card,typename templine_type_t> static inline templine_type_t EGA_Planar_Common_Block_xlat(const uint8_t t) {
     if (card == MCH_VGA)
         return vga.dac.xlat32[t];
@@ -2136,7 +2134,6 @@ extern uint8_t GDC_display_plane;
 extern uint8_t GDC_display_plane_pending;
 extern bool pc98_graphics_hide_odd_raster_200line;
 extern bool pc98_allow_scanline_effect;
-extern bool gdc_analog;
 
 unsigned char       pc98_text_first_row_scanline_start = 0x00;  /* port 70h */
 unsigned char       pc98_text_first_row_scanline_end = 0x0F;    /* port 72h */
@@ -3109,15 +3106,6 @@ void VGA_ProcessScanline(const uint8_t *raw) {
     }
 }
 
-extern uint32_t GFX_Rmask;
-extern unsigned char GFX_Rshift;
-extern uint32_t GFX_Gmask;
-extern unsigned char GFX_Gshift;
-extern uint32_t GFX_Bmask;
-extern unsigned char GFX_Bshift;
-extern uint32_t GFX_Amask;
-extern unsigned char GFX_Ashift;
-extern unsigned char GFX_bpp;
 extern uint32_t vga_capture_stride;
 
 template <const unsigned int bpp,typename BPPT> uint32_t VGA_CaptureConvertPixel(const BPPT raw) {

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -918,7 +918,7 @@ void CONFIG::Run(void) {
 							p->GetValue().ToString().c_str());
 					}
 					if (!strcasecmp(pvars[0].c_str(), "config")||!strcasecmp(pvars[0].c_str(), "4dos")) {
-						const char * extra = const_cast<char*>(psec->data.c_str());
+						const char * extra = psec->data.c_str();
 						if (extra&&strlen(extra)) {
 							std::istringstream in(extra);
 							char linestr[CROSS_LEN+1], cmdstr[CROSS_LEN], valstr[CROSS_LEN];
@@ -1070,7 +1070,7 @@ void CONFIG::Run(void) {
 				if (val == NO_SUCH_PROPERTY) {
 					if (!strcasecmp(pvars[0].c_str(), "config") && (!strcasecmp(pvars[1].c_str(), "set") || !strcasecmp(pvars[1].c_str(), "device") || !strcasecmp(pvars[1].c_str(), "devicehigh") || !strcasecmp(pvars[1].c_str(), "install") || !strcasecmp(pvars[1].c_str(), "installhigh"))) {
 						Section_prop* psec = dynamic_cast <Section_prop*>(sec);
-						const char * extra = const_cast<char*>(psec->data.c_str());
+						const char * extra = psec->data.c_str();
 						if (extra&&strlen(extra)) {
 							std::istringstream in(extra);
 							char linestr[CROSS_LEN+1], cmdstr[CROSS_LEN], valstr[CROSS_LEN];
@@ -1466,7 +1466,7 @@ void CONFIG::Run(void) {
                                 else if (CurMode->type==M_TEXT || IS_PC98_ARCH)
                                     WriteOut("[2J");
                                 else {
-                                    reg_ax=(uint16_t)CurMode->mode;
+                                    reg_ax=CurMode->mode;
                                     CALLBACK_RunRealInt(0x10);
                                 }
                                 lastset=iscol?2:1;

--- a/src/misc/savestates.cpp
+++ b/src/misc/savestates.cpp
@@ -547,7 +547,7 @@ int do_extract_currentfile(unzFile uf, const int* popt_extract_without_path, int
     }
 
     size_buf = 8192;
-    buf = (void*)malloc(size_buf);
+    buf = malloc(size_buf);
     if (buf==NULL)
     {
         printf("Error allocating memory\n");
@@ -964,7 +964,7 @@ int my_minizip(char ** savefile, char ** savefile2, char* savename=NULL) {
 	opt_compress_level = 9;
 
     size_buf = 16384;
-    buf = (void*)malloc(size_buf);
+    buf = malloc(size_buf);
     if (buf==NULL)
     {
         //printf("Error allocating memory\n");

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -884,7 +884,7 @@ bool Config::PrintConfig(char const * const configfilename,int everything,bool n
 
         (*tel)->PrintData(outfile,everything,norem);
 		if (!strcmp(temp, "config")||!strcmp(temp, "4dos")) {
-			const char * extra = const_cast<char*>(sec->data.c_str());
+			const char * extra = sec->data.c_str();
 			bool used1=false, used2=false;
 			char linestr[CROSS_LEN+1], *lin=linestr;
 			if (extra&&strlen(extra)) {

--- a/src/output/direct3d/direct3d.cpp
+++ b/src/output/direct3d/direct3d.cpp
@@ -1410,7 +1410,7 @@ HRESULT CDirect3D::CreateVertex(void)
     if (psActive) {
         vertices[0].position = D3DXVECTOR3(-0.5f, -0.5f, 0.0f);
         vertices[0].diffuse = 0xFFFFFFFF;
-        vertices[0].texcoord = D3DXVECTOR2(0.0f, (float)sizey);
+        vertices[0].texcoord = D3DXVECTOR2(0.0f, sizey);
 
         vertices[1].position = D3DXVECTOR3(-0.5f, 0.5f, 0.0f);
         vertices[1].diffuse = 0xFFFFFFFF;
@@ -1418,11 +1418,11 @@ HRESULT CDirect3D::CreateVertex(void)
 
         vertices[2].position = D3DXVECTOR3(0.5f, -0.5f, 0.0f);
         vertices[2].diffuse = 0xFFFFFFFF;
-        vertices[2].texcoord = D3DXVECTOR2((float)sizex, (float)sizey);
+        vertices[2].texcoord = D3DXVECTOR2(sizex, sizey);
 
         vertices[3].position = D3DXVECTOR3(0.5f, 0.5f, 0.0f);
         vertices[3].diffuse = 0xFFFFFFFF;
-        vertices[3].texcoord = D3DXVECTOR2((float)sizex, 0.0f);
+        vertices[3].texcoord = D3DXVECTOR2(sizex, 0.0f);
     }
     else {
         vertices[0].position = D3DXVECTOR3((float)dwX, (float)dwY, 0.0f);
@@ -1431,15 +1431,15 @@ HRESULT CDirect3D::CreateVertex(void)
 
         vertices[1].position = D3DXVECTOR3((float)dwX, (float)(dwY + dwScaledHeight), 0.0f);
         vertices[1].diffuse = 0xFFFFFFFF;
-        vertices[1].texcoord = D3DXVECTOR2(0.0f, (float)sizey);
+        vertices[1].texcoord = D3DXVECTOR2(0.0f, sizey);
 
         vertices[2].position = D3DXVECTOR3((float)(dwX + dwScaledWidth), (float)dwY, 0.0f);
         vertices[2].diffuse = 0xFFFFFFFF;
-        vertices[2].texcoord = D3DXVECTOR2((float)sizex, 0.0f);
+        vertices[2].texcoord = D3DXVECTOR2(sizex, 0.0f);
 
         vertices[3].position = D3DXVECTOR3((float)(dwX + dwScaledWidth), (float)(dwY + dwScaledHeight), 0.0f);
         vertices[3].diffuse = 0xFFFFFFFF;
-        vertices[3].texcoord = D3DXVECTOR2((float)sizex, (float)sizey);
+        vertices[3].texcoord = D3DXVECTOR2(sizex, sizey);
     }
 
     // Additional vertices required for some PS effects

--- a/src/output/output_direct3d.cpp
+++ b/src/output/output_direct3d.cpp
@@ -339,14 +339,14 @@ void OUTPUT_DIRECT3D_EndUpdate(const uint16_t *changedLines)
             Bitu tgtPitch;
             if (d3d->LockTexture(tgtPix, tgtPitch) && tgtPix) // if locking fails, target texture can be nullptr
             {
-                uint32_t* tgtTex = reinterpret_cast<uint32_t*>(static_cast<uint8_t*>(tgtPix));
+                uint32_t* tgtTex = reinterpret_cast<uint32_t*>(tgtPix);
 # if defined(XBRZ_PPL)
                 concurrency::task_group tg;
                 for (int i = 0; i < xbrzHeight; i += sdl_xbrz.task_granularity)
                 {
                     tg.run([=] {
                         const int iLast = min(i + sdl_xbrz.task_granularity, xbrzHeight);
-                        xbrz::pitchChange(&xbrzBuf[0], &tgtTex[0], (int)xbrzWidth, (int)xbrzHeight, (int)(xbrzWidth * sizeof(uint32_t)), (int)tgtPitch, (int)i, (int)iLast, [](uint32_t pix) { return pix; });
+                        xbrz::pitchChange(&xbrzBuf[0], &tgtTex[0], xbrzWidth, xbrzHeight, (int)(xbrzWidth * sizeof(uint32_t)), (int)tgtPitch, i, iLast, [](uint32_t pix) { return pix; });
                     });
                 }
                 tg.wait();

--- a/src/output/output_opengl.cpp
+++ b/src/output/output_opengl.cpp
@@ -903,7 +903,7 @@ void OUTPUT_OPENGL_EndUpdate(const uint16_t *changedLines)
                 }
                 else
                 {
-                    trgTex = reinterpret_cast<uint32_t*>(static_cast<void*>(sdl_opengl.framebuf));
+                    trgTex = reinterpret_cast<uint32_t*>(sdl_opengl.framebuf);
                 }
 
                 if (trgTex)

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -637,7 +637,7 @@ void DOS_Shell::Prepare(void) {
 				countryNo = country;
 				DOS_SetCountry(countryNo);
 			}
-			const char * extra = const_cast<char*>(section->data.c_str());
+			const char * extra = section->data.c_str();
 			if (extra) {
 				std::string vstr;
 				std::istringstream in(extra);
@@ -702,7 +702,7 @@ void DOS_Shell::Prepare(void) {
         GetEnvStr("PATH",line);
 		if (!strlen(config_data)) {
 			strcat(config_data, "rem=");
-			strcat(config_data, (char *)section->Get_string("rem"));
+			strcat(config_data, section->Get_string("rem"));
 			strcat(config_data, "\r\n");
 		}
 		VFILE_Register("CONFIG.SYS",(uint8_t *)config_data,(uint32_t)strlen(config_data));
@@ -717,7 +717,7 @@ void DOS_Shell::Prepare(void) {
 		strcpy(i4dos_data, "");
 		section = static_cast<Section_prop *>(control->GetSection("4dos"));
 		if (section!=NULL) {
-			const char * extra = const_cast<char*>(section->data.c_str());
+			const char * extra = section->data.c_str();
 			if (extra) {
 				std::istringstream in(extra);
 				if (in)	for (std::string line; std::getline(in, line); ) {
@@ -872,7 +872,7 @@ public:
         }
 
 		/* add stuff from the configfile unless -noautexec or -securemode is specified. */
-		const char * extra = const_cast<char*>(section->data.c_str());
+		const char * extra = section->data.c_str();
 		if (extra && !secure && !control->opt_noautoexec) {
 			/* detect if "echo off" is the first line */
 			size_t firstline_length = strcspn(extra,"\r\n");

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -2220,7 +2220,7 @@ void DOS_Shell::CMD_COPY(char * args) {
 
 		//Find first sourcefile
 		char sPath[DOS_PATHLENGTH];
-		bool ret=DOS_GetSFNPath(source.filename.c_str(),sPath,false) && DOS_FindFirst(((strchr(sPath, ' ')&&sPath[0]!='"'&&sPath[0]!='"'?"\"":"")+std::string(sPath)+(strchr(sPath, ' ')&&sPath[strlen(sPath)-1]!='"'?"\"":"")).c_str(),0xffff & ~DOS_ATTR_VOLUME);
+		bool ret=DOS_GetSFNPath(source.filename.c_str(),sPath,false) && DOS_FindFirst(((strchr(sPath, ' ')&&sPath[0]!='"'?"\"":"")+std::string(sPath)+(strchr(sPath, ' ')&&sPath[strlen(sPath)-1]!='"'?"\"":"")).c_str(),0xffff & ~DOS_ATTR_VOLUME);
 		if (!ret) {
 			WriteOut(MSG_Get("SHELL_CMD_FILE_NOT_FOUND"),source.filename.c_str());
 			dos.dta(save_dta);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -552,7 +552,7 @@ continue_1:
 	std::string pfull=std::string(spath)+std::string(pattern);
 	int fbak=lfn_filefind_handle;
 	lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
-    bool res=DOS_FindFirst((char *)((uselfn&&pfull.length()&&pfull[0]!='"'?"\"":"")+pfull+(uselfn&&pfull.length()&&pfull[pfull.length()-1]!='"'?"\"":"")).c_str(),0xffff & ~DOS_ATTR_VOLUME);
+    bool res=DOS_FindFirst(((uselfn&&pfull.length()&&pfull[0]!='"'?"\"":"")+pfull+(uselfn&&pfull.length()&&pfull[pfull.length()-1]!='"'?"\"":"")).c_str(),0xffff & ~DOS_ATTR_VOLUME);
 	if (!res) {
 		lfn_filefind_handle=fbak;
 		WriteOut(MSG_Get("SHELL_CMD_DEL_ERROR"),args);
@@ -1095,7 +1095,7 @@ void DOS_Shell::CMD_RENAME(char * args){
 	std::string pfull=std::string(spath)+std::string(pattern);
 	int fbak=lfn_filefind_handle;
 	lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
-	if (!DOS_FindFirst((char *)((uselfn&&pfull.length()&&pfull[0]!='"'?"\"":"")+pfull+(uselfn&&pfull.length()&&pfull[pfull.length()-1]!='"'?"\"":"")).c_str(), strchr(arg1,'*')!=NULL || strchr(arg1,'?')!=NULL ? 0xffff & ~DOS_ATTR_VOLUME & ~DOS_ATTR_DIRECTORY : 0xffff & ~DOS_ATTR_VOLUME)) {
+	if (!DOS_FindFirst(((uselfn&&pfull.length()&&pfull[0]!='"'?"\"":"")+pfull+(uselfn&&pfull.length()&&pfull[pfull.length()-1]!='"'?"\"":"")).c_str(), strchr(arg1,'*')!=NULL || strchr(arg1,'?')!=NULL ? 0xffff & ~DOS_ATTR_VOLUME & ~DOS_ATTR_DIRECTORY : 0xffff & ~DOS_ATTR_VOLUME)) {
 		lfn_filefind_handle=fbak;
 		WriteOut(MSG_Get("SHELL_CMD_RENAME_ERROR"),arg1);
 	} else {
@@ -1956,7 +1956,7 @@ void DOS_Shell::CMD_LS(char *args) {
 	}
 	int fbak=lfn_filefind_handle;
 	lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
-	bool ret = DOS_FindFirst((char *)((uselfn?"\"":"")+std::string(spattern)+(uselfn?"\"":"")).c_str(), 0xffff & ~DOS_ATTR_VOLUME);
+	bool ret = DOS_FindFirst(((uselfn?"\"":"")+std::string(spattern)+(uselfn?"\"":"")).c_str(), 0xffff & ~DOS_ATTR_VOLUME);
 	if (!ret) {
 		lfn_filefind_handle=fbak;
 		if (strlen(trim(args)))
@@ -2220,9 +2220,9 @@ void DOS_Shell::CMD_COPY(char * args) {
 
 		//Find first sourcefile
 		char sPath[DOS_PATHLENGTH];
-		bool ret=DOS_GetSFNPath(source.filename.c_str(),sPath,false) && DOS_FindFirst((char *)((strchr(sPath, ' ')&&sPath[0]!='"'&&sPath[0]!='"'?"\"":"")+std::string(sPath)+(strchr(sPath, ' ')&&sPath[strlen(sPath)-1]!='"'?"\"":"")).c_str(),0xffff & ~DOS_ATTR_VOLUME);
+		bool ret=DOS_GetSFNPath(source.filename.c_str(),sPath,false) && DOS_FindFirst(((strchr(sPath, ' ')&&sPath[0]!='"'&&sPath[0]!='"'?"\"":"")+std::string(sPath)+(strchr(sPath, ' ')&&sPath[strlen(sPath)-1]!='"'?"\"":"")).c_str(),0xffff & ~DOS_ATTR_VOLUME);
 		if (!ret) {
-			WriteOut(MSG_Get("SHELL_CMD_FILE_NOT_FOUND"),const_cast<char*>(source.filename.c_str()));
+			WriteOut(MSG_Get("SHELL_CMD_FILE_NOT_FOUND"),source.filename.c_str());
 			dos.dta(save_dta);
 			return;
 		}
@@ -2569,7 +2569,7 @@ void DOS_Shell::CMD_IF(char * args) {
 			int fbak=lfn_filefind_handle;
 			lfn_filefind_handle=uselfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
 			std::string sfull=std::string(spath)+std::string(pattern);
-			bool ret=DOS_FindFirst((char *)((uselfn&&sfull.length()&&sfull[0]!='"'?"\"":"")+sfull+(uselfn&&sfull.length()&&sfull[sfull.length()-1]!='"'?"\"":"")).c_str(),0xffff & ~(DOS_ATTR_VOLUME|DOS_ATTR_DIRECTORY));
+			bool ret=DOS_FindFirst(((uselfn&&sfull.length()&&sfull[0]!='"'?"\"":"")+sfull+(uselfn&&sfull.length()&&sfull[sfull.length()-1]!='"'?"\"":"")).c_str(),0xffff & ~(DOS_ATTR_VOLUME|DOS_ATTR_DIRECTORY));
 			lfn_filefind_handle=fbak;
 			dos.dta(save_dta);
 			if (ret==(!has_not)) DoCommand(args);
@@ -3768,7 +3768,7 @@ void DOS_Shell::CMD_FOR(char *args) {
 			std::string tmp;
 			int fbak=lfn_filefind_handle;
 			lfn_filefind_handle=lfn?LFN_FILEFIND_INTERNAL:LFN_FILEFIND_NONE;
-			if (DOS_FindFirst((char *)(std::string(spath)+std::string(pattern)).c_str(), ~(DOS_ATTR_VOLUME|DOS_ATTR_DIRECTORY|DOS_ATTR_DEVICE|DOS_ATTR_HIDDEN|DOS_ATTR_SYSTEM)))
+			if (DOS_FindFirst((std::string(spath)+std::string(pattern)).c_str(), ~(DOS_ATTR_VOLUME|DOS_ATTR_DIRECTORY|DOS_ATTR_DEVICE|DOS_ATTR_HIDDEN|DOS_ATTR_SYSTEM)))
 				{
 				dta.GetResult(name, lname, size, date, time, attr);
 				tmp=std::string(path)+std::string(lfn?lname:name);


### PR DESCRIPTION
Cleanup and a memory leak fix using static analyzers (SonarLint and Clang-Tidy).

Edit: Also fixes the help messages for specifying a vga bios. (The message for the "vga bios rom image" setting was being used for the "vga bios use rom image" setting, and "vga bios rom image" itself was missing its help message).

Edit2: The help message fix got done in https://github.com/joncampbell123/dosbox-x/commit/551d5f9f17fc799cfb6d178e5364bdacee141c1b so it's no longer in this PR.