### PR TITLE
Binary characters in source code

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -6856,10 +6856,10 @@ void COLOR::Run()
     } else
        back=true;
     if (back)
-        WriteOut("[0m");
+        WriteOut("\033[0m");
     else {
         bool fgl=fg>='0'&&fg<='7', bgl=bg>='0'&&bg<='7';
-        WriteOut(("["+std::string(fgl||bgl?"0;":"")+std::string(fgl?"":"1;")+std::string(bgl?"":"5;")+std::to_string(fgc)+";"+std::to_string(bgc)+"m").c_str());
+        WriteOut(("\033["+std::string(fgl||bgl?"0;":"")+std::string(fgl?"":"1;")+std::string(bgl?"":"5;")+std::to_string(fgc)+";"+std::to_string(bgc)+"m").c_str());
     }
 }
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5239,7 +5239,7 @@ void RebootGuest(bool pressed) {
 	}
 	if (!dos_kernel_disabled) {
 	    if (CurMode->type==M_TEXT || IS_PC98_ARCH) {
-			char msg[]="[2J";
+			char msg[]="\033[2J";
 			uint16_t s = (uint16_t)strlen(msg);
 			DOS_WriteFile(STDERR,(uint8_t*)msg,&s);
             throw int(6);
@@ -11355,7 +11355,7 @@ bool clear_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuit
         INT10_ScrollWindow(0, 0, rows, static_cast<uint8_t>(cols), -rows, 0x7, 0xff);
         INT10_SetCursorPos(0, 0, 0);
     } else if (IS_PC98_ARCH) {
-        char msg[]="[2J";
+        char msg[]="\033[2J";
         uint16_t s = (uint16_t)strlen(msg);
         DOS_WriteFile(STDERR,(uint8_t*)msg,&s);
     } else {

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -1514,7 +1514,7 @@ void CONFIG::Run(void) {
                                 else if (!CurMode)
                                     ;
                                 else if (CurMode->type==M_TEXT || IS_PC98_ARCH)
-                                    WriteOut("[2J");
+                                    WriteOut("\033[2J");
                                 else {
                                     reg_ax=CurMode->mode;
                                     CALLBACK_RunRealInt(0x10);

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -657,7 +657,7 @@ void DOS_Shell::Prepare(void) {
                 WriteOut(ParseMsg((std::string("\033[32m")+(MSG_Get("SHELL_STARTUP_LAST")+std::string("                                                       ")).substr(0,79)+std::string("\033[0m\n")).c_str()));
             }
         } else if (CurMode->type==M_TEXT || IS_PC98_ARCH)
-            WriteOut("[2J");
+            WriteOut("\033[2J");
 		if (!countryNo) {
 #if defined(WIN32)
 			char buffer[128];

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -420,7 +420,7 @@ void DOS_Shell::CMD_BREAK(char * args) {
 void DOS_Shell::CMD_CLS(char * args) {
 	HELP("CLS");
    if (CurMode->type==M_TEXT || IS_PC98_ARCH)
-       WriteOut("[2J");
+       WriteOut("\033[2J");
    else {
       if (IS_DOSV && DOSV_CheckCJKVideoMode()) reg_ax = GetTrueVideoMode();
       else reg_ax=(uint16_t)CurMode->mode;


### PR DESCRIPTION
Replaces binary escape control character in sources files with `\033` consistent with its use throughout the source