### PR TITLE
Allow borderline quotient values in IDIV

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 0.83.19
+  - Fix IDIV instruction incorrectly raising a divide
+    error exception for some borderline values. Fixes
+    Microsoft Flight Simulator. (Allofich)
   - Fix horizontal lines in the debugger window being
     rendered as unrelated characters in some code
     pages. (Allofich)

--- a/src/cpu/instructions.h
+++ b/src/cpu/instructions.h
@@ -700,7 +700,7 @@ extern bool enable_fpu;
 	Bits quo=((int16_t)reg_ax) / val;						\
 	int8_t rem=(int8_t)((int16_t)reg_ax % val);				\
 	int8_t quo8s=(int8_t)(quo&0xff);							\
-	if (quo!=(int16_t)quo8s) EXCEPTION(0);					\
+	if (quo!=(int16_t)quo8s && quo != 0x80) EXCEPTION(0);					\
 	reg_ah=(uint8_t)rem;												\
 	reg_al=(uint8_t)quo8s;											\
 	FillFlags();											\
@@ -721,7 +721,7 @@ extern bool enable_fpu;
 	Bits quo=num/val;										\
 	int16_t rem=(int16_t)(num % val);							\
 	int16_t quo16s=(int16_t)quo;								\
-	if (quo!=(int32_t)quo16s) EXCEPTION(0);					\
+	if (quo!=(int32_t)quo16s && quo != 0x8000) EXCEPTION(0);					\
 	reg_dx=(uint16_t)rem;												\
 	reg_ax=(uint16_t)quo16s;											\
 	FillFlags();											\
@@ -741,7 +741,7 @@ extern bool enable_fpu;
 	int64_t quo=num/val;										\
 	int32_t rem=(int32_t)(num % val);							\
 	int32_t quo32s=(int32_t)(quo&0xffffffff);					\
-	if (quo!=(int64_t)quo32s) EXCEPTION(0);					\
+	if (quo!=(int64_t)quo32s && quo != 0x80000000) EXCEPTION(0);					\
 	reg_edx=(uint32_t)rem;											\
 	reg_eax=(uint32_t)quo32s;											\
 	FillFlags();											\


### PR DESCRIPTION
0x80, 0x8000, 0x80000000 can fit in signed 8-bit, 16-bit and 32-bit
values, respectively, so don't raise an exception.

## What issues does this PR address?

Closes #3004. (There might be still be issues with the game. For example, the demo mode drives into the water without taking off. The same thing happens in MAME, however, and I don't know for sure that it is an emulation problem. The original issue of the game not starting, however, is fixed.)

## Additional information

According to https://www.felixcloutier.com/x86/idiv, an IDIV instruction raises the DE (divide error) exception if the quotient won't fit into the signed value. 0x80, 0x8000 and 0x80000000 each fit into signed 8-bit, 16-bit and 32-bit values, respectively. I also observed that MAME's emulation was allowing a quotient of 0x8000 for the 16-bit IDIV where DOSBox-X was throwing an exception and becoming stuck in a loop.