### PR TITLE
Fix infinite loop with 32-bit program and 8086

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -139,6 +139,8 @@
     of Apple Panic. (Allofich)
   - Fixed underflow when INT 13 AH=2 called for
     sector 0. (Allofich)
+  - Fixed infinite loop when trying to run a 32-bit
+    program with the 8086 CPU type.
   - Fixed possible crash with printing. (jamesbond3142)
   - Fixed possible freeze when shutting down Windows 9x
     after changing a CD image from the menu. (Wengier)

--- a/src/dos/dos_memory.cpp
+++ b/src/dos/dos_memory.cpp
@@ -158,12 +158,16 @@ static uint16_t GetMaximumMCBFreeSize(uint16_t mcb_segment)
 {
 	uint16_t largestSize = 0;
 	DOS_MCB mcb(mcb_segment);
+    uint16_t last_mcb_segment;
 	for (bool endOfChain = false; !endOfChain; mcb.SetPt(mcb_segment))
 	{
 		auto size = mcb.GetSize();
 		if (mcb.GetPSPSeg()==MCB_FREE) largestSize = (std::max)(largestSize, size);
 		endOfChain = DOS_MCB::MCBType(mcb.GetType())==DOS_MCB::MCBType::LastBlock;
+        last_mcb_segment = mcb_segment;
 		mcb_segment += size+1;
+        if (mcb_segment == last_mcb_segment) // Check for infinite loop
+            break;
 	}
 	return largestSize;
 }


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

Fixes #3053.

Running UNZIP with cpu=8086 caused an infinite loop in `GetMaximumMCBFreeSize`. The same `mcb_segment` was being checked over and over and the loop would never leave. This PR fixes it by breaking from the loop if `mcb_segment` is unchanged after an iteration.
