### PR TITLE
Make memory B0000-B7FFF unmapped in CGA mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,6 +46,9 @@
     of 8, rather than reading it from address 485h.
     Fixes corrupt graphics in the PC Booter version
     of Apple Panic. (Allofich)
+  - Make memory B0000-B7FFF unmapped for the CGA
+    emulation. Fixes "Backgammon 5.0" detecting that
+    an MDA is also present when using CGA. (Allofich)
   - Fixed possible crash with printing. (jamesbond3142)
   - Video emulation for PC-98 mode (for 400-line modes)
     is now 16:10 instead of 4:3. 480-line PC-98 modes

--- a/src/hardware/vga_memory.cpp
+++ b/src/hardware/vga_memory.cpp
@@ -2283,6 +2283,7 @@ void VGA_SetupHandlers(void) {
 	PageHandler *newHandler;
 	switch (machine) {
 	case MCH_CGA:
+        MEM_ResetPageHandler_Unmapped( VGA_PAGE_B0, 8 );            // B0000-B7FFF is unmapped
 		if (enableCGASnow && (vga.mode == M_TEXT || vga.mode == M_TANDY_TEXT))
 			MEM_SetPageHandler( VGA_PAGE_B8, 8, &vgaph.cgatext );
 		else


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

Fixes #3057. See the bug report for more details. With this PR "Backgammon 5.0" will no longer detect an MDA being also present when running with CGA.