### PR TITLE
Fix hang-up of PC-9801 version FD.

### DIFF
--- a/src/cpu/core_full/string.h
+++ b/src/cpu/core_full/string.h
@@ -117,13 +117,22 @@
 					} while (count != 0); break;
 
 				case R_STOSB:
-					do {
-						SaveMb(di_base+di_index,reg_al);
-						di_index=(di_index+(Bitu)add_index) & add_mask;
-						count--;
+					/* Countermeasures against code self-clearing in FD98.COM */
+					{
+						bool break_flag = true;
+						if(count_left == 1) {
+							count++;
+							count_left = 0;
+							break_flag = false;
+						}
+						do {
+							SaveMb(di_base+di_index,reg_al);
+							di_index=(di_index+(Bitu)add_index) & add_mask;
+							count--;
 
-						if ((--CPU_Cycles) <= 0) break;
-					} while (count != 0); break;
+							if ((--CPU_Cycles) <= 0 && break_flag) break;
+						} while (count != 0); break;
+					}
 				case R_STOSW:
 					add_index<<=1;
 					do {

--- a/src/cpu/core_normal/string.h
+++ b/src/cpu/core_normal/string.h
@@ -153,31 +153,40 @@ void DoString(STRING_OP type) {
 					} while (count != 0); break;
 
 				case R_STOSB:
-					do {
-						if (do_seg_limits) {
-							if (Segs.expanddown[es]) {
-								if (di_index <= SegLimit(es)) {
-									LOG_MSG("Limit check %x <= %x (E) ES:DI",(unsigned int)di_index,(unsigned int)SegLimit(es));
-									LOG_MSG("Segment limit violation");
-									throw GuestGenFaultException();
-								}
-							}
-							else {
-								if ((di_index+1U-1UL) > SegLimit(es)) {
-									LOG_MSG("Limit check %x+%x-1 = %x > %x ES:DI",(unsigned int)di_index,(unsigned int)1U,
-											(unsigned int)(di_index+1U-1U),(unsigned int)SegLimit(es));
-									LOG_MSG("Segment limit violation");
-									throw GuestGenFaultException();
-								}
-							}
+					/* Countermeasures against code self-clearing in FD98.COM */
+					{
+						bool break_flag = true;
+						if(count_left == 1) {
+							count++;
+							count_left = 0;
+							break_flag = false;
 						}
+						do {
+							if (do_seg_limits) {
+								if (Segs.expanddown[es]) {
+									if (di_index <= SegLimit(es)) {
+										LOG_MSG("Limit check %x <= %x (E) ES:DI",(unsigned int)di_index,(unsigned int)SegLimit(es));
+										LOG_MSG("Segment limit violation");
+										throw GuestGenFaultException();
+									}
+								}
+								else {
+									if ((di_index+1U-1UL) > SegLimit(es)) {
+										LOG_MSG("Limit check %x+%x-1 = %x > %x ES:DI",(unsigned int)di_index,(unsigned int)1U,
+												(unsigned int)(di_index+1U-1U),(unsigned int)SegLimit(es));
+										LOG_MSG("Segment limit violation");
+										throw GuestGenFaultException();
+									}
+								}
+							}
 
-						SaveMb(di_base+di_index,reg_al);
-						di_index=(di_index+(Bitu)add_index) & add_mask;
-						count--;
+							SaveMb(di_base+di_index,reg_al);
+							di_index=(di_index+(Bitu)add_index) & add_mask;
+							count--;
 
-						if ((--CPU_Cycles) <= 0) break;
-					} while (count != 0); break;
+							if ((--CPU_Cycles) <= 0 && break_flag) break;
+						} while (count != 0); break;
+					}
 				case R_STOSW:
 					add_index<<=1;
 					do {


### PR DESCRIPTION
# Description
This is a countermeasure for the phenomenon of runaway in the process of clearing the code part to 0 using "rep stosb" in the PC-9801 version of FD.
When cpu core is normal or full, "rep stosb" will not exit the loop with 1 byte remaining.
This does not happen if the cputype is set to 386_prefetch or some other prefetch.

**Does this PR address some issue(s) ?**
#2421 FD issues will be resolved.
