### PR TITLE
CMOS timing improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.83.19
+  - Better CMOS register B and C emulation. (Allofich)
 0.83.18
   - Cleaned up and more accurately worded CMOS-related
     log messages. (Allofich)

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -577,6 +577,7 @@ void CMOS_Reset(Section* sec) {
     cmos_writereg(0x71,0x26,1);
     cmos.reg=0xb;
     cmos_writereg(0x71,0x2,1);  //Struct tm *loctime is of 24 hour format,
+    cmos.regs[0x0c] = 0;
     if(date_host_forced) {
         cmos.regs[0x0d]=(uint8_t)0x80;
     } else {

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -87,8 +87,17 @@ static void cmos_timerevent(Bitu val) {
         PIC_ActivateIRQ(8);
     }
     if (cmos.timer.enabled) {
-        PIC_AddEvent(cmos_timerevent,cmos.timer.delay);
-        cmos.regs[0xc] = 0xC0;//Contraption Zack (music)
+        double index = PIC_FullIndex();
+        double remd = fmod(index, (double)cmos.timer.delay);
+        PIC_AddEvent(cmos_timerevent, (float)((double)cmos.timer.delay - remd));
+        if(index >= (cmos.last.timer + cmos.timer.delay)) {
+            cmos.last.timer = index;
+            cmos.regs[0xc] |= 0x40;    // Periodic Interrupt Flag (PF)
+        }
+        if(index >= (cmos.last.ended + 1000)) {
+            cmos.last.ended = index;
+            cmos.regs[0xc] |= 0x10;    // Update-Ended Interrupt Flag (UF)
+        }
     }
 }
 
@@ -255,7 +264,6 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
 
             cmos.ampm = !(val & 0x02);
             cmos.bcd = !(val & 0x04);
-            if ((val & 0x10) != 0) LOG(LOG_BIOS,LOG_ERROR)("CMOS:'Update ended interrupt' not supported yet");
             cmos.timer.enabled = (val & 0x40) > 0;
             cmos.lock = (val & 0x80) != 0;
 
@@ -278,9 +286,8 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
             cmos_checktimer();
         } else {
             cmos.bcd=!(val & 0x4);
-            cmos.regs[cmos.reg]=val & 0x7f;
+            cmos.regs[cmos.reg]=(uint8_t)val;
             cmos.timer.enabled=(val & 0x40)>0;
-            if (val&0x10) LOG(LOG_BIOS,LOG_ERROR)("CMOS:'Update ended interrupt' not supported yet");
             cmos_checktimer();
         }
         break;
@@ -418,27 +425,21 @@ static Bitu cmos_readreg(Bitu port,Bitu iolen) {
             }
         }
     case 0x0c:      /* Status register C */
+    {
         cmos.timer.acknowledged=true;
-        if (cmos.timer.enabled) {
-            /* In periodic interrupt mode only care for those flags */
-            uint8_t val=cmos.regs[0xc];
-            cmos.regs[0xc]=0;
-            return val;
-        } else {
-            /* Give correct values at certain times */
-            uint8_t val=0;
-            double index=PIC_FullIndex();
-            if (index>=(cmos.last.timer+cmos.timer.delay)) {
-                cmos.last.timer=index;
-                val|=0x40;
-            } 
-            if (index>=(cmos.last.ended+1000)) {
-                cmos.last.ended=index;
-                val|=0x10;
-            }
-            if(date_host_forced) cmos.regs[0xc] = 0;        // JAL_20060817 - reset here too!
-            return val;
+        uint8_t val = cmos.regs[0xc];
+        if (cmos.timer.enabled && ((cmos.regs[0xc] & 0x40) > 0)) { // If both PF and PIE are 1
+            val |= 0x80; // Set Interrupt Request Flag (IRQF) to 1
         }
+        else if(((cmos.regs[0xb] & 0x10) > 0) && ((cmos.regs[0xc] & 0x10) > 0)) { // If both UF and UIE are 1
+            val |= 0x80; // Set Interrupt Request Flag (IRQF) to 1
+        }
+        else if(((cmos.regs[0xb] & 0x20) > 0) && ((cmos.regs[0xc] & 0x20) > 0)) { // If both AF and AIE are 1
+            val |= 0x80; // Set Interrupt Request Flag (IRQF) to 1
+        }
+        cmos.regs[0xc] = 0; // All flags are cleared by reading the register
+        return val;
+    }
     case 0x10:      /* Floppy size */
         drive_a = 0;
         drive_b = 0;

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -285,7 +285,7 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
         }
         break;
     case 0x0c:      /* Status reg C */
-        if(date_host_forced) break;
+        break;
     case 0x0d:      /* Status reg D */
         if(!date_host_forced) {
             cmos.regs[cmos.reg]=val & 0x80; /*Bit 7=1:RTC Power on*/


### PR DESCRIPTION
Summary of changes brought by this PR:

Using information in https://www.tme.eu/Document/1990376f4a283f591c5baf9f5154462a/ds12885-887a.pdf (which I believe is similar or the same to http://hackipedia.org/browse.cgi/Computer/Platform/PC%2c%20IBM%20compatible/RTC%2c%20CMOS/MC146818A%20CMOS%20REAL-TIME%20CLOCK%20PLUS%20RAM%20%281984%29.pdf), I implemented bit setting behavior for CMOS register C. I also set the timing to account for potential differences between `PIC_FullIndex()` and `cmos.timer.delay`, as was being done in `cmos_checktimer`. This improves the MIDI timing in the game "Contraption Zack", which had a hack in place for it that I removed.

This also removes the fallthrough from register C to register D in the writing function (shouldn't be there, register C is read-only) and allows writing to bit 7 in register B, as is supposed to be possible.

"Contraption Zack" was my main test program, when I saw that there was a hack in place for it. It apparently expects "C0" (bits 6 and 7) in register C to play its MIDI music, and the hack gave it this value constantly. I couldn't find any footage of the game running on real hardware (supposedly it came out on Amiga as well but I couldn't find any footage of that, either), but the music had a fast tempo in DOSBox-X and had what sounded like a "hiccup" in the middle of it (around 8 seconds in).
[1.zip](https://github.com/joncampbell123/dosbox-x/files/7271978/1.zip)

With the changes of this PR, and running the game with CPU cycles set for "286 25MHz". (The game is supposed to be for a "286/16Mhz or faster" https://www.mobygames.com/game/contraption-zack/cover-art/gameCoverId,113758/)
it runs like this.
[2.zip](https://github.com/joncampbell123/dosbox-x/files/7271980/2.zip)

The tempo is quite a bit slower but I think this is probably correct, because you can now hear that the "hiccup" in how it sounded before is actually just a finishing loud note that coincides with the fade-out from the title screen now.

Of course if someone can confirm on real hardware that would be best.

The CPU cycles were also set for "286 25MHz" for the recording from master branch, but as the reg C is always "C0" when the game reads it in master branch, the CPU cycles don't affect music timing. With this PR, running with "286 12MHz" (below system requirements) the title music finished & restarted slightly before the fadeout. With "386DX 25MHz" it matched like it did with "286 25MHz".

Another game that has its music tempo slowed by this PR is "The Beverly Hillbillies".