### PR TITLE
FPU Improvements

### DIFF
--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -2085,6 +2085,7 @@ static void dyn_load_seg(SegNames seg,DynReg * src) {
 	gen_releasereg(&DynRegs[G_ES+seg]);
 }
 
+
 static void dyn_load_seg_off_ea(SegNames seg) {
 	if (decode.modrm.mod<3) {
 		dyn_fill_ea();

--- a/src/cpu/mmx.cpp
+++ b/src/cpu/mmx.cpp
@@ -116,7 +116,7 @@ uint16_t SaturateDwordSToWordU(int32_t value)
 }
 
 void setFPUTagEmpty() {
-	FPU_SetCW(0x37F);
+	fpu.cw.init();
 	fpu.sw = 0;
 	TOP = FPU_GET_TOP();
 	fpu.tags[0] = TAG_Empty;

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -434,8 +434,16 @@ void FPU_ESC3_Normal(Bitu rm) {
 	case 0x04:
 		switch (sub) {
 		case 0x00:				//FNENI
+			if (CPU_ArchitectureType==CPU_ARCHTYPE_8086)
+				fpu.cw.M = false;
+			else
+				LOG(LOG_FPU,LOG_ERROR)("8087 only fpu code used esc 3: group 4: subfuntion :%d",(int)sub);
+			break;
 		case 0x01:				//FNDIS
-			LOG(LOG_FPU,LOG_ERROR)("8087 only fpu code used esc 3: group 4: subfuntion :%d",(int)sub);
+			if (CPU_ArchitectureType==CPU_ARCHTYPE_8086)
+				fpu.cw.M = true;
+			else
+				LOG(LOG_FPU,LOG_ERROR)("8087 only fpu code used esc 3: group 4: subfuntion :%d",(int)sub);
 			break;
 		case 0x02:				//FNCLEX FCLEX
 			FPU_FCLEX();

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -25,15 +25,15 @@
 #include "paging.h"
 #include "cross.h"
 #include "mem.h"
-#include "fpu.h"
 #include "cpu.h"
+#include "fpu.h"
 #include "../cpu/lazyflags.h"
 
 FPU_rec fpu;
 
-void FPU_FLDCW(PhysPt addr){
-	uint16_t temp = mem_readw(addr);
-	FPU_SetCW(temp);
+void FPU_FLDCW(PhysPt addr)
+{
+	fpu.cw = mem_readw(addr);
 }
 
 uint16_t FPU_GetTag(void){

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -21,7 +21,7 @@
 static void FPU_FINIT(void) {
 	unsigned int i;
 
-	FPU_SetCW(0x37F);
+	fpu.cw.init();
 	fpu.sw = 0;
 	TOP=FPU_GET_TOP();
 	fpu.tags[0] = TAG_Empty;
@@ -629,7 +629,7 @@ static void FPU_FLDENV(PhysPt addr){
 		tag    = static_cast<uint16_t>(tagbig);
 	}
 	FPU_SetTag(tag);
-	FPU_SetCW(cw);
+	fpu.cw = cw;
 	TOP = FPU_GET_TOP();
 }
 

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -71,19 +71,19 @@ static void FPU_FPOP(void){
 }
 
 static double FROUND(double in){
-	switch(fpu.round){
-	case ROUND_Nearest:	
+	switch (fpu.cw.RC){
+	case fpu::RoundMode::Nearest:
 		if (in-floor(in)>0.5) return (floor(in)+1);
 		else if (in-floor(in)<0.5) return (floor(in));
 		else return (((static_cast<int64_t>(floor(in)))&1)!=0)?(floor(in)+1):(floor(in));
 		break;
-	case ROUND_Down:
+	case fpu::RoundMode::Down:
 		return (floor(in));
 		break;
-	case ROUND_Up:
+	case fpu::RoundMode::Up:
 		return (ceil(in));
 		break;
-	case ROUND_Chop:
+	case fpu::RoundMode::Chop:
 		return in; //the cast afterwards will do it right maybe cast here
 		break;
 	default:

--- a/src/fpu/fpu_instructions_longdouble.h
+++ b/src/fpu/fpu_instructions_longdouble.h
@@ -38,7 +38,7 @@ static inline void FPU_SyncCW(void) {
 #endif
 
 static void FPU_FINIT(void) {
-	FPU_SetCW(0x37F);
+	fpu.cw.init();
     FPU_SyncCW();
     fpu.sw = 0;
 	TOP=FPU_GET_TOP();
@@ -548,7 +548,7 @@ static void FPU_FLDENV(PhysPt addr){
 		tag    = static_cast<uint16_t>(tagbig);
 	}
 	FPU_SetTag(tag);
-	FPU_SetCW(cw);
+	fpu.cw.init();
     FPU_SyncCW();
 	TOP = FPU_GET_TOP();
 }

--- a/src/fpu/fpu_instructions_longdouble.h
+++ b/src/fpu/fpu_instructions_longdouble.h
@@ -84,19 +84,19 @@ static void FPU_FPOP(void){
 }
 
 static long double FROUND(long double in){
-	switch(fpu.round){
-	case ROUND_Nearest:	
+	switch(fpu.cw.RC){
+	case fpu::RoundMode::Nearest:
 		if (in-floorl(in)>0.5) return (floorl(in)+1);
 		else if (in-floorl(in)<0.5) return (floorl(in));
 		else return (((static_cast<int64_t>(floorl(in)))&1)!=0)?(floorl(in)+1):(floorl(in));
 		break;
-	case ROUND_Down:
+	case fpu::RoundMode::Down:
 		return (floorl(in));
 		break;
-	case ROUND_Up:
+	case fpu::RoundMode::Up:
 		return (ceill(in));
 		break;
-	case ROUND_Chop:
+	case fpu::RoundMode::Chop:
 		return in; //the cast afterwards will do it right maybe cast here
 		break;
 	default:

--- a/src/fpu/fpu_instructions_x86.h
+++ b/src/fpu/fpu_instructions_x86.h
@@ -77,7 +77,7 @@
 		__asm {								\
 		__asm	fnstcw	save_cw				\
 		__asm	mov		eax, TOP			\
-		__asm	fldcw	fpu.cw_mask_all		\
+		__asm	fldcw	fpu.cw.allMasked()  \
 		__asm	shl		eax, 4				\
 		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
 		__asm	op		szI PTR fpu.p_regs[128].m1		\
@@ -88,7 +88,7 @@
 		uint16_t new_sw,save_cw;				\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
-		__asm	fldcw	fpu.cw_mask_all		\
+		__asm	fldcw	fpu.cw.allMasked()  \
 		__asm	mov		eax, TOP			\
 		__asm	shl		eax, 4				\
 		__asm	mov		ebx, 8				\
@@ -215,7 +215,7 @@
 		__asm	fnstcw	save_cw				\
 		__asm	mov		eax, op1			\
 		__asm	shl		eax, 4				\
-		__asm	fldcw	fpu.cw_mask_all		\
+		__asm	fldcw	fpu.cw.allMasked()	\
 		__asm	mov		ebx, op2			\
 		__asm	shl		ebx, 4				\
 		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
@@ -229,7 +229,7 @@
 		uint16_t new_sw,save_cw;				\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
-		__asm	fldcw	fpu.cw_mask_all		\
+		__asm	fldcw	fpu.cw.allMasked()		\
 		__asm	mov		eax, op1			\
 		__asm	shl		eax, 4				\
 		__asm	mov		ebx, op2			\
@@ -252,7 +252,7 @@
 		__asm {								\
 		__asm	fnstcw	save_cw				\
 		__asm	mov		eax, op1			\
-		__asm	fldcw	fpu.cw_mask_all		\
+		__asm	fldcw	fpu.cw.allMasked()		\
 		__asm	shl		eax, 4				\
 		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
 		__asm	fxch	\
@@ -265,7 +265,7 @@
 		uint16_t new_sw,save_cw;				\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
-		__asm	fldcw	fpu.cw_mask_all		\
+		__asm	fldcw	fpu.cw.allMasked()		\
 		__asm	mov		eax, op1			\
 		__asm	shl		eax, 4				\
 		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
@@ -286,7 +286,7 @@
 		__asm {								\
 		__asm	fnstcw	save_cw				\
 		__asm	mov		eax, TOP			\
-		__asm	fldcw	fpu.cw_mask_all		\
+		__asm	fldcw	fpu.cw.allMasked()		\
 		__asm	shl		eax, 4				\
 		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
 		__asm	op							\
@@ -298,7 +298,7 @@
 		uint16_t new_sw,save_cw;				\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
-		__asm	fldcw	fpu.cw_mask_all		\
+		__asm	fldcw	fpu.cw.allMasked()		\
 		__asm	mov		eax, TOP			\
 		__asm	shl		eax, 4				\
 		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
@@ -317,7 +317,7 @@
 		uint16_t new_sw,save_cw;				\
 		__asm {								\
 		__asm	fnstcw	save_cw				\
-		__asm	fldcw	fpu.cw_mask_all		\
+		__asm	fldcw	fpu.cw.allMasked()		\
 		__asm	mov		eax, op1			\
 		__asm	shl		eax, 4				\
 		__asm	mov		ebx, op2			\
@@ -339,7 +339,7 @@
 		__asm {								\
 		__asm	fnstcw	save_cw				\
 		__asm	mov		eax, op1			\
-		__asm	fldcw	fpu.cw_mask_all		\
+		__asm	fldcw	fpu.cw.allMasked()		\
 		__asm	shl		eax, 4				\
 		__asm	fld		TBYTE PTR fpu.p_regs[eax].m1	\
 		__asm	fxch	\
@@ -553,7 +553,7 @@
 
 #ifdef WEAK_EXCEPTIONS
 #define FPUD_STORE(op,szI,szA)				\
-		uint16_t save_cw;						\
+		uint16_t save_cw,cw_masked=fpu.cw.allMasked();						\
 		__asm__ volatile (					\
 			"fnstcw		%0				\n"	\
 			"fldcw		%3				\n"	\
@@ -561,11 +561,11 @@
 			#op #szA "	%1				\n"	\
 			"fldcw		%0				"	\
 			:	"=m" (save_cw), "=m" (fpu.p_regs[8])	\
-			:	"m" (fpu.p_regs[TOP]), "m" (fpu.cw_mask_all)		\
+			:	"m" (fpu.p_regs[TOP]), "m" (cw_masked)		\
 		);
 #else
 #define FPUD_STORE(op,szI,szA)				\
-		uint16_t new_sw,save_cw;				\
+		uint16_t new_sw,save_cw,cw_masked=fpu.cw.allMasked();				\
 		__asm__ volatile (					\
 			"fnstcw		%1				\n"	\
 			"fldcw		%4				\n"	\
@@ -575,7 +575,7 @@
 			"fnstsw		%0				\n"	\
 			"fldcw		%1				"	\
 			:	"=&am" (new_sw), "=m" (save_cw), "=m" (fpu.p_regs[8])	\
-			:	"m" (fpu.p_regs[TOP]), "m" (fpu.cw_mask_all)			\
+			:	"m" (fpu.p_regs[TOP]), "m" (cw_masked)			\
 		);									\
 		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
 #endif
@@ -668,7 +668,7 @@
 // handles fadd,fmul,fsub,fsubr
 #ifdef WEAK_EXCEPTIONS
 #define FPUD_ARITH1(op)						\
-		uint16_t save_cw;						\
+		uint16_t save_cw,cw_masked=fpu.cw.allMasked();						\
 		__asm__ volatile (					\
 			"fnstcw		%0				\n"	\
 			"fldcw		%3				\n"	\
@@ -678,11 +678,11 @@
 			"fstpt		%1				\n"	\
 			"fldcw		%0				"	\
 			:	"=m" (save_cw), "+m" (fpu.p_regs[op1])				\
-			:	"m" (fpu.p_regs[op2]), "m" (fpu.cw_mask_all)		\
+			:	"m" (fpu.p_regs[op2]), "m" (cw_masked)		\
 		);
 #else
 #define FPUD_ARITH1(op)						\
-		uint16_t new_sw,save_cw;				\
+		uint16_t new_sw,save_cw,cw_masked=fpu.cw.allMasked();				\
 		__asm__ volatile (					\
 			"fnstcw		%1				\n"	\
 			"fldcw		%4				\n"	\
@@ -694,7 +694,7 @@
 			"fstpt		%2				\n"	\
 			"fldcw		%1				"	\
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[op1])	\
-			:	"m" (fpu.p_regs[op2]), "m" (fpu.cw_mask_all)		\
+			:	"m" (fpu.p_regs[op2]), "m" (cw_masked)		\
 		);									\
 		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
 #endif
@@ -702,7 +702,7 @@
 // handles fadd,fmul,fsub,fsubr
 #ifdef WEAK_EXCEPTIONS
 #define FPUD_ARITH1_EA(op)					\
-		uint16_t save_cw;						\
+		uint16_t save_cw,cw_masked=fpu.cw.allMasked();						\
 		__asm__ volatile (					\
 			"fnstcw		%0				\n"	\
 			"fldcw		%2				\n"	\
@@ -711,11 +711,11 @@
 			"fstpt		%1				\n"	\
 			"fldcw		%0				"	\
 			:	"=m" (save_cw), "+m" (fpu.p_regs[op1])		\
-			:	"m" (fpu.cw_mask_all)		\
+			:	"m" (cw_masked)		\
 		);
 #else
 #define FPUD_ARITH1_EA(op)					\
-		uint16_t new_sw,save_cw;				\
+		uint16_t new_sw,save_cw,cw_masked=fpu.cw.allMasked();				\
 		__asm__ volatile (					\
 			"fnstcw		%1				\n"	\
 			"fldcw		%3				\n"	\
@@ -726,7 +726,7 @@
 			"fstpt		%2				\n"	\
 			"fldcw		%1				"	\
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[op1])	\
-			:	"m" (fpu.cw_mask_all)		\
+			:	"m" (cw_masked)		\
 		);									\
 		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
 #endif
@@ -734,7 +734,7 @@
 // handles fsqrt,frndint
 #ifdef WEAK_EXCEPTIONS
 #define FPUD_ARITH2(op)						\
-		uint16_t save_cw;						\
+		uint16_t save_cw,cw_masked=fpu.cw.allMasked();						\
 		__asm__ volatile (					\
 			"fnstcw		%0				\n"	\
 			"fldcw		%2				\n"	\
@@ -743,11 +743,11 @@
 			"fstpt		%1				\n"	\
 			"fldcw		%0				"	\
 			:	"=m" (save_cw), "+m" (fpu.p_regs[TOP])		\
-			:	"m" (fpu.cw_mask_all)		\
+			:	"m" (cw_masked)		\
 		);
 #else
 #define FPUD_ARITH2(op)						\
-		uint16_t new_sw,save_cw;				\
+		uint16_t new_sw,save_cw,cw_masked=fpu.cw.allMasked();				\
 		__asm__ volatile (					\
 			"fnstcw		%1				\n"	\
 			"fldcw		%3				\n"	\
@@ -758,7 +758,7 @@
 			"fstpt		%2				\n"	\
 			"fldcw		%1				"	\
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[TOP])	\
-			:	"m" (fpu.cw_mask_all)		\
+			:	"m" (cw_masked)		\
 		);										\
 		fpu.sw=(new_sw&exc_mask)|(fpu.sw&0x80ff);
 #endif
@@ -766,7 +766,7 @@
 // handles fdiv,fdivr
 // (This is identical to FPUD_ARITH1 but without a WEAK_EXCEPTIONS variant)
 #define FPUD_ARITH3(op)						\
-		uint16_t new_sw,save_cw;				\
+		uint16_t new_sw,save_cw,cw_masked=fpu.cw.allMasked();				\
 		__asm__ volatile (					\
 			"fnstcw		%1				\n"	\
 			"fldcw		%4				\n"	\
@@ -778,14 +778,14 @@
 			"fstpt		%2				\n"	\
 			"fldcw		%1				"	\
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[op1])	\
-			:	"m" (fpu.p_regs[op2]), "m" (fpu.cw_mask_all)		\
+			:	"m" (fpu.p_regs[op2]), "m" (cw_masked)		\
 		);									\
 		fpu.sw=(new_sw&0xffbf)|(fpu.sw&0x80ff);
 
 // handles fdiv,fdivr
 // (This is identical to FPUD_ARITH1_EA but without a WEAK_EXCEPTIONS variant)
 #define FPUD_ARITH3_EA(op)					\
-		uint16_t new_sw,save_cw;				\
+		uint16_t new_sw,save_cw,cw_masked=fpu.cw.allMasked();				\
 		__asm__ volatile (					\
 			"fnstcw		%1				\n"	\
 			"fldcw		%3				\n"	\
@@ -796,7 +796,7 @@
 			"fstpt		%2				\n"	\
 			"fldcw		%1				"	\
 			:	"=&am" (new_sw), "=m" (save_cw), "+m" (fpu.p_regs[op1])	\
-			:	"m" (fpu.cw_mask_all)		\
+			:	"m" (cw_masked)		\
 		);									\
 		fpu.sw=(new_sw&0xffbf)|(fpu.sw&0x80ff);
 

--- a/src/fpu/fpu_instructions_x86.h
+++ b/src/fpu/fpu_instructions_x86.h
@@ -934,7 +934,7 @@ const uint16_t exc_mask=0xffbf;
 #endif
 
 static void FPU_FINIT(void) {
-	FPU_SetCW(0x37F);
+	fpu.cw.init();
 	fpu.sw=0;
 	TOP=FPU_GET_TOP();
 	fpu.tags[0]=TAG_Empty;
@@ -1284,7 +1284,7 @@ static void FPU_FLDENV(PhysPt addr){
 		tag    = static_cast<uint16_t>(tagbig);
 	}
 	FPU_SetTag(tag);
-	FPU_SetCW(cw);
+	fpu.cw = cw;
 	TOP=FPU_GET_TOP();
 }
 


### PR DESCRIPTION
# Description
Goal of this PR is to improve the FPU codebase and more accurately mimic the differences between the various math coprocessors. This first step addresses the control word (CW) and cleans up some of the code dealing with CW, adds bit definitions for it and implements missing functionality of the FENI and FDISI opcodes on the 8087 coprocessor.

**Does this PR address some issue(s) ?**
This commit fixes detection of of the 8087 coprocessor where the program detects the 8087 by examining whether or not it can set the main interrupt mask on the 8087 (which is not present on the 80187 and after).
