### PR TITLE
Add IOKit framework to LIBS when compiling for Mac OSX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -461,7 +461,7 @@ case "$host" in
            OBJCXXFLAGS="$OBJCXXFLAGS -std=gnu++11";
        fi
        AC_DEFINE(MACOSX, 1, [Compiling on Mac OS X])
-       LIBS="$LIBS -framework Carbon -framework CoreFoundation -framework CoreMIDI -framework AudioUnit -framework AudioToolbox -framework ApplicationServices -framework AppKit"
+       LIBS="$LIBS -framework Carbon -framework CoreFoundation -framework CoreMIDI -framework AudioUnit -framework AudioToolbox -framework ApplicationServices -framework AppKit -framework IOKit"
        dnl FEATURE: Whether to support direct serial port passthrough
        AC_DEFINE(C_DIRECTSERIAL, 1, [ Define to 1 if you want serial passthrough support (Win32, Posix and OS/2).])
        ;;


### PR DESCRIPTION
# Description

Adds IOKit framework to linker command needed for Mac OSX compilation


**Does this PR address some issue(s) ?**
When compiling from the autotools generated Makefile in Mac OS, it will be missing symbols for the IOKit framework
```
Undefined symbols for architecture x86_64:
  "_IOBSDNameMatching", referenced from:
      ___PHYSFS_platformDetectAvailableCDs in libdos.a(physfs_platform_apple.o)
  "_IOIteratorNext", referenced from:
      ___PHYSFS_platformDetectAvailableCDs in libdos.a(physfs_platform_apple.o)
  "_IOMasterPort", referenced from:
      ___PHYSFS_platformDetectAvailableCDs in libdos.a(physfs_platform_apple.o)
  "_IOObjectConformsTo", referenced from:
      ___PHYSFS_platformDetectAvailableCDs in libdos.a(physfs_platform_apple.o)
  "_IOObjectRelease", referenced from:
      ___PHYSFS_platformDetectAvailableCDs in libdos.a(physfs_platform_apple.o)
  "_IOObjectRetain", referenced from:
      ___PHYSFS_platformDetectAvailableCDs in libdos.a(physfs_platform_apple.o)
  "_IORegistryEntryCreateCFProperty", referenced from:
      ___PHYSFS_platformDetectAvailableCDs in libdos.a(physfs_platform_apple.o)
  "_IORegistryEntryCreateIterator", referenced from:
      ___PHYSFS_platformDetectAvailableCDs in libdos.a(physfs_platform_apple.o)
  "_IOServiceGetMatchingServices", referenced from:
      ___PHYSFS_platformDetectAvailableCDs in libdos.a(physfs_platform_apple.o)
ld: symbol(s) not found for architecture x86_64
```