### PR TITLE
ZDRIVE_NUM init

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -159,6 +159,8 @@ extern DOS_File ** Files;
 extern DOS_Drive * Drives[DOS_DRIVES];
 extern DOS_Device * Devices[DOS_DEVICES];
 
+extern uint8_t ZDRIVE_NUM;
+
 extern uint8_t dos_copybuf[0x10000];
 
 

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -4021,6 +4021,7 @@ public:
 
 		DOS_SetupPrograms();
 		DOS_SetupMisc();							/* Some additional dos interrupts */
+		ZDRIVE_NUM = 25;
 		DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).SetDrive(25); /* Else the next call gives a warning. */
 		DOS_SetDefaultDrive(25);
 
@@ -4212,8 +4213,6 @@ void DOS_ShutdownDrives() {
 
 void update_pc98_function_row(unsigned char setting,bool force_redraw=false);
 void DOS_Casemap_Free();
-
-extern uint8_t ZDRIVE_NUM;
 
 void DOS_EnableDriveMenu(char drv) {
     if (drv >= 'A' && drv <= 'Z') {


### PR DESCRIPTION
Added initialization of ZDRIVE_NUM instead of relying on it's initialized value so it will work across VM resets

**Does this PR address some issue(s) ?**
Resolves issue #2779 