### PR TITLE
Fixes related to IME input in TTF

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2935,6 +2935,7 @@ void RENDER_Reset(void);
 
 #if defined(USE_TTF)
 bool firstsize = true;
+void AdjustIMEFontSize();
 static Bitu OUTPUT_TTF_SetSize() {
     bool text=CurMode&&(CurMode->type==0||CurMode->type==2||CurMode->type==M_TEXT||IS_PC98_ARCH);
     if (text) {
@@ -3031,6 +3032,8 @@ static Bitu OUTPUT_TTF_SetSize() {
     mainMenu.updateRect();
     mainMenu.setRedraw();
 #endif
+
+	AdjustIMEFontSize();
 
     return GFX_CAN_32 | GFX_SCALING;
 }
@@ -7475,7 +7478,7 @@ void SetIMPosition() {
 #if defined(USE_TTF)
         if (ttf.inUse) {
             rect.x = x * ttf.width;
-            rect.y = y * ttf.height;
+            rect.y = y * ttf.height + (ttf.height - TTF_FontAscent(ttf.SDL_font)) / 2;
         } else {
 #endif
             rect.x = x * width;

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -1074,9 +1074,10 @@ static Bitu IRQ1_CtrlBreakAfterInt1B(void) {
     return CBRET_NONE;
 }
 
+bool isDBCSCP();
 static bool IsKanjiCode(uint16_t key)
 {
-	if(isJEGAEnabled() || IS_DOSV) {
+	if(isDBCSCP()) {
 		// Kanji
 		if((key & 0xff00) == 0xf000 || (key & 0xff00) == 0xf100) {
 			return true;

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -52,6 +52,9 @@ void DOSV_FillScreen();
 void ResolvePath(std::string& in);
 void INT10_ReadString(uint8_t row, uint8_t col, uint8_t flag, uint8_t attr, PhysPt string, uint16_t count,uint8_t page);
 bool INT10_SetDOSVModeVtext(uint16_t mode, enum DOSV_VTEXT_MODE vtext_mode);
+#if defined(USE_TTF)
+extern bool colorChanged, justChanged;
+#endif
 Bitu INT10_Handler(void) {
 	// NTS: We do have to check the "current video mode" from the BIOS data area every call.
 	//      Some OSes like Windows 95 rely on overwriting the "current video mode" byte in
@@ -203,12 +206,18 @@ Bitu INT10_Handler(void) {
 		switch (reg_al) {
 		case 0x00:							/* SET SINGLE PALETTE REGISTER */
 			INT10_SetSinglePaletteRegister(reg_bl,reg_bh);
+#if defined(USE_TTF)
+			colorChanged = justChanged = true;
+#endif
 			break;
 		case 0x01:							/* SET BORDER (OVERSCAN) COLOR*/
 			INT10_SetOverscanBorderColor(reg_bh);
 			break;
 		case 0x02:							/* SET ALL PALETTE REGISTERS */
 			INT10_SetAllPaletteRegisters(SegPhys(es)+reg_dx);
+#if defined(USE_TTF)
+			colorChanged = justChanged = true;
+#endif
 			break;
 		case 0x03:							/* TOGGLE INTENSITY/BLINKING BIT */
 			blinking=reg_bl==1;

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -2315,20 +2315,30 @@ static VideoModeBlock *ModeListVtext[] = {
 extern void IME_SetFontSize(int size);
 #endif
 
+void AdjustIMEFontSize()
+{
+	int cheight = CurMode->cheight;
+	if(IS_DOSV && cheight == 19) {
+		cheight = 16;
+	}
+#if defined(USE_TTF)
+	if(dos.im_enable_flag && ttf.inUse) {
+		cheight = TTF_FontAscent(ttf.SDL_font);
+	}
+#endif
+#if defined(WIN32) && !defined(HX_DOS) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
+	SDL_SetIMValues(SDL_IM_FONT_SIZE, cheight, NULL);
+#elif defined(WIN32) && !defined(HX_DOS) && defined(C_SDL2)
+	IME_SetFontSize(cheight);
+#endif
+}
+
 bool INT10_SetDOSVModeVtext(uint16_t mode, enum DOSV_VTEXT_MODE vtext_mode)
 {
 	if(SetCurMode(ModeListVtext[vtext_mode], mode)) {
 		FinishSetMode(true);
 		INT10_SetCursorShape(6, 7);
-		int cheight = CurMode->cheight;
-		if(IS_DOSV && cheight == 19) {
-			cheight = 16;
-		}
-#if defined(WIN32) && !defined(HX_DOS) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
-		SDL_SetIMValues(SDL_IM_FONT_SIZE, cheight, NULL);
-#elif defined(WIN32) && !defined(HX_DOS) && defined(C_SDL2)
-		IME_SetFontSize(cheight);
-#endif
+		AdjustIMEFontSize();
 	} else {
 		LOG(LOG_INT10, LOG_ERROR)("DOS/V:Trying to set illegal mode %X", mode);
 		return false;


### PR DESCRIPTION
# Description
Fixed problems with IME input in TTF and screen refresh when changing palettes.

**Does this PR address some issue(s) ?**
Adjusting text size during IME conversion in TTF.
The display position of the string being converted is a little off, but I couldn't come up with a good solution.

Fixed data corruption of some kanji input in TTF.
The characters with 0xf0 in the second byte (e.g. 酒) were corrupted.

Update TTF screen by executing palette change function in int 10h.
