### PR TITLE
ac_check_cxxflags fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ int main(){
   return 0;
 }
 EOF
-if $CXX $CPPFLAGS $CXXFLAGS -o conftest.o conftest.c++ [$1] > /dev/null 2>&1
+if $CXX $CPPFLAGS $CXXFLAGS -Werror -o conftest.o conftest.c++ [$1] > /dev/null 2>&1
 then
   AC_MSG_RESULT([yes])
   CXXFLAGS="${CXXFLAGS} [$1]"


### PR DESCRIPTION
# Description
Makes is so the check for CXX flags really does test whether the flag is supported or not. Some flags like warnings will generate warnings instead of errors if the flag does not exist so `-Werror` must be added to detect that.


**Does this PR address some issue(s) ?**
Clang does not have a `-Wlogical-op` flag but the current configure script detects it does. With this patch, it detects it correctly.

_Before_
```
...
checking whether g++ accepts " -Wall "... yes
checking whether gcc -E accepts " -Wall "... yes
checking whether g++ accepts " -Wextra "... yes
checking whether gcc -E accepts " -Wextra "... yes
checking whether g++ accepts " -Wunused "... yes
checking whether gcc -E accepts " -Wunused "... yes
checking whether g++ accepts " -pedantic "... yes
checking whether gcc -E accepts " -pedantic "... yes
checking whether g++ accepts " -Wlogical-op "... yes
checking whether g++ accepts " -Wsign-promo "... yes
checking whether gcc -E accepts " -Wsign-promo "... yes
checking whether g++ accepts " -Wconversion-null "... yes
checking whether gcc -E accepts " -Wconversion-null "... yes
checking whether g++ accepts " -Wno-deprecated-declarations "... yes
checking whether gcc -E accepts " -Wno-deprecated-declarations "... yes
checking whether g++ accepts " -Wno-implicit-fallthrough "... yes
checking whether gcc -E accepts " -Wno-implicit-fallthrough "... yes
checking whether g++ accepts " -Wno-strict-aliasing "... yes
checking whether gcc -E accepts " -Wno-strict-aliasing "... yes
checking whether g++ accepts " -Wno-missing-field-initializers "... yes
checking whether gcc -E accepts " -Wno-missing-field-initializers "... yes
checking whether g++ accepts " -Wno-format-zero-length "... yes
checking whether gcc -E accepts " -Wno-format-zero-length "... yes
checking whether g++ accepts " -Wno-address-of-packed-member "... yes
checking whether gcc -E accepts " -Wno-address-of-packed-member "... yes
checking whether g++ accepts " -Wno-int-to-void-pointer-cast "... yes
checking whether gcc -E accepts " -Wno-int-to-void-pointer-cast "... yes
...
```
_After_
```
...
checking whether g++ accepts " -Wall "... yes
checking whether gcc -E accepts " -Wall "... yes
checking whether g++ accepts " -Wextra "... yes
checking whether gcc -E accepts " -Wextra "... yes
checking whether g++ accepts " -Wunused "... yes
checking whether gcc -E accepts " -Wunused "... yes
checking whether g++ accepts " -pedantic "... yes
checking whether gcc -E accepts " -pedantic "... yes
checking whether g++ accepts " -Wlogical-op "... no
checking whether g++ accepts " -Wsign-promo "... yes
checking whether gcc -E accepts " -Wsign-promo "... yes
checking whether g++ accepts " -Wconversion-null "... yes
checking whether gcc -E accepts " -Wconversion-null "... yes
checking whether g++ accepts " -Wno-deprecated-declarations "... yes
checking whether gcc -E accepts " -Wno-deprecated-declarations "... yes
checking whether g++ accepts " -Wno-implicit-fallthrough "... yes
checking whether gcc -E accepts " -Wno-implicit-fallthrough "... yes
checking whether g++ accepts " -Wno-strict-aliasing "... yes
checking whether gcc -E accepts " -Wno-strict-aliasing "... yes
checking whether g++ accepts " -Wno-missing-field-initializers "... yes
checking whether gcc -E accepts " -Wno-missing-field-initializers "... yes
checking whether g++ accepts " -Wno-format-zero-length "... yes
checking whether gcc -E accepts " -Wno-format-zero-length "... yes
checking whether g++ accepts " -Wno-address-of-packed-member "... yes
checking whether gcc -E accepts " -Wno-address-of-packed-member "... yes
checking whether g++ accepts " -Wno-int-to-void-pointer-cast "... yes
checking whether gcc -E accepts " -Wno-int-to-void-pointer-cast "... yes
...
```