### PR TITLE
[MingW]Fixing pacman -S line to add missing meta-package

### DIFF
--- a/README.MinGW
+++ b/README.MinGW
@@ -22,6 +22,6 @@ export CXX="$TRIPLET-g++"
 # Open the MSYS2 MinGW 64-bit prompt,
 # then run:
 pacman -Syu # Keep up to date!
-pacman -S mingw-w64-x86_64-toolchain mingw-w64-x86_64-SDL2 mingw-w64-x86_64-libpng
+pacman -S base-devel gcc mingw-w64-x86_64-toolchain mingw-w64-x86_64-SDL2 mingw-w64-x86_64-libpng --needed
 cd /path/to/dosbox-code
 ./build-mingw-sdl2


### PR DESCRIPTION
You need base-devel to get all autotools and build tools that will be missing. 

Here is the cleaned up list (I removed description to save some space) from my archlinux installation as msys2 is using archlinux as base.

```
$ pacman -Ss base-devel
testing/automake 1.16.4-1 (base-devel) 
testing/texinfo 6.8-2 (base-devel) 
core/autoconf 2.71-1 (base-devel) 
core/automake 1.16.3-1 (base-devel) 
core/binutils 2.36.1-3 (base-devel) 
core/bison 3.7.6-1 (base-devel) 
core/fakeroot 1.25.3-2 (base-devel) 
core/file 5.40-5 (base-devel) 
core/findutils 4.8.0-1 (base-devel) 
core/flex 2.6.4-3 (base-devel) 
core/gawk 5.1.0-1 (base-devel) 
core/gcc 11.1.0-1 (base-devel) 
core/gettext 0.21-1 (base-devel) 
core/grep 3.6-1 (base-devel) 
core/groff 1.22.4-6 (base-devel) 
core/gzip 1.10-3 (base-devel) 
core/libtool 2.4.6+42+gb88cebd5-16 (base-devel) 
core/m4 1.4.19-1 (base-devel) 
core/make 4.3-3 (base-devel) 
core/pacman 6.0.0-5 (base-devel) 
core/patch 2.7.6-8 (base-devel) 
core/pkgconf 1.7.3-1 (base-devel) 
core/sed 4.8-1 (base-devel) 
core/sudo 1.9.7.p2-1 (base-devel) 
core/texinfo 6.8-1 (base-devel) [installé: 6.8-2]
core/which 2.21-5 (base-devel) 
```

I also added --needed to shorten installation time.

You also need gcc to build dependencies like sdl2 for example.

# Description

_Summary of changes brought by this PR._


**Does this PR address some issue(s) ?**

_Add the issue(s) fixed, e.g. ```#1234```_


**Does this PR introduce new feature(s) ?**

_Describe the feature(s) introduced._


**Are there any breaking changes ?**

_Describe the breaking changes in detail._


**Additional information**

_Add any additional information that may be useful._
