### PR TITLE
Don't run mouse setup code if there is no mouse.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -145,6 +145,8 @@
     the remaining block of undefined/undocumented EGC
     ROPs. This fixes "Atomic Punker" which uses EGC ROP
     0xBE for sprite rendering. (joncampbell123)
+  - Don't run mouse setup code if there is no emulated
+    mouse. (Allofich)
   - Integrated commits from mainline (Allofich)
     - Add proper opl3 handling of the waveform select
     to dbopl.

--- a/src/hardware/serialport/serialport.cpp
+++ b/src/hardware/serialport/serialport.cpp
@@ -103,6 +103,7 @@ device_COM::~device_COM() {
 // COM1 - COM9 objects
 CSerial* serialports[9] ={0,0,0,0,0,0,0,0,0};
 uint16_t serial_baseaddr[9] = {0,0,0,0,0,0,0,0,0};
+bool serialMouseEmulated = false;
 
 static Bitu SERIAL_Read (Bitu port, Bitu iolen) {
     (void)iolen;//UNUSED
@@ -1379,6 +1380,7 @@ public:
 			}
 			else if (type=="serialmouse") {
 				serialports[i] = new CSerialMouse (i, &cmd);
+                serialMouseEmulated = true;
 			}
 #ifdef DIRECTSERIAL_AVAILIBLE
 			else if (type=="directserial") {

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -1943,8 +1943,11 @@ void MOUSE_Startup(Section *sec) {
     Section_prop *section=static_cast<Section_prop *>(control->GetSection("dos"));
 	Section_prop * pc98_section=static_cast<Section_prop *>(control->GetSection("pc98"));
     RealPt i33loc=0;
+    extern bool serialMouseEmulated;
 
-    /* TODO: Needs to check for mouse, and fail to do anything if neither PS/2 nor serial mouse emulation enabled */
+    if (MouseTypeNone() && !serialMouseEmulated) {
+        return;
+    }
 
     en_int33_hide_if_intsub=section->Get_bool("int33 hide host cursor if interrupt subroutine");
 


### PR DESCRIPTION
I was testing the PC Booter game "Trilogy", which would hang almost immediately. I found out that the hang occurred if the mouse was moved (the game writes over the vector table, including the address for int 74, which is involved with the ps/2 mouse. Moving the mouse would send execution into the middle of bogus code because int 74's address was overwritten.) Probably the game is designed for an original IBM PC with no mouse.

The hang can be avoided by setting `int33` to false in the .conf file. However, if `int33` is left as true, the hang will happen even if you have no serial mouse or PS/2 mouse specified in the .conf file.

I found that `MOUSE_Startup`, which installs int 33 handling, had a TODO for doing nothing if there is no serial mouse or PS/2 mouse emulated. This PR implements that TODO, which also allows the problem with Trilogy to be avoided by specifying no mouse in the .conf file, which I think is better than setting `int33` to false, since int 33h is a DOS interrupt and shouldn't be relevant when using a PC booter game.