### PR TITLE
Limit prefix bug to when REP/REPZ is being used

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,8 @@
     opcodes 0x70-0x7F. (Allofich)
   - Fixed 0x0F opcode being valid on 80186 core when
     it should be invalid. (Allofich)
+  - Adjusted multiple-prefix bug for 8086/286 to only
+    apply when REP or REPZ is used. (Allofich)
   - Added stub IBM ROM BASIC points in the BIOS area
     so that when MS-DOS 1.x and 2.x BASIC.COM and BASICA.COM
     are run, a polite message is displayed instead of

--- a/src/cpu/core_normal_286.cpp
+++ b/src/cpu/core_normal_286.cpp
@@ -88,7 +88,12 @@ extern Bitu cycle_count;
 #define TEST_PREFIX_REP		(core.prefixes & PREFIX_REP)
 
 #define DO_PREFIX_SEG(_SEG)					\
-    if (GETFLAG(IF) && CPU_Cycles <= 0 && !mustCompleteInstruction) goto prefix_out; \
+    if (GETFLAG(IF) && CPU_Cycles <= 0 && !mustCompleteInstruction) \
+    {   \
+        uint8_t next = LoadMb(core.cseip + 1);  \
+        if (next == 0xf2 || next == 0xf3)   \
+            goto prefix_out;    \
+    }   \
 	BaseDS=SegBase(_SEG);					\
 	BaseSS=SegBase(_SEG);					\
 	core.base_val_ds=_SEG;					\

--- a/src/cpu/core_normal_8086.cpp
+++ b/src/cpu/core_normal_8086.cpp
@@ -124,7 +124,12 @@ extern Bitu cycle_count;
 #define TEST_PREFIX_REP		(core.prefixes & PREFIX_REP)
 
 #define DO_PREFIX_SEG(_SEG)					\
-    if (GETFLAG(IF) && CPU_Cycles <= 0 && !mustCompleteInstruction) goto prefix_out; \
+    if (GETFLAG(IF) && CPU_Cycles <= 0 && !mustCompleteInstruction) \
+    {   \
+        uint8_t next = LoadMb(core.cseip + 1);  \
+        if (next == 0xf2 || next == 0xf3)   \
+            goto prefix_out;    \
+    }   \
 	BaseDS=SegBase(_SEG);					\
 	BaseSS=SegBase(_SEG);					\
 	core.base_val_ds=_SEG;					\

--- a/src/cpu/core_prefetch_286.cpp
+++ b/src/cpu/core_prefetch_286.cpp
@@ -91,7 +91,12 @@ Bits CPU_Core_Prefetch_Trap_Run(void);
 #define TEST_PREFIX_REP		(core.prefixes & PREFIX_REP)
 
 #define DO_PREFIX_SEG(_SEG)					\
-    if (GETFLAG(IF) && CPU_Cycles <= 0) goto prefix_out; \
+    if (GETFLAG(IF) && CPU_Cycles <= 0) \
+    {   \
+        uint8_t next = LoadMb(core.cseip + 1);  \
+        if (next == 0xf2 || next == 0xf3)   \
+            goto prefix_out;    \
+    }   \
 	BaseDS=SegBase(_SEG);					\
 	BaseSS=SegBase(_SEG);					\
 	core.base_val_ds=_SEG;					\

--- a/src/cpu/core_prefetch_8086.cpp
+++ b/src/cpu/core_prefetch_8086.cpp
@@ -129,7 +129,12 @@ Bits CPU_Core_Prefetch_Trap_Run(void);
 #define TEST_PREFIX_REP		(core.prefixes & PREFIX_REP)
 
 #define DO_PREFIX_SEG(_SEG)					\
-    if (GETFLAG(IF) && CPU_Cycles <= 0) goto prefix_out; \
+    if (GETFLAG(IF) && CPU_Cycles <= 0) \
+    {   \
+        uint8_t next = LoadMb(core.cseip + 1);  \
+        if (next == 0xf2 || next == 0xf3)   \
+            goto prefix_out;    \
+    }   \
 	BaseDS=SegBase(_SEG);					\
 	BaseSS=SegBase(_SEG);					\
 	core.base_val_ds=_SEG;					\


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

This adjusts the emulation of the 8086/286 prefix bug so that it only happens if one of the two prefixes is either REP or REPZ.

Reason for this change:
- I started looking at this because the PC booter game "J-Bird" won't start in DOSBox-X when using cputype=8086. It gets stuck in a loop due to emulation of this bug triggering on `lds dx,cs:[0047]`. See discussion in https://github.com/joncampbell123/dosbox-x/commit/55509f051fd21d1c6e1785d212fe6512679a6f43. Information on this bug at https://www.pcjs.org/documents/manuals/intel/8086/ specifically says it happens with repeated string instructions, and the demonstration at https://www.youtube.com/watch?v=6FC-tcwMBnU also only shows it happening with a REP MOVSB. Preventing the bug from happening with LDS allows J-Bird to get further in starting up on 8086 (it still fails, going into a loop where it keeps briefly showing a cursor in the upper right. This matches what happens when the game is run in MAME, which also gets stuck there. 8086_prefetch works, meanwhile, works correctly even on current master branch code.)

Note that the pcjs site only mentions this bug for 8086/8088. The YouTube video also demonstrates on what the guy in the video says is an IBM 5160, which according to https://en.wikipedia.org/wiki/IBM_Personal_Computer_XT has an 8088. He does say at one point in the video and in the title that the bug happens from the 8086 through the 286, but I think it would be nice to have some other confirmation that it happens beyond the 8086/8088. I couldn't find any.

I'm making this a draft because my changes here are a bit of a guess and I don't know how to test that the prefix bug is happening correctly. J-Bird on cputype=8086 boots further, but I don't have a test case for when the prefix bug is supposed to happen.