### PR TITLE
Invalid operand with LEA instruction

### DIFF
--- a/src/cpu/core_normal/prefix_none.h
+++ b/src/cpu/core_normal/prefix_none.h
@@ -544,7 +544,7 @@
 			//Little hack to always use segprefixed version
 			BaseDS=BaseSS=0;
 			GetRMrw;
-			if (rm >= 0xc0) goto illegal_opcode;
+			if (rm >= 0xc0) goto illegal_opcode;     // Direct register causes #UD exception
 			if (TEST_PREFIX_ADDR) {
 				*rmrw=(uint16_t)(*EATable[256+rm])();
 			} else {

--- a/src/cpu/core_normal/prefix_none.h
+++ b/src/cpu/core_normal/prefix_none.h
@@ -544,6 +544,7 @@
 			//Little hack to always use segprefixed version
 			BaseDS=BaseSS=0;
 			GetRMrw;
+			if (rm >= 0xc0) goto illegal_opcode;
 			if (TEST_PREFIX_ADDR) {
 				*rmrw=(uint16_t)(*EATable[256+rm])();
 			} else {


### PR DESCRIPTION
# Description
The `LEA` opcode should generate an #UD exception if the source operand is set to a direct register. i.e. the mod field in the R/M byte is 0b11. 

**Does this PR address some issue(s) ?**
This fixes a segfault in dosbox-x as the code will jump to 0x0 as nothing exist in the `EATable` for the invalid mod field and corrects the decoding behavior for >=80186.