### PR TITLE
SVN r4466

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,9 @@
   - PC-98 INT DCh emulation fixed to better represent the
     function key shortcuts as real DOS does (Nanshiki)
   - Emulator fix for HX-DOS builds (Wengier)
+  - Integrated commits from mainline (Allofich)
+    - Fix the return value of register al from INT10 ah=0x0F
+    for non EGA/VGA machines.
 0.83.17
   - Added FISTTP instruction to experimental cputype (LBi)
   - Updated debugger to support and decode fisttp, fcomi,

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -186,7 +186,8 @@ Bitu INT10_Handler(void) {
 		break;
 	case 0x0F:								/* Get videomode */
 		reg_bh=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_PAGE);
-		reg_al=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE)|(real_readb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL)&0x80);
+		reg_al=real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE);
+		if (IS_EGAVGA_ARCH) reg_al|=real_readb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL)&0x80;
 		reg_ah=(uint8_t)real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
 		break;					
 	case 0x10:								/* Palette functions */


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/4466/

This adjusts part of https://sourceforge.net/p/dosbox/code-0/4444/ so that bit 7 of BIOSMEM_VIDEO_CTL (0x87) is only used for EGA and VGA machines when getting the video mode using INT 10 ah=0x0F.

Checking online, though, I found a source that, while it corroborates that this should be so for EGA and VGA, it also says it is the case for MCGA: https://stanislavs.org/helppc/int_10-f.html

This PR just follows the SVN commit (only EGA and VGA).