### PR TITLE
Set DS to 0x40 before calling INT 9 in PCjr

### DIFF
--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -1469,9 +1469,13 @@ void BIOS_SetupKeyboard(void) {
          * a+4 = iret (1 bytes) */
         phys_writeb(a+5,0x50);          /* push ax */
         phys_writew(a+6,0x60E4);        /* in al,60h */
-        phys_writew(a+8,0x09CD);        /* int 9h */
-        phys_writeb(a+10,0x58);         /* pop ax */
-        phys_writew(a+11,0x00EB + ((256-13)<<8));    /* jmp a+0 */
+        phys_writeb(a+8,0x1e);          /* push ds */
+        phys_writew(a+9,0x406a);        /* push 0x0040 */
+        phys_writeb(a+11,0x1f);         /* pop ds */
+        phys_writew(a+12,0x09CD);       /* int 9h */
+        phys_writeb(a+14,0x1f);         /* pop ds */
+        phys_writeb(a+15,0x58);         /* pop ax */
+        phys_writew(a+16,0x00EB + ((256-18)<<8));    /* jmp a+0 */
     }
 
     if (IS_PC98_ARCH) {


### PR DESCRIPTION
Summary of changes brought by this PR.

## What issues does this PR address?

Closes #2453.

Essentially the same fix as https://sourceforge.net/p/dosbox/code-0/3884/ (incorporated into DOSBox-X as https://github.com/joncampbell123/dosbox-x/commit/3b6aba9d6e4bfdee08d9b460d2bbfa14a373bdb6). Currently when running the game SHAMUS, that code is not run, but rather the "PCjr NMI Keyboard" routine defined in `bios_keyboard.cpp` is run.

The game runs without issue in MAME, so I traced the execution there and found it was setting DS to 0x40 before calling INT 9. I tried adjusting "PCjr NMI Keyboard" to set DS to 0x40 before the call to INT 9, and the crashes stopped.
