### PR TITLE
Fixed color in some modes under x86-64 MacOS SDL2

### DIFF
--- a/src/gui/render_templates.h
+++ b/src/gui/render_templates.h
@@ -123,7 +123,7 @@
 #elif DBPP == 16 // xRRRRRGggggBBBBB -> RRRRRGggggGBBBBB
 #define PMAKE(_VAL) ((_VAL & 31)|((_VAL & ~31)<<1)|((_VAL&0x0200)>>4))
 #elif DBPP == 32 // xRRRrrGGGggBBBbb -> RRRrrRRRGGGggGGGBBBbbBBB
-# if SDL_BYTEORDER == SDL_LIL_ENDIAN && defined(MACOSX) /* Mac OS X Intel builds use a weird RGBA order (alpha in the low 8 bits) */
+# if SDL_BYTEORDER == SDL_LIL_ENDIAN && defined(MACOSX) && !defined(C_SDL2) /* Mac OS X Intel builds use a weird RGBA order (alpha in the low 8 bits) */
 #  define PMAKE(_VAL)  (((_VAL&(31u<<10u))<<1u)|((_VAL&(31u<<5u))<<14u)|((_VAL&31u)<<27u))
 # else
 #  define PMAKE(_VAL)  (((_VAL&(31u<<10u))<<9u)|((_VAL&(31u<<5u))<<6u)|((_VAL&31u)<<3u)|((_VAL&(7<<12))<<4)|((_VAL&(7<<7))<<1)|((_VAL&(7<<2))>>2))
@@ -149,7 +149,7 @@
 #elif DBPP == 16
 #define PMAKE(_VAL) (_VAL)
 #elif DBPP == 32 // RRRrrGGggggBBBbb -> RRRrrRRRGGggggGGBBBbbBBB
-# if SDL_BYTEORDER == SDL_LIL_ENDIAN && defined(MACOSX) /* Mac OS X Intel builds use a weird RGBA order (alpha in the low 8 bits) */
+# if SDL_BYTEORDER == SDL_LIL_ENDIAN && defined(MACOSX) && !defined(C_SDL2) /* Mac OS X Intel builds use a weird RGBA order (alpha in the low 8 bits) */
 #  define PMAKE(_VAL)  (((_VAL&(31u<<11u))<<0u)|((_VAL&(63u<<5u))<<13u)|((_VAL&31u)<<27u))
 # else
 #  define PMAKE(_VAL)  (((_VAL&(31<<11))<<8)|((_VAL&(63<<5))<<5)|((_VAL&0xE01F)<<3)|((_VAL&(3<<9))>>1)|((_VAL&(7<<2))>>2))

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -579,7 +579,7 @@ static uint8_t * VGA_Draw_4BPP_Line_Double(Bitu vidstart, Bitu line) {
     return TempLine;
 }
 
-#if SDL_BYTEORDER == SDL_LIL_ENDIAN && defined(MACOSX) /* Mac OS X Intel builds use a weird RGBA order (alpha in the low 8 bits) */
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN && defined(MACOSX) && !defined(C_SDL2) /* Mac OS X Intel builds use a weird RGBA order (alpha in the low 8 bits) */
 static inline uint32_t guest_bgr_to_macosx_rgba(const uint32_t x) {
     /* guest: XRGB      X   R   G   B
      * host:  RGBX      B   G   R   X */
@@ -602,7 +602,7 @@ static uint8_t * VGA_Draw_Linear_Line_24_to_32(Bitu vidstart, Bitu /*line*/) {
      *          extra byte), then overwrites the extra byte with 0xFF to
      *          produce a valid RGBA 8:8:8:8 value with the original pixel's
      *          RGB plus alpha channel value of 0xFF. */
-#if SDL_BYTEORDER == SDL_LIL_ENDIAN && defined(MACOSX) /* Mac OS X Intel builds use a weird RGBA order (alpha in the low 8 bits) */
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN && defined(MACOSX) && !defined(C_SDL2) /* Mac OS X Intel builds use a weird RGBA order (alpha in the low 8 bits) */
     for (i=0;i < vga.draw.width;i++)
         ((uint32_t*)TempLine)[i] = guest_bgr_to_macosx_rgba(*((uint32_t*)(vga.draw.linear_base+offset+(i*3)))) | 0x000000FF;
 #else
@@ -1571,7 +1571,7 @@ static uint8_t * VGA_Draw_LIN16_Line_HWMouse(Bitu vidstart, Bitu /*line*/) {
 }
 
 static uint8_t * VGA_Draw_LIN32_Line_HWMouse(Bitu vidstart, Bitu /*line*/) {
-#if SDL_BYTEORDER == SDL_LIL_ENDIAN && defined(MACOSX) /* Mac OS X Intel builds use a weird RGBA order (alpha in the low 8 bits) */
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN && defined(MACOSX) && !defined(C_SDL2) /* Mac OS X Intel builds use a weird RGBA order (alpha in the low 8 bits) */
     Bitu offset = vidstart & vga.draw.linear_mask;
     Bitu i;
 
@@ -4582,7 +4582,7 @@ void VGA_ActivateHardwareCursor(void) {
         case M_LIN24:
             VGA_DrawLine=VGA_Draw_Linear_Line_24_to_32;
             break;
-#if SDL_BYTEORDER == SDL_LIL_ENDIAN && defined(MACOSX) /* Mac OS X Intel builds use a weird RGBA order (alpha in the low 8 bits) */
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN && defined(MACOSX) && !defined(C_SDL2) /* Mac OS X Intel builds use a weird RGBA order (alpha in the low 8 bits) */
         case M_LIN32:
             VGA_DrawLine=VGA_Draw_LIN32_Line_HWMouse;
             break;


### PR DESCRIPTION
From issue #1431, originally fixed for SDL1 at #614, there still seem to be some issue with regards to video and MacOS when using SDL2.

I'm not too familiar with the codebase, but from a quick glance through it it seems that DosBox-X assumes the pixel format returned from `SDL_GetWindowSurface()` without checking, which seems to be ARGB on everywhere else while BGRA on MacOS SDL1.

It seems that in some places where the conversions for MacOS occur there is a check to specifically target SDL1 OSX, while others apply it to SDL2 as well. I've added some at render_templates.h which fixed the issue for my particular situation.

There are other places that looks like this however, such as in sdlmain.cpp, vga_draw.cpp, output_opengl.cpp, but I didn't include them in this commit, as I'm not too sure about my understanding of the codebase.

I've only tested it on my Win 3.1 guest, as I don't have a convenient way to test many video configurations. Also as this Mac is not mine I don't have a way to test it very frequently. I'd like to ask for comments and contributions from people more experienced with this project or using the MacOS SDL2 port frequently.

Both screenshot from MacOS 11 (Big Sur) x86-64. First is the latest binary release MacOS SDL2 0.83.24, next is the latest git master with this PR applied. Guest is Windows 3.10 Japanese, with svga_s3 in 1024x768 64k colors.

![dosbox-x-sdl2](https://user-images.githubusercontent.com/94353674/164971947-330b6209-0868-40a1-9ed6-3ca47bdf50cb.png)
![dosbox-x-sdl2-fixed](https://user-images.githubusercontent.com/94353674/164971950-afcbff73-d6bf-4ecf-80b2-f253eae66378.png)

