### PR TITLE
IME input support in SDL2

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1067,6 +1067,17 @@ void DOSBOX_RealInit() {
         dos.im_enable_flag = false;
         SDL_SetIMValues(SDL_IM_ENABLE, 0, NULL);
     }
+#elif (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11) && defined(C_SDL2)
+    if (enableime && !control->opt_silent) {
+        dos.im_enable_flag = true;
+        SDL_StartTextInput();
+#if defined(LINUX)
+        SDL_SetHint(SDL_HINT_IME_INTERNAL_EDITING, "1");
+#endif
+    } else if (!control->opt_silent) {
+        dos.im_enable_flag = false;
+        SDL_StopTextInput();
+    }
 #endif
 #if defined(USE_TTF)
     if (IS_PC98_ARCH) ttf.cols = 80; // The number of columns on the screen is apparently fixed to 80 in PC-98 mode at this time

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -1119,6 +1119,11 @@ static bool IsEnhancedKey(uint16_t &key) {
     return false;
 }
 
+#if defined(WIN32) && !defined(HX_DOS) && defined(C_SDL2)
+extern void IME_SetEnable(BOOL state);
+extern bool IME_GetEnable();
+#endif
+
 extern bool DOS_BreakFlag;
 extern bool DOS_BreakConioFlag;
 
@@ -1262,6 +1267,20 @@ Bitu INT16_Handler(void) {
                     if(onoff)
                         reg_dl = 0x81;
                 }
+            }
+        }
+#elif defined(WIN32) && !defined(HX_DOS) && defined(C_SDL2)
+        if(IS_DOSV && IS_DOS_CJK && (DOSV_GetFepCtrl() & DOSV_FEP_CTRL_IAS)) {
+            if(reg_al == 0x00) {
+                if(reg_dl & 0x81)
+                    IME_SetEnable(TRUE);
+                else
+                    IME_SetEnable(FALSE);
+            } else if(reg_al == 0x01) {
+                if(IME_GetEnable())
+                    reg_dl = 0x81;
+                else
+                    reg_dl = 0x00;
             }
         }
 #endif

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -2314,17 +2314,23 @@ static VideoModeBlock *ModeListVtext[] = {
 	ModeList_DOSV_SXGA_24,
 };
 
+#if defined(WIN32) && !defined(HX_DOS) && defined(C_SDL2)
+extern void IME_SetFontSize(int size);
+#endif
+
 bool INT10_SetDOSVModeVtext(uint16_t mode, enum DOSV_VTEXT_MODE vtext_mode)
 {
 	if(SetCurMode(ModeListVtext[vtext_mode], mode)) {
 		FinishSetMode(true);
 		INT10_SetCursorShape(6, 7);
-#if defined(WIN32) && !defined(HX_DOS) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
 		int cheight = CurMode->cheight;
 		if(IS_DOSV && cheight == 19) {
 			cheight = 16;
 		}
+#if defined(WIN32) && !defined(HX_DOS) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
 		SDL_SetIMValues(SDL_IM_FONT_SIZE, cheight, NULL);
+#elif defined(WIN32) && !defined(HX_DOS) && defined(C_SDL2)
+		IME_SetFontSize(cheight);
 #endif
 	} else {
 		LOG(LOG_INT10, LOG_ERROR)("DOS/V:Trying to set illegal mode %X", mode);

--- a/vs2015/sdl2/src/video/windows/SDL_windowskeyboard.c
+++ b/vs2015/sdl2/src/video/windows/SDL_windowskeyboard.c
@@ -370,7 +370,8 @@ IME_Init(SDL_VideoData *videodata, HWND hwnd)
     videodata->ime_available = SDL_TRUE;
     IME_UpdateInputLocale(videodata);
     IME_SetupAPI(videodata);
-    videodata->ime_uiless = UILess_SetupSinks(videodata);
+    // Disabled because the candidate window will not be displayed.
+    //videodata->ime_uiless = UILess_SetupSinks(videodata);
     IME_UpdateInputLocale(videodata);
     IME_Disable(videodata, hwnd);
 }
@@ -878,14 +879,18 @@ IME_HandleMessage(HWND hwnd, UINT msg, WPARAM wParam, LPARAM *lParam, SDL_VideoD
     case WM_INPUTLANGCHANGE:
         IME_InputLangChanged(videodata);
         break;
+    case WM_IME_CHAR:
+        trap = SDL_TRUE;
+        break;
     case WM_IME_SETCONTEXT:
-        *lParam = 0;
+        // Disabled because the string being converted will not be displayed.
+        //*lParam = 0;
         break;
     case WM_IME_STARTCOMPOSITION:
-        trap = SDL_TRUE;
+        //trap = SDL_TRUE;
         break;
     case WM_IME_COMPOSITION:
-        trap = SDL_TRUE;
+        //trap = SDL_TRUE;
         himc = ImmGetContext(hwnd);
         if (*lParam & GCS_RESULTSTR) {
             IME_GetCompositionString(videodata, himc, GCS_RESULTSTR);


### PR DESCRIPTION
**Does this PR introduce new feature(s) ?**
Added support for IME input in SDL2.
Only Windows and Linux are supported.

**Additional information**
Linux will have the same input format as SDL1.
However, it will not work on Wayland.
