### PR TITLE
Preserve LFN after open/save with 8.3 name

### DIFF
--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -2073,8 +2073,9 @@ bool localDrive::Rename(const char * oldname,const char * newname) {
 	strcpy(newold,basedir);
 	strcat(newold,oldname);
 	CROSS_FILENAME(newold);
-	dirCache.ExpandName(newold);
-	
+    struct stat temp_stat;
+    if(stat(newold,&temp_stat)) dirCache.ExpandName(newold);
+
 	char newnew[CROSS_LEN];
 	strcpy(newnew,basedir);
 	strcat(newnew,newname);


### PR DESCRIPTION
This PR (code provided by an anonymous programmer, not by me) lets DOSBox-X preserve the LFN of a file when a program opens and saves the file, using its 8.3 name.

## What issue(s) does this PR address?

(https://github.com/joncampbell123/dosbox-x/issues/3304)

## Does this PR introduce new feature(s)?

Preserves LFNs after a program saves a file opened from its 8.3 name.

## Does this PR introduce any breaking change(s)?

Not that I know of.
