### PR TITLE
Use DOS errors defined in dos_inc.h

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -347,6 +347,7 @@ static INLINE uint16_t DOS_PackDate(uint16_t year,uint16_t mon,uint16_t day) {
 #define DOSERR_NOT_SAME_DEVICE 17
 #define DOSERR_NO_MORE_FILES 18
 #define DOSERR_WRITE_PROTECTED 19
+#define DOSERR_DRIVE_NOT_READY 21
 #define DOSERR_FILE_ALREADY_EXISTS 80
 
 


### PR DESCRIPTION
`dos_mscdex.cpp` defined some DOS error codes that are also defined in `dos_inc.h`. This removes them and instead uses the ones defined in `dos_inc.h`. It also adds error 21 to `dos_inc.h`, which was defined and used in `dos_mscdex.cpp` but was not in `dos_inc.h`.