### PR TITLE
Fix 2 types of warning in the GCC build

### DIFF
--- a/src/cpu/core_dynrec/decoder_opcodes.h
+++ b/src/cpu/core_dynrec/decoder_opcodes.h
@@ -1335,12 +1335,12 @@ static void dyn_read_port_byte_direct(uint8_t port) {
 }
 
 static void dyn_read_port_word_direct(uint8_t port) {
-	gen_mov_dword_to_reg_imm(FC_OP1,port);
+    gen_mov_dword_to_reg_imm(FC_OP1, port);
     if(decode.big_op)
         gen_call_function_raw(dynrec_io_readD);
     else
         gen_call_function_raw(dynrec_io_readW);
-	dyn_check_exception(FC_RETOP);
+    dyn_check_exception(FC_RETOP);
 }
 
 static void dyn_write_port_byte_direct(uint8_t port) {
@@ -1350,12 +1350,12 @@ static void dyn_write_port_byte_direct(uint8_t port) {
 }
 
 static void dyn_write_port_word_direct(uint8_t port) {
-	gen_mov_dword_to_reg_imm(FC_OP1,port);
+    gen_mov_dword_to_reg_imm(FC_OP1, port);
     if(decode.big_op)
         gen_call_function_raw(dynrec_io_writeD);
     else
         gen_call_function_raw(dynrec_io_writeW);
-	dyn_check_exception(FC_RETOP);
+    dyn_check_exception(FC_RETOP);
 }
 
 
@@ -1367,13 +1367,13 @@ static void dyn_read_port_byte(void) {
 }
 
 static void dyn_read_port_word(void) {
-	MOV_REG_WORD16_TO_HOST_REG(FC_OP1,DRC_REG_EDX);
-	gen_extend_word(false,FC_OP1);
+    MOV_REG_WORD16_TO_HOST_REG(FC_OP1, DRC_REG_EDX);
+    gen_extend_word(false, FC_OP1);
     if(decode.big_op)
         gen_call_function_raw(dynrec_io_readD);
     else
         gen_call_function_raw(dynrec_io_readW);
-	dyn_check_exception(FC_RETOP);
+    dyn_check_exception(FC_RETOP);
 }
 
 static void dyn_write_port_byte(void) {
@@ -1384,13 +1384,13 @@ static void dyn_write_port_byte(void) {
 }
 
 static void dyn_write_port_word(void) {
-	MOV_REG_WORD16_TO_HOST_REG(FC_OP1,DRC_REG_EDX);
-	gen_extend_word(false,FC_OP1);
+    MOV_REG_WORD16_TO_HOST_REG(FC_OP1, DRC_REG_EDX);
+    gen_extend_word(false, FC_OP1);
     if(decode.big_op)
         gen_call_function_raw(dynrec_io_writeD);
     else
         gen_call_function_raw(dynrec_io_writeW);
-	dyn_check_exception(FC_RETOP);
+    dyn_check_exception(FC_RETOP);
 }
 
 

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -1126,13 +1126,13 @@ bool share(int fd, int mode, uint32_t flags) {
     break;
   }
 #ifdef F_SETLK64
-  ret = lock_file_region( fd, F_SETLK64, &fl, 0x100000000LL, 1 );
-  if ( ret == -1 && errno == EINVAL )
+  ret = lock_file_region(fd, F_SETLK64, &fl, 0x100000000LL, 1);
+  if(ret == -1 && errno == EINVAL)
 #endif
-    lock_file_region( fd, F_SETLK, &fl, 0x100000000LL, 1 );
-    LOG(LOG_DOSMISC,LOG_DEBUG)("internal SHARE: locking: fd %d, type %d whence %d pid %d\n", fd, fl.l_type, fl.l_whence, fl.l_pid);
+      lock_file_region(fd, F_SETLK, &fl, 0x100000000LL, 1);
+  LOG(LOG_DOSMISC, LOG_DEBUG)("internal SHARE: locking: fd %d, type %d whence %d pid %d\n", fd, fl.l_type, fl.l_whence, fl.l_pid);
 
-    return true;
+  return true;
 }
 #endif
 

--- a/src/gui/sdl_ttf.c
+++ b/src/gui/sdl_ttf.c
@@ -1587,14 +1587,14 @@ SDL_Surface* TTF_RenderUNICODE_Shaded( TTF_Font* font,
 		return NULL;
 	}
 
-    if (width < (int)expect_width)
+    if(width < (int)expect_width)
         width = expect_width;
 
-	/* Create the target surface */
-	textbuf = SDL_CreateRGBSurface(SDL_SWSURFACE, width, height, 8, 0, 0, 0, 0);
-	if( textbuf == NULL ) {
-		return NULL;
-	}
+    /* Create the target surface */
+    textbuf = SDL_CreateRGBSurface(SDL_SWSURFACE, width, height, 8, 0, 0, 0, 0);
+    if(textbuf == NULL) {
+        return NULL;
+    }
 
 	/* Adding bound checking to avoid all kinds of memory corruption errors
 	   that may occur. */

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3701,7 +3701,7 @@ bool setColors(const char *colorArray, int n) {
             altBGR1[i].green=rgbColors[i].green;
             altBGR1[i].blue=rgbColors[i].blue;
         }
-	const char * nextRGB = colorArray;
+    const char* nextRGB = colorArray;
 	uint8_t * altPtr = (uint8_t *)altBGR1;
 	int rgbVal[3] = {-1,-1,-1};
 	for (int colNo = 0; colNo < (n>-1?1:16); colNo++) {
@@ -5346,7 +5346,7 @@ void GFX_SelectFontByPoints(int ptsize) {
         ttf.SDL_fontbi = TTF_OpenFontRW(rwfont, 1, ptsize);
     } else
         ttf.SDL_fontbi = NULL;
-	ttf.pointsize = ptsize;
+    ttf.pointsize = ptsize;
 	TTF_GlyphMetrics(ttf.SDL_font, 65, NULL, NULL, NULL, NULL, &ttf.width);
 	ttf.height = TTF_FontAscent(ttf.SDL_font)-TTF_FontDescent(ttf.SDL_font);
 	if (ttf.fullScrn) {
@@ -8850,7 +8850,7 @@ static void GenKBStroke(const UINT uiScanCode, const bool bDepressed, const SDLM
 static bool PasteClipboardNext() {
     if (strPasteBuffer.length() == 0)
         return false;
-	if (clipboard_biospaste) {
+    if(clipboard_biospaste) {
         if (strPasteBuffer[0]==13) {
             KEYBOARD_AddKey(KBD_enter, true);
             KEYBOARD_AddKey(KBD_enter, false);

--- a/src/hardware/parport/printer.cpp
+++ b/src/hardware/parport/printer.cpp
@@ -273,16 +273,16 @@ void CPrinter::selectCodepage(uint16_t cp)
         mapToUse = cpMap;
     else
 #endif
-	while(charmap[i].codepage!=0)
-    {
-		if(charmap[i].codepage==cp)
+        while(charmap[i].codepage != 0)
         {
-			mapToUse = charmap[i].map;
-			break;
-		}
-		i++;
-	}
-	if (mapToUse == NULL)
+            if(charmap[i].codepage == cp)
+            {
+                mapToUse = charmap[i].map;
+                break;
+            }
+            i++;
+        }
+    if(mapToUse == NULL)
     {
 		LOG(LOG_MISC,LOG_WARN)("Unsupported codepage %i. Using CP437 instead.", cp);
 		selectCodepage(437);
@@ -307,7 +307,7 @@ void CPrinter::updateFont()
     if (basedir.back()!='\\' && basedir.back()!='/')
         basedir += CROSS_FILESPLIT;
 
-	switch (LQtypeFace)
+    switch(LQtypeFace)
 	{
 	    case roman:
 		    fontName = basedir + "roman.ttf";

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -838,7 +838,7 @@ const char* Mouse_GetSelected(int x1, int y1, int x2, int y2, int w, int h, uint
 			text[len++]='\n';
 		}
 	}
-	text[len]=0;
+    text[len] = 0;
 	*textlen=len;
 	return text;
 }

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -2080,13 +2080,13 @@ protected:
             }
 
             selected++;
-		}
+        }
 
-        if (selected > items.size() - 1)
-	        selected = items.size() - 1;
+        if(selected > items.size() - 1)
+            selected = items.size() - 1;
 
-		if (selected >= 0 && items[(unsigned int)selected].size() == 0) selected = -1;
-	}
+        if(selected >= 0 && items[(unsigned int)selected].size() == 0) selected = -1;
+    }
 
 	virtual Size getPreferredWidth() {
 		Size width = 0,px = 0;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -844,12 +844,12 @@ void DOS_Shell::Run(void) {
     if (this != first_shell && !optInit)
         WriteOut(optK?"\n":"DOSBox-X command shell [Version %s %s]\nCopyright DOSBox-X Team. All rights reserved.\n\n",VERSION,SDL_STRING);
 
-	if (optInit) {
-		input_line[CMD_MAXLINE-1u] = 0;
-		strncpy(input_line,line.c_str(),CMD_MAXLINE-1u);
-		line.erase();
-		ParseLine(input_line);
-	}
+    if(optInit) {
+        input_line[CMD_MAXLINE - 1u] = 0;
+        strncpy(input_line, line.c_str(), CMD_MAXLINE - 1u);
+        line.erase();
+        ParseLine(input_line);
+    }
     if (!exit) {
         RunningProgram = "COMMAND";
         GFX_SetTitle(-1,-1,-1,false);
@@ -1739,16 +1739,16 @@ void SHELL_Init() {
     else if (!IS_PC98_ARCH)
         VFILE_RegisterBuiltinFileBlob(bfb_25_COM_other, "/TEXTUTIL/");
 
-	/* MEM.COM is not compatible with PC-98 and/or 8086 emulation */
-	if (!IS_PC98_ARCH && CPU_ArchitectureType >= CPU_ARCHTYPE_80186)
-		VFILE_RegisterBuiltinFileBlob(bfb_MEM_EXE, "/DOS/");
+    /* MEM.COM is not compatible with PC-98 and/or 8086 emulation */
+    if(!IS_PC98_ARCH && CPU_ArchitectureType >= CPU_ARCHTYPE_80186)
+        VFILE_RegisterBuiltinFileBlob(bfb_MEM_EXE, "/DOS/");
 
-	/* DSXMENU.EXE */
-	if (IS_PC98_ARCH)
-		VFILE_RegisterBuiltinFileBlob(bfb_DSXMENU_EXE_PC98, "/BIN/");
-	else {
-		VFILE_RegisterBuiltinFileBlob(bfb_DSXMENU_EXE_PC, "/BIN/");
-		VFILE_RegisterBuiltinFileBlob(bfb_EVAL_HLP, "/BIN/");
+    /* DSXMENU.EXE */
+    if(IS_PC98_ARCH)
+        VFILE_RegisterBuiltinFileBlob(bfb_DSXMENU_EXE_PC98, "/BIN/");
+    else {
+        VFILE_RegisterBuiltinFileBlob(bfb_DSXMENU_EXE_PC, "/BIN/");
+        VFILE_RegisterBuiltinFileBlob(bfb_EVAL_HLP, "/BIN/");
     }
 
 	VFILE_RegisterBuiltinFileBlob(bfb_EVAL_EXE, "/BIN/");


### PR DESCRIPTION
The GCC build is outputting a lot of warnings at the moment. This cleans it up some by fixing all of the warnings of two types.

-Wwrite-strings
This warning is being issued where strings are being passed in as arguments to `str_replace`, which takes arguments of type char *. Putting in an explicit cast to char * for all of these instances silences these. This was already being done in several places.

-Wmisleading-indentation
This warning is sprinkled all over where code has been added that uses spaces rather than tabs for whitespace and where an `if` or `else` and its contents are followed by tabbed code. The warning is that the tabbed code isn't guarded by the `if` or `else` but the indentation makes it look like it is. Running all the affected areas through an auto-format that uses spaces instead of tabs fixes these. 