### PR TITLE
Japanese Windows 3.1 related fixes

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1714,7 +1714,7 @@ static Bitu DOS_21Handler(void) {
                             break;
                         }
                     }
-                    if(!strncmp(name_start, "$IBMAFNT", 8) || !strncmp(name_start, "$IBMADSP", 8)) {
+                    if(!strncmp(name_start, "$IBMAFNT", 8)) {
                         ibmjp_handle = IBMJP_DEVICE_HANDLE;
                         reg_ax = IBMJP_DEVICE_HANDLE;
                         force_sfn = false;

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -100,6 +100,7 @@ extern const char* RunningProgram;
 extern std::string strPasteBuffer;
 extern bool i4dos, shellrun, clipboard_dosapi, swapad;
 extern RealPt DOS_DriveDataListHead;       // INT 2Fh AX=0803h DRIVER.SYS drive data table list
+extern uint16_t seg_win_startup_info;
 void PasteClipboard(bool bPressed);
 
 // INT 2F
@@ -305,6 +306,14 @@ static bool DOS_MultiplexFunctions(void) {
 			LOG_MSG("         the call chain. The Windows init broadcast is supposed to be handled\n");
 			LOG_MSG("         going down the chain by calling the previous INT 2Fh handler with registers\n");
 			LOG_MSG("         unmodified, and only modify registers on the way back up the chain!\n");
+		}
+
+		// Dummy data is required for the Microsoft version of Japanese Windows 3.1 in enhanced mode.
+		if(IS_DOSV && (reg_dx & 0x0001) == 0) {
+			real_writew(seg_win_startup_info, 0x02, reg_bx);
+			real_writew(seg_win_startup_info, 0x04, SegValue(es));
+			SegSet16(es, seg_win_startup_info);
+			reg_bx = 0;
 		}
 
 		return false; /* pass it on to other INT 2F handlers */

--- a/src/ints/int_dosv.cpp
+++ b/src/ints/int_dosv.cpp
@@ -1507,7 +1507,7 @@ void INT8_DOSV()
 #if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11) && (defined(C_SDL2) || defined(SDL_DOSBOX_X_SPECIAL))
 	SetIMPosition();
 #endif
-	if(!CheckAnotherDisplayDriver() && real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE) != 0x72) {
+	if(!CheckAnotherDisplayDriver() && real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE) != 0x72 && real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE) != 0x12) {
 		if(dosv_cursor_stat == 0) {
 			Bitu x = real_readb(BIOSMEM_SEG, BIOSMEM_CURSOR_POS);
 			Bitu y = real_readb(BIOSMEM_SEG, BIOSMEM_CURSOR_POS + 1) * real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);


### PR DESCRIPTION
# Description
Fixed a bug that caused setup.exe in Japanese Windows 3.1 to exit with an error, and a bug that prevented the Microsoft version from starting in enhanced mode.

**Does this PR address some issue(s) ?**
Fixed setup.exe not being able to start.
Fixed failure to start Microsoft Japanese Windows 3.1 in enhanced mode.
Fixed a problem with the Windows 3.1 splash screen.

**Additional information**
The reason why setup.exe could not start was because it could not find $IBMADSP by tracing the NUL device header in the int 21h ah=52h variable area.
Microsoft Japanese Windows could not start in enhanced mode because it needed to return the address of the Windows Startup Information structure with instance data in int 2fh ax=1605h.
