### PR TITLE
MSCDEX_IOCTL_Input documentation and cleanup

### DIFF
--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -69,11 +69,11 @@ enum { CDROM_USE_SDL, CDROM_USE_ASPI, CDROM_USE_IOCTL_DIO, CDROM_USE_IOCTL_DX, C
 //! \description CD-ROM time is represented as minutes, seconds, and frames (75 per second)
 typedef struct SMSF {
     //! \brief Time, minutes field
-    unsigned char   min;
+    unsigned char   min = 0;
     //! \brief Time, seconds field
-    unsigned char   sec;
+    unsigned char   sec = 0;
     //! \brief Time, frame field
-    unsigned char   fr;
+    unsigned char   fr = 0;
 } TMSF;
 
 //! \brief Output and channel control state

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -944,6 +944,7 @@ static uint16_t MSCDEX_IOCTL_Input(PhysPt buffer, uint8_t drive_unit) {
         LOG(LOG_MISC, LOG_ERROR)("MSCDEX: Unsupported IOCTL INPUT Subfunction %02X", (int)ioctl_fct);
         return 0x03; // Invalid function
     case 0x03: /* Error statistics */
+        // Undefined as of 5 Aug 88 specification
         LOG(LOG_MISC, LOG_ERROR)("MSCDEX: Unsupported IOCTL INPUT Subfunction %02X", (int)ioctl_fct);
         return 0x03; // Invalid function
     case 0x04: /* Audio channel info */
@@ -961,17 +962,22 @@ static uint16_t MSCDEX_IOCTL_Input(PhysPt buffer, uint8_t drive_unit) {
         mem_writed(buffer + 1, mscdex->GetDeviceStatus(drive_unit));
         break;
     case 0x07: /* Sector size */
-        if(mem_readb(buffer + 1) == 0) mem_writew(buffer + 2, 2048);
-        else if(mem_readb(buffer + 1) == 1) mem_writew(buffer + 2, 2352);
+    {
+        uint8_t read_mode = mem_readb(buffer + 1);
+        if(read_mode == 0) // Cooked
+            mem_writew(buffer + 2, 2048);
+        else if(read_mode == 1) // Raw
+            mem_writew(buffer + 2, 2352);
         else return 0x03; // Invalid function
         break;
+    }
     case 0x08: /* Volume size */
         mem_writed(buffer + 1, mscdex->GetVolumeSize(drive_unit));
         break;
     case 0x09: /* Media change status */
         uint8_t status;
         if(!mscdex->GetMediaStatus(drive_unit, status)) {
-            status = 0; // State unknown
+            status = 0; // Status unknown
         }
         mem_writeb(buffer + 1, status);
         break;

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -1010,7 +1010,7 @@ static uint16_t MSCDEX_IOCTL_Input(PhysPt buffer, uint8_t drive_unit) {
     }
     case 0x0B: /* Audio track info */
     {
-        uint8_t attr; TMSF start;
+        uint8_t attr = 0; TMSF start;
         uint8_t track = mem_readb(buffer + 1);
         mscdex->GetTrackInfo(drive_unit, track, attr, start);
         mem_writeb(buffer + 2, start.fr);
@@ -1022,7 +1022,7 @@ static uint16_t MSCDEX_IOCTL_Input(PhysPt buffer, uint8_t drive_unit) {
     }
     case 0x0C: /* Audio Q-Channel info */
     {
-        uint8_t attr, track, index;
+        uint8_t attr = 0, track, index;
         TMSF abs, rel;
         mscdex->GetQChannelData(drive_unit, attr, track, index, rel, abs);
         mem_writeb(buffer + 1, attr);
@@ -1042,7 +1042,7 @@ static uint16_t MSCDEX_IOCTL_Input(PhysPt buffer, uint8_t drive_unit) {
         return 0x03; // Invalid function
     case 0x0E: /* UPC code */
     {
-        uint8_t attr; char upc[8];
+        uint8_t attr = 0; char upc[8] = {};
         mscdex->GetUPC(drive_unit, attr, &upc[0]);
         mem_writeb(buffer + 1u, attr);
         for(unsigned int i = 0; i < 7; i++) mem_writeb(buffer + 2u + i, (unsigned char)upc[i]);

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -993,6 +993,7 @@ static uint16_t MSCDEX_IOCTL_Input(PhysPt buffer, uint8_t drive_unit) {
         mem_writeb(buffer + 1, status);
         break;
     case 0x0A: /* Audio disk info */
+    {
         uint8_t tr1, tr2; TMSF leadOut;
         if(!mscdex->GetCDInfo(drive_unit, tr1, tr2, leadOut)) return 0x05;
         mem_writeb(buffer + 1, tr1);
@@ -1002,6 +1003,7 @@ static uint16_t MSCDEX_IOCTL_Input(PhysPt buffer, uint8_t drive_unit) {
         mem_writeb(buffer + 5, leadOut.min);
         mem_writeb(buffer + 6, 0x00);
         break;
+    }
     case 0x0B: /* Audio track info */
     {
         uint8_t attr; TMSF start;
@@ -1045,10 +1047,11 @@ static uint16_t MSCDEX_IOCTL_Input(PhysPt buffer, uint8_t drive_unit) {
     }
     case 0x0F: /* Audio status info */
     {
-        bool playing, pause;
+        bool playing = false;
+        bool paused = false;
         TMSF resStart, resEnd;
-        mscdex->GetAudioStatus(drive_unit, playing, pause, resStart, resEnd);
-        mem_writeb(buffer + 1u, pause);
+        mscdex->GetAudioStatus(drive_unit, playing, paused, resStart, resEnd);
+        mem_writew(buffer + 1u, paused);
         mem_writeb(buffer + 3u, resStart.min);
         mem_writeb(buffer + 4u, resStart.sec);
         mem_writeb(buffer + 5u, resStart.fr);

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -105,7 +105,7 @@ public:
 	bool		StopAudio			(uint8_t subUnit);
 	bool		GetAudioStatus		(uint8_t subUnit, bool& playing, bool& pause, TMSF& start, TMSF& end);
 
-	bool		GetSubChannelData	(uint8_t subUnit, uint8_t& attr, uint8_t& track, uint8_t &index, TMSF& rel, TMSF& abs);
+	bool		GetQChannelData	(uint8_t subUnit, uint8_t& attr, uint8_t& track, uint8_t &index, TMSF& rel, TMSF& abs);
 
 	int			RemoveDrive			(uint16_t _drive);
 	int			AddDrive			(uint16_t _drive, char* physicalPath, uint8_t& subUnit);
@@ -488,7 +488,7 @@ bool CMscdex::PlayAudioMSF(uint8_t subUnit, uint32_t start, uint32_t length) {
 	return dinfo[subUnit].lastResult = PlayAudioSector(subUnit,sector,length);
 }
 
-bool CMscdex::GetSubChannelData(uint8_t subUnit, uint8_t& attr, uint8_t& track, uint8_t &index, TMSF& rel, TMSF& abs) {
+bool CMscdex::GetQChannelData(uint8_t subUnit, uint8_t& attr, uint8_t& track, uint8_t &index, TMSF& rel, TMSF& abs) {
 	if (subUnit>=numDrives) return false;
 	dinfo[subUnit].lastResult = cdrom[subUnit]->GetAudioSub(attr,track,index,rel,abs);
 	if (!dinfo[subUnit].lastResult) {
@@ -780,7 +780,7 @@ bool CMscdex::GetCurrentPos(uint8_t subUnit, TMSF& pos) {
 	if (subUnit>=numDrives) return false;
 	TMSF rel;
 	uint8_t attr,track,index;
-	dinfo[subUnit].lastResult = GetSubChannelData(subUnit, attr, track, index, rel, pos);
+	dinfo[subUnit].lastResult = GetQChannelData(subUnit, attr, track, index, rel, pos);
 	if (!dinfo[subUnit].lastResult) memset(&pos,0,sizeof(pos));
 	return dinfo[subUnit].lastResult;
 }
@@ -1024,7 +1024,7 @@ static uint16_t MSCDEX_IOCTL_Input(PhysPt buffer, uint8_t drive_unit) {
     {
         uint8_t attr, track, index;
         TMSF abs, rel;
-        mscdex->GetSubChannelData(drive_unit, attr, track, index, rel, abs);
+        mscdex->GetQChannelData(drive_unit, attr, track, index, rel, abs);
         mem_writeb(buffer + 1, attr);
         mem_writeb(buffer + 2, ((track / 10) << 4) | (track % 10)); // track in BCD
         mem_writeb(buffer + 3, index);

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -979,7 +979,11 @@ static uint16_t MSCDEX_IOCTL_Input(PhysPt buffer, uint8_t drive_unit) {
             mem_writew(buffer + 2, 2048);
         else if(read_mode == 1) // Raw
             mem_writew(buffer + 2, 2352);
-        else return 0x03; // Invalid function
+        else
+        {
+            MSCDEX_LOG_ERROR("MSCDEX: Sector size: invalid read mode %x", read_mode);
+            return 0x03; // Invalid function
+        }
         break;
     }
     case 0x08: /* Volume size */


### PR DESCRIPTION
Using 
https://oldlinux.superglobalmegacorp.com/Linux.old/docs/interrupts/inter61/INTERRUP.G
and
https://makbit.com/articles/mscdex.txt (some Russian software company's website. Can also be found on a github repository if you search for it)
as references:

1. Add stubs for missing IOCTL calls, document device status bits and a few other things
2. Reverse the writing to the CD-ROM "door locked" bit, as it appears to have been backwards, although nothing in the code uses this so no changes in behavior will be visible
3. Rename GetSubChannelData to GetQChannelData, based on above references
4. Write paused status as a WORD rather than a BYTE for accuracy (it's just a 0 or 1 value, so no change in behavior)
5. Add an error message for one case that silently errored
6. Make sure some variables are initialized
7. Overall tidying up