### PR TITLE
Fixed a problem with backtick key input when IME is not in use.

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8374,11 +8374,12 @@ void GFX_Events() {
 #endif
         default:
 #if defined(WIN32) && !defined(HX_DOS) && defined(SDL_DOSBOX_X_SPECIAL)
-            if(event.key.keysym.scancode == 0x70 || event.key.keysym.scancode == 0x94 || event.key.keysym.scancode == 0x29) {
-                if((event.key.keysym.scancode == 0x94 || event.key.keysym.scancode == 0x29) && dos.im_enable_flag) {
+            if(dos.im_enable_flag) {
+                if(event.key.keysym.scancode == 0x94 || event.key.keysym.scancode == 0x29) {
                     break;
+                } else if(event.key.keysym.scancode == 0x70) {
+                    event.type = SDL_KEYDOWN;
                 }
-                event.type = SDL_KEYDOWN;
             }
 #endif
             void MAPPER_CheckEvent(SDL_Event * event);


### PR DESCRIPTION
# Description
Fixed a problem with backtick key input when IME is not in use.

**Does this PR address some issue(s) ?**
Fixes issues #2770 and #2782.
