### PR TITLE
Read port 61h bit 6 as 1 for PC, 0 for PCjr/Tandy

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -94,6 +94,9 @@
     hard drive delay, and make it slower than before
     by default. It is adjustable via the "floppy drive
     data rate limit" config option. (Allofich)
+  - Always return bit 6 of port 61h as set for PC and as
+    clear for PCjr and Tandy. Allows Zaxxon to load in
+    PC mode. (Allofich)
   - Video emulation for PC-98 mode (for 400-line modes)
     is now 16:10 instead of 4:3. 480-line PC-98 modes
     are still 4:3. (joncampbell123)

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -678,6 +678,13 @@ static Bitu read_p61(Bitu, Bitu) {
     dbg = ((port_61_data & 0xF) |
         ((TIMER_GetOutput2() || (port_61_data&1) == 0)? 0x20:0) | // NTS: Timer 2 doesn't cycle if Port 61 gate turned off, and it becomes '1' when turned off
         ((fmod(PIC_FullIndex(),0.030) > 0.015)? 0x10:0));
+
+    // Always return bit 6 as set for a PC and as cleared for PCjr or Tandy. See https://www.vogons.org/viewtopic.php?t=50417.
+    if(machine == MCH_PCJR || machine == MCH_TANDY)
+        dbg &= 0xBF;
+    else
+        dbg |= 0x40;
+
     return dbg;
 }
 


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

The PC booter game "Zaxxon" reads from port 61h during startup, and depending on whether bit 6 is set or not loads different code from disk.

According to https://www.vogons.org/viewtopic.php?t=50417, this is a check for PC vs. PCjr/Tandy 1000. "Bit 6 will always be set on a PC because clearing it would hold the keyboard clock line low. It is always clear on a PCjr or original Tandy 1000 because BIOS sets the Sound Multiplexer's source to the 8253 PIT. This is not emulated in DOSBox, where bit 6 is always clear regardless of machine type."

I don't know exactly what hardware does, so this is hackish but based on what the poster said I made bit 6 to always be returned as clear for PCjr or Tandy, and as set for other machines.

## What issue(s) does this PR address?

With this change, Zaxxon will load from a different part of disk (PC mode, presumably).

Note that, regardless of which mode the game is run in, there is a problem where Zaxxon usually won't enter gameplay, instead returning to the initial copyright screen. I was hoping this fix would address that problem, but it doesn't seem to have done so.