### PR TITLE
Raise default floppy speed

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -3687,7 +3687,7 @@ public:
                 ::disk_data_rate = 3500000; /* Probably an average IDE data rate for early 1990s ISA IDE controllers in PIO mode */
         }
         if(::floppy_data_rate < 0) {
-            ::floppy_data_rate = 5000; // Slow enough so that PC Booter game title screens that depend on floppy drive speed will show for a few seconds
+            ::floppy_data_rate = 22400; // 175 kbps
         }
 		maxfcb=100;
 		DOS_FILES=200;


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

May be related to #3096.

According to an answer on https://stackoverflow.com/questions/52841124/how-fast-could-you-read-write-to-floppy-disks-both-3-1-4-and-5-1-2, floppy disk speeds "maxed out around 100-250kbps and I've never seen above 250kbps on a floppy."

This raises the default floppy speed from 5000 Bps (which I chose because it allowed some PC booter game screens to show for a few seconds) to 175 kbps, taking the average of 100 and 250.

Testing with the PC booter game "Tapper", the opening screens are still visible (though they go by faster than with 5000 of course) with the new value.
