### PR TITLE
More include cleanup

### DIFF
--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -23,6 +23,7 @@
 #ifndef DOSBOX_CROSS_H
 #include "cross.h"
 #endif
+#include "string.h"
 #ifndef DOSBOX_SUPPORT_H
 #include "support.h"
 #endif

--- a/include/parport.h
+++ b/include/parport.h
@@ -26,7 +26,7 @@
 #include "inout.h"
 #endif
 
-#include "control.h"
+#include "programs.h"
 
 class device_LPT : public DOS_Device {
 public:

--- a/include/pc98_cg.h
+++ b/include/pc98_cg.h
@@ -1,6 +1,4 @@
 
-#include "vga.h" /* uses VGA font RAM as CG ROM */
-
 /* mapping function from 16-bit WORD to font RAM offset */
 /* in: code = 16-bit JIS code word (unshifted)
  *     line = scan line within character cell

--- a/include/programs.h
+++ b/include/programs.h
@@ -20,11 +20,6 @@
 #ifndef DOSBOX_PROGRAMS_H
 #define DOSBOX_PROGRAMS_H
 
-#include <list>
-
-#ifndef DOSBOX_DOSBOX_H
-#include "dosbox.h"
-#endif
 #ifndef DOSBOX_DOS_INC_H
 #include "dos_inc.h"
 #endif

--- a/include/qcow2_disk.h
+++ b/include/qcow2_disk.h
@@ -20,7 +20,9 @@
 #ifndef DOSBOX_QCOW2_DISK_H
 #define DOSBOX_QCOW2_DISK_H
 
-#include "config.h"
+#include <stdint.h>
+#include <stdio.h>
+
 #include "bios_disk.h"
 
 class QCow2Image{

--- a/include/regionalloctracking.h
+++ b/include/regionalloctracking.h
@@ -1,6 +1,4 @@
 
-#include "dosbox.h"
-
 #ifndef DOSBOX_REGIONALLOCTRACKING_H
 #define DOSBOX_REGIONALLOCTRACKING_H
 

--- a/include/render.h
+++ b/include/render.h
@@ -25,8 +25,6 @@
 // 3: complex scalers on
 #define RENDER_USE_ADVANCED_SCALERS 3
 
-#include "config.h"
-
 #include "../src/gui/render_scalers.h"
 
 #define RENDER_SKIP_CACHE	16

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -4,7 +4,6 @@
 #include "video.h"
 
 #include "SDL.h"
-#include "SDL_video.h"
 
 #ifdef __WIN32__
 #include "SDL_syswm.h"

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -5,7 +5,6 @@
 #include "render.h"
 #include "video.h"
 
-#include "cross.h"
 #include "SDL.h"
 #include "SDL_video.h"
 

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -1,4 +1,3 @@
-#include "dosbox.h"
 
 #include "control.h"
 #include "menu.h"

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -1,8 +1,6 @@
 
-#include "control.h"
 #include "menu.h"
 #include "mouse.h"
-#include "render.h"
 #include "video.h"
 
 #include "SDL.h"

--- a/include/serialport.h
+++ b/include/serialport.h
@@ -26,9 +26,6 @@
 #ifndef DOSBOX_TIMER_H
 #include "timer.h"
 #endif
-#ifndef DOSBOX_DOS_INC_H
-#include "dos_inc.h"
-#endif
 #ifndef DOSBOX_PROGRAMS_H
 #include "programs.h"
 #endif

--- a/include/serialport.h
+++ b/include/serialport.h
@@ -20,9 +20,6 @@
 #ifndef DOSBOX_SERIALPORT_H
 #define DOSBOX_SERIALPORT_H
 
-#ifndef DOSBOX_DOSBOX_H
-#include "dosbox.h"
-#endif
 #ifndef DOSBOX_INOUT_H
 #include "inout.h"
 #endif

--- a/include/serialport.h
+++ b/include/serialport.h
@@ -23,9 +23,6 @@
 #ifndef DOSBOX_INOUT_H
 #include "inout.h"
 #endif
-#ifndef DOSBOX_TIMER_H
-#include "timer.h"
-#endif
 #ifndef DOSBOX_PROGRAMS_H
 #include "programs.h"
 #endif

--- a/include/shell.h
+++ b/include/shell.h
@@ -20,9 +20,6 @@
 #ifndef DOSBOX_SHELL_H
 #define DOSBOX_SHELL_H
 
-#ifndef DOSBOX_DOSBOX_H
-#include "dosbox.h"
-#endif
 #ifndef DOSBOX_PROGRAMS_H
 #include "programs.h"
 #endif

--- a/include/support.h
+++ b/include/support.h
@@ -21,7 +21,6 @@
 #define DOSBOX_SUPPORT_H
 
 #include <string.h>
-#include <string>
 #include <ctype.h>
 #ifndef DOSBOX_DOSBOX_H
 #include "dosbox.h"

--- a/include/support.h
+++ b/include/support.h
@@ -20,7 +20,6 @@
 #ifndef DOSBOX_SUPPORT_H
 #define DOSBOX_SUPPORT_H
 
-#include <ctype.h>
 #ifndef DOSBOX_DOSBOX_H
 #include "dosbox.h"
 #endif

--- a/include/support.h
+++ b/include/support.h
@@ -20,7 +20,6 @@
 #ifndef DOSBOX_SUPPORT_H
 #define DOSBOX_SUPPORT_H
 
-#include <string.h>
 #include <ctype.h>
 #ifndef DOSBOX_DOSBOX_H
 #include "dosbox.h"

--- a/include/vga.h
+++ b/include/vga.h
@@ -20,9 +20,6 @@
 #ifndef DOSBOX_VGA_H
 #define DOSBOX_VGA_H
 
-#ifndef DOSBOX_DOSBOX_H
-#include "dosbox.h"
-#endif
 #include "pic.h"
 
 #include <math.h> /* for fabs */

--- a/include/waveformatex.h
+++ b/include/waveformatex.h
@@ -2,7 +2,6 @@
 #ifndef __ISP_UTILS_V4_WIN_WAVEFORMATEX_H
 #define __ISP_UTILS_V4_WIN_WAVEFORMATEX_H
 
-#include "informational.h"
 #include "guid.h"	/* <- need windows_GUID definition below */
 
 #if defined(_MSC_VER)

--- a/src/aviwriter/avi.h
+++ b/src/aviwriter/avi.h
@@ -19,9 +19,6 @@
 #ifndef __VIDEOMGR_UTIL_AVI_H
 #define __VIDEOMGR_UTIL_AVI_H
 
-#include <stdint.h>
-
-#include "informational.h"
 #include "wave_mmreg.h"
 #include "waveformatex.h"
 #include "bitmapinfoheader.h"

--- a/src/aviwriter/avi_rw_iobuf.cpp
+++ b/src/aviwriter/avi_rw_iobuf.cpp
@@ -16,9 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#include <string.h>
 #include <stdlib.h>
-#include "rawint.h"
 #include "avi_rw_iobuf.h"
 #include <stdlib.h>
 #include <unistd.h>

--- a/src/aviwriter/avi_writer.cpp
+++ b/src/aviwriter/avi_writer.cpp
@@ -20,7 +20,6 @@
 #define _CRT_NONSTDC_NO_DEPRECATE
 
 #include "rawint.h"
-#include "avi.h"
 #include "avi_writer.h"
 #include "avi_rw_iobuf.h"
 #include <unistd.h>

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -26,6 +26,7 @@
 #include <ctype.h>
 #include <sys/stat.h>
 
+#include "control.h"
 #include "dosbox.h"
 #include "dos_inc.h"
 #include "bios.h"

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -35,6 +35,7 @@
 #include "paging.h"
 #include "callback.h"
 #include "regs.h"
+#include "timer.h"
 #include "menu.h"
 #include "mapper.h"
 #include "drives.h"

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -18,6 +18,8 @@
 
 
 #include <string.h>
+
+#include "control.h"
 #include "dosbox.h"
 #include "callback.h"
 #include "regs.h"

--- a/src/gui/menu_macos.mm
+++ b/src/gui/menu_macos.mm
@@ -1,6 +1,7 @@
 /* Mac OS X portion of menu.cpp */
 
 #include "config.h"
+#include "dos_inc.h"
 #include "menu.h"
 
 #include "sdlmain.h"

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -103,6 +103,7 @@ void GFX_OpenGLRedrawScreen(void), InitFontHandle();
 # endif
 #endif
 
+#include "control.h"
 #include "dosbox.h"
 #include "menudef.h"
 #include "pic.h"

--- a/src/hardware/parport/parport.cpp
+++ b/src/hardware/parport/parport.cpp
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <ctype.h>
 
+#include "control.h"
 #include "dosbox.h"
 
 #include "logging.h"

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -19,6 +19,7 @@
 
 #include <string.h>
 #include <ctype.h>
+#include <SDL_timer.h>
 
 #include "dosbox.h"
 

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <assert.h>
+#include "control.h"
 #include "dosbox.h"
 #include "mem.h"
 #include "cpu.h"

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -23,6 +23,7 @@
 #include "cpu.h"
 #include "bios.h"
 #include "regs.h"
+#include "timer.h"
 #include "cpu.h"
 #include "callback.h"
 #include "inout.h"

--- a/src/output/output_direct3d.cpp
+++ b/src/output/output_direct3d.cpp
@@ -6,6 +6,7 @@
 #include "dosbox.h"
 #include "logging.h"
 #include "menudef.h"
+#include "render.h"
 #include <output/output_direct3d.h>
 
 #include "sdlmain.h"

--- a/src/output/output_direct3d.cpp
+++ b/src/output/output_direct3d.cpp
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <math.h>
 
+#include "control.h"
 #include "dosbox.h"
 #include "logging.h"
 #include "menudef.h"

--- a/src/output/output_opengl.cpp
+++ b/src/output/output_opengl.cpp
@@ -11,6 +11,7 @@ extern "C" {
 #include "ppscale.h"
 #include "ppscale.c"
 }
+#include "control.h"
 #include "dosbox.h"
 #include "logging.h"
 #include "menudef.h"

--- a/src/output/output_surface.cpp
+++ b/src/output/output_surface.cpp
@@ -6,6 +6,7 @@
 #include "logging.h"
 #include "menudef.h"
 #include "sdlmain.h"
+#include "render.h"
 #include "vga.h"
 
 using namespace std;

--- a/src/output/output_surface_sdl.cpp
+++ b/src/output/output_surface_sdl.cpp
@@ -5,6 +5,7 @@
 #include "dosbox.h"
 #include "logging.h"
 #include "menudef.h"
+#include "render.h"
 #include "sdlmain.h"
 #include "vga.h"
 

--- a/src/output/output_surface_sdl2.cpp
+++ b/src/output/output_surface_sdl2.cpp
@@ -5,6 +5,7 @@
 #include "dosbox.h"
 #include "logging.h"
 #include "menudef.h"
+#include "render.h"
 #include "sdlmain.h"
 #include "vga.h"
 

--- a/src/output/output_tools_xbrz.cpp
+++ b/src/output/output_tools_xbrz.cpp
@@ -2,8 +2,10 @@
 #include <assert.h>
 #include <math.h>
 
+#include "control.h"
 #include "dosbox.h"
 #include "logging.h"
+#include "render.h"
 #include "sdlmain.h"
 
 using namespace std;

--- a/src/output/output_tools_xbrz.h
+++ b/src/output/output_tools_xbrz.h
@@ -1,4 +1,5 @@
 #include "dosbox.h"
+#include "setup.h"
 
 #ifndef DOSBOX_OUTPUT_TOOLS_XBRZ_H
 #define DOSBOX_OUTPUT_TOOLS_XBRZ_H


### PR DESCRIPTION
More untangling of the include statements. Removal of unneeded includes, "localization" of includes to the minimal scope of the files that actually use them, and minimizing included files (qcow2_disk.h included config.h but only used it for access to 2 standard libraries, so just include those 2 standard libraries directly)

Tested as building correctly on Visual Studio 2019, Linux GCC and macOS.