### PR TITLE
Fixing CGA, CGA_Mono and Hercules intro screens

### DIFF
--- a/contrib/translations/fr/fr_FR.lng
+++ b/contrib/translations/fr/fr_FR.lng
@@ -1590,16 +1590,18 @@ Vous pouvez effectuer des tâches par l'intermédiaire des menus ←[33mdéroula
 - régler la vitesse d'émulation avec ←[31mF11 ←[37m+ ←[31mPlus←[37m←[37m ou ←[31mF11 ←[37m+ ←[31mMoins←[37m ←[37m             
 .
 :SHELL_STARTUP_CGA
-Le mode composite CGA est pris en charge. Utilisez ←[31mCtrl+F8←[37m pour régler la sortie composite sur ON/OFF.
-Utilisez ←[31mCtrl+Shift+[F7/F8]←[37m pour modifier la teinte ; ←[31mCtrl+F7←[37m sélectionne le modèle CGA précoce/tardif.
+Le mode composite CGA est pris en charge. Utilisez ←[31mCtrl+F8←[37m pour régler      
+la sortie composite sur ON/OFF. Utilisez ←[31mCtrl+Shift+[F7/F8]←[37m pour modifier   
+la teinte ; ←[31mCtrl+F7←[37m sélectionne le modèle CGA précoce/tardif.               
 .
 :SHELL_STARTUP_CGA_MONO
-Utilisez ←[31mCtrl+F7←[37m pour faire défiler les couleurs monochromes verte, ambre et blanche,
-et ←[31mCtrl+F8←[37m pour modifier les paramètres de contraste/luminosité.                         
+Utilisez ←[31mCtrl+F7←[37m pour faire défiler les couleurs monochromes verte, ambre et
+blanche, et ←[31mCtrl+F8←[37m pour modifier les paramètres de contraste/luminosité.   
 .
 :SHELL_STARTUP_HERC
-Utilisez ←[31mCtrl+F7←[37m pour faire défiler les couleurs monochromes blanche, ambre et verte.      
-Utilisez ←[31mCtrl+F8←[37m pour activer le mélange horizontal (uniquement en mode graphique).          
+Utilisez ←[31mCtrl+F7←[37m pour faire défiler les couleurs monochromes blanche, ambre 
+et verte. Utilisez ←[31mCtrl+F8←[37m pour activer le mélange horizontal (uniquement   
+en mode graphique).                                                         
 .
 :SHELL_STARTUP_HEAD3
 ←[36mLe projet DOSBox-X sur Internet:                                            ←[37m


### PR DESCRIPTION
I tested only EGA/VGA/SVGA and PC98 intro screen. CGA, CGA_Mono and Hercules intro screen where broken.

# Description

_Summary of changes brought by this PR._


**Does this PR address some issue(s) ?**

_Add the issue(s) fixed, e.g. ```#1234```_


**Does this PR introduce new feature(s) ?**

_Describe the feature(s) introduced._


**Are there any breaking changes ?**

_Describe the breaking changes in detail._


**Additional information**

_Add any additional information that may be useful._
