### PR TITLE
CMOS log cleanup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.83.18
+  - Cleaned up and more accurately worded CMOS-related
+    log messages. (Allofich)
   - Fixed the names of virtual files and files on mounted
     FAT drive images being logged as "(null)". (Allofich)
   - Fixed packed structure alignment problem with MSVC

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -203,7 +203,7 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
         case 0x01:      /* Seconds Alarm */
         case 0x03:      /* Minutes Alarm */
         case 0x05:      /* Hours Alarm */
-            LOG(LOG_BIOS,LOG_NORMAL)("CMOS:Trying to set alarm");
+            LOG(LOG_BIOS,LOG_NORMAL)("CMOS:Writing to an alarm register");
             cmos.regs[cmos.reg] = (uint8_t)val;
             return;     // done
         }
@@ -241,13 +241,13 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
     case 0x03:      /* Minutes Alarm */
     case 0x05:      /* Hours Alarm */
         if(!date_host_forced) {
-            LOG(LOG_BIOS,LOG_NORMAL)("CMOS:Trying to set alarm");
+            LOG(LOG_BIOS,LOG_NORMAL)("CMOS:Writing to an alarm register");
             cmos.regs[cmos.reg]=(uint8_t)val;
             break;
         }
     case 0x0a:      /* Status reg A */
         cmos.regs[cmos.reg]=val & 0x7f;
-        if ((val & 0x70)!=0x20) LOG(LOG_BIOS,LOG_ERROR)("CMOS Illegal 22 stage divider value");
+        if ((val & 0x70)!=0x20) LOG(LOG_BIOS,LOG_ERROR)("CMOS:Illegal 22 stage divider value");
         cmos.timer.div=(val & 0xf);
         cmos_checktimer();
         break;
@@ -257,7 +257,7 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
 
             cmos.ampm = !(val & 0x02);
             cmos.bcd = !(val & 0x04);
-            if ((val & 0x10) != 0) LOG(LOG_BIOS,LOG_ERROR)("CMOS:Updated ended interrupt not supported yet");
+            if ((val & 0x10) != 0) LOG(LOG_BIOS,LOG_ERROR)("CMOS:'Update ended interrupt' not supported yet");
             cmos.timer.enabled = (val & 0x40) > 0;
             cmos.lock = (val & 0x80) != 0;
 
@@ -282,7 +282,7 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
             cmos.bcd=!(val & 0x4);
             cmos.regs[cmos.reg]=val & 0x7f;
             cmos.timer.enabled=(val & 0x40)>0;
-            if (val&0x10) LOG(LOG_BIOS,LOG_ERROR)("CMOS:Updated ended interrupt not supported yet");
+            if (val&0x10) LOG(LOG_BIOS,LOG_ERROR)("CMOS:'Update ended interrupt' not supported yet");
             cmos_checktimer();
         }
         break;
@@ -312,7 +312,7 @@ static Bitu cmos_readreg(Bitu port,Bitu iolen) {
     (void)port;//UNUSED
     (void)iolen;//UNUSED
     if (cmos.reg>0x3f) {
-        LOG(LOG_BIOS,LOG_ERROR)("CMOS:Read from illegal register %x",cmos.reg);
+        LOG(LOG_BIOS,LOG_ERROR)("CMOS:Read attempted from illegal register %x",cmos.reg);
         return 0xff;
     }
 
@@ -541,7 +541,7 @@ static Bitu cmos_readreg(Bitu port,Bitu iolen) {
         if( PS1AudioCard )
             return 0xFF;
     default:
-        LOG(LOG_BIOS,LOG_NORMAL)("CMOS:Read from reg %X",cmos.reg);
+        LOG(LOG_BIOS,LOG_NORMAL)("CMOS:Reading from register %X",cmos.reg);
         return cmos.regs[cmos.reg];
     }
 }

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -141,14 +141,14 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
 
         if (cmos.lock)              // if locked, use locktime instead of current time
         {
-            loctime = localtime((time_t*)&cmos.locktime.tv_sec);
+            loctime = localtime(&cmos.locktime.tv_sec);
         }
         else                        // not locked, use current time
         {
             struct timeval curtime;
             gettimeofday(&curtime, NULL);
             curtime.tv_sec += cmos.time_diff;
-            loctime = localtime((time_t*)&curtime.tv_sec);
+            loctime = localtime(&curtime.tv_sec);
         }
 
         switch (cmos.reg)
@@ -322,7 +322,7 @@ static Bitu cmos_readreg(Bitu port,Bitu iolen) {
 
         if (cmos.lock)              // if locked, use locktime instead of current time
         {
-            loctime = localtime((time_t*)&cmos.locktime.tv_sec);
+            loctime = localtime(&cmos.locktime.tv_sec);
         }
         else                        // not locked, get current time
         {
@@ -337,7 +337,7 @@ static Bitu cmos_readreg(Bitu port,Bitu iolen) {
             }
 
             curtime.tv_sec += cmos.time_diff;
-            loctime = localtime((time_t*)&curtime.tv_sec);
+            loctime = localtime(&curtime.tv_sec);
         }
 
         switch (cmos.reg)

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -381,25 +381,25 @@ static Bitu cmos_readreg(Bitu port,Bitu iolen) {
 
     switch (cmos.reg) {
     case 0x00:      /* Seconds */
-        if(!date_host_forced) return    MAKE_RETURN(loctime->tm_sec);
+        return    MAKE_RETURN(loctime->tm_sec);
     case 0x02:      /* Minutes */
-        if(!date_host_forced) return    MAKE_RETURN(loctime->tm_min);
+        return    MAKE_RETURN(loctime->tm_min);
     case 0x04:      /* Hours */
-        if(!date_host_forced) return    MAKE_RETURN(loctime->tm_hour);
+        return    MAKE_RETURN(loctime->tm_hour);
     case 0x06:      /* Day of week */
-        if(!date_host_forced) return    MAKE_RETURN(loctime->tm_wday + 1);
+        return    MAKE_RETURN(loctime->tm_wday + 1);
     case 0x07:      /* Date of month */
-        if(!date_host_forced) return    MAKE_RETURN(loctime->tm_mday);
+        return    MAKE_RETURN(loctime->tm_mday);
     case 0x08:      /* Month */
-        if(!date_host_forced) return    MAKE_RETURN(loctime->tm_mon + 1);
+        return    MAKE_RETURN(loctime->tm_mon + 1);
     case 0x09:      /* Year */
-        if(!date_host_forced) return    MAKE_RETURN(loctime->tm_year % 100);
+        return    MAKE_RETURN(loctime->tm_year % 100);
     case 0x32:      /* Century */
-        if(!date_host_forced) return    MAKE_RETURN(loctime->tm_year / 100 + 19);
+        return    MAKE_RETURN(loctime->tm_year / 100 + 19);
     case 0x01:      /* Seconds Alarm */
     case 0x03:      /* Minutes Alarm */
     case 0x05:      /* Hours Alarm */
-        if(!date_host_forced) return cmos.regs[cmos.reg];
+        return cmos.regs[cmos.reg];
     case 0x0a:      /* Status register A */
         if(date_host_forced) {
             // take bit 7 of reg b into account (if set, never updates)

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -236,15 +236,13 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
     case 0x09:      /* Year */
     case 0x32:              /* Century */
         /* Ignore writes to change alarm */
-        if(!date_host_forced) break;
+        break;
     case 0x01:      /* Seconds Alarm */
     case 0x03:      /* Minutes Alarm */
     case 0x05:      /* Hours Alarm */
-        if(!date_host_forced) {
-            LOG(LOG_BIOS,LOG_NORMAL)("CMOS:Writing to an alarm register");
-            cmos.regs[cmos.reg]=(uint8_t)val;
-            break;
-        }
+        LOG(LOG_BIOS,LOG_NORMAL)("CMOS:Writing to an alarm register");
+        cmos.regs[cmos.reg]=(uint8_t)val;
+        break;
     case 0x0a:      /* Status reg A */
         cmos.regs[cmos.reg]=val & 0x7f;
         if ((val & 0x70)!=0x20) LOG(LOG_BIOS,LOG_ERROR)("CMOS:Illegal 22 stage divider value");

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -234,7 +234,7 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
     case 0x07:      /* Date of month */
     case 0x08:      /* Month */
     case 0x09:      /* Year */
-    case 0x32:              /* Century */
+    case 0x32:      /* Century */
         /* Ignore writes to change alarm */
         break;
     case 0x01:      /* Seconds Alarm */
@@ -284,11 +284,11 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
             cmos_checktimer();
         }
         break;
-    case 0x0c:
+    case 0x0c:      /* Status reg C */
         if(date_host_forced) break;
-    case 0x0d:/* Status reg D */
+    case 0x0d:      /* Status reg D */
         if(!date_host_forced) {
-            cmos.regs[cmos.reg]=val & 0x80; /*Bit 7=1:RTC Pown on*/
+            cmos.regs[cmos.reg]=val & 0x80; /*Bit 7=1:RTC Power on*/
         }
         break;
     case 0x0f:      /* Shutdown status byte */

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -297,8 +297,8 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
         cmos.regs[cmos.reg]=val & 0x7f;
         break;
     default:
+        LOG(LOG_BIOS, LOG_NORMAL)("CMOS:Writing to register %x", cmos.reg);
         cmos.regs[cmos.reg]=val & 0x7f;
-        LOG(LOG_BIOS,LOG_ERROR)("CMOS:WRite to unhandled register %x",cmos.reg);
     }
 }
 


### PR DESCRIPTION
Cleanup and rewording of some CMOS logging.

I noticed while installing MS-DOS 6.22 in DOSBox-X that the following message was output to the log

`ERROR BIOS:CMOS:WRite to unhandled register 17`

According to http://www.bioscentral.com/misc/cmosmap.htm, register 17 is for "System Configuration Settings" and has these settings:
Bit 7 = Mouse support disable/enable
Bit 6 = Memory test above 1MB disable/enable
Bit 5 = Memory test tick sound disable/enable
Bit 4 = Memory parity error check disable/enable
Bit 3 = Setup utility trigger display disable/enable
Bit 2 = Hard disk type 47 RAM area (0:300h or upper 1KB of DOS area)
Bit 1 = Wait for <F1> if any error message disable/enable
Bit 0 = System boot up with Numlock (off/on)

I looked at the code in `hardware/cmos.cpp` and found that any write to a CMOS register past 0x0F (except for 0x32) will create this message, but the write is still performed. Reading from the registers is similar, but logs its message for such cases as `LOG_NORMAL`, not an error. Since the value the calling program tries to write is in fact written (almost, see below) and the read is not an error, I don't see why this is being called an error, so this PR changes it to LOG_NORMAL. Also I noticed messiness such as typos and lack of clarity in log messages, and redundant comparisons to `date_host_forced` when it is known to be false, so I fixed those as well.

Now something is I noticed that for some reason writes to some CMOS registers are ANDed with 0x7f, so bit 7 can never be written as 1. According to the site I linked above bit 7 mean something in these registers, such as in register 17 as shown above, or in register 10, where it means "Update in progress". Register 10 is also prevented from being written in DOSBox-X by being ANDed with 0x7f. Is it correct to prevent programs from writing bit 7?

The ANDing with 0x7f looks to have been pulled from SVN and SVN-Daum. @joncampbell123, do you know why they are there?