### PR TITLE
Change PostScript printfile signature

### DIFF
--- a/src/hardware/parport/filelpt.cpp
+++ b/src/hardware/parport/filelpt.cpp
@@ -123,7 +123,7 @@ CFileLPT::CFileLPT (Bitu nr, uint8_t initIrq, CommandLine* cmd, bool sq)
 
 char bufput[105];
 int bufct = 0;
-static char sig1PCL[] = "\x1b%-12345X@", sig2PCL[] = "\x1b\x45", sigPS[] = "\n%!PS";
+static char sig1PCL[] = "\x1b%-12345X@", sig2PCL[] = "\x1b\x45", sigPS[] = "\n%!";
 void CFileLPT::doAction() {
     if (action1.size()||action2.size()||action3.size()) {
         bool isPCL = false;															// For now


### PR DESCRIPTION
Generic PostScript signature makes possible printing from old PostScript drivers (like XyWrite drivers)

Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

Older PostScript printer drivers use `&!` as their signature, not `%!PS`. This change allows older printer drivers to print from PostScript drivers through DOSBox-X

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

No.
