### PR TITLE
Fix VMware mouse cursor in SDL2 build

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,9 +9,9 @@
     Blank the display (if VGA/SVGA machine type) upon
     suspend/standby and unblank upon leaving it.
     (joncampbell123)
-  - APM BIOS: Add dosbox.conf option to control whether
-    the power button triggers a suspend or standby
-    event. (joncampbell123)
+  - APM BIOS: Add dosbox-x.conf option to control
+    whether the power button triggers a suspend or
+    standby event. (joncampbell123)
   - APM BIOS: Add power button mapper event, tie
     power button to APM BIOS, return power button as
     APM suspend event, add code to APM BIOS to handle
@@ -62,7 +62,9 @@
     driver for Windows 3.x, the mouse will be seamlessly
     integrated with the host system, and can enter/exit
     the DOSBox-X window without having to capture/release
-    the mouse. (FeralChild & Wengier)
+    the mouse. Config option "vmware" is added (in [dos]
+    section) which allows to disable VMware mouse guest
+    integration. (FeralChild, Wengier, joncampbell123)
   - When country number is not specified and cannot be
     obtained from system, DOSBox-X will try to map the
     keyboard layout to country number. The country list
@@ -79,6 +81,9 @@
     EMS memory enabled. (grapeli)
   - Fix possible buffer overflow issue that may happen
     in certain conditions. (maron2000)
+  - Fix NewWadTool 1.3 unable to play music by ensuring
+    that periodic timer interrupt is triggered on every
+    cmos_timerevent. (cimarronm)
   - Fix handling of some DOS file I/O device drivers that
     expect a pre-filled input-buffer on READ function and
     also do not like to be called for every single byte

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -1,4 +1,4 @@
-# This is the configuration file for DOSBox-X 0.83.23. (Please use the latest version of DOSBox-X)
+# This is the configuration file for DOSBox-X 0.83.24. (Please use the latest version of DOSBox-X)
 # Lines starting with a # are comment lines and are ignored by DOSBox-X.
 # They are used to (briefly) document the effect of each option.
 # To write out ALL options, use command 'config -all' with -wc or -writeconf options.
@@ -248,7 +248,7 @@ debuggerrun = debugger
 #DOSBOX-X-ADV:#                                          weitek: If set, emulate the Weitek coprocessor. This option only has effect if cputype=386 or cputype=486.
 #DOSBOX-X-ADV:#                             bochs debug port e9: If set, emulate Bochs debug port E9h. ASCII text written to this I/O port is assumed to be debug output, and logged.
 #                                         machine: The type of machine DOSBox-X tries to emulate.
-#                                                    Possible values: hercules, cga, cga_mono, cga_rgb, cga_composite, cga_composite2, tandy, pcjr, pcjr_composite, pcjr_composite2, ega, jega, vgaonly, svga_s3, svga_s386c928, svga_s3vision864, svga_s3vision868, svga_s3trio32, svga_s3trio64, svga_s3trio64v+, svga_s3virge, svga_s3virgevx, svga_et3000, svga_et4000, svga_paradise, vesa_nolfb, vesa_oldvbe, vesa_oldvbe10, amstrad, pc98, pc9801, pc9821, fm_towns, mcga, mda.
+#                                                    Possible values: mda, cga, cga_mono, cga_rgb, cga_composite, cga_composite2, hercules, tandy, pcjr, pcjr_composite, pcjr_composite2, amstrad, ega, jega, mcga, vgaonly, svga_s3, svga_s386c928, svga_s3vision864, svga_s3vision868, svga_s3vision964, svga_s3vision968, svga_s3trio32, svga_s3trio64, svga_s3trio64v+, svga_s3virge, svga_s3virgevx, svga_et3000, svga_et4000, svga_paradise, vesa_nolfb, vesa_oldvbe, vesa_oldvbe10, pc98, pc9801, pc9821, fm_towns.
 #                                        captures: Directory where things like wave, midi, screenshot get captured.
 #                                        autosave: Enable the auto-save state feature. Specify a time interval in seconds, and optionally a save slot or start and end save slots.
 #                                                    For example, "autosave=10 11-20" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.
@@ -1006,6 +1006,7 @@ vsyncrate = 75
 #                                        Windows 95 or other preemptive multitasking OSes will not work with the dynamic_rec core.
 #                                        Possible values: auto, dynamic, dynamic_x86, dynamic_nodhfpu, dynamic, dynamic_rec, normal, full, simple.
 #                                 fpu: Enable FPU emulation
+#                                        Possible values: true, false, 1, 0, auto, 8087, 287, 387.
 #DOSBOX-X-ADV:#             processor serial number: For Pentium III emulation, this sets the 96-bit Processor Serial Number returned by CPUID.
 #DOSBOX-X-ADV:#                                        If not set, then emulation will act as if the PSN has been disabled by the BIOS.
 #DOSBOX-X-ADV:#                                        Enter as 4 sets of 16-bit hexadecimal digits XXXX-XXXX-XXXX-XXXX.
@@ -1069,6 +1070,8 @@ vsyncrate = 75
 #                             apmbios: Emulate Advanced Power Management (APM) BIOS calls.
 #DOSBOX-X-ADV:#                         apmbios pnp: If emulating ISA PnP BIOS, announce APM BIOS in PnP enumeration.
 #DOSBOX-X-ADV:#                                        Warning: this can cause Windows 95 OSR2 and later to enumerate the APM BIOS twice and cause problems.
+#DOSBOX-X-ADV:#              apm power button event: When the power button event is triggered from the mapper or the menu, and the guest is using the APM BIOS, which APM BIOS event to send
+#DOSBOX-X-ADV:#                                        Possible values: suspend, standby.
 #DOSBOX-X-ADV:#                     apmbios version: What version of the APM BIOS specification to emulate.
 #DOSBOX-X-ADV:#                                        You will need at least APM BIOS v1.1 for emulation to work with Windows 95/98/ME.
 #DOSBOX-X-ADV:#                                        Possible values: auto, 1.0, 1.1, 1.2.
@@ -1086,7 +1089,7 @@ vsyncrate = 75
 #DOSBOX-X-ADV:#                                        then jump to realmode with B still set (aka Huge Unreal mode). Needed for Project Angel.
 #DOSBOX-X-ADV-SEE:#
 #DOSBOX-X-ADV-SEE:# Advanced options (see full configuration reference file [dosbox-x.reference.full.conf] for more details):
-#DOSBOX-X-ADV-SEE:# -> processor serial number; double fault; reset on triple fault; always report double fault; always report triple fault; allow lmsw to exit protected mode; report fdiv bug; enable msr; enable cmpxchg8b; enable syscall; ignore undefined msr; interruptible rep string op; dynamic core cache block size; cycle emulation percentage adjust; stop turbo on key; use dynamic core with paging on; ignore opcode 63; apmbios pnp; apmbios version; apmbios allow realmode; apmbios allow 16-bit protected mode; apmbios allow 32-bit protected mode; integration device; integration device pnp; realbig16
+#DOSBOX-X-ADV-SEE:# -> processor serial number; double fault; reset on triple fault; always report double fault; always report triple fault; allow lmsw to exit protected mode; report fdiv bug; enable msr; enable cmpxchg8b; enable syscall; ignore undefined msr; interruptible rep string op; dynamic core cache block size; cycle emulation percentage adjust; stop turbo on key; use dynamic core with paging on; ignore opcode 63; apmbios pnp; apm power button event; apmbios version; apmbios allow realmode; apmbios allow 16-bit protected mode; apmbios allow 32-bit protected mode; integration device; integration device pnp; realbig16
 #DOSBOX-X-ADV-SEE:#
 core                                = auto
 fpu                                 = true
@@ -1115,6 +1118,7 @@ turbo                               = false
 #DOSBOX-X-ADV:ignore opcode 63                    = true
 apmbios                             = true
 #DOSBOX-X-ADV:apmbios pnp                         = false
+#DOSBOX-X-ADV:apm power button event              = suspend
 #DOSBOX-X-ADV:apmbios version                     = auto
 #DOSBOX-X-ADV:apmbios allow realmode              = true
 #DOSBOX-X-ADV:apmbios allow 16-bit protected mode = true
@@ -2162,6 +2166,7 @@ timeout     = 0
 #                                        startwait: Specify whether DOSBox-X should wait for the host system applications after they are started.
 #                                       startquiet: If set, before launching host system applications to run on the host DOSBox-X will not show messages like "Now run it as a Windows application".
 #DOSBOX-X-ADV:#                                       startincon: START command will start these commands (separated by space) in a console and wait for a key press before exiting.
+#                                           vmware: Enable VMware interface emulation including guest mouse integration (when used along with e.g. VMware mouse driver for Windows 3.x).
 #                                            int33: Enable INT 33H for mouse support.
 #DOSBOX-X-ADV:#   int33 hide host cursor if interrupt subroutine: If set, the cursor on the host will be hidden if the DOS application provides it's own
 #DOSBOX-X-ADV:#                                                     interrupt subroutine for the mouse driver to call, which is usually an indication that
@@ -2273,6 +2278,7 @@ starttranspath                                   = true
 startwait                                        = true
 startquiet                                       = false
 #DOSBOX-X-ADV:startincon                                       = assoc attrib chcp copy dir echo for ftype help if set type ver vol xcopy
+vmware                                           = true
 int33                                            = true
 #DOSBOX-X-ADV:int33 hide host cursor if interrupt subroutine   = true
 #DOSBOX-X-ADV:int33 hide host cursor when polling              = false

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -1,4 +1,4 @@
-# This is the configuration file for DOSBox-X 0.83.23. (Please use the latest version of DOSBox-X)
+# This is the configuration file for DOSBox-X 0.83.24. (Please use the latest version of DOSBox-X)
 # Lines starting with a # are comment lines and are ignored by DOSBox-X.
 # They are used to (briefly) document the effect of each option.
 # To write out ALL options, use command 'config -all' with -wc or -writeconf options.
@@ -161,7 +161,7 @@ debuggerrun = debugger
 #                              Possible values: true, false, 1, 0, auto.
 #          synchronize time: If set, DOSBox-X will try to automatically synchronize time with the host, unless you decide to change the date/time manually.
 #                   machine: The type of machine DOSBox-X tries to emulate.
-#                              Possible values: hercules, cga, cga_mono, cga_rgb, cga_composite, cga_composite2, tandy, pcjr, pcjr_composite, pcjr_composite2, ega, jega, vgaonly, svga_s3, svga_s386c928, svga_s3vision864, svga_s3vision868, svga_s3trio32, svga_s3trio64, svga_s3trio64v+, svga_s3virge, svga_s3virgevx, svga_et3000, svga_et4000, svga_paradise, vesa_nolfb, vesa_oldvbe, vesa_oldvbe10, amstrad, pc98, pc9801, pc9821, fm_towns, mcga, mda.
+#                              Possible values: mda, cga, cga_mono, cga_rgb, cga_composite, cga_composite2, hercules, tandy, pcjr, pcjr_composite, pcjr_composite2, amstrad, ega, jega, mcga, vgaonly, svga_s3, svga_s386c928, svga_s3vision864, svga_s3vision868, svga_s3vision964, svga_s3vision968, svga_s3trio32, svga_s3trio64, svga_s3trio64v+, svga_s3virge, svga_s3virgevx, svga_et3000, svga_et4000, svga_paradise, vesa_nolfb, vesa_oldvbe, vesa_oldvbe10, pc98, pc9801, pc9821, fm_towns.
 #                  captures: Directory where things like wave, midi, screenshot get captured.
 #                  autosave: Enable the auto-save state feature. Specify a time interval in seconds, and optionally a save slot or start and end save slots.
 #                              For example, "autosave=10 11-20" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.
@@ -413,6 +413,7 @@ vsyncrate = 75
 #                   Windows 95 or other preemptive multitasking OSes will not work with the dynamic_rec core.
 #                   Possible values: auto, dynamic, dynamic_x86, dynamic_nodhfpu, dynamic, dynamic_rec, normal, full, simple.
 #            fpu: Enable FPU emulation
+#                   Possible values: true, false, 1, 0, auto, 8087, 287, 387.
 # segment limits: Enforce checks for segment limits on 80286 and higher CPU types.
 #        cputype: CPU Type used in emulation. "auto" emulates a 486 which tolerates Pentium instructions.
 #                   "experimental" enables newer instructions not normally found in the CPU types emulated by DOSBox-X, such as FISTTP.
@@ -435,7 +436,7 @@ vsyncrate = 75
 #                   Do not disable if Windows 9x is configured around PnP devices, you will likely confuse it.
 #
 # Advanced options (see full configuration reference file [dosbox-x.reference.full.conf] for more details):
-# -> processor serial number; double fault; reset on triple fault; always report double fault; always report triple fault; allow lmsw to exit protected mode; report fdiv bug; enable msr; enable cmpxchg8b; enable syscall; ignore undefined msr; interruptible rep string op; dynamic core cache block size; cycle emulation percentage adjust; stop turbo on key; use dynamic core with paging on; ignore opcode 63; apmbios pnp; apmbios version; apmbios allow realmode; apmbios allow 16-bit protected mode; apmbios allow 32-bit protected mode; integration device; integration device pnp; realbig16
+# -> processor serial number; double fault; reset on triple fault; always report double fault; always report triple fault; allow lmsw to exit protected mode; report fdiv bug; enable msr; enable cmpxchg8b; enable syscall; ignore undefined msr; interruptible rep string op; dynamic core cache block size; cycle emulation percentage adjust; stop turbo on key; use dynamic core with paging on; ignore opcode 63; apmbios pnp; apm power button event; apmbios version; apmbios allow realmode; apmbios allow 16-bit protected mode; apmbios allow 32-bit protected mode; integration device; integration device pnp; realbig16
 #
 core           = auto
 fpu            = true
@@ -1058,6 +1059,7 @@ timeout     = 0
 #                  starttranspath: Specify whether DOSBox-X should automatically translate all paths in the command-line to host system paths when starting programs to run on the host system.
 #                       startwait: Specify whether DOSBox-X should wait for the host system applications after they are started.
 #                      startquiet: If set, before launching host system applications to run on the host DOSBox-X will not show messages like "Now run it as a Windows application".
+#                          vmware: Enable VMware interface emulation including guest mouse integration (when used along with e.g. VMware mouse driver for Windows 3.x).
 #                           int33: Enable INT 33H for mouse support.
 #                  keyboardlayout: Language code of the keyboard layout (or none).
 #                  customcodepage: Set a custom code page for CHCP command and specify a SBCS code page file, following the standard SBCS code page format.
@@ -1103,6 +1105,7 @@ startcmd                        = false
 starttranspath                  = true
 startwait                       = true
 startquiet                      = false
+vmware                          = true
 int33                           = true
 keyboardlayout                  = auto
 customcodepage                  = 

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -1,4 +1,4 @@
-# This is the configuration file for DOSBox-X 0.83.23. (Please use the latest version of DOSBox-X)
+# This is the configuration file for DOSBox-X 0.83.24. (Please use the latest version of DOSBox-X)
 # Lines starting with a # are comment lines and are ignored by DOSBox-X.
 # They are used to (briefly) document the effect of each option.
 # To write out ALL options, use command 'config -all' with -wc or -writeconf options.
@@ -240,7 +240,7 @@ debuggerrun = debugger
 #                                          weitek: If set, emulate the Weitek coprocessor. This option only has effect if cputype=386 or cputype=486.
 #                             bochs debug port e9: If set, emulate Bochs debug port E9h. ASCII text written to this I/O port is assumed to be debug output, and logged.
 #                                         machine: The type of machine DOSBox-X tries to emulate.
-#                                                    Possible values: hercules, cga, cga_mono, cga_rgb, cga_composite, cga_composite2, tandy, pcjr, pcjr_composite, pcjr_composite2, ega, jega, vgaonly, svga_s3, svga_s386c928, svga_s3vision864, svga_s3vision868, svga_s3trio32, svga_s3trio64, svga_s3trio64v+, svga_s3virge, svga_s3virgevx, svga_et3000, svga_et4000, svga_paradise, vesa_nolfb, vesa_oldvbe, vesa_oldvbe10, amstrad, pc98, pc9801, pc9821, fm_towns, mcga, mda.
+#                                                    Possible values: mda, cga, cga_mono, cga_rgb, cga_composite, cga_composite2, hercules, tandy, pcjr, pcjr_composite, pcjr_composite2, amstrad, ega, jega, mcga, vgaonly, svga_s3, svga_s386c928, svga_s3vision864, svga_s3vision868, svga_s3vision964, svga_s3vision968, svga_s3trio32, svga_s3trio64, svga_s3trio64v+, svga_s3virge, svga_s3virgevx, svga_et3000, svga_et4000, svga_paradise, vesa_nolfb, vesa_oldvbe, vesa_oldvbe10, pc98, pc9801, pc9821, fm_towns.
 #                                        captures: Directory where things like wave, midi, screenshot get captured.
 #                                        autosave: Enable the auto-save state feature. Specify a time interval in seconds, and optionally a save slot or start and end save slots.
 #                                                    For example, "autosave=10 11-20" will set a 10-second time interval for auto-saving, and the save slots used will be between 11 and 20.
@@ -982,6 +982,7 @@ vsyncrate = 75
 #                                        Windows 95 or other preemptive multitasking OSes will not work with the dynamic_rec core.
 #                                        Possible values: auto, dynamic, dynamic_x86, dynamic_nodhfpu, dynamic, dynamic_rec, normal, full, simple.
 #                                 fpu: Enable FPU emulation
+#                                        Possible values: true, false, 1, 0, auto, 8087, 287, 387.
 #             processor serial number: For Pentium III emulation, this sets the 96-bit Processor Serial Number returned by CPUID.
 #                                        If not set, then emulation will act as if the PSN has been disabled by the BIOS.
 #                                        Enter as 4 sets of 16-bit hexadecimal digits XXXX-XXXX-XXXX-XXXX.
@@ -1045,6 +1046,8 @@ vsyncrate = 75
 #                             apmbios: Emulate Advanced Power Management (APM) BIOS calls.
 #                         apmbios pnp: If emulating ISA PnP BIOS, announce APM BIOS in PnP enumeration.
 #                                        Warning: this can cause Windows 95 OSR2 and later to enumerate the APM BIOS twice and cause problems.
+#              apm power button event: When the power button event is triggered from the mapper or the menu, and the guest is using the APM BIOS, which APM BIOS event to send
+#                                        Possible values: suspend, standby.
 #                     apmbios version: What version of the APM BIOS specification to emulate.
 #                                        You will need at least APM BIOS v1.1 for emulation to work with Windows 95/98/ME.
 #                                        Possible values: auto, 1.0, 1.1, 1.2.
@@ -1087,6 +1090,7 @@ use dynamic core with paging on     = auto
 ignore opcode 63                    = true
 apmbios                             = true
 apmbios pnp                         = false
+apm power button event              = suspend
 apmbios version                     = auto
 apmbios allow realmode              = true
 apmbios allow 16-bit protected mode = true
@@ -2110,6 +2114,7 @@ timeout     = 0
 #                                        startwait: Specify whether DOSBox-X should wait for the host system applications after they are started.
 #                                       startquiet: If set, before launching host system applications to run on the host DOSBox-X will not show messages like "Now run it as a Windows application".
 #                                       startincon: START command will start these commands (separated by space) in a console and wait for a key press before exiting.
+#                                           vmware: Enable VMware interface emulation including guest mouse integration (when used along with e.g. VMware mouse driver for Windows 3.x).
 #                                            int33: Enable INT 33H for mouse support.
 #   int33 hide host cursor if interrupt subroutine: If set, the cursor on the host will be hidden if the DOS application provides it's own
 #                                                     interrupt subroutine for the mouse driver to call, which is usually an indication that
@@ -2217,6 +2222,7 @@ starttranspath                                   = true
 startwait                                        = true
 startquiet                                       = false
 startincon                                       = assoc attrib chcp copy dir echo for ftype help if set type ver vol xcopy
+vmware                                           = true
 int33                                            = true
 int33 hide host cursor if interrupt subroutine   = true
 int33 hide host cursor when polling              = false

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -913,7 +913,7 @@ Bitu keyboard_layout::read_codepage_file(const char* codepage_file_name, int32_t
 						sprintf(cp_filename, "EGA4.CPI"); break;
 			case 113:	case 737:	case 851:	case 868:	case 869:
 						sprintf(cp_filename, "EGA5.CPI"); break;
-			case 899:	case 30008:	case 58210:	case 59829:	case 60853:
+			case 899:	case 30008:	case 58210:	case 59829:	case 60258:	case 60853:
 						sprintf(cp_filename, "EGA6.CPI"); break;
 			case 30011:	case 30013:	case 30014:	case 30017:	case 30018:	case 30019:
 						sprintf(cp_filename, "EGA7.CPI"); break;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2799,7 +2799,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring->Set_help("Specifies a color scheme to use for the TTF output by supply all 16 color values in RGB: (r,g,b) or hexadecimal as in HTML: #RRGGBB\n"
                     "The original DOS colors (0-15): #000000 #0000aa #00aa00 #00aaaa #aa0000 #aa00aa #aa5500 #aaaaaa #555555 #5555ff #55ff55 #55ffff #ff5555 #ff55ff #ffff55 #ffffff\n"
                     "gray scaled color scheme: (0,0,0)  #0e0e0e  (75,75,75) (89,89,89) (38,38,38) (52,52,52) #717171 #c0c0c0 #808080 (28,28,28) (150,150,150) (178,178,178) (76,76,76) (104,104,104) (226,226,226) (255,255,255)\n"
-                    "An optional leading \"+\" sign allows the preset color scheme to be used when switching from another output.\n");
+                    "An optional leading \"+\" sign allows the preset color scheme to be used when switching from another output.");
     Pstring->SetBasic(true);
 
 	Pstring = secprop->Add_string("outputswitch", Property::Changeable::Always, "auto");
@@ -4300,7 +4300,7 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring->Set_help("START command will start these commands (separated by space) in a console and wait for a key press before exiting.");
 
     Pbool = secprop->Add_bool("vmware",Property::Changeable::WhenIdle,true);
-    Pbool->Set_help("Enable VMware interface emulation including guest mouse integration.");
+    Pbool->Set_help("Enable VMware interface emulation including guest mouse integration (when used along with e.g. VMware mouse driver for Windows 3.x).");
     Pbool->SetBasic(true);
 
     Pbool = secprop->Add_bool("int33",Property::Changeable::WhenIdle,true);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4121,7 +4121,7 @@ static void HandleMouseMotion(SDL_MouseMotionEvent * motion) {
         const auto isdown = Mouse_GetButtonState() != 0;
 
 #if defined(C_SDL2)
-        if (!sdl.mouse.locked)
+        if (!vmware_mouse && !sdl.mouse.locked)
 #else
         /* SDL1 has some sort of weird mouse warping bug in fullscreen mode no matter whether the mouse is captured or not (Windows, Linux/X11) */
         if (!vmware_mouse && !sdl.mouse.locked && !sdl.desktop.fullscreen)
@@ -4136,7 +4136,7 @@ static void HandleMouseMotion(SDL_MouseMotionEvent * motion) {
         /* Show only when DOS app is not using mouse */
 
 #if defined(C_SDL2)
-        if (!sdl.mouse.locked)
+        if (!vmware_mouse && !sdl.mouse.locked)
 #else
         /* SDL1 has some sort of weird mouse warping bug in fullscreen mode no matter whether the mouse is captured or not (Windows, Linux/X11) */
         if (!vmware_mouse && !sdl.mouse.locked && !sdl.desktop.fullscreen)

--- a/tests/drives_tests.cpp
+++ b/tests/drives_tests.cpp
@@ -75,6 +75,29 @@ TEST(WildFileCmp, QuestionMark)
     EXPECT_EQ(true, WildFileCmp("TEST", "???T.???"));
 }
 
+TEST(WildFileCmp, LongCompare)
+{
+    EXPECT_EQ(false, LWildFileCmp("TEST", ""));
+    EXPECT_EQ(true, LWildFileCmp("TEST.EXE", "*"));
+    EXPECT_EQ(true, LWildFileCmp("TEST", "?EST"));
+    EXPECT_EQ(false, LWildFileCmp("TEST", "???Z"));
+    EXPECT_EQ(true, LWildFileCmp("TEST.EXE", "T*T.*"));
+    EXPECT_EQ(true, LWildFileCmp("TEST.EXE", "T*T.?X?"));
+    EXPECT_EQ(true, LWildFileCmp("TEST.EXE", "T??T.E*E"));
+    EXPECT_EQ(true, LWildFileCmp("Test.exe", "*ST.E*"));
+    EXPECT_EQ(true, LWildFileCmp("Test long name", "*NAME"));
+    EXPECT_EQ(true, LWildFileCmp("Test long name", "*T*L*M*"));
+    EXPECT_EQ(true, LWildFileCmp("Test long name.txt", "T*long*.T??"));
+    EXPECT_EQ(true, LWildFileCmp("Test long name.txt", "??st*name.*t"));
+    EXPECT_EQ(true, LWildFileCmp("Test long name.txt", "Test?long?????.*t"));
+    EXPECT_EQ(true, LWildFileCmp("Test long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long.txt", "Test*long.???"));
+    EXPECT_EQ(true, LWildFileCmp("Test long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long.txt", "Test long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long.txt"));
+    EXPECT_EQ(false, LWildFileCmp("Test long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long.txt", "Test long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long.txt"));
+    EXPECT_EQ(false, LWildFileCmp("TEST", "Z*"));
+    EXPECT_EQ(false, LWildFileCmp("TEST FILE NAME", "*Y*"));
+    EXPECT_EQ(false, LWildFileCmp("TEST FILE NAME", "*F*X*"));
+}
+
 /**
  * Set_Labels tests. These test the conversion of a FAT/CD-ROM volume
  * label to an MS-DOS 8.3 label with a variety of edge cases & oddities.


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

This fixes the host mouse cursor not getting hidden in SDL2 builds when using the VMware mouse driver in Windows 3.x, resulting 2 visible mouse cursors in these builds. SDL1 builds did not have this problem.

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No