### PR TITLE
SVN updates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,9 @@
   - Better CMOS register B and C emulation. (Allofich)
   - Integrated commits from mainline (Allofich)
     - Support for DMF floppy disk images.
+    - Zero-out DX in EXEC overlay command.
+    - Improve stack check for wrap-around cases.
+    - Change to misc_output for SVGA_S3Trio.
 0.83.18
   - Cleaned up and more accurately worded CMOS-related
     log messages. (Allofich)

--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -468,7 +468,8 @@ bool DOS_Execute(const char* name, PhysPt block_pt, uint8_t flags) {
 	}
 	CALLBACK_SCF(false);		/* Carry flag cleared for caller if successfull */
     if(flags == OVERLAY) {
-        reg_ax = 0;             // Testing with MS-DOS (6.22) shows that if INT 21 AX=4B is called with the overlay flag (AL==3), then AX is 0 on return.
+        reg_ax = 0;             // Testing with MS-DOS (6.22) shows that if INT 21 AX=4B is called with the overlay flag (AL==3), then AX and DX are 0 on return.
+        reg_dx = 0;
         return true;			/* Everything done for overlays */
     }
 	RealPt csip,sssp;
@@ -497,7 +498,7 @@ bool DOS_Execute(const char* name, PhysPt block_pt, uint8_t flags) {
 		if (sssp >= RealMake(pspseg+memsize,0)) E_Exit("DOS:Initial SS:IP beyond allocated memory block for EXE image");
 		if (csip >= RealMake(pspseg+memsize,0)) E_Exit("DOS:Initial CS:IP beyond allocated memory block for EXE image");
 		if (head.initSP<4) LOG(LOG_EXEC,LOG_ERROR)("stack underflow/wrap at EXEC SS:SP=%04x:%04x",head.initSS,head.initSP);
-		if ((pspseg+memsize)<(loadseg+head.initSS+(head.initSP>>4)))
+		if ((pspseg+memsize)<(RealSeg(sssp)+(RealOff(sssp)>>4)))
 			LOG(LOG_EXEC,LOG_ERROR)("stack outside memory block at EXEC");
 	}
 

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -1738,7 +1738,9 @@ bool INT10_SetVideoMode(uint16_t mode) {
 	if (svgaCard == SVGA_S3Trio) {
 		/* Setup the correct clock */
 		if (CurMode->mode>=0x100) {
-			misc_output|=0xef;		//Select clock 3 
+			if (CurMode->vdispend>480)
+				misc_output|=0xc0;	//480-line sync
+			misc_output|=0x0c;		//Select clock 3
 			Bitu clock=CurMode->vtotal*8*CurMode->htotal*70;
 			if(CurMode->type==M_LIN15 || CurMode->type==M_LIN16) clock/=2;
 			VGA_SetClock(3,clock/1000);


### PR DESCRIPTION
https://sourceforge.net/p/dosbox/code-0/4467/ - In this PR. In addition to AX being set to 0, looks like DX is also set to 0 by the EXEC overlay function. I checked with MS-DOS 6.22 and DX was indeed 0 on return.

Also went back and put in changes to SVGA_S3Trio `misc_output` from https://sourceforge.net/p/dosbox/code-0/3913/. This is related to https://github.com/joncampbell123/dosbox-x/issues/1071. The aspect ratio changes still need to be looked at but we might as well get this part of r3913 in since it's a no-conflict update to SVN-inherited behavior.