### PR TITLE
Fixed a problem with VGA 640x480 16-color display on ET-3000.

### DIFF
--- a/src/hardware/vga_tseng.cpp
+++ b/src/hardware/vga_tseng.cpp
@@ -906,7 +906,7 @@ void FinishSetMode_ET3K(Bitu crtc_base, VGA_ModeExtraData* modeData) {
     IO_Write(crtc_base,0x25);IO_Write(crtc_base+1,et4k_ver_overflow);
 
     // Clear remaining ext CRTC registers
-    for (uint8_t i=0x16; i<=0x21; i++) {
+    for (uint8_t i=0x1b; i<=0x21; i++) {
         IO_Write(crtc_base,i);
         IO_Write(crtc_base+1,0);
     }


### PR DESCRIPTION
# Description
Fixed a problem with VGA 640x480 16-color display on ET-3000.

**Does this PR address some issue(s) ?**
When clearing the extended register, the Mode Control Register was also cleared, which caused the screen display to be distorted.

**Additional information**
This is not related to this case, but it seems that the builtin files (defrag_exe.cpp, etc.) have not been added to the Visual Studio project.