### PR TITLE
Make HWND and HIMC variables Windows-specific

### DIFF
--- a/vs2015/sdl/include/SDL_syswm.h
+++ b/vs2015/sdl/include/SDL_syswm.h
@@ -87,8 +87,10 @@ struct SDL_SysWMmsg {
 typedef struct SDL_SysWMinfo {
 	SDL_version version;
 	SDL_SYSWM_TYPE subsystem;
+	#ifdef WIN32
 	HWND ime;				/* The Win32 input method window */
 	HIMC imc;				/* The Win32 input method context */
+	#endif
 	union {
 	    struct {
 	    	Display *display;	/**< The X11 display */


### PR DESCRIPTION
Fix non-Windows build failing because of Windows-specific types.