### PR TITLE
Doesn't build on arm64 FreeBSD 13.0-RELEASE

### DIFF
--- a/include/byteorder.h
+++ b/include/byteorder.h
@@ -115,11 +115,11 @@
 #define _BSD_SOURCE
 #include <endian.h>
 
-#elif defined(__NetBSD__) || defined(__OpenBSD__)
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 
 #include <sys/endian.h>
 
-#elif defined(__FreeBSD__) || defined(__DragonFly__)
+#elif defined(__DragonFly__)
 
 #include <sys/endian.h>
 

--- a/include/iconvpp.hpp
+++ b/include/iconvpp.hpp
@@ -20,7 +20,11 @@
 #  error Unable to determine byte order
 # endif
 #else
-# include <endian.h>
+# if defined(__FreeBSD__)
+#  include <sys/endian.h>
+# else
+#  include <endian.h>
+# endif
 # define ICONV_BYTE_ORDER BYTE_ORDER
 # define ICONV_LITTLE_ENDIAN LITTLE_ENDIAN
 # define ICONV_BIG_ENDIAN BIG_ENDIAN

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -6517,7 +6517,7 @@ bool AUTOTYPE::ReadDoubleArg(const std::string &name,
 	if (cmd->FindString(flag, str_value, true)) {
 		// Can the user's value be parsed?
 		const double user_value = to_finite<double>(str_value);
-#if defined(MACOSX) || defined(EMSCRIPTEN) || ((defined(ANDROID) || defined(__ANDROID__)) && defined(__clang__))
+#if defined(__FreeBSD__) || defined(MACOSX) || defined(EMSCRIPTEN) || ((defined(ANDROID) || defined(__ANDROID__)) && defined(__clang__))
 		if (isfinite(user_value)) { /* *sigh* Really, clang, really? */
 #else
 		if (std::isfinite(user_value)) {

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -990,7 +990,11 @@ static SDLKey sdlkey_map[MAX_SCANCODES] = { // Convert hardware scancode (XKB = 
 };
 
 #else // !MACOSX && !Linux
-
+#if defined(__FreeBSD__)
+// Todo: recheck sdl mapping
+#define SDLK_JP_RO (SDLKey)0x73
+#define SDLK_JP_YEN (SDLKey)0x7d
+#endif
 #define MAX_SCANCODES 0xdf
 static SDLKey sdlkey_map[MAX_SCANCODES] = {
     /* Refer to http://download.microsoft.com/download/1/6/1/161ba512-40e2-4cc9-843a-923143f3456c/translate.pdf PS/2 Set 1 Make */

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -217,7 +217,9 @@ typedef enum PROCESS_DPI_AWARENESS {
 # include "SDL_version.h"
 # ifndef SDL_DOSBOX_X_SPECIAL
 #  warning It is STRONGLY RECOMMENDED to compile the DOSBox-X code using the SDL 1.x library provided in this source repository.
+#if !defined(__FreeBSD__)
 #  error You can ignore this by commenting out this error, but you will encounter problems if you use the unmodified SDL 1.x library.
+#endif
 # endif
 #endif
 

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -1320,7 +1320,12 @@ OPL_Mode Module::oplmode=OPL_none;
 }	//Adlib Namespace
 
 std::string getoplmode() {
+#if !defined(__FreeBSD__)
+	// Todo: is this needed at all? opmode cannot be null...
 	if (Adlib::Module::oplmode == NULL || Adlib::Module::oplmode == OPL_none) return "None";
+#else
+	if (Adlib::Module::oplmode == 0 || Adlib::Module::oplmode == OPL_none) return "None";
+#endif
     else if (Adlib::Module::oplmode == OPL_cms) return "CMS";
     else if (Adlib::Module::oplmode == OPL_opl2) return "OPL2";
     else if (Adlib::Module::oplmode == OPL_dualopl2) return "Dual OPL2";

--- a/src/hardware/voodoo_opengl.cpp
+++ b/src/hardware/voodoo_opengl.cpp
@@ -547,7 +547,11 @@ void voodoo_ogl_invalidate_paltex(void) {
 }
 
 
+#if defined(__FreeBSD__)
+GLhandleARB m_hProgramObject   = (GLhandleARB)0;
+#else
 GLhandleARB m_hProgramObject   = (GLhandleARB)NULL;
+#endif
 
 
 void ogl_printInfoLog(GLhandleARB obj)


### PR DESCRIPTION
# Description

Code compiles on FreeBSD, but SDL code has to be reconsidered (I have just removed the error when using v1)


**Does this PR address some issue(s) ?**

Fixes ```#2605```


**Additional information**

When starting, it runs into a flickering screen with 
```
LOG: Aspect ratio: 640 x 480  xToY=1.333 yToX=0.750
LOG: menuScale=1
LOG: Screen report: Method 'None' (-1.000 x -1.000 pixels) at (0.000 x 0.000) (-1.000 x -1.000 mm) (-0.039 x -0.039 in) (-1.000 x -1.000 DPI)
LOG: font texture id=2 will make 128 x 256
```
I could need a little hint what to search for to fix it