### PR TITLE
Use keyboard buffer of 0x1E to 0x3E for CGA

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,12 @@
 0.83.19
+  - Use 0x1E to 0x3E for the keyboard buffer of the CGA
+    machine. Fixes the controls locking up in the PC booter
+    version of Apple Panic. (Allofich)
   - Fix PCjr NMI handler to use 8086-level instructions
     when loading DS with segment 0x0040 so that it
     works properly with cputype=8086.
+  - Fix PCjr NMI handler to load DS with segment 0x0040.
+    Fixes crashes in SHAMUS. (Allofich)
   - Fix IDIV instruction incorrectly raising a divide
     error exception for some borderline values. Fixes
     Microsoft Flight Simulator. (Allofich)

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -312,8 +312,8 @@ bool BIOS_AddKeyToBuffer(uint16_t code) {
         start=0x502;
         end=0x522;
     }
-    else if (machine==MCH_PCJR) {
-        /* should be done for cga and others as well, to be tested */
+    else if (machine==MCH_PCJR || machine==MCH_CGA) {
+        /* should be done for others as well, to be tested */
         start=0x1e;
         end=0x3e;
     } else {
@@ -374,8 +374,8 @@ static bool get_key(uint16_t &code) {
         start=0x502;
         end=0x522;
     }
-    else if (machine==MCH_PCJR) {
-        /* should be done for cga and others as well, to be tested */
+    else if (machine==MCH_PCJR || machine==MCH_CGA) {
+        /* should be done for others as well, to be tested */
         start=0x1e;
         end=0x3e;
     } else {


### PR DESCRIPTION
Summary of changes brought by this PR.

The controls would lock up in the PC Booter version of Apple Panic after playing for a bit. It turned out this was because the game overwrites the memory defined in DOSBox-X for `BIOS_KEYBOARD_BUFFER_START` (0x480) and `BIOS_KEYBOARD_BUFFER_END` (0x482) with other values. This removes the correct boundaries to the key buffer, so it gets written beyond where it should stop and after some time the address defined in DOSBox-X for `BIOS_KEYBOARD_AX_KBDSTATUS` (0x4EB) gets overwritten. When this happens the code in `IRQ1_Handler` to interpret key presses thinks that the "Kana holding" bit is set and returns incorrect results from that point on, and the game can no longer be controlled.

I noticed there was code to fix the keyboard buffer at 0x1E to 0x3E for PCjr, and a todo for using it for CGA "and others". Apple Panic works as a CGA game, so I tried applying this code to the CGA machine. The buffer now works for CGA mode and the controls no longer lock up.

Also updated the CHANGELOG.