### PR TITLE
Use Chinese titles of games

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,9 +9,10 @@
     and force dynamic allocation below that address to
     prevent further conflicts should others submit
     pull requests for additional fixed locations. This
-    fixes some games like "Liao" which appear to assume
-    some of these fixed BIOS addresses and will crash
-    if they are wrong.
+    fixes some games like "聊齋誌異之幽谷傳奇" (Liáozhāi
+    zhì yì zhī yōugǔ chuánqí) which appear to assume
+    some of these fixed BIOS addresses and will
+    crash if they are wrong.
   - Fixed bugs in the region memory allocator C++ class
     that claimed the entire free block even if the
     size wanted was smaller. Added field to remember if
@@ -3048,9 +3049,9 @@
   - Added dosbox.conf option to instruct DOSBox-X to leave
     the PC speaker clock gate enabled if set, for games
     that use that PIT output as a time source. Setting
-    the option to "true" allows "Bàoxiào sānguózhì", a game
-    with strange and elaborate timing code, to run without
-    hanging at the second title screen.
+    the option to "true" allows "爆笑三国誌" (Bàoxiào
+    sānguózhì), a game with strange and elaborate timing
+    code, to run without hanging at the second title screen.
   - VGA port 3DAh "undefined bits" setting changed to 0x04
     to accomodate "Blues Brothers"
   - Configuration GUI: If the settings are scrollable,


### PR DESCRIPTION
Puts the Chinese titles of two games in the changelog.

聊齋誌異之幽谷傳奇 is the game referred to in https://github.com/joncampbell123/dosbox-x/issues/2971.

爆笑三国志 is the game referred to in https://github.com/joncampbell123/dosbox-x/issues/1274.

The reason is that these are the actual titles, and the transliterations "Liáozhāi zhì yì zhī yōugǔ chuánqí" and "Bàoxiào sānguózhì" don't bring up search results for these games, while the Chinese character titles do.