### PR TITLE
Fix unresponsive 'A' key in Mac SDL1 build (Issue #2787)

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1175,7 +1175,7 @@ Bitu GetKeyCode(SDL_keysym keysym) {
         SDLKey key = SDLK_UNKNOWN;
 
 #if defined (MACOSX)
-        if ((keysym.scancode == 0) && (keysym.sym == 'a')) key = keysym.sym;  // zero value makes the keyboard crazy
+        if ((keysym.scancode == 0) && (keysym.sym == 'a')) return keysym.sym;  // zero value makes the keyboard crazy
 #endif
 
         if (keysym.scancode==0


### PR DESCRIPTION
# Description

Fix unresponsive 'A' key in Mac SDL1 build with `usescancodes=true` option.


**Does this PR address some issue(s) ?**

Fix Issue #2787



