### PR TITLE
Fix more GCC warnings

### DIFF
--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -2179,6 +2179,7 @@ static void dyn_closeblock(void) {
 	cache_closeblock();
 }
 
+/* UNUSED
 static void dyn_normal_exit(BlockReturn code) {
 	gen_protectflags();
 	dyn_reduce_cycles();
@@ -2186,7 +2187,7 @@ static void dyn_normal_exit(BlockReturn code) {
 	dyn_save_critical_regs();
 	gen_return(code);
 	dyn_closeblock();
-}
+}*/
 
 static void dyn_exit_link(Bits eip_change) {
 	gen_protectflags();

--- a/src/cpu/core_dyn_x86/dyn_mmx.h
+++ b/src/cpu/core_dyn_x86/dyn_mmx.h
@@ -54,6 +54,7 @@ extern uint32_t * lookupRMEAregd[256];
 #define Fetchb() imm
 #define GetEArd	uint32_t * eard=lookupRMEAregd[rm];
 
+/* UNUSED
 static void gen_mmx_op(Bitu op, Bitu rm, Bitu imm = 0, PhysPt eaa = 0) {
 	switch (op)
 	{
@@ -63,7 +64,7 @@ static void gen_mmx_op(Bitu op, Bitu rm, Bitu imm = 0, PhysPt eaa = 0) {
 	}
 illegal_opcode:
 	return;
-}
+}*/
 
 static void dyn_mmx_op(Bitu op) {
 	//Bitu imm = 0;

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -477,15 +477,17 @@ static void gen_needcarry(void) {
 	}
 }
 
+/* UNUSED
 static void gen_setzeroflag(void) {
 	if (x64gen.flagsactive) IllegalOption("gen_setzeroflag");
 	opcode(1).setea(4,-1,0,CALLSTACK).setimm(0x40,1).Emit8(0x83); // or dword [rsp+8/40],0x40
-}
+}*/
 
+/* UNUSED
 static void gen_clearzeroflag(void) {
 	if (x64gen.flagsactive) IllegalOption("gen_clearzeroflag");
 	opcode(4).setea(4,-1,0,CALLSTACK).setimm(~0x40,1).Emit8(0x83); // and dword [rsp+8/40],~0x40
-}
+}*/
 
 static bool skip_flags=false;
 

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -3527,7 +3527,7 @@ static Bitu DOS_29Handler(void)
 					break;
 				case 'p':/* reassign keys (needs strings) */
 					{
-						uint16_t src, dst;
+						/*uint16_t src, dst;
 						i = 0;
 						if(int29h_data.ansi.data[i] == 0) {
 							i++;
@@ -3541,7 +3541,7 @@ static Bitu DOS_29Handler(void)
 						} else {
 							dst = int29h_data.ansi.data[i++];
 						}
-						//DOS_SetConKey(src, dst);
+						DOS_SetConKey(src, dst);*/
 						ClearAnsi29h();
 					}
 					break;

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -235,6 +235,7 @@ uint32_t DOS_CheckExtDevice(const char *name, bool already_flag) {
 	return 0;
 }
 
+/* UNUSED
 static void DOS_CheckOpenExtDevice(const char *name) {
 	uint32_t addr;
 
@@ -242,7 +243,7 @@ static void DOS_CheckOpenExtDevice(const char *name) {
 		DOS_ExtDevice *device = new DOS_ExtDevice(name, addr >> 16, addr & 0xffff);
 		DOS_AddDevice(device);
 	}
-}
+}*/
 
 class device_NUL : public DOS_Device {
 public:

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -6156,7 +6156,7 @@ void MODE::Run(void) {
             IO_Write(0x60,0xf3); IO_Write(0x60,(uint8_t)(((delay-1)<<5)|(32-rate)));
         }
         if ((optc||optl)&&(cols!=COLS||lines!=LINES)) {
-            std::string cmd="line_"+std::to_string(cols)+"x"+std::to_string(lines);
+            std::string cmd="line_"+std::to_string((int)cols)+"x"+std::to_string((int)lines);
             if (!setlines(cmd.c_str())) goto modeparam;
         }
         return;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -7454,13 +7454,14 @@ void SetIMPosition() {
         y = address / 80;
     } else
         INT10_GetCursorPos(&y, &x, page);
-    int nrows=25, ncols=80;
+    /* UNUSED
+    int nrows = 25, ncols = 80;
     if (IS_PC98_ARCH)
         nrows=real_readb(0x60,0x113) & 0x01 ? 25 : 20;
     else {
         nrows=(IS_EGAVGA_ARCH?real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS):24)+1;
         ncols=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-    }
+    }*/
     if ((im_x != x || im_y != y) && GetTicks() - last_ticks > 100) {
         last_ticks = GetTicks();
         im_x = x;

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -3879,11 +3879,11 @@ std::string GetSBirq() {
 }
 
 std::string GetSBldma() {
-    return sb.hw.dma8==0xff?"None":std::to_string(sb.hw.dma8);
+    return sb.hw.dma8==0xff?"None":std::to_string((int)sb.hw.dma8);
 }
 
 std::string GetSBhdma() {
-    return sb.hw.dma16==0xff?"None":std::to_string(sb.hw.dma16);
+    return sb.hw.dma16==0xff?"None":std::to_string((int)sb.hw.dma16);
 }
 
 extern void HWOPL_Cleanup();

--- a/src/hardware/voodoo_emu.cpp
+++ b/src/hardware/voodoo_emu.cpp
@@ -1134,7 +1134,8 @@ void poly_render_triangle(void *dest, poly_draw_scanline_func callback, const po
 	INT32 curscan, scaninc=1;
 
 	INT32 v1yclip, v3yclip;
-	INT32 v1y, v3y, v1x;
+    INT32 v1y, v3y;
+    //INT32 v1x; UNUSED
 
 	/* first sort by Y */
 	if (v2->y < v1->y)
@@ -1157,7 +1158,7 @@ void poly_render_triangle(void *dest, poly_draw_scanline_func callback, const po
 	}
 
 	/* compute some integral X/Y vertex values */
-	v1x = round_coordinate(v1->x);
+	//v1x = round_coordinate(v1->x); UNUSED
 	v1y = round_coordinate(v1->y);
 	v3y = round_coordinate(v3->y);
 
@@ -1295,10 +1296,10 @@ static void update_statistics(voodoo_state *v, bool accumulate)
  *************************************/
 
 void register_w(UINT32 offset, UINT32 data) {
-	voodoo_reg reg;
+	//voodoo_reg reg; UNUSED
 	UINT32 regnum  = (offset) & 0xff;
 	UINT32 chips   = (offset>>8) & 0xf;
-	reg.u = data;
+	//reg.u = data; UNUSED
 
 	INT64 data64;
 

--- a/src/libs/decoders/internal/speexdsp/fftwrap.c
+++ b/src/libs/decoders/internal/speexdsp/fftwrap.c
@@ -42,6 +42,7 @@
 #define MAX_FFT_SIZE 2048
 
 #ifdef FIXED_POINT
+/* UNUSED
 static int maximize_range(spx_word16_t *in, spx_word16_t *out, spx_word16_t bound, int len)
 {
    int i, shift;
@@ -64,8 +65,9 @@ static int maximize_range(spx_word16_t *in, spx_word16_t *out, spx_word16_t boun
       out[i] = SHL16(in[i], shift);
    }
    return shift;
-}
+}*/
 
+/* UNUSED
 static void renorm_range(spx_word16_t *in, spx_word16_t *out, int shift, int len)
 {
    int i;
@@ -74,6 +76,7 @@ static void renorm_range(spx_word16_t *in, spx_word16_t *out, int shift, int len
       out[i] = PSHR16(in[i], shift);
    }
 }
+*/
 #endif
 
 #define USE_SMALLFT

--- a/src/libs/libchdr/libchdr_chd.c
+++ b/src/libs/libchdr/libchdr_chd.c
@@ -2143,28 +2143,28 @@ static chd_error hunk_read_uncompressed(chd_file *chd, UINT64 offset, size_t siz
     the CHD's hunk cache
 -------------------------------------------------*/
 
-static chd_error hunk_read_into_cache(chd_file *chd, UINT32 hunknum)
-{
-	chd_error err;
-
-	/* track the max */
-	if (hunknum > chd->maxhunk)
-		chd->maxhunk = hunknum;
-
-	/* if we're already in the cache, we're done */
-	if (chd->cachehunk == hunknum)
-		return CHDERR_NONE;
-	chd->cachehunk = ~0;
-
-	/* otherwise, read the data */
-	err = hunk_read_into_memory(chd, hunknum, chd->cache);
-	if (err != CHDERR_NONE)
-		return err;
-
-	/* mark the hunk successfully cached in */
-	chd->cachehunk = hunknum;
-	return CHDERR_NONE;
-}
+//static chd_error hunk_read_into_cache(chd_file *chd, UINT32 hunknum) UNUSED
+//{
+//	chd_error err;
+//
+//	/* track the max */
+//	if (hunknum > chd->maxhunk)
+//		chd->maxhunk = hunknum;
+//
+//	/* if we're already in the cache, we're done */
+//	if (chd->cachehunk == hunknum)
+//		return CHDERR_NONE;
+//	chd->cachehunk = ~0;
+//
+//	/* otherwise, read the data */
+//	err = hunk_read_into_memory(chd, hunknum, chd->cache);
+//	if (err != CHDERR_NONE)
+//		return err;
+//
+//	/* mark the hunk successfully cached in */
+//	chd->cachehunk = hunknum;
+//	return CHDERR_NONE;
+//}
 #endif
 
 /*-------------------------------------------------

--- a/src/libs/libchdr/libchdr_flac.c
+++ b/src/libs/libchdr/libchdr_flac.c
@@ -27,12 +27,12 @@ FLAC__StreamDecoderWriteStatus flac_decoder_write_callback(void* client_data, co
 static void flac_decoder_error_callback_static(const FLAC__StreamDecoder *decoder, FLAC__StreamDecoderErrorStatus status, void *client_data);
 
 /* getters (valid after reset) */
-static uint32_t sample_rate(flac_decoder *decoder)  { return decoder->sample_rate; }
+//static uint32_t sample_rate(flac_decoder *decoder)  { return decoder->sample_rate; } UNUSED
 static uint8_t channels(flac_decoder *decoder)  { return decoder->channels; }
-static uint8_t bits_per_sample(flac_decoder *decoder) { return decoder->bits_per_sample; }
-static uint32_t total_samples(flac_decoder *decoder)  { return FLAC__stream_decoder_get_total_samples(decoder->decoder); }
-static FLAC__StreamDecoderState state(flac_decoder *decoder) { return FLAC__stream_decoder_get_state(decoder->decoder); }
-static const char *state_string(flac_decoder *decoder) { return FLAC__stream_decoder_get_resolved_state_string(decoder->decoder); }
+//static uint8_t bits_per_sample(flac_decoder *decoder) { return decoder->bits_per_sample; } UNUSED
+//static uint32_t total_samples(flac_decoder *decoder)  { return FLAC__stream_decoder_get_total_samples(decoder->decoder); } UNUSED
+//static FLAC__StreamDecoderState state(flac_decoder *decoder) { return FLAC__stream_decoder_get_state(decoder->decoder); } UNUSED
+//static const char *state_string(flac_decoder *decoder) { return FLAC__stream_decoder_get_resolved_state_string(decoder->decoder); } UNUSED
 
 /*-------------------------------------------------
  *  flac_decoder - constructor

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -1353,15 +1353,19 @@ void CONFIG::Run(void) {
                             if (!strcasecmp(inputline.substr(0, 15).c_str(), "windowposition=")) {
                                 const char* windowposition = section->Get_string("windowposition");
                                 int GetDisplayNumber(void);
+#if defined(C_SDL2) || defined (WIN32)
                                 int posx = -1, posy = -1;
+#endif
                                 if (windowposition && *windowposition) {
                                     char result[100];
                                     safe_strncpy(result, windowposition, sizeof(result));
                                     char* y = strchr(result, ',');
                                     if (y && *y) {
                                         *y = 0;
+#if defined(C_SDL2) || defined (WIN32)
                                         posx = atoi(result);
                                         posy = atoi(y + 1);
+#endif
                                     }
                                 }
 #if defined(C_SDL2)


### PR DESCRIPTION
Fixes several warnings of type -Wunused-function and -Wunused-but-set-variable. Also fixes all -Wsign-promo warnings (there were only 4).