### PR TITLE
Get Information IOCTL system call returned value

### DIFF
--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -626,6 +626,9 @@ bool DOS_IOCTL(void) {
 	case 0x00:		/* Get Device Information */
 		if (Files[handle]->GetInformation() & DeviceInfoFlags::Device) {	//Check for device
 			reg_dx=Files[handle]->GetInformation() & ~EXT_DEVICE_BIT;
+            // DOS copies the upper byte of device attributes in DH resulting in two bits being set
+            // for a device
+            reg_dx |= DeviceAttributeFlags::CharacterDevice;
 		} else {
 			uint8_t hdrive=Files[handle]->GetDrive();
 			if (hdrive==0xff) {


### PR DESCRIPTION
Sets bit 15 on the returned value for devices (marked as reserved bit in documentation) as done in MSDOS.

See #3372 for more information

## What issue(s) does this PR address?

@Wengier found a program, Softscape Tools, which uses bit 15 from the Get Information IOCTL system call for device detection on `stdout`. There are probably other programs as well that use this reserved bit for device detection.