### PR TITLE
Fix MSVC builds failing to mount image files

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -471,7 +471,6 @@ struct _PC98RawPartition {
 	uint16_t	end_cyl;	/* end cylinder */
 	char		name[16];
 };
-#pragma pack(pop)
 
 struct partTable {
 	uint8_t booter[446];
@@ -491,7 +490,8 @@ struct partTable {
 #if SECTOR_SIZE_MAX > 512
     uint8_t  extra[SECTOR_SIZE_MAX - 512];
 #endif
-} GCC_ATTRIBUTE(packed);
+};
+#pragma pack(pop)
 
 void updateDPT(void);
 void incrementFDD(void);


### PR DESCRIPTION
Closes #2871. Closes #2876. Closes #2887. (appear to all be the same issue)

I removed the `GCC_ATTRIBUTE(packed);` as I believe it is redundant (it's absent in the `_PC98RawPartition` struct that is just above the `partTable` struct), but if it is still needed I can put it back.