### PR TITLE
Debugger: Shift+TAB

### DIFF
--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -2769,6 +2769,7 @@ bool ParseCommand(char* str) {
 		DEBUG_ShowMsg("Page Up/Down              - Page up/down in the current window.\n");
 		DEBUG_ShowMsg("Home/End                  - Move to begin/end of the current window.\n");
         DEBUG_ShowMsg("TAB                       - Select next window\n");
+        DEBUG_ShowMsg("Shift + TAB               - Select previous window\n");
         DEBUG_EndPagedContent();
 
 		return true;
@@ -3349,6 +3350,10 @@ uint32_t DEBUG_CheckKeys(void) {
         case 0x09: //TAB
                 void DBGUI_NextWindow(void);
                 DBGUI_NextWindow();
+                break;
+        case KEY_BTAB:
+                void DBGUI_PrevWindow(void);
+                DBGUI_PrevWindow();
                 break;
 		case 0x0A: //Parse typed Command
                 if (codeViewData.inputPos > 0) {

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -161,6 +161,15 @@ void DBGBlock::next_window(void) {
     if (order >= 0) active_win = win_order[order];
 }
 
+void DBGBlock::prev_window(void) {
+    int order = win_find_order((int)active_win);
+
+    if (order < 0) order = 0;
+
+    order = win_prev_by_order(order);
+    if (order >= 0) active_win = win_order[order];
+}
+
 void DBGBlock::swap_order(int o1,int o2) {
     if (o1 != o2)
         std::swap(win_order[o1],win_order[o2]);
@@ -557,6 +566,12 @@ void DBGUI_NextWindow(void) {
     dbg.next_window();
 	DrawBars();
 	DEBUG_DrawScreen();
+}
+
+void DBGUI_PrevWindow(void) {
+    dbg.prev_window();
+    DrawBars();
+    DEBUG_DrawScreen();
 }
 
 void DBGUI_NextWindowIfActiveHidden(void) {

--- a/src/debug/debug_inc.h
+++ b/src/debug/debug_inc.h
@@ -102,6 +102,7 @@ public:
     int win_next_by_order(int order);
     void swap_order(int o1,int o2);
     void next_window(void);
+    void prev_window(void);
 };
 
 


### PR DESCRIPTION
**Does this PR introduce new feature(s) ?**
Adds shift+tab key combination in the debugger to switch to previous window complimenting the existing functionality of tab switching to next window
