### PR TITLE
RetroWave OPL3 fix and enhancement

### DIFF
--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -435,6 +435,10 @@ namespace Retrowave_OPL3 {
 			uint8_t real_reg = reg & 0xff;
 			uint8_t real_val = val;
 
+			if (real_reg == 1)
+				// Prevent writes to the test registers.
+				return;
+
 			if (port) {
 #ifdef RETROWAVE_USE_BUFFER
 				retrowave_opl3_queue_port1(&retrowave_global_context, real_reg, real_val);
@@ -1220,7 +1224,6 @@ Module::Module( Section* configuration ) : Module_base(configuration) {
 		  handler = new OPL3DUOBOARD::Handler(oplport.c_str());
 	    }
 	else if (oplemu == "retrowave_opl3") {
-		oplmode = OPL_opl3;
 		handler = new Retrowave_OPL3::Handler(retrowave_bus, retrowave_port, retrowave_spi_cs);
 	}
 	else if (oplemu == "mame") {

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -428,15 +428,14 @@ namespace OPL3DUOBOARD {
 
 namespace Retrowave_OPL3 {
 	struct Handler : public Adlib::Handler {
-		int opl3_port = 0;
-
 		virtual void WriteReg(uint32_t reg, uint8_t val) {
 //			printf("writereg: 0x%08x 0x%02x\n", reg, val);
 
+			uint16_t port = reg & 0x100;
 			uint8_t real_reg = reg & 0xff;
 			uint8_t real_val = val;
 
-			if (opl3_port) {
+			if (port) {
 #ifdef RETROWAVE_USE_BUFFER
 				retrowave_opl3_queue_port1(&retrowave_global_context, real_reg, real_val);
 #else
@@ -456,14 +455,9 @@ namespace Retrowave_OPL3 {
 
 			switch (port & 3) {
 				case 0:
-					opl3_port = 0;
 					return val;
 				case 2:
-					opl3_port = 1;
-					if (val == 0x05)
-						return 0x100 | val;
-					else
-						return val;
+					return 0x100 | val;
 			}
 
 			return 0;


### PR DESCRIPTION
This PR fixes a problem with 4 operator instruments not working on the RetroWave OPL3; this issue was mentioned in the video ShortCircuit did on this device (https://www.youtube.com/watch?v=WsSY0C8ivOA). It also enables the use of OPL types other than OPL3 with the RetroWave.
See the commit comments for more details.