### PR TITLE
Fixed GET INPUT/OUTPUT STATUS not working for character devices registered at device.com.

### DIFF
--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -126,6 +126,7 @@ public:
 	virtual uint16_t	GetInformation(void);
 	virtual bool	ReadFromControlChannel(PhysPt bufptr,uint16_t size,uint16_t * retcode);
 	virtual bool	WriteToControlChannel(PhysPt bufptr,uint16_t size,uint16_t * retcode);
+	virtual uint8_t	GetStatus(bool input_flag);
 	void SetDeviceNumber(Bitu num) { devnum=num;}
 private:
 	Bitu devnum;

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -724,6 +724,14 @@ bool DOS_Device::WriteToControlChannel(PhysPt bufptr,uint16_t size,uint16_t * re
 	return Devices[devnum]->WriteToControlChannel(bufptr,size,retcode);
 }
 
+uint8_t DOS_Device::GetStatus(bool input_flag) {
+	Bit16u info = Devices[devnum]->GetInformation();
+	if(info & EXT_DEVICE_BIT) {
+		return Devices[devnum]->GetStatus(input_flag);
+	}
+	return (info & 0x40) ? 0x00 : 0xff;
+}
+
 DOS_File::DOS_File(const DOS_File& orig) : flags(orig.flags), open(orig.open), attr(orig.attr),
 time(orig.time), date(orig.date), refCtr(orig.refCtr), hdrive(orig.hdrive) {
 	if(orig.name) {

--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -625,7 +625,7 @@ bool DOS_IOCTL(void) {
 	switch(reg_al) {
 	case 0x00:		/* Get Device Information */
 		if (Files[handle]->GetInformation() & 0x8000) {	//Check for device
-			reg_dx=Files[handle]->GetInformation();
+			reg_dx=Files[handle]->GetInformation() & ~EXT_DEVICE_BIT;
 		} else {
 			uint8_t hdrive=Files[handle]->GetDrive();
 			if (hdrive==0xff) {
@@ -676,7 +676,7 @@ bool DOS_IOCTL(void) {
 		return false;
 	case 0x06:      /* Get Input Status */
 		if (Files[handle]->GetInformation() & 0x8000) {		//Check for device
-			reg_al=(Files[handle]->GetInformation() & 0x40) ? 0x0 : 0xff;
+			reg_al = ((DOS_Device*)(Files[handle]))->GetStatus(true);
 		} else { // FILE
 			uint32_t oldlocation=0;
 			Files[handle]->Seek(&oldlocation, DOS_SEEK_CUR);
@@ -692,6 +692,10 @@ bool DOS_IOCTL(void) {
 		}
 		return true;
 	case 0x07:		/* Get Output Status */
+		if (Files[handle]->GetInformation() & EXT_DEVICE_BIT) {
+			reg_al = ((DOS_Device*)(Files[handle]))->GetStatus(false);
+			return true;
+		}
 		LOG(LOG_IOCTL,LOG_NORMAL)("07:Fakes output status is ready for handle %d",(int)handle);
 		reg_al=0xff;
 		return true;

--- a/src/dos/dos_tables.cpp
+++ b/src/dos/dos_tables.cpp
@@ -399,6 +399,9 @@ void DOS_SetupTables(void) {
 	}
     dos_infoblock.SetFirstDPB(RealMake(dos.tables.dpb,0));
 
+	/* Create Device command packet area */
+	dos.dcp = DOS_GetMemory(3, "External device command packet");
+
 	/* Create a fake disk buffer head */
 	seg=DOS_GetMemory(6,"Fake disk buffer head");
 	for (uint8_t ct=0; ct<0x20; ct++) real_writeb(seg,ct,0);


### PR DESCRIPTION
# Description
Fixed GET INPUT/OUTPUT STATUS not working for character devices registered at device.com.

**Does this PR address some issue(s) ?**
Fixed the problem that int 21h ax=4406h/ax=4407h did not call the registered device driver.
The memory for Device Command Packet(DCP) was not allocated, which is also fixed.
