### PR TITLE
Boot from Toshiba DOS image file for J-3100.

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2682,6 +2682,11 @@ public:
                 }
             }
             else {
+                // Toshiba DOS bootloader checks the floppy disk drives running in the BIOS working area.
+                if(IS_J3100) {
+                    mem_writeb(BIOS_DRIVE_RUNNING, 0x01);
+                    mem_writeb(BIOS_DISK_MOTOR_TIMEOUT, 10);
+                }
                 SegSet16(cs, 0);
                 SegSet16(ds, 0);
                 SegSet16(es, 0);

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -1485,9 +1485,15 @@ static void write_pc98_a20(Bitu port,Bitu val,Bitu iolen) {
 void RemoveEMSPageFrame(void) {
     LOG(LOG_MISC,LOG_DEBUG)("Removing EMS page frame");
 
-    /* Setup rom at 0xe0000-0xf0000 */
-    for (Bitu ct=0xe0;ct<0xf0;ct++) {
-        memory.phandlers[ct] = &rom_page_handler;
+    if(IS_PC98_ARCH || IS_J3100) {
+        for (Bitu ct=0xd0;ct<0xe0;ct++) {
+            memory.phandlers[ct] = &rom_page_handler;
+        }
+    } else {
+        /* Setup rom at 0xe0000-0xf0000 */
+        for (Bitu ct=0xe0;ct<0xf0;ct++) {
+            memory.phandlers[ct] = &rom_page_handler;
+        }
     }
 }
 

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -10305,6 +10305,7 @@ void GEN_PowerButton(bool pressed) {
 
 
 extern uint8_t int10_font_08[256 * 8];
+extern uint16_t j3_font_offset;
 
 /* NTS: Do not use callbacks! This function is called before CALLBACK_Init() */
 void ROMBIOS_Init() {
@@ -10543,6 +10544,10 @@ void ROMBIOS_Init() {
                 LOG_MSG("WARNING: Unable to load user boot hook binary '%s' into ROM BIOS memory",path.c_str());
             }
         }
+    }
+    // J-3100's DOS reads 8x16 font data directly from F000:CA00.
+    if(IS_J3100) {
+        ROMBIOS_GetMemory(256*16, "J-3100 8x16 font data", 1, 0xf0000 + j3_font_offset);
     }
 }
 

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -519,6 +519,21 @@ imageDisk::imageDisk(FILE* imgFile, const char* imgName, uint32_t imgSizeK, bool
                             imgName,cylinders,heads,sectors,sector_size);
                     break;
                 }
+                // Supports cases where the size of a 1.2 Mbytes disk image file is 1.44 Mbytes.
+                if(DiskGeometryList[i].ksize == 1200 && (imgSizeK > 1200 && imgSizeK <= 1440)) {
+                    char buff[0x20];
+                    if (fseek(imgFile,0,SEEK_SET) == 0 && ftell(imgFile) == 0 && fread(buff,sizeof(buff),1,imgFile) == 1) {
+                        if(buff[0x18] == DiskGeometryList[i].secttrack) {
+                            founddisk = true;
+                            active = true;
+                            floppytype = i;
+                            heads = DiskGeometryList[i].headscyl;
+                            cylinders = DiskGeometryList[i].cylcount;
+                            sectors = DiskGeometryList[i].secttrack;
+                            break;
+                        }
+                    }
+                }
                 i++;
             }
         }

--- a/src/ints/int_dosv.cpp
+++ b/src/ints/int_dosv.cpp
@@ -1751,8 +1751,8 @@ static uint16_t j3_cursor_x;
 static uint16_t j3_cursor_y;
 static Bitu j3_text_color;
 static Bitu j3_back_color;
-static uint16_t j3_font_offset;
 static uint16_t j3_machine_code = 0;
+uint16_t j3_font_offset = 0xca00;
 
 static uint16_t jis2shift(uint16_t jis)
 {


### PR DESCRIPTION
To boot a Toshiba J-3100 DOS image file, the drive running status setting in the BIOS work area and the 8x16 dot font data must be set to a fixed address.
EMS frame address is also different, so the release process also needs to be modified.
In addition, when a 3.5inch 1.2M floppy disk is imaged with RawWrite, it becomes 1.44M in size, so countermeasures for this are also necessary.