### PR TITLE
Fix non-MSVC builds

### DIFF
--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -16,6 +16,9 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <stdarg.h>
+#include <string.h>
+
 #include "config.h"
 
 #if (C_DYNAMIC_X86)

--- a/src/cpu/core_dynrec.cpp
+++ b/src/cpu/core_dynrec.cpp
@@ -19,6 +19,8 @@
 #include "config.h"
 
 #if (C_DYNREC)
+#include <string.h>
+
 #if defined (WIN32)
 #include <windows.h>
 #include <winbase.h>

--- a/src/cpu/core_normal_286.cpp
+++ b/src/cpu/core_normal_286.cpp
@@ -16,6 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <stdio.h>
+
 #include "cpu.h"
 #include "lazyflags.h"
 #include "callback.h"

--- a/src/cpu/core_prefetch.cpp
+++ b/src/cpu/core_prefetch.cpp
@@ -16,6 +16,9 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <stdio.h>
+#include <string.h>
+
 #include "cpu.h"
 #include "lazyflags.h"
 #include "callback.h"

--- a/src/cpu/core_prefetch_286.cpp
+++ b/src/cpu/core_prefetch_286.cpp
@@ -16,6 +16,9 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <stdio.h>
+#include <string.h>
+
 #include "cpu.h"
 #include "lazyflags.h"
 #include "callback.h"

--- a/src/cpu/core_prefetch_8086.cpp
+++ b/src/cpu/core_prefetch_8086.cpp
@@ -16,6 +16,9 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <stdio.h>
+#include <string.h>
+
 #include "cpu.h"
 #include "lazyflags.h"
 #include "callback.h"

--- a/src/cpu/core_simple.cpp
+++ b/src/cpu/core_simple.cpp
@@ -16,6 +16,9 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <stdio.h>
+#include <stdlib.h>
+
 #include "cpu.h"
 #include "lazyflags.h"
 #include "callback.h"


### PR DESCRIPTION
Should fix non-MSVC builds. Closes #2863.

I reproduced the same build error as the bug reporter in a GitHub Actions build using Linux and GCC. The changes in this PR fix the issue. (I thought I had tested https://github.com/joncampbell123/dosbox-x/pull/2860 with GitHub Actions as having built successfully on Linux and macOS, but I think I must have only run those test builds on the master branch code)

This replaces all the standard library includes that were removed in https://github.com/joncampbell123/dosbox-x/pull/2860. They may not all be necessary but putting them all back does fix the build.