### PR TITLE
Use 80-bit long double in core_dyn_x86 again when supported

### DIFF
--- a/src/cpu/core_dyn_x86/dyn_fpu.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu.h
@@ -47,6 +47,8 @@ static void FPU_FFREE(Bitu st) {
 
 #if C_FPU_X86
 #include "../../fpu/fpu_instructions_x86.h"
+#elif defined(HAS_LONG_DOUBLE)
+#include "../../fpu/fpu_instructions_longdouble.h"
 #else
 #include "../../fpu/fpu_instructions.h"
 #endif


### PR DESCRIPTION
Re-applies the change of https://github.com/joncampbell123/dosbox-x/commit/0b0baa0cc36caaa84c47827e9660e9cd6a4001e3 to core_dyn_x86. When core_dyn_x86 was brought back, this change was not restored with it. There might be other changes DOSBox-X made to core_dyn_x86 before it was removed that need to be applied again. I'll take a look at some point.