### PR TITLE
Disable segment limits check for 8086/186

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -127,6 +127,9 @@
   - Always return bit 6 of port 61h as set for PC and as
     clear for PCjr and Tandy. Allows Zaxxon to load in
     PC mode. (Allofich)
+  - Disable segment limit check for 8086/186. Fixes
+    "Karnov" and "Guerilla Warfare" when run with
+    8086 CPU emulation. (Allofich)
   - Video emulation for PC-98 mode (for 400-line modes)
     is now 16:10 instead of 4:3. 480-line PC-98 modes
     are still 4:3. (joncampbell123)

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -3295,7 +3295,8 @@ public:
 		reg_ebp=0;
 		reg_esp=0;
 
-		do_seg_limits = section->Get_bool("segment limits");
+        if (CPU_ArchitectureType >= CPU_ARCHTYPE_286)
+            do_seg_limits = section->Get_bool("segment limits");
 	
 		SegSet16(cs,0); Segs.limit[cs] = do_seg_limits ? 0xFFFF : ((PhysPt)(~0UL)); Segs.expanddown[cs] = false;
 		SegSet16(ds,0); Segs.limit[ds] = do_seg_limits ? 0xFFFF : ((PhysPt)(~0UL)); Segs.expanddown[ds] = false;


### PR DESCRIPTION
Disables the segment limits check for the 8086 and 186 cores.

## What issue(s) does this PR address?

Fixes #3092.

Note that although the suggested fix was to compile out the checks, I decided to do it this way for a few reasons.
- It's just a one line change this way
- If we're going to exclude the 186 from using the segment limits, it's awkward to check for it (since it uses CPU_ARCHTYPE_286) with #if statements. (I couldn't find information on whether the 186 raises an exception on exceeding the segment limit or not)
- Also compiling out those checks would potentially be beneficial for the 8086/186 core performance, but I don't think those cores are where performance is much of a concern.