### PR TITLE
Don't run CPU_Enable_SkipAutoAdjust when using priority pause

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8221,7 +8221,10 @@ void GFX_Events() {
 
                         SetPriority(sdl.priority.nofocus);
                         GFX_LosingFocus();
-                        CPU_Enable_SkipAutoAdjust();
+
+                        if( sdl.priority.nofocus != PRIORITY_LEVEL_PAUSE ) {
+                            CPU_Enable_SkipAutoAdjust();
+                        }
                     }
                 }
 


### PR DESCRIPTION
Should fix the issue of CPU cycles being halved when refocusing the application using the "priority = ?, pause" config setting.

## What issues does this PR address?

Closes #2983

## Does this PR introduce new feature(s)?

No

## Are there any breaking changes?

Unknown

## Additional information