### PR TITLE
Fix virtual file names being logged as (null)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.83.18
+  - Fixed the names of virtual files being logged in
+    some messages as "(null)". (Allofich)
   - Fixed packed structure alignment problem with MSVC
     (Microsoft C++) builds regarding some disk image
     formats. These problems prevented VS2019 builds from

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 0.83.18
-  - Fixed the names of virtual files being logged in
-    some messages as "(null)". (Allofich)
+  - Fixed the names of virtual files and files on mounted
+    FAT drive images being logged as "(null)". (Allofich)
   - Fixed packed structure alignment problem with MSVC
     (Microsoft C++) builds regarding some disk image
     formats. These problems prevented VS2019 builds from

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -2147,6 +2147,7 @@ bool fatDrive::FileOpen(DOS_File **file, const char *name, uint32_t flags) {
 	if(!getFileDirEntry(name, &fileEntry, &dirClust, &subEntry)) return false;
 	/* TODO: check for read-only flag and requested write access */
 	*file = new fatFile(name, BPB.is_fat32() ? fileEntry.Cluster32() : fileEntry.loFirstClust, fileEntry.entrysize, this);
+    (*file)->SetName(name);
 	(*file)->flags = flags;
 	((fatFile *)(*file))->dirCluster = dirClust;
 	((fatFile *)(*file))->dirIndex = subEntry;

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -363,6 +363,7 @@ bool Virtual_Drive::FileOpen(DOS_File * * file,const char * name,uint32_t flags)
             strcasecmp(name,(std::string(onpos?vfnames[onpos]+std::string(1, '\\'):"")+cur_file->lname).c_str())==0))) {
 			/* We have a match */
 			*file=new Virtual_File(cur_file->data,cur_file->size);
+            (*file)->SetName(cur_file->name);
 			(*file)->flags=flags;
 			return true;
 		}


### PR DESCRIPTION
Summary of changes brought by this PR:

Fixes the file names of virtual DOSBox-X files like "AUTOEXEC.BAT" and "LOADFIX.COM", etc. from being logged as "(null)" when they are read or closed.

For example, enable file IO logging output to a file and simply open and close DOSBox-X. Check the log and you will see after AUTOEXEC.BAT is opened there are entries of reading from "(null)" and closing "(null)" in the current code. With this PR they will correctly show "AUTOEXEC.BAT".