### PR TITLE
Fix CPU cycles being halved when application regains focus in SDL2 while using "priority = ?, pause"

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -7881,7 +7881,9 @@ void GFX_Events() {
 #endif
                 SetPriority(sdl.priority.nofocus);
                 GFX_LosingFocus();
-                CPU_Enable_SkipAutoAdjust();
+                if( sdl.priority.nofocus != PRIORITY_LEVEL_PAUSE ) {
+                    CPU_Enable_SkipAutoAdjust();
+                }
                 break;
             default:
                 ;


### PR DESCRIPTION
Fix CPU cycles being halved when application regains focus in SDL2 while using "priority = ?, pause".
This was only fixed for the SDL1 build before.

Related PR : #2985 

## What issue(s) does this PR address?

#2983