### PR TITLE
adding fisttp instruction

### DIFF
--- a/src/debug/debug_disasm.cpp
+++ b/src/debug/debug_disasm.cpp
@@ -379,6 +379,8 @@ static char const *fop_15[] = { "fprem", "fyl2xp1", "fsqrt", "fsincos",
                    "frndint", "fscale", "fsin", "fcos" };
 static char const *fop_21[] = { 0, "fucompp", 0, 0, 0, 0, 0, 0 };
 static char const *fop_28[] = { "[fneni]", "[fndis]", "fclex", "finit", "[fnsetpm]", "[frstpm]", 0, 0 };
+static char const* fop_29[] = { "*fucomi %GF" };
+static char const* fop_30[] = { "*fcomi %GF" };
 static char const *fop_32[] = { "*fadd %GF,st" };
 static char const *fop_33[] = { "*fmul %GF,st" };
 static char const *fop_34[] = { "*fcom %GF,st" };
@@ -403,16 +405,18 @@ static char const *fop_54[] = { "*fdivrp %GF,st" };
 static char const *fop_55[] = { "*fdivp %GF,st" };
 static char const *fop_56[] = { "*ffreep %GF" };
 static char const *fop_60[] = { "fstsw ax", 0, 0, 0, 0, 0, 0, 0 };
+static char const* fop_61[] = { "*fucomip %GF" };
+static char const* fop_62[] = { "*fcomip %GF" };
 
 static char const **fspecial[] = { /* 0=use st(i), 1=undefined 0 in fop_* means undefined */
   0, 0, 0, 0, 0, 0, 0, 0,
   fop_8, fop_9, fop_10, fop_11, fop_12, fop_13, fop_14, fop_15,
   f0, f0, f0, f0, f0, fop_21, f0, f0,
-  f0, f0, f0, f0, fop_28, f0, f0, f0,
+  f0, f0, f0, f0, fop_28, fop_29, fop_30, f0,
   fop_32, fop_33, fop_34, fop_35, fop_36, fop_37, fop_38, fop_39,
   fop_40, fop_41, fop_42, fop_43, fop_44, fop_45, f0, f0,
   fop_48, fop_49, fop_50, fop_51, fop_52, fop_53, fop_54, fop_55,
-  fop_56, f0, f0, f0, fop_60, f0, f0, f0,
+  fop_56, f0, f0, f0, fop_60, fop_61, fop_62, f0,
 };
 
 static const char *floatops[] = { /* assumed " %EF" at end of each.  mod != 3 only */
@@ -422,15 +426,15 @@ static const char *floatops[] = { /* assumed " %EF" at end of each.  mod != 3 on
        "fldenv", "fldcw", "fstenv", "fstcw",
 /*16*/ "fiadd", "fimul", "ficomw", "ficompw",
        "fisub", "fisubr", "fidiv", "fidivr",
-/*24*/ "fild", 0, "fist", "fistp",
+/*24*/ "fild", "fisttp", "fist", "fistp",
        "frstor", "fldt", 0, "fstpt",
 /*32*/ "faddq", "fmulq", "fcomq", "fcompq",
        "fsubq", "fsubrq", "fdivq", "fdivrq",
-/*40*/ "fldq", 0, "fstq", "fstpq",
+/*40*/ "fldq", "fisttpq", "fstq", "fstpq",
        0, 0, "fsave", "fstsw",
 /*48*/ "fiaddw", "fimulw", "ficomw", "ficompw",
        "fisubw", "fisubrw", "fidivw", "fidivr",
-/*56*/ "fildw", 0, "fistw", "fistpw",
+/*56*/ "fildw", "fisttpw", "fistw", "fistpw",
        "fbldt", "fildq", "fbstpt", "fistpq"
 };
 

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -382,7 +382,13 @@ void FPU_ESC3_EA(Bitu rm,PhysPt addr) {
 		}
 		break;
 	case 0x01:	/* FISTTP */
-		LOG(LOG_FPU,LOG_WARN)("ESC 3 EA:Unhandled group %d subfunction %d",(int)group,(int)sub);
+        if(CPU_ArchitectureType == CPU_ARCHTYPE_EXPERIMENTAL)
+        {
+            FPU_FSTT_I32(addr);
+            FPU_FPOP();
+        }
+        else
+            LOG(LOG_FPU, LOG_WARN)("ESC 3 EA:Unhandled group %d subfunction %d", (int)group, (int)sub);
 		break;
 	case 0x02:	/* FIST */
 		FPU_FST_I32(addr);
@@ -535,7 +541,13 @@ void FPU_ESC5_EA(Bitu rm,PhysPt addr) {
 		}
 		break;
 	case 0x01:  /* FISTTP longint*/
-		LOG(LOG_FPU,LOG_WARN)("ESC 5 EA:Unhandled group %d subfunction %d",(int)group,(int)sub);
+        if(CPU_ArchitectureType == CPU_ARCHTYPE_EXPERIMENTAL)
+        {
+            FPU_FSTT_I64(addr);
+            FPU_FPOP();
+        }
+        else
+            LOG(LOG_FPU, LOG_WARN)("ESC 5 EA:Unhandled group %d subfunction %d", (int)group, (int)sub);
 		break;
 	case 0x02:   /* FST double real*/
 		FPU_FST_F64(addr);
@@ -657,8 +669,14 @@ void FPU_ESC7_EA(Bitu rm,PhysPt addr) {
 			}
 		}
 		break;
-	case 0x01:
-		LOG(LOG_FPU,LOG_WARN)("ESC 7 EA:Unhandled group %d subfunction %d",(int)group,(int)sub);
+	case 0x01:  /* FISTTP int16_t */
+        if(CPU_ArchitectureType == CPU_ARCHTYPE_EXPERIMENTAL)
+        {
+            FPU_FSTT_I16(addr);
+            FPU_FPOP();
+        }
+        else
+            LOG(LOG_FPU, LOG_WARN)("ESC 7 EA:Unhandled group %d subfunction %d", (int)group, (int)sub);
 		break;
 	case 0x02:   /* FIST int16_t */
 		FPU_FST_I16(addr);

--- a/src/fpu/fpu_instructions_x86.h
+++ b/src/fpu/fpu_instructions_x86.h
@@ -1066,6 +1066,22 @@ static void FPU_FST_I64(PhysPt addr) {
 	mem_writed(addr+4,fpu.p_regs[8].m2);
 }
 
+static void FPU_FSTT_I16(PhysPt addr) {
+    FPUD_STORE(fisttp, WORD, s)
+    mem_writew(addr, (uint16_t)fpu.p_regs[8].m1);
+}
+
+static void FPU_FSTT_I32(PhysPt addr) {
+    FPUD_STORE(fisttp, DWORD, l)
+    mem_writed(addr, fpu.p_regs[8].m1);
+}
+
+static void FPU_FSTT_I64(PhysPt addr) {
+    FPUD_STORE(fisttp, QWORD, q)
+    mem_writed(addr, fpu.p_regs[8].m1);
+    mem_writed(addr + 4, fpu.p_regs[8].m2);
+}
+
 static void FPU_FBST(PhysPt addr) {
 	FPUD_STORE(fbstp,TBYTE,)
 	mem_writed(addr,fpu.p_regs[8].m1);


### PR DESCRIPTION
This PR adds the fisttp fpu instruction requested in issue #2526 and extends the debugger with some more fpu opcodes.