### PR TITLE
Include cleanup

### DIFF
--- a/include/8255.h
+++ b/include/8255.h
@@ -1,7 +1,4 @@
 
-#include <stdio.h>
-#include <stdint.h>
-
 //! \brief Intel 8255 base emulation class
 //!
 //! \description Intel 8255 Programmable Peripheral Interface emulation class.

--- a/include/bios.h
+++ b/include/bios.h
@@ -16,10 +16,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#include <stdio.h>
-#include <stddef.h>
-#include <stdint.h>
-
 #include "regionalloctracking.h"
 
 #ifndef DOSBOX_BIOS_H

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -22,9 +22,6 @@
 #ifndef DOSBOX_DOS_INC_H
 #include "dos_inc.h"
 #endif
-#ifndef DOSBOX_BIOS_H
-#include "bios.h"
-#endif
 #include "../src/dos/cdrom.h"
 
 /* The Section handling Bios Disk Access */

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -19,11 +19,6 @@
 #ifndef DOSBOX_BIOS_DISK_H
 #define DOSBOX_BIOS_DISK_H
 
-#include <stdio.h>
-#include <stdlib.h>
-#ifndef DOSBOX_MEM_H
-#include "mem.h"
-#endif
 #ifndef DOSBOX_DOS_INC_H
 #include "dos_inc.h"
 #endif

--- a/include/bitmapinfoheader.h
+++ b/include/bitmapinfoheader.h
@@ -2,9 +2,6 @@
 #ifndef __ISP_UTILS_V4_BITMAPINFOHEADER
 #define __ISP_UTILS_V4_BITMAPINFOHEADER
 
-#include <stdint.h>
-#include "informational.h"
-
 /* [doc] windows_BITMAPFILEHEADER
  *
  * Packed portable representation of the Microsoft Windows BITMAPFILEHEADER

--- a/include/bitop.h
+++ b/include/bitop.h
@@ -2,8 +2,6 @@
 #include <limits.h>
 #include <stdint.h>
 
-#include <utility>
-
 namespace bitop {
 
 /* Return the number of bits of the data type.

--- a/include/clockdomain.h
+++ b/include/clockdomain.h
@@ -7,8 +7,6 @@
  *
  * (C) 2014 Jonathan Campbell */
 
-#include <assert.h>
-
 #ifndef DOSBOX_CLOCKDOMAIN_H
 #define DOSBOX_CLOCKDOMAIN_H
 

--- a/include/clockdomain.h
+++ b/include/clockdomain.h
@@ -7,18 +7,11 @@
  *
  * (C) 2014 Jonathan Campbell */
 
-#include <stdint.h>
 #include <assert.h>
-#include <math.h>
-
-#include <string>
-#include <vector>
-#include <list>
 
 #ifndef DOSBOX_CLOCKDOMAIN_H
 #define DOSBOX_CLOCKDOMAIN_H
 
-#include "dosbox.h"
 /* this code contains support for existing DOSBox code that uses PIC_AddEvent, etc. callbacks */
 #include "pic.h"
 

--- a/include/control.h
+++ b/include/control.h
@@ -28,27 +28,6 @@
 #ifndef DOSBOX_PROGRAMS_H
 #include "programs.h"
 #endif
-#ifndef DOSBOX_SETUP_H
-#include "setup.h"
-#endif
-
-#ifndef CH_LIST
-#define CH_LIST
-#include <list>
-#endif
-
-#ifndef CH_VECTOR
-#define CH_VECTOR
-#include <vector>
-#endif
-
-#ifndef CH_STRING
-#define CH_STRING
-#include <string>
-#endif
-
-
-
 
 class Config{
 public:

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -20,14 +20,8 @@
 #ifndef DOSBOX_CPU_H
 #define DOSBOX_CPU_H
 
-#ifndef DOSBOX_DOSBOX_H
-#include "dosbox.h" 
-#endif
 #ifndef DOSBOX_REGS_H
 #include "regs.h"
-#endif
-#ifndef DOSBOX_MEM_H
-#include "mem.h"
 #endif
 
 #define CPU_AUTODETERMINE_NONE		0x00

--- a/include/cross.h
+++ b/include/cross.h
@@ -24,10 +24,7 @@
 #include "dosbox.h"
 #endif
 
-#include <stdio.h>
 #include <sys/stat.h>
-#include <sys/types.h>
-#include <string>
 
 #if defined (_MSC_VER)						/* MS Visual C++ */
 #include <direct.h>

--- a/include/dma.h
+++ b/include/dma.h
@@ -19,7 +19,6 @@
 
 #ifndef DOSBOX_DMA_H
 #define DOSBOX_DMA_H
-#include <fstream>
 
 enum DMAEvent {
 	DMA_REACHED_TC,

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -20,14 +20,10 @@
 #ifndef DOSBOX_DOS_INC_H
 #define DOSBOX_DOS_INC_H
 
-#include <stddef.h>
 #define CTBUF 127
 
 #ifndef DOSBOX_DOS_SYSTEM_H
 #include "dos_system.h"
-#endif
-#ifndef DOSBOX_MEM_H
-#include "mem.h"
 #endif
 #include <stddef.h> //for offsetof
 

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -20,10 +20,6 @@
 #ifndef DOSBOX_DOS_SYSTEM_H
 #define DOSBOX_DOS_SYSTEM_H
 
-#include <vector>
-#ifndef DOSBOX_DOSBOX_H
-#include "dosbox.h"
-#endif
 #ifndef DOSBOX_CROSS_H
 #include "cross.h"
 #endif
@@ -33,7 +29,6 @@
 #ifndef DOSBOX_MEM_H
 #include "mem.h"
 #endif
-#include <ctype.h>
 
 #define DOS_NAMELENGTH 12u
 #define DOS_NAMELENGTH_ASCII (DOS_NAMELENGTH+1)

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -21,7 +21,6 @@
 #define DOSBOX_DOSBOX_H
 
 #include "config.h"
-#include "logging.h"
 
 #if defined(C_ICONV)
 /* good */

--- a/include/ethernet.h
+++ b/include/ethernet.h
@@ -19,9 +19,7 @@
 #ifndef DOSBOX_ETHERNET_H
 #define DOSBOX_ETHERNET_H
 
-#include "config.h"
 #include "control.h"
-#include <functional>
 
 /** A virtual Ethernet connection
  * While emulated Ethernet adapters provide the ability for the guest OS to

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -19,10 +19,6 @@
 #ifndef DOSBOX_FPU_H
 #define DOSBOX_FPU_H
 
-#ifndef DOSBOX_MEM_H
-#include "mem.h"
-#endif
-
 #include "mmx.h"
 
 void FPU_ESC0_Normal(Bitu rm);

--- a/include/hardware.h
+++ b/include/hardware.h
@@ -20,8 +20,6 @@
 #ifndef DOSBOX_HARDWARE_H
 #define DOSBOX_HARDWARE_H
 
-#include <stdio.h>
-
 class Section;
 enum OPL_Mode {
 	OPL_none,OPL_cms,OPL_opl2,OPL_dualopl2,OPL_opl3,OPL_opl3gold,OPL_hardware,OPL_hardwareCMS

--- a/include/ipx.h
+++ b/include/ipx.h
@@ -33,9 +33,6 @@
 #endif
 #endif
 
-#ifndef DOSBOX_DOSBOX_H
-#include "dosbox.h"
-#endif
 #ifndef DOSBOX_MEM_H
 #include "mem.h"
 #endif

--- a/include/logging.h
+++ b/include/logging.h
@@ -19,7 +19,6 @@
 #ifndef DOSBOX_LOGGING_H
 #define DOSBOX_LOGGING_H
 
-#include <stdio.h>
 #include "setup.h"
 
 enum LOG_TYPES {

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -20,8 +20,6 @@
 #ifndef DOSBOX_MIXER_H
 #define DOSBOX_MIXER_H
 
-#include <sstream>
-
 #ifndef DOSBOX_DOSBOX_H
 #include "dosbox.h"
 #endif

--- a/include/np2glue.h
+++ b/include/np2glue.h
@@ -2,11 +2,8 @@
  * to help port code from Neko Project II and match the typedefs
  * it uses. */
 
-#include <math.h>
 #include <stdio.h>
 #include <stdint.h>
-#include <string.h>
-#include <stdlib.h>
 #include <limits.h>
 
 #if defined(WIN32)

--- a/include/paging.h
+++ b/include/paging.h
@@ -21,7 +21,6 @@
 #define DOSBOX_PAGING_H
 
 #ifndef DOSBOX_DOSBOX_H
-#include <iostream>
 #include "dosbox.h"
 #endif
 #ifndef DOSBOX_MEM_H

--- a/include/programs.h
+++ b/include/programs.h
@@ -27,16 +27,6 @@
 #include "dos_inc.h"
 #endif
 
-#ifndef CH_LIST
-#define CH_LIST
-#include <list>
-#endif
-
-#ifndef CH_STRING
-#define CH_STRING
-#include <string>
-#endif
-
 class CommandLine {
 public:
 	enum opt_style {

--- a/include/qcow2_disk.h
+++ b/include/qcow2_disk.h
@@ -20,11 +20,6 @@
 #ifndef DOSBOX_QCOW2_DISK_H
 #define DOSBOX_QCOW2_DISK_H
 
-
-#include <iostream>
-#include <fstream>
-#include <iomanip>
-#include <stdint.h>
 #include "config.h"
 #include "bios_disk.h"
 

--- a/include/regionalloctracking.h
+++ b/include/regionalloctracking.h
@@ -1,9 +1,6 @@
 
 #include "dosbox.h"
 
-#include <vector>
-#include <string>
-
 #ifndef DOSBOX_REGIONALLOCTRACKING_H
 #define DOSBOX_REGIONALLOCTRACKING_H
 

--- a/include/regs.h
+++ b/include/regs.h
@@ -19,8 +19,6 @@
 #ifndef DOSBOX_REGS_H
 #define DOSBOX_REGS_H
 
-#include <iostream>
-
 #ifndef DOSBOX_MEM_H
 #include "mem.h"
 #endif

--- a/include/setup.h
+++ b/include/setup.h
@@ -43,12 +43,6 @@
 #include <string>
 #endif
 
-#ifndef CH_CSTDIO
-#define CH_CSTDIO
-#include <stdio.h>
-#endif
-
-
 class Hex {
 private:
 	int _hex;

--- a/include/shell.h
+++ b/include/shell.h
@@ -20,17 +20,12 @@
 #ifndef DOSBOX_SHELL_H
 #define DOSBOX_SHELL_H
 
-#include <ctype.h>
 #ifndef DOSBOX_DOSBOX_H
 #include "dosbox.h"
 #endif
 #ifndef DOSBOX_PROGRAMS_H
 #include "programs.h"
 #endif
-
-#include <string>
-#include <list>
-#include <map>
 
 #include <SDL.h>
 #if SDL_VERSION_ATLEAST(2, 0, 0)

--- a/include/util_pointer.h
+++ b/include/util_pointer.h
@@ -6,10 +6,6 @@
 #ifndef __UTIL_POINTER_H
 #define __UTIL_POINTER_H
 
-#include <stdint.h>			/* need standard C library integer types */
-#include <stddef.h>
-#include <alloca.h>
-
 #define min_uintptr_t			((uintptr_t)0)
 #define max_uintptr_t			( ~((uintptr_t)0) )
 

--- a/include/vga.h
+++ b/include/vga.h
@@ -23,7 +23,6 @@
 #ifndef DOSBOX_DOSBOX_H
 #include "dosbox.h"
 #endif
-#include <iostream>
 
 #define VGA_LFB_MAPPED
 

--- a/include/wave_mmreg.h
+++ b/include/wave_mmreg.h
@@ -2,8 +2,6 @@
 #ifndef __ISP_UTILS_V4_WAVEMMREG_H
 #define __ISP_UTILS_V4_WAVEMMREG_H
 
-#include <stdint.h>
-
 /* [doc] windows_WAVE_FORMAT_... constants
  * 
  * windows_WAVE_FORMAT_PCM              8 & 16-bit PCM

--- a/include/waveformatex.h
+++ b/include/waveformatex.h
@@ -2,8 +2,6 @@
 #ifndef __ISP_UTILS_V4_WIN_WAVEFORMATEX_H
 #define __ISP_UTILS_V4_WIN_WAVEFORMATEX_H
 
-#include <stdint.h>
-
 #include "informational.h"
 #include "guid.h"	/* <- need windows_GUID definition below */
 

--- a/src/cpu/callback.cpp
+++ b/src/cpu/callback.cpp
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
+#include <assert.h>
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>

--- a/src/dos/cdrom_ioctl_linux.cpp
+++ b/src/dos/cdrom_ioctl_linux.cpp
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
  
-
+#include <assert.h>
 #include <string.h>
 #include "cdrom.h"
 #include "support.h"

--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -16,6 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <assert.h>
 
 #include "dos_inc.h"
 #include "../ints/int10.h"

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -44,6 +44,7 @@
  *      up the code? The less spurious memory leaks, the easier it is to identify
  *      actual leaks among the noise and to patch them up. Thus, "valgrind hunting" --J.C. */
 
+#include <assert.h>
 #include <stdlib.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -16,6 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <assert.h>
+
 #include "../dos/drives.h"
 #include "control.h"
 #include "cpu.h"

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
+#include <assert.h>
 #include <string.h>
 #include "dosbox.h"
 #include "mem.h"

--- a/src/hardware/floppy.cpp
+++ b/src/hardware/floppy.cpp
@@ -28,6 +28,7 @@
 #include "control.h"
 #include "callback.h"
 #include "bios_disk.h"
+#include "bios.h"
 
 #ifdef _MSC_VER
 # define MIN(a,b) ((a) < (b) ? (a) : (b))

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
+#include <assert.h>
 #include <string.h>
 #include <iomanip>
 #include <sstream>

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
+#include <assert.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -22,6 +22,7 @@
 #include "callback.h"
 #include "bios_disk.h"
 #include "../src/dos/cdrom.h"
+#include "bios.h"
 
 #if defined(_MSC_VER)
 # pragma warning(disable:4244) /* const fmath::local::uint64_t to double possible loss of data */

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
+#include <assert.h>
 #include <string.h>
 #include "control.h"
 #include "dosbox.h"

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -16,6 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <assert.h>
 
 #include "dosbox.h"
 #include "keyboard.h"

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -22,6 +22,7 @@
     That should call the mixer start from there or something.
 */
 
+#include <assert.h>
 #include <string.h>
 #include <sys/types.h>
 #define _USE_MATH_DEFINES // needed for M_PI in Visual Studio as documented [https://msdn.microsoft.com/en-us/library/4hwaceh6.aspx]

--- a/src/hardware/mpu401.cpp
+++ b/src/hardware/mpu401.cpp
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
+#include <assert.h>
 #include <string.h>
 #include "dosbox.h"
 #include "inout.h"

--- a/src/hardware/pc98_fm.cpp
+++ b/src/hardware/pc98_fm.cpp
@@ -21,6 +21,7 @@
 #include "mixer.h"
 #include "callback.h"
 
+#include <assert.h>
 #include <string.h>
 #include <stdlib.h>
 #include <string>

--- a/src/hardware/pci_bus.cpp
+++ b/src/hardware/pci_bus.cpp
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
+#include <assert.h>
 #include <string.h>
 #include "dosbox.h"
 #include "inout.h"

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -16,6 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <assert.h>
+
 #include "dosbox.h"
 #include "inout.h"
 #include "cpu.h"

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -46,6 +46,7 @@
 # pragma warning(disable:4065) /* switch without case */
 #endif
 
+#include <assert.h>
 #include <iomanip>
 #include <sstream>
 #include <stdlib.h>

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
+#include <assert.h>
 #include <math.h>
 #include "dosbox.h"
 #include "inout.h"

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -116,6 +116,8 @@
  *   chained 256-color modes differently.
  */
 
+#include <assert.h>
+
 #include "dosbox.h"
 #include "setup.h"
 #include "video.h"

--- a/src/hardware/voodoo.cpp
+++ b/src/hardware/voodoo.cpp
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -16,6 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <assert.h>
+
 #include "dosbox.h"
 #include "callback.h"
 #include "bios.h"

--- a/src/ints/bios_vhd.cpp
+++ b/src/ints/bios_vhd.cpp
@@ -17,6 +17,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
 
+#include <assert.h>
+
 #include "dosbox.h"
 #include "callback.h"
 #include "bios.h"

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -16,6 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <assert.h>
 
 #include "dosbox.h"
 #include "control.h"

--- a/src/ints/int10_vesa.cpp
+++ b/src/ints/int10_vesa.cpp
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
+#include <assert.h>
 #include <string.h>
 #include <stddef.h>
 

--- a/src/ints/xms.cpp
+++ b/src/ints/xms.cpp
@@ -16,7 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stddef.h>

--- a/src/misc/ethernet.cpp
+++ b/src/misc/ethernet.cpp
@@ -16,6 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <assert.h>
+
 #include "ethernet.h"
 #include "ethernet_pcap.h"
 #include "ethernet_slirp.h"

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -22,6 +22,8 @@
 #include "setup.h"
 #include "control.h"
 #include "support.h"
+
+#include <assert.h>
 #include <fstream>
 #include <string>
 #include <sstream>


### PR DESCRIPTION
I'm looking at cleaning up the #include statements.

There are 2 commits.

The first commit is only deletions, taking out #include statements from files in the include folder that were not necessary for compiling in Visual Studio, GCC or Clang.

The second commit localizes a few #include statements. For example a bunch of files were dependent on an `#include <assert.h>` in `clockdomain.h` to use assert statements. The only files that include `clockdomain.h` are `dosbox.h` and `dosbox.cpp`, so I guess they were indirectly getting access to `assert.h` through one of those, but the chain of dependencies is intertwined and not easy to see. Minimal includes (each file directly including only the files it needs) will make the dependencies between files easier to understand, remove clutter, and hopefully speed up compile time and time for static analysis/real-time detection of errors, etc. in coding programs.