### PR TITLE
Includes cleanup

### DIFF
--- a/include/bitmapinfoheader.h
+++ b/include/bitmapinfoheader.h
@@ -2,6 +2,8 @@
 #ifndef __ISP_UTILS_V4_BITMAPINFOHEADER
 #define __ISP_UTILS_V4_BITMAPINFOHEADER
 
+#include "guid.h"
+
 /* [doc] windows_BITMAPFILEHEADER
  *
  * Packed portable representation of the Microsoft Windows BITMAPFILEHEADER

--- a/src/aviwriter/avi.h
+++ b/src/aviwriter/avi.h
@@ -19,10 +19,7 @@
 #ifndef __VIDEOMGR_UTIL_AVI_H
 #define __VIDEOMGR_UTIL_AVI_H
 
-#include "wave_mmreg.h"
 #include "waveformatex.h"
-#include "bitmapinfoheader.h"
-#include "riff.h"
 
 #if defined(_MSC_VER)
 # pragma pack(push,1)

--- a/src/aviwriter/avi_writer.cpp
+++ b/src/aviwriter/avi_writer.cpp
@@ -19,6 +19,7 @@
 /* Shut up! */
 #define _CRT_NONSTDC_NO_DEPRECATE
 
+#include "bitmapinfoheader.h"
 #include "rawint.h"
 #include "avi_writer.h"
 #include "avi_rw_iobuf.h"

--- a/src/aviwriter/avi_writer.h
+++ b/src/aviwriter/avi_writer.h
@@ -20,6 +20,7 @@
 #define __ISP_UTILS_AVI_WRITER_H
 
 #include "avi.h"
+#include "riff.h"
 
 enum {
 	AVI_WRITER_STATE_INIT=0,

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -16,8 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-#include "dosbox.h"
+#include "config.h"
 
 #if (C_DYNAMIC_X86)
 #if defined (WIN32)
@@ -37,7 +36,6 @@
 #include "cpu.h"
 #include "debug.h"
 #include "paging.h"
-#include "inout.h"
 #include "fpu.h"
 
 #define CACHE_MAXSIZE	(4096*8)

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -20,13 +20,8 @@
 #include "dosbox.h"
 
 #if (C_DYNAMIC_X86)
-
-#include <stdarg.h>
-#include <string.h>
-
 #if defined (WIN32)
 #include <windows.h>
-#include <winbase.h>
 #endif
 
 #if (C_HAVE_MPROTECT)

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -21,7 +21,6 @@
 
 #if (C_DYNAMIC_X86)
 
-#include <assert.h>
 #include <stdarg.h>
 #include <string.h>
 

--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -16,6 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <assert.h>
 
 class CacheBlock {
 public:

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -16,6 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include "inout.h"
+
 #define X86_DYNFPU_DH_ENABLED
 #define X86_INLINED_MEMACCESS
 

--- a/src/cpu/core_dyn_x86/string.h
+++ b/src/cpu/core_dyn_x86/string.h
@@ -16,6 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include "inout.h"
+
 enum STRING_OP {
 	STR_OUTSB=0,STR_OUTSW,STR_OUTSD,
 	STR_INSB=4,STR_INSW,STR_INSD,

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -16,12 +16,9 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-#include "dosbox.h"
+#include "config.h"
 
 #if (C_DYNREC)
-
-#include <assert.h>
 #include <string.h>
 
 #if defined (WIN32)

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -19,8 +19,6 @@
 #include "config.h"
 
 #if (C_DYNREC)
-#include <string.h>
-
 #if defined (WIN32)
 #include <windows.h>
 #include <winbase.h>

--- a/src/cpu/core_dynrec/cache.h
+++ b/src/cpu/core_dynrec/cache.h
@@ -16,6 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <assert.h>
+
 #include "logging.h"
 
 class CodePageHandlerDynRec;	// forward

--- a/src/cpu/core_normal.cpp
+++ b/src/cpu/core_normal.cpp
@@ -18,7 +18,6 @@
 
 #include "cpu.h"
 #include "lazyflags.h"
-#include "inout.h"
 #include "callback.h"
 #include "pic.h"
 #include "fpu.h"

--- a/src/cpu/core_normal/string.h
+++ b/src/cpu/core_normal/string.h
@@ -16,6 +16,7 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include "inout.h"
 #include "logging.h"
 
 enum STRING_OP {

--- a/src/cpu/core_normal_286.cpp
+++ b/src/cpu/core_normal_286.cpp
@@ -18,7 +18,6 @@
 
 #include "cpu.h"
 #include "lazyflags.h"
-#include "inout.h"
 #include "callback.h"
 #include "pic.h"
 #include "fpu.h"

--- a/src/cpu/core_normal_286.cpp
+++ b/src/cpu/core_normal_286.cpp
@@ -16,16 +16,12 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#include "dosbox.h"
-#include "mem.h"
 #include "cpu.h"
 #include "lazyflags.h"
 #include "inout.h"
 #include "callback.h"
 #include "pic.h"
 #include "fpu.h"
-#include "paging.h"
-#include "mmx.h"
 
 bool CPU_RDMSR();
 bool CPU_WRMSR();

--- a/src/cpu/core_normal_8086.cpp
+++ b/src/cpu/core_normal_8086.cpp
@@ -18,7 +18,6 @@
 
 #include "cpu.h"
 #include "lazyflags.h"
-#include "inout.h"
 #include "callback.h"
 #include "pic.h"
 #include "fpu.h"

--- a/src/cpu/core_normal_8086.cpp
+++ b/src/cpu/core_normal_8086.cpp
@@ -16,18 +16,12 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#include <stdio.h>
-
-#include "dosbox.h"
-#include "mem.h"
 #include "cpu.h"
 #include "lazyflags.h"
 #include "inout.h"
 #include "callback.h"
 #include "pic.h"
 #include "fpu.h"
-#include "paging.h"
-#include "mmx.h"
 
 #define CPU_CORE CPU_ARCHTYPE_8086
 #define CPU_Core_Normal_Trap_Run CPU_Core8086_Normal_Trap_Run

--- a/src/cpu/core_prefetch.cpp
+++ b/src/cpu/core_prefetch.cpp
@@ -18,7 +18,6 @@
 
 #include "cpu.h"
 #include "lazyflags.h"
-#include "inout.h"
 #include "callback.h"
 #include "pic.h"
 #include "fpu.h"

--- a/src/cpu/core_prefetch.cpp
+++ b/src/cpu/core_prefetch.cpp
@@ -16,24 +16,14 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-#include <stdio.h>
-#include <string.h>
-
-#include "dosbox.h"
-#include "mem.h"
 #include "cpu.h"
 #include "lazyflags.h"
 #include "inout.h"
 #include "callback.h"
 #include "pic.h"
 #include "fpu.h"
-#include "paging.h"
-#include "mmx.h"
 
 using namespace std;
-
-#include <algorithm>
 
 #define CPU_CORE CPU_ARCHTYPE_386
 

--- a/src/cpu/core_prefetch_286.cpp
+++ b/src/cpu/core_prefetch_286.cpp
@@ -16,15 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-#include <stdio.h>
-#include <string.h>
-
-#include "dosbox.h"
-#include "mem.h"
 #include "cpu.h"
 #include "lazyflags.h"
-#include "inout.h"
 #include "callback.h"
 #include "pic.h"
 #include "fpu.h"

--- a/src/cpu/core_prefetch_8086.cpp
+++ b/src/cpu/core_prefetch_8086.cpp
@@ -16,15 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
-#include <stdio.h>
-#include <string.h>
-
-#include "dosbox.h"
-#include "mem.h"
 #include "cpu.h"
 #include "lazyflags.h"
-#include "inout.h"
 #include "callback.h"
 #include "pic.h"
 #include "fpu.h"

--- a/src/cpu/core_simple.cpp
+++ b/src/cpu/core_simple.cpp
@@ -16,14 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-
-#include "dosbox.h"
-#include "mem.h"
 #include "cpu.h"
 #include "lazyflags.h"
-#include "inout.h"
 #include "callback.h"
 #include "pic.h"
 #include "fpu.h"

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -21,6 +21,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <limits.h>
+
+#include "bitmapinfoheader.h"
 #include "dosbox.h"
 #include "control.h"
 #include "hardware.h"
@@ -33,6 +35,7 @@
 #include "mixer.h"
 #include "render.h"
 #include "cross.h"
+#include "wave_mmreg.h"
 
 #if (C_SSHOT)
 #include <zlib.h>


### PR DESCRIPTION
Continuing to remove remove unnecessary includes and localize includes to the files where they are used in order to make inter-file dependencies simpler and easier to see, and to maybe speed up compilation a little bit.