### PR TITLE
Set some fixed BIOS addresses.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.83.19
+  - Set some parts of the emulated BIOS to addresses
+    that they are fixed to in real BIOSes. (Allofich)
   - Fix SELINFO command not showing output correctly
     in the debugger window. (Allofich)
   - Better CMOS register B and C emulation. (Allofich)

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -9405,13 +9405,30 @@ public:
         }
 
         /* pick locations */
-        BIOS_DEFAULT_RESET_LOCATION = PhysToReal416(ROMBIOS_GetMemory(64/*several callbacks*/,"BIOS default reset location",/*align*/4));
-        BIOS_DEFAULT_HANDLER_LOCATION = PhysToReal416(ROMBIOS_GetMemory(1/*IRET*/,"BIOS default handler location",/*align*/4));
-        BIOS_DEFAULT_INT5_LOCATION = PhysToReal416(ROMBIOS_GetMemory(1/*IRET*/, "BIOS default INT5 location",/*align*/4));
-        BIOS_DEFAULT_IRQ0_LOCATION = PhysToReal416(ROMBIOS_GetMemory(0x13/*see callback.cpp for IRQ0*/,"BIOS default IRQ0 location",/*align*/4));
-        BIOS_DEFAULT_IRQ1_LOCATION = PhysToReal416(ROMBIOS_GetMemory(0x20/*see callback.cpp for IRQ1*/,"BIOS default IRQ1 location",/*align*/4));
-        BIOS_DEFAULT_IRQ07_DEF_LOCATION = PhysToReal416(ROMBIOS_GetMemory(7/*see callback.cpp for EOI_PIC1*/,"BIOS default IRQ2-7 location",/*align*/4));
-        BIOS_DEFAULT_IRQ815_DEF_LOCATION = PhysToReal416(ROMBIOS_GetMemory(9/*see callback.cpp for EOI_PIC1*/,"BIOS default IRQ8-15 location",/*align*/4));
+        if(!IS_PC98_ARCH) {
+            if (machine == MCH_PCJR)
+                BIOS_DEFAULT_RESET_LOCATION = PhysToReal416(ROMBIOS_GetMemory(64/*several callbacks*/, "BIOS default reset location",/*align*/1, 0xF0043)); // POST Entry Point
+            else
+                //BIOS_DEFAULT_RESET_LOCATION = PhysToReal416(ROMBIOS_GetMemory(64/*several callbacks*/, "BIOS default reset location",/*align*/1, 0xFE05B)); // POST Entry Point. TODO: This fails to be allocated.
+                BIOS_DEFAULT_RESET_LOCATION = PhysToReal416(ROMBIOS_GetMemory(64/*several callbacks*/, "BIOS default reset location",/*align*/4));
+            BIOS_DEFAULT_HANDLER_LOCATION = PhysToReal416(ROMBIOS_GetMemory(1/*IRET*/, "BIOS default handler location",/*align*/1, 0xFFF53)); // Dummy Interrupt Handler (IRET)
+            BIOS_DEFAULT_INT5_LOCATION = PhysToReal416(ROMBIOS_GetMemory(1/*IRET*/, "BIOS default INT5 location",/*align*/1, 0xFFF54)); // INT 05 (Print Screen) Entry Point
+            BIOS_DEFAULT_IRQ0_LOCATION = PhysToReal416(ROMBIOS_GetMemory(0x13/*see callback.cpp for IRQ0*/, "BIOS default IRQ0 location",/*align*/1, 0xFFEA5)); // INT 08 Entry Point
+            BIOS_DEFAULT_IRQ1_LOCATION = PhysToReal416(ROMBIOS_GetMemory(0x20/*see callback.cpp for IRQ1*/, "BIOS default IRQ1 location",/*align*/4));
+            //BIOS_DEFAULT_IRQ1_LOCATION = PhysToReal416(ROMBIOS_GetMemory(0x20/*see callback.cpp for IRQ1*/, "BIOS default IRQ1 location",/*align*/1, 0xFE987)); // INT 09 Entry Point. TODO: This fails to be allocated.
+            BIOS_DEFAULT_IRQ07_DEF_LOCATION = PhysToReal416(ROMBIOS_GetMemory(7/*see callback.cpp for EOI_PIC1*/, "BIOS default IRQ2-7 location",/*align*/1, 0xFFF55));
+            BIOS_DEFAULT_IRQ815_DEF_LOCATION = PhysToReal416(ROMBIOS_GetMemory(9/*see callback.cpp for EOI_PIC1*/, "BIOS default IRQ8-15 location",/*align*/1, 0xFE880));
+        }
+        else
+        {
+            BIOS_DEFAULT_RESET_LOCATION = PhysToReal416(ROMBIOS_GetMemory(64/*several callbacks*/, "BIOS default reset location",/*align*/4));
+            BIOS_DEFAULT_HANDLER_LOCATION = PhysToReal416(ROMBIOS_GetMemory(1/*IRET*/, "BIOS default handler location",/*align*/4));
+            BIOS_DEFAULT_INT5_LOCATION = PhysToReal416(ROMBIOS_GetMemory(1/*IRET*/, "BIOS default INT5 location",/*align*/4));
+            BIOS_DEFAULT_IRQ0_LOCATION = PhysToReal416(ROMBIOS_GetMemory(0x13/*see callback.cpp for IRQ0*/, "BIOS default IRQ0 location",/*align*/4));
+            BIOS_DEFAULT_IRQ1_LOCATION = PhysToReal416(ROMBIOS_GetMemory(0x20/*see callback.cpp for IRQ1*/, "BIOS default IRQ1 location",/*align*/4));
+            BIOS_DEFAULT_IRQ07_DEF_LOCATION = PhysToReal416(ROMBIOS_GetMemory(7/*see callback.cpp for EOI_PIC1*/, "BIOS default IRQ2-7 location",/*align*/4));
+            BIOS_DEFAULT_IRQ815_DEF_LOCATION = PhysToReal416(ROMBIOS_GetMemory(9/*see callback.cpp for EOI_PIC1*/, "BIOS default IRQ8-15 location",/*align*/4));
+        }
 
         write_FFFF_signature();
 


### PR DESCRIPTION
Summary of changes brought by this PR.

Sets some fixed BIOS addresses.

The values are from DOSBox SVN (see pre-change values in https://github.com/joncampbell123/dosbox-x/commit/d548d1eb222d9702a69a9dfc575f86556fe40d3b) and the INT5 value is from the table seen at https://www.vcfed.org/forum/forum/genres/pcs-and-clones/1215993-fixed-addresses-in-the-bios-what-program-still-uses-them. That table also agrees with the DOSBox SVN values where they overlap, and I added labels from there as source comments.

## What issues does this PR address?

https://github.com/joncampbell123/dosbox-x/issues/2971

The game still has at least one remaining issue: missing music when run from the DOSBox-X shell that is present when run from a booted MS-DOS image.

## Additional information

Two values caused problems and are commented out.

1) The BIOS_DEFAULT_RESET_LOCATION (for non-PCJr) causes DOSBox-X to crash on startup. (The PCJr one works.)
2) The BIOS_DEFAULT_IRQ1_LOCATION causes keyboard input at the DOS prompt to not work. Trying to type causes a freeze.

@joncampbell123, any ideas? `ROMBIOS_GetMemory` looks like it protects against itself overwriting used memory on subsequent calls, but maybe those two locations get overwritten somewhere.