### PR TITLE
Resetting render.scale.cacheRead in RENDER_Reset

### DIFF
--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -797,7 +797,6 @@ forcenormal:
     render.scale.outWrite = 0;
     /* Signal the next frame to first reinit the cache */
     render.scale.clearCache = true;
-    render.scale.cacheRead = (uint8_t*)&scalerSourceCache;
     render.active=true;
 
     last_gfx_flags = gfx_flags;
@@ -1344,24 +1343,23 @@ private:
 		READ_POD( &render.fullFrame, render.fullFrame );
 		READ_POD( &render.frameskip, render.frameskip );
 		READ_POD( &render.aspect, render.aspect );
-		scalerOperation_t op = render.scale.op;
+        scalerOperation_t op = render.scale.op;
 		Bitu size = render.scale.size;
 		bool hardware = render.scale.hardware;
-		READ_POD( &render.scale, render.scale );
-		render.scale.op = op;
+        uint8_t* cacheRead = render.scale.cacheRead;
+        uint8_t* outWrite = render.scale.outWrite;
+        READ_POD( &render.scale, render.scale );
+        render.scale.cacheRead = cacheRead;
+        render.scale.outWrite = outWrite;
+        render.scale.op = op;
 		render.scale.size = size;
 		render.scale.hardware = hardware;
-
-		//***************************************
-		//***************************************
-
+ 
 		// reset screen
-		//memset( &render.frameskip, 0, sizeof(render.frameskip) );
-
 		if (render.aspect==ASPECT_FALSE) {
 			render.scale.clearCache = true;
 			if( render.scale.outWrite ) { GFX_EndUpdate(NULL); }
-			RENDER_SetSize( render.src.width, render.src.height, render.src.bpp, render.src.fps, render.src.ratio );
+			RENDER_SetSize( render.src.width, render.src.height, render.src.bpp, render.src.fps, render.src.scrn_ratio );
 		} else
 			GFX_ResetScreen();
 	}

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -797,6 +797,7 @@ forcenormal:
     render.scale.outWrite = 0;
     /* Signal the next frame to first reinit the cache */
     render.scale.clearCache = true;
+    render.scale.cacheRead = (uint8_t*)&scalerSourceCache;
     render.active=true;
 
     last_gfx_flags = gfx_flags;

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -1310,17 +1310,14 @@ namespace
 class SerializeRender : public SerializeGlobalPOD
 {
 public:
-	SerializeRender() : SerializeGlobalPOD("Render")
-	{}
+	SerializeRender() : SerializeGlobalPOD("Render") {}
 
 private:
 	virtual void getBytes(std::ostream& stream)
 	{
-		SerializeGlobalPOD::getBytes(stream);
-
-
 		// - pure data
-		WRITE_POD( &render.src, render.src );
+        SerializeGlobalPOD::getBytes(stream);
+        WRITE_POD( &render.src, render.src );
 		WRITE_POD( &render.pal, render.pal );
 		WRITE_POD( &render.updating, render.updating );
 		WRITE_POD( &render.active, render.active );
@@ -1332,10 +1329,8 @@ private:
 
 	virtual void setBytes(std::istream& stream)
 	{
-		SerializeGlobalPOD::setBytes(stream);
-
-
 		// - pure data
+        SerializeGlobalPOD::setBytes(stream);
 		READ_POD( &render.src, render.src );
 		READ_POD( &render.pal, render.pal );
 		READ_POD( &render.updating, render.updating );
@@ -1348,9 +1343,13 @@ private:
 		bool hardware = render.scale.hardware;
         uint8_t* cacheRead = render.scale.cacheRead;
         uint8_t* outWrite = render.scale.outWrite;
+        Bitu cachePitch = render.scale.cachePitch;
+        Bitu outPitch = render.scale.outPitch;
         READ_POD( &render.scale, render.scale );
         render.scale.cacheRead = cacheRead;
+        render.scale.cachePitch = cachePitch;
         render.scale.outWrite = outWrite;
+        render.scale.outPitch = outPitch;
         render.scale.op = op;
 		render.scale.size = size;
 		render.scale.hardware = hardware;


### PR DESCRIPTION
Resetting render.scale.cacheRead in RENDER_Reset

## What issue(s) does this PR address?

Fixes #3144 

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No?

## Additional information

Proposed for a fix for #3144.

It seems the cacheRead pointer (into scalerSourceCache) runs away into unknown memory lands because it is not properly reset between changing modes (or at least loading game states as the ticket mentions).

So let's reset it in RENDER_Reset(). Fixes to issue for me. Tested on Win10 with VS.

