### PR TITLE
Loading command shell in upper memory

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -4048,6 +4048,12 @@ void DOSBOX_SetupConfigSections(void) {
 			"Similarly, FAT32 disk images will be supported with a reported DOS version of 7.1 or higher.\n");
     Pstring->SetBasic(true);
 
+    Pstring = secprop->Add_string("loadhigh shell",Property::Changeable::OnlyAtStart,"auto");
+    Pstring->Set_values(truefalseautoopt);
+    Pstring->Set_help("Load the command shell in upper memory if umb is supported. If set to auto (default), it "
+                      "is enabled if the reported DOS version is at least 7.0.\n");
+    Pstring->SetBasic(true);
+
     Pstring = secprop->Add_string("lfn",Property::Changeable::WhenIdle,"auto");
     Pstring->Set_values(lfn_settings);
     Pstring->Set_help("Enable long filename support. If set to auto (default), it is enabled if the reported DOS version is at least 7.0.\n"

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -4048,7 +4048,7 @@ void DOSBOX_SetupConfigSections(void) {
 			"Similarly, FAT32 disk images will be supported with a reported DOS version of 7.1 or higher.\n");
     Pstring->SetBasic(true);
 
-    Pstring = secprop->Add_string("loadhigh shell",Property::Changeable::OnlyAtStart,"auto");
+    Pstring = secprop->Add_string("shellhigh",Property::Changeable::OnlyAtStart,"auto");
     Pstring->Set_values(truefalseautoopt);
     Pstring->Set_help("Load the command shell in upper memory if umb is supported. If set to auto (default), it "
                       "is enabled if the reported DOS version is at least 7.0.\n");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1556,9 +1556,9 @@ void SHELL_Init() {
     dos.psp(8);
 
     auto savedMemAllocStrategy = DOS_GetMemAllocStrategy();
-    auto loadHighShell = std::string(static_cast<Section_prop*>(control->GetSection("dos"))->Get_string("loadhigh shell"));
-    if (loadHighShell=="true" || loadHighShell=="1" ||
-        (loadHighShell=="auto" && dos.version.major >= 7))
+    auto shellHigh = std::string(static_cast<Section_prop*>(control->GetSection("dos"))->Get_string("shellhigh"));
+    if (shellHigh=="true" || shellHigh=="1" ||
+        (shellHigh=="auto" && dos.version.major >= 7))
     {
 	    DOS_SetMemAllocStrategy(savedMemAllocStrategy | 0x80);
     }

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1555,6 +1555,14 @@ void SHELL_Init() {
     // can properly allocate memory.
     dos.psp(8);
 
+    auto savedMemAllocStrategy = DOS_GetMemAllocStrategy();
+    auto loadHighShell = std::string(static_cast<Section_prop*>(control->GetSection("dos"))->Get_string("loadhigh shell"));
+    if (loadHighShell=="true" || loadHighShell=="1" ||
+        (loadHighShell=="auto" && dos.version.major >= 7))
+    {
+	    DOS_SetMemAllocStrategy(savedMemAllocStrategy | 0x80);
+    }
+
     // COMMAND.COM environment block
     tmp = dosbox_shell_env_size>>4;
 	if (!DOS_AllocateMemory(&env_seg,&tmp)) E_Exit("COMMAND.COM failed to allocate environment block segment");
@@ -1565,6 +1573,8 @@ void SHELL_Init() {
     total_sz = tmp;
 	if (!DOS_AllocateMemory(&psp_seg,&tmp)) E_Exit("COMMAND.COM failed to allocate main body + PSP segment");
     LOG_MSG("COMMAND.COM main body (PSP):      0x%04x sz=0x%04x",psp_seg,tmp);
+
+    DOS_SetMemAllocStrategy(savedMemAllocStrategy);
 
     // now COMMAND.COM has a main body and PSP segment, reflect it
     dos.psp(psp_seg);


### PR DESCRIPTION
# Description
Add config option under dos for loading the command shell in upper memory

**Does this PR introduce new feature(s) ?**
The the option "loadhigh shell" under the dos section to support loading the command shell in upper memory. A value of `auto` will attempt to load in upper memory if the dos version is set to 7.0 or greater