### PR TITLE
Fpu improvements

### DIFF
--- a/src/fpu/fpu_instructions_longdouble.h
+++ b/src/fpu/fpu_instructions_longdouble.h
@@ -548,7 +548,7 @@ static void FPU_FLDENV(PhysPt addr){
 		tag    = static_cast<uint16_t>(tagbig);
 	}
 	FPU_SetTag(tag);
-	fpu.cw.init();
+	fpu.cw = cw;
     FPU_SyncCW();
 	TOP = FPU_GET_TOP();
 }


### PR DESCRIPTION
# Description
Refactored the RegBit class a bit, fixed typo bug in the fpu_longdouble code, and now accout for the reserved '1' bits in the FPU control word.