### PR TITLE
Fix horizontal lines in the debugger not being rendered properly in some code pages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 0.83.19
+  - Fix horizontal lines in the debugger window being
+    rendered as unrelated characters in some code
+    pages. (Allofich)
   - Added config option "dosvfunc" in [ttf] section to
     support DOS/V applications when country information
     is set to Japan in TTF output. (nanshiki)

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -418,7 +418,7 @@ static void DrawSubWinBox(WINDOW *wnd,const char *title) {
     		attrset(COLOR_PAIR(PAIR_WHITE_BLUE));
     }
 
-    mvhline(y-1,x,ACS_HLINE,w);
+    mvhline(y-1,x,ACS_S1,w);
     if (title != NULL) mvaddstr(y-1,x+4,title);
 }
 


### PR DESCRIPTION
Closes #2923.

If anyone has a better solution, that's fine, but I think this is good enough to resolve the problem.