### PR TITLE
Add support for 2048 bytes-per-cluster DMF images

### DIFF
--- a/patch-integration/Skipped SVN commits.txt
+++ b/patch-integration/Skipped SVN commits.txt
@@ -77,4 +77,3 @@ Commit#:	Reason for skipping:
 4429		Conflict
 4445		Conflict
 4446		Conflict
-4448		Additional parameters for DOSBox-X needed

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -47,7 +47,7 @@ diskGeo DiskGeometryList[] = {
     { 720,  9, 2, 80, 3, 512, 112, 2, 0xF9},      // IBM PC double density 3.5" double-sided 720KB
     {1200, 15, 2, 80, 2, 512, 224, 1, 0xF9},      // IBM PC double density 5.25" double-sided 1.2MB
     {1440, 18, 2, 80, 4, 512, 224, 1, 0xF0},      // IBM PC high density 3.5" double-sided 1.44MB
-    {1680, 21, 2, 80, 4, 512,  16, 4, 0xF0},      // DS/HD 3.5" (DMF)
+    {1680, 21, 2, 80, 4, 512,  16, 4, 0xF0},      // IBM PC high density 3.5" double-sided 1.68MB (DMF)
     {2880, 36, 2, 80, 6, 512, 240, 2, 0xF0},      // IBM PC high density 3.5" double-sided 2.88MB
 
     {1232,  8, 2, 77, 7, 1024,192, 1, 0xFE},      // NEC PC-98 high density 3.5" double-sided 1.2MB "3-mode"

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -47,6 +47,7 @@ diskGeo DiskGeometryList[] = {
     { 720,  9, 2, 80, 3, 512, 112, 2, 0xF9},      // IBM PC double density 3.5" double-sided 720KB
     {1200, 15, 2, 80, 2, 512, 224, 1, 0xF9},      // IBM PC double density 5.25" double-sided 1.2MB
     {1440, 18, 2, 80, 4, 512, 224, 1, 0xF0},      // IBM PC high density 3.5" double-sided 1.44MB
+    {1680, 21, 2, 80, 4, 512,  16, 4, 0xF0},      // DS/HD 3.5" (DMF)
     {2880, 36, 2, 80, 6, 512, 240, 2, 0xF0},      // IBM PC high density 3.5" double-sided 2.88MB
 
     {1232,  8, 2, 77, 7, 1024,192, 1, 0xFE},      // NEC PC-98 high density 3.5" double-sided 1.2MB "3-mode"


### PR DESCRIPTION
Summary of changes brought by this PR.

## What issues does this PR address?

Closes #1472. Closes #2962.

## Does this PR introduce new feature(s)?

Adds ability to mount 2048-byte-per-cluster DMF floppy images.

## Additional information

Simply adds the following line:

{1680, 21, 2, 80, 4, 512,  16, 4, 0xF0}

1680, 21, 2, 80, 4 is from DOSBox SVN
https://sourceforge.net/p/dosbox/code-0/4448/

512, 16, 4 is from information available online about DMF floppies. 512 bytes per sector x 4 sectors per cluster = 2048 bytes per cluster, the number that readily comes up online.

0xF0 is from looking at a DMF floppy image (Windows 95 setup, disk 2). It is the Media Descriptor at offset 0x15, as described here:
http://www.dewassoc.com/kbase/hard_drives/boot_sector.htm

Other values in the image also match with the numbers above (sectors per track, heads per cylinder, etc.)