### PR TITLE
Fix VS2019 build

### DIFF
--- a/include/fpu.h
+++ b/include/fpu.h
@@ -181,7 +181,7 @@ struct FPUControlWord
 		reservedMask = 0x40,
 		initValue    = 0x37f
 	};
-	enum class RoundMode
+	enum RoundMode
 	{
 		Nearest = 0,
 		Down    = 1,

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -72,18 +72,18 @@ static void FPU_FPOP(void){
 
 static double FROUND(double in){
 	switch (fpu.cw.RC){
-	case fpu::RoundMode::Nearest:
+	case FPUControlWord::RoundMode::Nearest:
 		if (in-floor(in)>0.5) return (floor(in)+1);
 		else if (in-floor(in)<0.5) return (floor(in));
 		else return (((static_cast<int64_t>(floor(in)))&1)!=0)?(floor(in)+1):(floor(in));
 		break;
-	case fpu::RoundMode::Down:
+	case FPUControlWord::RoundMode::Down:
 		return (floor(in));
 		break;
-	case fpu::RoundMode::Up:
+	case FPUControlWord::RoundMode::Up:
 		return (ceil(in));
 		break;
-	case fpu::RoundMode::Chop:
+	case FPUControlWord::RoundMode::Chop:
 		return in; //the cast afterwards will do it right maybe cast here
 		break;
 	default:

--- a/src/fpu/fpu_instructions_longdouble.h
+++ b/src/fpu/fpu_instructions_longdouble.h
@@ -85,18 +85,18 @@ static void FPU_FPOP(void){
 
 static long double FROUND(long double in){
 	switch(fpu.cw.RC){
-	case fpu::RoundMode::Nearest:
+	case FPUControlWord::RoundMode::Nearest:
 		if (in-floorl(in)>0.5) return (floorl(in)+1);
 		else if (in-floorl(in)<0.5) return (floorl(in));
 		else return (((static_cast<int64_t>(floorl(in)))&1)!=0)?(floorl(in)+1):(floorl(in));
 		break;
-	case fpu::RoundMode::Down:
+	case FPUControlWord::RoundMode::Down:
 		return (floorl(in));
 		break;
-	case fpu::RoundMode::Up:
+	case FPUControlWord::RoundMode::Up:
 		return (ceill(in));
 		break;
-	case fpu::RoundMode::Chop:
+	case FPUControlWord::RoundMode::Chop:
 		return in; //the cast afterwards will do it right maybe cast here
 		break;
 	default:


### PR DESCRIPTION
Closes #2793. VS2019 fails to build if these enum values are in an `enum class`. It also needs to access the enum values through `FPUControlWord`, the name of the struct holding the enum, rather than through `fpu`. With these changes, it builds successfully.