### PR TITLE
Fix build failure on Clang and GCC

### DIFF
--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -21,12 +21,12 @@
 #endif
 
 #include "SDL.h"
+
+#include "dosbox.h"
 #include "menu.h"
 #include "../libs/gui_tk/gui_tk.h"
 
 #include "build_timestamp.h"
-
-#include "dosbox.h"
 #include "keyboard.h"
 #include "video.h"
 #include "render.h"


### PR DESCRIPTION
When test compiling Linux builds through Travis CI, I am currently getting an error about the function `MSG_Get` being undefined when it is used in `../libs/gui_tk/gui_tk.h`, included from `sdl_gui.cpp`.

`MSG_Get` is declared in `dosbox.h`. Moving the #include of `dosbox.h` in `sdl_gui.cpp` to be before the #include of `../libs/gui_tk/gui_tk.h` fixes the error.