### PR TITLE
Fix with how DOS_Execute allocates memory to comply with the memory a…

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -233,6 +233,7 @@ void DOS_Terminate(uint16_t pspseg,bool tsr,uint8_t exitcode);
 
 /* Memory Handling Routines */
 void DOS_SetupMemory(void);
+uint16_t DOS_GetMaximumFreeSize(uint16_t minBlocks);
 bool DOS_AllocateMemory(uint16_t * segment,uint16_t * blocks);
 bool DOS_ResizeMemory(uint16_t segment,uint16_t * blocks);
 bool DOS_FreeMemory(uint16_t segment);
@@ -670,6 +671,11 @@ public:
 	uint8_t GetType(void) { return (uint8_t)sGet(sMCB,type);}
 	uint16_t GetSize(void) { return (uint16_t)sGet(sMCB,size);}
 	uint16_t GetPSPSeg(void) { return (uint16_t)sGet(sMCB,psp_segment);}
+	enum class MCBType : uint8_t
+	{
+		ValidBlock = 'M',
+		LastBlock = 'Z'
+	};
 private:
 	#ifdef _MSC_VER
 	#pragma pack (1)

--- a/src/dos/dos_memory.cpp
+++ b/src/dos/dos_memory.cpp
@@ -161,7 +161,7 @@ static uint16_t GetMaximumMCBFreeSize(uint16_t mcb_segment)
 	for (bool endOfChain = false; !endOfChain; mcb.SetPt(mcb_segment))
 	{
 		auto size = mcb.GetSize();
-		if (mcb.GetPSPSeg()==MCB_FREE) largestSize = std::max(largestSize, size);
+		if (mcb.GetPSPSeg()==MCB_FREE) largestSize = (std::max)(largestSize, size);
 		endOfChain = DOS_MCB::MCBType(mcb.GetType())==DOS_MCB::MCBType::LastBlock;
 		mcb_segment += size+1;
 	}
@@ -170,10 +170,9 @@ static uint16_t GetMaximumMCBFreeSize(uint16_t mcb_segment)
 
 uint16_t DOS_GetMaximumFreeSize(uint16_t minBlocks)
 {
-	uint16_t umbFreeSize = 0;
 	if (memAllocStrategy & 0xc0)
 	{
-		umbFreeSize = GetMaximumMCBFreeSize(dos_infoblock.GetStartOfUMBChain());
+		auto umbFreeSize = GetMaximumMCBFreeSize(dos_infoblock.GetStartOfUMBChain());
 		if (memAllocStrategy & 0x40 || umbFreeSize >= minBlocks) return umbFreeSize;
 	}
 	return GetMaximumMCBFreeSize(dos.firstMCB);

--- a/src/dos/dos_memory.cpp
+++ b/src/dos/dos_memory.cpp
@@ -16,6 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <algorithm>
 
 #include "dosbox.h"
 #include "logging.h"
@@ -151,6 +152,31 @@ void DOS_zeromem(uint16_t seg,uint16_t para) {
 		mem_writeb(ofs++,0);
 		cnt--;
 	}
+}
+
+static uint16_t GetMaximumMCBFreeSize(uint16_t mcb_segment)
+{
+	uint16_t largestSize = 0;
+	DOS_MCB mcb(mcb_segment);
+	for (bool endOfChain = false; !endOfChain; mcb.SetPt(mcb_segment))
+	{
+		auto size = mcb.GetSize();
+		if (mcb.GetPSPSeg()==MCB_FREE) largestSize = std::max(largestSize, size);
+		endOfChain = DOS_MCB::MCBType(mcb.GetType())==DOS_MCB::MCBType::LastBlock;
+		mcb_segment += size+1;
+	}
+	return largestSize;
+}
+
+uint16_t DOS_GetMaximumFreeSize(uint16_t minBlocks)
+{
+	uint16_t umbFreeSize = 0;
+	if (memAllocStrategy & 0xc0)
+	{
+		umbFreeSize = GetMaximumMCBFreeSize(dos_infoblock.GetStartOfUMBChain());
+		if (memAllocStrategy & 0x40 || umbFreeSize >= minBlocks) return umbFreeSize;
+	}
+	return GetMaximumMCBFreeSize(dos.firstMCB);
 }
 
 bool DOS_AllocateMemory(uint16_t * segment,uint16_t * blocks) {


### PR DESCRIPTION
…llocation strategy for UMB...now, it will allocate and execute in UMB if there is enough memory for the minimum allocation of the executable

# Description

Currently, `DOS_Execute` will search for the largest block of memory irregardless of the memory allocation strategy set and as a result will almost never execute anything in upper memory. The environment block will be allocated in UMB but none of the executable. This patch aligns with the behavior of `loadhigh` in DOS which will allocate in the upper memory if there is enough memory for the size of the executable.


**Does this PR address some issue(s) ?**

Should address PR #2558 

Here is an example with snarf (dos screen capture TSR)
_Before Patch_
```
C:\>lh SNARF.EXE

Snarf 2.0 is now installed in memory

C:\>mem /c

Modules using memory below 1 MB:

  Name            Total          Conventional       Upper Memory
  --------  ----------------   ----------------   ----------------
  SYSTEM      28,720   (28K)     28,720   (28K)          0    (0K)
  COMMAND      3,216    (3K)      3,216    (3K)          0    (0K)
  SNARF        3,984    (4K)      3,984    (4K)          0    (0K)
  Free       700,224  (684K)    618,304  (604K)     81,920   (80K)

Memory Type         Total      Used       Free
----------------  --------   --------   --------
Conventional          640K        36K       604K
Upper                  80K         0K        80K
Reserved              304K       304K         0K
Extended (XMS)     15,360K       448K    14,912K
----------------  --------   --------   --------
Total memory       16,384K       788K    15,596K

Total under 1 MB      720K        36K       684K

Total Expanded (EMS)                   15M (15,269,888 bytes)
Free Expanded (EMS)                    15M (15,269,888 bytes)
...
```

_After Patch_
```
C:\>lh SNARF.EXE

Snarf 2.0 is now installed in memory

C:\>mem /c

Modules using memory below 1 MB:

  Name            Total          Conventional       Upper Memory
  --------  ----------------   ----------------   ----------------
  SYSTEM      28,720   (28K)     28,720   (28K)          0    (0K)
  COMMAND      3,216    (3K)      3,216    (3K)          0    (0K)
  SNARF        3,984    (4K)          0    (0K)      3,984    (4K)
  Free       700,224  (684K)    622,288  (608K)     77,936   (76K)

Memory Type         Total      Used       Free
----------------  --------   --------   --------
Conventional          640K        32K       608K
Upper                  80K         4K        76K
Reserved              304K       304K         0K
Extended (XMS)     15,360K       448K    14,912K
----------------  --------   --------   --------
Total memory       16,384K       788K    15,596K

Total under 1 MB      720K        36K       684K

Total Expanded (EMS)                   15M (15,269,888 bytes)
Free Expanded (EMS)                    15M (15,269,888 bytes)
...
```