### PR TITLE
Make floppy disk I/O configurable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -68,6 +68,10 @@
   - Make memory B0000-B7FFF unmapped for the CGA
     emulation. Fixes "Backgammon 5.0" detecting that
     an MDA is also present when using CGA. (Allofich)
+  - Make floppy I/O delay separataly configurable from
+    hard drive delay, and make it slower than before
+    by default.(Allofich)
+  - Fixed possible crash with printing. (jamesbond3142)
   - Video emulation for PC-98 mode (for 400-line modes)
     is now 16:10 instead of 4:3. 480-line PC-98 modes
     are still 4:3. (joncampbell123)

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -966,6 +966,9 @@ timeout     = 0
 #      hard drive data rate limit: Slow down (limit) hard disk throughput. This setting controls the limit in bytes/second.
 #                                    Set to 0 to disable the limit, or -1 (default) to use a reasonable limit.
 #                                    The disk I/O performance as in DOSBox SVN can be achieved by setting this to 0.
+#    floppy drive data rate limit: Slow down (limit) floppy disk throughput. This setting controls the limit in bytes/second.
+#                                    Set to 0 to disable the limit, or -1 (default) to use a reasonable limit.
+#                                    The disk I/O performance as in DOSBox SVN can be achieved by setting this to 0.
 #                        ansi.sys: If set (by default), ANSI.SYS emulation is on. If clear, ANSI.SYS is not emulated and will not appear to be installed.
 #                                    NOTE: This option has no effect in PC-98 mode where MS-DOS systems integrate ANSI.SYS into the DOS kernel.
 #                     log console: If set, log DOS CON output to the log file. Setting to "quiet" will log DOS CON output only (no debugging output).

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -1926,6 +1926,9 @@ timeout     = 0
 #                       hard drive data rate limit: Slow down (limit) hard disk throughput. This setting controls the limit in bytes/second.
 #                                                     Set to 0 to disable the limit, or -1 (default) to use a reasonable limit.
 #                                                     The disk I/O performance as in DOSBox SVN can be achieved by setting this to 0.
+#                     floppy drive data rate limit: Slow down (limit) floppy disk throughput. This setting controls the limit in bytes/second.
+#                                                     Set to 0 to disable the limit, or -1 (default) to use a reasonable limit.
+#                                                     The disk I/O performance as in DOSBox SVN can be achieved by setting this to 0.
 #                                drive z is remote: If set, DOS will report drive Z as remote. If not set, DOS will report drive Z as local.
 #                                                     If auto (default), DOS will report drive Z as remote or local depending on the program.
 #                                                     Set this option to true to prevent SCANDISK.EXE from attempting scan and repair drive Z:

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3897,6 +3897,12 @@ void DOSBOX_SetupConfigSections(void) {
                    "The disk I/O performance as in DOSBox SVN can be achieved by setting this to 0.");
     Pint->SetBasic(true);
 
+    Pint = secprop->Add_int("floppy drive data rate limit", Property::Changeable::WhenIdle, -1);
+    Pint->Set_help("Slow down (limit) floppy disk throughput. This setting controls the limit in bytes/second.\n"
+                   "Set to 0 to disable the limit, or -1 (default) to use a reasonable limit.\n"
+                   "The disk I/O performance as in DOSBox SVN can be achieved by setting this to 0.");
+    Pint->SetBasic(true);
+
     Pstring = secprop->Add_string("drive z is remote",Property::Changeable::WhenIdle,"auto");
     Pstring->Set_values(truefalseautoopt);
     Pstring->Set_help("If set, DOS will report drive Z as remote. If not set, DOS will report drive Z as local.\n"

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -734,7 +734,7 @@ void IDE_ResetDiskByBIOS(unsigned char disk);
 void IDE_EmuINT13DiskReadByBIOS(unsigned char disk,unsigned int cyl,unsigned int head,unsigned sect);
 void IDE_EmuINT13DiskReadByBIOS_LBA(unsigned char disk,uint64_t lba);
 
-void diskio_delay(Bits value/*bytes*/);
+void diskio_delay(Bits value/*bytes*/, int type = -1);
 
 static Bitu INT13_DiskHandler(void) {
     uint16_t segat, bufptr;
@@ -859,7 +859,10 @@ static Bitu INT13_DiskHandler(void) {
         for(i=0;i<reg_al;i++) {
             last_status = imageDiskList[drivenum]->Read_Sector((uint32_t)reg_dh, (uint32_t)(reg_ch | ((reg_cl & 0xc0)<< 2)), (uint32_t)((reg_cl & 63)+i), sectbuf);
 
-            diskio_delay(512);
+            if (drivenum < 2)
+                diskio_delay(512, 0); // Floppy
+            else
+                diskio_delay(512);
 
             /* IDE emulation: simulate change of IDE state that would occur on a real machine after INT 13h */
             IDE_EmuINT13DiskReadByBIOS(reg_dl, (uint32_t)(reg_ch | ((reg_cl & 0xc0)<< 2)), (uint32_t)reg_dh, (uint32_t)((reg_cl & 63)+i));
@@ -908,7 +911,10 @@ static Bitu INT13_DiskHandler(void) {
                 bufptr++;
             }
 
-            diskio_delay(512);
+            if(drivenum < 2)
+                diskio_delay(512, 0); // Floppy
+            else
+                diskio_delay(512);
 
             last_status = imageDiskList[drivenum]->Write_Sector((uint32_t)reg_dh, (uint32_t)(reg_ch | ((reg_cl & 0xc0) << 2)), (uint32_t)((reg_cl & 63) + i), &sectbuf[0]);
             if(last_status != 0x00) {
@@ -1117,7 +1123,10 @@ static Bitu INT13_DiskHandler(void) {
         for(i=0;i<dap.num;i++) {
             last_status = imageDiskList[drivenum]->Read_AbsoluteSector(dap.sector+i, sectbuf);
 
-            diskio_delay(512);
+            if(drivenum < 2)
+                diskio_delay(512, 0); // Floppy
+            else
+                diskio_delay(512);
 
             IDE_EmuINT13DiskReadByBIOS_LBA(reg_dl,dap.sector+i);
 
@@ -1152,7 +1161,10 @@ static Bitu INT13_DiskHandler(void) {
                 bufptr++;
             }
 
-            diskio_delay(512);
+            if(drivenum < 2)
+                diskio_delay(512, 0); // Floppy
+            else
+                diskio_delay(512);
 
             last_status = imageDiskList[drivenum]->Write_AbsoluteSector(dap.sector+i, &sectbuf[0]);
             if(last_status != 0x00) {


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?
https://github.com/joncampbell123/dosbox-x/issues/2835 (partially)

I've been testing old PC booter games lately, and I've found that some of them have their title screens fly by very quickly due to the floppy drive emulation being too fast.

Probably the most extreme example I've seen of this is "Tapper" (RGB version).

https://user-images.githubusercontent.com/19624336/140979897-3080e22b-381f-45c2-9f57-51a922d9af17.mp4

This PR is a simple hack to lower the floppy drive speed to something more reasonable so that title screens like these can be seen. It's only applied when the floppy is accessed through Int 13 and the new speed is not based on a real drive's speed. Floppy drive speeds cited by people online make for a (by modern standards) very slow load that is probably more accurate but also probably much longer than most of us want to wait. Instead the speed I chose here is a rough equivalent of the speed I saw when loading Tapper in MAME. It's still about 420x slower than before.

https://user-images.githubusercontent.com/19624336/140981697-7b6b28b1-0109-477e-9685-9287a67119fb.mp4


