### PR TITLE
Include dependencies in fpu_instructions_x86.h

### DIFF
--- a/src/fpu/fpu_instructions_x86.h
+++ b/src/fpu/fpu_instructions_x86.h
@@ -16,7 +16,10 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
+#include "cpu.h"
+#include "fpu.h"
+#include "mem.h"
+#include "regs.h"
 
 // #define WEAK_EXCEPTIONS
 


### PR DESCRIPTION
This allows the file to be viewed in the Visual Studio solution without being full of errors.

This also allows static analysis tools, etc. used within Visual Studio to function on this file.