### PR TITLE
Ensures periodic timer interrupt is triggered on every cmos_timerevent

### DIFF
--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -90,10 +90,7 @@ static void cmos_timerevent(Bitu val) {
         double index = PIC_FullIndex();
         double remd = fmod(index, (double)cmos.timer.delay);
         PIC_AddEvent(cmos_timerevent, (float)((double)cmos.timer.delay - remd));
-        if(index >= (cmos.last.timer + cmos.timer.delay)) {
-            cmos.last.timer = index;
-            cmos.regs[0xc] |= 0x40;    // Periodic Interrupt Flag (PF)
-        }
+        cmos.regs[0xc] |= 0x40;    // Periodic Interrupt Flag (PF)
         if(index >= (cmos.last.ended + 1000)) {
             cmos.last.ended = index;
             cmos.regs[0xc] |= 0x10;    // Update-Ended Interrupt Flag (UF)


### PR DESCRIPTION
The patch ensures that the periodic interrupt flag is set on every timer event. @Allofich previous patch improves the periodic interrupt timing ensuring that it does not continuously lag behind but also jitters this interval and can result in missing periodic flags being set.

As a side note, the update-ended interrupt is still not really supported as it won't even fire without the periodic interrupt being enable. It may be a good idea to add that the warning that it is not fully supported back, but in all honesty the entire RTC codebase could probably use a rewrite to clean it up and make it match the hardware implementation much better. 

## What issue(s) does this PR address?
Fixes issue #3361 which is a result of the periodic flag not being set while an interrupt is triggered on the PIC 
