### PR TITLE
Added SDL hint for opengl acceleration so that SDL2 will select the O…

### DIFF
--- a/src/output/output_opengl.cpp
+++ b/src/output/output_opengl.cpp
@@ -327,6 +327,7 @@ void OUTPUT_OPENGL_Select( GLKind kind )
     sdl_opengl.use_shader = false;
     initgl=0;
 #if defined(C_SDL2)
+    SDL_SetHint(SDL_HINT_FRAMEBUFFER_ACCELERATION, "opengl");
     void GFX_SetResizeable(bool enable);
     GFX_SetResizeable(true);
     sdl.window = GFX_SetSDLWindowMode(640,400, SCREEN_OPENGL);


### PR DESCRIPTION
…penGL renderer over Metal when SDL_GetWindowSurface is called after the window has been created

# Description

Dosbox creates a SDL window and does not explicitly create a renderer so once `SDL_GetWindowSurface` is called, SDL will create one and on SDL2 libs with Metal builtin, it will default to Metal over OpenGL. This hint will cause it chose the OpenGL renderer.


**Does this PR address some issue(s) ?**
Fixes issue where OpenGL output cannot be selected...log shows ```LOG: WARNING: SDL2 unable to create GL context```