### PR TITLE
French translation - Fixing a tiny typo in voodoo section :)

### DIFF
--- a/contrib/translations/fr/fr_FR.lng
+++ b/contrib/translations/fr/fr_FR.lng
@@ -2660,7 +2660,7 @@ Effacer la couche graphique
 3dfx Voodoo/Glide
 .
 :MENU:3dfx_voodoo
-Carte Voodo interne
+Carte Voodoo interne
 .
 :MENU:3dfx_glide
 Passage Glide


### PR DESCRIPTION
Looks like there were a missing o in "voodoo interne" line :)

Besides this, translations are looking good!

# Description

_Summary of changes brought by this PR._


**Does this PR address some issue(s) ?**

_Add the issue(s) fixed, e.g. ```#1234```_


**Does this PR introduce new feature(s) ?**

_Describe the feature(s) introduced._


**Are there any breaking changes ?**

_Describe the breaking changes in detail._


**Additional information**

_Add any additional information that may be useful._
