### PR TITLE
Fix WordStar macro issues

### DIFF
--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -799,6 +799,8 @@ uint8_t DOS_FindDevice(char const * name) {
 						break;
 					}
 				}
+			} else {
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
**Does this PR address some issue(s) ?**
Fixed a bug in #3012. 

**Additional information**
Inside DOS_FindDevice(), I'm checking if I can open a device registered at device.com.
In order to determine if the device is a registered device, GetInformation() is called, but the GetInfomation() of the built-in CON device calls int 16h, which seems to be the cause of this phenomenon.
It has been modified so that DOS_FindDevice () does not call GetInformation () of the built-in CON device. 
