### PR TITLE
FPU Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -343,6 +343,9 @@ contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml
 *.deps
 src/dosbox-x
 Makefile
+config.h
+config.status
+stamp-h1
 
 doxygen
 doxygen/*

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
 0.83.25
+  - Fix fscale FPU operation and FPU status word
+    updates (cimarronm)
+  - Fix FPU stack value log messages on x86-based builds
+    (cimarronm)
   - Added config option "turbo last second" (in [cpu]
     section) which allows to stop the Turbo function
     after specified number of seconds. (Wengier)

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -420,6 +420,11 @@ struct FPUStatusWord
 		IE = false; DE = false; ZE = false; OE = false; UE = false; PE = false;
 		ES = false;
 	}
+	enum
+	{
+		conditionMask = 0x4700,
+		conditionAndExceptionMask = 0x47bf
+	};
 	std::string to_string() const;
 };
 

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -370,6 +370,58 @@ struct FPUControlWord
 	}
 };
 
+struct FPUStatusWord
+{
+	uint16_t reg;
+	RegBit<FPUStatusWord, 0>     IE;  // Invalid operation
+	RegBit<FPUStatusWord, 1>     DE;  // Denormalized operand
+	RegBit<FPUStatusWord, 2>     ZE;  // Divide-by-zero
+	RegBit<FPUStatusWord, 3>     OE;  // Overflow
+	RegBit<FPUStatusWord, 4>     UE;  // Underflow
+	RegBit<FPUStatusWord, 5>     PE;  // Precision
+	RegBit<FPUStatusWord, 6>     SF;  // Stack Flag (non-8087/802087)
+	RegBit<FPUStatusWord, 7>     IR;  // Interrupt request (8087-only)
+	RegBit<FPUStatusWord, 7>     ES;  // Error summary     (non-8087)
+	RegBit<FPUStatusWord, 8>     C0;  // Condition flag
+	RegBit<FPUStatusWord, 9>     C1;  // Condition flag
+	RegBit<FPUStatusWord, 10>    C2;  // Condition flag
+	RegBit<FPUStatusWord, 11, 3> top; // Top of stack pointer
+	RegBit<FPUStatusWord, 14>    C3;  // Condition flag
+	RegBit<FPUStatusWord, 15>    B;   // Busy flag
+
+	FPUStatusWord() : reg(0), IE(*this), DE(*this), ZE(*this), OE(*this), UE(*this),
+	                  PE(*this), SF(*this), IR(*this), ES(*this), C0(*this), C1(*this),
+	                  C2(*this), top(*this), C3(*this), B(*this) {}
+	FPUStatusWord(const FPUStatusWord& other) = default;
+	FPUStatusWord& operator=(const FPUStatusWord& other)
+	{
+		reg = other.reg;
+		return *this;
+	}
+	template<class T>
+	FPUStatusWord& operator=(T val)
+	{
+		reg = val;
+		return *this;
+	}
+	operator unsigned() const
+	{
+		return reg;
+	}
+	template <class T>
+	FPUStatusWord& operator |=(T val)
+	{
+		*this |= reg | val;
+		return *this;
+	}
+	void init() { reg = 0; }
+	void clearExceptions()
+	{
+		IE = false; DE = false; ZE = false; OE = false; UE = false; PE = false;
+		ES = false;
+	}
+};
+
 typedef struct {
 #if defined(HAS_LONG_DOUBLE)//probably shouldn't allow struct to change size based on this
 	FPU_Reg		_do_not_use__regs[9];
@@ -385,8 +437,7 @@ typedef struct {
 #endif
 	FPU_Tag		tags[9];
 	FPUControlWord  cw;
-	uint16_t		sw;
-	uint32_t		top;
+	FPUStatusWord   sw;
 	XMM_Reg			xmmreg[8]; // SSE emulation
 	uint32_t		mxcsr; // SSE control register
 } FPU_rec;
@@ -401,8 +452,8 @@ typedef struct {
 
 extern FPU_rec fpu;
 
-#define TOP fpu.top
-#define STV(i)  ( (fpu.top+ (i) ) & 7 )
+#define TOP fpu.sw.top
+#define STV(i)  ( (fpu.sw.top + (i) ) & 7 )
 
 
 uint16_t FPU_GetTag(void);
@@ -413,39 +464,24 @@ static INLINE void FPU_SetTag(uint16_t tag){
 		fpu.tags[i] = static_cast<FPU_Tag>((tag >>(2*i))&3);
 }
 
-static INLINE uint8_t FPU_GET_TOP(void) {
-	return (fpu.sw & 0x3800U) >> 11U;
-}
-
-static INLINE void FPU_SET_TOP(Bitu val){
-	fpu.sw &= ~0x3800U;
-	fpu.sw |= (val & 7U) << 11U;
-}
-
-
 static INLINE void FPU_SET_C0(Bitu C){
-	fpu.sw &= ~0x0100U;
-	if(C) fpu.sw |=  0x0100U;
+	fpu.sw.C0 = !!C;
 }
 
 static INLINE void FPU_SET_C1(Bitu C){
-	fpu.sw &= ~0x0200U;
-	if(C) fpu.sw |=  0x0200U;
+	fpu.sw.C1 = !!C;
 }
 
 static INLINE void FPU_SET_C2(Bitu C){
-	fpu.sw &= ~0x0400U;
-	if(C) fpu.sw |=  0x0400U;
+	fpu.sw.C2 = !!C;
 }
 
 static INLINE void FPU_SET_C3(Bitu C){
-	fpu.sw &= ~0x4000U;
-	if(C) fpu.sw |= 0x4000U;
+	fpu.sw.C3 = !!C;
 }
 
 static INLINE void FPU_SET_D(Bitu C){
-	fpu.sw &= ~0x0002U;
-	if(C) fpu.sw |= 0x0002U;
+	fpu.sw.DE = !!C;
 }
 
 static INLINE void FPU_LOG_WARN(Bitu tree, bool ea, Bitu group, Bitu sub) {

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -420,7 +420,9 @@ struct FPUStatusWord
 		IE = false; DE = false; ZE = false; OE = false; UE = false; PE = false;
 		ES = false;
 	}
+	std::string to_string() const;
 };
+
 
 typedef struct {
 #if defined(HAS_LONG_DOUBLE)//probably shouldn't allow struct to change size based on this

--- a/src/cpu/core_dyn_x86/dyn_fpu.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu.h
@@ -535,8 +535,6 @@ static void dyn_fpu_esc5(){
 			break;
 		case 0x07:   /*FNSTSW */
 			gen_protectflags(); 
-			gen_load_host(&TOP,DREG(TMPB),4); 
-			gen_call_function((void*)&FPU_SET_TOP,"%Dd",DREG(TMPB));
 			gen_load_host(&fpu.sw,DREG(TMPB),4); 
 			dyn_call_function_pagefault_check((void*)&mem_writew,"%Drd%Drd",DREG(EA),DREG(TMPB));
 			break;
@@ -622,8 +620,6 @@ static void dyn_fpu_esc7(){
 		case 0x04:
 			switch(sub){
 				case 0x00:     /* FNSTSW AX*/
-					gen_load_host(&TOP,DREG(TMPB),4);
-					gen_call_function((void*)&FPU_SET_TOP,"%Drd",DREG(TMPB)); 
 					gen_mov_host(&fpu.sw,DREG(EAX),2);
 					break;
 				default:

--- a/src/cpu/core_dynrec/dyn_fpu.h
+++ b/src/cpu/core_dynrec/dyn_fpu.h
@@ -540,8 +540,6 @@ static void dyn_fpu_esc5(){
 			gen_call_function_R(FPU_FSAVE,FC_ADDR);
 			break;
 		case 0x07:   /*FNSTSW */
-			gen_mov_word_to_reg(FC_OP1,(void*)(&TOP),true);
-			gen_call_function_R(FPU_SET_TOP,FC_OP1);
 			dyn_fill_ea(FC_OP1); 
 			gen_mov_word_to_reg(FC_OP2,(void*)(&fpu.sw),false);
 			gen_call_function_RR(mem_writew,FC_OP1,FC_OP2);
@@ -632,8 +630,6 @@ static void dyn_fpu_esc7(){
 		case 0x04:
 			switch(decode.modrm.rm){
 				case 0x00:     /* FNSTSW AX*/
-					gen_mov_word_to_reg(FC_OP1,(void*)(&TOP),true);
-					gen_call_function_R(FPU_SET_TOP,FC_OP1); 
 					gen_mov_word_to_reg(FC_OP1,(void*)(&fpu.sw),false);
 					MOV_REG_WORD16_FROM_HOST_REG(FC_OP1,DRC_REG_EAX);
 					break;

--- a/src/cpu/mmx.cpp
+++ b/src/cpu/mmx.cpp
@@ -112,8 +112,7 @@ uint16_t SaturateDwordSToWordU(int32_t value)
 
 void setFPUTagEmpty() {
 	fpu.cw.init();
-	fpu.sw = 0;
-	TOP = FPU_GET_TOP();
+	fpu.sw.init();
 	fpu.tags[0] = TAG_Empty;
 	fpu.tags[1] = TAG_Empty;
 	fpu.tags[2] = TAG_Empty;

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -4667,7 +4667,9 @@ static void LogFPUInfo(void) {
     for (unsigned int i=0;i < 8;i++) {
         unsigned int adj = STV(i);
 
-#if defined(HAS_LONG_DOUBLE)//probably shouldn't allow struct to change size based on this
+#if C_FPU_X86
+        DEBUG_ShowMsg(" st(%u): %s val=%.20Lf", i, FPU_tag(fpu.tags[adj]), reinterpret_cast<long double&>(fpu.p_regs[adj]));
+#elif defined(HAS_LONG_DOUBLE)//probably shouldn't allow struct to change size based on this
         DEBUG_ShowMsg(" st(%u): %s val=%.9f",i,FPU_tag(fpu.tags[adj]),(double)fpu.regs_80[adj].v);
 #else
         DEBUG_ShowMsg(" st(%u): %s use80=%u val=%.9f",i,FPU_tag(fpu.tags[adj]),fpu.use80[adj],fpu.regs[adj].d);

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -4662,7 +4662,7 @@ const char *FPU_tag(unsigned int i) {
 static void LogFPUInfo(void) {
     DEBUG_BeginPagedContent();
 
-    DEBUG_ShowMsg("FPU TOP=%u",static_cast<unsigned>(fpu.sw.top));
+    DEBUG_ShowMsg("status: %s", fpu.sw.to_string().c_str());
 
     for (unsigned int i=0;i < 8;i++) {
         unsigned int adj = STV(i);

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -362,7 +362,7 @@ static char* F80ToString(int regIndex, char* dest) {
 }
 
 static bool F80TestUpdate(int regIndex) {
-	if(fpu.top != oldfpu.top) { /* If the top changed then all registers rotated places, thus updated. */
+	if(fpu.sw.top != oldfpu.sw.top) { /* If the top changed then all registers rotated places, thus updated. */
 		return true;
 	}
 	
@@ -4662,7 +4662,7 @@ const char *FPU_tag(unsigned int i) {
 static void LogFPUInfo(void) {
     DEBUG_BeginPagedContent();
 
-    DEBUG_ShowMsg("FPU TOP=%u",fpu.top);
+    DEBUG_ShowMsg("FPU TOP=%u",static_cast<unsigned>(fpu.sw.top));
 
     for (unsigned int i=0;i < 8;i++) {
         unsigned int adj = STV(i);

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -20,6 +20,7 @@
 #include "dosbox.h"
 #if C_FPU
 
+#include <string>
 #include <math.h>
 #include <float.h>
 #include "paging.h"
@@ -1185,4 +1186,14 @@ public:
         registerPOD(fpu);
     }
 } dummy;
+}
+
+std::string FPUStatusWord::to_string() const
+{
+	return "B=" + std::to_string(B) + " C3-C0=" + std::to_string(C3) + std::to_string(C2) +
+	       std::to_string(C1) + std::to_string(C0) + " ES=" + std::to_string(ES) +
+	       " SF=" + std::to_string(SF) + " PE=" + std::to_string(PE) +
+	       " UE=" + std::to_string(UE) + " OE=" + std::to_string(OE) +
+	       " ZE=" + std::to_string(ZE) + " DE=" + std::to_string(DE) +
+	       " IE=" + std::to_string(IE) + " TOP=" + std::to_string(top);
 }

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -53,11 +53,6 @@ uint16_t FPU_GetTag(void){
 #include "fpu_instructions.h"
 #endif
 
-/* WATCHIT : ALWAYS UPDATE REGISTERS BEFORE AND AFTER USING THEM 
-			STATUS WORD =>	FPU_SET_TOP(TOP) BEFORE a read
-			TOP=FPU_GET_TOP() after a write;
-			*/
-
 static void EATREE(Bitu _rm){
 	Bitu group=(_rm >> 3) & 7;
 	switch(group){
@@ -563,7 +558,6 @@ void FPU_ESC5_EA(Bitu rm,PhysPt addr) {
 		FPU_FSAVE(addr);
 		break;
 	case 0x07:   /*FNSTSW    NG DISAGREES ON THIS*/
-		FPU_SET_TOP(TOP);
 		mem_writew(addr,fpu.sw);
 		//seems to break all dos4gw games :)
 		break;
@@ -748,7 +742,6 @@ void FPU_ESC7_Normal(Bitu rm) {
 	case 0x04:
 		switch(sub){
 			case 0x00:     /* FNSTSW AX*/
-				FPU_SET_TOP(TOP);
 				reg_ax = fpu.sw;
 				break;
 			default:
@@ -1098,8 +1091,6 @@ static INLINE uint8_t fpu_tag_word_abridged(void) {
 void CPU_FXSAVE(PhysPt eaa) {
 	unsigned int i;
 
-	FPU_SET_TOP(TOP);
-
 	/* Ref: [https://www.felixcloutier.com/x86/fxsave] */
 	mem_writew(eaa+0x000,fpu.cw);					/* +0x000 FPU control word */
 	mem_writew(eaa+0x002,fpu.sw);					/* +0x002 FPU status word */
@@ -1149,8 +1140,6 @@ void CPU_FXRSTOR(PhysPt eaa) {
 	fpu.cw = mem_readw(eaa+0x000);					/* +0x000 FPU control word */
 	fpu.sw = mem_readw(eaa+0x002);					/* +0x002 FPU status word */
 	fpu.mxcsr = mem_readd(eaa+0x018);				/* +0x018 MXCSR */
-
-	TOP = FPU_GET_TOP();
 
 	/* NTS: Remember that st(i) TOP pointer is in FPU status word */
 

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -22,8 +22,7 @@ static void FPU_FINIT(void) {
 	unsigned int i;
 
 	fpu.cw.init();
-	fpu.sw = 0;
-	TOP=FPU_GET_TOP();
+	fpu.sw.init();
 	fpu.tags[0] = TAG_Empty;
 	fpu.tags[1] = TAG_Empty;
 	fpu.tags[2] = TAG_Empty;
@@ -37,7 +36,7 @@ static void FPU_FINIT(void) {
 }
 
 static void FPU_FCLEX(void){
-	fpu.sw &= 0x7f00;			//should clear exceptions
+	fpu.sw.clearExceptions();
 }
 
 static void FPU_FNOP(void){
@@ -636,7 +635,6 @@ static void FPU_FSCALE(void){
 }
 
 static void FPU_FSTENV(PhysPt addr){
-	FPU_SET_TOP(TOP);
 	if(!cpu.code.big) {
 		mem_writew(addr+0,static_cast<uint16_t>(fpu.cw));
 		mem_writew(addr+2,static_cast<uint16_t>(fpu.sw));
@@ -664,7 +662,6 @@ static void FPU_FLDENV(PhysPt addr){
 	}
 	FPU_SetTag(tag);
 	fpu.cw = cw;
-	TOP = FPU_GET_TOP();
 }
 
 static void FPU_FSAVE(PhysPt addr){

--- a/src/fpu/fpu_instructions_longdouble.h
+++ b/src/fpu/fpu_instructions_longdouble.h
@@ -40,8 +40,7 @@ static inline void FPU_SyncCW(void) {
 static void FPU_FINIT(void) {
 	fpu.cw.init();
     FPU_SyncCW();
-    fpu.sw = 0;
-	TOP=FPU_GET_TOP();
+    fpu.sw.init();
 	fpu.tags[0] = TAG_Empty;
 	fpu.tags[1] = TAG_Empty;
 	fpu.tags[2] = TAG_Empty;
@@ -54,7 +53,7 @@ static void FPU_FINIT(void) {
 }
 
 static void FPU_FCLEX(void){
-	fpu.sw &= 0x7f00;			//should clear exceptions
+	fpu.sw.clearExceptions();
 }
 
 static void FPU_FNOP(void){
@@ -539,7 +538,6 @@ static void FPU_FSCALE(void){
 }
 
 static void FPU_FSTENV(PhysPt addr){
-	FPU_SET_TOP(TOP);
 	if(!cpu.code.big) {
 		mem_writew(addr+0,static_cast<uint16_t>(fpu.cw));
 		mem_writew(addr+2,static_cast<uint16_t>(fpu.sw));
@@ -568,7 +566,6 @@ static void FPU_FLDENV(PhysPt addr){
 	FPU_SetTag(tag);
 	fpu.cw = cw;
     FPU_SyncCW();
-	TOP = FPU_GET_TOP();
 }
 
 static void FPU_FSAVE(PhysPt addr){

--- a/src/fpu/fpu_instructions_x86.h
+++ b/src/fpu/fpu_instructions_x86.h
@@ -938,8 +938,7 @@ const uint16_t exc_mask=0xffbf;
 
 static void FPU_FINIT(void) {
 	fpu.cw.init();
-	fpu.sw=0;
-	TOP=FPU_GET_TOP();
+	fpu.sw.init();
 	fpu.tags[0]=TAG_Empty;
 	fpu.tags[1]=TAG_Empty;
 	fpu.tags[2]=TAG_Empty;
@@ -952,7 +951,7 @@ static void FPU_FINIT(void) {
 }
 
 static void FPU_FCLEX(void){
-	fpu.sw&=0x7f00;				//should clear exceptions
+	fpu.sw.clearExceptions();
 }
 
 static void FPU_FNOP(void){
@@ -1304,7 +1303,6 @@ static void FPU_FSCALE(void){
 
 
 static void FPU_FSTENV(PhysPt addr){
-	FPU_SET_TOP(TOP);
 	if(!cpu.code.big) {
 		mem_writew(addr+0,static_cast<uint16_t>(fpu.cw));
 		mem_writew(addr+2,static_cast<uint16_t>(fpu.sw));
@@ -1331,7 +1329,6 @@ static void FPU_FLDENV(PhysPt addr){
 	}
 	FPU_SetTag(tag);
 	fpu.cw = cw;
-	TOP=FPU_GET_TOP();
 }
 
 static void FPU_FSAVE(PhysPt addr){


### PR DESCRIPTION
## What issue(s) does this PR address?
### Fixes fpu debug output on x86 processors
#### Before
FPU stack values show zeros on x86-based builds
![image](https://user-images.githubusercontent.com/1505899/163541082-283d0d3a-ffc7-417c-9650-0166259df8fb.png)
#### After
![image](https://user-images.githubusercontent.com/1505899/163541113-3d1c99b5-067f-4839-865a-3189c8fc35e0.png)
### Fixes fscale operation
#### Before
35 test fail on fscale operations under MCPDIAG
![image](https://user-images.githubusercontent.com/1505899/163541258-ee3948ab-e9c9-4f45-8058-05ed120f1d9c.png)
#### After
![image](https://user-images.githubusercontent.com/1505899/163541234-597c5a82-c431-41e9-82ab-a9cf98fb4ffe.png)

## Does this PR introduce new feature(s)?
1. Adds status word print out to `fpu` debug command
2. Adds status word struct and cleanup of code around status word updates