### PR TITLE
Don't try to read sector for INT 13 with cl=0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -52,6 +52,8 @@
     of 8, rather than reading it from address 485h.
     Fixes corrupt graphics in the PC Booter version
     of Apple Panic. (Allofich)
+  - Fixed underflow when INT 13 AH=2 called for
+    sector 0. (Allofich)
   - Fixed possible crash with printing. (jamesbond3142)
   - Fixed possible freeze when shutting down Windows 9x
     after changing a CD image from the menu. (Wengier)

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -257,6 +257,11 @@ uint8_t imageDisk::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,v
     if (req_sector_size != sector_size)
         return 0x05;
 
+    if (sector == 0) {
+        LOG_MSG("Attempted to read invalid sector 0.");
+        return 0x05;
+    }
+
     sectnum = ( (cylinder * heads + head) * sectors ) + sector - 1L;
 
     return Read_AbsoluteSector(sectnum, data);

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -685,7 +685,8 @@ static uint8_t GetDosDriveNumber(uint8_t biosNum) {
 
 static bool driveInactive(uint8_t driveNum) {
     if(driveNum>=(2 + MAX_HDD_IMAGES)) {
-        LOG(LOG_BIOS,LOG_ERROR)("Disk %d non-existant", (int)driveNum);
+        int driveCalledFor = reg_dl & 0x7f;
+        LOG(LOG_BIOS,LOG_ERROR)("Disk %d non-existent", driveCalledFor);
         last_status = 0x01;
         CALLBACK_SCF(true);
         return true;


### PR DESCRIPTION
The PC booter game "Backgammon 5.0" creates this message in the log when run:

`Attempt to read invalid sector in Read_AbsoluteSector for sector 4294967295`

I think this message is misleading. What happens is Backgammon 5.0 calls INT 13 AH=2 (read sectors into memory) with CL=0. CL is the sector number, but valid values are 1 through 63.
http://www.ctyme.com/intr/rb-0607.htm
(Or, may only be 1 through 17, based on this site: https://stanislavs.org/helppc/int_13-2.html)

DOSBox-X gets the sector as
`( (cylinder * heads + head) * sectors ) + sector - 1L;` which for this call evaluates to 0 - 1, wrapping around to 4294967295. It tries to read this sector, which is beyond the size of the floppy and makes the error occur. The invalid sector called by the program, though, was 0, not 4294967295. This PR just catches this situation a moment earlier so the log message is more accurate.

Checking real BIOS behavior in MAME, it also returns an error of 4 in AH on this call and sets the carry flag, as DOSBox-X does.