### PR TITLE
Remove unneeded includes

### DIFF
--- a/src/aviwriter/avi_rw_iobuf.cpp
+++ b/src/aviwriter/avi_rw_iobuf.cpp
@@ -18,9 +18,6 @@
 
 #include <stdlib.h>
 #include "avi_rw_iobuf.h"
-#include <stdlib.h>
-#include <unistd.h>
-#include <ctype.h>
 
 /* common index writing code.
  * This code originally wrote the index one struct at a type.

--- a/src/aviwriter/guid.cpp
+++ b/src/aviwriter/guid.cpp
@@ -16,18 +16,10 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#include <sys/types.h>
-#include <sys/stat.h>
 #ifndef _MSC_VER
 # include <inttypes.h>
 #endif
-#include <unistd.h>
 #include <string.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <errno.h>
-#include <fcntl.h>
 
 #include "guid.h"
 

--- a/src/aviwriter/riff.cpp
+++ b/src/aviwriter/riff.cpp
@@ -23,7 +23,6 @@
 #include "riff.h"
 #include <unistd.h>
 #include <stdlib.h>
-#include <string.h>
 #include <assert.h>
 #ifdef _MSC_VER
 # include <io.h>

--- a/src/aviwriter/riff_wav_writer.cpp
+++ b/src/aviwriter/riff_wav_writer.cpp
@@ -19,15 +19,10 @@
 /* Shut up! */
 #define _CRT_NONSTDC_NO_DEPRECATE
 
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <stdlib.h>
-#include <string.h>
 #include <assert.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <stdio.h>
-#include <math.h>
 #ifdef _MSC_VER
 # include <io.h>
 #endif

--- a/src/aviwriter/riff_wav_writer.h
+++ b/src/aviwriter/riff_wav_writer.h
@@ -19,10 +19,8 @@
 #ifndef __ISP_UTILS_V4_AVI_RIFF_WAV_WRITER_H
 #define __ISP_UTILS_V4_AVI_RIFF_WAV_WRITER_H
 
-#include <stdint.h>
 #include "riff.h"
 #include "waveformatex.h"
-#include "bitmapinfoheader.h"
 
 typedef struct riff_wav_writer {
 	riff_stack*		riff;

--- a/src/cpu/callback.cpp
+++ b/src/cpu/callback.cpp
@@ -17,14 +17,11 @@
  */
 
 #include <assert.h>
-#include <stdlib.h>
 #include <string.h>
 
-#include "dosbox.h"
 #include "callback.h"
 #include "logging.h"
 #include "bios.h"
-#include "mem.h"
 #include "cpu.h"
 
 #if C_EMSCRIPTEN

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -23,10 +23,7 @@
 
 #include <assert.h>
 #include <stdarg.h>
-#include <stdio.h>
 #include <string.h>
-#include <stddef.h>
-#include <stdlib.h>
 
 #if defined (WIN32)
 #include <windows.h>
@@ -43,8 +40,6 @@
 #endif /* C_HAVE_MPROTECT */
 
 #include "callback.h"
-#include "regs.h"
-#include "mem.h"
 #include "cpu.h"
 #include "debug.h"
 #include "paging.h"

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -22,11 +22,7 @@
 #if (C_DYNREC)
 
 #include <assert.h>
-#include <stdarg.h>
-#include <stdio.h>
 #include <string.h>
-#include <stddef.h>
-#include <stdlib.h>
 
 #if defined (WIN32)
 #include <windows.h>

--- a/src/cpu/core_normal.cpp
+++ b/src/cpu/core_normal.cpp
@@ -16,11 +16,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-
-#include "dosbox.h"
-#include "mem.h"
 #include "cpu.h"
 #include "lazyflags.h"
 #include "inout.h"

--- a/src/cpu/core_normal_286.cpp
+++ b/src/cpu/core_normal_286.cpp
@@ -16,9 +16,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-
 #include "dosbox.h"
 #include "mem.h"
 #include "cpu.h"


### PR DESCRIPTION
Removal of #include statements unnecessary for compilation.

Built correctly on VS2019 (with https://github.com/joncampbell123/dosbox-x/pull/2804 applied) and when test building on Linux GCC and OS-X on Travis-CI.