### PR TITLE
Kanji characters are not displayed correctly when booting DOS image on J-3100 for Linux

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8977,7 +8977,7 @@ fresh_boot:
         if (dos_kernel_shutdown) {
 
             inshell = false;
-            if (!IS_PC98_ARCH&&!IS_JEGA_ARCH&&dos.loaded_codepage!=437) dos.loaded_codepage=437;
+            if (!IS_PC98_ARCH&&!IS_JEGA_ARCH&&!IS_J3100&&dos.loaded_codepage!=437) dos.loaded_codepage=437;
 
             /* NTS: we take different paths depending on whether we're just shutting down DOS
              *      or doing a hard reboot. */


### PR DESCRIPTION
When the code page is 437 on Linux, the Kanji font data cannot be obtained correctly. Fixed code page not reverting to 437 when booting image, even for J-3100.