### PR TITLE
Change default value of mt32.rate option to 48kHz

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,7 +14,10 @@
     Pharkas when sbtype=sb16. (joncampbell123)
   - Avoid crashes due to assertion failure when media 
     keys are pressed (maron2000)
-
+  - Fix CD audio playback failure (cue + mp3) when
+    trying to play from pregap sectors. (maron2000)
+  - Change default value of mt32.rate to 48kHz to match
+    default value of mt32.analog option. (maron2000)
 0.83.22
   - Added Pentium 3 Processor Serial Number emulation.
     Serial number can be set from dosbox-x.conf or not

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3085,7 +3085,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pint->Set_values(mt32reverbLevels);
     Pint->Set_help("MT-32 reverb level");
 
-    Pint = secprop->Add_int("mt32.rate", Property::Changeable::WhenIdle, 44100);
+    Pint = secprop->Add_int("mt32.rate", Property::Changeable::WhenIdle, 48000);
     Pint->Set_values(rates);
     Pint->Set_help("Sample rate of MT-32 emulation.");
 

--- a/src/gui/midi_mt32.h
+++ b/src/gui/midi_mt32.h
@@ -278,6 +278,9 @@ public:
         int sampleRate = section->Get_int("mt32.rate");
         service->setStereoOutputSampleRate(sampleRate);
         service->setSamplerateConversionQuality((MT32Emu::SamplerateConversionQuality)section->Get_int("mt32.src.quality"));
+        const uint32_t mt32_samplerate = 32000U;
+        const uint32_t mt32_sampleratemodes[] = { mt32_samplerate, mt32_samplerate, mt32_samplerate / 2 * 3, mt32_samplerate * 3,0 };
+        if(sampleRate != mt32_sampleratemodes[section->Get_int("mt32.analog")]) LOG_MSG("MIDI: Warning sampling rates of \"mt32.rate\" and \"mt32.analog\" settings are different. May result in incorrect pitch.");
 
         if (MT32EMU_RC_OK != (rc = service->openSynth())) {
             delete service;


### PR DESCRIPTION
The default value of mt32.rate option is 44.1kHz at present but the sampling rate defined by default value of mt32.analog option is 48Khz and therefore result in lower pitch sound than expected.
Therefore, this PR  fixes the default values of respective options to be consistent, and prints warning in log if usere set values which may result in unexpected pitches. 

## What issue(s) does this PR address?
Closes  #3277
