### PR TITLE
Correction of 0x00 to 0x1f characters in J-3100 Japanese mode.

### DIFF
--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -553,7 +553,7 @@ void WriteCharDCGASbcs(uint16_t col, uint16_t row, uint8_t chr, uint8_t attr)
 	uint8_t *font;
 	RealPt fontdata;
 
-	if(J3_IsJapanese()) {
+	if(J3_IsJapanese() && chr >= 0x20) {
 		font = GetSbcsFont(chr);
 	} else {
 		fontdata = RealGetVec(0x43);
@@ -565,7 +565,7 @@ void WriteCharDCGASbcs(uint16_t col, uint16_t row, uint8_t chr, uint8_t attr)
 	y = row * 16;
 	off = (y >> 2) * 80 + 8 * 1024 * (y & 3) + x;
 	for(uint8_t h = 0 ; h < 16 ; h++) {
-		if(J3_IsJapanese()) {
+		if(J3_IsJapanese() && chr >= 0x20) {
 			data = *font++;
 		} else {
 			data = mem_readb(Real2Phys(fontdata++));

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -604,6 +604,12 @@ const char *ParseMsg(const char *msg) {
                     msg = str_replace((char *)msg, (char*)"\xC8", (char *)std::string(1, 0x18).c_str());
                     msg = str_replace((char *)msg, (char*)"\xBC", (char *)std::string(1, 0x17).c_str());
                     msg = str_replace((char *)msg, (char*)"\xCD", (char *)std::string(1, 0x13).c_str());
+                } else if(J3_IsJapanese()) {
+                    msg = str_replace((char *)msg, (char*)"\xC9", "+");
+                    msg = str_replace((char *)msg, (char*)"\xBB", "+");
+                    msg = str_replace((char *)msg, (char*)"\xC8", "+");
+                    msg = str_replace((char *)msg, (char*)"\xBC", "+");
+                    msg = str_replace((char *)msg, (char*)"\xCD", "-");
                 } else {
                     msg = str_replace((char *)msg, (char*)"\xC9", (char *)std::string(1, 1).c_str());
                     msg = str_replace((char *)msg, (char*)"\xBB", (char *)std::string(1, 2).c_str());
@@ -615,6 +621,9 @@ const char *ParseMsg(const char *msg) {
                 if (IS_JEGA_ARCH) {
                     msg = str_replace((char *)msg, (char*)"\xBA ", (char *)(std::string(1, 0x14)+" ").c_str());
                     msg = str_replace((char *)msg, (char*)" \xBA", (char *)(" "+std::string(1, 0x14)).c_str());
+                } else if(J3_IsJapanese()) {
+                    msg = str_replace((char *)msg, (char*)"\xBA ", "| ");
+                    msg = str_replace((char *)msg, (char*)" \xBA", " |");
                 } else {
                     msg = str_replace((char *)msg, (char*)"\xBA ", (char *)(std::string(1, 5)+" ").c_str());
                     msg = str_replace((char *)msg, (char*)" \xBA", (char *)(" "+std::string(1, 5)).c_str());


### PR DESCRIPTION
**Does this PR address some issue(s) ?**
For the J-3100 Japanese mode, the character codes 00h-1fh must use the CP437 design, not the DOS/V CP932 design.

**Additional information**
In Japanese mode of the J-3100, DOS character output and video BIOS cannot display half-width box-drawing characters.
Therefore, in the case of J-3100 mode, the frame of the welcome banner is modified to be displayed with -+|.