### PR TITLE
Fix more GCC warnings

### DIFF
--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -77,24 +77,24 @@ static bool MakeCodePage(Bitu lin_addr,CodePageHandler * &cph) {
 	uint8_t rdval;
 	const Bitu cflag = cpu.code.big ? PFLAG_HASCODE32:PFLAG_HASCODE16;
 	//Ensure page contains memory:
-	if (GCC_UNLIKELY(mem_readb_checked((const PhysPt)lin_addr,&rdval))) return true;
-	PageHandler * handler=get_tlb_readhandler((const PhysPt)lin_addr);
+	if (GCC_UNLIKELY(mem_readb_checked((PhysPt)lin_addr,&rdval))) return true;
+	PageHandler * handler=get_tlb_readhandler((PhysPt)lin_addr);
 	if (handler->flags & PFLAG_HASCODE) {
 		cph=( CodePageHandler *)handler;
 		if (handler->flags & cflag) return false;
 		cph->ClearRelease();
 		cph=0;
-		handler=get_tlb_readhandler((const PhysPt)lin_addr);
+		handler=get_tlb_readhandler((PhysPt)lin_addr);
 	}
 	if (handler->flags & PFLAG_NOCODE) {
 		if (PAGING_ForcePageInit(lin_addr)) {
-			handler=get_tlb_readhandler((const PhysPt)lin_addr);
+			handler=get_tlb_readhandler((PhysPt)lin_addr);
 			if (handler->flags & PFLAG_HASCODE) {
 				cph=( CodePageHandler *)handler;
 				if (handler->flags & cflag) return false;
 				cph->ClearRelease();
 				cph=0;
-				handler=get_tlb_readhandler((const PhysPt)lin_addr);
+				handler=get_tlb_readhandler((PhysPt)lin_addr);
 			}
 		}
 		if (handler->flags & PFLAG_NOCODE) {
@@ -143,7 +143,7 @@ static uint8_t decode_fetchb(void) {
 			/* trigger possible page fault here */
 			decode.page.first++;
 			Bitu fetchaddr=decode.page.first << 12;
-			mem_readb((const PhysPt)fetchaddr);
+			mem_readb((PhysPt)fetchaddr);
 			MakeCodePage(fetchaddr,decode.page.code);
 			CacheBlock * newblock=cache_getblock();
 			decode.active_block->crossblock=newblock;

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -2487,7 +2487,7 @@ static CacheBlock * CreateCacheBlock(CodePageHandler * codepage,PhysPt start,Bit
 	decode.code_start=start;
 	decode.eip_location=start;
 	decode.code=start;
-	Bitu cycles=0;
+	//Bitu cycles=0; UNUSED
 	decode.page.code=codepage;
 	decode.page.index=start&4095;
 	decode.page.wmap=codepage->write_map;

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -336,6 +336,7 @@ static INLINE void dyn_set_eip_end(void) {
 }
 
 static INLINE void dyn_set_eip_end(DynReg * endreg) {
+    (void)endreg;//UNUSED
 	gen_protectflags();
 	if (cpu.code.big) gen_dop_word(DOP_MOV,true,DREG(TMPW),DREG(EIP));
 	else gen_extend_word(false,DREG(TMPW),DREG(EIP));

--- a/src/cpu/core_dynrec/operators.h
+++ b/src/cpu/core_dynrec/operators.h
@@ -2026,7 +2026,7 @@ static bool DRC_CALL_CONV dynrec_io_writeD(Bitu port) {
 	bool ex = CPU_IO_Exception(port,4);
 	if (!ex) IO_WriteD(port,reg_eax);
 	return ex;
-};
+}
 
 static bool DRC_CALL_CONV dynrec_io_readB(Bitu port) DRC_FC;
 static bool DRC_CALL_CONV dynrec_io_readB(Bitu port) {

--- a/src/cpu/paging.cpp
+++ b/src/cpu/paging.cpp
@@ -642,22 +642,22 @@ static INLINE void InitPageCheckPresence(PhysPt lin_addr,bool writing,X86PageEnt
 	Bitu d_index=lin_page >> 10;
 	Bitu t_index=lin_page & 0x3ff;
 	Bitu table_addr=(paging.base.page<<12)+d_index*4;
-	table.load=phys_readd((const PhysPt)table_addr);
+	table.load=phys_readd((PhysPt)table_addr);
 	if (!table.block.p) {
 		LOG(LOG_PAGING,LOG_NORMAL)("NP Table");
 		PAGING_PageFault(lin_addr,table_addr,
 			(writing?0x02:0x00) | (((cpu.cpl&cpu.mpl)==0)?0x00:0x04));
-		table.load=phys_readd((const PhysPt)table_addr);
+		table.load=phys_readd((PhysPt)table_addr);
 		if (GCC_UNLIKELY(!table.block.p))
 			E_Exit("Pagefault didn't correct table");
 	}
 	Bitu entry_addr=(table.block.base<<12)+t_index*4;
-	entry.load=phys_readd((const PhysPt)entry_addr);
+	entry.load=phys_readd((PhysPt)entry_addr);
 	if (!entry.block.p) {
 //		LOG(LOG_PAGING,LOG_NORMAL)("NP Page");
 		PAGING_PageFault(lin_addr,entry_addr,
 			(writing?0x02:0x00) | (((cpu.cpl&cpu.mpl)==0)?0x00:0x04));
-		entry.load=phys_readd((const PhysPt)entry_addr);
+		entry.load=phys_readd((PhysPt)entry_addr);
 		if (GCC_UNLIKELY(!entry.block.p))
 			E_Exit("Pagefault didn't correct page");
 	}
@@ -668,7 +668,7 @@ static INLINE bool InitPageCheckPresence_CheckOnly(PhysPt lin_addr,bool writing,
 	Bitu d_index=lin_page >> 10;
 	Bitu t_index=lin_page & 0x3ff;
 	Bitu table_addr=(paging.base.page<<12)+d_index*4;
-	table.load=phys_readd((const PhysPt)table_addr);
+	table.load=phys_readd((PhysPt)table_addr);
 	if (!table.block.p) {
 		paging.cr2=lin_addr;
 		cpu.exception.which=EXCEPTION_PF;
@@ -676,7 +676,7 @@ static INLINE bool InitPageCheckPresence_CheckOnly(PhysPt lin_addr,bool writing,
 		return false;
 	}
 	Bitu entry_addr=(table.block.base<<12)+t_index*4;
-	entry.load=phys_readd((const PhysPt)entry_addr);
+	entry.load=phys_readd((PhysPt)entry_addr);
 	if (!entry.block.p) {
 		paging.cr2=lin_addr;
 		cpu.exception.which=EXCEPTION_PF;
@@ -861,7 +861,7 @@ initpage_retry:
 
 			if (!table.block.a) {
 				table.block.a=1;		//Set access
-				phys_writed((const PhysPt)((paging.base.page<<12)+(lin_page >> 10)*4),table.load);
+				phys_writed((PhysPt)((paging.base.page<<12)+(lin_page >> 10)*4),table.load);
 			}
 			if (!entry.block.a) {
 				entry.block.a=1;					//Set access
@@ -1337,7 +1337,7 @@ public:
 
 			if (!table.block.a) {
 				table.block.a=1;		//Set access
-				phys_writed((const PhysPt)((paging.base.page<<12)+(lin_page >> 10)*4),table.load);
+				phys_writed((PhysPt)((paging.base.page<<12)+(lin_page >> 10)*4),table.load);
 			}
 			if ((!entry.block.a) || (!entry.block.d)) {
 				entry.block.a=1;	//Set access
@@ -1390,7 +1390,7 @@ public:
 
 			if (!table.block.a) {
 				table.block.a=1;		//Set access
-				phys_writed((const PhysPt)((paging.base.page<<12)+(lin_page >> 10)*4),table.load);
+				phys_writed((PhysPt)((paging.base.page<<12)+(lin_page >> 10)*4),table.load);
 			}
 			if (!entry.block.a) {
 				entry.block.a=1;	//Set access
@@ -1408,7 +1408,7 @@ public:
 static InitPageUserROHandler init_page_handler_userro;
 
 bool PAGING_ForcePageInit(Bitu lin_addr) {
-	PageHandler * handler=get_tlb_readhandler((const PhysPt)lin_addr);
+	PageHandler * handler=get_tlb_readhandler((PhysPt)lin_addr);
 	if (handler==&init_page_handler) {
 		init_page_handler.InitPageForced(lin_addr);
 		return true;

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -2365,16 +2365,19 @@ static Bitu DOS_21Handler(void) {
                         mem_writeb(data + 0x00,reg_al);
                         mem_writew(data + 0x01,0x26);
 						if (!countryNo) {
-							char buffer[128];
                             if (IS_PC98_ARCH)
                                 countryNo = 81;
 #if defined(WIN32)
-							else if (GetLocaleInfo(LOCALE_USER_DEFAULT, LOCALE_ICOUNTRY, buffer, 128)) {
+							else
+                            {
+                                char buffer[128];
+                                if (GetLocaleInfo(LOCALE_USER_DEFAULT, LOCALE_ICOUNTRY, buffer, 128)) {
 								countryNo = uint16_t(atoi(buffer));
 								DOS_SetCountry(countryNo);
+                                }
 							}
 #endif
-							else
+							if (!countryNo)
 								countryNo = 1;													// Defaults to 1 (US) if failed
 						}
 						mem_writew(data + 0x03, countryNo);

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -164,6 +164,8 @@ bool DOS_ExtDevice::Close() {
 }
 
 bool DOS_ExtDevice::Seek(uint32_t * pos,uint32_t type) {
+    (void)pos;//UNUSED
+    (void)type;//UNUSED
 	return true;
 }
 

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -551,7 +551,7 @@ void MenuBrowseFDImage(char drive, int num, int type) {
     lTheOpenFileName = tinyfd_openFileDialog("Select a floppy image file","",4,lFilterPatterns,lFilterDescription,0);
 
     if (lTheOpenFileName) {
-        uint8_t mediaid = 0xF0;
+        //uint8_t mediaid = 0xF0; UNUSED
         std::vector<std::string> options;
         if (mountiro[drive-'A']) options.emplace_back("readonly");
         fatDrive *newDrive = new fatDrive(lTheOpenFileName, 0, 0, 0, 0, options);

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -2237,9 +2237,9 @@ bool toLock(int fd, bool is_lock, uint32_t pos, uint16_t size) {
 
 // ert, 20100711: Locking extensions
 // Wengier, 20201230: All platforms
-static bool lockWarn = true;
 bool localFile::LockFile(uint8_t mode, uint32_t pos, uint16_t size) {
 #if defined(WIN32)
+    static bool lockWarn = true;
 	HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(fhandle));
     if (file_access_tries>0) {
         if (mode > 1) {
@@ -3395,7 +3395,7 @@ bool physfsFile::prepareWrite() {
 		PHYSFS_close(fhandle);
 		fhandle = PHYSFS_openAppend(pname);
 #ifndef WIN32
-		int rc = fcntl(**(int**)fhandle->opaque,F_SETFL,0);
+		fcntl(**(int**)fhandle->opaque,F_SETFL,0);
 #endif
 		PHYSFS_seek(fhandle, pos);
 	}

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -2996,6 +2996,7 @@ bool physfsDrive::FileOpen(DOS_File * * file,const char * name,uint32_t flags) {
 }
 
 bool physfsDrive::FileCreate(DOS_File * * file,const char * name,uint16_t attributes) {
+    (void)attributes;//UNUSED
     if (!getOverlaydir()) {
         DOS_SetError(DOSERR_ACCESS_DENIED);
         return false;
@@ -3148,6 +3149,8 @@ bool physfsDrive::Rename(const char * oldname,const char * newname) {
 }
 
 bool physfsDrive::SetFileAttr(const char * name,uint16_t attr) {
+    (void)name;//UNUSED
+    (void)attr;//UNUSED
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
 }
@@ -3485,30 +3488,38 @@ bool physfscdromDrive::FileOpen(DOS_File * * file,const char * name,uint32_t fla
 
 bool physfscdromDrive::FileCreate(DOS_File * * file,const char * name,uint16_t attributes)
 {
+    (void)file;//UNUSED
+    (void)name;//UNUSED
+    (void)attributes;//UNUSED
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
 };
 
 bool physfscdromDrive::FileUnlink(const char * name)
 {
+    (void)name;//UNUSED
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
 };
 
 bool physfscdromDrive::RemoveDir(const char * dir)
 {
+    (void)dir;//UNUSED
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
 };
 
 bool physfscdromDrive::MakeDir(const char * dir)
 {
+    (void)dir;//UNUSED
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
 };
 
 bool physfscdromDrive::Rename(const char * oldname,const char * newname)
 {
+    (void)oldname;//UNUSED
+    (void)newname;//UNUSED
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
 };
@@ -3522,6 +3533,7 @@ bool physfscdromDrive::GetFileAttr(const char * name,uint16_t * attr)
 
 bool physfscdromDrive::FindFirst(const char * _dir,DOS_DTA & dta,bool fcb_findfirst)
 {
+    (void)fcb_findfirst;//UNUSED
 	// If media has changed, reInit drivecache.
 	if (MSCDEX_HasMediaChanged(subUnit)) {
 		dirCache.EmptyCache();

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -3468,7 +3468,7 @@ physfscdromDrive::physfscdromDrive(const char driveLetter, const char * startdir
 	// Get Volume Label
 	char name[32];
 	if (MSCDEX_GetVolumeName(subUnit,name)) dirCache.SetLabel(name,true,true);
-};
+}
 
 const char *physfscdromDrive::GetInfo() {
 	sprintf(info,"PhysFS CDRom %s", mountarc.c_str());
@@ -3484,7 +3484,7 @@ bool physfscdromDrive::FileOpen(DOS_File * * file,const char * name,uint32_t fla
 		return false;
 	}
 	return physfsDrive::FileOpen(file,name,flags);
-};
+}
 
 bool physfscdromDrive::FileCreate(DOS_File * * file,const char * name,uint16_t attributes)
 {
@@ -3493,28 +3493,28 @@ bool physfscdromDrive::FileCreate(DOS_File * * file,const char * name,uint16_t a
     (void)attributes;//UNUSED
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
-};
+}
 
 bool physfscdromDrive::FileUnlink(const char * name)
 {
     (void)name;//UNUSED
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
-};
+}
 
 bool physfscdromDrive::RemoveDir(const char * dir)
 {
     (void)dir;//UNUSED
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
-};
+}
 
 bool physfscdromDrive::MakeDir(const char * dir)
 {
     (void)dir;//UNUSED
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
-};
+}
 
 bool physfscdromDrive::Rename(const char * oldname,const char * newname)
 {
@@ -3522,14 +3522,14 @@ bool physfscdromDrive::Rename(const char * oldname,const char * newname)
     (void)newname;//UNUSED
 	DOS_SetError(DOSERR_ACCESS_DENIED);
 	return false;
-};
+}
 
 bool physfscdromDrive::GetFileAttr(const char * name,uint16_t * attr)
 {
 	bool result = physfsDrive::GetFileAttr(name,attr);
 	if (result) *attr |= DOS_ATTR_READ_ONLY;
 	return result;
-};
+}
 
 bool physfscdromDrive::FindFirst(const char * _dir,DOS_DTA & dta,bool fcb_findfirst)
 {
@@ -3542,7 +3542,7 @@ bool physfscdromDrive::FindFirst(const char * _dir,DOS_DTA & dta,bool fcb_findfi
 		if (MSCDEX_GetVolumeName(subUnit,name)) dirCache.SetLabel(name,true,true);
 	}
 	return physfsDrive::FindFirst(_dir,dta);
-};
+}
 
 void physfscdromDrive::SetDir(const char* path)
 {
@@ -3554,7 +3554,7 @@ void physfscdromDrive::SetDir(const char* path)
 		if (MSCDEX_GetVolumeName(subUnit,name)) dirCache.SetLabel(name,true,true);
 	}
 	physfsDrive::SetDir(path);
-};
+}
 
 bool physfscdromDrive::isRemote(void) {
 	return true;

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -530,6 +530,7 @@ bool Virtual_Drive::FindNext(DOS_DTA & dta) {
 }
 
 bool Virtual_Drive::SetFileAttr(const char * name,uint16_t attr) {
+    (void)attr;//UNUSED
 	if (*name == 0) {
 		DOS_SetError(DOSERR_ACCESS_DENIED);
 		return true;

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -1925,6 +1925,8 @@ void MSG_WM_COMMAND_handle(SDL_SysWMmsg &Message) {
 #if DOSBOXMENU_TYPE == DOSBOXMENU_HMENU
     if (mainMenu.mainMenuWM_COMMAND((unsigned int)LOWORD(wParam))) return;
 #endif
+#else
+    (void)Message;//UNUSED
 #endif
 }
 

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -746,12 +746,8 @@ char help_command_temp[MENU_HELP_COMMAND_MAX][30];
 
 /* help debug ("DebugMenu" or "HelpDebugMenu") */
 #if C_DEBUG
-static const char *def_menu_debug[] =
-#else
-static const char *def_menu_help_debug[] =
-#endif
+static const char* def_menu_debug[] =
 {
-#if C_DEBUG
     "mapper_debugger",
     "--",
     "debugger_rundebug",
@@ -768,18 +764,21 @@ static const char *def_menu_help_debug[] =
     "show_logtext",
     "save_logas",
     "--",
-#endif
-#if defined(C_DEBUG) || !defined(MACOSX) && !defined(LINUX) && !defined(HX_DOS) && !defined(C_EMSCRIPTEN)
     "show_console",
     "wait_on_error",
-#endif
-#if C_DEBUG
     "--",
     "debug_logint21",
     "debug_logfileio",
-#endif
     NULL
 };
+#elif !defined(MACOSX) && !defined(LINUX) && !defined(HX_DOS) && !defined(C_EMSCRIPTEN)
+static const char* def_menu_help_debug[] =
+{
+    "show_console",
+    "wait_on_error",
+    NULL
+};
+#endif
 
 /* help menu ("HelpMenu") */
 static const char *def_menu_help[] =

--- a/src/gui/midi_mt32.h
+++ b/src/gui/midi_mt32.h
@@ -230,6 +230,7 @@ public:
 	}
 
     bool Open(const char *conf) {
+        (void)conf;//UNUSED
         service = new MT32Emu::Service();
         uint32_t version = service->getLibraryVersionInt();
         if (version < 0x020100) {

--- a/src/gui/sdl_ttf.c
+++ b/src/gui/sdl_ttf.c
@@ -329,6 +329,7 @@ static void TTF_SetFTError(const char *msg, FT_Error error)
 	}
 	TTF_SetError("%s: %s", msg, err_msg);
 #else
+	(void)error;//UNUSED
 	TTF_SetError("%s", msg);
 #endif /* USE_FREETYPE_ERRORS */
 }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3410,6 +3410,8 @@ void GFX_SetShader(const char* src) {
 		glDeleteProgram(sdl_opengl.program_object);
 		sdl_opengl.program_object = 0;
 	}
+#else
+    (void)src;//UNUSED
 #endif
 }
 
@@ -11113,6 +11115,7 @@ bool vid_pc98_graphics_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * 
 
 bool voodoo_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
     Section_prop *section = static_cast<Section_prop *>(control->GetSection("voodoo"));
     if (section == NULL) return false;
     const char *voodoostr = section->Get_string("voodoo_card");
@@ -11126,6 +11129,7 @@ bool voodoo_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menui
 
 bool glide_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
     Section_prop *section = static_cast<Section_prop *>(control->GetSection("voodoo"));
     if (section == NULL) return false;
     bool glideon = addovl;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4990,7 +4990,9 @@ void GFX_EndUpdate(const uint16_t *changedLines) {
 #endif
     if (((sdl.desktop.type != SCREEN_OPENGL) || !RENDER_GetForceUpdate()) && !sdl.updating)
         return;
+#if C_OPENGL
     bool actually_updating = sdl.updating;
+#endif
     sdl.updating = false;
 #if defined(USE_TTF)
     if (ttf.inUse) {
@@ -8916,7 +8918,7 @@ static bool PasteClipboardNext() {
 		const UINT   uiScanCodeAlt = MapVirtualKey(VK_MENU, MAPVK_VK_TO_VSC);
 #else
     {
-		UINT uiScanCode = cKey;
+		//UINT uiScanCode = cKey; UNUSED
 		const UINT   uiScanCodeAlt = 0xFF;
 #endif
 		if (KEYBOARD_BufferSpaceAvail() < (10+kPasteMinBufExtra)) // For simplicity, we just mimic Alt+<3 digits>
@@ -9586,7 +9588,6 @@ void DOSBox_ConsolePauseWait() {
 bool usecfgdir = false;
 bool DOSBOX_parse_argv() {
     std::string optname,tmp;
-    uint8_t disp2_color=0;
     std::string disp2_opt;
 
     assert(control != NULL);
@@ -9857,6 +9858,7 @@ bool DOSBOX_parse_argv() {
         }
 #if C_DEBUG
         else if (optname == "display2") {
+        uint8_t disp2_color = 0;
             if (control->cmdline->NextOptArgv(tmp)) {
                 if (strcasecmp(tmp.c_str(),"amber")==0) disp2_color=1;
                 else if (strcasecmp(tmp.c_str(),"green")==0) disp2_color=2;

--- a/src/hardware/RetroWaveLib/Board/OPL3.h
+++ b/src/hardware/RetroWaveLib/Board/OPL3.h
@@ -34,5 +34,5 @@ extern void retrowave_opl3_reset(RetroWaveContext *ctx);
 extern void retrowave_opl3_mute(RetroWaveContext *ctx);
 
 #ifdef __cplusplus
-};
+}
 #endif

--- a/src/hardware/RetroWaveLib/Platform/Linux_SPI.h
+++ b/src/hardware/RetroWaveLib/Platform/Linux_SPI.h
@@ -52,7 +52,7 @@ extern int retrowave_init_linux_spi(RetroWaveContext *ctx, const char *spi_dev, 
 extern void retrowave_deinit_linux_spi(RetroWaveContext *ctx);
 
 #ifdef __cplusplus
-};
+}
 #endif
 
 #endif

--- a/src/hardware/RetroWaveLib/Platform/POSIX_SerialPort.c
+++ b/src/hardware/RetroWaveLib/Platform/POSIX_SerialPort.c
@@ -89,6 +89,8 @@ static inline void set_device_lock(RetroWavePlatform_POSIXSerialPort *ctx, int v
 }
 
 static void io_callback(void *userp, uint32_t data_rate, const void *tx_buf, void *rx_buf, uint32_t len) {
+	(void)data_rate;//UNUSED
+	(void)rx_buf;//UNUSED
 	RetroWavePlatform_POSIXSerialPort *ctx = userp;
 
 	set_device_lock(ctx, 1);

--- a/src/hardware/RetroWaveLib/Platform/POSIX_SerialPort.h
+++ b/src/hardware/RetroWaveLib/Platform/POSIX_SerialPort.h
@@ -53,7 +53,7 @@ extern int retrowave_init_posix_serialport(RetroWaveContext *ctx, const char *tt
 extern void retrowave_deinit_posix_serialport(RetroWaveContext *ctx);
 
 #ifdef __cplusplus
-};
+}
 #endif
 
 #endif

--- a/src/hardware/RetroWaveLib/Protocol/Serial.h
+++ b/src/hardware/RetroWaveLib/Protocol/Serial.h
@@ -44,5 +44,5 @@ extern uint32_t retrowave_protocol_serial_packed_length(uint32_t len_in);
 extern uint32_t retrowave_protocol_serial_pack(const void *_buf_in, uint32_t len_in, void *_buf_out);
 
 #ifdef __cplusplus
-};
+}
 #endif

--- a/src/hardware/RetroWaveLib/RetroWave.h
+++ b/src/hardware/RetroWaveLib/RetroWave.h
@@ -55,5 +55,5 @@ extern void retrowave_flush(RetroWaveContext *ctx);
 extern uint8_t retrowave_invert_byte(uint8_t val);
 
 #ifdef __cplusplus
-};
+}
 #endif

--- a/src/hardware/RetroWaveLib/RetroWave_DOSBoX.cpp
+++ b/src/hardware/RetroWaveLib/RetroWave_DOSBoX.cpp
@@ -8,7 +8,11 @@ RetroWaveContext retrowave_global_context;
 int retrowave_global_context_inited = 0;
 
 static void retrowave_iocb_empty(void *userp, uint32_t data_rate, const void *tx_buf, void *rx_buf, uint32_t len) {
-
+	(void)userp;//UNUSED
+	(void)data_rate;//UNUSED
+	(void)tx_buf;//UNUSED
+	(void)rx_buf;//UNUSED
+	(void)len;//UNUSED
 }
 
 static std::vector<std::string> string_split(const std::string &s, char delim) {

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -409,10 +409,12 @@ namespace OPL3DUOBOARD {
 		}
 
 		virtual void Generate(MixerChannel* chan, Bitu samples) {
+            (void)samples;//UNUSED
 			int16_t buf[1] = { 0 };
 			chan->AddSamples_m16(1, buf);
 		}
 		virtual void Init(Bitu rate) {
+            (void)rate;//UNUSED
 			opl3DuoBoard.reset();
 		}
 		~Handler() {
@@ -466,6 +468,7 @@ namespace Retrowave_OPL3 {
 		}
 
 		virtual void Generate(MixerChannel* chan, Bitu samples) {
+            (void)samples;//UNUSED
 #ifdef RETROWAVE_USE_BUFFER
 			retrowave_flush(&retrowave_global_context);
 #endif
@@ -474,6 +477,7 @@ namespace Retrowave_OPL3 {
 		}
 
 		virtual void Init(Bitu rate) {
+            (void)rate;//UNUSED
 			retrowave_opl3_reset(&retrowave_global_context);
 		}
 

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -2344,7 +2344,7 @@ std::string GetIDEInfo() {
         IDEController *c = GetIDEController(index);
         if (c)
         for (int slave = 0; slave < 2; slave++) {
-            IDEATADevice *dev = dynamic_cast<IDEATADevice*>(c->device[slave]);
+            //IDEATADevice *dev = dynamic_cast<IDEATADevice*>(c->device[slave]); UNUSED
             info+="IDE position "+std::to_string(index+1)+(slave?'s':'m')+": ";
             if (dynamic_cast<IDEATADevice*>(c->device[slave])) info+="disk image";
             else if (dynamic_cast<IDEATAPICDROMDevice*>(c->device[slave])) info+="CD image";

--- a/src/hardware/mame/emu.h
+++ b/src/hardware/mame/emu.h
@@ -115,6 +115,8 @@ public:
 		vsprintf(buf,format,msg);
 		va_end(msg);
 		LOG(LOG_MISC,LOG_NORMAL)("%s",buf);
+#else
+        (void)format;//UNUSED
 #endif
 	}
 

--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -1570,6 +1570,7 @@ void JEGA_readFont() {
 }
 
 void write_p3d5_jega(Bitu reg, Bitu val, Bitu iolen) {
+    (void)iolen;//UNUSED
 	switch (reg) {
 	case 0xb9://Mode register 1
 		jega.RMOD1 = val;
@@ -1645,6 +1646,7 @@ void write_p3d5_jega(Bitu reg, Bitu val, Bitu iolen) {
 }
 //CRT Control Register can be read from I/O 3D5h, after setting index at I/O 3D4h
 Bitu read_p3d5_jega(Bitu reg, Bitu iolen) {
+    (void)iolen;//UNUSED
 	switch (reg) {
 	case 0xb9:
 		return jega.RMOD1;

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -7121,6 +7121,8 @@ char *getSetupLine(const char *capt, const char *cont) {
 const char *GetCPUType();
 void updateDateTime(int x, int y, int pos)
 {
+    (void)x;//UNUSED
+    (void)y;//UNUSED
     char str[50];
     time_t curtime = time(NULL);
     struct tm *loctime = localtime (&curtime);

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -8873,7 +8873,7 @@ startfunction:
         BIOS_Int10RightJustifiedPrint(x,y,msg);
         if (machine != MCH_PC98 && textsplash) {
             Bitu edx = reg_edx;
-            int oldx = x, oldy = y;
+            //int oldx = x, oldy = y; UNUSED
             unsigned int lastline = 7;
             for (unsigned int i=0; i<=lastline; i++) {
                 for (unsigned int j=0; j<strlen(logostr[i]); j++) {

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -860,7 +860,7 @@ static Bitu IRQ1_Handler_PC98(void) {
         bool kana = modflags & 0x04;  //bit 2
         bool grph = modflags & 0x08;  //bit 3
         bool ctrl = !!(modflags & 0x10);  //bit 4
-        bool caps_capitals = (modflags & 1) ^ ((modflags >> 1) & 1); /* CAPS XOR SHIFT */
+        //bool caps_capitals = (modflags & 1) ^ ((modflags >> 1) & 1); /* CAPS XOR SHIFT */ UNUSED
 
         /* According to Neko Project II, the BIOS maintains a "pressed key" bitmap at 0x50:0x2A.
          * Without this bitmap many PC-98 games are unplayable. */

--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -460,6 +460,7 @@ void INT10_WriteChar_viaRealInt(uint8_t chr, uint8_t attr, uint8_t page, uint16_
 }
 
 void INT10_ScrollWindow_viaRealInt(uint8_t rul, uint8_t cul, uint8_t rlr, uint8_t clr, int8_t nlines, uint8_t attr, uint8_t page) {
+    (void)page;//UNUSED
 	BIOS_NCOLS;
 	BIOS_NROWS;
 
@@ -1428,6 +1429,8 @@ void INT10_ReadCharAttr(uint16_t * result,uint8_t page) {
 }
 
 void INT10_ReadString(uint8_t row, uint8_t col, uint8_t flag, uint8_t attr, PhysPt string, uint16_t count,uint8_t page) {
+    (void)flag;//UNUSED
+    (void)attr;//UNUSED
 	uint16_t result;
 	while (count > 0) {
 		ReadCharAttr(col, row, page, &result);

--- a/src/ints/int_dosv.cpp
+++ b/src/ints/int_dosv.cpp
@@ -192,7 +192,6 @@ static bool LoadFontxFile(const char *fname, int height = 16) {
 #endif
 	}
 	if (getfontx2header(mfile, &head) != 0) {
-		long int sz = 0;
 		if (dos.loaded_codepage == 936 || dos.loaded_codepage == 950) {
             fseek(mfile, 0L, SEEK_END);
             long int sz = ftell(mfile);

--- a/src/libs/decoders/internal/speexdsp/filterbank.c
+++ b/src/libs/decoders/internal/speexdsp/filterbank.c
@@ -53,6 +53,7 @@
 
 FilterBank *filterbank_new(int banks, spx_word32_t sampling, int len, int type)
 {
+   (void)type;//UNUSED
    FilterBank *bank;
    spx_word32_t df;
    spx_word32_t max_mel, mel_interval;

--- a/src/libs/decoders/internal/speexdsp/jitter.c
+++ b/src/libs/decoders/internal/speexdsp/jitter.c
@@ -712,6 +712,8 @@ EXPORT int jitter_buffer_get_another(JitterBuffer *jitter, JitterBufferPacket *p
 /* Let the jitter buffer know it's the right time to adjust the buffering delay to the network conditions */
 static int _jitter_buffer_update_delay(JitterBuffer *jitter, JitterBufferPacket *packet, spx_int32_t *start_offset)
 {
+   (void)packet;//UNUSED
+   (void)start_offset;//UNUSED
    spx_int16_t opt = compute_opt_delay(jitter);
    /*fprintf(stderr, "opt adjustment is %d ", opt);*/
 

--- a/src/libs/decoders/internal/speexdsp/kiss_fft_speex.c
+++ b/src/libs/decoders/internal/speexdsp/kiss_fft_speex.c
@@ -364,6 +364,7 @@ void kf_work(
         int m2
         )
 {
+   (void)s2;//UNUSED
    int i;
     kiss_fft_cpx * Fout_beg=Fout;
     const int p=*factors++; /* the radix  */

--- a/src/libs/decoders/internal/speexdsp/mdf.c
+++ b/src/libs/decoders/internal/speexdsp/mdf.c
@@ -681,6 +681,7 @@ EXPORT void speex_echo_playback(SpeexEchoState *st, const spx_int16_t *play)
 /** Performs echo cancellation on a frame (deprecated, last arg now ignored) */
 EXPORT void speex_echo_cancel(SpeexEchoState *st, const spx_int16_t *in, const spx_int16_t *far_end, spx_int16_t *out, spx_int32_t *Yout)
 {
+   (void)Yout;//UNUSED
    speex_echo_cancellation(st, in, far_end, out);
 }
 
@@ -1191,6 +1192,7 @@ EXPORT void speex_echo_cancellation(SpeexEchoState *st, const spx_int16_t *in, c
 /* Compute spectrum of estimated echo for use in an echo post-filter */
 void speex_echo_get_residual(SpeexEchoState *st, spx_word32_t *residual_echo, int len)
 {
+   (void)len;//UNUSED
    int i;
    spx_word16_t leak2;
    int N;

--- a/src/libs/decoders/internal/speexdsp/preprocess.c
+++ b/src/libs/decoders/internal/speexdsp/preprocess.c
@@ -718,6 +718,7 @@ void speex_echo_get_residual(SpeexEchoState *st, spx_word32_t *Yout, int len);
 
 EXPORT int speex_preprocess(SpeexPreprocessState *st, spx_int16_t *x, spx_int32_t *echo)
 {
+   (void)echo;//UNUSED
    return speex_preprocess_run(st, x);
 }
 

--- a/src/libs/decoders/internal/speexdsp/scal.c
+++ b/src/libs/decoders/internal/speexdsp/scal.c
@@ -154,7 +154,9 @@ EXPORT void speex_decorrelate(SpeexDecorrState *st, const spx_int16_t *in, spx_i
    for (ch=0;ch<st->channels;ch++)
    {
       int i;
+#ifdef VORBIS_PSYCHO
       int N=2*st->frame_size;
+#endif
       float beta, beta2;
       float *x;
       float max_alpha = 0;

--- a/src/libs/decoders/mp3.cpp
+++ b/src/libs/decoders/mp3.cpp
@@ -95,7 +95,7 @@ static void MP3_close(Sound_Sample* const sample)
 
 static Uint32 MP3_read(Sound_Sample* const sample)
 {
-    Sound_SampleInternal* const internal = static_cast<Sound_SampleInternal* const>(sample->opaque);
+    Sound_SampleInternal* const internal = static_cast<Sound_SampleInternal*>(sample->opaque);
     const Sint32 channels = (int) sample->actual.channels;
     mp3_t* p_mp3 = static_cast<mp3_t*>(internal->decoder_private);
 

--- a/src/libs/decoders/opus.c
+++ b/src/libs/decoders/opus.c
@@ -185,6 +185,7 @@ static Sint32 RWops_opus_seek(void* stream, const opus_int64 offset, const Sint3
  */
 static Sint32 RWops_opus_close(void* stream)
 {
+	(void)stream;//UNUSED
 	/* SDL closes this for us */
 	// return SDL_RWclose((SDL_RWops*)stream);
 	return 0;
@@ -289,6 +290,9 @@ static __inline__ void output_opus_info(const OggOpusFile* of, const OpusHead* o
 	SNDDBG(("Opus vendor:            %s\n", ot->vendor));
 	for (int i = 0; i < ot->comments; i++)
 		SNDDBG(("Opus: user comment:     '%s'\n", ot->user_comments[i]));
+#else
+	(void)of;//UNUSED
+	(void)oh;//UNUSED
 #endif
 } /* output_opus_comments */
 
@@ -301,6 +305,7 @@ static __inline__ void output_opus_info(const OggOpusFile* of, const OpusHead* o
  */
 static Sint32 opus_open(Sound_Sample* sample, const char* ext)
 {
+	(void)ext;//UNUSED
 	Sint32 rcode;
 	Sound_SampleInternal* internal = (Sound_SampleInternal*)sample->opaque;
 

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -2345,6 +2345,7 @@ static const Ticks vscroll_unitinit = 50;
 static const Ticks vscroll_unitpersec = 600;
 
 Ticks WindowInWindow::DragTimer_Callback::timerExpired(Ticks time) {
+    (void)time;//UNUSED
     if (wnd != NULL) {
         if (wnd->vscroll_downarrowhold) {
             Ticks tdelta = Timer::now() - wnd->drag_start;

--- a/src/libs/libchdr/FLAC/share/compat.h
+++ b/src/libs/libchdr/FLAC/share/compat.h
@@ -201,7 +201,7 @@ extern "C" {
 int flac_snprintf(char *str, size_t size, const char *fmt, ...);
 int flac_vsnprintf(char *str, size_t size, const char *fmt, va_list va);
 #ifdef __cplusplus
-};
+}
 #endif
 
 #endif /* FLAC__SHARE__COMPAT_H */

--- a/src/libs/libchdr/libchdr_chd.c
+++ b/src/libs/libchdr/libchdr_chd.c
@@ -2265,7 +2265,7 @@ static chd_error hunk_read_into_memory(chd_file *chd, UINT32 hunknum, UINT8 *des
 			blockoffs = (uint64_t)get_bigendian_uint32(rawmap) * (uint64_t)chd->header.hunkbytes;
 			if (blockoffs != 0) {
 				core_fseek(chd->file, blockoffs, SEEK_SET);
-				int result = core_fread(chd->file, dest, chd->header.hunkbytes);
+				core_fread(chd->file, dest, chd->header.hunkbytes);
 			/* TODO
 			else if (m_parent_missing)
 				throw CHDERR_REQUIRES_PARENT; */
@@ -2541,7 +2541,7 @@ static void zlib_codec_free(void *codec)
 	/* deinit the streams */
 	if (data != NULL)
 	{
-		int i;
+		//int i; UNUSED
 
 		inflateEnd(&data->inflater);
 

--- a/src/libs/libchdr/libchdr_chd.c
+++ b/src/libs/libchdr/libchdr_chd.c
@@ -1842,6 +1842,9 @@ CHD_EXPORT chd_error chd_get_metadata(chd_file *chd, UINT32 searchtag, UINT32 se
 
 CHD_EXPORT chd_error chd_codec_config(chd_file *chd, int param, void *config)
 {
+	(void)chd;//UNUSED
+	(void)param;//UNUSED
+	(void)config;//UNUSED
 	return CHDERR_INVALID_PARAMETER;
 }
 
@@ -1852,6 +1855,7 @@ CHD_EXPORT chd_error chd_codec_config(chd_file *chd, int param, void *config)
 
 CHD_EXPORT const char *chd_get_codec_name(UINT32 codec)
 {
+	(void)codec;//UNUSED
 	return "Unknown";
 }
 
@@ -2494,6 +2498,7 @@ static chd_error metadata_find_entry(chd_file *chd, UINT32 metatag, UINT32 metai
 
 static chd_error zlib_codec_init(void *codec, uint32_t hunkbytes)
 {
+	(void)hunkbytes;//UNUSED
 	int zerr;
 	chd_error err;
 	zlib_codec_data *data = (zlib_codec_data*)codec;

--- a/src/libs/libchdr/libchdr_flac.c
+++ b/src/libs/libchdr/libchdr_flac.c
@@ -210,6 +210,7 @@ uint32_t flac_decoder_finish(flac_decoder* decoder)
 
 FLAC__StreamDecoderReadStatus flac_decoder_read_callback_static(const FLAC__StreamDecoder *decoder, FLAC__byte buffer[], size_t *bytes, void *client_data)
 {
+	(void)decoder;//UNUSED
 	return flac_decoder_read_callback(client_data, buffer, bytes);
 }
 
@@ -250,6 +251,7 @@ FLAC__StreamDecoderReadStatus flac_decoder_read_callback(void* client_data, FLAC
 
 void flac_decoder_metadata_callback_static(const FLAC__StreamDecoder *decoder, const FLAC__StreamMetadata *metadata, void *client_data)
 {
+	(void)decoder;//UNUSED
 	flac_decoder *fldecoder;
 	/* ignore all but STREAMINFO metadata */
 	if (metadata->type != FLAC__METADATA_TYPE_STREAMINFO)
@@ -270,6 +272,7 @@ void flac_decoder_metadata_callback_static(const FLAC__StreamDecoder *decoder, c
 
 FLAC__StreamDecoderTellStatus flac_decoder_tell_callback_static(const FLAC__StreamDecoder *decoder, FLAC__uint64 *absolute_byte_offset, void *client_data)
 {
+	(void)decoder;//UNUSED
 	*absolute_byte_offset = ((flac_decoder *)client_data)->compressed_offset;
 	return FLAC__STREAM_DECODER_TELL_STATUS_OK;
 }
@@ -282,6 +285,7 @@ FLAC__StreamDecoderTellStatus flac_decoder_tell_callback_static(const FLAC__Stre
 
 FLAC__StreamDecoderWriteStatus flac_decoder_write_callback_static(const FLAC__StreamDecoder *decoder, const FLAC__Frame *frame, const FLAC__int32 * const buffer[], void *client_data)
 {
+	(void)decoder;//UNUSED
 	return flac_decoder_write_callback(client_data, frame, buffer);
 }
 
@@ -329,4 +333,7 @@ FLAC__StreamDecoderWriteStatus flac_decoder_write_callback(void *client_data, co
 
 void flac_decoder_error_callback_static(const FLAC__StreamDecoder *decoder, FLAC__StreamDecoderErrorStatus status, void *client_data)
 {
+	(void)decoder;//UNUSED
+	(void)status;//UNUSED
+	(void)client_data;//UNUSED
 }

--- a/src/libs/physfs/physfs.c
+++ b/src/libs/physfs/physfs.c
@@ -269,6 +269,9 @@ static PHYSFS_sint64 memoryIo_read(PHYSFS_Io *io, void *buf, PHYSFS_uint64 len)
 static PHYSFS_sint64 memoryIo_write(PHYSFS_Io *io, const void *buffer,
                                     PHYSFS_uint64 len)
 {
+    (void)io;//UNUSED
+    (void)buffer;//UNUSED
+    (void)len;//UNUSED
     BAIL(PHYSFS_ERR_OPEN_FOR_READING, -1);
 } /* memoryIo_write */
 
@@ -332,7 +335,10 @@ static PHYSFS_Io *memoryIo_duplicate(PHYSFS_Io *io)
     return retval;
 } /* memoryIo_duplicate */
 
-static int memoryIo_flush(PHYSFS_Io *io) { return 1;  /* it's read-only. */ }
+static int memoryIo_flush(PHYSFS_Io *io) {
+    (void)io;//UNUSED
+    return 1;  /* it's read-only. */
+    }
 
 static void memoryIo_destroy(PHYSFS_Io *io)
 {
@@ -1884,6 +1890,7 @@ typedef struct setSaneCfgEnumData
 static PHYSFS_EnumerateCallbackResult setSaneCfgEnumCallback(void *_data,
                                                 const char *dir, const char *f)
 {
+    (void)dir;
     setSaneCfgEnumData *data = (setSaneCfgEnumData *) _data;
     const size_t extlen = data->archiveExtLen;
     const size_t l = strlen(f);
@@ -2262,6 +2269,7 @@ static int locateInStringList(const char *str,
 static PHYSFS_EnumerateCallbackResult enumFilesCallback(void *data,
                                         const char *origdir, const char *str)
 {
+    (void)origdir;//UNUSED
     PHYSFS_uint32 pos;
     void *ptr;
     char *newstr;

--- a/src/libs/physfs/physfs_archiver_7z.c
+++ b/src/libs/physfs/physfs_archiver_7z.c
@@ -62,11 +62,13 @@ static PHYSFS_ErrorCode szipErrorCode(const SRes rc)
 
 static void *SZIP_ISzAlloc_Alloc(void *p, size_t size)
 {
+    (void)p;//UNUSED
     return allocator.Malloc(size ? size : 1);
 } /* SZIP_ISzAlloc_Alloc */
 
 static void SZIP_ISzAlloc_Free(void *p, void *address)
 {
+    (void)p;//UNUSED
     if (address)
         allocator.Free(address);
 } /* SZIP_ISzAlloc_Free */
@@ -215,6 +217,7 @@ static void SZIP_closeArchive(void *opaque)
 static void *SZIP_openArchive(PHYSFS_Io *io, const char *name,
                               int forWriting, int *claimed)
 {
+    (void)name;//UNUSED
     static const PHYSFS_uint8 wantedsig[] = { '7','z',0xBC,0xAF,0x27,0x1C };
     SZIPLookToRead stream;
     ISzAlloc *alloc = &SZIP_SzAlloc;
@@ -317,24 +320,32 @@ SZIP_openRead_failed:
 
 static PHYSFS_Io *SZIP_openWrite(void *opaque, const char *filename)
 {
+    (void)opaque;//UNUSED
+    (void)filename;//UNUSED
     BAIL(PHYSFS_ERR_READ_ONLY, NULL);
 } /* SZIP_openWrite */
 
 
 static PHYSFS_Io *SZIP_openAppend(void *opaque, const char *filename)
 {
+    (void)opaque;//UNUSED
+    (void)filename;//UNUSED
     BAIL(PHYSFS_ERR_READ_ONLY, NULL);
 } /* SZIP_openAppend */
 
 
 static int SZIP_remove(void *opaque, const char *name)
 {
+    (void)opaque;//UNUSED
+    (void)name;//UNUSED
     BAIL(PHYSFS_ERR_READ_ONLY, 0);
 } /* SZIP_remove */
 
 
 static int SZIP_mkdir(void *opaque, const char *name)
 {
+    (void)opaque;//UNUSED
+    (void)name;//UNUSED
     BAIL(PHYSFS_ERR_READ_ONLY, 0);
 } /* SZIP_mkdir */
 

--- a/src/libs/physfs/physfs_archiver_dir.c
+++ b/src/libs/physfs/physfs_archiver_dir.c
@@ -42,6 +42,7 @@ static char *cvtToDependent(const char *prepend, const char *path,
 static void *DIR_openArchive(PHYSFS_Io *io, const char *name,
                              int forWriting, int *claimed)
 {
+    (void)forWriting;//UNUSED
     PHYSFS_Stat st;
     const char dirsep = __PHYSFS_platformDirSeparator;
     char *retval = NULL;

--- a/src/libs/physfs/physfs_archiver_grp.c
+++ b/src/libs/physfs/physfs_archiver_grp.c
@@ -59,6 +59,7 @@ static int grpLoadEntries(PHYSFS_Io *io, const PHYSFS_uint32 count, void *arc)
 static void *GRP_openArchive(PHYSFS_Io *io, const char *name,
                              int forWriting, int *claimed)
 {
+    (void)name;//UNUSED
     PHYSFS_uint8 buf[12];
     PHYSFS_uint32 count = 0;
     void *unpkarc = NULL;

--- a/src/libs/physfs/physfs_archiver_hog.c
+++ b/src/libs/physfs/physfs_archiver_hog.c
@@ -64,6 +64,7 @@ static int hogLoadEntries(PHYSFS_Io *io, void *arc)
 static void *HOG_openArchive(PHYSFS_Io *io, const char *name,
                              int forWriting, int *claimed)
 {
+    (void)name;//UNUSED
     PHYSFS_uint8 buf[3];
     void *unpkarc = NULL;
 

--- a/src/libs/physfs/physfs_archiver_iso9660.c
+++ b/src/libs/physfs/physfs_archiver_iso9660.c
@@ -334,6 +334,7 @@ static int parseVolumeDescriptor(PHYSFS_Io *io, PHYSFS_uint64 *_rootpos,
 static void *ISO9660_openArchive(PHYSFS_Io *io, const char *filename,
                                  int forWriting, int *claimed)
 {
+    (void)filename;//UNUSED
     PHYSFS_uint64 rootpos = 0;
     PHYSFS_uint64 len = 0;
     int joliet = 0;

--- a/src/libs/physfs/physfs_archiver_mvl.c
+++ b/src/libs/physfs/physfs_archiver_mvl.c
@@ -56,6 +56,7 @@ static int mvlLoadEntries(PHYSFS_Io *io, const PHYSFS_uint32 count, void *arc)
 static void *MVL_openArchive(PHYSFS_Io *io, const char *name,
                              int forWriting, int *claimed)
 {
+    (void)name;//UNUSED
     PHYSFS_uint8 buf[4];
     PHYSFS_uint32 count = 0;
     void *unpkarc;

--- a/src/libs/physfs/physfs_archiver_qpak.c
+++ b/src/libs/physfs/physfs_archiver_qpak.c
@@ -59,6 +59,7 @@ static int qpakLoadEntries(PHYSFS_Io *io, const PHYSFS_uint32 count, void *arc)
 static void *QPAK_openArchive(PHYSFS_Io *io, const char *name,
                               int forWriting, int *claimed)
 {
+    (void)name;//UNUSED
     PHYSFS_uint32 val = 0;
     PHYSFS_uint32 pos = 0;
     PHYSFS_uint32 count = 0;

--- a/src/libs/physfs/physfs_archiver_slb.c
+++ b/src/libs/physfs/physfs_archiver_slb.c
@@ -62,6 +62,7 @@ static int slbLoadEntries(PHYSFS_Io *io, const PHYSFS_uint32 count, void *arc)
 static void *SLB_openArchive(PHYSFS_Io *io, const char *name,
                              int forWriting, int *claimed)
 {
+    (void)name;//UNUSED
     PHYSFS_uint32 version;
     PHYSFS_uint32 count;
     PHYSFS_uint32 tocPos;

--- a/src/libs/physfs/physfs_archiver_unpacked.c
+++ b/src/libs/physfs/physfs_archiver_unpacked.c
@@ -83,6 +83,9 @@ static PHYSFS_sint64 UNPK_read(PHYSFS_Io *io, void *buffer, PHYSFS_uint64 len)
 
 static PHYSFS_sint64 UNPK_write(PHYSFS_Io *io, const void *b, PHYSFS_uint64 len)
 {
+    (void)io;//UNUSED
+    (void)b;//UNUSED
+    (void)len;//UNUSED
     BAIL(PHYSFS_ERR_READ_ONLY, -1);
 } /* UNPK_write */
 
@@ -140,7 +143,10 @@ UNPK_duplicate_failed:
     return NULL;
 } /* UNPK_duplicate */
 
-static int UNPK_flush(PHYSFS_Io *io) { return 1;  /* no write support. */ }
+static int UNPK_flush(PHYSFS_Io *io) {
+    (void)io;//UNUSED
+    return 1;  /* no write support. */
+}
 
 static void UNPK_destroy(PHYSFS_Io *io)
 {
@@ -217,24 +223,32 @@ UNPK_openRead_failed:
 
 PHYSFS_Io *UNPK_openWrite(void *opaque, const char *name)
 {
+    (void)opaque;//UNUSED
+    (void)name;//UNUSED
     BAIL(PHYSFS_ERR_READ_ONLY, NULL);
 } /* UNPK_openWrite */
 
 
 PHYSFS_Io *UNPK_openAppend(void *opaque, const char *name)
 {
+    (void)opaque;//UNUSED
+    (void)name;//UNUSED
     BAIL(PHYSFS_ERR_READ_ONLY, NULL);
 } /* UNPK_openAppend */
 
 
 int UNPK_remove(void *opaque, const char *name)
 {
+    (void)opaque;//UNUSED
+    (void)name;//UNUSED
     BAIL(PHYSFS_ERR_READ_ONLY, 0);
 } /* UNPK_remove */
 
 
 int UNPK_mkdir(void *opaque, const char *name)
 {
+    (void)opaque;//UNUSED
+    (void)name;//UNUSED
     BAIL(PHYSFS_ERR_READ_ONLY, 0);
 } /* UNPK_mkdir */
 

--- a/src/libs/physfs/physfs_archiver_vdf.c
+++ b/src/libs/physfs/physfs_archiver_vdf.c
@@ -96,6 +96,7 @@ static int vdfLoadEntries(PHYSFS_Io *io, const PHYSFS_uint32 count,
 static void *VDF_openArchive(PHYSFS_Io *io, const char *name,
                              int forWriting, int *claimed)
 {
+    (void)name;//UNUSED
     PHYSFS_uint8 ignore[16];
     PHYSFS_uint8 sig[VDF_SIGNATURE_LENGTH];
     PHYSFS_uint32 count, timestamp, version, dataSize, rootCatOffset;

--- a/src/libs/physfs/physfs_archiver_wad.c
+++ b/src/libs/physfs/physfs_archiver_wad.c
@@ -73,6 +73,7 @@ static int wadLoadEntries(PHYSFS_Io *io, const PHYSFS_uint32 count, void *arc)
 static void *WAD_openArchive(PHYSFS_Io *io, const char *name,
                              int forWriting, int *claimed)
 {
+    (void)name;//UNUSED
     PHYSFS_uint8 buf[4];
     PHYSFS_uint32 count;
     PHYSFS_uint32 directoryOffset;

--- a/src/libs/physfs/physfs_archiver_zip.c
+++ b/src/libs/physfs/physfs_archiver_zip.c
@@ -362,6 +362,9 @@ static PHYSFS_sint64 ZIP_read(PHYSFS_Io *_io, void *buf, PHYSFS_uint64 len)
 
 static PHYSFS_sint64 ZIP_write(PHYSFS_Io *io, const void *b, PHYSFS_uint64 len)
 {
+    (void)io;//UNUSED
+    (void)b;//UNUSED
+    (void)len;//UNUSED
     BAIL(PHYSFS_ERR_READ_ONLY, -1);
 } /* ZIP_write */
 
@@ -489,7 +492,10 @@ failed:
     return NULL;
 } /* ZIP_duplicate */
 
-static int ZIP_flush(PHYSFS_Io *io) { return 1;  /* no write support. */ }
+static int ZIP_flush(PHYSFS_Io *io) {
+    (void)io;//UNUSED
+    return 1;  /* no write support. */
+}
 
 static void ZIP_destroy(PHYSFS_Io *io)
 {
@@ -1461,6 +1467,7 @@ static void ZIP_closeArchive(void *opaque)
 static void *ZIP_openArchive(PHYSFS_Io *io, const char *name,
                              int forWriting, int *claimed)
 {
+    (void)name;//UNUSED
     ZIPinfo *info = NULL;
     ZIPentry *root = NULL;
     PHYSFS_uint64 dstart = 0;  /* data start */
@@ -1623,24 +1630,32 @@ ZIP_openRead_failed:
 
 static PHYSFS_Io *ZIP_openWrite(void *opaque, const char *filename)
 {
+    (void)opaque;//UNUSED
+    (void)filename;//UNUSED
     BAIL(PHYSFS_ERR_READ_ONLY, NULL);
 } /* ZIP_openWrite */
 
 
 static PHYSFS_Io *ZIP_openAppend(void *opaque, const char *filename)
 {
+    (void)opaque;//UNUSED
+    (void)filename;//UNUSED
     BAIL(PHYSFS_ERR_READ_ONLY, NULL);
 } /* ZIP_openAppend */
 
 
 static int ZIP_remove(void *opaque, const char *name)
 {
+    (void)opaque;//UNUSED
+    (void)name;//UNUSED
     BAIL(PHYSFS_ERR_READ_ONLY, 0);
 } /* ZIP_remove */
 
 
 static int ZIP_mkdir(void *opaque, const char *name)
 {
+    (void)opaque;//UNUSED
+    (void)name;//UNUSED
     BAIL(PHYSFS_ERR_READ_ONLY, 0);
 } /* ZIP_mkdir */
 

--- a/src/libs/physfs/physfs_platform_unix.c
+++ b/src/libs/physfs/physfs_platform_unix.c
@@ -334,6 +334,7 @@ char *__PHYSFS_platformCalcBaseDir(const char *argv0)
 
 char *__PHYSFS_platformCalcPrefDir(const char *org, const char *app)
 {
+    (void)org;//UNUSED
     /*
      * We use XDG's base directory spec, even if you're not on Linux.
      *  This isn't strictly correct, but the results are relatively sane

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -867,7 +867,7 @@ static bool doTree(DOS_Shell * shell, char * args, DOS_DTA dta, bool optA, bool 
         if (!level) shell->WriteOut(MSG_Get("SHELL_CMD_TREE_ERROR"));
         return level;
     }
-    uint16_t attribute=0;
+    //uint16_t attribute=0; UNUSED
 	strcpy(path,full);
 	*(strrchr_dbcs(path,'\\')+1)=0;
 	char * end=strrchr_dbcs(full,'\\')+1;*end=0;


### PR DESCRIPTION
1. Fixes all `-Wignored-qualifiers` warnings.
These warnings appear on ignored const qualifiers in casts. Most of these were caused by me in https://github.com/joncampbell123/dosbox-x/commit/a4bb7d8221f5ec958e2298fce0e31819009ba78f by using `const` when casting values.

2. Fixes some `-Wunused-parameter` warnings.
There are still a ton of these, but this is a start.