### PR TITLE
Use xdg-open by default for -opencaptures and -opensaves

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -9924,10 +9924,22 @@ bool DOSBOX_parse_argv() {
             if (!control->cmdline->NextOptArgv(control->opt_editconf)) return false;
         }
         else if (optname == "opencaptures") {
-            if (!control->cmdline->NextOptArgv(control->opt_opencaptures)) return false;
+            if (!control->cmdline->NextOptArgv(control->opt_opencaptures)) {
+#if defined(LINUX)
+		    control->opt_opencaptures = "xdg-open";
+#else
+            return false;
+#endif
+	    }
         }
         else if (optname == "opensaves") {
-            if (!control->cmdline->NextOptArgv(control->opt_opensaves)) return false;
+            if (!control->cmdline->NextOptArgv(control->opt_opensaves)) {
+#if defined(LINUX)
+		    control->opt_opensaves = "xdg-open";
+#else
+            return false;
+#endif
+	    }
         }
         else if (optname == "eraseconf") {
             control->opt_eraseconf = true;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -9926,18 +9926,18 @@ bool DOSBOX_parse_argv() {
         else if (optname == "opencaptures") {
             if (!control->cmdline->NextOptArgv(control->opt_opencaptures)) {
 #if defined(LINUX)
-		    control->opt_opencaptures = "xdg-open";
+                control->opt_opencaptures = "xdg-open";
 #else
-            return false;
+                return false;
 #endif
 	    }
         }
         else if (optname == "opensaves") {
             if (!control->cmdline->NextOptArgv(control->opt_opensaves)) {
 #if defined(LINUX)
-		    control->opt_opensaves = "xdg-open";
+                control->opt_opensaves = "xdg-open";
 #else
-            return false;
+                return false;
 #endif
 	    }
         }


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

By default ``-opencaptures`` and ``-opensaves`` requires a file manager to be specified as an argument. With this change, if one is not specified on Linux, it will default to ``xdg-open`` which should be present on all modern Linux desktop environments and which will in turn open the folder in the default file manager.

I guess a similar change may be done for macosx and windows with "open" or via an api.