### PR TITLE
AllocationInfo was incorrectly using f_bsize instead of f_frsize for …

### DIFF
--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -1760,7 +1760,7 @@ bool localDrive::AllocationInfo(uint16_t * _bytes_sector,uint8_t * _sectors_clus
 		if (res) {
 			int ratio = stat.f_blocks / 65536, tmp=ratio;
 			*_bytes_sector = 512;
-			*_sectors_cluster = stat.f_bsize/512 > 64? 64 : stat.f_bsize/512;
+			*_sectors_cluster = stat.f_frsize/512 > 64? 64 : stat.f_frsize/512;
 			if (ratio>1) {
 				if (ratio * (*_sectors_cluster) > 64) tmp = (*_sectors_cluster+63)/(*_sectors_cluster);
 				*_sectors_cluster = ratio * (*_sectors_cluster) > 64? 64 : ratio * (*_sectors_cluster);
@@ -2624,7 +2624,7 @@ bool physfsDrive::AllocationInfo(uint16_t * _bytes_sector,uint8_t * _sectors_clu
 		if (res) {
 			int ratio = stat.f_blocks / 65536, tmp=ratio;
 			*_bytes_sector = 512;
-			*_sectors_cluster = stat.f_bsize/512 > 64? 64 : stat.f_bsize/512;
+			*_sectors_cluster = stat.f_frsize/512 > 64? 64 : stat.f_frsize/512;
 			if (ratio>1) {
 				if (ratio * (*_sectors_cluster) > 64) tmp = (*_sectors_cluster+63)/(*_sectors_cluster);
 				*_sectors_cluster = ratio * (*_sectors_cluster) > 64? 64 : ratio * (*_sectors_cluster);


### PR DESCRIPTION
…compuations involving f_blocks and f_bavail

# Description

This fixes the `AllocationInfo` method's computation of drive and free size under unix.

`f_blocks`, `f_bfree` and `b_avail` are in units of `f_frsize` (the block size of the actual physical filesystem). As I understand it, `f_bsize` is the logical block size used by the virtual filesystem for memory allocation, io, etc.

For linux systems, `f_bsize==f_frsize` so no issue is seen.

**Does this PR address some issue(s) ?**
On macOS 11.4 on a locally mounted folder with 298 GB free, I would see it showing over 2 TB free space
```
...
...
TEST     IMG            368,000 07-05-2021 11:41p
TEST2    IMG            368,640 07-08-2021  0:18a
THE-CH~1 ZIP            971,926 07-06-2021 11:53p
THE-CH~2 ZIP          1,147,349 07-06-2021 11:54p
   63 File(s)     1,046,452,233 Bytes
   22 Dir(s)  2,387,742,883,840 Bytes free
```

With this patch, it shows the correct value
```
...
...
TEST     IMG            368,000 07-05-2021 11:41p
TEST2    IMG            368,640 07-08-2021  0:18a
THE-CH~1 ZIP            971,926 07-06-2021 11:53p
THE-CH~2 ZIP          1,147,349 07-06-2021 11:54p
   63 File(s)     1,046,452,233 Bytes
   22 Dir(s)    298,472,210,432 Bytes free
```