### PR TITLE
Fix 'u' key (Turkish-F), 'q' key (AZERTY) issues on Mac SDL1 version

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1174,7 +1174,11 @@ Bitu GetKeyCode(SDL_keysym keysym) {
         SDLKey key = SDLK_UNKNOWN;
 
 #if defined (MACOSX)
-        if ((keysym.scancode == 0) && (keysym.sym == 'a')) return keysym.sym;  // zero value makes the keyboard crazy
+        // zero value makes the keyboard crazy
+        // Hack for 'a' key (QWERTY, QWERTZ), 'u' key (Turkish-F), 'q' key (AZERTY) on Mac
+        // (FIX ME if there are other keys returning scancode 0)
+        if((keysym.scancode == 0) &&
+            ((keysym.sym == 'a') || (keysym.sym == 'u') || (keysym.sym == 'q'))) return 'a';
 #endif
 
         if (keysym.scancode==0


### PR DESCRIPTION
# Description

On Mac SDL1 version (https://github.com/joncampbell123/dosbox-x/commit/8269de0e90c6eb7d8890a4c2fc2fea79e7c52f48: latest before this pull request), 
'u' key on Turkish-F keyboard and 'q' key on AZERTY keyboard returns scancode 0,
and are regarded as 'Unknown key' and cannot input letters. (`usescancodes` option is `true` or `auto`)
This patch makes those keys recognized as 'a' key, which is consistent with Windows and Linux versions.

**Does this PR address some issue(s) ?**

Fixes issue https://github.com/joncampbell123/dosbox-x/issues/2848

