### PR TITLE
Re-apply core_dyn_x86 commits lost when that core was removed and restored

### DIFF
--- a/src/cpu/core_dyn_x86/cache.h
+++ b/src/cpu/core_dyn_x86/cache.h
@@ -116,7 +116,7 @@ public:
 		addr&=4095;
 		if (host_readb(hostmem+addr)==(uint8_t)val) return;
 		host_writeb(hostmem+addr,val);
-		if (!*(uint8_t*)&write_map[addr]) {
+		if ((*(uint8_t*)&write_map[addr]) == 0) {
 			if (active_blocks) return;
 			active_count--;
 			if (!active_count) Release();
@@ -136,7 +136,7 @@ public:
 		addr&=4095;
 		if (host_readw(hostmem+addr)==(uint16_t)val) return;
 		host_writew(hostmem+addr,val);
-		if (!*(uint16_t*)&write_map[addr]) {
+		if ((*(uint16_t*)&write_map[addr]) == 0) {
 			if (active_blocks) return;
 			active_count--;
 			if (!active_count) Release();
@@ -156,7 +156,7 @@ public:
 		addr&=4095;
 		if (host_readd(hostmem+addr)==(uint32_t)val) return;
 		host_writed(hostmem+addr,val);
-		if (!*(uint32_t*)&write_map[addr]) {
+		if ((*(uint32_t*)&write_map[addr]) == 0) {
 			if (active_blocks) return;
 			active_count--;
 			if (!active_count) Release();
@@ -175,7 +175,7 @@ public:
 		}
 		addr&=4095;
 		if (host_readb(hostmem+addr)==(uint8_t)val) return false;
-		if (!*(uint8_t*)&write_map[addr]) {
+		if ((*(uint8_t*)&write_map[addr]) == 0) {
 			if (!active_blocks) {
 				active_count--;
 				if (!active_count) Release();
@@ -201,7 +201,7 @@ public:
 		}
 		addr&=4095;
 		if (host_readw(hostmem+addr)==(uint16_t)val) return false;
-		if (!*(uint16_t*)&write_map[addr]) {
+		if ((*(uint16_t*)&write_map[addr]) == 0) {
 			if (!active_blocks) {
 				active_count--;
 				if (!active_count) Release();
@@ -227,7 +227,7 @@ public:
 		}
 		addr&=4095;
 		if (host_readd(hostmem+addr)==(uint32_t)val) return false;
-		if (!*(uint32_t*)&write_map[addr]) {
+		if ((*(uint32_t*)&write_map[addr]) == 0) {
 			if (!active_blocks) {
 				active_count--;
 				if (!active_count) Release();

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -733,7 +733,7 @@ static void dyn_read_byte(DynReg * addr,DynReg * dst,bool high,bool release=fals
 	gen_fill_branch(je_loc);
 	cache_addb(0x51);		// push ecx
 	cache_addb(0xe8);
-	cache_addd(((uint32_t)&(use_dynamic_core_with_paging ? mem_readb_checked_dcx86_pagefault : mem_readb_checked_dcx86)) - (uint32_t)cache_rwtox(cache.pos)-4);
+	cache_addd((uint32_t)((char*)(&(use_dynamic_core_with_paging ? mem_readb_checked_dcx86_pagefault : mem_readb_checked_dcx86)) - (char*)cache_rwtox(cache.pos) - 4));
 	cache_addw(0xc483);		// add esp,4
 	cache_addb(0x04);
 
@@ -828,8 +828,8 @@ static void dyn_read_word(DynReg * addr,DynReg * dst,bool dword,bool release=fal
 	}
 	cache_addb(0x51);		// push ecx
 	cache_addb(0xe8);
-	if (dword) cache_addd(((uint32_t)&(use_dynamic_core_with_paging ? mem_readd_checked_dcx86_pagefault : mem_readd_checked_dcx86)) - (uint32_t)cache_rwtox(cache.pos)-4);
-	else cache_addd(((uint32_t)&(use_dynamic_core_with_paging ? mem_readw_checked_dcx86_pagefault : mem_readw_checked_dcx86)) - (uint32_t)cache_rwtox(cache.pos)-4);
+	if (dword) cache_addd((uint32_t)((char*)(&(use_dynamic_core_with_paging ? mem_readd_checked_dcx86_pagefault : mem_readd_checked_dcx86)) - (char*)cache_rwtox(cache.pos) - 4));
+	else cache_addd((uint32_t)((char*)(&(use_dynamic_core_with_paging ? mem_readw_checked_dcx86_pagefault : mem_readw_checked_dcx86)) - (char*)cache_rwtox(cache.pos) - 4));
 	cache_addw(0xc483);		// add esp,4
 	cache_addb(0x04);
 
@@ -897,7 +897,7 @@ static void dyn_write_byte(DynReg * addr,DynReg * val,bool high,bool release=fal
 	cache_addb(0x50);	// push eax
 	if (GCC_UNLIKELY(high)) cache_addw(0xe086+((genreg->index+(genreg->index<<3))<<8));
 	cache_addb(0xe8);
-	cache_addd(((uint32_t)&(use_dynamic_core_with_paging ? mem_writeb_checked_pagefault : mem_writeb_checked)) - (uint32_t)cache_rwtox(cache.pos)-4);
+	cache_addd((uint32_t)((char*)(&(use_dynamic_core_with_paging ? mem_writeb_checked_pagefault : mem_writeb_checked)) - (char*)cache_rwtox(cache.pos) - 4));
 	cache_addw(0xc483);		// add esp,8
 	cache_addb(0x08);
 	cache_addb(0x5a);		// pop edx
@@ -941,8 +941,8 @@ static void dyn_write_word(DynReg * addr,DynReg * val,bool dword,bool release=fa
 	cache_addb(0x50+genreg->index);
 	cache_addb(0x50);	// push eax
 	cache_addb(0xe8);
-	if (dword) cache_addd(((uint32_t)&(use_dynamic_core_with_paging ? mem_writed_checked_pagefault : mem_writed_checked)) - (uint32_t)cache_rwtox(cache.pos)-4);
-	else cache_addd(((uint32_t)&(use_dynamic_core_with_paging ? mem_writew_checked_pagefault : mem_writew_checked)) - (uint32_t)cache_rwtox(cache.pos)-4);
+	if (dword) cache_addd((uint32_t)((char*)(&(use_dynamic_core_with_paging ? mem_writed_checked_pagefault : mem_writed_checked)) - (char*)cache_rwtox(cache.pos) - 4));
+	else cache_addd((uint32_t)((char*)(&(use_dynamic_core_with_paging ? mem_writew_checked_pagefault : mem_writew_checked)) - (char*)cache_rwtox(cache.pos) - 4));
 	cache_addw(0xc483);		// add esp,8
 	cache_addb(0x08);
 	cache_addb(0x5a);		// pop edx

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -602,13 +602,13 @@ static void dyn_fill_blocks(void) {
 #if C_TARGETCPU == X86
 				cache_addb(0xd9);   // FNSTCW fpu.host_cw
 				cache_addb(0x3d);
-				cache_addd((uint32_t)(&dyn_dh_fpu.host_cw));
+				cache_addd((uintptr_t)(&dyn_dh_fpu.host_cw));
 				cache_addb(0xdd);	// FRSTOR fpu.state (fpu_restore)
 				cache_addb(0x25);
-				cache_addd((uint32_t)(&dyn_dh_fpu.state));
+				cache_addd((uintptr_t)(&dyn_dh_fpu.state));
 				cache_addb(0xC6);   // mov byte [fpu.state_used], 1
 				cache_addb(0x05);
-				cache_addd((uint32_t)(&dyn_dh_fpu.state_used));
+				cache_addd((uintptr_t)(&dyn_dh_fpu.state_used));
 				cache_addb(1);
 #else // X86_64
 				opcode(7).setabsaddr(&dyn_dh_fpu.host_cw).Emit8(0xD9); // FNSTCW [&fpu.host_cw]
@@ -697,7 +697,7 @@ static void dyn_read_intro(DynReg * addr,bool release_addr=true) {
 		x86gen.regs[X86_REG_EAX]->Clear();
 		x86gen.regs[X86_REG_ECX]->Clear();
 		cache_addw(0x0d8b);		//Mov ecx,[data]
-		cache_addd((uint32_t)addr->data);
+		cache_addd((uintptr_t)addr->data);
 	}
 	x86gen.regs[X86_REG_EDX]->Clear();
 
@@ -721,7 +721,7 @@ static void dyn_read_byte(DynReg * addr,DynReg * dst,bool high,bool release=fals
 	cache_addb(0x0c);
 	cache_addw(0x048b);		// mov eax,paging.tlb.read[eax*TYPE uint32_t]
 	cache_addb(0x85);
-	cache_addd((uint32_t)(&paging.tlb.read[0]));
+	cache_addd((uintptr_t)(&paging.tlb.read[0]));
 	cache_addw(0xc085);		// test eax,eax
 	uint8_t* je_loc=gen_create_branch(BR_Z);
 
@@ -733,7 +733,7 @@ static void dyn_read_byte(DynReg * addr,DynReg * dst,bool high,bool release=fals
 	gen_fill_branch(je_loc);
 	cache_addb(0x51);		// push ecx
 	cache_addb(0xe8);
-	cache_addd((uint32_t)((char*)(&(use_dynamic_core_with_paging ? mem_readb_checked_dcx86_pagefault : mem_readb_checked_dcx86)) - (char*)cache_rwtox(cache.pos) - 4));
+	cache_addd((uintptr_t)(&(use_dynamic_core_with_paging ? mem_readb_checked_dcx86_pagefault : mem_readb_checked_dcx86)) - (uintptr_t)cache_rwtox(cache.pos) - (uintptr_t)4);
 	cache_addw(0xc483);		// add esp,4
 	cache_addb(0x04);
 
@@ -741,7 +741,7 @@ static void dyn_read_byte(DynReg * addr,DynReg * dst,bool high,bool release=fals
 	dyn_check_bool_exception_al();
 
 	cache_addw(0x058a);		//mov al,[]
-	cache_addd((uint32_t)(&core_dyn.readdata));
+	cache_addd((uintptr_t)(&core_dyn.readdata));
 
 	gen_fill_jump(jmp_loc);
 
@@ -810,7 +810,7 @@ static void dyn_read_word(DynReg * addr,DynReg * dst,bool dword,bool release=fal
 	cache_addd(0x000fffff);
 	cache_addw(0x048b);		// mov eax,paging.tlb.read[eax*TYPE uint32_t]
 	cache_addb(0x85);
-	cache_addd((uint32_t)(&paging.tlb.read[0]));
+	cache_addd((uintptr_t)(&paging.tlb.read[0]));
 	cache_addw(0xc085);		// test eax,eax
 	uint8_t* je_loc=gen_create_branch(BR_Z);
 
@@ -824,12 +824,12 @@ static void dyn_read_word(DynReg * addr,DynReg * dst,bool dword,bool release=fal
 
 	if (!dword) {
 		cache_addw(0x0589+(genreg->index<<11));   // mov [core_dyn.readdata], dst
-		cache_addd((uint32_t)&core_dyn.readdata);
+		cache_addd((uintptr_t)&core_dyn.readdata);
 	}
 	cache_addb(0x51);		// push ecx
 	cache_addb(0xe8);
-	if (dword) cache_addd((uint32_t)((char*)(&(use_dynamic_core_with_paging ? mem_readd_checked_dcx86_pagefault : mem_readd_checked_dcx86)) - (char*)cache_rwtox(cache.pos) - 4));
-	else cache_addd((uint32_t)((char*)(&(use_dynamic_core_with_paging ? mem_readw_checked_dcx86_pagefault : mem_readw_checked_dcx86)) - (char*)cache_rwtox(cache.pos) - 4));
+	if (dword) cache_addd((uintptr_t)(&(use_dynamic_core_with_paging ? mem_readd_checked_dcx86_pagefault : mem_readd_checked_dcx86)) - (uintptr_t)cache_rwtox(cache.pos) - (uintptr_t)4);
+	else cache_addd((uintptr_t)(&(use_dynamic_core_with_paging ? mem_readw_checked_dcx86_pagefault : mem_readw_checked_dcx86)) - (uintptr_t)cache_rwtox(cache.pos) - (uintptr_t)4);
 	cache_addw(0xc483);		// add esp,4
 	cache_addb(0x04);
 
@@ -867,7 +867,7 @@ static void dyn_write_intro(DynReg * addr,bool release_addr=true) {
 		x86gen.regs[X86_REG_ECX]->Clear();
 		x86gen.regs[X86_REG_ECX]->notusable=true;
 		cache_addb(0xa1);		//Mov eax,[data]
-		cache_addd((uint32_t)addr->data);
+		cache_addd((uintptr_t)addr->data);
 	}
 
 	cache_addw(0xc88b);		// mov ecx,eax
@@ -881,7 +881,7 @@ static void dyn_write_byte(DynReg * addr,DynReg * val,bool high,bool release=fal
 	cache_addb(0x0c);
 	cache_addw(0x0c8b);		// mov ecx,paging.tlb.write[ecx*TYPE uint32_t]
 	cache_addb(0x8d);
-	cache_addd((uint32_t)(&paging.tlb.write[0]));
+	cache_addd((uintptr_t)(&paging.tlb.write[0]));
 	cache_addw(0xc985);		// test ecx,ecx
 	uint8_t* je_loc=gen_create_branch(BR_Z);
 
@@ -897,7 +897,7 @@ static void dyn_write_byte(DynReg * addr,DynReg * val,bool high,bool release=fal
 	cache_addb(0x50);	// push eax
 	if (GCC_UNLIKELY(high)) cache_addw(0xe086+((genreg->index+(genreg->index<<3))<<8));
 	cache_addb(0xe8);
-	cache_addd((uint32_t)((char*)(&(use_dynamic_core_with_paging ? mem_writeb_checked_pagefault : mem_writeb_checked)) - (char*)cache_rwtox(cache.pos) - 4));
+	cache_addd((uintptr_t)(&(use_dynamic_core_with_paging ? mem_writeb_checked_pagefault : mem_writeb_checked)) - (uintptr_t)cache_rwtox(cache.pos) - (uintptr_t)4);
 	cache_addw(0xc483);		// add esp,8
 	cache_addb(0x08);
 	cache_addb(0x5a);		// pop edx
@@ -925,7 +925,7 @@ static void dyn_write_word(DynReg * addr,DynReg * val,bool dword,bool release=fa
 	cache_addd(0x000fffff);
 	cache_addw(0x0c8b);		// mov ecx,paging.tlb.write[ecx*TYPE uint32_t]
 	cache_addb(0x8d);
-	cache_addd((uint32_t)(&paging.tlb.write[0]));
+	cache_addd((uintptr_t)(&paging.tlb.write[0]));
 	cache_addw(0xc985);		// test ecx,ecx
 	uint8_t* je_loc=gen_create_branch(BR_Z);
 
@@ -941,8 +941,8 @@ static void dyn_write_word(DynReg * addr,DynReg * val,bool dword,bool release=fa
 	cache_addb(0x50+genreg->index);
 	cache_addb(0x50);	// push eax
 	cache_addb(0xe8);
-	if (dword) cache_addd((uint32_t)((char*)(&(use_dynamic_core_with_paging ? mem_writed_checked_pagefault : mem_writed_checked)) - (char*)cache_rwtox(cache.pos) - 4));
-	else cache_addd((uint32_t)((char*)(&(use_dynamic_core_with_paging ? mem_writew_checked_pagefault : mem_writew_checked)) - (char*)cache_rwtox(cache.pos) - 4));
+	if (dword) cache_addd((uintptr_t)(&(use_dynamic_core_with_paging ? mem_writed_checked_pagefault : mem_writed_checked)) - (uintptr_t)cache_rwtox(cache.pos) - (uintptr_t)4);
+	else cache_addd((uintptr_t)(&(use_dynamic_core_with_paging ? mem_writew_checked_pagefault : mem_writew_checked)) - (uintptr_t)cache_rwtox(cache.pos) - (uintptr_t)4);
 	cache_addw(0xc483);		// add esp,8
 	cache_addb(0x08);
 	cache_addb(0x5a);		// pop edx
@@ -2484,7 +2484,7 @@ static CacheBlock * CreateCacheBlock(CodePageHandler * codepage,PhysPt start,Bit
 		DynRegs[i].genreg=0;
 	}
 	gen_reinit();
-	gen_save_host_direct(&cache.block.running,(Bitu)decode.block);
+	gen_save_host_direct(&cache.block.running,(uintptr_t)decode.block);
 	/* Start with the cycles check */
 	gen_protectflags();
 	gen_dop_word(DOP_TEST,true,DREG(CYCLES),DREG(CYCLES));

--- a/src/cpu/core_dyn_x86/dyn_fpu.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu.h
@@ -106,7 +106,6 @@ static void dyn_fpu_esc0(){
 	if (decode.modrm.val >= 0xc0) { 
 		dyn_fpu_top();
 		Bitu group=(decode.modrm.val >> 3) & 7;
-		//Bitu sub=(decode.modrm.val & 7);
 		switch (group){
 		case 0x00:		//FADD ST,STi /
 			gen_call_function((void*)&FPU_FADD,"%Drd%Drd",DREG(TMPB),DREG(EA));
@@ -436,7 +435,6 @@ static void dyn_fpu_esc3(){
 static void dyn_fpu_esc4(){
 	dyn_get_modrm();  
 	Bitu group=(decode.modrm.val >> 3) & 7;
-	//Bitu sub=(decode.modrm.val & 7);
 	if (decode.modrm.val >= 0xc0) { 
 		dyn_fpu_top();
 		switch(group){

--- a/src/cpu/core_dyn_x86/risc_x86.h
+++ b/src/cpu/core_dyn_x86/risc_x86.h
@@ -1000,7 +1000,7 @@ static uint8_t * gen_create_branch_long(BranchTypes type) {
 }
 
 static void gen_fill_branch_long(uint8_t * data,uint8_t * from=cache.pos) {
-	*(uint32_t*)data=(from-data-4);
+	*((uint32_t*)data) = (from-data-4);
 }
 
 static uint8_t * gen_create_jump(uint8_t * to=0) {

--- a/src/cpu/core_dyn_x86/risc_x86.h
+++ b/src/cpu/core_dyn_x86/risc_x86.h
@@ -57,7 +57,7 @@ public:
 		dynreg->genreg=this;
 		if ((!stale) && (dynreg->flags & (DYNFLG_LOAD|DYNFLG_ACTIVE))) {
 			cache_addw(0x058b+(index << (8+3)));		//Mov reg,[data]
-			cache_addd((uint32_t)dynreg->data);
+			cache_addd((uintptr_t)dynreg->data);
 		}
 		dynreg->flags|=DYNFLG_ACTIVE;
 	}
@@ -65,7 +65,7 @@ public:
 		if (GCC_UNLIKELY(!((Bitu)dynreg))) IllegalOption("GenReg->Save");
 		dynreg->flags&=~DYNFLG_CHANGED;
 		cache_addw(0x0589+(index << (8+3)));		//Mov [data],reg
-		cache_addd((uint32_t)dynreg->data);
+		cache_addd((uintptr_t)dynreg->data);
 	}
 	void Release(void) {
 		if (GCC_UNLIKELY(!((Bitu)dynreg))) return;
@@ -307,7 +307,7 @@ static void gen_load_host(void * data,DynReg * dr1,Bitu size) {
 		IllegalOption("gen_load_host");
 	}
 	cache_addb(0x5+(gr1->index<<3));
-	cache_addd((uint32_t)data);
+	cache_addd((uintptr_t)data);
 	dr1->flags|=DYNFLG_CHANGED;
 }
 
@@ -321,7 +321,7 @@ static void gen_mov_host(void * data,DynReg * dr1,Bitu size,Bitu di1=0) {
 		IllegalOption("gen_mov_host");
 	}
 	cache_addb(0x5+((gr1->index+di1)<<3));
-	cache_addd((uint32_t)data);
+	cache_addd((uintptr_t)data);
 	dr1->flags|=DYNFLG_CHANGED;
 }
 
@@ -335,7 +335,7 @@ static void gen_save_host(void * data,DynReg * dr1,Bitu size,Bitu di1=0) {
 		IllegalOption("gen_save_host");
 	}
 	cache_addb(0x5+((gr1->index+di1)<<3));
-	cache_addd((uint32_t)data);
+	cache_addd((uintptr_t)data);
 	dr1->flags|=DYNFLG_CHANGED;
 }
 
@@ -409,7 +409,7 @@ static void gen_dop_byte_imm_mem(DualOps op,DynReg * dr1,uint8_t di1,void* data)
 	dr1->flags|=DYNFLG_CHANGED;
 nochange:
 	cache_addw(tmp+((gr1->index+di1)<<11));
-	cache_addd((uint32_t)data);
+	cache_addd((uintptr_t)data);
 }
 
 static void gen_sop_byte(SingleOps op,DynReg * dr1,uint8_t di1) {
@@ -497,7 +497,7 @@ static void gen_lea_imm_mem(DynReg * ddr,DynReg * dsr,void* data) {
 	GenReg * gdr=FindDynReg(ddr);
 	uint8_t rm_base=(gdr->index << 3);
 	cache_addw(0x058b+(rm_base<<8));
-	cache_addd((uint32_t)data);
+	cache_addd((uintptr_t)data);
 	GenReg * gsr=FindDynReg(dsr);
 	cache_addb(0x8d);		//LEA
 	cache_addb(rm_base+0x44);
@@ -590,7 +590,7 @@ static void gen_dop_word_imm_mem(DualOps op,bool dword,DynReg * dr1,void* data) 
 nochange:
 	if (!dword) cache_addb(0x66);
 	cache_addw(tmp+(gr1->index<<11));
-	cache_addd((uint32_t)data);
+	cache_addd((uintptr_t)data);
 }
 
 static void gen_dop_word_var(DualOps op,bool dword,DynReg * dr1,void* drd) {
@@ -613,7 +613,7 @@ static void gen_dop_word_var(DualOps op,bool dword,DynReg * dr1,void* drd) {
 	}
 	if (!dword) cache_addb(0x66);
 	cache_addw(tmp|(0x05+((gr1->index)<<3))<<8);
-	cache_addd((uint32_t)drd);
+	cache_addd((uintptr_t)drd);
 }
 
 static void gen_imul_word(bool dword,DynReg * dr1,DynReg * dr2) {
@@ -886,7 +886,7 @@ static void gen_call_function(void * func,char const* ops,...) {
 		DynRegs[G_ESP].genreg->Save();
 	/* Do the actual call to the procedure */
 	cache_addb(0xe8);
-	cache_addd((uint32_t)func - (uint32_t)cache_rwtox(cache.pos)-4);
+	cache_addd((uintptr_t)func - (uintptr_t)cache_rwtox(cache.pos) - (uintptr_t)4);
 	/* Restore the params of the stack */
 	if (paramcount) {
 		cache_addw(0xc483);				//add ESP,imm byte
@@ -961,9 +961,9 @@ static void gen_call_write(DynReg * dr,uint32_t val,Bitu write_size) {
 	/* Do the actual call to the procedure */
 	cache_addb(0xe8);
 	switch (write_size) {
-		case 1: cache_addd((uint32_t)(use_dynamic_core_with_paging ? mem_writeb_checked_pagefault : mem_writeb_checked) - (uint32_t)cache_rwtox(cache.pos)-4); break;
-		case 2: cache_addd((uint32_t)(use_dynamic_core_with_paging ? mem_writew_checked_pagefault : mem_writew_checked) - (uint32_t)cache_rwtox(cache.pos)-4); break;
-		case 4: cache_addd((uint32_t)(use_dynamic_core_with_paging ? mem_writed_checked_pagefault : mem_writed_checked) - (uint32_t)cache_rwtox(cache.pos)-4); break;
+		case 1: cache_addd((uintptr_t)(use_dynamic_core_with_paging ? mem_writeb_checked_pagefault : mem_writeb_checked) - (uintptr_t)cache_rwtox(cache.pos) - (uintptr_t)4); break;
+		case 2: cache_addd((uintptr_t)(use_dynamic_core_with_paging ? mem_writew_checked_pagefault : mem_writew_checked) - (uintptr_t)cache_rwtox(cache.pos) - (uintptr_t)4); break;
+		case 4: cache_addd((uintptr_t)(use_dynamic_core_with_paging ? mem_writed_checked_pagefault : mem_writed_checked) - (uintptr_t)cache_rwtox(cache.pos) - (uintptr_t)4); break;
 		default: IllegalOption("gen_call_write");
 	}
 
@@ -1031,7 +1031,7 @@ static void gen_fill_short_jump(uint8_t * data, uint8_t * to=cache.pos) {
 
 static void gen_jmp_ptr(void * ptr,Bits imm=0) {
 	cache_addb(0xa1);
-	cache_addd((uint32_t)ptr);
+	cache_addd((uintptr_t)ptr);
 	cache_addb(0xff);		//JMP EA
 	if (!imm) {			//NO EBP
 		cache_addb(0x20);
@@ -1062,13 +1062,13 @@ static void gen_load_flags(DynReg * dynreg) {
 
 static void gen_save_host_direct(void * data,Bits imm) {
 	cache_addw(0x05c7);		//MOV [],dword
-	cache_addd((uint32_t)data);
+	cache_addd((uintptr_t)data);
 	cache_addd(imm);
 }
 
 static void gen_test_host_byte(void * data, uint8_t imm) {
 	cache_addw(0x05f6); // test [],byte
-	cache_addd((uint32_t)data);
+	cache_addd((uintptr_t)data);
 	cache_addb(imm);
 }
 
@@ -1086,7 +1086,7 @@ static void gen_return(BlockReturn retcode) {
 static void gen_return_fast(BlockReturn retcode,bool ret_exception=false) {
 	if (GCC_UNLIKELY(x86gen.flagsactive)) IllegalOption("gen_return_fast");
 	cache_addw(0x0d8b);			//MOV ECX, the flags
-	cache_addd((uint32_t)&cpu_regs.flags);
+	cache_addd((uintptr_t)&cpu_regs.flags);
 	if (!ret_exception) {
 		cache_addw(0xc483);			//ADD ESP,4
 		cache_addb(0x4);

--- a/src/cpu/core_dyn_x86/string.h
+++ b/src/cpu/core_dyn_x86/string.h
@@ -97,19 +97,19 @@ static void dyn_string(STRING_OP op) {
 			gen_lea(DREG(EA),si_base,DREG(ESI),0,0);
 		}
 		switch (op&3) {
-		case 0:dyn_read_byte(DREG(EA),tmp_reg,false);break;
-		case 1:dyn_read_word(DREG(EA),tmp_reg,false);break;
-		case 2:dyn_read_word(DREG(EA),tmp_reg,true);break;
+			case 0:dyn_read_byte(DREG(EA),tmp_reg,false);break;
+			case 1:dyn_read_word(DREG(EA),tmp_reg,false);break;
+			case 2:dyn_read_word(DREG(EA),tmp_reg,true);break;
 		}
 		switch (op) {
-		case STR_OUTSB:
-			gen_call_function((void*)&IO_WriteB,"%Dw%Dl",DREG(EDX),tmp_reg);break;
-		case STR_OUTSW:
-			gen_call_function((void*)&IO_WriteW,"%Dw%Dw",DREG(EDX),tmp_reg);break;
-		case STR_OUTSD:
-			gen_call_function((void*)&IO_WriteD,"%Dw%Dd",DREG(EDX),tmp_reg);break;
-        default:
-            break;
+			case STR_OUTSB:
+				gen_call_function((void*)&IO_WriteB,"%Dw%Dl",DREG(EDX),tmp_reg);break;
+			case STR_OUTSW:
+				gen_call_function((void*)&IO_WriteW,"%Dw%Dw",DREG(EDX),tmp_reg);break;
+			case STR_OUTSD:
+				gen_call_function((void*)&IO_WriteD,"%Dw%Dd",DREG(EDX),tmp_reg);break;
+			default:
+				break;
 		}
 	}
 	if (usedi) {


### PR DESCRIPTION
I went through the history of the files in the core_dyn_x86 folder and found the remaining commits that were missing from the current code following its removal and restoration. This recreates the changes of those missing commits.