### PR TITLE
FIX cmos_timerevent() interval issue (cmos.cpp)

### DIFF
--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -102,8 +102,8 @@ static void cmos_timerevent(Bitu val) {
             cmos.last.ended = index;
             cmos.regs[0xc] |= 0x10;    // Update-Ended Interrupt Flag (UF)
         }
-        fired_irq8 = false;
     }
+    fired_irq8 = false;
 }
 
 static void cmos_checktimer(void) {

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -80,18 +80,26 @@ static struct {
     struct timeval safetime;    // UTC time of last safe time
 } cmos;
 
+static bool fired_irq8 = false;
 static void cmos_timerevent(Bitu val) {
     (void)val;//UNUSED
     if (cmos.timer.acknowledged) {
         cmos.timer.acknowledged=false;
         PIC_ActivateIRQ(8);
+        fired_irq8 = true;
     }
     if (cmos.timer.enabled) {
         double index = PIC_FullIndex();
-        double remd = fmod(index, (double)cmos.timer.delay);
+        double remd = fma((index/(double)cmos.timer.delay), -(double)cmos.timer.delay, index);
+        //double remd = fmod(index, (double)cmos.timer.delay); // original delay calculation
+        //double remd = index - trunc(index / (double)cmos.timer.delay) * (double)cmos.timer.delay; // alternative fix
         PIC_AddEvent(cmos_timerevent, (float)((double)cmos.timer.delay - remd));
+        //LOG_MSG("cmos timerevent: index=%f, interval=%f", index, cmos.timer.delay - remd);
         cmos.regs[0xc] |= 0x40;    // Periodic Interrupt Flag (PF)
-        if(index >= (cmos.last.ended + 1000)) {
+        if(index >= (cmos.last.ended + 1000 - 0.001)) { // consider sometimes index is slightly before 1.0sec
+            //LOG_MSG("cmos timerevent: index=%f, interval=%f", index, cmos.last.ended - index);
+            if(!fired_irq8 && (cmos.regs[0x0b] & 0x10)) PIC_ActivateIRQ(8); // ensure to fire IRQ when UIE flag is set
+            fired_irq8 = false;
             cmos.last.ended = index;
             cmos.regs[0xc] |= 0x10;    // Update-Ended Interrupt Flag (UF)
         }
@@ -106,7 +114,9 @@ static void cmos_checktimer(void) {
     LOG(LOG_PIT,LOG_NORMAL)("RTC Timer at %.2f hz",1000.0/cmos.timer.delay);
 //  PIC_AddEvent(cmos_timerevent,cmos.timer.delay);
     /* A rtc is always running */
-    double remd=fmod(PIC_FullIndex(),(double)cmos.timer.delay);
+    //double remd=fmod(PIC_FullIndex(),(double)cmos.timer.delay);
+    double index = PIC_FullIndex();
+    double remd = fma((index / (double)cmos.timer.delay), -(double)cmos.timer.delay, index);
     PIC_AddEvent(cmos_timerevent,(float)((double)cmos.timer.delay-remd)); //Should be more like a real pc. Check
 //  status reg A reading with this (and with other delays actually)
 }

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -99,10 +99,10 @@ static void cmos_timerevent(Bitu val) {
         if(index >= (cmos.last.ended + 1000 - 0.001)) { // consider sometimes index is slightly before 1.0sec
             //LOG_MSG("cmos timerevent: index=%f, interval=%f", index, cmos.last.ended - index);
             if(!fired_irq8 && (cmos.regs[0x0b] & 0x10)) PIC_ActivateIRQ(8); // ensure to fire IRQ when UIE flag is set
-            fired_irq8 = false;
             cmos.last.ended = index;
             cmos.regs[0xc] |= 0x10;    // Update-Ended Interrupt Flag (UF)
         }
+        fired_irq8 = false;
     }
 }
 

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -275,7 +275,7 @@ struct PIT_Block {
                 break;
             case 3:		/* Square Wave Rate Generator */
                 {
-                    double tmp = fmod(index,(double)delay) * 2;
+                    double tmp = fmod(index,(double)delay * 2);
 
                     if (tmp < 0) {
                         fprintf(stderr,"tmp %.9f index %.9f delay %.9f now %.3f start %.3f\n",tmp,index,delay,now,start);


### PR DESCRIPTION
cmos_timerevent() issues events in a fixed interval with some time adjustments.
I found that the adjustment value calculated using fmod() function is somewhat unstable, resulting in issuing events at an unneeded timing.
This PR replaces fmod() by fma() function, which is assumed to provide more accurate values.
You can confirm the interval between events by enabling the log output.
Also,  IRQ8 may be fired by UIE flag, so added a code to ensure it.

Tested running "NWT tools" and "Contraption Zack" mentioned in #3361.

Edit: This fix is better but _NOT critical_ so you can wait to apply it in the later releases, considering that it is now end of the month to prepare a release.