### PR TITLE
DBCS vector table fix.

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -40,8 +40,8 @@ struct CommandTail{
 #pragma pack ()
 #endif
 
-#define IS_DOS_JAPANESE (mem_readb(Real2Phys(dos.tables.dbcs)) == 0x81 && mem_readb(Real2Phys(dos.tables.dbcs) + 0x01) == 0x9F)
-#define IS_DOS_CJK ((mem_readb(Real2Phys(dos.tables.dbcs)) == 0x81 || mem_readb(Real2Phys(dos.tables.dbcs)) == 0xA1) && (mem_readb(Real2Phys(dos.tables.dbcs) + 0x01) == 0x9F || mem_readb(Real2Phys(dos.tables.dbcs) + 0x01) == 0xFE))
+#define IS_DOS_JAPANESE (mem_readb(Real2Phys(dos.tables.dbcs) + 0x02) == 0x81 && mem_readb(Real2Phys(dos.tables.dbcs) + 0x03) == 0x9F)
+#define IS_DOS_CJK ((mem_readb(Real2Phys(dos.tables.dbcs) + 0x02) == 0x81 || mem_readb(Real2Phys(dos.tables.dbcs) + 0x02) == 0xA1) && (mem_readb(Real2Phys(dos.tables.dbcs) + 0x03) == 0x9F || mem_readb(Real2Phys(dos.tables.dbcs) + 0x03) == 0xFE))
 #define IS_DOSV (dos.set_jdosv_enabled || dos.set_kdosv_enabled || dos.set_cdosv_enabled || dos.set_pdosv_enabled)
 #define IS_JDOSV (dos.set_jdosv_enabled)
 #define IS_KDOSV (dos.set_kdosv_enabled)

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -2337,7 +2337,7 @@ static Bitu DOS_21Handler(void) {
         case 0x63:                  /* DOUBLE BYTE CHARACTER SET */
             if(reg_al == 0 && dos.tables.dbcs != 0) {
                 SegSet16(ds,RealSeg(dos.tables.dbcs));
-                reg_si=RealOff(dos.tables.dbcs);        
+                reg_si=RealOff(dos.tables.dbcs) + 2;        
                 reg_al = 0;
                 CALLBACK_SCF(false); //undocumented
             } else reg_al = 0xff; //Doesn't officially touch carry flag

--- a/src/dos/dos_tables.cpp
+++ b/src/dos/dos_tables.cpp
@@ -217,23 +217,27 @@ void SetupDBCSTable() {
         // write a valid table, or else Windows 3.1 is unhappy.
         // Values are copied from INT 21h AX=6300h as returned by an MS-DOS 6.22 boot disk
         if (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV || dos.loaded_codepage == 932) {   // Japanese
-            mem_writeb(Real2Phys(dos.tables.dbcs)+0,0x81);   // low/high DBCS pair 1
-            mem_writeb(Real2Phys(dos.tables.dbcs)+1,0x9F);
-            mem_writeb(Real2Phys(dos.tables.dbcs)+2,0xE0);   // low/high DBCS pair 2
-            mem_writeb(Real2Phys(dos.tables.dbcs)+3,0xFC);
-            mem_writed(Real2Phys(dos.tables.dbcs)+4,0);
+            mem_writew(Real2Phys(dos.tables.dbcs)+0,0x0006);
+            mem_writeb(Real2Phys(dos.tables.dbcs)+2,0x81);   // low/high DBCS pair 1
+            mem_writeb(Real2Phys(dos.tables.dbcs)+3,0x9F);
+            mem_writeb(Real2Phys(dos.tables.dbcs)+4,0xE0);   // low/high DBCS pair 2
+            mem_writeb(Real2Phys(dos.tables.dbcs)+5,0xFC);
+            mem_writed(Real2Phys(dos.tables.dbcs)+6,0);
         } else if (IS_PDOSV || dos.loaded_codepage == 936) { // Simplified Chinese
-            mem_writeb(Real2Phys(dos.tables.dbcs)+0,gbk?0x81:0xA1);   // low/high DBCS pair
-            mem_writeb(Real2Phys(dos.tables.dbcs)+1,0xFE);
-            mem_writed(Real2Phys(dos.tables.dbcs)+2,0);
+            mem_writew(Real2Phys(dos.tables.dbcs)+0,0x0004);
+            mem_writeb(Real2Phys(dos.tables.dbcs)+2,gbk?0x81:0xA1);   // low/high DBCS pair
+            mem_writeb(Real2Phys(dos.tables.dbcs)+3,0xFE);
+            mem_writed(Real2Phys(dos.tables.dbcs)+4,0);
         } else if (IS_KDOSV || dos.loaded_codepage == 949) { // Korean
-            mem_writeb(Real2Phys(dos.tables.dbcs)+0,0x81);   // low/high DBCS pair
-            mem_writeb(Real2Phys(dos.tables.dbcs)+1,0xFE);
-            mem_writed(Real2Phys(dos.tables.dbcs)+2,0);
+            mem_writew(Real2Phys(dos.tables.dbcs)+0,0x0004);
+            mem_writeb(Real2Phys(dos.tables.dbcs)+2,0x81);   // low/high DBCS pair
+            mem_writeb(Real2Phys(dos.tables.dbcs)+3,0xFE);
+            mem_writed(Real2Phys(dos.tables.dbcs)+4,0);
         } else if (IS_CDOSV || dos.loaded_codepage == 950) { // Traditional Chinese
-            mem_writeb(Real2Phys(dos.tables.dbcs)+0,0x81);   // low/high DBCS pair
-            mem_writeb(Real2Phys(dos.tables.dbcs)+1,0xFE);
-            mem_writed(Real2Phys(dos.tables.dbcs)+2,0);
+            mem_writew(Real2Phys(dos.tables.dbcs)+0,0x0004);
+            mem_writeb(Real2Phys(dos.tables.dbcs)+2,0x81);   // low/high DBCS pair
+            mem_writeb(Real2Phys(dos.tables.dbcs)+3,0xFE);
+            mem_writed(Real2Phys(dos.tables.dbcs)+4,0);
         } else {
             mem_writed(Real2Phys(dos.tables.dbcs),0);        //empty table
         }


### PR DESCRIPTION

# Description

Fixed a bug related to DBCS vector table.


**Does this PR address some issue(s) ?**

Fix incorrect return value for int 21h ax=6300h, ax=6507h.

**Additional information**

It is a DBCS vector table, but correctly, the table size is placed at the beginning, and in Japanese, it is 0006h,819fh,0e0fch in words.
The int 21h ax=6300h will return the address pointing to 819fh, while the int 21h ax=6507h will return the address pointing to 0006h.
See below for more information.
http://www.ctyme.com/intr/rb-3142.htm#Table1746
http://www.ctyme.com/intr/rb-3163.htm#Table1756
