### PR TITLE
IME support in videodriver=windib

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -7396,7 +7396,7 @@ void SetIMPosition() {
             SDL_SetIMPosition((x+1) * ttf.pointsize / 2, (y+1) * ttf.pointsize);
         else
 #endif
-        SDL_SetIMPosition((x+1) * width, (y+1) * height - (DOSV_CheckCJKVideoMode()?2:0));
+        SDL_SetIMPosition((x+1) * width, (y+1) * height - (IS_DOSV?-1:(DOSV_CheckCJKVideoMode()?2:0)));
 	}
 }
 #endif
@@ -8173,7 +8173,7 @@ void GFX_Events() {
 				int len;
 				char chars[10];
 				if(len = SDL_FlushIMString(NULL)) {
-					uint16_t *buff = (uint16_t *)malloc((len + 2)), uname[2];
+					uint16_t *buff = (uint16_t *)malloc((len + 1)*sizeof(uint16_t)), uname[2];
 					SDL_FlushIMString(buff);
 					SetIMPosition();
 					for(int no = 0 ; no < len ; no++) {

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -294,6 +294,9 @@ static scancode_tbl scan_to_scanascii_pc98[0x80] = {
     {   none,   none,   none,   none,   none,   none }  /* 7f      */
 };
 
+#include <queue>
+std::queue <Bit16u>over_key_buffer;
+
 bool BIOS_AddKeyToBuffer(uint16_t code) {
     if (!IS_PC98_ARCH) {
         if (mem_readb(BIOS_KEYBOARD_FLAGS2)&8) return true;
@@ -328,7 +331,12 @@ bool BIOS_AddKeyToBuffer(uint16_t code) {
     }
     /* Check for buffer Full */
     //TODO Maybe beeeeeeep or something although that should happend when internal buffer is full
-    if (ttail==head) return false;
+    if (ttail==head) {
+        if(IS_DOSV) {
+            over_key_buffer.push(code);
+        }
+        return false;
+    }
 
     if (IS_PC98_ARCH) {
         real_writew(0x0,tail,code);
@@ -391,6 +399,12 @@ static bool get_key(uint16_t &code) {
     else {
         mem_writew(BIOS_KEYBOARD_BUFFER_HEAD,thead);
         code = real_readw(0x40,head);
+    }
+    if(IS_DOSV) {
+        if (!over_key_buffer.empty()) {
+            add_key(over_key_buffer.front());
+            over_key_buffer.pop();
+        }
     }
 
     return true;

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -2324,7 +2324,11 @@ bool INT10_SetDOSVModeVtext(uint16_t mode, enum DOSV_VTEXT_MODE vtext_mode)
 		FinishSetMode(true);
 		INT10_SetCursorShape(6, 7);
 #if defined(WIN32) && !defined(HX_DOS) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
-		SDL_SetIMValues(SDL_IM_FONT_SIZE, CurMode->cheight, NULL);
+		int cheight = CurMode->cheight;
+		if(IS_DOSV && cheight == 19) {
+			cheight = 16;
+		}
+		SDL_SetIMValues(SDL_IM_FONT_SIZE, cheight, NULL);
 #endif
 	} else {
 		LOG(LOG_INT10, LOG_ERROR)("DOS/V:Trying to set illegal mode %X", mode);


### PR DESCRIPTION

# Description

IME support in videodriver=windib


**Does this PR address some issue(s) ?**

Fixed the problem that IME could not be used to input text with videodriver=windib. #2572
Other fixes include adjusting the character size during conversion, handling the key buffer when the IME final string is long, and fixing the buffer size problem when getting the IME string.
