### PR TITLE
Includes cleanup

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -22,6 +22,7 @@
 #ifndef DOSBOX_DOS_INC_H
 #include "dos_inc.h"
 #endif
+#include "logging.h"
 #include "../src/dos/cdrom.h"
 
 /* The Section handling Bios Disk Access */

--- a/include/bitop.h
+++ b/include/bitop.h
@@ -1,6 +1,5 @@
 
 #include <limits.h>
-#include <stdint.h>
 
 namespace bitop {
 

--- a/include/clockdomain.h
+++ b/include/clockdomain.h
@@ -10,8 +10,7 @@
 #ifndef DOSBOX_CLOCKDOMAIN_H
 #define DOSBOX_CLOCKDOMAIN_H
 
-/* this code contains support for existing DOSBox code that uses PIC_AddEvent, etc. callbacks */
-#include "pic.h"
+#include <string>
 
 class ClockDomain {
 public:

--- a/include/control.h
+++ b/include/control.h
@@ -28,6 +28,7 @@
 #ifndef DOSBOX_PROGRAMS_H
 #include "programs.h"
 #endif
+#include "setup.h"
 
 class Config{
 public:

--- a/include/cross.h
+++ b/include/cross.h
@@ -20,9 +20,8 @@
 #ifndef DOSBOX_CROSS_H
 #define DOSBOX_CROSS_H
 
-#ifndef DOSBOX_DOSBOX_H
-#include "dosbox.h"
-#endif
+#include <stdio.h>
+#include <string>
 
 #if defined (_MSC_VER)						/* MS Visual C++ */
 #include <direct.h>

--- a/include/cross.h
+++ b/include/cross.h
@@ -24,8 +24,6 @@
 #include "dosbox.h"
 #endif
 
-#include <sys/stat.h>
-
 #if defined (_MSC_VER)						/* MS Visual C++ */
 #include <direct.h>
 #include <io.h>

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -25,6 +25,8 @@
 #ifndef DOSBOX_DOS_SYSTEM_H
 #include "dos_system.h"
 #endif
+
+#include <list>
 #include <stddef.h> //for offsetof
 
 #ifdef _MSC_VER

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -174,10 +174,6 @@ void					DOSBOX_SetNormalLoop();
 
 #define FM_TOWNS_ARCH_CASE      MCH_FM_TOWNS
 
-#ifndef DOSBOX_LOGGING_H
-#include "logging.h"
-#endif // the logging system.
-
 extern ClockDomain			clockdom_PCI_BCLK;
 extern ClockDomain			clockdom_ISA_OSC;
 extern ClockDomain			clockdom_ISA_BCLK;

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -19,6 +19,7 @@
 #ifndef DOSBOX_FPU_H
 #define DOSBOX_FPU_H
 
+#include "logging.h"
 #include "mmx.h"
 
 void FPU_ESC0_Normal(Bitu rm);

--- a/include/logging.h
+++ b/include/logging.h
@@ -19,6 +19,7 @@
 #ifndef DOSBOX_LOGGING_H
 #define DOSBOX_LOGGING_H
 
+#include "config.h"
 #include "setup.h"
 
 enum LOG_TYPES {

--- a/include/menu.h
+++ b/include/menu.h
@@ -17,7 +17,6 @@
  */
 
 #include <string>
-#include "config.h"
 #include "menudef.h"
 void SetVal(const std::string& secname, const std::string& preval, const std::string& val);
 

--- a/include/menu.h
+++ b/include/menu.h
@@ -17,7 +17,6 @@
  */
 
 #include <string>
-#include "menudef.h"
 void SetVal(const std::string& secname, const std::string& preval, const std::string& val);
 
 #include <SDL_video.h>

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -20,10 +20,6 @@
 #ifndef DOSBOX_MIXER_H
 #define DOSBOX_MIXER_H
 
-#ifndef DOSBOX_DOSBOX_H
-#include "dosbox.h"
-#endif
-
 typedef void (*MIXER_MixHandler)(uint8_t * sampdate,uint32_t len);
 typedef void (*MIXER_Handler)(Bitu len);
 

--- a/include/ne2000.h
+++ b/include/ne2000.h
@@ -33,8 +33,6 @@
 // to provide a windowed memory region for the chip and a MAC address.
 //
 
-#include "dosbox.h"
-
 #define bx_bool int
 #define bx_param_c uint8_t
 

--- a/include/paging.h
+++ b/include/paging.h
@@ -20,9 +20,6 @@
 #ifndef DOSBOX_PAGING_H
 #define DOSBOX_PAGING_H
 
-#ifndef DOSBOX_DOSBOX_H
-#include "dosbox.h"
-#endif
 #ifndef DOSBOX_MEM_H
 #include "mem.h"
 #endif

--- a/include/parport.h
+++ b/include/parport.h
@@ -22,15 +22,11 @@
 // set to 1 for debug messages and debugging log:
 #define PARALLEL_DEBUG 0
 
-#ifndef DOSBOX_DOSBOX_H
-#include "dosbox.h"
-#endif
 #ifndef DOSBOX_INOUT_H
 #include "inout.h"
 #endif
 
 #include "control.h"
-#include "dos_inc.h"
 
 class device_LPT : public DOS_Device {
 public:

--- a/include/programs.h
+++ b/include/programs.h
@@ -20,6 +20,8 @@
 #ifndef DOSBOX_PROGRAMS_H
 #define DOSBOX_PROGRAMS_H
 
+#include <list>
+
 #ifndef DOSBOX_DOSBOX_H
 #include "dosbox.h"
 #endif

--- a/include/vga.h
+++ b/include/vga.h
@@ -23,6 +23,7 @@
 #ifndef DOSBOX_DOSBOX_H
 #include "dosbox.h"
 #endif
+#include "pic.h"
 
 #include <math.h> /* for fabs */
 

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -16,6 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include "logging.h"
+
 class CodePageHandlerDynRec;	// forward
 
 // basic cache block representation

--- a/src/cpu/core_normal/string.h
+++ b/src/cpu/core_normal/string.h
@@ -16,6 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include "logging.h"
+
 enum STRING_OP {
 	// simple string ops
 	R_OUTSB,R_OUTSW,R_OUTSD,

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -33,6 +33,7 @@
 #include "support.h"
 #include "control.h"
 #include "zipfile.h"
+#include "logging.h"
 
 /* dynamic core, policy, method, and flags.
  * We're going to make dynamic core more flexible, AND make sure

--- a/src/cpu/dynamic_alloc_common.h
+++ b/src/cpu/dynamic_alloc_common.h
@@ -1,4 +1,6 @@
 
+#include "logging.h"
+
 /* Define temporary pagesize so the MPROTECT case and the regular case share as much code as possible */
 #if (C_HAVE_MPROTECT)
 #define PAGESIZE_TEMP PAGESIZE

--- a/src/cpu/flags.cpp
+++ b/src/cpu/flags.cpp
@@ -25,6 +25,7 @@
 #include "cpu.h"
 #include "lazyflags.h"
 #include "pic.h"
+#include "logging.h"
 
 LazyFlags lflags;
 

--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -29,6 +29,7 @@
 #include "cpu.h"
 #include "debug.h"
 #include "setup.h"
+#include "logging.h"
 
 extern bool dos_kernel_disabled;
 PagingBlock paging;

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -37,6 +37,7 @@
 #include "menu.h"
 #include "debug.h"
 #include "debug_inc.h"
+#include "pic.h"
 
 #include <stdexcept>
 #include <exception>

--- a/src/dos/cdrom.cpp
+++ b/src/dos/cdrom.cpp
@@ -26,6 +26,7 @@
 #include <unistd.h>
 
 #include "dosbox.h"
+#include "logging.h"
 #include "SDL.h"
 #include "support.h"
 #include "cdrom.h"

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -43,6 +43,7 @@
 #endif
 
 #include "drives.h"
+#include "logging.h"
 #include "support.h"
 #include "setup.h"
 #include "src/libs/decoders/audio_convert.c"

--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -19,6 +19,7 @@
 #include <assert.h>
 
 #include "dos_inc.h"
+#include "logging.h"
 #include "../ints/int10.h"
 #include <string.h>
 #include "inout.h"

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -42,6 +42,7 @@
 #include "render.h"
 #include "jfont.h"
 #include "../ints/int10.h"
+#include "pic.h"
 #if defined(WIN32)
 #include "../dos/cdrom.h"
 #include <shellapi.h>

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -29,6 +29,7 @@
 #include "dosbox.h"
 #include "dos_inc.h"
 #include "bios.h"
+#include "logging.h"
 #include "mem.h"
 #include "paging.h"
 #include "callback.h"

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -24,6 +24,8 @@
 #include <string.h>
 #include <assert.h>
 #include <ctype.h>
+#include <sys/stat.h>
+
 #include "dosbox.h"
 #include "dos_inc.h"
 #include "bios.h"

--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -19,7 +19,9 @@
 
 #include <string.h>
 #include <ctype.h>
+
 #include "dosbox.h"
+#include "logging.h"
 #include "mem.h"
 #include "dos_inc.h"
 #include "regs.h"

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -27,6 +27,7 @@
 
 #include "dosbox.h"
 #include "bios.h"
+#include "logging.h"
 #include "mem.h"
 #include "regs.h"
 #include "dos_inc.h"

--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -20,6 +20,7 @@
 #include <string.h>
 #include "dosbox.h"
 #include "callback.h"
+#include "logging.h"
 #include "mem.h"
 #include "regs.h"
 #include "bios_disk.h"

--- a/src/dos/dos_memory.cpp
+++ b/src/dos/dos_memory.cpp
@@ -18,6 +18,7 @@
 
 
 #include "dosbox.h"
+#include "logging.h"
 #include "mem.h"
 #include "bios.h"
 #include "dos_inc.h"

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -19,6 +19,7 @@
 
 #include "dosbox.h"
 #include "callback.h"
+#include "logging.h"
 #include "mem.h"
 #include "regs.h"
 #include "dos_inc.h"

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -30,6 +30,8 @@
 #include <string>
 #include <vector>
 #include <sys/stat.h>
+
+#include "menudef.h"
 #include "programs.h"
 #include "support.h"
 #include "drives.h"

--- a/src/dos/dos_tables.cpp
+++ b/src/dos/dos_tables.cpp
@@ -18,6 +18,7 @@
 
 
 #include "dosbox.h"
+#include "logging.h"
 #include "mem.h"
 #include "jfont.h"
 #include "dos_inc.h"

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -19,6 +19,7 @@
 
 #include "drives.h"
 #include "dos_inc.h"
+#include "logging.h"
 #include "support.h"
 #include "cross.h"
 

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -30,6 +30,7 @@
 #include "dosbox.h"
 #include "dos_inc.h"
 #include "drives.h"
+#include "logging.h"
 #include "support.h"
 #include "cross.h"
 #include "inout.h"

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -23,6 +23,7 @@
 #include "dosbox.h"
 #include "dos_inc.h"
 #include "drives.h"
+#include "logging.h"
 #include "support.h"
 #include "control.h"
 #include "cross.h"

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -54,6 +54,7 @@
 #include "dosbox.h"
 #include "debug.h"
 #include "cpu.h"
+#include "logging.h"
 #include "video.h"
 #include "pic.h"
 #include "cpu.h"

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -55,6 +55,7 @@
 #include "debug.h"
 #include "cpu.h"
 #include "logging.h"
+#include "menudef.h"
 #include "video.h"
 #include "pic.h"
 #include "cpu.h"

--- a/src/gui/bitop.cpp
+++ b/src/gui/bitop.cpp
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <stdint.h>
 
 #include "bitop.h"
 

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -23,6 +23,7 @@
 #include "cpu.h"
 #include "render.h"
 #include "menu.h"
+#include "menudef.h"
 #include "SDL.h"
 #include "SDL_syswm.h"
 #include "bios_disk.h"

--- a/src/gui/midi_mt32.h
+++ b/src/gui/midi_mt32.h
@@ -1,5 +1,7 @@
 #include <SDL_thread.h>
 #include <SDL_timer.h>
+
+#include "logging.h"
 #include "mixer.h"
 #include "control.h"
 #include "cross.h"

--- a/src/gui/midi_timidity.h
+++ b/src/gui/midi_timidity.h
@@ -17,6 +17,7 @@
 #ifdef C_SDL_NET
 //#ifdef C_TIMIDITY
 
+#include "logging.h"
 #include "SDL.h"
 #include "SDL_net.h"
 

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -24,6 +24,7 @@
 #include <sstream>
 
 #include "dosbox.h"
+#include "logging.h"
 #include "video.h"
 #include "render.h"
 #include "setup.h"

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -39,6 +39,10 @@
 #include "bios_disk.h"
 #include "../dos/drives.h"
 
+#if defined(WIN32)
+#include "shellapi.h"
+#endif
+
 #include <iostream>
 #include <sstream>
 #include <stdexcept>

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -32,6 +32,7 @@
 
 #include "dosbox.h"
 #include "logging.h"
+#include "menudef.h"
 #include "video.h"
 #include "keyboard.h"
 #include "mouse.h"

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -31,6 +31,7 @@
 #include "SDL.h"
 
 #include "dosbox.h"
+#include "logging.h"
 #include "video.h"
 #include "keyboard.h"
 #include "mouse.h"

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -148,6 +148,10 @@ void GFX_OpenGLRedrawScreen(void);
 # include <shobjidl.h>
 #endif
 
+#if defined(WIN32)
+#include "resource.h"
+#endif
+
 #if defined(WIN32) && defined(__MINGW32__) /* MinGW does not have IID_ITaskbarList3 */
 /* MinGW now contains this, the older MinGW for HX-DOS does not.
  * Keep things simple and just #define around it like this */

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -103,6 +103,7 @@ void GFX_OpenGLRedrawScreen(void);
 #endif
 
 #include "dosbox.h"
+#include "menudef.h"
 #include "pic.h"
 #include "timer.h"
 #include "setup.h"

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -91,6 +91,7 @@ void GFX_OpenGLRedrawScreen(void);
 #include <sys/types.h>
 #include <algorithm> // std::transform
 #include <fcntl.h>
+#include <sys/stat.h>
 #ifdef WIN32
 # include <signal.h>
 # include <sys/stat.h>

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -23,6 +23,7 @@
 #include <sys/types.h>
 #include "adlib.h"
 
+#include "logging.h"
 #include "setup.h"
 #include "mapper.h"
 #include "mem.h"

--- a/src/hardware/disney.cpp
+++ b/src/hardware/disney.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "mixer.h"
 #include "pic.h"
 #include "setup.h"

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -19,6 +19,7 @@
 #include <assert.h>
 #include <string.h>
 #include "dosbox.h"
+#include "logging.h"
 #include "mem.h"
 #include "inout.h"
 #include "dma.h"

--- a/src/hardware/dongle.cpp
+++ b/src/hardware/dongle.cpp
@@ -1,6 +1,7 @@
 #include <string.h>
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "pic.h"
 #include "setup.h"
 #include "control.h"

--- a/src/hardware/glide.cpp
+++ b/src/hardware/glide.cpp
@@ -19,6 +19,7 @@
 
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "mem.h"
 #include "paging.h"
 #include "glide.h"

--- a/src/hardware/gus.cpp
+++ b/src/hardware/gus.cpp
@@ -22,6 +22,7 @@
 #include <sstream>
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "mixer.h"
 #include "dma.h"
 #include "pic.h"

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -23,6 +23,7 @@
 #include "dosbox.h"
 #include "control.h"
 #include "hardware.h"
+#include "logging.h"
 #include "setup.h"
 #include "support.h"
 #include "mem.h"

--- a/src/hardware/innova.cpp
+++ b/src/hardware/innova.cpp
@@ -19,6 +19,7 @@
 #include <string.h>
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "mixer.h"
 #include "pic.h"
 #include "setup.h"

--- a/src/hardware/iohandler.cpp
+++ b/src/hardware/iohandler.cpp
@@ -21,6 +21,7 @@
 #include "control.h"
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "setup.h"
 #include "cpu.h"
 #include "../src/cpu/lazyflags.h"

--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -25,6 +25,7 @@
 #include <time.h>
 #include <stdio.h>
 #include "cross.h"
+#include "logging.h"
 #include "support.h"
 #include "cpu.h"
 #include "regs.h"

--- a/src/hardware/ipxserver.cpp
+++ b/src/hardware/ipxserver.cpp
@@ -23,6 +23,7 @@
 
 #include "dosbox.h"
 #include "ipxserver.h"
+#include "logging.h"
 #include "timer.h"
 #include <stdlib.h>
 #include <string.h>

--- a/src/hardware/joystick.cpp
+++ b/src/hardware/joystick.cpp
@@ -20,6 +20,7 @@
 #include <string.h>
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "setup.h"
 #include "joystick.h"
 #include "pic.h"

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -20,6 +20,7 @@
 
 #include "dosbox.h"
 #include "keyboard.h"
+#include "logging.h"
 #include "support.h"
 #include "setup.h"
 #include "inout.h"

--- a/src/hardware/mame/emu.h
+++ b/src/hardware/mame/emu.h
@@ -3,6 +3,8 @@
 
 
 #include "dosbox.h"
+#include "logging.h"
+
 #if defined(_MSC_VER) && (_MSC_VER  <= 1500) 
 #include <SDL.h>
 #else

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -21,6 +21,7 @@
 #include <assert.h>
 #include "dosbox.h"
 #include "dos_inc.h"
+#include "logging.h"
 #include "mem.h"
 #include "menu.h"
 #include "inout.h"

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -49,6 +49,7 @@
 #include "mem.h"
 #include "pic.h"
 #include "dosbox.h"
+#include "logging.h"
 #include "mixer.h"
 #include "timer.h"
 #include "setup.h"

--- a/src/hardware/mpu401.cpp
+++ b/src/hardware/mpu401.cpp
@@ -20,6 +20,7 @@
 #include <string.h>
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "pic.h"
 #include "setup.h"
 #include "cpu.h"

--- a/src/hardware/ne2000.cpp
+++ b/src/hardware/ne2000.cpp
@@ -3,6 +3,7 @@
 #include "dosbox.h"
 #include <string.h>
 #include <stdio.h>
+#include "logging.h"
 #include "support.h"
 #include "inout.h"
 #include "setup.h"

--- a/src/hardware/parport/directlpt_linux.cpp
+++ b/src/hardware/parport/directlpt_linux.cpp
@@ -18,6 +18,7 @@
 
 
 #include "config.h"
+#include "logging.h"
 #include "setup.h"
 
 #if C_DIRECTLPT

--- a/src/hardware/parport/directlpt_win32.cpp
+++ b/src/hardware/parport/directlpt_win32.cpp
@@ -28,6 +28,7 @@
 /* Windows version */
 #if defined (WIN32)
 
+#include "logging.h"
 #include "parport.h"
 //#include "../../libs/porttalk/porttalk.h"
 #include "directlpt_win32.h"

--- a/src/hardware/parport/filelpt.cpp
+++ b/src/hardware/parport/filelpt.cpp
@@ -22,6 +22,7 @@
 #include "parport.h"
 #include "filelpt.h"
 #include "callback.h"
+#include "logging.h"
 #include "pic.h"
 #include "hardware.h" //OpenCaptureFile
 #include <stdio.h>

--- a/src/hardware/parport/parport.cpp
+++ b/src/hardware/parport/parport.cpp
@@ -22,6 +22,7 @@
 
 #include "dosbox.h"
 
+#include "logging.h"
 #include "support.h"
 #include "inout.h"
 #include "pic.h"

--- a/src/hardware/parport/printer.cpp
+++ b/src/hardware/parport/printer.cpp
@@ -23,6 +23,7 @@
 #include <math.h>
 #include <sys/stat.h>
 
+#include "logging.h"
 #include "setup.h"
 #include "mapper.h"
 #include "printer_if.h"

--- a/src/hardware/parport/printer.cpp
+++ b/src/hardware/parport/printer.cpp
@@ -21,6 +21,8 @@
 #if C_PRINTER
 
 #include <math.h>
+#include <sys/stat.h>
+
 #include "setup.h"
 #include "mapper.h"
 #include "printer_if.h"

--- a/src/hardware/pc98.cpp
+++ b/src/hardware/pc98.cpp
@@ -1,5 +1,6 @@
 
 #include "dosbox.h"
+#include "logging.h"
 #include "setup.h"
 #include "video.h"
 #include "pic.h"

--- a/src/hardware/pc98_fm.cpp
+++ b/src/hardware/pc98_fm.cpp
@@ -1,5 +1,6 @@
 
 #include "dosbox.h"
+#include "logging.h"
 #include "setup.h"
 #include "video.h"
 #include "pic.h"

--- a/src/hardware/pci_bus.cpp
+++ b/src/hardware/pci_bus.cpp
@@ -20,6 +20,7 @@
 #include <string.h>
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "paging.h"
 #include "mem.h"
 #include "pci_bus.h"

--- a/src/hardware/pcspeaker.cpp
+++ b/src/hardware/pcspeaker.cpp
@@ -26,6 +26,7 @@
 //#define SPKR_DEBUGGING
 #include <math.h>
 #include "dosbox.h"
+#include "logging.h"
 #include "mixer.h"
 #include "timer.h"
 #include "setup.h"

--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -22,6 +22,7 @@
 #include "inout.h"
 #include "cpu.h"
 #include "callback.h"
+#include "logging.h"
 #include "pic.h"
 #include "timer.h"
 #include "setup.h"

--- a/src/hardware/ps1_sound.cpp
+++ b/src/hardware/ps1_sound.cpp
@@ -20,6 +20,7 @@
 #include <string.h>
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "mixer.h"
 #include "mem.h"
 #include "setup.h"

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -54,6 +54,7 @@
 #include <math.h>
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "mixer.h"
 #include "dma.h"
 #include "pic.h"

--- a/src/hardware/serialport/directserial.cpp
+++ b/src/hardware/serialport/directserial.cpp
@@ -21,6 +21,7 @@
 
 #if C_DIRECTSERIAL
 
+#include "logging.h"
 #include "serialport.h"
 #include "directserial.h"
 #include "misc_util.h"

--- a/src/hardware/serialport/misc_util.cpp
+++ b/src/hardware/serialport/misc_util.cpp
@@ -26,6 +26,7 @@
 /*****************************************************************************/
 // C++ SDLnet wrapper
 
+#include "logging.h"
 #include "misc_util.h"
 
 struct _TCPsocketX {

--- a/src/hardware/serialport/nullmodem.cpp
+++ b/src/hardware/serialport/nullmodem.cpp
@@ -23,6 +23,7 @@
 #if C_MODEM
 
 #include "control.h"
+#include "logging.h"
 #include "serialport.h"
 #include "nullmodem.h"
 

--- a/src/hardware/serialport/serialfile.cpp
+++ b/src/hardware/serialport/serialfile.cpp
@@ -18,7 +18,7 @@
 
 
 #include "dosbox.h"
-
+#include "pic.h"
 #include "setup.h"
 #include "serialdummy.h"
 #include "serialport.h"

--- a/src/hardware/serialport/serialfile.cpp
+++ b/src/hardware/serialport/serialfile.cpp
@@ -18,6 +18,7 @@
 
 
 #include "dosbox.h"
+#include "logging.h"
 #include "pic.h"
 #include "setup.h"
 #include "serialdummy.h"

--- a/src/hardware/serialport/seriallog.cpp
+++ b/src/hardware/serialport/seriallog.cpp
@@ -18,7 +18,7 @@
 
 
 #include "dosbox.h"
-
+#include "logging.h"
 #include "setup.h"
 #include "serialdummy.h"
 #include "serialport.h"

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -23,6 +23,7 @@
 #include "dosbox.h"
 
 #include "inout.h"
+#include "logging.h"
 #include "pic.h"
 #include "setup.h"
 #include "bios.h"					// SetComPorts(..)

--- a/src/hardware/serialport/softmodem.h
+++ b/src/hardware/serialport/softmodem.h
@@ -21,6 +21,7 @@
 #define DOSBOX_SERIALMODEM_H
 
 #include "dosbox.h"
+#include "logging.h"
 #if C_MODEM
 #include "serialport.h"
 

--- a/src/hardware/tandy_sound.cpp
+++ b/src/hardware/tandy_sound.cpp
@@ -22,6 +22,7 @@
 
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "mixer.h"
 #include "mem.h"
 #include "setup.h"

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -20,6 +20,7 @@
 #include <math.h>
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "pic.h"
 #include "cpu.h"
 #include "mem.h"

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -119,6 +119,7 @@
 #include <assert.h>
 
 #include "dosbox.h"
+#include "logging.h"
 #include "setup.h"
 #include "video.h"
 #include "pic.h"

--- a/src/hardware/vga_attr.cpp
+++ b/src/hardware/vga_attr.cpp
@@ -19,6 +19,7 @@
 
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "vga.h"
 
 #define attr(blah) vga.attr.blah

--- a/src/hardware/vga_crtc.cpp
+++ b/src/hardware/vga_crtc.cpp
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "vga.h"
 #include "debug.h"
 #include "cpu.h"

--- a/src/hardware/vga_dac.cpp
+++ b/src/hardware/vga_dac.cpp
@@ -18,6 +18,7 @@
 
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "render.h"
 #include "vga.h"
 

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -24,6 +24,7 @@
 #if defined (WIN32)
 #include <d3d9.h>
 #endif
+#include "logging.h"
 #include "time.h"
 #include "timer.h"
 #include "setup.h"

--- a/src/hardware/vga_gfx.cpp
+++ b/src/hardware/vga_gfx.cpp
@@ -19,6 +19,7 @@
 
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "vga.h"
 
 #define gfx(blah) vga.gfx.blah

--- a/src/hardware/vga_memory.cpp
+++ b/src/hardware/vga_memory.cpp
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "dosbox.h"
+#include "logging.h"
 #include "mem.h"
 #include "vga.h"
 #include "paging.h"

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -21,6 +21,7 @@
 #include <math.h>
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "vga.h"
 #include "mem.h"
 #include "pic.h"

--- a/src/hardware/vga_paradise.cpp
+++ b/src/hardware/vga_paradise.cpp
@@ -18,6 +18,7 @@
 
 
 #include "dosbox.h"
+#include "logging.h"
 #include "setup.h"
 #include "vga.h"
 #include "inout.h"

--- a/src/hardware/vga_pc98_cg.cpp
+++ b/src/hardware/vga_pc98_cg.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "dosbox.h"
+#include "logging.h"
 #include "setup.h"
 #include "video.h"
 #include "pic.h"

--- a/src/hardware/vga_pc98_crtc.cpp
+++ b/src/hardware/vga_pc98_crtc.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "dosbox.h"
+#include "logging.h"
 #include "setup.h"
 #include "video.h"
 #include "pic.h"

--- a/src/hardware/vga_pc98_egc.cpp
+++ b/src/hardware/vga_pc98_egc.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "dosbox.h"
+#include "logging.h"
 #include "setup.h"
 #include "video.h"
 #include "pic.h"

--- a/src/hardware/vga_pc98_gdc.cpp
+++ b/src/hardware/vga_pc98_gdc.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "dosbox.h"
+#include "logging.h"
 #include "setup.h"
 #include "video.h"
 #include "pic.h"

--- a/src/hardware/vga_s3.cpp
+++ b/src/hardware/vga_s3.cpp
@@ -19,6 +19,7 @@
 
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "vga.h"
 #include "mem.h"
 #include "pci_bus.h"

--- a/src/hardware/vga_seq.cpp
+++ b/src/hardware/vga_seq.cpp
@@ -19,6 +19,7 @@
 
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "vga.h"
 
 #define seq(blah) vga.seq.blah

--- a/src/hardware/vga_tseng.cpp
+++ b/src/hardware/vga_tseng.cpp
@@ -19,6 +19,7 @@
 
 
 #include "dosbox.h"
+#include "logging.h"
 #include "setup.h"
 #include "vga.h"
 #include "inout.h"

--- a/src/hardware/vga_xga.cpp
+++ b/src/hardware/vga_xga.cpp
@@ -20,6 +20,7 @@
 #include <string.h>
 #include "dosbox.h"
 #include "inout.h"
+#include "logging.h"
 #include "vga.h"
 #include <math.h>
 #include <stdio.h>

--- a/src/hardware/voodoo.cpp
+++ b/src/hardware/voodoo.cpp
@@ -22,6 +22,7 @@
 
 #include "dosbox.h"
 #include "config.h"
+#include "logging.h"
 #include "setup.h"
 #include "cross.h"
 #include "control.h"

--- a/src/hardware/voodoo_emu.cpp
+++ b/src/hardware/voodoo_emu.cpp
@@ -77,6 +77,7 @@ iterated W    = 18.32 [48 bits]
 
 #include "dosbox.h"
 #include "cross.h"
+#include "logging.h"
 
 #include "voodoo_emu.h"
 #include "voodoo_opengl.h"

--- a/src/hardware/voodoo_interface.cpp
+++ b/src/hardware/voodoo_interface.cpp
@@ -22,7 +22,7 @@
 
 #include "dosbox.h"
 #include "cross.h"
-
+#include "logging.h"
 #include "vga.h"
 #include "pic.h"
 #include "paging.h"

--- a/src/hardware/voodoo_opengl.cpp
+++ b/src/hardware/voodoo_opengl.cpp
@@ -26,6 +26,7 @@
 #include <map>
 
 #include "dosbox.h"
+#include "logging.h"
 #include "video.h"
 
 #include "voodoo_emu.h"

--- a/src/hardware/voodoo_vogl.cpp
+++ b/src/hardware/voodoo_vogl.cpp
@@ -27,6 +27,7 @@
 
 #include "dosbox.h"
 #include "dos_inc.h"
+#include "logging.h"
 
 #if C_OPENGL
 

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -48,6 +48,7 @@ extern bool PS1AudioCard;
 #include "shell.h"
 #include "render.h"
 #include <time.h>
+#include <sys/stat.h>
 
 #if defined(DB_HAVE_CLOCK_GETTIME) && ! defined(WIN32)
 //time.h is already included

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -19,6 +19,7 @@
 
 #include "dosbox.h"
 #include "callback.h"
+#include "logging.h"
 #include "mem.h"
 #include "bios.h"
 #include "keyboard.h"

--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include "dosbox.h"
 #include "callback.h"
+#include "logging.h"
 #include "mem.h"
 #include "paging.h"
 #include "bios.h"

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -20,6 +20,7 @@
 
 #include "dosbox.h"
 #include "control.h"
+#include "logging.h"
 #include "mem.h"
 #include "menu.h"
 #include "callback.h"

--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -21,6 +21,7 @@
 
 #include "dosbox.h"
 #include "bios.h"
+#include "logging.h"
 #include "mem.h"
 #include "inout.h"
 #include "int10.h"

--- a/src/ints/int10_memory.cpp
+++ b/src/ints/int10_memory.cpp
@@ -18,6 +18,7 @@
 
 
 #include "dosbox.h"
+#include "logging.h"
 #include "mem.h"
 #include "cpu.h"
 #include "inout.h"

--- a/src/ints/int10_misc.cpp
+++ b/src/ints/int10_misc.cpp
@@ -18,6 +18,7 @@
 
 
 #include "dosbox.h"
+#include "logging.h"
 #include "mem.h"
 #include "inout.h"
 #include "int10.h"

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -21,6 +21,7 @@
 #include <string.h>
 
 #include "dosbox.h"
+#include "logging.h"
 #include "mem.h"
 #include "inout.h"
 #include "int10.h"

--- a/src/ints/int10_put_pixel.cpp
+++ b/src/ints/int10_put_pixel.cpp
@@ -18,6 +18,7 @@
 
 
 #include "dosbox.h"
+#include "logging.h"
 #include "mem.h"
 #include "inout.h"
 #include "int10.h"

--- a/src/ints/int_dosv.cpp
+++ b/src/ints/int_dosv.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "dosbox.h"
+#include "logging.h"
 #include "regs.h"
 #include "paging.h"
 #include "mem.h"

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -25,6 +25,7 @@
 
 #include "dosbox.h"
 #include "callback.h"
+#include "logging.h"
 #include "mem.h"
 #include "regs.h"
 #include "cpu.h"

--- a/src/ints/xms.cpp
+++ b/src/ints/xms.cpp
@@ -22,6 +22,7 @@
 #include <stddef.h>
 #include "dosbox.h"
 #include "callback.h"
+#include "logging.h"
 #include "mem.h"
 #include "regs.h"
 #include "dos_inc.h"

--- a/src/misc/ethernet.cpp
+++ b/src/misc/ethernet.cpp
@@ -21,6 +21,7 @@
 #include "ethernet.h"
 #include "ethernet_pcap.h"
 #include "ethernet_slirp.h"
+#include "logging.h"
 #include <cstring>
 #include "dosbox.h"
 #include "control.h"

--- a/src/misc/ethernet_pcap.cpp
+++ b/src/misc/ethernet_pcap.cpp
@@ -22,6 +22,7 @@
 
 #include "ethernet_pcap.h"
 #include "dosbox.h"
+#include "logging.h"
 #include "support.h" /* strcasecmp */
 #include <cstring>
 

--- a/src/misc/ethernet_slirp.cpp
+++ b/src/misc/ethernet_slirp.cpp
@@ -21,6 +21,7 @@
 #if C_SLIRP
 
 #include "ethernet_slirp.h"
+#include "logging.h"
 #include <time.h>
 #include <algorithm>
 #include "dosbox.h"

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -22,6 +22,7 @@
 #include <string.h>
 #include "dosbox.h"
 #include "cross.h"
+#include "logging.h"
 #include "support.h"
 #include "setup.h"
 #include "control.h"

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -25,6 +25,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/stat.h>
+
 #include "programs.h"
 #include "callback.h"
 #include "regs.h"

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -29,6 +29,7 @@
 
 #include "programs.h"
 #include "callback.h"
+#include "logging.h"
 #include "regs.h"
 #include "support.h"
 #include "cross.h"

--- a/src/misc/regionalloctracking.cpp
+++ b/src/misc/regionalloctracking.cpp
@@ -1,6 +1,7 @@
 
 #include <assert.h>
 #include "dosbox.h"
+#include "logging.h"
 #include "mem.h"
 #include "cpu.h"
 #include "bios.h"

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -19,6 +19,7 @@
 
 #include "dosbox.h"
 #include "cross.h"
+#include "logging.h"
 #include "setup.h"
 #include "control.h"
 #include "support.h"

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -30,6 +30,7 @@
   
 #include "dosbox.h"
 #include "debug.h"
+#include "logging.h"
 #include "support.h"
 #include "video.h"
 #include "menu.h"

--- a/src/output/direct3d/direct3d.cpp
+++ b/src/output/direct3d/direct3d.cpp
@@ -18,6 +18,7 @@
 
 #include "dosbox.h"
 #include "control.h"
+#include "logging.h"
 #include "menu.h"
 
 bool informd3d = false;

--- a/src/output/output_direct3d.cpp
+++ b/src/output/output_direct3d.cpp
@@ -3,6 +3,7 @@
 #include <math.h>
 
 #include "dosbox.h"
+#include "logging.h"
 #include <output/output_direct3d.h>
 
 #include "sdlmain.h"

--- a/src/output/output_direct3d.cpp
+++ b/src/output/output_direct3d.cpp
@@ -4,6 +4,7 @@
 
 #include "dosbox.h"
 #include "logging.h"
+#include "menudef.h"
 #include <output/output_direct3d.h>
 
 #include "sdlmain.h"

--- a/src/output/output_opengl.cpp
+++ b/src/output/output_opengl.cpp
@@ -13,6 +13,7 @@ extern "C" {
 }
 #include "dosbox.h"
 #include "logging.h"
+#include "menudef.h"
 #include <output/output_opengl.h>
 
 #include <algorithm>

--- a/src/output/output_opengl.cpp
+++ b/src/output/output_opengl.cpp
@@ -12,6 +12,7 @@ extern "C" {
 #include "ppscale.c"
 }
 #include "dosbox.h"
+#include "logging.h"
 #include <output/output_opengl.h>
 
 #include <algorithm>

--- a/src/output/output_surface.cpp
+++ b/src/output/output_surface.cpp
@@ -3,6 +3,7 @@
 #include <math.h>
 
 #include "dosbox.h"
+#include "logging.h"
 #include "sdlmain.h"
 #include "vga.h"
 

--- a/src/output/output_surface.cpp
+++ b/src/output/output_surface.cpp
@@ -4,6 +4,7 @@
 
 #include "dosbox.h"
 #include "logging.h"
+#include "menudef.h"
 #include "sdlmain.h"
 #include "vga.h"
 

--- a/src/output/output_surface_sdl.cpp
+++ b/src/output/output_surface_sdl.cpp
@@ -3,6 +3,7 @@
 #include <math.h>
 
 #include "dosbox.h"
+#include "logging.h"
 #include "sdlmain.h"
 #include "vga.h"
 

--- a/src/output/output_surface_sdl.cpp
+++ b/src/output/output_surface_sdl.cpp
@@ -4,6 +4,7 @@
 
 #include "dosbox.h"
 #include "logging.h"
+#include "menudef.h"
 #include "sdlmain.h"
 #include "vga.h"
 

--- a/src/output/output_surface_sdl2.cpp
+++ b/src/output/output_surface_sdl2.cpp
@@ -3,6 +3,7 @@
 #include <math.h>
 
 #include "dosbox.h"
+#include "logging.h"
 #include "sdlmain.h"
 #include "vga.h"
 

--- a/src/output/output_surface_sdl2.cpp
+++ b/src/output/output_surface_sdl2.cpp
@@ -4,6 +4,7 @@
 
 #include "dosbox.h"
 #include "logging.h"
+#include "menudef.h"
 #include "sdlmain.h"
 #include "vga.h"
 

--- a/src/output/output_tools_xbrz.cpp
+++ b/src/output/output_tools_xbrz.cpp
@@ -3,6 +3,7 @@
 #include <math.h>
 
 #include "dosbox.h"
+#include "logging.h"
 #include "sdlmain.h"
 
 using namespace std;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -20,6 +20,8 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
+#include <sys/stat.h>
+
 #include "dosbox.h"
 #include "regs.h"
 #include "control.h"

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -23,6 +23,7 @@
 #include <sys/stat.h>
 
 #include "dosbox.h"
+#include "logging.h"
 #include "regs.h"
 #include "control.h"
 #include "shell.h"

--- a/src/shell/shell_batch.cpp
+++ b/src/shell/shell_batch.cpp
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "logging.h"
 #include "shell.h"
 #include "support.h"
 

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -23,6 +23,7 @@
 
 
 #include "dosbox.h"
+#include "logging.h"
 #include "shell.h"
 #include "callback.h"
 #include "regs.h"

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -22,6 +22,8 @@
 #include <algorithm> //std::copy
 #include <iterator>  //std::front_inserter
 #include <regex>
+
+#include "logging.h"
 #include "shell.h"
 #include "timer.h"
 #include "bios.h"


### PR DESCRIPTION
- Removal of unnecessary #include statements
- Localization of #include statements (meaning, move #include statements out of header files that don't actually need them into the inheriting .cpp files that do use them, so that they are not needlessly included in all files that include those header files)
- Minimize #includes (for example, if file A includes a standard library and file B includes file A but only uses it for those standard library functions, then instead of file B including file A have it just include the standard library functions directly) 