### PR TITLE
Dosdev

### DIFF
--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -134,6 +134,46 @@ private:
 	Bitu devnum;
 };
 
+struct ExtDeviceData {
+    uint16_t attribute;
+    uint16_t segment;
+    uint16_t strategy;
+    uint16_t interrupt;
+};
+
+class DOS_ExtDevice : public DOS_Device {
+public:
+    DOS_ExtDevice(const DOS_ExtDevice& orig) :DOS_Device(orig) {
+        ext = orig.ext;
+    }
+    DOS_ExtDevice(const char* name, uint16_t seg, uint16_t off) {
+        SetName(name);
+        ext.attribute = real_readw(seg, off + 4);
+        ext.segment = seg;
+        ext.strategy = real_readw(seg, off + 6);
+        ext.interrupt = real_readw(seg, off + 8);
+    }
+    DOS_ExtDevice& operator= (const DOS_ExtDevice& orig) {
+        DOS_Device::operator=(orig);
+        ext = orig.ext;
+        return *this;
+    }
+
+    virtual bool	Read(uint8_t* data, uint16_t* size);
+    virtual bool	Write(const uint8_t* data, uint16_t* size);
+    virtual bool	Seek(uint32_t* pos, uint32_t type);
+    virtual bool	Close();
+    virtual uint16_t	GetInformation(void);
+    virtual bool	ReadFromControlChannel(PhysPt bufptr, uint16_t size, uint16_t* retcode);
+    virtual bool	WriteToControlChannel(PhysPt bufptr, uint16_t size, uint16_t* retcode);
+    virtual uint8_t	GetStatus(bool input_flag);
+    bool CheckSameDevice(uint16_t seg, uint16_t s_off, uint16_t i_off);
+    uint16_t CallDeviceFunction(uint8_t command, uint8_t length, uint16_t seg, uint16_t offset, uint16_t size);
+private:
+    struct ExtDeviceData ext;
+
+};
+
 class localFile : public DOS_File {
 public:
 	localFile();

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1890,11 +1890,18 @@ static Bitu DOS_21Handler(void) {
                 else if(Files[handle]->GetInformation() & EXT_DEVICE_BIT)
                 {
                     fRead = !(((DOS_ExtDevice*)Files[handle])->CallDeviceFunction(4, 26, SegValue(ds), reg_dx, toread) & 0x8000);
+#if defined(USE_TTF)
+                    if(fRead && ttf.inUse && reg_bx == WPvga512CHMhandle)
+                        MEM_BlockRead(SegPhys(ds) + reg_dx, dos_copybuf, toread);
+#endif
                 }
-                else fRead = DOS_ReadFile(reg_bx, dos_copybuf, &toread);
+                else
+                {
+                    if(fRead = DOS_ReadFile(reg_bx, dos_copybuf, &toread))
+                        MEM_BlockWrite(SegPhys(ds) + reg_dx, dos_copybuf, toread);
+                }
 
                 if (fRead) {
-                    MEM_BlockWrite(SegPhys(ds)+reg_dx,dos_copybuf,toread);
                     reg_ax=toread;
 #if defined(USE_TTF)
                     if (ttf.inUse && reg_bx == WPvga512CHMhandle){

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1859,6 +1859,8 @@ static Bitu DOS_21Handler(void) {
             /* TODO: If handle is STDIN and not binary do CTRL+C checking */
             { 
                 uint16_t toread=reg_cx;
+                uint32_t handle = RealHandle(reg_bx);
+                bool fRead = false;
 
                 /* if the offset and size exceed the end of the 64KB segment,
                  * truncate the read according to observed MS-DOS 5.0 behavior
@@ -1879,7 +1881,19 @@ static Bitu DOS_21Handler(void) {
                 }
 
                 dos.echo=true;
-                if (DOS_ReadFile(reg_bx,dos_copybuf,&toread)) {
+
+                if(handle >= DOS_FILES) {
+                    DOS_SetError(DOSERR_INVALID_HANDLE);
+                } else 
+                if(!Files[handle] || !Files[handle]->IsOpen())
+                    DOS_SetError(DOSERR_INVALID_HANDLE);
+                else if(Files[handle]->GetInformation() & EXT_DEVICE_BIT)
+                {
+                    fRead = !(((DOS_ExtDevice*)Files[handle])->CallDeviceFunction(4, 26, SegValue(ds), reg_dx, toread) & 0x8000);
+                }
+                else fRead = DOS_ReadFile(reg_bx, dos_copybuf, &toread);
+
+                if (fRead) {
                     MEM_BlockWrite(SegPhys(ds)+reg_dx,dos_copybuf,toread);
                     reg_ax=toread;
 #if defined(USE_TTF)
@@ -1928,6 +1942,7 @@ static Bitu DOS_21Handler(void) {
             unmask_irq0 |= disk_io_unmask_irq0;
             {
                 uint16_t towrite=reg_cx;
+                bool fWritten;
 
                 /* if the offset and size exceed the end of the 64KB segment,
                  * truncate the write according to observed MS-DOS 5.0 READ behavior
@@ -1946,7 +1961,24 @@ static Bitu DOS_21Handler(void) {
 
                 MEM_BlockRead(SegPhys(ds)+reg_dx,dos_copybuf,towrite);
                 packerr=reg_bx==2&&towrite==22&&!strncmp((char *)dos_copybuf,"Packed file is corrupt",towrite);
-                if ((packerr && !(i4dos && !shellrun) && (!autofixwarn || (autofixwarn==2 && infix==0) || (autofixwarn==1 && infix==1))) || DOS_WriteFile(reg_bx,dos_copybuf,&towrite)) {
+                fWritten = (packerr && !(i4dos && !shellrun) && (!autofixwarn || (autofixwarn == 2 && infix == 0) || (autofixwarn == 1 && infix == 1)));
+                if(!fWritten)
+                {
+                    uint32_t handle = RealHandle(reg_bx);
+
+                    if(handle >= DOS_FILES) {
+                        DOS_SetError(DOSERR_INVALID_HANDLE);
+                    }
+                    else
+                        if(!Files[handle] || !Files[handle]->IsOpen())
+                            DOS_SetError(DOSERR_INVALID_HANDLE);
+                        else if(Files[handle]->GetInformation() & EXT_DEVICE_BIT)
+                        {
+                            fWritten = !(((DOS_ExtDevice*)Files[handle])->CallDeviceFunction(8, 26, SegValue(ds), reg_dx, towrite) & 0x8000);
+                        }
+                        else fWritten = DOS_WriteFile(reg_bx, dos_copybuf, &towrite);
+                }
+                if (fWritten) {
                     reg_ax=towrite;
                     CALLBACK_SCF(false);
                 } else {

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -877,7 +877,10 @@ bool DOS_OpenFile(char const * name,uint8_t flags,uint16_t * entry,bool fcb) {
 	}
 	bool exists=false;
 	if (device) {
-		Files[handle]=new DOS_Device(*Devices[devnum]);
+        if (Devices[devnum]->GetInformation() & EXT_DEVICE_BIT)
+            Files[handle] = new DOS_ExtDevice(*(DOS_ExtDevice*)Devices[devnum]);
+        else
+		    Files[handle]=new DOS_Device(*Devices[devnum]);
 	} else {
         exists=Drives[drive]->FileOpen(&Files[handle],fullname,flags) || Drives[drive]->FileOpen(&Files[handle],upcase(fullname),flags);
 		if (exists) Files[handle]->SetDrive(drive);


### PR DESCRIPTION
This pull request fixes the handling of DOS file I/O device drivers

## What issue(s) does this PR address?

There are some device drivers that expect a pre-filled input-buffer on READ function (3Fh) and also don't like to be called for every single byte in that buffer. Therefore the current implementation doesn't work correctly for them.
Therefore to do proper buffer transfers, the device driver should be called directly with the correct buffer pointer in place which also eliminates unnecessary copying.
The current code also has a bug that it lets the buffer point to the beginning of the DCP, which is not desirable, because:

https://github.com/joncampbell123/dosbox-x/blob/6533d69657346833adb3b12860f52ba7bf8f0c6f/src/dos/dos_devices.cpp#L138

but:

https://github.com/joncampbell123/dosbox-x/blob/6533d69657346833adb3b12860f52ba7bf8f0c6f/src/dos/dos_devices.cpp#L101

`0x20 & 0xF = 0`!

