### PR TITLE
Added the ability to display CGA 4-color mode with DCGA dither pattern

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1064,7 +1064,7 @@ void DOSBOX_RealInit() {
         if(j3100mode != "off" && j3100mode != "0") {
             dos.set_j3100_enabled = true;
             if (j3100mode != "manual") j3100_start = true;
-            if (j3100type != "default") J3_SetType(j3100type);
+            J3_SetType(j3100type);
         }
     }
     if (!strcasecmp(dosvstr, "ko")) dos.set_kdosv_enabled = true;

--- a/src/hardware/vga_attr.cpp
+++ b/src/hardware/vga_attr.cpp
@@ -128,6 +128,8 @@ Bitu read_p3c0(Bitu /*port*/,Bitu /*iolen*/) {
 	return retval;
 }
  
+bool J3_IsCga4Dcga();
+
 void write_p3c0(Bitu /*port*/,Bitu val,Bitu iolen) {
 	if (!vga.internal.attrindex) {
 		attr(index)=val & 0x1F;
@@ -159,6 +161,11 @@ void write_p3c0(Bitu /*port*/,Bitu val,Bitu iolen) {
 		case 0x04:		case 0x05:		case 0x06:		case 0x07:
 		case 0x08:		case 0x09:		case 0x0a:		case 0x0b:
 		case 0x0c:		case 0x0d:		case 0x0e:		case 0x0f:
+			if(J3_IsCga4Dcga()) {
+				if(attr(index) == 0 && val != 0) {
+					val = 0;
+				}
+			}
 			if (attr(disabled) & 0x1) {
                 VGA_ATTR_SetPalette(attr(index),(uint8_t)val);
 

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -587,8 +587,14 @@ static Bitu read_cga(Bitu port,Bitu /*iolen*/) {
     return ~0UL;
 }
 
+bool J3_IsCga4Dcga();
+
 static void write_cga(Bitu port,Bitu val,Bitu /*iolen*/) {
     Bitu changed;
+
+	if(J3_IsCga4Dcga()) {
+		return;
+	}
 
 	switch (port) {
 	case 0x3d8:

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -1416,7 +1416,7 @@ Bitu INT16_Handler(void) {
             if(reg_ax == size / 2) {
                 reg_ax = 0xffff;
             }
-            reg_bx = J3_GetMachineCode() == 0 ? 0x6a74 : J3_GetMachineCode();
+            reg_bx = J3_GetMachineCode();
         }
         break;
     default:

--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -52,6 +52,8 @@ void DOSV_FillScreen();
 void ResolvePath(std::string& in);
 void INT10_ReadString(uint8_t row, uint8_t col, uint8_t flag, uint8_t attr, PhysPt string, uint16_t count,uint8_t page);
 bool INT10_SetDOSVModeVtext(uint16_t mode, enum DOSV_VTEXT_MODE vtext_mode);
+void INT10_SetJ3ModeCGA4(uint16_t mode);
+bool J3_IsCga4Dcga();
 #if defined(USE_TTF)
 extern bool colorChanged, justChanged;
 extern bool ttf_dosv;
@@ -95,9 +97,14 @@ Bitu INT10_Handler(void) {
 			}
 			DOSV_FillScreen();
 		} else {
-			INT10_SetVideoMode(reg_al);
-			if(reg_al == 0x74 && IS_J3100)
-				DOSV_FillScreen();
+			if(J3_IsCga4Dcga()) {
+				INT10_SetVideoMode(0x74);
+				INT10_SetJ3ModeCGA4(reg_al);
+			} else {
+				INT10_SetVideoMode(reg_al);
+				if(reg_al == 0x74 && IS_J3100)
+					DOSV_FillScreen();
+			}
 		}
 		Mouse_AfterNewVideoMode(true);
 		break;

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -2011,7 +2011,7 @@ att_text16:
 			}
 			break;
 		case M_DCGA:
-			if (IS_J3100 && J3_GetMachineCode()) {
+			if (IS_J3100) {
 				uint8_t r, g, b;
 				uint8_t vmode = GetTrueVideoMode();
 				J3_GetPalette(0, r, g, b);
@@ -2033,9 +2033,8 @@ att_text16:
 				break;
 			}
 		case M_CGA2:
-			if(IS_J3100 && J3_GetMachineCode()) {
+			if(IS_J3100) {
 				uint8_t r, g, b;
-				uint8_t vmode = GetTrueVideoMode();
 				J3_GetPalette(0, r, g, b);
 				IO_Write(0x3c9, r);
 				IO_Write(0x3c9, g);
@@ -2440,6 +2439,13 @@ bool INT10_SetDOSVModeVtext(uint16_t mode, enum DOSV_VTEXT_MODE vtext_mode)
 		return false;
 	}
 	return true;
+}
+
+void INT10_SetJ3ModeCGA4(uint16_t mode)
+{
+	if(SetCurMode(ModeList_VGA, mode)) {
+		FinishSetMode(true);
+	}
 }
 
 Bitu INT10_WriteVESAModeList(Bitu max_modes);

--- a/src/ints/int_dosv.cpp
+++ b/src/ints/int_dosv.cpp
@@ -2199,7 +2199,9 @@ uint16_t J3_GetMachineCode() {
 }
 
 void J3_SetType(std::string type) {
-	j3_machine_code = ConvHexWord((char *)type.c_str());
+	if(type != "default") {
+		j3_machine_code = ConvHexWord((char *)type.c_str());
+	}
 	if(j3_machine_code == 0) j3_machine_code = 0x6a74;
 	enum J3_COLOR j3_color = colorNormal;
 	for(Bitu count = 0 ; j3_machine_list[count].name != NULL ; count++) {
@@ -2251,4 +2253,9 @@ void J3_SetBiosArea(uint16_t mode)
 	} else {
 		real_writeb(BIOSMEM_J3_SEG, BIOSMEM_J3_MODE, 0x00);
 	}
+}
+
+bool J3_IsCga4Dcga()
+{
+	return IS_J3100 && (TrueVideoMode == 0x04 || TrueVideoMode == 0x05);
 }


### PR DESCRIPTION
Since the J-3100 uses a monochrome plasma display or LCD and cannot display color, CGA modes 0x04 and 0x05 were represented by a dither pattern in DCGA screen mode.
Added a process to display CGA 4-color mode as DCGA when j3100=on.
If you look at the Video mode of the [Toshiba T3100e portable](https://www.seasip.info/VintagePC/t3100e.html), you will see that the T3100 also has this feature, so it might be better to add an option so that it can be used even if the J-3100 mode is not enabled.
Also, in order to set the text and background colors in DCGA even if j3100type=default, the judgment of whether it is default or not is moved to the inside of J3_SetType().

![diff](https://user-images.githubusercontent.com/42603716/153373626-931203ef-fdde-4dd8-8e58-c40ca0cc24a9.png)
Left: normal CGA 4-color mode display, right: DCGA dither pattern display

