### PR TITLE
Debug help cleanup

### DIFF
--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -2768,8 +2768,7 @@ bool ParseCommand(char* str) {
 		DEBUG_ShowMsg("Up/Down                   - Scroll up/down in the current window.\n");
 		DEBUG_ShowMsg("Page Up/Down              - Page up/down in the current window.\n");
 		DEBUG_ShowMsg("Home/End                  - Move to begin/end of the current window.\n");
-        DEBUG_ShowMsg("TAB                       - Select next window\n");
-        DEBUG_ShowMsg("Shift + TAB               - Select previous window\n");
+        DEBUG_ShowMsg("TAB/Shift+TAB             - Select next/prev window\n");
         DEBUG_EndPagedContent();
 
 		return true;


### PR DESCRIPTION
Combines tab and shift+tab into one line for the debug help messages and makes it consistent with the previous help messages for things line up/down, home/end, etc.