### PR TITLE
Updated the shell interperter which function to find only executable …

### DIFF
--- a/include/shell.h
+++ b/include/shell.h
@@ -85,6 +85,7 @@ private:
 	
 private:
 	void ProcessCmdLineEnvVarStitution(char * line);
+	static bool hasExecutableExtension(const char* name);
 
 public:
 


### PR DESCRIPTION
…files and avoiding matching directories or other files

# Description

Updated functionality of the which function to match only executable files in the current directory or path


**Does this PR address some issue(s) ?**

This fixes unexpected behavior in the shell where executable commands return "Bad command or filename" when it does exist in the path.

For example, the debug command (under z:\dos\debug.exe) will match the z:\debug directory (for the first entry in the path of z:\) 
leading to it trying to execute the z:\debug directory itself.
*old behavior*
```
A:\>echo %PATH%
Z:\;Z:\SYSTEM;Z:\BIN;Z:\DOS;Z:\4DOS;Z:\DEBUG;Z:\TEXTUTIL

A:\>debug
Bad command or filename - "DEBUG"
```
*new behavior*
```
A:\>echo %PATH%
Z:\;Z:\SYSTEM;Z:\BIN;Z:\DOS;Z:\4DOS;Z:\DEBUG;Z:\TEXTUTIL

A:\>debug
-r
AX=0000 BX=0000 CX=0000 DX=0000 SP=FFFE BP=0000 SI=0000 DI=0000
DS=0DAB ES=0DAB SS=0DAB CS=0DAB IP=0100 NV UP EI NG NZ NA PO NC
0DAB:0100 C3                RET
```