### PR TITLE
Fix buffer overflow issue in dos.cpp

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -55,6 +55,7 @@
     trying to play from pregap sectors. (maron2000)
   - Change default value of mt32.rate to 48kHz to match
     default value of mt32.analog option. (maron2000)
+  - Fix a buffer overflow issue in dos.cpp (maron2000)
 0.83.22
   - Added Pentium 3 Processor Serial Number emulation.
     Serial number can be set from dosbox-x.conf or not

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -2145,8 +2145,11 @@ static Bitu DOS_21Handler(void) {
                 MEM_BlockRead(Real2Phys(block.exec.cmdtail),&ctail,CTBUF+1);
                 if (DOS_Execute(name1,SegPhys(es)+reg_bx,reg_al)) {
                     strcpy(appname, name1);
-                    strncpy(appargs, ctail.buffer, ctail.count);
-                    *(appargs+ctail.count)=0;
+                    memset(appargs, 0, sizeof(appargs));
+                    strncpy(appargs, ctail.buffer, strlen(ctail.buffer) <= sizeof(appargs) ? strlen(ctail.buffer) : sizeof(appargs));
+                    //FIX_ME (Hack): sometimes ctail.count returns weird value result in buffer overflow
+                    //strncpy(appargs, ctail.buffer, ctail.count);
+                    //*(appargs+ctail.count)=0;
                 } else {
                     reg_ax=dos.errorcode;
                     CALLBACK_SCF(true);


### PR DESCRIPTION
In certain conditions when strncpy in dos.cpp attempts to copy a string beyond the size of the array, DOSBox-X results in a crash due to buffer overflow.
This patch fixes such overflow cases.

## What issue(s) does this PR address?
Fixes #3285
