### PR TITLE
Correct game name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3052,7 +3052,7 @@
   - Added dosbox.conf option to instruct DOSBox-X to leave
     the PC speaker clock gate enabled if set, for games
     that use that PIT output as a time source. Setting
-    the option to "true" allows "爆笑三国誌" (Bàoxiào
+    the option to "true" allows "爆笑三國志" (Bàoxiào
     sānguózhì), a game with strange and elaborate timing
     code, to run without hanging at the second title screen.
   - VGA port 3DAh "undefined bits" setting changed to 0x04


### PR DESCRIPTION
Writes the name of "Bàoxiào sānguózhì" as  爆笑三國志, exactly as seen on an image of the floppy disk for the game at https://www.ruten.com.tw/item/show?21819995322528.