### PR TITLE
Fix CGA to always use 8-pixel-height characters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,6 +27,10 @@
     apply when REP or REPZ is used. (Allofich)
   - Fixed 0x0F opcode being valid on 80186 core when
     it should be invalid. (Allofich)
+  - Fixed CGA modes to always use a character height
+    of 8, rather than reading it from address 485h.
+    Fixes corrupt graphics in the PC Booter version
+    of Apple Panic. (Allofich)
   - Fixed possible crash with printing. (jamesbond3142)
   - Video emulation for PC-98 mode (for 400-line modes)
     is now 16:10 instead of 4:3. 480-line PC-98 modes

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -1140,7 +1140,7 @@ static void INT10_Seg40Init(void) {
 	}
 	else {
 		real_writeb(BIOSMEM_SEG,BIOSMEM_VIDEO_CTL,0x00);
-		if (machine == MCH_TANDY || machine == MCH_CGA || machine == MCH_PCJR)
+		if (machine == MCH_TANDY || machine == MCH_PCJR)
 			real_writeb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT,8); /* FIXME: INT 10h teletext routines depend on this */
 		else
 			real_writeb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT,0);

--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -1529,7 +1529,7 @@ void WriteChar(uint16_t col,uint16_t row,uint8_t page,uint16_t chr,uint8_t attr,
     /* Externally used by the mouse routine */
     PhysPt fontdata;
     uint16_t cols = real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);
-    uint8_t back, cheight = IS_PC98_ARCH ? 16 : real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
+    uint8_t back, cheight = IS_PC98_ARCH ? 16 : machine == MCH_CGA ? 8 : real_readb(BIOSMEM_SEG,BIOSMEM_CHAR_HEIGHT);
 
     if (CurMode->type != M_PC98)
         chr &= 0xFF;


### PR DESCRIPTION
I noticed that the PC Booter version of the game "Apple Panic" had corrupted graphics, while the non-booter version that you can find for download does not.

![Corrupted](https://user-images.githubusercontent.com/19624336/140644033-4d6ce7a1-90ce-4133-a4c9-0df877d13692.png)
PC Booter game Apple Panic with corrupted graphics

I located the problem in `WriteChar` in `int10_char.cpp`. Character height was being read from address 0x485 in the BIOS. In the non-booter version, this worked because of a line that sets that value to 8, but that seems to be a hack based on the FIXME comment there. The PC Booter version overwrites that value and it ends up as 40h. This causes the graphics corruption when the game tries to draw text on the screen.

The game runs correctly in MAME. MAME's debugger supports setting watchpoints, and 0x485 was not read by the INT 10 AH 9 routine used to draw text to the screen (MAME uses dumped BIOS ROM code, so this should be how a real BIOS CGA BIOS acts). http://www.ctyme.com/intr/rb-0069.htm#Table10 lists INT 10 modes, and all CGA modes use 8 for pixel height. Hardcoding to 8 for CGA fixes the graphics in Apple Panic. I also removed the hack setting 0x485 to 8 for CGA (it remains for Tandy and PCjr).

![Fixed](https://user-images.githubusercontent.com/19624336/140644501-8c611b81-8edf-432c-b218-e06dbb8a0323.png)


