### PR TITLE
Update CHANGELOG and config file comments

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,25 +16,31 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
+      - name: Build minimal
+        run: |
+          ./build --disable-freetype --disable-libfluidsynth --disable-mt32 --disable-screenshots
       - name: Install libraries
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y nasm fluidsynth libfluidsynth-dev libpcap-dev libslirp-dev libsdl-net1.2-dev libsdl2-net-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev
+          sudo apt-get install -y nasm fluidsynth libfluidsynth-dev fluid-soundfont-gm libpcap-dev libslirp-dev libsdl-net1.2-dev libsdl2-net-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev
+          mkdir src/bin
       - name: Build Linux SDL1
         run: |
           top=`pwd`
-          mkdir $top/src/bin
           ./build-debug
           strip --strip-all $top/src/dosbox-x
-          $top/src/dosbox-x -tests
           cp $top/src/dosbox-x $top/src/bin/dosbox-x-sdl1
       - name: Build Linux SDL2
         run: |
           top=`pwd`
           ./build-debug-sdl2
           strip --strip-all $top/src/dosbox-x
-          $top/src/dosbox-x -tests
           cp $top/src/dosbox-x $top/src/bin/dosbox-x-sdl2
+      - name: Unit testing
+        run: |
+          top=`pwd`
+          $top/src/bin/dosbox-x-sdl1 -tests
+          $top/src/bin/dosbox-x-sdl2 -tests
       - name: Upload release package
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,21 +16,24 @@ jobs:
       - name: Install libraries
         run: |
           brew install autoconf automake nasm glfw glew sdl_net sdl2_net
+          mkdir src/bin
       - name: Build macOS SDL1
         run: |
           top=`pwd`
-          mkdir $top/src/bin
           ./build-macosx
           strip $top/src/dosbox-x
-          $top/src/dosbox-x -tests
           cp $top/src/dosbox-x $top/src/bin/dosbox-x-sdl1
       - name: Build macOS SDL2
         run: |
           top=`pwd`
           ./build-macosx-sdl2
           strip $top/src/dosbox-x
-          $top/src/dosbox-x -tests
           cp $top/src/dosbox-x $top/src/bin/dosbox-x-sdl2
+      - name: Unit testing
+        run: |
+          top=`pwd`
+          $top/src/bin/dosbox-x-sdl1 -tests
+          $top/src/bin/dosbox-x-sdl2 -tests
       - name: Upload release package
         uses: actions/upload-artifact@v2
         with:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 0.83.25
   - Allowed to boot from Toshiba DOS image file for the
     Toshiba J-3100 emulation. (nanshiki)
+  - Default S3 machine types now support XGA/SXGA VText
+    in DOS/V, in addition to svga_et4000. (nanshiki)
   - Added config option "aspect_ratio" (in [render]
     section) which when set will force the specified
     aspect ratio (e.g. 16:9 or 3:2) in the aspect ratio
@@ -16,21 +18,29 @@
     [dosbox] section) which when set to false DOSBox-X
     will disallow the quit option after displaying a
     warning message. (Wengier)
-  - Added /T option for CHOICE command to set a default
-    choice as in DOS, e.g. CHOICE /T:Y,3 (Wengier)
-  - Added Korean language option in Windows installer.
-    Also, language option page will be shown regardless
-    of the output option selected. (Wengier)
-  - Fix fscale FPU operation and FPU status word
-    updates (cimarronm)
-  - Fix FPU stack value log messages on x86-based builds
-    (cimarronm)
   - Added config option "turbo last second" (in [cpu]
     section) which allows to stop the Turbo function
     after specified number of seconds. (Wengier)
   - Updated FLAC, MP3, and WAV decoder libraries to the
     latest versions (v0.12.38, v0.6.32, and v0.13.6)
     respectively; per David Reid). (Wengier)
+  - Added /T option for CHOICE command to set a default
+    choice as in DOS, e.g. CHOICE /T:Y,3 (Wengier)
+  - Added Korean language option in Windows installer.
+    Also, language option page will be shown regardless
+    of the output option selected. (Wengier)
+  - Set int33 event status bit 8 when passing absolute
+    mouse coordinates, which is useful in emulation or
+    virtualization environments where the mouse may be
+    integrated with the host cursor. (javispedro)
+  - DOSBox-X returns 1 instead of 0 when E_Exit occurs
+    or unit tests fail. (Wengier)
+  - Fixed built-in IPX and Modem emulation unavailable
+    in MinGW builds. (Wengier)
+  - Fixed lockup in classic Jumpman. (maron2000)
+  - Fixed fscale FPU operation and updated FPU status
+    word. Also fixed FPU stack value log messages on
+    x86-based builds. (cimarronm)
   - Fixed bug that OpenGL Voodoo window may not appear
     correctly if the DOSBox-X window was previously in
     full-screen mode in some builds. DOSBox-X will now
@@ -38,11 +48,6 @@
     mode) in this case. Also fixed some menu options
     including rebooting DOSBox-X while Voodoo emulation
     is currently active. (Wengier)
-  - DOSBox-X returns 1 instead of 0 when E_Exit occurs
-    or unit tests fail. (Wengier)
-  - Fixed built-in IPX and Modem emulation unavailable
-    in MinGW builds. (Wengier)
-  - Fixed lockup in classic Jumpman. (maron2000)
   - Fixed crash when switching to dynamic_rec core from
     menu when dynamic_x86 is also available. Also fixed
     the dynamic_rec core may not be displayed correctly
@@ -101,8 +106,9 @@
     paired with a 287 chip as is said to be how early
     386 Compaq systems were wired, for example.
     (joncampbell123)
-  - 3Dfx Voodoo window is now resizable when using OpenGL
-    mode, in addition to software mode. (kekko & Wengier)
+  - 3Dfx Voodoo window is now resizable (inc. maximized
+    window) when using OpenGL mode, in addition to the
+    software mode. (MartyShepard, kekko, Wengier)
   - Menu options "CJK: Switch between DBCS/SBCS modes",
     CJK: Auto-detect box-drawing characters", and "Reset
     color scheme" (in "Video" -> "TTF options") are now

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,6 +27,8 @@
   - Updated FLAC, MP3, and WAV decoder libraries to the
     latest versions (v0.12.38, v0.6.32, and v0.13.6)
     respectively; per David Reid). (Wengier)
+  - Added support for upper case characters (A-Z) for
+    AUTOTYPE command. (kcgen)
   - Added /T option for CHOICE command to set a default
     choice as in DOS, e.g. CHOICE /T:Y,3 (Wengier)
   - Added Korean language option in Windows installer.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 0.83.25
+  - Menu options "Force scaler" and "Print text screen"
+    can now be assigned to keyboard shortcuts from the
+    Mapper Editor. (Wengier)
   - Allowed to boot from Toshiba DOS image file for the
     Toshiba J-3100 emulation. (nanshiki)
   - Default S3 machine types now support XGA/SXGA VText

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,6 +42,8 @@
     or unit tests fail. (Wengier)
   - Fixed built-in IPX and Modem emulation unavailable
     in MinGW builds. (Wengier)
+  - Fixed -machine command-line option (as listed by
+    "INTRO USAGE" command) not working. (Wengier)
   - Fixed lockup in classic Jumpman. (maron2000)
   - Fixed fscale FPU operation and updated FPU status
     word. Also fixed FPU stack value log messages on

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
-**Welcome to the DOSBox-X project website located on GitHub.**
+**Welcome to the DOSBox-X project homepage located on GitHub.**
 
-**Be sure to also visit DOSBox-X's homepage at [https://dosbox-x.com](https://dosbox-x.com)**
+**Be sure to also visit DOSBox-X's website at [https://dosbox-x.com](https://dosbox-x.com) (or [http://dosbox-x.software](http://dosbox-x.software))**
 
-**Alternative domain of project homepage: [http://dosbox-x.software](http://dosbox-x.software)**
+**Discord channel for DOSBox-X: [https://discord.gg/khVZR5UK](https://discord.gg/khVZR5UK)**
 
 ## Table of Contents
 

--- a/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
+++ b/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
@@ -10,7 +10,7 @@
     <category>Emulation</category>
   </categories>
   <releases>
-          <release version="@PACKAGE_VERSION@" date="2022-4-18"/>
+          <release version="@PACKAGE_VERSION@" date="2022-4-21"/>
   </releases>
   <screenshots>
 	  <screenshot type="default">

--- a/contrib/translations/en/en_US.lng
+++ b/contrib/translations/en/en_US.lng
@@ -2278,6 +2278,12 @@ Pasting from the clipboard
 :MENU:mapper_pasteend
 Stop clipboard pasting
 .
+:MENU:mapper_ejectpage
+Send form-feed
+.
+:MENU:mapper_printtext
+Print DOS text screen
+.
 :MENU:mapper_pause
 Pause emulation
 .
@@ -2296,17 +2302,17 @@ Toggle fullscreen
 :MENU:mapper_resetsize
 Reset window size
 .
-:MENU:mapper_incsize
-Increase TTF font size
-.
-:MENU:mapper_decsize
-Decrease TTF font size
-.
 :MENU:mapper_dbcssbcs
 CJK: Switch between DBCS/SBCS modes
 .
 :MENU:mapper_autoboxdraw
 CJK: Auto-detect box-drawing characters
+.
+:MENU:mapper_incsize
+Increase TTF font size
+.
+:MENU:mapper_decsize
+Decrease TTF font size
 .
 :MENU:mapper_resetcolor
 Reset TTF color scheme
@@ -2478,9 +2484,6 @@ Set ratio
 .
 :MENU:VideoScalerMenu
 Scaler
-.
-:MENU:scaler_forced
-Force scaler
 .
 :MENU:scaler_set_none
 None
@@ -3121,6 +3124,9 @@ Increase frameskip
 :MENU:mapper_aspratio
 Fit to aspect ratio
 .
+:MENU:mapper_fscaler
+Force scaler
+.
 :MENU:mapper_recwave
 Record audio to WAV
 .
@@ -3138,9 +3144,6 @@ Record video to AVI
 .
 :MENU:mapper_scrshot
 Take screenshot
-.
-:MENU:mapper_debugger
-Start DOSBox-X Debugger
 .
 :MENU:mapper_volup
 Increase volume
@@ -3244,8 +3247,8 @@ Swap floppy drive
 :MENU:mapper_swapcd
 Swap CD drive
 .
-:MENU:mapper_ejectpage
-Send form-feed
+:MENU:mapper_debugger
+Start DOSBox-X Debugger
 .
 :MENU:mapper_rescanall
 Rescan all drives
@@ -3388,9 +3391,6 @@ Show mounted drive numbers
 :MENU:list_ideinfo
 Show IDE disk or CD status
 .
-:MENU:print_textscreen
-Print DOS text screen
-.
 :MENU:pc98_use_uskb
 Use US keyboard layout
 .
@@ -3441,6 +3441,9 @@ Pause with interrupt
 .
 :MAPPER:prevslot
 Previous save slot
+.
+:MAPPER:printtext
+Print text screen
 .
 :MAPPER:quickrun
 Quick launch program

--- a/contrib/translations/en/en_US.lng
+++ b/contrib/translations/en/en_US.lng
@@ -2464,6 +2464,9 @@ Aspect ratio
 :MENU:video_ratio_1_1
 1:1
 .
+:MENU:video_ratio_3_2
+3:2
+.
 :MENU:video_ratio_4_3
 4:3
 .

--- a/contrib/translations/es/es_ES.lng
+++ b/contrib/translations/es/es_ES.lng
@@ -2469,6 +2469,9 @@ Relación de aspecto
 :MENU:video_ratio_1_1
 1:1
 .
+:MENU:video_ratio_3_2
+3:2
+.
 :MENU:video_ratio_4_3
 4:3
 .

--- a/contrib/translations/es/es_ES.lng
+++ b/contrib/translations/es/es_ES.lng
@@ -2283,6 +2283,12 @@ Pegar desde el portapapeles
 :MENU:mapper_pasteend
 Detener el pegado del portapapeles
 .
+:MENU:mapper_ejectpage
+Enviar salto de página (Form-feed)
+.
+:MENU:mapper_printtext
+Imprimir pantalla de texto DOS
+.
 :MENU:mapper_pause
 Pausar emulación
 .
@@ -2301,17 +2307,17 @@ Pasar a pantalla completa
 :MENU:mapper_resetsize
 Restaurar ventana
 .
-:MENU:mapper_incsize
-Aumentar tamaño de fuente TTF
-.
-:MENU:mapper_decsize
-Reducir tamaño de fuente TTF
-.
 :MENU:mapper_dbcssbcs
 CJK: Cambiar modo DBCS/SBCS
 .
 :MENU:mapper_autoboxdraw
 CJK: Auto-detecta símbolos de dibujo de caja
+.
+:MENU:mapper_incsize
+Aumentar tamaño de fuente TTF
+.
+:MENU:mapper_decsize
+Reducir tamaño de fuente TTF
 .
 :MENU:mapper_resetcolor
 Resetear esquema de color de TTF
@@ -2483,9 +2489,6 @@ Establecer proporción
 .
 :MENU:VideoScalerMenu
 Escalador
-.
-:MENU:scaler_forced
-Forzar escalador
 .
 :MENU:scaler_set_none
 Ninguno
@@ -3126,6 +3129,9 @@ Incrementar salto de fotogramas
 :MENU:mapper_aspratio
 Ajustar a relación de aspecto
 .
+:MENU:mapper_fscaler
+Forzar escalador
+.
 :MENU:mapper_recwave
 Grabar audio en WAV
 .
@@ -3143,9 +3149,6 @@ Grabar video en AVI
 .
 :MENU:mapper_scrshot
 Capturar pantalla
-.
-:MENU:mapper_debugger
-Iniciar depurador de DOSBox-X
 .
 :MENU:mapper_volup
 Subir volumen
@@ -3249,8 +3252,8 @@ Intercambiar disqueteras
 :MENU:mapper_swapcd
 Intercambiar unidad de CD
 .
-:MENU:mapper_ejectpage
-Enviar salto de página (Form-feed)
+:MENU:mapper_debugger
+Iniciar depurador de DOSBox-X
 .
 :MENU:mapper_rescanall
 Volver a escanear todas las unidades
@@ -3393,9 +3396,6 @@ Mostrar número de las unidades montadas
 :MENU:list_ideinfo
 Mostrar estado de disco IDE o CD
 .
-:MENU:print_textscreen
-Imprimir pantalla de texto DOS
-.
 :MENU:pc98_use_uskb
 Usar distribución de teclado US
 .
@@ -3446,6 +3446,9 @@ Pausa con interrupción
 .
 :MAPPER:prevslot
 Slot guardado previo
+.
+:MAPPER:printtext
+Imprimir pantalla d'texto
 .
 :MAPPER:quickrun
 Lanzar prog. rápido

--- a/contrib/translations/fr/fr_FR.lng
+++ b/contrib/translations/fr/fr_FR.lng
@@ -2283,6 +2283,12 @@ Collage à partir du presse-papiers
 :MENU:mapper_pasteend
 Arrêter le collage du presse-papiers
 .
+:MENU:mapper_ejectpage
+Envoyer sauts de page
+.
+:MENU:mapper_printtext
+Imprimer l'écran de texte DOS
+.
 :MENU:mapper_pause
 Pauser émulation
 .
@@ -2301,17 +2307,17 @@ Basculer plein écran
 :MENU:mapper_resetsize
 Réinit. taille fenêtre
 .
-:MENU:mapper_incsize
-Augmenter taille police
-.
-:MENU:mapper_decsize
-Diminuer taille police
-.
 :MENU:mapper_dbcssbcs
 CJK : Commutation entre les modes DBCS/SBCS
 .
 :MENU:mapper_autoboxdraw
 CJK : Détection automatique des caractères de type "box-drawing".
+.
+:MENU:mapper_incsize
+Augmenter taille police
+.
+:MENU:mapper_decsize
+Diminuer taille police
 .
 :MENU:mapper_resetcolor
 Réinitialiser le schéma de couleurs TTF
@@ -2483,9 +2489,6 @@ Définir le rapport
 .
 :MENU:VideoScalerMenu
 Mise à l'échelle
-.
-:MENU:scaler_forced
-Forcer la mise à l'échelle
 .
 :MENU:scaler_set_none
 Aucun
@@ -3127,6 +3130,9 @@ Augmenter le frameskip
 :MENU:mapper_aspratio
 Ajuster format image
 .
+:MENU:mapper_fscaler
+Forcer la l'échelle
+.
 :MENU:mapper_recwave
 Enreg. audio WAV
 .
@@ -3144,9 +3150,6 @@ Enreg. vidéo en AVI
 .
 :MENU:mapper_scrshot
 Capture d'écran
-.
-:MENU:mapper_debugger
-Démarrer débogueur DOSBox-X
 .
 :MENU:mapper_volup
 Monter le volume
@@ -3251,8 +3254,8 @@ Remplacer lecteur disquette
 :MENU:mapper_swapcd
 Remplacer lecteur CDs
 .
-:MENU:mapper_ejectpage
-Envoyer sauts de page
+:MENU:mapper_debugger
+Démarrer débogueur DOSBox-X
 .
 :MENU:mapper_rescanall
 Rescanner tous les disques
@@ -3395,9 +3398,6 @@ Afficher les numéros des lecteurs montés
 :MENU:list_ideinfo
 Afficher l'état du disque IDE ou du CD
 .
-:MENU:print_textscreen
-Imprimer l'écran de texte DOS
-.
 :MENU:pc98_use_uskb
 Utiliser la disposition clavier US
 .
@@ -3448,7 +3448,10 @@ Pause avec interrupt.
 .
 :MAPPER:prevslot
 Emplacement svg préc.
-
+.
+:MAPPER:printtext
+Imprimer texte d'écran
+.
 :MAPPER:quickrun
 Lancer prog. rapidement
 .

--- a/contrib/translations/fr/fr_FR.lng
+++ b/contrib/translations/fr/fr_FR.lng
@@ -2469,6 +2469,9 @@ Ratio d'aspect
 :MENU:video_ratio_1_1
 1:1
 .
+:MENU:video_ratio_3_2
+3:2
+.
 :MENU:video_ratio_4_3
 4:3
 .

--- a/contrib/translations/ja/ja_JP.lng
+++ b/contrib/translations/ja/ja_JP.lng
@@ -2266,6 +2266,12 @@ DOS画面上のテキストをすべてコピー
 :MENU:mapper_pasteend
 クリップボードからの貼り付けを停止
 .
+:MENU:mapper_printtext
+DOS テキスト画面を印刷
+.
+:MENU:mapper_ejectpage
+改ページ送信
+.
 :MENU:mapper_pause
 一時停止
 .
@@ -2284,17 +2290,17 @@ DOS画面上のテキストをすべてコピー
 :MENU:mapper_resetsize
 ウィンドウサイズ初期化
 .
-:MENU:mapper_incsize
-TTFフォントサイズ: 拡大
-.
-:MENU:mapper_decsize
-TTFフォントサイズ: 縮小
-.
 :MENU:mapper_dbcssbcs
 CJK: DBCS/SBCS モードを切替
 .
 :MENU:mapper_autoboxdraw
 CJK: 罫線文字を自動検出
+.
+:MENU:mapper_incsize
+TTFフォントサイズ: 拡大
+.
+:MENU:mapper_decsize
+TTFフォントサイズ: 縮小
 .
 :MENU:mapper_resetcolor
 TTFカラースキームをリセット
@@ -2466,9 +2472,6 @@ Pentium III 866MHz EB (~407000 サイクル)
 .
 :MENU:VideoScalerMenu
 スケーラ
-.
-:MENU:scaler_forced
-スケーラ強制使用
 .
 :MENU:scaler_set_none
 等倍
@@ -3109,6 +3112,9 @@ INT 21h コールを記録
 :MENU:mapper_aspratio
 アスペクト比に合わせる
 .
+:MENU:mapper_fscaler
+スケーラ強制使用
+.
 :MENU:mapper_recwave
 音声を WAV に保存
 .
@@ -3126,9 +3132,6 @@ FM (OPL) 出力を保存
 .
 :MENU:mapper_scrshot
 スクリーンショット
-.
-:MENU:mapper_debugger
-DOSBox-X デバッガの起動
 .
 :MENU:mapper_volup
 ボリューム:上
@@ -3232,8 +3235,8 @@ Pentium III
 :MENU:mapper_swapcd
 CD ドライブを入替
 .
-:MENU:mapper_ejectpage
-改ページ送信
+:MENU:mapper_debugger
+DOSBox-X デバッガの起動
 .
 :MENU:mapper_rescanall
 すべてのドライブを再スキャン
@@ -3376,9 +3379,6 @@ Ctrl+W/Z キーに変換
 :MENU:list_ideinfo
 IDE ディスク・CD の状態を表示
 .
-:MENU:print_textscreen
-DOS テキスト画面を印刷
-.
 :MENU:pc98_use_uskb
 USキーボードレイアウトを使用
 .
@@ -3429,6 +3429,9 @@ CPU:標準コア
 .
 :MAPPER:prevslot
 前のセーブスロット
+.
+:MAPPER:printtext
+テキスト画面を印刷
 .
 :MAPPER:quickrun
 クイック起動

--- a/contrib/translations/ja/ja_JP.lng
+++ b/contrib/translations/ja/ja_JP.lng
@@ -2452,6 +2452,9 @@ Pentium III 866MHz EB (~407000 サイクル)
 :MENU:video_ratio_1_1
 1:1
 .
+:MENU:video_ratio_3_2
+3:2
+.
 :MENU:video_ratio_4_3
 4:3
 .

--- a/contrib/translations/ko/ko_KR.lng
+++ b/contrib/translations/ko/ko_KR.lng
@@ -2281,6 +2281,12 @@ DOS 화면의 모든 글자 복사
 :MENU:mapper_pasteend
 클립보드에서 붙여넣기 중지
 .
+:MENU:mapper_ejectpage
+페이지 나누기
+.
+:MENU:mapper_printtext
+DOS 글자 화면 인쇄
+.
 :MENU:mapper_pause
 일시정지
 .
@@ -2481,9 +2487,6 @@ Pentium III 866MHz EB (~407000 주기)
 .
 :MENU:VideoScalerMenu
 스케일러
-.
-:MENU:scaler_forced
-스케일러 강제 사용
 .
 :MENU:scaler_set_none
 등배
@@ -3124,6 +3127,9 @@ INT 21h 호출 기록
 :MENU:mapper_aspratio
 종횡비에 맞추기
 .
+:MENU:mapper_fscaler
+스케일러 강제 사용
+.
 :MENU:mapper_recwave
 오디오를 WAV에 저장
 .
@@ -3141,9 +3147,6 @@ FM (OPL) 출력 저장
 .
 :MENU:mapper_scrshot
 스크린샷을 찍기
-.
-:MENU:mapper_debugger
-DOSBox-X 디버거 시작
 .
 :MENU:mapper_volup
 음량: 올림
@@ -3247,8 +3250,8 @@ DOSBox-X 디버거 시작
 :MENU:mapper_swapcd
 CD 드라이브를 교체
 .
-:MENU:mapper_ejectpage
-페이지 나누기
+:MENU:mapper_debugger
+DOSBox-X 디버거 시작
 .
 :MENU:mapper_rescanall
 모든 드라이브를 다시 검사
@@ -3391,9 +3394,6 @@ Ctrl+W/Z 키로 변환
 :MENU:list_ideinfo
 IDE 디스크 CD의 상태를 표시
 .
-:MENU:print_textscreen
-DOS 글자 화면 인쇄
-.
 :MENU:pc98_use_uskb
 미국 키보드 레이아웃 사용
 .
@@ -3444,6 +3444,9 @@ CPU:표준 코어
 .
 :MAPPER:prevslot
 이전 세이브 슬롯
+.
+:MAPPER:printtext
+글자 화면 인쇄
 .
 :MAPPER:quickrun
 빠른 시작

--- a/contrib/translations/ko/ko_KR.lng
+++ b/contrib/translations/ko/ko_KR.lng
@@ -2467,6 +2467,9 @@ Pentium III 866MHz EB (~407000 주기)
 :MENU:video_ratio_1_1
 1:1
 .
+:MENU:video_ratio_3_2
+3:2
+.
 :MENU:video_ratio_4_3
 4:3
 .

--- a/contrib/translations/ko/ko_KR.lng
+++ b/contrib/translations/ko/ko_KR.lng
@@ -11,14 +11,14 @@ MOUNT 하고 싶은 경우는 여기에 기재할 수 있습니다.
 # 이것은 DOSBox-X %s 설정 파일입니다. (최신 버전의 DOSBox-X를 사용하십시오)
 # #으로 시작하는 줄은 주석 줄이며 DOSBox-X는 무시합니다.
 # 각 선택사항의 의미 (의 개요)를 설명하기 위해서 사용합니다.
-# 모든 선택사항을 내보내려면 'config -all' 명령에에 -wc 또는 -writeconf 과 함께 사용하십시오.
+# 모든 선택사항을 내보내려면 'config -all' 명령에 -wc 또는 -writeconf 선택사항을 추가하여 실행하십시오.
 
 .
 :CONFIG_SUGGESTED_VALUES
-가능한 값
+구성 가능한 값
 .
 :CONFIG_ADVANCED_OPTION
-고급 선택사항 (자세한 내용은 전체 구성 참조 파일 [dosbox-x.reference.full.conf]를 참조하십시오.)
+고급 선택사항 (자세한 구성 참조 파일 [dosbox-x.reference.full.conf] 참조하십시오)
 .
 :CONFIG_TOOL
 DOSBox-X 구성 도구
@@ -51,7 +51,7 @@ DOSBox-X 구성 도구
 닫기
 .
 :DEBUGCMD
-디버거 명령을 입력하십시오
+디버거 명령을 입력하십시오.
 .
 :ADD
 추가
@@ -165,7 +165,7 @@ DOS 명령 도움말
 소개
 .
 :CONFIGURE_GROUP
-설정할 그룹을 고름:
+설정할 그룹을 고르십시오:
 .
 :SHOW_ADVOPT
 고급 선택사항 표시
@@ -192,7 +192,7 @@ DOS 명령 도움말
 언어 파일 이름(선택 사항):
 .
 :INTRO_MESSAGE
-DOSBox-X에 오신 것을 환영합니다. 무료로 완전한 DOS 에뮬레이션 패키지입니다.
+완전한 도스 에뮬레이션 꾸러미인 도스박스-X에 오신 것을 환영합니다.
 DOSBox-X는 일반적인 DOS와 비슷한 DOS 쉘을 표시합니다.
 DOS 기계에서 윈도우즈 3.x 또는 9x/Me를 실행할 수도 있습니다.
 .
@@ -332,7 +332,7 @@ DOSBox-X 명령줄 구성 유틸리티 구성 가능한 선택사항:
 -startmapper: DOSBox-X 매퍼 편집기를 시작합니다.
 -gui: 그래픽 구성 도구를 시작합니다.
 -get "section property": 지정한 속성의 값을 돌려준다 (%%CONFIG%%에도).
--set (-setf로 강제) "section property=value": 지정의 프로퍼티의 값을 설정.
+-set (-setf로 강제) "section property=value": 속성 값을 설정합니다.
 
 .
 :PROGRAM_CONFIG_HLP_PROPHLP
@@ -445,7 +445,7 @@ MOUSE [/?] [/U] [/V]
 
 .
 :PROGRAM_MOUNT_STATUS_ELTORITO
-%c 드라이브가 El Torito 형식의 플로피 드라이브로 탑재었습니다.
+%c 드라이브가 El Torito 형식의 플로피 드라이브로 탑재되었습니다.
 
 .
 :PROGRAM_MOUNT_STATUS_RAMDRIVE
@@ -741,7 +741,7 @@ CD-ROM 지원
 .
 :PROGRAM_INTRO_MENU_QUIT_HELP
 
-[1m   [1m[KDosbox-X 소개 종료합니다.[0m
+[1m   [1m[KDosbox-X 소개를 종료합니다.[0m
 
 .
 :PROGRAM_INTRO_USAGE_TOP
@@ -896,7 +896,7 @@ MSCDEX를 설치하고 파일의 속성을 읽기 전용으로 만듭니다.
 :PROGRAM_BOOT_PRINT_ERROR
 이 명령은 DOSBox-X를 플로피 또는 하드 디스크 이미지에서 시작합니다.
 
-이 명령은 메뉴 명령으로 교체 가능한 플로피 디스크 그룹을 지정할 수 있습니다.
+이 명령은 차림표 명령으로 교체 가능한 플로피 디스크 그룹을 지정할 수 있습니다.
 drive: 는 탑재된 드라이브 중에서 부팅할 드라이브를 지정합니다.
 드라이브 문자를 지정하지 않으면 기본적으로 A 드라이브에서 부팅합니다.
 매개 변수를 지정하지 않으면 현재 드라이브에서 부팅을 시도합니다.
@@ -1128,7 +1128,7 @@ IMGMOUNT 사용 예 :
                                   (부팅 가능하다면 [33;1m BOOT A :[0m으로 부팅)
   [32;1mIMGMOUNT A -ro dos.ima[0m - FD 이미지 dos.ima 를 A: 읽기 전용으로 탑재
   [32;1mIMGMOUNT A :dsk1.img dsk2.img[0m - FD 이미지 dsk1.img and dsk2.img 를 A:
-                                  드라이브로 "디스크 교체"메뉴로 교체 가능
+                                  드라이브로 "디스크 교체"차림표로 교체 가능
                                   그런 다음 dsk1.img 읽기 전용 (dsk2.img는 쓰기 가능)
   [32;1mIMGMOUNT A -bootcd D[0m - CD 드라이브 D: 부팅 FD A로 탑재
   [32;1mIMGMOUNT C -t ram -size 10000[0m - C: 드라이브에 10MB RAM 드라이브를 장착
@@ -1144,9 +1144,9 @@ IMGMOUNT 사용 예 :
  [34;1m[-bat] [-fat] [-fatcopies] [-rootdir] [-force] [-source source] [-retries #][0m
   file: 만들 이미지 이름(없는 경우 [33;1mIMGMAKE.IMG[0m) - [31;1m 호스트의 경로[0m
   -t: 이미지 유형
-    [33;1m 플로피 템플릿[0m (용량을 지정하는 이름 KB or fd=fd_1440):
+    [33;1m 플로피 서식[0m (용량을 지정하는 이름 KB or fd=fd_1440):
      fd_160 fd_180 fd_200 fd_320 fd_360 fd_400 fd_720 fd_1200 fd_1440 fd_2880
-    [33;1m 하드 디스크 템플릿:[0m
+    [33;1m 하드 디스크 서식:[0m
      hd_250: 250MB 이미지, hd_520: 520MB 이미지, hd_1gig: 1GB 이미지
      hd_2gig: 2GB 이미지, hd_4gig: 4GB 이미지, hd_8gig: 8GB 이미지
      hd_st251 : 40MB 이미지, hd_st225 : 20MB 이미지 (이전 드라이브의 지오메트리)
@@ -1157,10 +1157,10 @@ IMGMOUNT 사용 예 :
   -force: 기존 이미지 파일을 강제 덮어쓰기
   -bat: 이 이미지를 IMGMOUNT 명령으로 탑재하는 .bat 파일을 생성한다.
   -fat : FAT 파일 시스템 유형 (12, 16, or 32).
-  -spc: 클러스터당 섹터를 강제 지정합니다. 2의 제곱으로 하는 것.
-  -fatcopies: FAT 테이블 수를 강제 지정.
+  -spc: 클러스터당 섹터를 강제 지정합니다. 2의 제곱으로 해야합니다.
+  -fatcopies: FAT 테이블 수를 강제로 지정합니다.
   -rootdir : 루트 디렉토리 항목의 크기 (FAT32에서는 무시됨)
-  -source: 드라이브 문자 - 지정되면 이미지가 플로피에서 로드됩니다.
+  -source: 드라이브 문자 - 지정되면 이미지가 플로피에서 불러오기됩니다.
   -retries : 상태가 좋지 않은 플로피를 다시 읽는 횟수 (1-99).
   [32;1m-examples: 사용 예 보기[0m
 .
@@ -1168,7 +1168,7 @@ IMGMOUNT 사용 예 :
 IMGMAKE의 몇 가지 사용 예:
 
   [32;1mIMGMAKE -t fd[0m                   - 1.44MB FD 이미지 만들기 [33;1mIMGMAKE.IMG[0m
-  [32;1mIMGMAKE -t fd_1440                  -force[0m - FD 이미지를 강제로 생성] [33;1mIMGMAKE.IMG[0m
+  [32;1mIMGMAKE -t fd_1440 -force[0m       - FD 이미지를 강제로 생성] [33;1mIMGMAKE.IMG[0m
   [32;1mIMGMAKE dos.img -t fd_2880[0m      - dos.img라는 이름의 2.88MB FD 이미지 만들기
   [32;1mIMGMAKE c:\disk.img -t hd -size 50[0m      - 50MB HDD 이미지 만들기 c:\disk.img
   [32;1mIMGMAKE c:\disk.img -t hd_520 -nofs[0m     - 공백 520MB HDD 이미지 만들기
@@ -1183,7 +1183,7 @@ IMGMAKE의 몇 가지 사용 예:
 
 .
 :PROGRAM_IMGMAKE_FLREAD2
-%s = 양호, %s = 다시 시도 후 양호, ! =CRC 오류, x = 섹터를 찾을 수 없음, ? = 알 수 없음
+%s =양호, %s =다시 시도 후 양호, ! =CRC 오류, x =섹터를 찾을 수 없음, ? =알 수 없음
 
 
 .
@@ -1209,11 +1209,11 @@ IMGMAKE의 몇 가지 사용 예:
 플로피를 읽을 수 없습니다.
 .
 :PROGRAM_KEYB_INFO
-코드 페이지 %i로 설정했습니다.
+코드 페이지를 %i로 설정했습니다.
 
 .
 :PROGRAM_KEYB_INFO_LAYOUT
-코드 페이지 %i를(를) 키 레이아웃 %s용으로 불러왔습니다.
+코드 페이지를 %i로 키 레이아웃 %s용으로 불러왔습니다.
 
 .
 :PROGRAM_KEYB_SHOWHELP
@@ -1226,11 +1226,11 @@ IMGMAKE의 몇 가지 사용 예:
   (.kl,.cpi/.cpx 파일은 dosbox-x 실행 파일이 있는 디렉토리에 배치합니다.)
 
 사용 예:
-  [32;1mKEYB[0m          불러온 코드 페이지 표시
-  [32;1mKEYB sp[0m       스페인어 (SP) 레이아웃을 읽고, 적절한 코드 페이지를 사용
-  [32;1mKEYB sp 850[0m   스페인어 (SP) 레이아웃을 읽고, 코드 페이지 850을 사용
-  [32;1mKEYB sp 850 mycp.cpi[0m 위와 같은, 그러나 mycp.cpi 파일을 사용
-  [32;1mKEYB sp_mod 850[0m      레이아웃을 sp_mod.kl에서 불러오고, 코드 페이지 850을 사용
+  [32;1mKEYB[0m          불러온 코드 페이지를 표시합니다.
+  [32;1mKEYB sp[0m       스페인어 (SP) 레이아웃을 읽고, 적절한 코드 페이지를 사용합니다.
+  [32;1mKEYB sp 850[0m   스페인어 (SP) 레이아웃을 읽고, 코드 페이지 850을 사용니다.
+  [32;1mKEYB sp 850 mycp.cpi[0m 위와 같은, 그러나 mycp.cpi 파일을 사용합니다.
+  [32;1mKEYB sp_mod 850[0m      레이아웃을 sp_mod.kl에서 불러오고, 코드 페이지 850을 사용합니다.
 
 .
 :PROGRAM_KEYB_NOERROR
@@ -1260,7 +1260,7 @@ IMGMAKE의 몇 가지 사용 예:
 
 [34;1mMODE[0m display-type : 설정 가능한 코드 [1mCO80[0m, [1mBW80[0m, [1mCO40[0m, [1mBW40[0m, 또는 [1mMONO[0m
 [34;1mMODE CON COLS=[0mc[34;1mLINES=[0mn :설정 가능한 컬럼·행 c=80 or 132, n=25, 43, 50, or 60
-[34;1mMODE CON RATE=[0mr [34;1mDELAY=[0md :설정 가능 범위 r=1-32 (32=최속)), d=1-4 (1=최소)
+[34;1mMODE CON RATE=[0mr [34;1mDELAY=[0md :설정 가능 범위 r=1-32 (32=최속), d=1-4 (1=최소)
 
 .
 :PROGRAM_MODE_INVALID_PARAMETERS
@@ -1378,11 +1378,11 @@ ECHO는 <OFF>입니다.
 .
 :SHELL_CMD_DATE_HELP_LONG
 DATE [[/T] [/H] [/S] | date]
-  date: 새로 지정한 날짜
-  /S: 항상 호스트 날짜/시간을 DOS 시간으로 사용
-  /F: DOSBox-X의 내부 시간으로 되돌리기(/S의 반대)
-  /T: 날짜 표시만
-  /H: 호스트와 동기화
+  date:       새로 지정한 날짜
+  /S:         항상 호스트 날짜/시간을 DOS 시간으로 사용
+  /F:         DOSBox-X의 내부 시간으로 되돌리기(/S의 반대)
+  /T:         날짜 표시만
+  /H:         호스트와 동기화
 
 .
 :SHELL_CMD_TIME_HELP
@@ -1402,9 +1402,9 @@ DATE [[/T] [/H] [/S] | date]
 .
 :SHELL_CMD_TIME_HELP_LONG
 TIME [[/T] [/H] | time]
-  time: 새로 지정하는 시간
-  /T: 시간 단순 표시
-  /H: 호스트와 동기화
+  time:       새로 지정하는 시간
+  /T:         시간 단순 표시
+  /H:         호스트와 동기화
 
 .
 :SHELL_CMD_MKDIR_EXIST
@@ -1745,14 +1745,14 @@ DOSBox-X 명령의 도움말을 표시합니다.
 HELP [/A or /ALL]
 HELP [command]
 
-   /A or /ALL 지원되는 내부 명령 목록을 표시합니다.
-   [command] 지정된 command에 대한 도움말을 표시합니다.
+   /A or /ALL   지원되는 내부 명령 목록을 표시합니다.
+   [command]    지정된 command에 대한 도움말을 표시합니다.
 
 [0m예: [37;1mHELP COPY[0m 또는 [37;1mCOPY /?[0m 은 COPY 명령에 대한 도움말 정보를 표시합니다.
 
 참고: [33;1mMOUNT[0m, [33;1mIMGMOUNT[0m 같은 외부 명령은 HELP [/A] 목록에 표시되지 않습니다.
-    이러한 명령은 Z: 드라이브에 프로그램으로 존재합니다 (예: MOUNT.COM).
-    [33;1mcommand /?[0m 또는 [33;1mHELP command[0m로 그 명령의 도움말 정보를 표시 할 수 있습니다.
+      이러한 명령은 Z: 드라이브에 프로그램으로 존재합니다 (예: MOUNT.COM).
+      [33;1mcommand /?[0m 또는 [33;1mHELP command[0m로 그 명령의 도움말 정보를 표시 할 수 있습니다.
 
 .
 :SHELL_CMD_LS_HELP
@@ -1801,7 +1801,7 @@ SET [variable=[string]]
 환경 변수 목록을 보려면 매개 변수 없이 SET을 입력합니다.
 
 .
-:SHELL_CMD_IF_HELP --- 에서냐 으로냐
+:SHELL_CMD_IF_HELP
 배치 프로그램으로 조건 분기합니다.
 
 .
@@ -1810,17 +1810,17 @@ IF [NOT] ERRORLEVEL number command
 IF [NOT] string1==string2 command
 IF [NOT] EXIST filename command
 
-  NOT 조건이 충족되지 않으면 DOS는 명령을 실행합니다.
+  NOT               조건이 충족되지 않으면 DOS는 명령을 실행합니다.
 
   ERRORLEVEL number 마지막으로 실행한 프로그램의 종료 코드가 number와 같거나
                     큰 숫자일 때 true를 돌려줍니다.
 
-  string1==string2 두 문자열이 일치할 때 true를 돌려줍니다.
+  string1==string2  두 문자열이 일치할 때 true를 돌려줍니다.
 
-  EXIST filename 파일 이름이 filename 인 파일이 있을 때 참(true)
+  EXIST filename    파일 이름이 filename 인 파일이 있을 때 참(true)
                     돌려줍니다.
 
-  command 조건이 충족되면 실행할 명령을 지정합니다.
+  command           조건이 충족되면 실행할 명령을 지정합니다.
                     명령 다음에 ELSE 키워드 다음에 조건이 부적합하면
                     실행할 명령을 지정할 수 있습니다.
 
@@ -1863,10 +1863,10 @@ SHIFT
 FOR %%variable IN (set) DO command [command-parameters]
 
   %%variable 대체 가능한 매개 변수 지정
-  (set) 하나 이상의 파일로 구성된 세트 지정 (와일드 카드 사용 가능)
-  command 각 파일에 대해 실행할 명령 지정
+  (set)     하나 이상의 파일로 구성된 집합을 지정합니다. 와일드 카드를 사용할 수 있습니다.
+  command   각 파일에 대해 실행할 명령을 지정합니다.
   command-parameters
-             지정된 명령의 매개 변수 또는 스위치 지정
+            지정된 명령의 매개 변수 또는 스위치 지정
 
 배치 프로그램에서 명령을 사용하는 경우 %%variable을 %%%%variable로 설정
 
@@ -1921,13 +1921,13 @@ REN [drive:][path][directoryname1 | filename1] [directoryname2 | filename2]
 DEL [/P] [/F] [/Q] names
 ERASE [/P] [/F] [/Q] names
 
-  names 하나 이상의 파일 또는 디렉토리를 지정합니다.
+  names         하나 이상의 파일 또는 디렉토리를 지정합니다.
                 와일드카드를 사용하여 여러 파일을 삭제할 수 있습니다.
                 디렉토리를 지정하면 그 안의 모든 파일이 삭제됩니다.
-  /P 각 파일을 삭제하기 전에 확인 메시지를 표시합니다.
-  /F 쓰기 금지 파일을 강제로 삭제합니다.
-  /Q 숨김 모드. 와일드카드로 일괄 삭제할 때 확인
-  　　　　　　메시지를 표시하지 않습니다.
+  /P            각 파일을 삭제하기 전에 확인 메시지를 표시합니다.
+  /F            쓰기 금지 파일을 강제로 삭제합니다.
+  /Q            숨김 모드. 와일드카드로 일괄 삭제할 때 확인 메시지를
+  　　　　　　　표시하지 않습니다.
 
 .
 :SHELL_CMD_COPY_HELP
@@ -1937,19 +1937,18 @@ ERASE [/P] [/F] [/Q] names
 :SHELL_CMD_COPY_HELP_LONG
 COPY [/Y | /-Y] source [+source [+ ...]] [destination]
 
-  source 복사할 파일(하나 이상)을 지정합니다.
-  destination 복사할 디렉토리 파일 이름을 지정합니다.
-  /Y 복사 대상에 같은 이름의 파일이 있으면 덮어쓸 것인지
+  source        복사할 파일(하나 이상)을 지정합니다.
+  destination   복사할 디렉토리 파일 이름을 지정합니다.
+  /Y            복사 대상에 같은 이름의 파일이 있으면 덮어쓸 것인지
                 확인 메시지를 표시하지 않습니다.
-  /-Y 복사 대상에 같은 이름의 파일이 있으면 덮어 쓸 것인지
+  /-Y           복사 대상에 같은 이름의 파일이 있으면 덮어 쓸 것인지
                 확인 메시지를 표시합니다.
 
-스위치 /Y 는 ​​환경 변수 COPYCMD 에 미리 설정해 둘 수가 있습니다.
+스위치 /Y 는 경 변수 COPYCMD 에 미리 설정해 둘 수가 있습니다.
 이 스위치는 명령행에서 /-Y를 지정하여 비활성화할 수 있습니다.
 
 파일을 병합하려면 대상에 단일 파일 이름을 지정하고 소스에
-여러 파일을 지정합니다. (와일드 카드 또는 file1 + file2 + file3
-지정)
+여러 파일을 지정합니다. (와일드 카드 또는 파일1 + 파일2 + 파일3 지정)
 
 .
 :SHELL_CMD_CALL_HELP
@@ -1959,7 +1958,7 @@ COPY [/Y | /-Y] source [+source [+ ...]] [destination]
 :SHELL_CMD_CALL_HELP_LONG
 CALL [drive:][path]filename [batch-parameters]
 
-batch-parameters 배치 파일을 실행하는 데 필요한 스위치 매개 변수를
+batch-parameters   배치 파일을 실행하는 데 필요한 스위치 매개 변수를
                    지정합니다.
 
 .
@@ -1971,9 +1970,9 @@ batch-parameters 배치 파일을 실행하는 데 필요한 스위치 매개 �
 SUBST [drive1: [drive2:]path]
 SUBST drive1: /D
 
-  drive1: 경로를 할당할 가상 드라이브를 지정합니다.
+  drive1:       경로를 할당할 가상 드라이브를 지정합니다.
   [drive2:]path 가상 드라이브에 할당할 로컬 드라이브와 경로를 지정합니다.
-  /D drive1의 할당을 해제합니다.
+  /D            drive1의 할당을 해제합니다.
 
 가상 드라이브의 목록을 보려면 매개 변수 없이 SUBST를 입력합니다.
 
@@ -2001,7 +2000,6 @@ CHOICE [/C:choices] [/N] [/S] text
   text         프롬프트에 표시할 글자
 
 ERRORLEVEL은 사용자가 선택 항목에서 누르는 키의 위치로 설정됩니다.
-
 .
 :SHELL_CMD_ATTRIB_HELP
 파일의 속성을 표시 및 변경합니다.
@@ -2010,15 +2008,15 @@ ERRORLEVEL은 사용자가 선택 항목에서 누르는 키의 위치로 설정
 :SHELL_CMD_ATTRIB_HELP_LONG
 ATTRIB [+R | -R] [+A | -A] [+S | -S] [+H | -H] [드라이브:][경로][파일이름] [/S]
 
-  + 속성을 설정
-  - 속성을 지움
-  R 읽기 전용
-  A 아카이브
-  S 시스템 파일
-  H 숨겨진 파일
+  +   속성을 설정합니다.
+  -   속성을 지웁니다.
+  R   읽기 전용
+  A   압축 파일
+  S   시스템 파일
+  H   숨겨진 파일
   [drive:][path][filename]
       ATTRIB 명령이 속성을 설정하는 파일 디렉토리를 지정
-  /S 지정된 경로의 디렉토리에 있는 모든 파일에 대한 속성을 설정
+  /S  지정된 경로의 디렉토리에 있는 모든 파일에 대한 속성을 설정
 
 .
 :SHELL_CMD_PATH_HELP
@@ -2040,7 +2038,7 @@ POPD로 복귀 할 디렉토리를 저장하고 지정된 디렉토리로 이동
 :SHELL_CMD_PUSHD_HELP_LONG
 PUSHD [path]
 
-path 지정된 디렉토리를 현재 디렉토리로 만듭니다.
+path        지정된 디렉토리를 현재 디렉토리로 만듭니다.
 
 저장된 디렉토리를 보려면 매개 변수없이 PUSHD를 입력하십시오.
 
@@ -2071,9 +2069,9 @@ DOSBox-X 자신과 DOSBox-X가 반환하는 DOS 버전을 표시 및 설정합�
 VER [/R]
 VER [SET] number 또는 VER SET [major minor]
 
-  /R DOSBox-X Git 커밋 버전 및 빌드 날짜 및 시간 표시
-  [SET] number DOSBox-X가 반환하는 DOS 버전을 지정한 number로 지정
-  SET [major minor] DOSBox-X가 반환하는 DOS 버전을 major.minor 형식으로 지정
+  /R                DOSBox-X Git 커밋 버전 및 빌드 날짜 및 시간 표시합니다.
+  [SET] number      DOSBox-X가 반환하는 DOS 버전을 지정한 number로 지정합니다.
+  SET [major minor] DOSBox-X가 반환하는 DOS 버전을 major.minor 형식으로 지정합니다.
 
  [0m예, [37;1mVER 6.0[0m 또는 [37;1mVER 7.1[0m이라고 하면 DOS버전은 각각 6.0과 7.1에,
   반면, [37;1mVER SET 7 1[0m은 DOS 버전이 7.1이 아닌 7.01입니다.
@@ -2226,7 +2224,7 @@ TRUENAME [/H] 파일
 :SHELL_CMD_DXCAPTURE_HELP_LONG
 DX-CAPTURE [/V|/-V] [/A|/-A] [/M|/-M] [command] [options]
 
-비디오 및 오디오 캡처를 시작한 후 프로그램을 실행하고 프로그램 종료시 캡처도 종료됩니다. 
+비디오 및 오디오 갈무리를 시작한 후 프로그램을 실행하고 프로그램 종료시 갈무리도 종료됩니다. 
 * ???비디오 -> 영상 오디오 -> 음성??
 
 .
@@ -2245,9 +2243,9 @@ DOSBox-X 명령 셸 시작
 
 다음 선택사항을 사용할 수 있습니다.
 
-  /C 지정한 명령을 실행하여 셸을 종료합니다.
-  /K 지정한 명령을 실행하고 셸을 종료하지 않습니다.
-  /P 명령 셸을 시작하고 상주합니다. 
+  /C    지정한 명령을 실행하여 셸을 종료합니다.
+  /K    지정한 명령을 실행하고 셸을 종료하지 않습니다.
+  /P    명령 셸을 시작하고 상주합니다. 
   /INIT 명령 셸을 초기화합니다.
 
 .
@@ -2258,7 +2256,7 @@ DOSBox-X 명령 셸 시작
 게스트 시스템을 다시 설정
 .
 :MENU:mapper_loadmap
-매퍼 파일 로드 중...
+매퍼 파일을 불러오고 있음...
 .
 :MENU:mapper_quickrun
 빠른 시작...
@@ -2267,7 +2265,7 @@ DOSBox-X 명령 셸 시작
 DOSBox-X를 종료
 .
 :MENU:mapper_capmouse
-마우스를 캡처
+마우스를 갈무리
 .
 :MENU:mapper_fastedit
 빠른 편집: 선택 시 복사 및 글자 붙여넣기
@@ -2297,13 +2295,13 @@ DOS 글자 화면 인쇄
 구성 도구
 .
 :MENU:mapper_mapper
-매퍼 에디터
+매퍼 편집기
 .
 :MENU:mapper_fullscr
 전체 화면 표시로 전환
 .
 :MENU:mapper_resetsize
-윈도우 크기 초기화
+창 크기 초기화
 .
 :MENU:mapper_incsize
 TTF 글꼴 크기: 확대
@@ -2321,7 +2319,7 @@ CJK: 테두리 문자 자동 감지
 TTF 색 구성표 재설정
 .
 :MENU:mapper_pwrbutton
-APM 전원 버튼
+APM 전원 단추
 .
 :MENU:mapper_togmenu
 기본 차림표 막대를 숨김/표시
@@ -2336,7 +2334,7 @@ APM 전원 버튼
 호스트 키 선택
 .
 :MENU:WheelToArrow
-마우스 휠 동작
+마우스 바퀴 동작
 .
 :MENU:SharedClipboard
 클립보드 공유 설정
@@ -2384,28 +2382,28 @@ CPU 속도 조정
 486DX5 133MHz(~47810 주기)
 .
 :MENU:cpu586-60
-Pentium 60MHz (~31545 주기)
+펜티엄 60MHz (~31545 주기)
 .
 :MENU:cpu586-66
-Pentium 66MHz (~35620 주기)
+펜티엄 66MHz (~35620 주기)
 .
 :MENU:cpu586-75
-Pentium 75MHz (~43500 주기)
+펜티엄 75MHz (~43500 주기)
 .
 :MENU:cpu586-90
-Pentium 90MHz(~52000 주기)
+펜티엄 90MHz(~52000 주기)
 .
 :MENU:cpu586-100
-Pentium 100MHz(~60000 주기)
+펜티엄 100MHz(~60000 주기)
 .
 :MENU:cpu586-120
-Pentium 120MHz(~74000 주기)
+펜티엄 120MHz(~74000 주기)
 .
 :MENU:cpu586-133
-Pentium 133MHz(~80000 주기)
+펜티엄 133MHz(~80000 주기)
 .
 :MENU:cpu586-166
-Pentium 166MHz MMX(~97240 주기)
+펜티엄 166MHz MMX(~97240 주기)
 .
 :MENU:cpuak6-166
 AMD K6 166MHz(~110000 주기)
@@ -2417,19 +2415,19 @@ AMD K6 200MHz(~130000 주기)
 AMD K6-2 300MHz(~193000 주기)
 .
 :MENU:cpuath-600
-AMD Athlon 600MHz (~306000 주기)
+AMD 애슬론 600MHz (~306000 주기)
 .
 :MENU:cpu686-866
-Pentium III 866MHz EB (~407000 주기)
+펜티엄 III 866MHz EB (~407000 주기)
 .
 :MENU:VideoMenu
 비디오
 .
 :MENU:VideoFrameskipMenu
-프레임 스킵
+프레임 건너뛰기
 .
 :MENU:frameskip_0
-끄다
+끄기
 .
 :MENU:frameskip_1
 1 프레임
@@ -2489,7 +2487,7 @@ Pentium III 866MHz EB (~407000 주기)
 비율 설정
 .
 :MENU:VideoScalerMenu
-스케일러
+확대
 .
 :MENU:scaler_set_none
 등배
@@ -2546,10 +2544,10 @@ RGB 2X
 RGB 3X
 .
 :MENU:scaler_set_advmame2x
-Advanced MAME 2X
+고급 마메 2X
 .
 :MENU:scaler_set_advmame3x
-Advanced MAME 3X
+고급 마메 3X
 .
 :MENU:scaler_set_hq2x
 HQ 2X
@@ -2558,25 +2556,25 @@ HQ 2X
 HQ 3X
 .
 :MENU:scaler_set_advinterp2x
-Advanced Interpolation 2X
+고급 보간 2X
 .
 :MENU:scaler_set_advinterp3x
-Advanced Interpolation 3X
+고급 보간 3X
 .
 :MENU:scaler_set_2xsai
 2xSai
 .
 :MENU:scaler_set_super2xsai
-Super2xSai
+슈퍼2xSai
 .
 :MENU:scaler_set_supereagle
-SuperEagle
+슈퍼이글
 .
 :MENU:scaler_set_xbrz
 xBRZ
 .
 :MENU:scaler_set_xbrz_bilinear
-xBRZ Bilinear
+xBRZ 이선형
 .
 :MENU:refresh_rate
 새로 고침 속도 ...
@@ -2588,16 +2586,16 @@ xBRZ Bilinear
 Surface
 .
 :MENU:output_direct3d
-Direct3D
+다이렉트3D
 .
 :MENU:output_opengl
-OpenGL
+오픈GL
 .
 :MENU:output_openglnb
-OpenGL nearest
+오픈GL nearest
 .
 :MENU:output_openglpp
-OpenGL perfect
+오픈GL perfect
 .
 :MENU:output_ttf
 TrueType 글꼴
@@ -2618,7 +2616,7 @@ TrueType 글꼴
 호스트
 .
 :MENU:vsync_off
-끄다
+끄기
 .
 :MENU:vsync_set_syncrate
 동기화 속도 설정
@@ -2627,7 +2625,7 @@ TrueType 글꼴
 오버스캔
 .
 :MENU:overscan_0
-끄다
+끄기
 .
 :MENU:overscan_1
 1
@@ -2675,28 +2673,28 @@ TrueType 글꼴
 강조: 글자 깜박임
 .
 :MENU:line_80x25
-스크린: 80 컬럼 x 25 라인
+스크린: 80 칸 x 25 줄
 .
 :MENU:line_80x43
-스크린: 80 컬럼 x 43 라인
+스크린: 80 칸 x 43 줄
 .
 :MENU:line_80x50
-스크린: 80 컬럼 x 50 라인
+스크린: 80 칸 x 50 줄
 .
 :MENU:line_80x60
-스크린: 80 컬럼 x 60 라인
+스크린: 80 칸 x 60 줄
 .
 :MENU:line_132x25
-스크린: 132 열 x 25 행
+스크린: 132 칸 x 25 줄
 .
 :MENU:line_132x43
-스크린: 132 열 x 43 행
+스크린: 132 칸 x 43 줄
 .
 :MENU:line_132x50
-스크린: 132 열 x 50 행
+스크린: 132 칸 x 50 줄
 .
 :MENU:line_132x60
-스크린: 132 열 x 60 행
+스크린: 132 칸 x 60 줄
 .
 :MENU:VideoTTFMenu
 TTF 선택사항
@@ -2786,10 +2784,10 @@ GRCG를 사용설정
 Glide를 통과
 .
 :MENU:load_d3d_shader
-Direct3D 픽셀 셰이더 선택...
+다이렉트3D 픽셀 셰이더 선택...
 .
 :MENU:load_glsl_shader
-OpenGL (GLSL) 셰이더 선택...
+오픈GL (GLSL) 셰이더 선택...
 .
 :MENU:load_ttf_font
 TrueType 글꼴 (TTF/OTF)을 선택...
@@ -2801,7 +2799,7 @@ TrueType 글꼴 (TTF/OTF)을 선택...
 음성의 좌우 교환
 .
 :MENU:mixer_mute
-음소거
+소리끔
 .
 :MENU:mixer_info
 소리 믹서 볼륨을 표시
@@ -2918,10 +2916,10 @@ AVI + ZMBV
 MPEG-TS + H.264
 .
 :MENU:saveoptionmenu
-상태 저장/로드 선택사항
+상태 저장/불러오기 선택사항
 .
 :MENU:saveslotmenu
-세이브 슬롯 선택
+저장 슬롯을 선택
 .
 :MENU:enable_autosave
 자동 상태 저장 사용
@@ -2984,7 +2982,7 @@ MPEG-TS + H.264
 선택사항: 쓰기 금지로 탑재
 .
 :MENU:drive_mountarc
-서고(ZIP/7Z)를 탑재
+압축 파일(ZIP/7Z)을 탑재
 .
 :MENU:drive_mountimg
 디스크/CD 이미지를 탑재
@@ -2993,7 +2991,7 @@ MPEG-TS + H.264
 여러 디스크/CD 이미지를 탑재
 .
 :MENU:drive_mountiro
-선택사항: 쓰기 금지로 탑재
+선택사항: 이미지를 읽기 전용으로 탑재
 .
 :MENU:drive_unmount
 드라이브 탑재를 해제
@@ -3041,7 +3039,7 @@ DOSBox-X 정보
 로그용 콘솔을 표시
 .
 :MENU:disable_logging
-로깅 출력 비활성화
+로깅 출력을 사용 안함
 .
 :MENU:wait_on_error
 오류시 콘솔 중지
@@ -3122,31 +3120,31 @@ INT 21h 호출 기록
 다음 슬롯을 선택
 .
 :MENU:mapper_decfskip
-프레임 스킵:감소
+프레임 건너뀌기: 감소
 .
 :MENU:mapper_incfskip
-프레임 스킵:증가
+프레임 건너뛰기: 증가
 .
 :MENU:mapper_aspratio
 종횡비에 맞추기
 .
 :MENU:mapper_fscaler
-스케일러 강제 사용
+확대 강제 사용
 .
 :MENU:mapper_recwave
-오디오를 WAV에 저장
+오디오를 WAV로 저장
 .
 :MENU:mapper_recmtwave
-오디오를 멀티 트랙 AVI에 저장
+오디오를 멀티 트랙 AVI로 저장
 .
 :MENU:mapper_caprawmidi
-MIDI 출력 저장
+MIDI 출력을 저장
 .
 :MENU:mapper_caprawopl
-FM (OPL) 출력 저장
+FM (OPL) 출력을 저장
 .
 :MENU:mapper_video
-동영상을 AVI에 저장
+동영상을 AVI로 저장
 .
 :MENU:mapper_scrshot
 스크린샷을 찍기
@@ -3167,10 +3165,10 @@ FM (OPL) 출력 저장
 특수 키를 보내기
 .
 :MENU:mapper_cycledown
-주기: 감소
+주기: 낮춤
 .
 :MENU:mapper_cycleup
-주기: 증가
+주기: 올림
 .
 :MENU:mapper_normal
 표준 코어
@@ -3269,10 +3267,10 @@ FPS 및 RT 속도를 제목 표시줄에 표시
 DOSBox-X 인스턴스를 다시 시작
 .
 :MENU:restartconf
-구성 파일을 사용하여 DOSBox-X 재부팅 ...
+구성 파일을 사용하여 DOSBox-X 를 다시 부팅 ...
 .
 :MENU:restartlang
-언어 파일을 사용하여 DOSBox-X 재부팅 ...
+언어 파일을 사용하여 DOSBox-X 를 다시 부팅 ...
 .
 :MENU:auto_lock_mouse
 마우스 자동 잠금
@@ -3344,7 +3342,7 @@ Mapper "특수 키 보내기": Ctrl+Break
 Mapper "특수 키 보내기": Ctrl+Alt+Del
 .
 :MENU:wheel_none
-휠 동작을 키로 변환하지 않음
+바퀴 동작을 키로 변환하지 않음
 .
 :MENU:wheel_updown
 커서 상하로 변환
@@ -3410,7 +3408,7 @@ FM/OPL 출력 저장
 주기 자동 설정 전환
 .
 :MAPPER:debugger
-디버거 표시
+디버거 시작
 .
 :MAPPER:decsize
 TTF 크기: 축소
@@ -3431,7 +3429,7 @@ TTF 크기: 확대
 매퍼 파일 읽기
 .
 :MAPPER:nextslot
-다음 세이브 슬롯
+다음 저장 슬롯
 .
 :MAPPER:normal
 CPU:표준 코어
@@ -3446,7 +3444,7 @@ CPU:표준 코어
 일시 정지 인터럽트 유효
 .
 :MAPPER:prevslot
-이전 세이브 슬롯
+이전 저장 슬롯
 .
 :MAPPER:printtext
 글자 화면 인쇄
@@ -3467,13 +3465,13 @@ DOS 시스템을 다시 부팅
 녹음 수준: 위
 .
 :MAPPER:rescanall
-드라이브 재검색
+드라이브 다시 검사
 .
 :MAPPER:reset
-DOSBox-X 재부팅
+DOSBox-X 다시 부팅
 .
 :MAPPER:resetcolor
-색 구성표 재설정
+색 구성표를 다시 설정
 .
 :MAPPER:showstate
 상태 정보 표시
@@ -3482,5 +3480,5 @@ DOSBox-X 재부팅
 CPU: 간단한 코어
 .
 :MAPPER:togmenu
-차림펴 막대 표시를 바꿈
+차림표 막대 표시를 바꿈
 .

--- a/contrib/translations/pt/pt_BR.lng
+++ b/contrib/translations/pt/pt_BR.lng
@@ -2301,6 +2301,12 @@ Colar da transferência
 :MENU:mapper_pasteend
 Parar a colagem da área de transferência
 .
+:MENU:mapper_ejectpage
+Enviar salto de página
+.
+:MENU:mapper_printtext
+Imprimir tela de texto DOS
+.
 :MENU:mapper_pause
 Pausar emulação
 .
@@ -2319,17 +2325,17 @@ Alternar tela cheia
 :MENU:mapper_resetsize
 Restaurar janela
 .
-:MENU:mapper_incsize
-Aumentar tamanho da fonte TTF
-.
-:MENU:mapper_decsize
-Reduzir tamanho de fonte TTF
-.
 :MENU:mapper_dbcssbcs
 CJK: Alternar entre modos DBCS/SBCS
 .
 :MENU:mapper_autoboxdraw
 CJK: Detectar automaticamente símbolos de desenho de caixa
+.
+:MENU:mapper_incsize
+Aumentar tamanho da fonte TTF
+.
+:MENU:mapper_decsize
+Reduzir tamanho de fonte TTF
 .
 :MENU:mapper_resetcolor
 Restaurar esquema de cor de TTF
@@ -2501,9 +2507,6 @@ Definir proporção
 .
 :MENU:VideoScalerMenu
 Redimensionador
-.
-:MENU:scaler_forced
-Forçar escala
 .
 :MENU:scaler_set_none
 Nenhum
@@ -3109,7 +3112,7 @@ Alternar bloqueio de velocidade
 Turbo (Avanço rápido)
 .
 :MENU:mapper_speednorm
-Normal
+Velocidade normal
 .
 :MENU:mapper_speedup
 Acelerar
@@ -3144,6 +3147,9 @@ Aumentar salto de quadros
 :MENU:mapper_aspratio
 Ajustar à proporção de tela
 .
+:MENU:mapper_fscaler
+Forçar escala
+.
 :MENU:mapper_recwave
 Gravar áudio em WAV
 .
@@ -3161,9 +3167,6 @@ Gravar vídeo em AVI
 .
 :MENU:mapper_scrshot
 Capturar tela
-.
-:MENU:mapper_debugger
-Iniciar depurador do DOSBox-X
 .
 :MENU:mapper_volup
 Aumentar volume
@@ -3267,8 +3270,8 @@ Trocar unidade de disquete
 :MENU:mapper_swapcd
 Trocar de unidade de CD
 .
-:MENU:mapper_ejectpage
-Enviar salto de página
+:MENU:mapper_debugger
+Iniciar depurador do DOSBox-X
 .
 :MENU:mapper_rescanall
 Reverificar todas as unidades
@@ -3411,9 +3414,6 @@ Mostrar número das unidades montadas
 :MENU:list_ideinfo
 Mostrar estado de disco IDE ou CD
 .
-:MENU:print_textscreen
-Imprimir tela de texto DOS
-.
 :MENU:pc98_use_uskb
 Usar esquema de teclado americano
 .
@@ -3464,6 +3464,9 @@ Pausar com interrupção
 .
 :MAPPER:prevslot
 Compartimento salvo anterior
+.
+:MAPPER:printtext
+Imprimir tela de texto
 .
 :MAPPER:quickrun
 Lançar prog. rápido

--- a/contrib/translations/pt/pt_BR.lng
+++ b/contrib/translations/pt/pt_BR.lng
@@ -2487,6 +2487,9 @@ proporção da tela
 :MENU:video_ratio_1_1
 1:1
 .
+:MENU:video_ratio_3_2
+3:2
+.
 :MENU:video_ratio_4_3
 4:3
 .

--- a/contrib/translations/tr/tr_TR.lng
+++ b/contrib/translations/tr/tr_TR.lng
@@ -2465,6 +2465,9 @@ en boy oranı
 :MENU:video_ratio_1_1
 1:1
 .
+:MENU:video_ratio_3_2
+3:2
+.
 :MENU:video_ratio_4_3
 4:3
 .

--- a/contrib/translations/tr/tr_TR.lng
+++ b/contrib/translations/tr/tr_TR.lng
@@ -2279,6 +2279,12 @@ Panodan yapıştırılıyor
 :MENU:mapper_pasteend
 Panodan yapıştırmayı durdur
 .
+:MENU:mapper_ejectpage
+Form beslemesi gönder
+.
+:MENU:mapper_printtext
+DOS metin ekranını yazdır
+.
 :MENU:mapper_pause
 Öykünmeyi duraklat
 .
@@ -2297,17 +2303,17 @@ Tam ekrana gir/çık
 :MENU:mapper_resetsize
 Pencereyi sıfırla
 .
-:MENU:mapper_incsize
-TTF yazıtipi boyutunu artır
-.
-:MENU:mapper_decsize
-TTF yazıtipi boyutunu azalt
-.
 :MENU:mapper_dbcssbcs
 ÇJK: DBCS/SBCS kipleri arasında geçiş yap
 .
 :MENU:mapper_autoboxdraw
 ÇJK: Kutu karakterleri kendiliğinden algıla
+.
+:MENU:mapper_incsize
+TTF yazıtipi boyutunu artır
+.
+:MENU:mapper_decsize
+TTF yazıtipi boyutunu azalt
 .
 :MENU:mapper_resetcolor
 TTF renk şemasını sıfırla
@@ -2479,9 +2485,6 @@ Oranı ayarla
 .
 :MENU:VideoScalerMenu
 Ölçekleyici
-.
-:MENU:scaler_forced
-Ölçekleyiciyi zorla
 .
 :MENU:scaler_set_none
 Hiçbiri
@@ -3122,6 +3125,9 @@ Bir sonraki slotu seç
 :MENU:mapper_aspratio
 Orana sığdır
 .
+:MENU:mapper_fscaler
+Ölçekleyiciyi zorla
+.
 :MENU:mapper_recwave
 Sesi WAV olarak kaydet
 .
@@ -3139,9 +3145,6 @@ Videoyu AVI olarak kaydet
 .
 :MENU:mapper_scrshot
 Ekran görüntüsü al
-.
-:MENU:mapper_debugger
-DOSBox-X hata ayıklayıcısını başlat
 .
 :MENU:mapper_volup
 Ses düzeyini artır
@@ -3245,8 +3248,8 @@ Disket sürücüleri değiştir
 :MENU:mapper_swapcd
 CD sürücüsünü değiştir
 .
-:MENU:mapper_ejectpage
-Form beslemesi gönder
+:MENU:mapper_debugger
+DOSBox-X hata ayıklayıcısını başlat
 .
 :MENU:mapper_rescanall
 Tüm sürücüleri yeniden tara
@@ -3389,9 +3392,6 @@ Bağlı disk numaralarını göster
 :MENU:list_ideinfo
 IDE disk veya CD durumunu göster
 .
-:MENU:print_textscreen
-DOS metin ekranını yazdır
-.
 :MENU:pc98_use_uskb
 ABD klavye dizilimi kullan
 .
@@ -3442,6 +3442,9 @@ Yarıda keserek durdur
 .
 :MAPPER:prevslot
 Önceki kaydetme slotu
+.
+:MAPPER:printtext
+Metin ekranını yazdır
 .
 :MAPPER:quickrun
 Hızlı program başlat

--- a/contrib/translations/zh/zh_CN.lng
+++ b/contrib/translations/zh/zh_CN.lng
@@ -2430,6 +2430,9 @@ AMD Athlon 600MHz (约 306000 周期)
 :MENU:video_ratio_1_1
 1:1
 .
+:MENU:video_ratio_3_2
+3:2
+.
 :MENU:video_ratio_4_3
 4:3
 .

--- a/contrib/translations/zh/zh_CN.lng
+++ b/contrib/translations/zh/zh_CN.lng
@@ -2244,6 +2244,12 @@ To adjust the emulated CPU speed, use [31mhost+Plus[37m and [31mhost+Minus[3
 :MENU:mapper_pasteend
 停止剪贴板复制
 .
+:MENU:mapper_ejectpage
+发送打印机换页符
+.
+:MENU:mapper_printtext
+打印 DOS 屏幕文字
+.
 :MENU:mapper_pause
 暂停模拟
 .
@@ -2262,17 +2268,17 @@ To adjust the emulated CPU speed, use [31mhost+Plus[37m and [31mhost+Minus[3
 :MENU:mapper_resetsize
 重置屏幕大小
 .
-:MENU:mapper_incsize
-增加 TTF 字体大小
-.
-:MENU:mapper_decsize
-减少 TTF 字体大小
-.
 :MENU:mapper_dbcssbcs
 中日韩文字: 切换双字节/单字节模式
 .
 :MENU:mapper_autoboxdraw
 中日韩文字: 自动检测制表符
+.
+:MENU:mapper_incsize
+增加 TTF 字体大小
+.
+:MENU:mapper_decsize
+减少 TTF 字体大小
 .
 :MENU:mapper_resetcolor
 重置 TTF 配色方案
@@ -2444,9 +2450,6 @@ AMD Athlon 600MHz (约 306000 周期)
 .
 :MENU:VideoScalerMenu
 缩放器
-.
-:MENU:scaler_forced
-强制使用缩放器
 .
 :MENU:scaler_set_none
 无
@@ -3087,6 +3090,9 @@ DOS 命令
 :MENU:mapper_aspratio
 长宽比适合模式
 .
+:MENU:mapper_fscaler
+强制使用缩放器
+.
 :MENU:mapper_recwave
 录制音频到 WAV
 .
@@ -3104,9 +3110,6 @@ DOS 命令
 .
 :MENU:mapper_scrshot
 捕获屏幕快照
-.
-:MENU:mapper_debugger
-启动 DOSBox-X 调试器
 .
 :MENU:mapper_volup
 提高音量
@@ -3210,8 +3213,8 @@ DOS 命令
 :MENU:mapper_swapcd
 交换光盘镜像
 .
-:MENU:mapper_ejectpage
-发送打印机换页符
+:MENU:mapper_debugger
+启动 DOSBox-X 调试器
 .
 :MENU:mapper_rescanall
 刷新所有驱动器
@@ -3354,9 +3357,6 @@ Mapper "输入特殊键": Ctrl+Alt+Del
 :MENU:list_ideinfo
 显示 IDE 驱动器状态
 .
-:MENU:print_textscreen
-打印 DOS 屏幕文字
-.
 :MENU:pc98_use_uskb
 使用美式键盘布局
 .
@@ -3401,6 +3401,9 @@ CPU: 正常内核
 .
 :MAPPER:prevslot
 上一个存档
+.
+:MAPPER:printtext
+打印屏幕文字
 .
 :MAPPER:quickrun
 快速启动程序

--- a/contrib/translations/zh/zh_TW.lng
+++ b/contrib/translations/zh/zh_TW.lng
@@ -2251,6 +2251,12 @@ To adjust the emulated CPU speed, use [31mhost+Plus[37m and [31mhost+Minus[3
 :MENU:mapper_pasteend
 停止將剪貼簿內容貼上
 .
+:MENU:mapper_ejectpage
+傳送印表機換頁符號
+.
+:MENU:mapper_printtext
+列印 DOS 畫面文字
+.
 :MENU:mapper_pause
 暫停模擬
 .
@@ -2269,17 +2275,17 @@ To adjust the emulated CPU speed, use [31mhost+Plus[37m and [31mhost+Minus[3
 :MENU:mapper_resetsize
 重設視窗大小
 .
-:MENU:mapper_incsize
-放大 TTF 字型
-.
-:MENU:mapper_decsize
-縮小 TTF 字型
-.
 :MENU:mapper_dbcssbcs
 中日韓文字: 切換雙位元組/單位元組模式
 .
 :MENU:mapper_autoboxdraw
 中日韓文字: 自動檢測製表符號
+.
+:MENU:mapper_incsize
+放大 TTF 字型
+.
+:MENU:mapper_decsize
+縮小 TTF 字型
 .
 :MENU:mapper_resetcolor
 重設 TTF 色彩配置
@@ -2451,9 +2457,6 @@ AMD Athlon 600MHz (約 306000 個週期)
 .
 :MENU:VideoScalerMenu
 縮放器
-.
-:MENU:scaler_forced
-強制使用縮放器
 .
 :MENU:scaler_set_none
 無
@@ -3094,6 +3097,9 @@ Turbo (快轉模式)
 :MENU:mapper_aspratio
 符合長寬比模式
 .
+:MENU:mapper_fscaler
+強制使用縮放器
+.
 :MENU:mapper_recwave
 錄製音訊到 WAV
 .
@@ -3111,9 +3117,6 @@ Turbo (快轉模式)
 .
 :MENU:mapper_scrshot
 抓取螢幕畫面
-.
-:MENU:mapper_debugger
-啟動 DOSBox-X 偵錯工具
 .
 :MENU:mapper_volup
 提高音量
@@ -3217,8 +3220,8 @@ Turbo (快轉模式)
 :MENU:mapper_swapcd
 切換光碟映像
 .
-:MENU:mapper_ejectpage
-傳送印表機換頁符號
+:MENU:mapper_debugger
+啟動 DOSBox-X 偵錯工具
 .
 :MENU:mapper_rescanall
 重新整理所有磁碟機
@@ -3361,9 +3364,6 @@ Mapper "傳送特殊鍵": Ctrl+Alt+Del
 :MENU:list_ideinfo
 顯示 IDE 磁碟或光碟狀態
 .
-:MENU:print_textscreen
-列印 DOS 畫面文字
-.
 :MENU:pc98_use_uskb
 使用美式鍵盤配置
 .
@@ -3399,6 +3399,9 @@ CPU: 一般核心
 .
 :MAPPER:prevslot
 上一個儲存位置
+.
+:MENU:printtext
+列印畫面文字
 .
 :MAPPER:quickrun
 快速啟動程式

--- a/contrib/translations/zh/zh_TW.lng
+++ b/contrib/translations/zh/zh_TW.lng
@@ -2437,6 +2437,9 @@ AMD Athlon 600MHz (約 306000 個週期)
 :MENU:video_ratio_1_1
 1:1
 .
+:MENU:video_ratio_3_2
+3:2
+.
 :MENU:video_ratio_4_3
 4:3
 .

--- a/contrib/windows/installer/dosbox-x.reference.setup.conf
+++ b/contrib/windows/installer/dosbox-x.reference.setup.conf
@@ -713,9 +713,9 @@ pc-98 anex86 font                        =
 #              del: Maps the undefined del symbol (0x7F) to the next character (0x80) for the Japanese DOS/V and other Japanese mode emulations.
 #       fepcontrol: FEP control API for the DOS/V emulation.
 #                     Possible values: ias, mskanji, both.
-#           vtext1: V-text screen mode 1 for the DOS/V emulation. Set "machine=svga_et4000" for all available options; enter command "VTEXT 1" for this mode.
+#           vtext1: V-text screen mode 1 for the DOS/V emulation. Enter command "VTEXT 1" for this mode. Note that XGA/SXGA mode is only supported by the svga_s3trio and svga_et4000 machine types.
 #                     Possible values: xga, xga24, sxga, sxga24, svga.
-#           vtext2: V-text screen mode 2 for the DOS/V emulation. Set "machine=svga_et4000" for all available options; enter command "VTEXT 2" for this mode.
+#           vtext2: V-text screen mode 2 for the DOS/V emulation. Enter command "VTEXT 2" for this mode. Note that XGA/SXGA mode is only supported by the svga_s3trio and svga_et4000 machine types.
 #                     Possible values: xga, xga24, sxga, sxga24, svga.
 #   use20pixelfont: Enables 20 pixel font will be used instead of the 24 pixel system font for the Japanese DOS/V emulation (with V-text enabled).
 #            j3100: With the setting dosv=jp and a non-off value of this option, the Toshiba J-3100 machine will be emulated with DCGA support.
@@ -1378,9 +1378,8 @@ prebuffer       = 25
 #DOSBOX-X-ADV:#                            Possible values: 0, 1, 2, 3.
 #DOSBOX-X-ADV:#        mt32.niceampramp: Toggles "Nice Amp Ramp" mode that improves amplitude ramp for sustaining instruments.
 #DOSBOX-X-ADV:#                            Quick changes of volume or expression on a MIDI channel may result in amp jumps on real hardware.
-#DOSBOX-X-ADV:#                            When "Nice Amp Ramp" mode is enabled, amp changes gradually instead.
+#DOSBOX-X-ADV:#                            When "Nice Amp Ramp" mode is enabled (default), amp changes gradually instead.
 #DOSBOX-X-ADV:#                            Otherwise, the emulation accuracy is preserved.
-#DOSBOX-X-ADV:#                            Default is true.
 #            fluid.driver: Driver to use with Fluidsynth, not needed under Windows. Available drivers depend on what Fluidsynth was compiled with.
 #                            Possible values: pulseaudio, alsa, oss, coreaudio, dsound, portaudio, sndman, jack, file, default.
 #         fluid.soundfont: Soundfont (.SF2 or .SF3) to use with Fluidsynth. One must be specified (e.g. GeneralUser_GS.sf2).
@@ -1469,9 +1468,9 @@ fluid.soundfont         =
 #DOSBOX-X-ADV:#                                         irq hack: Specify a hack related to the Sound Blaster IRQ to avoid crashes in a handful of games and demos.
 #DOSBOX-X-ADV:#                                                         none                   Emulate IRQs normally
 #DOSBOX-X-ADV:#                                                         cs_equ_ds              Do not fire IRQ unless two CPU segment registers match: CS == DS. Read DOSBox-X Wiki or source code for details.
-#                                              dma: The DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the DMA unassigned
+#                                              dma: The DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the DMA unassigned.
 #                                                     Possible values: 1, 5, 0, 3, 6, 7, -1.
-#                                             hdma: The High DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the High DMA unassigned
+#                                             hdma: The High DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the High DMA unassigned.
 #                                                     Possible values: 1, 5, 0, 3, 6, 7, -1.
 #DOSBOX-X-ADV:#                              dsp command aliases: If set (on by default), emulation will support known undocumented aliases
 #DOSBOX-X-ADV:#                                                     of common Sound Blaster DSP commands. Some broken DOS games and demos rely on these aliases.
@@ -1643,7 +1642,7 @@ blaster environment variable                     = true
 #DOSBOX-X-ADV:#                                       if desired. Else, Gravis Ultrasound emulation will change the sample rate of it's output according to the number of active channels, just like real hardware.
 #DOSBOX-X-ADV:#                                       Note: DOSBox-X defaults to 'false', while mainline DOSBox SVN is currently hardcoded to render as if this setting is 'true'.
 #                         gusmemsize: Amount of RAM on the Gravis Ultrasound in KB. Set to -1 for default.
-#                  gus master volume: Master Gravis Ultrasound GF1 volume, in decibels. Reducing the master volume can help with games or demoscene productions where the music is too loud and clipping
+#                  gus master volume: Master Gravis Ultrasound GF1 volume, in decibels. Reducing the master volume can help with games or demoscene productions where the music is too loud and clipping.
 #                            gusbase: The IO base address of the Gravis Ultrasound.
 #                                       Possible values: 240, 220, 260, 280, 2a0, 2c0, 2e0, 300, 210, 230, 250.
 #                             gusirq: The IRQ number of the Gravis Ultrasound.

--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -346,9 +346,9 @@ pc-98 anex86 font               =
 #              del: Maps the undefined del symbol (0x7F) to the next character (0x80) for the Japanese DOS/V and other Japanese mode emulations.
 #       fepcontrol: FEP control API for the DOS/V emulation.
 #                     Possible values: ias, mskanji, both.
-#           vtext1: V-text screen mode 1 for the DOS/V emulation. Set "machine=svga_et4000" for all available options; enter command "VTEXT 1" for this mode.
+#           vtext1: V-text screen mode 1 for the DOS/V emulation. Enter command "VTEXT 1" for this mode. Note that XGA/SXGA mode is only supported by the svga_s3trio and svga_et4000 machine types.
 #                     Possible values: xga, xga24, sxga, sxga24, svga.
-#           vtext2: V-text screen mode 2 for the DOS/V emulation. Set "machine=svga_et4000" for all available options; enter command "VTEXT 2" for this mode.
+#           vtext2: V-text screen mode 2 for the DOS/V emulation. Enter command "VTEXT 2" for this mode. Note that XGA/SXGA mode is only supported by the svga_s3trio and svga_et4000 machine types.
 #                     Possible values: xga, xga24, sxga, sxga24, svga.
 #   use20pixelfont: Enables 20 pixel font will be used instead of the 24 pixel system font for the Japanese DOS/V emulation (with V-text enabled).
 #            j3100: With the setting dosv=jp and a non-off value of this option, the Toshiba J-3100 machine will be emulated with DCGA support.
@@ -635,9 +635,9 @@ fluid.soundfont =
 #                          irq: The IRQ number of the Sound Blaster (usually 5 or 7, depending on the sound card type and the game).
 #                                 Set to 0 for the default setting of the sound card, or set to -1 to start DOSBox-X with the IRQ unassigned.
 #                                 Possible values: 7, 5, 3, 9, 10, 11, 12, 0, -1.
-#                          dma: The DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the DMA unassigned
+#                          dma: The DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the DMA unassigned.
 #                                 Possible values: 1, 5, 0, 3, 6, 7, -1.
-#                         hdma: The High DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the High DMA unassigned
+#                         hdma: The High DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the High DMA unassigned.
 #                                 Possible values: 1, 5, 0, 3, 6, 7, -1.
 #               enable speaker: Start the DOS virtual machine with the Sound Blaster speaker enabled.
 #                                 Sound Blaster Pro and older cards have a speaker disable/enable command.
@@ -686,7 +686,7 @@ blaster environment variable = true
 #           gusrate: Sample rate of Ultrasound emulation.
 #                      Possible values: 49716, 48000, 44100, 32000, 22050, 16000, 11025, 8000.
 #        gusmemsize: Amount of RAM on the Gravis Ultrasound in KB. Set to -1 for default.
-# gus master volume: Master Gravis Ultrasound GF1 volume, in decibels. Reducing the master volume can help with games or demoscene productions where the music is too loud and clipping
+# gus master volume: Master Gravis Ultrasound GF1 volume, in decibels. Reducing the master volume can help with games or demoscene productions where the music is too loud and clipping.
 #           gusbase: The IO base address of the Gravis Ultrasound.
 #                      Possible values: 240, 220, 260, 280, 2a0, 2c0, 2e0, 300, 210, 230, 250.
 #            gusirq: The IRQ number of the Gravis Ultrasound.

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -693,9 +693,9 @@ pc-98 show graphics layer on initialize  = true
 #              del: Maps the undefined del symbol (0x7F) to the next character (0x80) for the Japanese DOS/V and other Japanese mode emulations.
 #       fepcontrol: FEP control API for the DOS/V emulation.
 #                     Possible values: ias, mskanji, both.
-#           vtext1: V-text screen mode 1 for the DOS/V emulation. Set "machine=svga_et4000" for all available options; enter command "VTEXT 1" for this mode.
+#           vtext1: V-text screen mode 1 for the DOS/V emulation. Enter command "VTEXT 1" for this mode. Note that XGA/SXGA mode is only supported by the svga_s3trio and svga_et4000 machine types.
 #                     Possible values: xga, xga24, sxga, sxga24, svga.
-#           vtext2: V-text screen mode 2 for the DOS/V emulation. Set "machine=svga_et4000" for all available options; enter command "VTEXT 2" for this mode.
+#           vtext2: V-text screen mode 2 for the DOS/V emulation. Enter command "VTEXT 2" for this mode. Note that XGA/SXGA mode is only supported by the svga_s3trio and svga_et4000 machine types.
 #                     Possible values: xga, xga24, sxga, sxga24, svga.
 #   use20pixelfont: Enables 20 pixel font will be used instead of the 24 pixel system font for the Japanese DOS/V emulation (with V-text enabled).
 #            j3100: With the setting dosv=jp and a non-off value of this option, the Toshiba J-3100 machine will be emulated with DCGA support.
@@ -1346,9 +1346,8 @@ prebuffer       = 25
 #                            Possible values: 0, 1, 2, 3.
 #        mt32.niceampramp: Toggles "Nice Amp Ramp" mode that improves amplitude ramp for sustaining instruments.
 #                            Quick changes of volume or expression on a MIDI channel may result in amp jumps on real hardware.
-#                            When "Nice Amp Ramp" mode is enabled, amp changes gradually instead.
+#                            When "Nice Amp Ramp" mode is enabled (default), amp changes gradually instead.
 #                            Otherwise, the emulation accuracy is preserved.
-#                            Default is true.
 #            fluid.driver: Driver to use with Fluidsynth, not needed under Windows. Available drivers depend on what Fluidsynth was compiled with.
 #                            Possible values: pulseaudio, alsa, oss, coreaudio, dsound, portaudio, sndman, jack, file, default.
 #         fluid.soundfont: Soundfont (.SF2 or .SF3) to use with Fluidsynth. One must be specified (e.g. GeneralUser_GS.sf2).
@@ -1433,9 +1432,9 @@ fluid.chorus.type       = 0
 #                                         irq hack: Specify a hack related to the Sound Blaster IRQ to avoid crashes in a handful of games and demos.
 #                                                         none                   Emulate IRQs normally
 #                                                         cs_equ_ds              Do not fire IRQ unless two CPU segment registers match: CS == DS. Read DOSBox-X Wiki or source code for details.
-#                                              dma: The DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the DMA unassigned
+#                                              dma: The DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the DMA unassigned.
 #                                                     Possible values: 1, 5, 0, 3, 6, 7, -1.
-#                                             hdma: The High DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the High DMA unassigned
+#                                             hdma: The High DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the High DMA unassigned.
 #                                                     Possible values: 1, 5, 0, 3, 6, 7, -1.
 #                              dsp command aliases: If set (on by default), emulation will support known undocumented aliases
 #                                                     of common Sound Blaster DSP commands. Some broken DOS games and demos rely on these aliases.
@@ -1603,7 +1602,7 @@ io port aliasing                                 = true
 #                                       if desired. Else, Gravis Ultrasound emulation will change the sample rate of it's output according to the number of active channels, just like real hardware.
 #                                       Note: DOSBox-X defaults to 'false', while mainline DOSBox SVN is currently hardcoded to render as if this setting is 'true'.
 #                         gusmemsize: Amount of RAM on the Gravis Ultrasound in KB. Set to -1 for default.
-#                  gus master volume: Master Gravis Ultrasound GF1 volume, in decibels. Reducing the master volume can help with games or demoscene productions where the music is too loud and clipping
+#                  gus master volume: Master Gravis Ultrasound GF1 volume, in decibels. Reducing the master volume can help with games or demoscene productions where the music is too loud and clipping.
 #                            gusbase: The IO base address of the Gravis Ultrasound.
 #                                       Possible values: 240, 220, 260, 280, 2a0, 2c0, 2e0, 300, 210, 230, 250.
 #                             gusirq: The IRQ number of the Gravis Ultrasound.

--- a/include/build_timestamp.h
+++ b/include/build_timestamp.h
@@ -1,4 +1,4 @@
 /*auto-generated*/
-#define UPDATED_STR "Apr 18, 2022 5:42:19pm"
-#define GIT_COMMIT_HASH "67e0873"
+#define UPDATED_STR "Apr 21, 2022 7:17:46pm"
+#define GIT_COMMIT_HASH "c71ef43"
 #define COPYRIGHT_END_YEAR "2022"

--- a/include/control.h
+++ b/include/control.h
@@ -107,7 +107,7 @@ public:
     void SwitchToSecureMode() { secure_mode = true; }//can't be undone
     void ClearExtraData() { Section_prop *sec_prop; Section_line *sec_line; for (const_it tel = sectionlist.begin(); tel != sectionlist.end(); ++tel) {sec_prop = dynamic_cast<Section_prop *>(*tel); sec_line = dynamic_cast<Section_line *>(*tel); if (sec_prop) sec_prop->data = ""; else if (sec_line) sec_line->data = "";} }
 public:
-    std::string opt_editconf,opt_opensaves,opt_opencaptures,opt_lang;
+    std::string opt_editconf,opt_opensaves,opt_opencaptures,opt_lang="",opt_machine="";
     std::vector<std::string> config_file_list;
     std::vector<std::string> opt_o;
     std::vector<std::string> opt_c;

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -4956,41 +4956,13 @@ void DEBUG_ReinitCallback(void) {
 }
 
 void DEBUG_Init() {
-	DOSBoxMenu::item *item;
-
     LOG(LOG_MISC, LOG_DEBUG)("Initializing debug system");
 
-	/* Add some keyhandlers */
-	MAPPER_AddHandler(DEBUG_Enable_Handler,
-	#if defined(MACOSX)
-		// MacOS     NOTE: ALT-F12 to launch debugger. pause maps to F16 on macOS,
-		// which is not easy to input on a modern mac laptop
-		MK_f12
-	#else
-		MK_pause
-	#endif
-        ,MMOD2,"debugger","Show debugger",&item);
-	item->set_text("Start DOSBox-X Debugger");
 	/* Reset code overview and input line */
 	memset((void*)&codeViewData,0,sizeof(codeViewData));
 	/* Setup callback */
 	debugCallback=CALLBACK_Allocate();
 	CALLBACK_Setup(debugCallback,DEBUG_EnableDebugger,CB_RETF,"debugger");
-
-#if defined(MACOSX) || defined(LINUX)
-	/* Mac OS X does not have a console for us to just allocate on a whim like Windows does.
-	   So the debugger interface is useless UNLESS the user has started us from a terminal
-	   (whether over SSH or from the Terminal app).
-       
-       Linux/X11 also does not have a console we can allocate on a whim. You either run
-       this program from XTerm for the debugger, or not. */
-    bool allow = true;
-
-    if (!isatty(0) || !isatty(1) || !isatty(2))
-	    allow = false;
-
-    mainMenu.get_item("mapper_debugger").enable(allow).refresh_item(mainMenu);
-#endif
 
 	/* shutdown function */
 	AddExitFunction(AddExitFunctionFuncPair(DEBUG_ShutDown));

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -6723,7 +6723,7 @@ void AUTOTYPE::PrintKeys()
 	auto name = names.begin();
 	for (size_t row = 0; row < rows; ++row) {
 		for (size_t i = row; i < names.size(); i += rows)
-			WriteOut("  %-*s", static_cast<int>(max_length), name[i].c_str());
+			WriteOut("  %-*s", static_cast<int>(max_length), (name[i].size()==1&&name[i][0]>='a'&&name[i][0]<='z'?name[i]+" ("+std::string(1, toupper(name[i][0]))+")":name[i]).c_str());
 		WriteOut_NoParsing("\n");
 	}
 }
@@ -6816,7 +6816,7 @@ void AUTOTYPE::Run()
 	}
 
 	// Print available keys
-	if (cmd->FindExist("-list", false)) {
+	if (cmd->FindExist("-list", false) || cmd->FindExist("/list", false)) {
 		PrintKeys();
 		return;
 	}

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1012,9 +1012,9 @@ void DOSBOX_RealInit() {
 
     // TODO: should be parsed by motherboard emulation or lower level equiv..?
     std::string cmd_machine;
-    if (control->cmdline->FindString("-machine",cmd_machine,true)){
+    if (control->opt_machine != ""){
         //update value in config (else no matching against suggested values
-        section->HandleInputline(std::string("machine=") + cmd_machine);
+        section->HandleInputline(std::string("machine=") + control->opt_machine);
     }
 
     // NTS: svga_s3 means S3 Trio64 emulation to match general DOSBox SVN emulation behavior.

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2191,12 +2191,12 @@ void DOSBOX_SetupConfigSections(void) {
 	const char* vtext_settings[] = { "xga", "xga24", "sxga", "sxga24", "svga", 0};
 	Pstring = secprop->Add_path("vtext1",Property::Changeable::WhenIdle,"svga");
 	Pstring->Set_values(vtext_settings);
-	Pstring->Set_help("V-text screen mode 1 for the DOS/V emulation. Set \"machine=svga_et4000\" for all available options; enter command \"VTEXT 1\" for this mode.");
+	Pstring->Set_help("V-text screen mode 1 for the DOS/V emulation. Enter command \"VTEXT 1\" for this mode. Note that XGA/SXGA mode is only supported by the svga_s3trio and svga_et4000 machine types.");
     Pstring->SetBasic(true);
 
 	Pstring = secprop->Add_path("vtext2",Property::Changeable::WhenIdle,"xga");
 	Pstring->Set_values(vtext_settings);
-	Pstring->Set_help("V-text screen mode 2 for the DOS/V emulation. Set \"machine=svga_et4000\" for all available options; enter command \"VTEXT 2\" for this mode.");
+	Pstring->Set_help("V-text screen mode 2 for the DOS/V emulation. Enter command \"VTEXT 2\" for this mode. Note that XGA/SXGA mode is only supported by the svga_s3trio and svga_et4000 machine types.");
     Pstring->SetBasic(true);
 
 	Pbool = secprop->Add_bool("use20pixelfont",Property::Changeable::OnlyAtStart,false);
@@ -3142,9 +3142,8 @@ void DOSBOX_SetupConfigSections(void) {
     Pbool = secprop->Add_bool("mt32.niceampramp", Property::Changeable::WhenIdle, true);
     Pbool->Set_help("Toggles \"Nice Amp Ramp\" mode that improves amplitude ramp for sustaining instruments.\n"
         "Quick changes of volume or expression on a MIDI channel may result in amp jumps on real hardware.\n"
-        "When \"Nice Amp Ramp\" mode is enabled, amp changes gradually instead.\n"
-        "Otherwise, the emulation accuracy is preserved.\n"
-        "Default is true.");
+        "When \"Nice Amp Ramp\" mode is enabled (default), amp changes gradually instead.\n"
+        "Otherwise, the emulation accuracy is preserved.");
 
 #if C_FLUIDSYNTH || defined(WIN32) && !defined(HX_DOS)
 	const char *fluiddrivers[] = {"pulseaudio", "alsa", "oss", "coreaudio", "dsound", "portaudio", "sndman", "jack", "file", "default",0};
@@ -3262,12 +3261,12 @@ void DOSBOX_SetupConfigSections(void) {
 
     Pint = secprop->Add_int("dma",Property::Changeable::WhenIdle,1);
     Pint->Set_values(dmassb);
-    Pint->Set_help("The DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the DMA unassigned");
+    Pint->Set_help("The DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the DMA unassigned.");
     Pint->SetBasic(true);
 
     Pint = secprop->Add_int("hdma",Property::Changeable::WhenIdle,5);
     Pint->Set_values(dmassb);
-    Pint->Set_help("The High DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the High DMA unassigned");
+    Pint->Set_help("The High DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the High DMA unassigned.");
     Pint->SetBasic(true);
 
     Pbool = secprop->Add_bool("dsp command aliases",Property::Changeable::WhenIdle,true);
@@ -3525,7 +3524,7 @@ void DOSBOX_SetupConfigSections(void) {
 
     Pdouble = secprop->Add_double("gus master volume",Property::Changeable::WhenIdle,0);
     Pdouble->SetMinMax(-120.0,6.0);
-    Pdouble->Set_help("Master Gravis Ultrasound GF1 volume, in decibels. Reducing the master volume can help with games or demoscene productions where the music is too loud and clipping");
+    Pdouble->Set_help("Master Gravis Ultrasound GF1 volume, in decibels. Reducing the master volume can help with games or demoscene productions where the music is too loud and clipping.");
     Pdouble->SetBasic(true);
 
     Phex = secprop->Add_hex("gusbase",Property::Changeable::WhenIdle,0x240);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -77,6 +77,7 @@
 #include "render.h"
 #include "pci_bus.h"
 #include "parport.h"
+#include "keyboard.h"
 #include "clockdomain.h"
 
 #if C_EMSCRIPTEN
@@ -931,7 +932,21 @@ void Init_VGABIOS() {
     if (rom_fp) fclose(rom_fp);
 }
 
-void SetCyclesCount_mapper_shortcut(bool pressed);
+void SetCyclesCount_mapper_shortcut_RunInternal(void) {
+    GUI_Shortcut(16);
+}
+
+void SetCyclesCount_mapper_shortcut_RunEvent(Bitu /*val*/) {
+    KEYBOARD_ClrBuffer();   //Clear buffer
+    GFX_LosingFocus();      //Release any keys pressed (buffer gets filled again).
+    SetCyclesCount_mapper_shortcut_RunInternal();
+}
+
+void SetCyclesCount_mapper_shortcut(bool pressed) {
+    if (!pressed) return;
+    PIC_AddEvent(SetCyclesCount_mapper_shortcut_RunEvent, 0.0001f); //In case mapper deletes the key object that ran it
+}
+
 void DOSBOX_RealInit() {
     DOSBoxMenu::item *item;
 

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -346,6 +346,7 @@ static const char *def_menu_video_frameskip[] =
 static const char *def_menu_video_ratio[] =
 {
     "video_ratio_1_1",
+    "video_ratio_3_2",
     "video_ratio_4_3",
     "video_ratio_16_9",
     "video_ratio_16_10",

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -522,7 +522,7 @@ static const char *def_menu_video[] =
 #endif
     "--",
     "refresh_rate",
-    "scaler_forced",
+    "mapper_fscaler",
     "VideoScalerMenu",
     "VideoOutputMenu",
 #if !defined(C_SDL2)
@@ -583,7 +583,7 @@ static const char *def_menu_dos[] =
     "mapper_rescanall",
     "--",
 #if C_PRINTER
-    "print_textscreen",
+    "mapper_printtext",
     "mapper_ejectpage",
 #endif
     NULL
@@ -1756,7 +1756,7 @@ void SetScaleForced(bool forced)
     SetVal("render", "scaler", value);
 
     RENDER_CallBack(GFX_CallBackReset);
-    mainMenu.get_item("scaler_forced").check(render.scale.forced).refresh_item(mainMenu);
+    mainMenu.get_item("mapper_fscaler").check(render.scale.forced).refresh_item(mainMenu);
 }
 
 // Sets the scaler to use.

--- a/src/gui/menu_callback.cpp
+++ b/src/gui/menu_callback.cpp
@@ -680,27 +680,6 @@ bool list_ideinfo_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const
     return true;
 }
 
-#if C_PRINTER
-bool PRINTER_isInited();
-void PrintScreen(const char *text, uint16_t len);
-bool print_screen_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
-    (void)menu;//UNUSED
-    (void)menuitem;//UNUSED
-    if (!PRINTER_isInited()) {
-        systemmessagebox("Error","Printer support is not enabled in the configuration.","ok", "error", 1);
-        return false;
-    }
-    if (!CurMode||CurMode->type!=M_TEXT) {
-        systemmessagebox("Error","The current DOS screen is not in text mode.","ok", "error", 1);
-        return false;
-    }
-    uint16_t len=0;
-    const char* text = Mouse_GetSelected(0,0,(int)(currentWindowWidth-1-sdl.clip.x),(int)(currentWindowHeight-1-sdl.clip.y),(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len);
-    if (len) PrintScreen(text, len);
-    return true;
-}
-#endif
-
 const char *drive_opts[][2] = {
 #if defined(WIN32)
 	{ "mountauto",              "Auto-mount Windows drive" },
@@ -817,16 +796,7 @@ bool dos_debug_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const me
     return true;
 }
 
-void SetScaleForced(bool forced);
 void OutputSettingMenuUpdate(void);
-
-bool scaler_forced_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
-    (void)menu;//UNUSED
-    (void)menuitem;//UNUSED
-    SetScaleForced(!render.scale.forced);
-    return true;
-}
-
 void MENU_swapstereo(bool enabled);
 bool MENU_get_swapstereo(void);
 
@@ -2171,41 +2141,6 @@ bool scaler_set_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const m
     return true;
 }
 
-void CALLBACK_Idle(void);
-
-void PauseWithInterruptsEnabled(Bitu /*val*/) {
-    /* we can ONLY do this when the CPU is either in real mode or v86 mode.
-     * doing this from protected mode will only crash the game.
-     * also require that interrupts are enabled before pausing. */
-    if (cpu.pmode) {
-        if (!(reg_flags & FLAG_VM)) {
-            PIC_AddEvent(PauseWithInterruptsEnabled,0.001);
-            return;
-        }
-    }
-
-    if (!(reg_flags & FLAG_IF)) {
-        PIC_AddEvent(PauseWithInterruptsEnabled,0.001);
-        return;
-    }
-
-    while (pausewithinterrupts_enable) CALLBACK_Idle();
-}
-
-void PauseWithInterrupts_mapper_shortcut(bool pressed) {
-    if (!pressed) return;
-
-    if (!pausewithinterrupts_enable) {
-        pausewithinterrupts_enable = true;
-        PIC_AddEvent(PauseWithInterruptsEnabled,0.001);
-    }
-    else {
-        pausewithinterrupts_enable = false;
-    }
-
-    mainMenu.get_item("mapper_pauseints").check(pausewithinterrupts_enable).refresh_item(mainMenu);
-}
-
 bool video_frameskip_common_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
 
@@ -2900,30 +2835,6 @@ bool help_prt_callback(DOSBoxMenu * const /*menu*/, DOSBoxMenu::item * const /*m
     return true;
 }
 
-
-void SetCyclesCount_mapper_shortcut_RunInternal(void) {
-    GUI_Shortcut(16);
-}
-
-void SetCyclesCount_mapper_shortcut_RunEvent(Bitu /*val*/) {
-    KEYBOARD_ClrBuffer();   //Clear buffer
-    GFX_LosingFocus();      //Release any keys pressed (buffer gets filled again).
-    SetCyclesCount_mapper_shortcut_RunInternal();
-}
-
-void SetCyclesCount_mapper_shortcut(bool pressed) {
-    if (!pressed) return;
-    PIC_AddEvent(SetCyclesCount_mapper_shortcut_RunEvent, 0.0001f); //In case mapper deletes the key object that ran it
-}
-
-void AspectRatio_mapper_shortcut(bool pressed) {
-    if (!pressed) return;
-
-    if (!GFX_GetPreventFullscreen()) {
-        SetVal("render", "aspect", render.aspect ? "false" : "true");
-    }
-}
-
 void AllocCallback1() {
         /* stock top-level menu items */
         {
@@ -3027,9 +2938,6 @@ void AllocCallback1() {
             {
                 DOSBoxMenu::item &item = mainMenu.alloc_item(DOSBoxMenu::submenu_type_id,"VideoScalerMenu");
                 item.set_text("Scaler");
-
-                mainMenu.alloc_item(DOSBoxMenu::item_type_id,"scaler_forced").set_text("Force scaler").
-                    set_callback_function(scaler_forced_menu_callback);
 
                 for (size_t i=0;scaler_menu_opts[i][0] != NULL;i++) {
                     const std::string name = std::string("scaler_set_") + scaler_menu_opts[i][0];
@@ -3568,8 +3476,5 @@ void AllocCallback2() {
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"make_diskimage").set_text("Create blank disk image...").set_callback_function(make_diskimage_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"list_drivenum").set_text("Show mounted drive numbers").set_callback_function(list_drivenum_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"list_ideinfo").set_text("Show IDE disk or CD status").set_callback_function(list_ideinfo_menu_callback);
-#if C_PRINTER
-        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"print_textscreen").set_text("Print DOS text screen").set_callback_function(print_screen_menu_callback);
-#endif
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"pc98_use_uskb").set_text("Use US keyboard layout").set_callback_function(pc98_force_uskb_menu_callback).check(pc98_force_ibm_layout);
 }

--- a/src/gui/menu_callback.cpp
+++ b/src/gui/menu_callback.cpp
@@ -1835,6 +1835,7 @@ void UpdateOverscanMenu(void) {
 
 void aspect_ratio_menu() {
     mainMenu.get_item("video_ratio_1_1").check(aspect_ratio_x==1&&aspect_ratio_y==1).enable(true).refresh_item(mainMenu);
+    mainMenu.get_item("video_ratio_3_2").check(aspect_ratio_x==3&&aspect_ratio_y==2).enable(true).refresh_item(mainMenu);
     mainMenu.get_item("video_ratio_4_3").check((aspect_ratio_x==4&&aspect_ratio_y==3)||!aspect_ratio_x||!aspect_ratio_y).enable(true).refresh_item(mainMenu);
     mainMenu.get_item("video_ratio_16_9").check(aspect_ratio_x==16&&aspect_ratio_y==9).enable(true).refresh_item(mainMenu);
     mainMenu.get_item("video_ratio_16_10").check(aspect_ratio_x==16&&aspect_ratio_y==10).enable(true).refresh_item(mainMenu);
@@ -1849,6 +1850,10 @@ bool aspect_ratio_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const
         aspect_ratio_x = 1;
         aspect_ratio_y = 1;
         SetVal("render", "aspect_ratio", "1:1");
+    } else if (!strcmp(mname, "video_ratio_3_2")) {
+        aspect_ratio_x = 3;
+        aspect_ratio_y = 2;
+        SetVal("render", "aspect_ratio", "3:2");
     } else if (!strcmp(mname, "video_ratio_4_3")) {
         aspect_ratio_x = 4;
         aspect_ratio_y = 3;
@@ -2921,6 +2926,8 @@ void AllocCallback1() {
                 item.set_text("Aspect ratio");
 
                 mainMenu.alloc_item(DOSBoxMenu::item_type_id,"video_ratio_1_1").set_text("1:1").
+                    set_callback_function(aspect_ratio_menu_callback);
+                mainMenu.alloc_item(DOSBoxMenu::item_type_id,"video_ratio_3_2").set_text("3:2").
                     set_callback_function(aspect_ratio_menu_callback);
                 mainMenu.alloc_item(DOSBoxMenu::item_type_id,"video_ratio_4_3").set_text("4:3").
                     set_callback_function(aspect_ratio_menu_callback);

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -366,7 +366,15 @@ extern Bitu PIC_Ticks;
 extern bool pause_on_vsync;
 extern bool checkmenuwidth;
 void PauseDOSBox(bool pressed);
-void AspectRatio_mapper_shortcut(bool pressed);
+bool GFX_GetPreventFullscreen(void);
+
+void AspectRatio_mapper_shortcut(bool pressed) {
+    if (!pressed) return;
+
+    if (!GFX_GetPreventFullscreen()) {
+        SetVal("render", "aspect", render.aspect ? "false" : "true");
+    }
+}
 
 void RENDER_EndUpdate( bool abort ) {
     if (GCC_UNLIKELY(!render.updating))
@@ -1053,7 +1061,7 @@ extern const char *scaler_menu_opts[][2];
 void RENDER_UpdateScalerMenu(void) {
     const std::string scaler = RENDER_GetScaler();
 
-    mainMenu.get_item("scaler_forced").check(render.scale.forced).refresh_item(mainMenu);
+    mainMenu.get_item("mapper_fscaler").check(render.scale.forced).refresh_item(mainMenu);
     for (size_t i=0;scaler_menu_opts[i][0] != NULL;i++) {
         const std::string name = std::string("scaler_set_") + scaler_menu_opts[i][0];
         mainMenu.get_item(name).check(scaler == scaler_menu_opts[i][0]).refresh_item(mainMenu);
@@ -1196,6 +1204,13 @@ void setAspectRatio(Section_prop * section) {
 	aspect_ratio_menu();
 }
 
+void SetScaleForced(bool forced);
+void ForceScaler(bool pressed) {
+    if (!pressed) return;
+    SetScaleForced(!render.scale.forced);
+    return;
+}
+
 void RENDER_Init() {
     Section_prop * section=static_cast<Section_prop *>(control->GetSection("render"));
 
@@ -1262,6 +1277,9 @@ void RENDER_Init() {
 
 	MAPPER_AddHandler(&AspectRatio_mapper_shortcut, MK_nothing, 0, "aspratio", "Fit to aspect ratio", &item);
 	item->set_text("Fit to aspect ratio");
+
+	MAPPER_AddHandler(ForceScaler, MK_nothing, 0, "fscaler", "Force scaler", &item);
+	item->set_text("Force scaler");
 
 	if (machine==MCH_HERC || machine==MCH_MDA) {
 		void HercBlend(bool pressed), CycleHercPal(bool pressed);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -306,7 +306,8 @@ unsigned int sendkeymap=0;
 std::string configfile = "";
 std::string strPasteBuffer = "";
 ScreenSizeInfo screen_size_info;
-void DOSBOX_UnlockSpeed2(bool pressed), FormFeed(bool pressed);
+void FormFeed(bool pressed), PrintText(bool pressed);
+void DOSBOX_UnlockSpeed2(bool pressed), DEBUG_Enable_Handler(bool pressed);
 int FileDirExistCP(const char *name), FileDirExistUTF8(std::string &localname, const char *name);
 bool CodePageHostToGuestUTF16(char *d/*CROSS_LEN*/,const uint16_t *s/*CROSS_LEN*/);
 
@@ -1263,7 +1264,41 @@ void HideMenu_mapper_shortcut(bool pressed) {
 #endif
 }
 
-void PauseWithInterrupts_mapper_shortcut(bool pressed);
+void CALLBACK_Idle(void);
+
+void PauseWithInterruptsEnabled(Bitu /*val*/) {
+    /* we can ONLY do this when the CPU is either in real mode or v86 mode.
+     * doing this from protected mode will only crash the game.
+     * also require that interrupts are enabled before pausing. */
+    if (cpu.pmode) {
+        if (!(reg_flags & FLAG_VM)) {
+            PIC_AddEvent(PauseWithInterruptsEnabled,0.001);
+            return;
+        }
+    }
+
+    if (!(reg_flags & FLAG_IF)) {
+        PIC_AddEvent(PauseWithInterruptsEnabled,0.001);
+        return;
+    }
+
+    while (pausewithinterrupts_enable) CALLBACK_Idle();
+}
+
+void PauseWithInterrupts_mapper_shortcut(bool pressed) {
+    if (!pressed) return;
+
+    if (!pausewithinterrupts_enable) {
+        pausewithinterrupts_enable = true;
+        PIC_AddEvent(PauseWithInterruptsEnabled,0.001);
+    }
+    else {
+        pausewithinterrupts_enable = false;
+    }
+
+    mainMenu.get_item("mapper_pauseints").check(pausewithinterrupts_enable).refresh_item(mainMenu);
+}
+
 void PauseDOSBoxLoop(Bitu /*unused*/) {
     bool paused = true;
     SDL_Event event;
@@ -3473,6 +3508,14 @@ static void GUI_StartUp() {
     MAPPER_AddHandler(PasteClipStop,MK_nothing, 0,"pasteend", "Stop clipboard paste", &item);
     item->set_text("Stop clipboard pasting");
 
+#if C_PRINTER
+    MAPPER_AddHandler(&FormFeed, MK_f2 , MMOD1, "ejectpage", "Send form-feed", &item);
+    item->set_text("Send form-feed");
+
+    MAPPER_AddHandler(&PrintText, MK_nothing, 0, "printtext", "Print text screen", &item);
+    item->set_text("Print DOS text screen");
+#endif
+
     MAPPER_AddHandler(&PauseDOSBox, MK_pause, MMODHOST, "pause", "Pause emulation");
 
     MAPPER_AddHandler(&PauseWithInterrupts_mapper_shortcut, MK_nothing, 0, "pauseints", "Pause with interrupt", &item);
@@ -3497,12 +3540,6 @@ static void GUI_StartUp() {
     item->set_text("Reset window size");
 
 #if defined(USE_TTF)
-    MAPPER_AddHandler(&TTF_IncreaseSize, MK_uparrow, MMODHOST, "incsize", "Increase TTF size", &item);
-    item->set_text("Increase TTF font size");
-
-    MAPPER_AddHandler(&TTF_DecreaseSize, MK_downarrow, MMODHOST, "decsize", "Decrease TTF size", &item);
-    item->set_text("Decrease TTF font size");
-
     void DBCSSBCS_mapper_shortcut(bool pressed);
     MAPPER_AddHandler(&DBCSSBCS_mapper_shortcut, MK_nothing, 0, "dbcssbcs", "CJK: Switch between DBCS/SBCS modes", &item);
     item->set_text("CJK: Switch between DBCS/SBCS modes");
@@ -3510,6 +3547,12 @@ static void GUI_StartUp() {
     void AutoBoxDraw_mapper_shortcut(bool pressed);
     MAPPER_AddHandler(&AutoBoxDraw_mapper_shortcut, MK_nothing, 0, "autoboxdraw", "CJK: Auto-detect box-drawing characters", &item);
     item->set_text("CJK: Auto-detect box-drawing characters");
+
+    MAPPER_AddHandler(&TTF_IncreaseSize, MK_uparrow, MMODHOST, "incsize", "Increase TTF size", &item);
+    item->set_text("Increase TTF font size");
+
+    MAPPER_AddHandler(&TTF_DecreaseSize, MK_downarrow, MMODHOST, "decsize", "Decrease TTF size", &item);
+    item->set_text("Decrease TTF font size");
 
     void ResetColors_mapper_shortcut(bool pressed);
     MAPPER_AddHandler(&ResetColors_mapper_shortcut, MK_nothing, 0, "resetcolor", "Reset color scheme", &item);
@@ -8610,11 +8653,6 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         DONGLE_Init();
 #if C_PRINTER
         PRINTER_Init();
-        {
-            DOSBoxMenu::item *item;
-            MAPPER_AddHandler(FormFeed, MK_f2 , MMOD1, "ejectpage", "Send form-feed", &item);
-            item->set_text("Send form-feed");
-        }
 #endif
         PARALLEL_Init();
         NE2K_Init();
@@ -8629,6 +8667,38 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 
         /* let's assume motherboards are sane on boot because A20 gate is ENABLED on first boot */
         MEM_A20_Enable(true);
+
+#if C_DEBUG
+        {
+            DOSBoxMenu::item *item;
+            /* Add some keyhandlers */
+            MAPPER_AddHandler(DEBUG_Enable_Handler,
+#if defined(MACOSX)
+            // MacOS     NOTE: ALT-F12 to launch debugger. pause maps to F16 on macOS,
+            // which is not easy to input on a modern mac laptop
+            MK_f12
+#else
+            MK_pause
+#endif
+            ,MMOD2,"debugger","Show debugger",&item);
+            item->set_text("Start DOSBox-X Debugger");
+
+#if defined(MACOSX) || defined(LINUX)
+            /* Mac OS X does not have a console for us to just allocate on a whim like Windows does.
+               So the debugger interface is useless UNLESS the user has started us from a terminal
+               (whether over SSH or from the Terminal app).
+
+               Linux/X11 also does not have a console we can allocate on a whim. You either run
+               this program from XTerm for the debugger, or not. */
+            bool allow = true;
+
+            if (!isatty(0) || !isatty(1) || !isatty(2))
+                allow = false;
+
+            mainMenu.get_item("mapper_debugger").enable(allow).refresh_item(mainMenu);
+#endif
+        }
+#endif
 
         /* OS init now */
         DOS_Init();
@@ -8711,7 +8781,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         bool MENU_get_mute(void);
         mainMenu.get_item("mixer_mute").check(MENU_get_mute()).refresh_item(mainMenu);
 
-        mainMenu.get_item("scaler_forced").check(render.scale.forced).refresh_item(mainMenu);
+        mainMenu.get_item("mapper_fscaler").check(render.scale.forced).refresh_item(mainMenu);
         mainMenu.get_item("3dfx_voodoo").check(strcasecmp(static_cast<Section_prop *>(control->GetSection("voodoo"))->Get_string("voodoo_card"), "false")).refresh_item(mainMenu);
         mainMenu.get_item("3dfx_glide").check(addovl).refresh_item(mainMenu);
 
@@ -8758,7 +8828,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         mainMenu.get_item("ttf_extcharset").enable(TTF_using()&&!IS_PC98_ARCH&&!IS_JEGA_ARCH&&enable_dbcs_tables).check(dos.loaded_codepage==936?gbk:(dos.loaded_codepage==950||dos.loaded_codepage==951?chinasea:gbk&&chinasea));
 #endif
 #if C_PRINTER
-        mainMenu.get_item("print_textscreen").enable(!IS_PC98_ARCH);
+        mainMenu.get_item("mapper_printtext").enable(!IS_PC98_ARCH);
 #endif
         mainMenu.get_item("pc98_5mhz_gdc").enable(IS_PC98_ARCH);
         mainMenu.get_item("pc98_allow_200scanline").enable(IS_PC98_ARCH);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -6632,9 +6632,9 @@ bool DOSBOX_parse_argv() {
         else if (optname == "?" || optname == "h" || optname == "help") {
             DOSBox_ShowConsole();
 
-            fprintf(stderr,"\ndosbox-x [name] [options]\n");
             fprintf(stderr,"\nDOSBox-X version %s %s, copyright 2011-%s The DOSBox-X Team.\n",VERSION,SDL_STRING,COPYRIGHT_END_YEAR);
             fprintf(stderr,"DOSBox-X project maintainer: joncampbell123 (The Great Codeholio)\n\n");
+            fprintf(stderr,"dosbox-x [name] [options]\n");
             fprintf(stderr,"Options can be started with either \"-\" or \"/\" (e.g. \"-help\" or \"/help\"):\n\n");
             fprintf(stderr,"  -?, -h, -help                           Show this help screen\n");
             fprintf(stderr,"  -v, -ver, -version                      Display DOSBox-X version information\n");
@@ -6668,6 +6668,7 @@ bool DOSBOX_parse_argv() {
             fprintf(stderr,"  -display2 <color>                       Enable standard & monochrome dual-screen mode with <color>\n");
 #endif
             fprintf(stderr,"  -lang <message file>                    Use specific message file instead of language= setting\n");
+            fprintf(stderr,"  -machine <type>                         Start DOSBox-X with a specific machine <type>\n");
             fprintf(stderr,"  -nodpiaware                             Ignore (do not signal) Windows DPI awareness\n");
             fprintf(stderr,"  -securemode                             Enable secure mode (no drive mounting etc)\n");
             fprintf(stderr,"  -prerun                                 If [name] is given, run it before AUTOEXEC.BAT config section\n");
@@ -6744,6 +6745,9 @@ bool DOSBOX_parse_argv() {
         }
         else if (optname == "nolog") {
             control->opt_nolog = true;
+        }
+        else if (optname == "machine") {
+            if (!control->cmdline->NextOptArgv(control->opt_machine)) return false;
         }
         else if (optname == "time-limit") {
             if (!control->cmdline->NextOptArgv(tmp)) return false;

--- a/src/hardware/parport/printer.cpp
+++ b/src/hardware/parport/printer.cpp
@@ -48,6 +48,7 @@ extern FT_Face GetTTFFace();
 extern std::string GetDOSBoxXPath(bool withexe=false);
 extern bool CheckBoxDrawing(uint8_t c1, uint8_t c2, uint8_t c3, uint8_t c4);
 extern bool CodePageGuestToHostUTF16(uint16_t *d/*CROSS_LEN*/,const char *s/*CROSS_LEN*/);
+extern bool systemmessagebox(char const * aTitle, char const * aMessage, char const * aDialogType, char const * aIconType, int aDefaultButton);
 extern bool isDBCSCP(), isKanji1(uint8_t chr);
 extern void GFX_CaptureMouse(void);
 extern std::map<int, int> lowboxdrawmap;
@@ -1959,7 +1960,6 @@ void CPrinter::doAction(const char *fname) {
             fail=system((action+" "+fname).c_str())!=0;
 #endif
         }
-        bool systemmessagebox(char const * aTitle, char const * aMessage, char const * aDialogType, char const * aIconType, int aDefaultButton);
         if (fail) systemmessagebox("Error", "The requested file handler failed to complete.", "ok","error", 1);
     }
 }
@@ -2419,6 +2419,22 @@ void PrintScreen(const char *text, uint16_t len)
     if (!defaultPrinter) defaultPrinter = new CPrinter(confdpi, confwidth, confheight, confoutputDevice, confmultipageOutput);
     for (int i=0; i<len; i++) defaultPrinter->printChar(text[i]);
     FormFeed(true);
+}
+
+void PrintText(bool pressed) {
+    if (!pressed) return;
+    if (!PRINTER_isInited()) {
+        systemmessagebox("Error","Printer support is not enabled in the configuration.","ok", "error", 1);
+        return;
+    }
+    if (!CurMode||CurMode->type!=M_TEXT) {
+        systemmessagebox("Error","The current DOS screen is not in text mode.","ok", "error", 1);
+        return;
+    }
+    uint16_t len=0;
+    const char* text = Mouse_GetSelected(0,0,(int)(currentWindowWidth-1-sdl.clip.x),(int)(currentWindowHeight-1-sdl.clip.y),(int)(currentWindowWidth-sdl.clip.x),(int)(currentWindowHeight-sdl.clip.y), &len);
+    if (len) PrintScreen(text, len);
+    return;
 }
 
 static void PRINTER_EventHandler(Bitu param)

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -57,7 +57,7 @@ extern const char *modifier;
 extern unsigned int sendkeymap;
 extern std::string langname, configfile, dosbox_title;
 extern int autofixwarn, enablelfn, fat32setver, paste_speed, wheel_key, freesizecap, wpType, wpVersion, wpBG, wpFG, lastset, blinkCursor;
-extern bool dos_kernel_disabled, force_nocachedir, wpcolon, lockmount, enable_config_as_shell_commands, load, winrun, winautorun, startcmd, startwait, startquiet, starttranspath, mountwarning, wheel_guest, clipboard_dosapi, noremark_save_state, force_load_state, sync_time, manualtime, ttfswitch, loadlang, showbold, showital, showline, showsout, char512, printfont, rtl, gbk, chinasea, uao, showdbcs, dbcs_sbcs, autoboxdraw, halfwidthkana, ticksLocked, outcon, enable_dbcs_tables, show_recorded_filename;
+extern bool dos_kernel_disabled, force_nocachedir, wpcolon, lockmount, enable_config_as_shell_commands, lesssize, load, winrun, winautorun, startcmd, startwait, startquiet, starttranspath, mountwarning, wheel_guest, clipboard_dosapi, noremark_save_state, force_load_state, sync_time, manualtime, ttfswitch, loadlang, showbold, showital, showline, showsout, char512, printfont, rtl, gbk, chinasea, uao, showdbcs, dbcs_sbcs, autoboxdraw, halfwidthkana, ticksLocked, outcon, enable_dbcs_tables, show_recorded_filename;
 
 /* This registers a file on the virtual drive and creates the correct structure for it*/
 
@@ -934,7 +934,9 @@ void ApplySetting(std::string pvar, std::string inputline, bool quiet) {
 #endif
                 } else if (!strcasecmp(inputline.substr(0, 7).c_str(), "ptsize=")||!strcasecmp(inputline.substr(0, 8).c_str(), "winperc=")) {
 #if defined(USE_TTF)
+                     lesssize = true;
                      if (TTF_using()) ttf_reset();
+                     lesssize = false;
 #endif
                 } else if (!strcasecmp(inputline.substr(0, 5).c_str(), "lins=")||!strcasecmp(inputline.substr(0, 5).c_str(), "cols=")) {
 #if defined(USE_TTF)

--- a/src/output/output_ttf.cpp
+++ b/src/output/output_ttf.cpp
@@ -77,6 +77,7 @@ bool printfont = true;
 bool autoboxdraw = true;
 bool halfwidthkana = true;
 bool ttf_dosv = false;
+bool lesssize = false;
 bool lastmenu = true;
 bool initttf = false;
 bool copied = false;
@@ -822,18 +823,32 @@ void OUTPUT_TTF_Select(int fsize) {
             curSize &= ~1;
     }
 #if DOSBOXMENU_TYPE == DOSBOXMENU_HMENU
-resize:
+resize1:
 #endif
     GFX_SelectFontByPoints(curSize);
 #if DOSBOXMENU_TYPE == DOSBOXMENU_HMENU
     if (!ttf.fullScrn && menu_gui && menu.toggle && menuwidth_atleast(ttf.cols*ttf.width+ttf.offX*2+GetSystemMetrics(SM_CXBORDER)*2)>0) {
         if (ttf.cols*ttf.width > maxWidth || ttf.lins*ttf.height > maxHeight) E_Exit("Cannot accommodate a window for %dx%d", ttf.lins, ttf.cols);
         curSize++;
-        goto resize;
+        goto resize1;
     }
 #endif
-    if (fontSize>=MIN_PTSIZE && 100*ttf.cols*ttf.width/maxWidth*ttf.lins*ttf.height/maxHeight > 100)
+	GetMaxWidthHeight(&maxWidth, &maxHeight);
+#if defined(WIN32)
+	if (!ttf.fullScrn) {
+		maxWidth -= GetSystemMetrics(SM_CXBORDER)*2;
+		maxHeight -= GetSystemMetrics(SM_CYCAPTION) + GetSystemMetrics(SM_CYBORDER)*2;
+	}
+#endif
+resize2:
+    if (fontSize>=MIN_PTSIZE && 100*ttf.cols*ttf.width/maxWidth*ttf.lins*ttf.height/maxHeight > 100 || (lesssize && (ttf.cols*ttf.width>maxWidth || ttf.lins*ttf.height>maxHeight))) {
+        if (lesssize && curSize > MIN_PTSIZE) {
+            curSize--;
+            GFX_SelectFontByPoints(curSize);
+            goto resize2;
+        }
         E_Exit("Cannot accommodate a window for %dx%d", ttf.lins, ttf.cols);
+    }
     if (ttf.SDL_font && ttf.width) {
         int widthb, widthm, widthx, width0, width1, width9;
         widthb = widthm = widthx = width0 = width1 = width9 = 0;

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -3275,7 +3275,7 @@ void DOS_Shell::CMD_CHOICE(char * args){
 	static char defchoice[3] = {'y','n',0};
 	char *rem1 = NULL, *rem2 = NULL, *rem = NULL, waitchar = 0, *ptr;
 	int waitsec = 0;
-	bool optC = false;
+	bool optC = false, optT = false;
 	bool optN = ScanCMDBool(args,"N");
 	bool optS = ScanCMDBool(args,"S"); //Case-sensitive matching
 	// ignore /b and /m switches for compatibility
@@ -3290,13 +3290,14 @@ void DOS_Shell::CMD_CHOICE(char * args){
 			WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"),rem1);
 			return;
 		}
-		optC = tolower(rem1[1]) == 'c';
+		optC = rem1&&tolower(rem1[1]) == 'c';
+		optT = rem1&&tolower(rem1[1]) == 't';
 		if (args == rem1) args = strchr(rem1,0)+1;
 		if (rem1) rem1 += 2;
 		if(rem1 && rem1[0]==':') rem1++; /* optional : after /c */
 		if (optC) rem = rem1;
-		else {
-			if (*rem1&&*(rem1+1)==',') {
+		else if (optT) {
+			if (rem1&&*rem1&&*(rem1+1)==',') {
 				waitchar = *rem1;
 				waitsec = atoi(rem1+2);
 			} else
@@ -3304,18 +3305,21 @@ void DOS_Shell::CMD_CHOICE(char * args){
 		}
 		if (args > last) args = NULL;
 		if (args) {
+			last = strchr(args,0);
+			StripSpaces(args);
 			rem2 = ScanCMDRemain(args);
 			if (rem2 && *rem2 && (tolower(rem2[1]) != 'c') && (tolower(rem2[1]) != 't')) {
 				WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"),rem2);
 				return;
 			}
-			optC = tolower(rem2[1]) == 'c';
+			optC = rem2&&tolower(rem2[1]) == 'c';
+			optT = rem2&&tolower(rem2[1]) == 't';
 			if (args == rem2) args = strchr(rem2,0)+1;
 			if (rem2) rem2 += 2;
 			if(rem2 && rem2[0]==':') rem2++; /* optional : after /t */
 			if (optC) rem = rem2;
-			else {
-				if (*rem2&&*(rem2+1)==',') {
+			else if (optT) {
+				if (rem2&&*rem2&&*(rem2+1)==',') {
 					waitchar = *rem2;
 					waitsec = atoi(rem2+2);
 				} else

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -3270,10 +3270,41 @@ void DOS_Shell::CMD_LOADHIGH(char *args){
 	} else this->ParseLine(args);
 }
 
+bool get_param(char *&args, char *&rem, char *&temp, char &wait_char, int &wait_sec)
+{
+	const char *last = strchr(args, 0);
+	StripSpaces(args);
+	temp = ScanCMDRemain(args);
+	const bool optC = temp && tolower(temp[1]) == 'c';
+	const bool optT = temp && tolower(temp[1]) == 't';
+	if (temp && *temp && !optC && !optT)
+		return false;
+	if (temp) {
+		if (args == temp)
+			args = strchr(temp, 0) + 1;
+		temp += 2;
+		if (temp[0] == ':')
+			temp++;
+	}
+	if (optC) {
+		rem = temp;
+	} else if (optT) {
+		if (temp && *temp && *(temp + 1) == ',') {
+			wait_char = *temp;
+			wait_sec = atoi(temp + 2);
+		} else
+			wait_sec = 0;
+	}
+	if (args > last)
+		args = NULL;
+	if (args) args = trim(args);
+	return true;
+}
+
 void DOS_Shell::CMD_CHOICE(char * args){
 	HELP("CHOICE");
 	static char defchoice[3] = {'y','n',0};
-	char *rem1 = NULL, *rem2 = NULL, *rem = NULL, waitchar = 0, *ptr;
+	char *rem1 = NULL, *rem2 = NULL, *rem = NULL, *temp = NULL, waitchar = 0, *ptr;
 	int waitsec = 0;
 	bool optC = false, optT = false;
 	bool optN = ScanCMDBool(args,"N");
@@ -3282,50 +3313,11 @@ void DOS_Shell::CMD_CHOICE(char * args){
 	ScanCMDBool(args,"B");
 	ScanCMDBool(args,"M"); // Text
 	ScanCMDBool(args,"T"); //Default Choice after timeout
-	if (args) {
-		char *last = strchr(args,0);
-		StripSpaces(args);
-		rem1 = ScanCMDRemain(args);
-		if (rem1 && *rem1 && (tolower(rem1[1]) != 'c') && (tolower(rem1[1]) != 't')) {
-			WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"),rem1);
+
+	while (args && *args == '/') {
+		if (!get_param(args, rem, temp, waitchar, waitsec)) {
+			WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"), temp);
 			return;
-		}
-		optC = rem1&&tolower(rem1[1]) == 'c';
-		optT = rem1&&tolower(rem1[1]) == 't';
-		if (args == rem1) args = strchr(rem1,0)+1;
-		if (rem1) rem1 += 2;
-		if(rem1 && rem1[0]==':') rem1++; /* optional : after /c */
-		if (optC) rem = rem1;
-		else if (optT) {
-			if (rem1&&*rem1&&*(rem1+1)==',') {
-				waitchar = *rem1;
-				waitsec = atoi(rem1+2);
-			} else
-				waitsec = 0;
-		}
-		if (args > last) args = NULL;
-		if (args) {
-			last = strchr(args,0);
-			StripSpaces(args);
-			rem2 = ScanCMDRemain(args);
-			if (rem2 && *rem2 && (tolower(rem2[1]) != 'c') && (tolower(rem2[1]) != 't')) {
-				WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"),rem2);
-				return;
-			}
-			optC = rem2&&tolower(rem2[1]) == 'c';
-			optT = rem2&&tolower(rem2[1]) == 't';
-			if (args == rem2) args = strchr(rem2,0)+1;
-			if (rem2) rem2 += 2;
-			if(rem2 && rem2[0]==':') rem2++; /* optional : after /t */
-			if (optC) rem = rem2;
-			else if (optT) {
-				if (rem2&&*rem2&&*(rem2+1)==',') {
-					waitchar = *rem2;
-					waitsec = atoi(rem2+2);
-				} else
-					waitsec = 0;
-			}
-			if (args > last) args = NULL;
 		}
 	}
 	if (!rem || !*rem) rem = defchoice; /* No choices specified use YN */
@@ -3352,9 +3344,11 @@ void DOS_Shell::CMD_CHOICE(char * args){
 		WriteOut("%c]?",rem[len-1]);
 	}
 
+	// TO-DO: Find out how real DOS handles /T option for making a choice after delay; use AUTOTYPE for now
 	std::vector<std::string> sequence;
-	if (waitchar && *rem && (strchr(rem, toupper(waitchar)) || strchr(rem, tolower(waitchar))) && waitsec > 0) {
-		sequence.push_back(std::string(1, tolower(waitchar)));
+	bool in_char = optS ? (strchr(rem, waitchar) != nullptr) : (strchr(rem, toupper(waitchar)) || strchr(rem, tolower(waitchar)));
+	if (waitchar && *rem && in_char && waitsec > 0) {
+		sequence.emplace_back(std::string(1, optS?waitchar:tolower(waitchar)));
 		MAPPER_AutoType(sequence, waitsec * 1000, 500, true);
 	}
 	uint16_t n=1;


### PR DESCRIPTION
This makes some cleanups to the CHANGELOG including additions of entries of PRs made by @nanshiki and @javispedro. Also updated the config file comments to mention that the XGA/SXGA mode for DOS/V V-Text is now supported by both svga_s3trio and svga_et4000 modes.
