### PR TITLE
update rpm spec for bash completion

### DIFF
--- a/contrib/linux/dosbox-x.spec.in
+++ b/contrib/linux/dosbox-x.spec.in
@@ -72,7 +72,7 @@ appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/*.metainfo.xml
 %{_datadir}/icons/hicolor/scalable/apps/dosbox-x.svg
 %{_datadir}/metainfo/com.dosbox_x.DOSBox-X.metainfo.xml
 %{_mandir}/man1/dosbox-x.1.gz
+%{_datadir}/bash-completion/completions/dosbox-x
 %doc CHANGELOG
 %doc dosbox-x.reference.conf
 %doc dosbox-x.reference.full.conf
-


### PR DESCRIPTION
Without this the RPM build will fail as it finds an "unpackaged" file.