### PR TITLE
Fixed the display position of IME conversion candidates on Linux.

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -7377,7 +7377,7 @@ void* GetSetSDLValue(int isget, std::string& target, void* setval) {
 }
 
 #if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
-static Bitu im_x, im_y;
+static uint8_t im_x, im_y;
 static uint32_t last_ticks;
 void SetIMPosition() {
 	uint8_t x, y;
@@ -7391,8 +7391,6 @@ void SetIMPosition() {
 		ncols=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
     }
     if (IS_PC98_ARCH && x<ncols-3) x+=2;
-    x--;
-    y--;
 
 	if ((im_x != x || im_y != y) && GetTicks() - last_ticks > 100) {
 		last_ticks = GetTicks();
@@ -7405,13 +7403,13 @@ void SetIMPosition() {
         uint8_t width = CurMode && DOSV_CheckCJKVideoMode() ? CurMode->cwidth : (height / 2);
 #if defined(USE_TTF)
         if (ttf.inUse)
-            SDL_SetIMPosition((x+1) * ttf.width, (y+1) * ttf.height);
+            SDL_SetIMPosition(x * ttf.width, y * ttf.height);
         else
 #endif
 #if DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW /* SDL drawn menus */
-        SDL_SetIMPosition((x+1) * width, (y+1) * height - (IS_DOSV?-1:(DOSV_CheckCJKVideoMode()?2:0)) + mainMenu.menuBarHeightBase);
+        SDL_SetIMPosition(x * width, y * height - (IS_DOSV?-1:(DOSV_CheckCJKVideoMode()?2:0)) + mainMenu.menuBarHeightBase);
 #else
-        SDL_SetIMPosition((x+1) * width, (y+1) * height - (IS_DOSV?-1:(DOSV_CheckCJKVideoMode()?2:0)));
+        SDL_SetIMPosition(x * width, y * height - (IS_DOSV?-1:(DOSV_CheckCJKVideoMode()?2:0)));
 #endif
 	}
 }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8245,8 +8245,8 @@ void GFX_Events() {
 #endif
         default:
 #if defined(WIN32) && !defined(HX_DOS) && defined(SDL_DOSBOX_X_SPECIAL)
-            if(event.key.keysym.scancode == 0x70 || event.key.keysym.scancode == 0x94) {
-                if(event.key.keysym.scancode == 0x94 && dos.im_enable_flag) {
+            if(event.key.keysym.scancode == 0x70 || event.key.keysym.scancode == 0x94 || event.key.keysym.scancode == 0x29) {
+                if((event.key.keysym.scancode == 0x94 || event.key.keysym.scancode == 0x29) && dos.im_enable_flag) {
                     break;
                 }
                 event.type = SDL_KEYDOWN;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -7398,8 +7398,8 @@ void SetIMPosition() {
 		last_ticks = GetTicks();
 		im_x = x;
 		im_y = y;
-#if DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW
-		y+=mainMenu.menuBarHeightBase;
+#if defined(LINUX)
+		y++;
 #endif
 		uint8_t height = IS_PC98_ARCH?16:real_readb(BIOSMEM_SEG, BIOSMEM_CHAR_HEIGHT);
         uint8_t width = CurMode && DOSV_CheckCJKVideoMode() ? CurMode->cwidth : (height / 2);
@@ -7408,7 +7408,11 @@ void SetIMPosition() {
             SDL_SetIMPosition((x+1) * ttf.width, (y+1) * ttf.height);
         else
 #endif
+#if DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW /* SDL drawn menus */
+        SDL_SetIMPosition((x+1) * width, (y+1) * height - (IS_DOSV?-1:(DOSV_CheckCJKVideoMode()?2:0)) + mainMenu.menuBarHeightBase);
+#else
         SDL_SetIMPosition((x+1) * width, (y+1) * height - (IS_DOSV?-1:(DOSV_CheckCJKVideoMode()?2:0)));
+#endif
 	}
 }
 #endif


### PR DESCRIPTION
# Description
Fixed the display position of IME conversion candidates on Linux.


**Does this PR address some issue(s) ?**
Fixed the problem that the IME conversion candidate position was far down in Linux SDL2.
