### PR TITLE
Fix 0x0F opcode being accepted on 80186

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.83.20
+  - Fixed 0x0F opcode being valid on 80186 core when
+    it should be invalid. (Allofich)
   - Added stub IBM ROM BASIC points in the BIOS area
     so that when MS-DOS 1.x and 2.x BASIC.COM and BASICA.COM
     are run, a polite message is displayed instead of

--- a/src/cpu/core_normal/prefix_none.h
+++ b/src/cpu/core_normal/prefix_none.h
@@ -48,18 +48,17 @@
 	CASE_W(0x0e)												/* PUSH CS */		
 		Push_16(SegValue(cs));break;
 	CASE_B(0x0f)												/* 2 byte opcodes*/
-#if CPU_CORE < CPU_ARCHTYPE_286
-		if (CPU_ArchitectureType < CPU_ARCHTYPE_286) {
-			/* 8086 emulation: treat as "POP CS" */
-			if (CPU_PopSeg(cs,false)) RUNEXCEPTION();
-			break;
-		}
-		else
+#if CPU_CORE == CPU_ARCHTYPE_8086
+		/* 8086 emulation: treat as "POP CS" */
+		if (CPU_PopSeg(cs,false)) RUNEXCEPTION();
+		break;
+#else
+        if (CPU_ArchitectureType == CPU_ARCHTYPE_80186)
+            goto illegal_opcode;
+        core.opcode_index|=OPCODE_0F;
+        goto restart_opcode;
+        break;
 #endif
-		{
-			core.opcode_index|=OPCODE_0F;
-			goto restart_opcode;
-		} break;
 	CASE_B(0x10)												/* ADC Eb,Gb */
 		RMEbGb(ADCB);break;
 	CASE_W(0x11)												/* ADC Ew,Gw */

--- a/vs2015/log.txt
+++ b/vs2015/log.txt
@@ -1,0 +1,171 @@
+Logging: opened logfile 'log.txt' successfully. All further logging will go to this file.
+Win32 EnumDisplayDevices #0: name=\\.\DISPLAY1 string=NVIDIA GeForce GTX 660
+Win32 EnumDisplayDevices #1: name=\\.\DISPLAY2 string=NVIDIA GeForce GTX 660
+Win32 EnumDisplayDevices #2: name=\\.\DISPLAY3 string=NVIDIA GeForce GTX 660
+Win32 EnumDisplayDevices #3: name=\\.\DISPLAY4 string=NVIDIA GeForce GTX 660
+DOSBox-X version 0.83.20 (Windows SDL1)
+         0       MISC:Copyright 2011-2021 The DOSBox-X Team. Project maintainer: joncampbell123 (The Great Codeholio). DOSBox-X published under GNU GPL.
+         0       GUI:Press Ctrl-F10 to capture/release mouse, Alt-F10 for configuration.
+Windows keyboard layout ID is 0x0409
+Host keyboard layout is now us (US English)
+Mapper keyboard layout is now us (US English)
+The default output for the video system: direct3d
+Configured windowposition: 
+Screen report: Method 'Win98base' (1920.000 x 1080.000 pixels) at (0.000 x 0.000) (508.000 x 285.750 mm) (20.000 x 11.250 in) (96.000 x 96.000 DPI)
+WARNING: DOS/V is only supported for VGA video cards.
+ISA BCLK: 8333333.333Hz (25000000/3)
+monopal: green, 
+Active save slot: 1 [Empty]
+USING AVI+ZMBV
+Max 1048576 sz 16384
+Final 16384
+MIDI:Opened device:win32
+         0       CPU:Real mode
+CPU warning: 80186 cpu type is experimental at this time
+         0       FPU:FPU core: x86 FPU
+         0 WARN  MISC:Can't find matching event for key_jp_ro
+VOODOO LFB now at d0000000
+Serial1: BASE 3f8h
+Serial2: BASE 2f8h
+Parallel1: BASE 378h
+MPU-401 Registering I/O ports as if IBM PC MPU-401 at base 330h
+         0       MISC:MPU IRQ 9
+         0       VGA:Video RAM: 16KB
+Screen report: Method 'Win98base' (1920.000 x 1080.000 pixels) at (0.000 x 0.000) (508.000 x 285.750 mm) (20.000 x 11.250 in) (96.000 x 96.000 DPI)
+Allocated APM BIOS pm entry point at f000:ce40
+Writing code to fce40
+         0       KEYBOARD:Keyboard AUX emulation enabled
+         0       SBLASTER:DSP:Reset
+Screen report: Method 'Win98base' (1920.000 x 1080.000 pixels) at (0.000 x 0.000) (508.000 x 285.750 mm) (20.000 x 11.250 in) (96.000 x 96.000 DPI)
+Windows: IID_ITaskbarList3 is available
+         3       INT10:Set Video Mode 3
+         3       INT10:Set Video Mode 3
+         3       VGA:Blinking 32
+         3       MOUSE:INT 15H PS/2 emulation enabled
+ISA Plug & Play BIOS enabled
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page c0
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page c1
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page c2
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page c3
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page c4
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page c5
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page c6
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page c7
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page c8
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page c9
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page ca
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page cb
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page cc
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page cd
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page ce
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page cf
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page d0
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page d1
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page d2
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page d3
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page d4
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page d5
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page d6
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page d7
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page d8
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page d9
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page da
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page db
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page dc
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page dd
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page de
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page df
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page e0
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page e1
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page e2
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page e3
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page e4
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page e5
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page e6
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page e7
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page e8
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page e9
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page ea
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page eb
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page ec
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page ed
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page ee
+         5 WARN  MISC:MEM_SlowPath called within system RAM at page ef
+         8       INT10:Set Video Mode 6
+         8       INT10:Set Video Mode 6
+         8       VGA:Blinking 0
+      1751       VGA:h total  57 end  40 blank ( 40/ 57) retrace ( 41/ 47)
+      1751       VGA:v total 262 end 200 blank (200/262) retrace (224/240)
+      1751       VGA:VGA refresh rate is now, 119.846
+      1751       VGA:screen: 1.333, scanfield: 1.382, scan: 0.965, vratio: 3.200
+      1751       VGA:h total 0.03185 (31.40kHz) blank(0.02235/0.03185) retrace(0.02291/0.02626)
+      1751       VGA:v total 0.00000 (infHz) blank(6.36952/8.34407) retrace(7.13387/7.64343)
+      1751       VGA:video clock: 14.32MHz mode M_TANDY2
+      1751       VGA:640x200, 119.85Hz, 8bpp, screen 1.333
+pixratio 1.200, dw false, dh true
+Aspect ratio: 640 x 480  xToY=1.333 yToX=0.750
+Screen report: Method 'Win98base' (1920.000 x 1080.000 pixels) at (0.000 x 0.000) (508.000 x 285.750 mm) (20.000 x 11.250 in) (96.000 x 96.000 DPI)
+Screen report: Method 'Win98base' (1920.000 x 1080.000 pixels) at (0.000 x 0.000) (508.000 x 285.750 mm) (20.000 x 11.250 in) (96.000 x 96.000 DPI)
+Screen report: Method 'Win98base' (1920.000 x 1080.000 pixels) at (0.000 x 0.000) (508.000 x 285.750 mm) (20.000 x 11.250 in) (96.000 x 96.000 DPI)
+Aspect ratio: 640 x 480  xToY=1.333 yToX=0.750
+Screen report: Method 'Win98base' (1920.000 x 1080.000 pixels) at (0.000 x 0.000) (508.000 x 285.750 mm) (20.000 x 11.250 in) (96.000 x 96.000 DPI)
+     18003 ERROR CPU:CPU Type 25
+     35856 ERROR CPU:CPU Type 25
+     53755 ERROR CPU:CPU Type 25
+     71590 ERROR CPU:CPU Type 25
+     89491 ERROR CPU:CPU Type 25
+    107375 ERROR CPU:CPU Type 25
+    125244 ERROR CPU:CPU Type 25
+    143151 ERROR CPU:CPU Type 25
+    160993 ERROR CPU:CPU Type 25
+    178899 ERROR CPU:CPU Type 25
+    196751 ERROR CPU:CPU Type 25
+    214634 ERROR CPU:CPU Type 25
+    232534 ERROR CPU:CPU Type 25
+    250385 ERROR CPU:CPU Type 25
+    268283 ERROR CPU:CPU Type 25
+    286134 ERROR CPU:CPU Type 25
+    304028 ERROR CPU:CPU Type 25
+    321910 ERROR CPU:CPU Type 25
+    334240       INT10:Set Video Mode 3
+    334240       INT10:Set Video Mode 3
+    334240       VGA:Blinking 32
+    334243       DOSMISC:DOS clipboard device (dummy access) is enabled with the name CLIP$
+XMS: 50 handles allocated for use by the DOS environment
+CPU is 80186 or lower model that lacks the address lines needed for 'extended memory' to exist, disabling XMS
+EMS page frame at 0xe000-0xefff
+CPU is 286 or lower, setting EMS emulation to ems=emsboard and disabling VCPI and v86 startup
+COMMAND.COM env size:             720 bytes
+COMMAND.COM environment block:    0x0701 sz=0x002d
+COMMAND.COM main body (PSP):      0x072f sz=0x009a
+COMMAND.COM stack:                0x0749
+    334243       FILES:file open command 2 file CON
+    334243       FILES:file open command 2 file CON
+    334243       FILES:file open command 2 file CON
+    334243       FILES:file open command 2 file PRN
+    334243       MOUSE:INT 33H emulation enabled
+    334248 ERROR CPU:CPU Type 25
+    334556       VGA:h total 114 end  80 blank ( 80/114) retrace ( 81/ 93)
+    334556       VGA:v total 262 end 200 blank (200/262) retrace (216/232)
+    334556       VGA:VGA refresh rate is now, 59.923
+    334556       VGA:screen: 1.333, scanfield: 1.382, scan: 0.965, vratio: 3.200
+    334556       VGA:h total 0.06370 (15.70kHz) blank(0.04470/0.06370) retrace(0.04526/0.05196)
+    334556       VGA:v total 8.34407 (119.85Hz) blank(12.73905/16.68815) retrace(13.75817/14.77729)
+    334556       VGA:video clock: 14.32MHz mode M_TANDY_TEXT
+    334556       VGA:640x200, 59.92Hz, 8bpp, screen 1.333
+pixratio 1.200, dw false, dh true
+Aspect ratio: 640 x 480  xToY=1.333 yToX=0.750
+Screen report: Method 'Win98base' (1920.000 x 1080.000 pixels) at (0.000 x 0.000) (508.000 x 285.750 mm) (20.000 x 11.250 in) (96.000 x 96.000 DPI)
+    334890 ERROR CPU:CPU Type 25
+    339957 ERROR CPU:CPU Type 25
+    357709 ERROR CPU:CPU Type 25
+    369578 ERROR CPU:CPU Type 25
+    385907 ERROR CPU:CPU Type 25
+    402125 ERROR CPU:CPU Type 25
+    418442 ERROR CPU:CPU Type 25
+    434959 ERROR CPU:CPU Type 25
+    450989 ERROR CPU:CPU Type 25
+    463434 ERROR CPU:CPU Type 25
+    476999 ERROR CPU:CPU Type 25
+    491255 ERROR CPU:CPU Type 25
+***| TYPE HELP (+ENTER) TO GET AN OVERVIEW OF ALL COMMANDS |***


### PR DESCRIPTION
According to https://www.pcjs.org/documents/manuals/intel/8086/

> POP CS (0x0F)
> 
> This single-byte opcode existed only on the 8086/8088, and was of limited use, since it altered CS without a corresponding IP.
> 
> There is no POP CS instruction on later x86 CPUs. The opcode was explicitly made invalid on the 80186/80188, but was reused on later CPUs (starting with the 80286) as the first byte in a series of two-byte opcodes.

Under current code, the 80186 accepts 0x0F as the first byte of a two-byte opcode like the 286+, but this PR makes it an illegal opcode instead to match what the above site says.

Note that the current code misleadingly looks like it would make 80186 wrongly treat 0F like the 8086 does, but the 80186 shares the 80286 code and CPU_CORE is set to CPU_ARCHTYPE_286 for it, so `CPU_CORE < CPU_ARCHTYPE_286` won't be entered for it.