### PR TITLE
Support for DOS/V applications when country information is set to Japan in TTF

### DIFF
--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -685,6 +685,9 @@ public:
 // Section 4-8.
 //
 // The PDF documents ANSI codes defined on PC-98, which may or may not be a complete listing.
+#if defined(USE_TTF)
+extern bool ttf_dosv;
+#endif
 
 bool device_CON::Read(uint8_t * data,uint16_t * size) {
 	uint16_t oldax=reg_ax;
@@ -694,7 +697,11 @@ bool device_CON::Read(uint8_t * data,uint16_t * size) {
 	if ((readcache) && (*size)) {
 		data[count++]=readcache;
 		if (dos.echo) {
+#if defined(USE_TTF)
+			if (IS_DOSV || ttf_dosv) {
+#else
 			if (IS_DOSV) {
+#endif
 				reg_al = readcache;
 				CALLBACK_RunRealInt(0x29);
 			} else
@@ -729,7 +736,11 @@ bool device_CON::Read(uint8_t * data,uint16_t * size) {
 			*size=count;
 			reg_ax=oldax;
 			if(dos.echo) { 
+#if defined(USE_TTF)
+				if (IS_DOSV || ttf_dosv) {
+#else
 				if (IS_DOSV) {
+#endif
 					reg_al = 13;
 					CALLBACK_RunRealInt(0x29);
 					reg_al = 10;
@@ -752,7 +763,11 @@ bool device_CON::Read(uint8_t * data,uint16_t * size) {
 			}
 			break;
 		case 0xe0: /* Extended keys in the  int 16 0x10 case */
+#if defined(USE_TTF)
+			if((isJEGAEnabled() || IS_DOSV || ttf_dosv) && (reg_ah == 0xf0 || reg_ah == 0xf1)) {
+#else
 			if((isJEGAEnabled() || IS_DOSV) && (reg_ah == 0xf0 || reg_ah == 0xf1)) {
+#endif
 				data[count++]=reg_al;
 			} else if(!reg_ah) { /*extended key if reg_ah isn't 0 */
 				data[count++] = reg_al;
@@ -809,7 +824,11 @@ bool device_CON::Read(uint8_t * data,uint16_t * size) {
 		}
 		if(dos.echo) { //what to do if *size==1 and character is BS ?????
 			// TODO: If CTRL+C checking is applicable do not echo (reg_al == 3)
+#if defined(USE_TTF)
+			if (IS_DOSV || ttf_dosv) {
+#else
 			if (IS_DOSV) {
+#endif
 				if(inshell && CheckHat(reg_al)) {
 					uint8_t ch = reg_al + 0x40;
 					reg_al = '^';
@@ -847,7 +866,11 @@ void DOS_BreakAction();
 
 bool device_CON::Write(const uint8_t * data,uint16_t * size) {
 	uint16_t count=0;
+#if defined(USE_TTF)
+	if (IS_DOSV || ttf_dosv) {
+#else
 	if (IS_DOSV) {
+#endif
 		while (*size > count) {
 			reg_al = data[count];
 			if(reg_al == 0x07) {

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -64,6 +64,9 @@ extern std::string log_dev_con_str;
 extern const char* RunningProgram;
 extern bool log_int21, log_fileio;
 extern bool sync_time, manualtime;
+#if defined(USE_TTF)
+extern bool ttf_dosv;
+#endif
 extern int lfn_filefind_handle, autofixwarn;
 extern uint16_t customcp_to_unicode[256];
 int customcp = 0, altcp = 0;
@@ -288,7 +291,11 @@ static bool hat_flag[] = {
 
 bool CheckHat(uint8_t code)
 {
+#if defined(USE_TTF)
+	if(IS_JEGA_ARCH || IS_DOSV || ttf_dosv) {
+#else
 	if(IS_JEGA_ARCH || IS_DOSV) {
+#endif
 		if(code <= 0x1a) {
 			return hat_flag[code];
 		}
@@ -1050,7 +1057,11 @@ static Bitu DOS_21Handler(void) {
                                     if(isKanji1(c)) {
                                         flag = 1;
                                     }
+#if defined(USE_TTF)
+                                    if(IS_JEGA_ARCH || IS_DOSV || ttf_dosv) {
+#else
                                     if(IS_JEGA_ARCH || IS_DOSV) {
+#endif
                                         if(CheckHat(c)) {
                                             flag = 2;
                                         }
@@ -1087,7 +1098,11 @@ static Bitu DOS_21Handler(void) {
                         DOS_BreakAction();
                         if (!DOS_BreakTest()) return CBRET_NONE;
                     }
+#if defined(USE_TTF)
+                    if ((IS_JEGA_ARCH || IS_DOSV || ttf_dosv) && c == 7) {
+#else
                     if ((IS_JEGA_ARCH || IS_DOSV) && c == 7) {
+#endif
                         DOS_WriteFile(STDOUT, &c, &n);
                         continue;
                     }
@@ -1693,7 +1708,11 @@ static Bitu DOS_21Handler(void) {
 		{
             unmask_irq0 |= disk_io_unmask_irq0;
             MEM_StrCopy(SegPhys(ds)+reg_dx,name1,DOSNAMEBUF);
+#if defined(USE_TTF)
+            if((IS_DOSV || ttf_dosv) && IS_DOS_JAPANESE) {
+#else
             if(IS_DOSV && IS_DOS_JAPANESE) {
+#endif
                 char *name_start = name1;
                 if(name1[0] == '@' && name1[1] == ':') {
                     name_start += 2;
@@ -1714,7 +1733,11 @@ static Bitu DOS_21Handler(void) {
                             break;
                         }
                     }
+#if defined(USE_TTF)
+                    if(!strncmp(name_start, "$IBMAFNT", 8) || (ttf_dosv && !strncmp(name_start, "$IBMADSP", 8))) {
+#else
                     if(!strncmp(name_start, "$IBMAFNT", 8)) {
+#endif
                         ibmjp_handle = IBMJP_DEVICE_HANDLE;
                         reg_ax = IBMJP_DEVICE_HANDLE;
                         force_sfn = false;
@@ -3887,7 +3910,11 @@ public:
 			// to clear the screen is that it uses INT 29h to directly send ANSI codes rather than
 			// standard I/O calls to write to the CON device.
 			callback[6].Install(INT29_HANDLER,CB_IRET,"CON Output Int 29");
+#if defined(USE_TTF)
+		} else if (IS_DOSV || ttf_dosv) {
+#else
 		} else if (IS_DOSV) {
+#endif
 			int29h_data.ansi.attr = 0x07;
 			callback[6].Install(DOS_29Handler,CB_IRET,"CON Output Int 29");
 		} else if (section->Get_bool("ansi.sys")) { // NTS: DOS CON device is not yet initialized, therefore will not return correct value of "is ANSI.SYS installed"?
@@ -4066,7 +4093,11 @@ public:
             INT10_AX_SetCRTBIOSMode(0x51);
             INT16_AX_SetKBDBIOSMode(0x51);
         }
+#if defined(USE_TTF)
+		if(IS_DOSV || ttf_dosv) {
+#else
 		if(IS_DOSV) {
+#endif
 			DOSV_Setup();
 			if(IS_DOSV) {
 				INT10_DOSV_SetCRTBIOSMode(0x03);

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -29,6 +29,7 @@
 #include "support.h"
 #include "parport.h"
 #include "drives.h" //Wildcmp
+#include "render.h"
 /* Include all the devices */
 
 #include "dev_con.h"

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -306,6 +306,9 @@ extern bool rom_bios_vptable_enable;
 extern bool rom_bios_8x8_cga_font;
 extern bool allow_port_92_reset;
 extern bool allow_keyb_reset;
+#if defined(USE_TTF)
+extern bool ttf_dosv;
+#endif
 
 extern bool DOSBox_Paused(), isDBCSCP(), InitCodePage();
 
@@ -1052,7 +1055,11 @@ void DOSBOX_RealInit() {
     if (!cp) InitCodePage();
     if (IS_JEGA_ARCH || IS_DOSV || isDBCSCP()) {
         JFONT_Init();  // Load DBCS fonts for JEGA etc
+#if defined(USE_TTF)
+        if (IS_DOSV || ttf_dosv) DOSV_SetConfig(dosv_section);
+#else
         if (IS_DOSV) DOSV_SetConfig(dosv_section);
+#endif
     }
     gbk = dosv_section->Get_bool("gbk");
     dos.loaded_codepage = cp;
@@ -2756,6 +2763,9 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring->Set_help("If set to true, the cursor blinks for the TTF output; setting it to false will turn the blinking off.\n"
                       "You can also change the blinking rate by setting an interger between 1 (fastest) and 7 (slowest), or 0 for no cursor.");
     Pstring->SetBasic(true);
+
+	Pbool = secprop->Add_bool("dosv", Property::Changeable::OnlyAtStart, false);
+    Pbool->Set_help("If set, enables FEP control to function for DOS/V applications, and changes the blinking of character attributes to high brightness.");
 
     secprop=control->AddSection_prop("voodoo",&Null_Init,false); //Voodoo
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -325,6 +325,7 @@ bool dbcs_sbcs = true;
 bool printfont = true;
 bool autoboxdraw = true;
 bool halfwidthkana = true;
+bool ttf_dosv = false;
 int outputswitch = -1;
 int wpType = 0;
 int wpVersion = 0;
@@ -4018,6 +4019,7 @@ void OUTPUT_TTF_Select(int fsize=-1) {
         dbcs_sbcs = ttf_section->Get_bool("autodbcs");
         autoboxdraw = ttf_section->Get_bool("autoboxdraw");
         halfwidthkana = ttf_section->Get_bool("halfwidthkana");
+        ttf_dosv = ttf_section->Get_bool("dosv");
         const char *outputstr=ttf_section->Get_string("outputswitch");
 #if C_DIRECT3D
         if (!strcasecmp(outputstr, "direct3d"))

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -137,6 +137,10 @@ void SetGameState_Run(int value), SaveGameState_Run(void);
 size_t GetGameState_Run(void);
 uint8_t *GetDbcsFont(Bitu code);
 
+#if defined(USE_TTF)
+extern bool ttf_dosv;
+#endif
+
 void memxor(void *_d,unsigned int byte,size_t count) {
     unsigned char *d = (unsigned char*)_d;
     while (count-- > 0) *d++ ^= byte;
@@ -4009,10 +4013,18 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
                         Bitu attr = (*vidmem >> 8u) & 0xFFu;
                         vidmem+=2; // because planar EGA/VGA, and odd/even mode as real hardware arranges alphanumeric mode in VRAM
                         Bitu background = attr >> 4;
-                        if (vga.draw.blinking)									// if blinking is enabled bit7 is not mapped to attributes
+#if defined(USE_TTF)
+                        if (vga.draw.blinking && !ttf_dosv)							// if blinking is enabled bit7 is not mapped to attributes
+#else
+                        if (vga.draw.blinking)							// if blinking is enabled bit7 is not mapped to attributes
+#endif
                             background &= 7;
                         // choose foreground color if blinking not set for this cell or blink on
+#if defined(USE_TTF)
+                        Bitu foreground = (vga.draw.blink || (!(attr&0x80)) || ttf_dosv) ? (attr&0xf) : background;
+#else
                         Bitu foreground = (vga.draw.blink || (!(attr&0x80))) ? (attr&0xf) : background;
+#endif
                         // How about underline?
                         (*draw).fg = foreground;
                         (*draw).bg = background;

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -29,6 +29,7 @@
 #include "SDL.h"
 #include "int10.h"
 #include "jfont.h"
+#include "render.h"
 
 #if defined(_MSC_VER)
 # pragma warning(disable:4244) /* const fmath::local::uint64_t to double possible loss of data */
@@ -297,6 +298,10 @@ static scancode_tbl scan_to_scanascii_pc98[0x80] = {
 #include <queue>
 std::queue <uint16_t>over_key_buffer;
 
+#if defined(USE_TTF)
+extern bool ttf_dosv;
+#endif
+
 bool BIOS_AddKeyToBuffer(uint16_t code) {
     if (!IS_PC98_ARCH) {
         if (mem_readb(BIOS_KEYBOARD_FLAGS2)&8) return true;
@@ -332,7 +337,11 @@ bool BIOS_AddKeyToBuffer(uint16_t code) {
     /* Check for buffer Full */
     //TODO Maybe beeeeeeep or something although that should happend when internal buffer is full
     if (ttail==head) {
+#if defined(USE_TTF)
+        if(IS_DOSV || ttf_dosv) {
+#else
         if(IS_DOSV) {
+#endif
             over_key_buffer.push(code);
         }
         return false;
@@ -400,7 +409,11 @@ static bool get_key(uint16_t &code) {
         mem_writew(BIOS_KEYBOARD_BUFFER_HEAD,thead);
         code = real_readw(0x40,head);
     }
+#if defined(USE_TTF)
+    if(IS_DOSV || ttf_dosv) {
+#else
     if(IS_DOSV) {
+#endif
         if (!over_key_buffer.empty()) {
             add_key(over_key_buffer.front());
             over_key_buffer.pop();
@@ -1255,7 +1268,11 @@ Bitu INT16_Handler(void) {
         break;
     case 0x13:
 #if defined(WIN32) && !defined(HX_DOS) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
+#if defined(USE_TTF)
+        if((IS_DOSV || ttf_dosv) && IS_DOS_CJK && (DOSV_GetFepCtrl() & DOSV_FEP_CTRL_IAS)) {
+#else
         if(IS_DOSV && IS_DOS_CJK && (DOSV_GetFepCtrl() & DOSV_FEP_CTRL_IAS)) {
+#endif
             if(reg_al == 0x00) {
                 if(reg_dl & 0x81)
                     SDL_SetIMValues(SDL_IM_ONOFF, 1, NULL);
@@ -1271,7 +1288,11 @@ Bitu INT16_Handler(void) {
             }
         }
 #elif defined(WIN32) && !defined(HX_DOS) && defined(C_SDL2)
+#if defined(USE_TTF)
+        if((IS_DOSV || ttf_dosv) && IS_DOS_CJK && (DOSV_GetFepCtrl() & DOSV_FEP_CTRL_IAS)) {
+#else
         if(IS_DOSV && IS_DOS_CJK && (DOSV_GetFepCtrl() & DOSV_FEP_CTRL_IAS)) {
+#endif
             if(reg_al == 0x00) {
                 if(reg_dl & 0x81)
                     IME_SetEnable(TRUE);
@@ -1287,7 +1308,11 @@ Bitu INT16_Handler(void) {
 #endif
         break;
     case 0x14:
+#if defined(USE_TTF)
+        if((IS_DOSV || ttf_dosv) && IS_DOS_CJK && (DOSV_GetFepCtrl() & DOSV_FEP_CTRL_IAS)) {
+#else
         if(IS_DOSV && IS_DOS_CJK && (DOSV_GetFepCtrl() & DOSV_FEP_CTRL_IAS)) {
+#endif
             if(reg_al == 0x02) {
                 // get
                 reg_al = fep_line;

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -54,6 +54,7 @@ void INT10_ReadString(uint8_t row, uint8_t col, uint8_t flag, uint8_t attr, Phys
 bool INT10_SetDOSVModeVtext(uint16_t mode, enum DOSV_VTEXT_MODE vtext_mode);
 #if defined(USE_TTF)
 extern bool colorChanged, justChanged;
+extern bool ttf_dosv;
 #endif
 Bitu INT10_Handler(void) {
 	// NTS: We do have to check the "current video mode" from the BIOS data area every call.
@@ -606,7 +607,11 @@ CX	640x480	800x600	  1024x768/1280x1024
 			INT10_WriteString(reg_dh,reg_dl,reg_al,reg_bl,SegPhys(es)+reg_bp,reg_cx,reg_bh);
 		break;
 	case 0x18:
+#if defined(USE_TTF)
+		if((IS_DOSV || ttf_dosv) && DOSV_CheckCJKVideoMode()) {
+#else
 		if(IS_DOSV && DOSV_CheckCJKVideoMode()) {
+#endif
 			uint8_t *font;
 			Bitu size = 0;
 			if(reg_al == 0) {
@@ -687,7 +692,11 @@ CX	640x480	800x600	  1024x768/1280x1024
 		}
 		break;
 	case 0x1d:
+#if defined(USE_TTF)
+		if((IS_DOSV || ttf_dosv) && DOSV_CheckCJKVideoMode()) {
+#else
 		if(IS_DOSV && DOSV_CheckCJKVideoMode()) {
+#endif
 			if(reg_al == 0x00) {
 				real_writeb(BIOSMEM_SEG, BIOSMEM_NB_ROWS, int10.text_row - reg_bl);
 			} else if(reg_al == 0x01) {

--- a/src/ints/int_dosv.cpp
+++ b/src/ints/int_dosv.cpp
@@ -104,6 +104,7 @@ static bool use20pixelfont;
 #endif
 #if defined(USE_TTF)
 extern bool autoboxdraw;
+extern bool ttf_dosv;
 #endif
 
 bool gbk = false;
@@ -130,7 +131,11 @@ bool isKanji1(uint8_t chr) {
 }
 
 bool isKanji2(uint8_t chr) {
+#if defined(USE_TTF)
+    if (dos.loaded_codepage == 936 || dos.loaded_codepage == 949 || dos.loaded_codepage == 950 || ((IS_DOSV || ttf_dosv) && !IS_JDOSV))
+#else
     if (dos.loaded_codepage == 936 || dos.loaded_codepage == 949 || dos.loaded_codepage == 950 || (IS_DOSV && !IS_JDOSV))
+#endif
         return chr >= 0x40 && chr <= 0xfe;
     else
         return (chr >= 0x40 && chr <= 0x7e) || (del_flag && chr == 0x7f) || (chr >= 0x80 && chr <= 0xfc);


### PR DESCRIPTION
# Description
Support for DOS/V applications when country information is set to Japan in TTF

**Does this PR introduce new feature(s) ?**
Added an option to make the blinking of FEP controls and character attributes in TTF high brightness.

**Additional information**
When the country information is set to Japan in TTF, most DOS/V applications work, but there are some problems because FEP control is not available and there is no blinking in the character attributes.
Add the [ttf] dosv option, and if it is true, control FEP and treat the blinking character attribute as high brightness.
