### PR TITLE
Update manpage and bash completion for -machine option

### DIFF
--- a/contrib/linux/dosbox-x
+++ b/contrib/linux/dosbox-x
@@ -27,10 +27,10 @@ _dosbox-x()
                     -nogui -nomenu -showcycles -showrt -savedir -defaultdir
                     -defaultconf -defaultmapper -date-host-forced -display2
                     -nodpiaware -securemode -prerun -hostrun -noconfig -silent
-                    -time-limit -fastlaunch -debug -o -machine
+                    -time-limit -fastlaunch -machine -debug -tests
                   )\
      _repeat_opts=(
-                    -conf -c -set
+                    -conf -c -o -set
                   )\
   _exclusive_opts=(
                     -ver -version -printconf -editconf -resetconf
@@ -100,7 +100,7 @@ _dosbox-x()
       return;;
     -o)
       readarray -t -O ${#COMPREPLY[@]} COMPREPLY \
-      < <(printf "» -c\nCommand-line option(s) to pass to program (enclose in quotes, if it contains spaces)")
+      < <(printf "» -o\nCommand-line option(s) to pass to program (enclose in quotes, if it contains spaces)")
       return;;
     -set)
       readarray -t -O ${#COMPREPLY[@]} COMPREPLY \

--- a/contrib/linux/dosbox-x
+++ b/contrib/linux/dosbox-x
@@ -27,7 +27,7 @@ _dosbox-x()
                     -nogui -nomenu -showcycles -showrt -savedir -defaultdir
                     -defaultconf -defaultmapper -date-host-forced -display2
                     -nodpiaware -securemode -prerun -hostrun -noconfig -silent
-                    -time-limit -fastlaunch -debug -o
+                    -time-limit -fastlaunch -debug -o -machine
                   )\
      _repeat_opts=(
                     -conf -c -set
@@ -41,6 +41,25 @@ _dosbox-x()
 
   # setup nameref to point to array
   [[ ${prev:0:1} == - ]] && local -n _sub_opts=${prev//+(-)/_}
+
+  ### Arrays holding sub. options
+  # The name should be the trigger option with leading "-"s replaced with "_"
+  # for example, --machine => _machine
+  # latter parts of the script will reference these arrays via a "nameref"
+  # i.e. The last option dictates the available sub. options
+
+  #
+  # shellcheck disable=SC2034
+  local -a \
+    _machine=(
+               mda hercules cga cga_mono cga_composite cga_composite2
+               pcjr pcjr_composite pcjr_composite2 tandy amstrad ega jega
+               mcga vgaonly svga_s3 svga_s386c928 svga_s3vision864
+               svga_s3vision868 svga_s3vision964 svga_s3vision968 svga_s3trio32
+               svga_s3trio64 svga_s3trio64v+ svga_s3virge svga_s3virgevx
+               svga_et3000 svga_et4000 svga_paradise vesa_nolfb
+               vesa_oldvbe vesa_oldvbe10 pc98 pc9801 pc9821
+             )
 
   local _conf="$HOME/.config/dosbox-x/"
 
@@ -57,6 +76,10 @@ _dosbox-x()
 
       # filter out previously selected confs
       COMPREPLY=( "${COMPREPLY[@]#@(${words_filter})}" )
+      return;;
+    -machine)
+      readarray -t -O 0 COMPREPLY \
+        < <( compgen -W "${_sub_opts[*]}" -- "${cur}" )
       return;;
     -socket)
       readarray -t -O ${#COMPREPLY[@]} COMPREPLY \

--- a/contrib/linux/dosbox-x.1
+++ b/contrib/linux/dosbox-x.1
@@ -1,376 +1,1095 @@
-.TH "DOSBOX-X" "1" "Dec 28, 2021" "" ""
+'\" t
+.\"     Title: dosbox-x
+.\"    Author: DOSBox-X is maintained by the DOSBox-X Team
+.\" Generator: Asciidoctor 2.0.15
+.\"      Date: 2022-04-26
+.\"    Manual: dosbox-x
+.\"    Source: dosbox-x
+.\"  Language: English
+.\"
+.TH "DOSBOX\-X" "1" "2022-04-26" "dosbox\-x" "dosbox\-x"
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.ss \n[.ss] 0
+.nh
+.ad l
+.de URL
+\fI\\$2\fP <\\$1>\\$3
+..
+.als MTO URL
+.if \n[.g] \{\
+.  mso www.tmac
+.  am URL
+.    ad l
+.  .
+.  am MTO
+.    ad l
+.  .
+.  LINKSTYLE blue R < >
+.\}
 .SH "NAME"
-dosbox\-x \- a x86/DOS and PC98 emulator
+dosbox-x \- a x86/DOS and PC98 emulator
 .SH "SYNOPSIS"
-\fB\ dosbox\-x [OPTIONS] [NAME]\fR
-.br 
-\fB\ dosbox\-x -c "\fIcommand parameter\fB" [OPTIONS] [NAME]\fR
-.br
-\fB\ dosbox\-x -set "\fIconfig option=value\fB" [OPTIONS] [NAME]\fR
-.br
-\fB\ dosbox\-x -conf \fIconfig_file.conf\fB [OPTIONS] [NAME]\fR
-
+.sp
+\fBdosbox\-x\fP [\fIOPTIONS\fP] [\fIFILE\fP]
 .SH "DESCRIPTION"
-This manual page briefly documents \fBdosbox\-x\fR, an x86/DOS and PC98
-emulator.
-.LP 
-.LP 
+.sp
+This manual page briefly documents DOSBox\-X, an x86/DOS and PC98 emulator.
+.sp
 Options are listed below. Depending on the option, one or more may be specified.
-.LP 
-The optional \fBNAME\fR argument should be a DOS executable or a
-directory. If it is a dos executable (.com .exe .bat), the program will 
-run automatically. If it is a directory, a DOS session will run with 
-the directory specified mounted as the C:\\ drive.
-If the dos executable requires parameters, enclose the command and 
-it's parameters in quotes.
-.LP 
-For an introduction type \fIINTRO\fR inside dosbox\-x.
+.sp
+The optional \fIFILE\fP argument should be a DOS executable or a directory.
+If it is a DOS executable (.com .exe .bat), the program will run automatically.
+If it is a directory, the directory specified will be mounted as the C:\(rs drive.
+If the DOS executable requires parameters, enclose the command and it\(cqs parameters in quotes.
+.sp
+For an introduction type \fIINTRO\fP inside dosbox\-x.
 .SH "OPTIONS"
+.sp
 A summary of available options.
-.PP 
-\fB\-? \fRor \fB\-h \fRor \fB\-help\fR
-.RS
+.sp
+\fB\-?\fP, \fB\-h\fP or \fB\-help\fP
+.RS 4
 Display the help screen and exit.
 .RE
-\fB\-v \fR or\fB\-ver \fRor \fB\-version\fR
-.RS
+.sp
+\fB\-v\fP, \fB\-ver\fP or \fB\-version\fP
+.RS 4
 Display the version information and exit.
 .RE
-\fB\-fullscreen \fRor\fB \-fs\fR
-.RS
+.sp
+\fB\-fullscreen\fP, \fB\-fs\fP
+.RS 4
 Start dosbox\-x in fullscreen mode.
 .RE
-\fB\-conf \fIconfigfile\fR
-.RS
-Start \fBdosbox\-x\fR with the options specified in
-\fIconfigfile\fR. This file has also has a section called
-\fI[autoexec]\fR\ in which you can put commands you wish to execute on startup.
-Multiple \fB\-conf\fR options with \fIconfigfiles\fR can be specified and
-they will be overlayed on each other.
+.sp
+\fB\-machine\fP \fImachinetype\fP
+.RS 4
+Start dosbox\-x with a specific machine type.  Valid choices are:
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBmda\fP
+.sp
+IBM Monochrome Display Adapter (text only)
 .RE
-\fB\-editconf\fI[editor]\fR
-.RS
-Open the default configuration file in a text editor. If no editor name
-is given, then use the program from the EDITOR environment variable.
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBhercules\fP
+.sp
+Hercules Graphics Card (monochrome)
 .RE
-\fB\-userconf\fR
-.RS
-Load the configuration file located in ~/.config/dosbox\-x. Can be combined with
-the \fB\-conf \fRoption.
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBcga\fP
+.sp
+IBM Color Graphics Adapter, with automatic RGB/Composite switching.
 .RE
-\fB\-printconf\fR
-.RS
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBcga_mono\fP
+.sp
+IBM CGA attached to a monochrome display
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBcga_rgb\fP
+.sp
+IBM CGA attached to an RGB monitor
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBcga_composite\fP
+.sp
+IBM CGA (early revision) attached to an NTSC TV
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBcga_composite2\fP
+.sp
+IBM CGA (late revision) attached to an NTSC TV
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBpcjr\fP
+.sp
+IBM PCjr
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBpcjr_composite\fP
+.sp
+IBM PCjr (late revision) attached to NTSC TV
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBpcjr_composite2\fP
+.sp
+IBM PCjr (late revision) attached to NTSC TV
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBtandy\fP
+.sp
+Tandy 1000 Graphics Adapter
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBamstrad\fP
+.sp
+Amstrad PC1512 graphics mode
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBega\fP
+.sp
+IBM Enhanced Graphics Adapter
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBjega\fP
+.sp
+Japanese Enhanced Graphics Adapter (Microsoft AX)
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBmcga\fP
+.sp
+IBM Multi\-Color Graphics Array
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBvgaonly\fP
+.sp
+IBM Video Graphics Array (see below)
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBsvga_paradise\fP
+.sp
+SVGA \- Paradise Systems PVGA1A
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBsvga_et3000\fP
+.sp
+SVGA \- Tseng Labs ET3000
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBsvga_et4000\fP
+.sp
+SVGA \- Tseng Labs ET4000
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBsvga_s3\fP
+.sp
+VESA SVGA \- S3 Trio64 \- VBE 2.0
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBsvga_s386c928\fP
+.sp
+VESA SVGA \- S3 86c928 \- VBE 2.0 (experimental)
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBsvga_s3vision864\fP
+.sp
+VESA SVGA \- S3 Vision 864 \- VBE 2.0
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBsvga_s3vision868\fP
+.sp
+VESA SVGA \- S3 Vision 868 \- VBE 2.0
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBsvga_s3vision964\fP
+.sp
+VESA SVGA \- S3 Vision 964 \- VBE 2.0
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBsvga_s3vision968\fP
+.sp
+VESA SVGA \- S3 Vision 968 \- VBE 2.0
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBsvga_s3trio32\fP
+.sp
+VESA SVGA \- S3 Trio32 \- VBE 2.0
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBsvga_s3trio64\fP
+.sp
+VESA SVGA \- S3 Trio64 \- VBE 2.0 (same as \fBsvga_s3\fP)
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBsvga_s3trio64v+\fP
+.sp
+VESA SVGA \- S3 Trio64V+ \- VBE 2.0
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBsvga_s3virge\fP
+.sp
+VESA SVGA \- S3 ViRGE \- VBE 2.0 (experimental)
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBsvga_s3virgevx\fP
+.sp
+VESA SVGA \- S3 ViRGE VX \- VBE 2.0 (experimental)
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBvesa_oldvbe\fP
+.sp
+VESA SVGA \- S3 Trio64 with VESA BIOS Extensions (VBE) 1.2
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBvesa_oldvbe10\fP
+.sp
+VESA SVGA \- S3 Trio64 wtih VESA BIOS Extensions (VBE) 1.0
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBvesa_nolfb\fP
+.sp
+VESA SVGA \- S3 Trio64 with VBE 2.0 with Linear Frame Buffer disabled
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBpc98\fP
+.sp
+Japanese NEC PC\-98 emulation
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBpc9801\fP
+.sp
+same as \fBpc98\fP
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBpc9821\fP
+.sp
+same as \fBpc98\fP
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBfm_towns\fP
+.sp
+Japanese Fujitsu FM Towns (not implemented)
+.RE
+.RE
+.sp
+The default is \fBsvga_s3\fP.
+.sp
+For some special VGA effects the machinetype \fBvgaonly\fP can be used, note that this disables SVGA capabilities and might be slower due to the higher emulation accuracy.
+.if n .sp
+.RS 4
+.it 1 an-trap
+.nr an-no-space-flag 1
+.nr an-break-flag 1
+.br
+.ps +1
+.B Note
+.ps -1
+.br
+.sp
+The \fImachinetype\fP affects not only the emulated video card, but may also effect the available sound cards.
+.sp .5v
+.RE
+.sp
+\fB\-conf\fP \fIconfigfile\fP
+.RS 4
+Start dosbox\-x with the options specified in \fIconfigfile\fP. This file may also have a section called \fI[autoexec]\fP in which you can put commands you wish to execute on startup.
+Multiple \fB\-conf\fP options with \fIconfigfiles\fP can be specified and they will be overlayed on each other.
+.RE
+.sp
+\fB\-editconf\fP [\fIeditor\fP]
+.RS 4
+Open the default configuration file in a text editor. If no editor name is given, then use the program from the EDITOR environment variable.
+.RE
+.sp
+\fB\-userconf\fP
+.RS 4
+Load the configuration file located in ~/.config/dosbox\-x. Can be combined with the \fB\-conf\fP option.
+.RE
+.sp
+\fB\-printconf\fP
+.RS 4
 Prints the location of the default configuration file and exit.
 .RE
-\fB\-eraseconf, \-resetconf\fR
-.RS
+.sp
+\fB\-eraseconf\fP, \fB\-resetconf\fP
+.RS 4
 Removes the default configuration file and exit.
 .RE
-\fB\-erasemapper, \-resetmapper\fR
-.RS
-Removes the mapperfile configured in the clean default configuration file and
-exit.
+.sp
+\fB\-erasemapper\fP, \fB\-resetmapper\fP
+.RS 4
+Removes the mapperfile configured in the clean default configuration file and exit.
 .RE
-\fB\-opencaptures \fIprogram\fR
-.RS
-Calls \fIprogram\fR with as first parameter the location of the captures
-folder and exit.
+.sp
+\fB\-opencaptures\fP \fIprogram\fP
+.RS 4
+Calls program with as first parameter the location of the captures folder and exit.
 .RE
-\fB\-opensaves \fIprogram\fR
-.RS
-Calls \fIprogram\fR with as first parameter the location of the saves folder
-and exit.
+.sp
+\fB\-opensaves\fP \fIprogram\fP
+.RS 4
+Calls program with as first parameter the location of the saves folder and exit.
 .RE
-\fB\-startui\fR or \fB\-startgui\fR or \fB\-starttool\fR
-.RS
+.sp
+\fB\-startui\fP, \fB\-startgui\fP or \fB\-starttool\fP
+.RS 4
 Start DOSBox\-X with GUI configuration tool.
 .RE
-\fB\-startmapper\fR
-.RS
-Start the internal keymapper on startup of dosbox\-x. You can use it to change
-the keys dosbox\-x uses.
+.sp
+\fB\-startmapper\fP
+.RS 4
+Start the internal keymapper on startup of dosbox\-x. You can use it to change the keys dosbox\-x uses.
 .RE
-\fB\-promptfolder\fR
-.RS
+.sp
+\fB\-promptfolder\fP
+.RS 4
 Prompt for the working directory when DOSBox\-X starts.
 .RE
-\fB\-nopromptfolder\fR
-.RS
+.sp
+\fB\-nopromptfolder\fP
+.RS 4
 Do not prompt for the working directory when DOSBox\-X starts.
 .RE
-\fB\-nogui\fR or \fB\-nomenu\fR
-.RS
+.sp
+\fB\-nogui\fP or \fB\-nomenu\fP
+.RS 4
 Do not show the GUI menu bar when in windowed mode.
 .RE
-\fB\-showcycles\fR
-.RS
+.sp
+\fB\-showcycles\fP
+.RS 4
 Show cycles count (FPS) in the title.
 .RE
-\fB\-showrt\fR
-.RS
+.sp
+\fB\-showrt\fP
+.RS 4
 Show emulation speed relative to realtime in the title.
 .RE
-\fB\-socket\fI socketnumber\fR
-.RS
-Passes the TCP socket number \fIsocketnumber\fR to the nullmodem emulation.
-See WIKI for details.
+.sp
+\fB\-socket\fP \fIsocketnumber\fP
+.RS 4
+Passes the TCP socket number \fIsocketnumber\fP for the nullmodem emulation.
+See the WIKI for details.
 .RE
-\fB\-savedir \fIpath\fR
-.RS
+.sp
+\fB\-savedir\fP \fIpath\fP
+.RS 4
 Set path for the save slots.
 .RE
-\fB\-defaultdir \fIpath\fR
-.RS
+.sp
+\fB\-defaultdir\fP \fIpath\fP
+.RS 4
 Set the default working path for DOSBox\-X.
 .RE
-\fB\-defaultconf\fR
-.RS
+.sp
+\fB\-defaultconf\fP
+.RS 4
 Use the default config settings for DOSBox\-X.
 .RE
-\fB\-defaultmapper\fR
-.RS
+.sp
+\fB\-defaultmapper\fP
+.RS 4
 Use the default key mappings for DOSBox\-X.
 .RE
-\fB\-data\-host\-forced\fR
-.RS
+.sp
+\fB\-data\-host\-forced\fP
+.RS 4
 Force synchronization of date and time with the host.
 .RE
-\fB\-display2 \fIcolor\fR
-.RS
-Enable standard & monochrome dual\-screen mode with \fIcolor\fR.
+.sp
+\fB\-display2\fP [\fIcolor\fP]
+.RS 4
+Enable both standard & monochrome dual\-screen mode. The monochrome display defaults to white, but can optionally be set to \fIgreen\fP or \fIamber\fP.
 .RE
-\fB\-lang \fImessage_file\fR
-.RS
-Start dosbox\-x with the language specified in \fImessage_file\fR.
+.sp
+\fB\-lang\fP \fImessage_file\fP
+.RS 4
+Start dosbox\-x with the language specified in \fImessage_file\fP.
 .RE
-\fB\-nodpiaware\fR
-.RS
+.sp
+\fB\-nodpiaware\fP
+.RS 4
 Ignore (do not signal) Windows DPI awareness.
 .RE
-\fB\-securemode\fR
-.RS
-Enable secure mode, which is meant to prevent a DOS program potentially gaining
-access to files outside directories mounted in the [autoexec] section of the
-config file. It does this by running \fBZ:\\SYSTEM\\CONFIG.COM \-securemode\fR
-after completing the [autoexec] section (which in turn disables any changes to
-how the drives are mounted "inside" dosbox). It also disables various other
-CONFIG.COM options that could be exploited.
+.sp
+\fB\-securemode\fP
+.RS 4
+Enable  secure mode, which is meant to prevent a DOS program potentially gaining access to files outside directories mounted in the [autoexec] section of the config file.
+It does this by running \fBZ:\(rsSYSTEM\(rsCONFIG.COM \-securemode\fP after completing the [autoexec] section (which in turn disables any changes to how the drives are mounted "inside" dosbox\-x).
+It also disables various other CONFIG.COM options that could be exploited.
 .RE
-\fB\-prerun\fR
-.RS
-If \fBname\fR is given, run it before the AUTOEXEC.B AT config section
+.sp
+\fB\-prerun\fP
+.RS 4
+If \fIFILE\fP is given, run it before the AUTOEXEC.BAT config section
 .RE
-\fB\-hostrun\fR
-.RS
-Enable START command, CLIP$ device and long filename support
+.sp
+\fB\-hostrun\fP
+.RS 4
+Enable START command, CLIP$ device and long filename (LFN) support
 .RE
-\fB\-noconfig\fR
-.RS
-Skips the [config] section of the loaded configuration file. This is equivalent to CONFIG.SYS in DOS.
+.sp
+\fB\-noconfig\fP
+.RS 4
+Skips the [config] section of the loaded configuration file. This is equivalent to skipping CONFIG.SYS in DOS.
 .RE
-\fB\-noautoexec\fR
-.RS
-Skips the [autoexec] section of the loaded configuration file. This is equivalent to AUTOEXEC.B AT in DOS.
+.sp
+\fB\-noautoexec\fP
+.RS 4
+Skips the [autoexec] section of the loaded configuration file. This is equivalent to skipping AUTOEXEC.BAT in DOS.
 .RE
-\fB\-exit\fR
-.RS
-dosbox\-x will close itself when the DOS program specified by \fBNAME\fR ends.
+.sp
+\fB\-exit\fP
+.RS 4
+dosbox\-x will close itself when the DOS program specified by \fIFILE\fP ends.
 .RE
-\fB\-silent\fR
-.RS
+.sp
+\fB\-silent\fP
+.RS 4
 Run DOSBox\-X silently and exit after executing the [autoexec] section of the loaded config file.
 .RE
-\fB\-o \fIoption(s)\fR
-.RS
-Provide command-line option(s) for [name] if specified.
+.sp
+\fB\-o\fP \fIoption(s)\fP
+.RS 4
+Provide command\-line option(s) for [\fIFILE\fP] if specified.
 .RE
-\fB\-c \fIcommand\fR
-.RS
-Runs the specified \fIcommand \fRbefore running \fBNAME\fR. Multiple
-commands can be specified. Each \fIcommand\fR should start with \fB\-c\fR
-though. A command can be an Internal Program, a DOS command or an executable on
-a mounted drive. If the command requires parameters, enclose the command and
-its parameters in quotes.
+.sp
+\fB\-c\fP \fIcommand\fP
+.RS 4
+Runs the specified command before running [\fIFILE\fP].
+Multiple commands can be specified.
+Each command should start with \fB\-c\fP though.
+A command can be an Internal Program, a DOS command or an executable on a mounted drive.
+If the command requires parameters, enclose the command and its parameters in quotes.
 .RE
-\fB\-set \fIsection property=value\fR
-.RS
-Set the config option (override any config file). If the property contains
-spaces, ensure to enclose the string in quotes. The section is the name of a
-dosbox\-x config section such as [video] without the brackets. Multiple \fB\-set 
-\fR commands may be specified. If a property is unique, the section may be
-ommitted. e.g. \fB\-set dosbox machine=hercules\fR is equivalent to
-\fB\-set machine=hercules\fR
+.sp
+\fB\-set\fP \fIsection property=value\fP
+.RS 4
+Set the config option (override any config file).
+If the property contains spaces, ensure to enclose the string in quotes.
+The section is the name of a dosbox\-x config section such as \fB[video]\fP without the brackets.
+Multiple \fB\-set\fP commands may be specified.
+If a property is unique, the section may be omitted.
+e.g. \fB\-set sdl output=ttf\fP is equivalent to \fB\-set output=ttf\fP
 .RE
-\fB\-time\-limit\fIn\fR
-.RS
-Kill the emulator after\fI\'n'\fR seconds.
+.sp
+\fB\-time\-limit\fP \fIseconds\fP
+.RS 4
+Kill the emulator after \fIseconds\fP.
 .RE
-\fB\-fastlaunch\fR
-.RS
+.sp
+\fB\-fastlaunch\fP
+.RS 4
 Fast launch mode (skip the BIOS logo and welcome banner).
 .RE
-\fB\-helpdebug\fR
-.RS
+.sp
+\fB\-helpdebug\fP
+.RS 4
 Show debug\-related options and exit.
 .RE
-\fB\-scaler \fIscaler\fR
-.RS
-Uses the graphical scaler specified by \fIscaler\fR. See the configuration
-file for the available scalers.
-.RE
-\fB\-forcescaler \fIscaler\fR
-.RS
-Similar to the \fB\-scaler\fR parameter, but tries to force usage of the
-specified scaler even if it might not fit.
-.RE
-.SH "INTERNAL COMMAND.COM COMMANDS"
-.B dosbox\-x
-Supports most of the internal DOS commands found in COMMAND.COM. Help text is integrated for these commands in DOSBox\-X, and will not be duplicated here.
+.SH "INTERNAL INTERPRETER COMMANDS"
+.sp
+\fBdosbox\-x\fP Supports most of the internal DOS commands found in COMMAND.COM.
+Help text is integrated for these commands in DOSBox\-X, and will not be duplicated here.
 An explanation of these commands can also be found on the DOSBox\-X wiki on the Supported Commands page.
-.TP
-.RS
-.IP "\- ALIAS, ATTRIB, BREAK, CALL, CD/CDDIR, CHCP, CHOICE, CLS, COPY"
-.IP "\- COUNTRY, CTTY, DATE, DEL/ERASE, DELTREE, ECHO, EXIT, DIR, FOR"
-.IP "\- GOTO, HELP, IF, LFNFOR, LH/LOADHIGH, MD/MKDIR, MORE, PATH"
-.IP "\- PAUSE, PROMPT, RD/RMDIR, REM, REN/RENAME, SET, SHIFT, SUBST"
-.IP "\- TIME, TRUENAME, TYPE, VER, VERIFY, VOL"
+.sp
+\fBALIAS\fP, \fBATTRIB\fP, \fBBREAK\fP, \fBCALL\fP, \fBCD\fP/\fBCDDIR\fP, \fBCHCP\fP, \fBCHOICE\fP, \fBCLS\fP,
+\fBCOPY\fP, \fBCOUNTRY\fP, \fBCTTY\fP, \fBDATE\fP, \fBDEL\fP/\fBERASE\fP, \fBDELTREE\fP, \fBECHO\fP, \fBEXIT\fP,
+\fBDIR\fP, \fBFOR\fP, \fBGOTO\fP, \fBHELP\fP, \fBIF\fP, \fBLFNFOR\fP, \fBLH\fP/\fBLOADHIGH\fP, \fBMD\fP/\fBMKDIR\fP,
+\fBMORE\fP, \fBPATH\fP, \fBPAUSE\fP, \fBPROMPT\fP, \fBRD\fP/\fBRMDIR\fP, \fBREM\fP, \fBREN\fP/\fBRENAME\fP, \fBSET\fP,
+\fBSHIFT\fP, \fBSUBST\fP, \fBTIME\fP, \fBTRUENAME\fP, \fBTYPE\fP, \fBVER\fP, \fBVERIFY\fP, \fBVOL\fP
+.SH "OTHER PROVIDED COMMANDS"
+.sp
+In addition, the following extra commands are available on the emulated Z: drive:
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBZ:\(rs4DOS\fP
+.sp
+\fB4DOS\fP, \fB4HELP\fP, \fBOPTION\fP, \fBBATCOMP\fP
 .RE
-
-.SH "OTHER INTERNAL COMMANDS"
-These are internal DOSBox\-X commands that are are not part of DOS. They are documented on the DOSBox\-X wiki on the Supported Commands page.
-.TP
-.RS
-.IP "\- DEBUGBOX (only on debug enabled builds)"
-.IP "\- DX\-CAPTURE"
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBZ:\(rsBIN\fP
+.sp
+\fBEVAL\fP, \fBSHUTDOWN\fP, \fBDSXMENU\fP, \fBCWSDPMI\fP, \fBEMSMAGIC\fP, \fBUNZIP\fP, \fBZIP\fP, \fBMPXPLAY\fP,
+\fBDOSMID\fP, \fBCDPLAY\fP, \fBDOS4GW\fP, \fBDOS32A\fP, \fBDOSIDLE\fP, \fBUTF16\fP, \fBUTF8\fP, \fBAUTOTYPE\fP,
+\fBADDKEY\fP, \fBLS\fP, \fBTITLE\fP, \fBCOLOR\fP, \fBSETCOLOR\fP
 .RE
-
-.SH "EXTERNAL DOS COMMANDS"
-These are external DOS commands located on the emulated Z:\ drive.
-.TP 
-.RS
-.IP "\- APPEND, BUFFERS, COMMAND, DEBUG, DEVICE, EDIT, FCBS, FIND, FORMAT"
-.IP "\- KEYB, LABEL, LASTDRIV, LOADFIX, MEM, MODE, MOVE, SORT"
-.IP "\- TREE, XCOPY
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBZ:\(rsDOS\fP
+.sp
+\fBMEM\fP, \fBEDIT\fP, \fBPRINT\fP, \fBDISKCOPY\fP, \fBDEFRAG\fP, \fBFORMAT\fP, \fBFDISK\fP, \fBSYS\fP, \fBFC\fP,
+\fBCOMP\fP, \fBCHKDSK\fP, \fBBUFFERS\fP, \fBDEVICE\fP, \fBAPPEND\fP, \fBXCOPY\fP, \fBSORT\fP, \fBREPLACE\fP,
+\fBLASTDRIV\fP, \fBFILES\fP, \fBFCBS\fP, \fBFIND\fP, \fBMOVE\fP, \fBDEBUG\fP, \fBEDLIN\fP, \fBCHOICE\fP,
+\fBDELTREE\fP, \fBTREE\fP, \fBLABEL\fP, \fBLOADFIX\fP, \fBMOUSE\fP, \fBMODE\fP, \fBKEYB\fP
 .RE
-
-.SH "OTHER EXTERNAL COMMANDS"
-In addition, the following extra commands are available on the emulated Z:\ drive:
-.TP
-.RS
-.IP "\- 25, 28, 50, 4DOS, A20GATE, ADDKEY, AUTOTYPE, BOOT, CAPMOUSE"
-.IP "\- CDPLAY, CFGTOOL, CONFIG, CWSDPMI, DOS32A, DOS4GW, DOSIDLE"
-.IP "\- DOSMID, DSXMENU, FLAGSAVE, HEXMEM16, HEXMEM32, IMGMAKE"
-.IP "\- IMGMOUNT, INTRO, LOADROM, LS, MIXER, MOUNT, MOUSE, MPXPLAY"
-.IP "\- RE\-DOS, RESCAN, SETCOLOR, START, VESAMOED, VFRCRATE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBZ:\(rsDEBUG\fP
+.sp
+\fBHEXMEM32\fP, \fBHEXMEM16\fP, \fBA20GATE\fP, \fBBIOSTEST\fP, \fBINT2FDBG\fP, \fBNMITEST\fP, \fBLOADROM\fP,
+\fBVESAMOED\fP, \fBVFRCRATE\fP
 .RE
-
-The following external commands are only available on debug enabled builds:
-.TP
-.RS
-.IP "\- BIOSTEST, NMITEST, INT2FDBG"
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBZ:\(rsSYSTEM\fP
+.sp
+\fBPARALLEL\fP, \fBSERIAL\fP, \fBMIXER\fP, \fBCAPMOUSE\fP, \fBFLAGSAVE\fP, \fBCFGTOOL\fP, \fBRESCAN\fP,
+\fBRE\-DOS\fP, \fBCOUNTRY\fP, \fBCONFIG\fP, \fBBOOT\fP, \fBMOUNT\fP, \fBIMGSWAP\fP, \fBIMGMAKE\fP,
+\fBIMGMOUNT\fP, \fBINTRO\fP, \fBHELP\fP
 .RE
-
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.  sp -1
+.  IP \(bu 2.3
+.\}
+\fBZ:\(rsTEXTUTIL\fP
+.sp
+\fBCGA\fP, \fBCLR\fP, \fBEGA\fP, \fBSCANRES\fP, \fBVGA\fP, \fBDCGA\fP, \fB132X25\fP, \fB132X43\fP, \fB132X50\fP,
+\fB132X60\fP, \fB80X25\fP, \fB80X50\fP, \fB80X60\fP
+.RE
 .SH "SPECIAL KEYS"
-.TP 14m
-.IP CTRL\-F7
+.sp
+\fBCTRL\-F7\fP
+.RS 4
 CGA emulation only \- Switch between early and late model IBM CGA emulation.
-.IP CTRL\-F8
-CGA emulation only \- Switch beteen Auto, RGBI and Composite monitor output
-emulation.
-.IP CTRL\-SHIFT\-F7
+.RE
+.sp
+\fBCTRL\-F8\fP
+.RS 4
+CGA emulation only \- Switch between Auto, RGBI and Composite monitor output emulation.
+.RE
+.sp
+\fBCTRL\-SHIFT\-F7\fP
+.RS 4
 CGA emulation only \- Decrease Hue
-.IP CTRL\-SHIFT\-F8
+.RE
+.sp
+\fBCTRL\-SHIFT\-F8\fP
+.RS 4
 CGA emulation only \- Increase Hue
-.IP CTRL\-F7
+.RE
+.sp
+\fBCTRL\-F7\fP
+.RS 4
 CGA Mono and Hercules emulation only \- Cycle between Green, Amber, White and Grey
-.IP CTRL\-F8
-CGA Mono and Hercules emulation only \- Cycle between low and high bightness
-.IP F12\-F
+.RE
+.sp
+\fBCTRL\-F8\fP
+.RS 4
+CGA Mono and Hercules emulation only \- Cycle between low and high brightness
+.RE
+.sp
+\fBF12\-F\fP
+.RS 4
 Switch between fullscreen and window mode.
-.IP F12\-R
+.RE
+.sp
+\fBF12\-R\fP
+.RS 4
 Reset the virtual machine inside DOSBox\-X
-.IP F12\-B
+.RE
+.sp
+\fBF12\-B\fP
+.RS 4
 Reboot the emulated DOS (integrated DOS or guest DOS) inside DOSBox\-X.
-.IP F12\-C
+.RE
+.sp
+\fBF12\-C\fP
+.RS 4
 Start DOSBox\-X’s graphical configuration tool.
-.IP F12\-M
+.RE
+.sp
+\fBF12\-M\fP
+.RS 4
 Start DOSBox\-X’s mapper editor.
-.IP F12\-Esc
+.RE
+.sp
+\fBF12\-Esc\fP
+.RS 4
 Show/hide DOSBox\-X’s drop\-down menu bar.
-.IP F12\-Del
+.RE
+.sp
+\fBF12\-Del\fP
+.RS 4
 Send the selected special key combination (Ctrl+Alt+Del by default) to the guest system.
-.IP F12\-{+}
+.RE
+.sp
+\fBF12\-{+}\fP
+.RS 4
 Increase the sound volume of DOSBox\-X’s emulated DOS.
-.IP F12\-{\-}
+.RE
+.sp
+\fBF12\-{\-}\fP
+.RS 4
 Decrease the sound volume of DOSBox\-X’s emulated DOS.
-.IP F12\-]
+.RE
+.sp
+\fBF12\-]\fP
+.RS 4
 Increase the emulated DOS’s current speed relative to real\-time.
-.IP F12\-[
+.RE
+.sp
+\fBF12\-[\fP
+.RS 4
 Decrease the emulated DOS’s current speed relative to real\-time.
-.IP F12\-{=}
+.RE
+.sp
+\fBF12\-{=}\fP
+.RS 4
 Increase DOSBox\-X’s emulation CPU cycles.
-.IP F12\-{\-}
+.RE
+.sp
+\fBF12\-{\-}\fP
+.RS 4
 Decrease DOSBox\-X’s emulation CPU cycles.
-.IP F12\-Up
+.RE
+.sp
+\fBF12\-Up\fP
+.RS 4
 Increase the font size for the TrueType font (TTF) output.
-.IP F12\-Down
+.RE
+.sp
+\fBF12\-Down\fP
+.RS 4
 Decrease the font size for the TrueType font (TTF) output.
-.IP F12\-Left
+.RE
+.sp
+\fBF12\-Left\fP
+.RS 4
 Reset the emulated DOS’s current CPU speed to the normal speed.
-.IP F12\-Right
+.RE
+.sp
+\fBF12\-Right\fP
+.RS 4
 Toggle DOSBox\-X’s speed lock.
-.IP F12\-D
+.RE
+.sp
+\fBF12\-D\fP
+.RS 4
 Swap between mounted CD images.
-.IP F12\-O
+.RE
+.sp
+\fBF12\-O\fP
+.RS 4
 Swap between mounted floppy images.
-.IP F12\-P
+.RE
+.sp
+\fBF12\-P\fP
+.RS 4
 Take a screenshot of the current screen in PNG format.
-.IP F12\-I
+.RE
+.sp
+\fBF12\-I\fP
+.RS 4
 Start/Stop capturing an AVI video of the current session.
-.IP F12\-W
-Start/Stop recording a WAV audio of the current session.
-Alt+Pause
-Start DOSBox\-X’s Debugger.
-.IP F12\-[,]
+.RE
+.sp
+\fBF12\-W\fP
+.RS 4
+Start/Stop recording a WAV audio of the current session.  Alt+Pause Start DOSBox\-X’s Debugger.
+.RE
+.sp
+\fBF12\-[,]\fP
+.RS 4
 Select the previous save slot to save to or load from.
-.IP F12\-[.]
+.RE
+.sp
+\fBF12\-[.]\fP
+.RS 4
 Select the next save slot to save to or load from.
-.IP F12\-S
+.RE
+.sp
+\fBF12\-S\fP
+.RS 4
 Save current state to the selected save slot.
-.IP F12\-L
+.RE
+.sp
+\fBF12\-L\fP
+.RS 4
 Load the state from the selected save slot.
-.IP F12\-Pause
+.RE
+.sp
+\fBF12\-Pause\fP
+.RS 4
 Pause emulation (press again to continue).
-.IP Ctrl+F5
+.RE
+.sp
+\fBCtrl+F5\fP
+.RS 4
 Copy all text on the DOS screen to the host clipboard.
-.IP Ctrl+F6
+.RE
+.sp
+\fBCtrl+F6\fP
+.RS 4
 Paste the text in the host clipboard to the DOS screen.
-.IP Ctrl+F9
+.RE
+.sp
+\fBCtrl+F9\fP
+.RS 4
 Exit DOSBox\-X.
-.IP Ctrl+F10
+.RE
+.sp
+\fBCtrl+F10\fP
+.RS 4
 Capture the mouse for use with the emulated DOS.
-.PP
+.RE
+.sp
 These are the default keybindings. They can be changed in the keymapper.
-.PP
-Saved/recorded files can be found in current_directory/capture
-(can be changed in the configfile). The directory has to exist prior to starting
-dosbox\-x else nothing gets saved or recorded!
-.PP
-\fBNote:\fR Once you increase your dosbox\-x cycles beyond your computer's
-maximum capacity, it will produce the same effect as slowing down the emulation.
+.sp
+Saved/recorded files can be found in current_directory/capture (can be changed in the configfile).
+The directory has to exist prior to starting dosbox\-x else nothing gets saved or recorded!
+.if n .sp
+.RS 4
+.it 1 an-trap
+.nr an-no-space-flag 1
+.nr an-break-flag 1
+.br
+.ps +1
+.B Note
+.ps -1
+.br
+.sp
+Once you increase your dosbox\-x cycles beyond your computer\(cqs maximum capacity, it will produce the same effect as slowing down the emulation.
 This maximum will vary from computer to computer, there is no standard.
+.sp .5v
+.RE
 .SH "ENVIRONMENT"
+.sp
 Any configuration option can be overridden using an environment variable.
-Environment variables starting with prefix \fBDOSBOX\fR are processed and
-interpreted as follows:
-\fBDOSBOX_SECTIONNAME_PROPERTYNAME=value\fR
-.PP
+Environment variables starting with prefix \fBDOSBOX\fP are processed and interpreted as follows: \fBDOSBOX_SECTIONNAME_PROPERTYNAME=value\fP
+.sp
 For example, you can override the render aspect this way:
-.PP
-\fB$ DOSBOX_RENDER_ASPECT=false dosbox\-x\fR
+.sp
+\fB$ DOSBOX_RENDER_ASPECT=false dosbox\-x\fP
 .SH "BUGS"
-To report a bug, please visit \fIhttps://github.com/joncampbell123/dosbox\-x/issues\fR
-.SH "SEE ALSO"
-You can find a wiki dedicated to DOSBox\-X at \fIhttps://dosbox\-x.com/wiki\fR
+.sp
+To report a bug, please visit \c
+.URL "https://github.com/joncampbell123/dosbox\-x/issues" "" ""
+.SH "RESOURCES"
+.sp
+\fBproject web site:\fP \c
+.URL "https://dosbox\-x.com" "" ""
+.sp
+\fBProject Wiki:\fP \c
+.URL "https://dosbox\-x.com/wiki" "" ""
 .SH "AUTHOR"
-DOSBox\-X project is maintained by the DOSBox\-X Team (\fIhttps://dosbox\-x.com/\fR)
+.sp
+DOSBox-X is maintained by the DOSBox-X Team

--- a/contrib/linux/dosbox-x.1
+++ b/contrib/linux/dosbox-x.1
@@ -849,7 +849,7 @@ In addition, the following extra commands are available on the emulated Z: drive
 .sp
 \fBPARALLEL\fP, \fBSERIAL\fP, \fBMIXER\fP, \fBCAPMOUSE\fP, \fBFLAGSAVE\fP, \fBCFGTOOL\fP, \fBRESCAN\fP,
 \fBRE\-DOS\fP, \fBCOUNTRY\fP, \fBCONFIG\fP, \fBBOOT\fP, \fBMOUNT\fP, \fBIMGSWAP\fP, \fBIMGMAKE\fP,
-\fBIMGMOUNT\fP, \fBINTRO\fP, \fBHELP\fP
+\fBIMGMOUNT\fP, \fBINTRO\fP, \fBHELP\fP, \fBNE2000\fP
 .RE
 .sp
 .RS 4

--- a/contrib/linux/dosbox-x.1
+++ b/contrib/linux/dosbox-x.1
@@ -778,6 +778,20 @@ An explanation of these commands can also be found on the DOSBox\-X wiki on the 
 .SH "OTHER PROVIDED COMMANDS"
 .sp
 In addition, the following extra commands are available on the emulated Z: drive:
+.if n .sp
+.RS 4
+.it 1 an-trap
+.nr an-no-space-flag 1
+.nr an-break-flag 1
+.br
+.ps +1
+.B Note
+.ps -1
+.br
+.sp
+Some commands (like NE2000) are only present in case the corresponding feature is enabled.
+.sp .5v
+.RE
 .sp
 .RS 4
 .ie n \{\

--- a/contrib/linux/dosbox-x.asciidoc
+++ b/contrib/linux/dosbox-x.asciidoc
@@ -324,7 +324,7 @@ In addition, the following extra commands are available on the emulated Z: drive
 --
 *PARALLEL*, *SERIAL*, *MIXER*, *CAPMOUSE*, *FLAGSAVE*, *CFGTOOL*, *RESCAN*,
 *RE-DOS*, *COUNTRY*, *CONFIG*, *BOOT*, *MOUNT*, *IMGSWAP*, *IMGMAKE*,
-*IMGMOUNT*, *INTRO*, *HELP*
+*IMGMOUNT*, *INTRO*, *HELP*, *NE2000*
 --
 - *Z:\TEXTUTIL*
 +

--- a/contrib/linux/dosbox-x.asciidoc
+++ b/contrib/linux/dosbox-x.asciidoc
@@ -1,0 +1,397 @@
+= dosbox-x(1)
+DOSBox-X is maintained by the DOSBox-X Team
+:doctype: manpage
+:manmanual: dosbox-x
+:mansource: dosbox-x
+
+== Name
+dosbox-x - a x86/DOS and PC98 emulator
+
+== Synopsis
+*dosbox-x* [_OPTIONS_] [_FILE_]
+
+== Description
+This manual page briefly documents DOSBox-X, an x86/DOS and PC98 emulator.
+
+Options are listed below. Depending on the option, one or more may be specified.
+
+The optional _FILE_ argument should be a DOS executable or a directory.
+If it is a DOS executable (.com .exe .bat), the program will run automatically.
+If it is a directory, the directory specified will be mounted as the C:\ drive.
+If the DOS executable requires parameters, enclose the command and it's parameters in quotes.
+
+For an introduction type _INTRO_ inside dosbox-x.
+
+== Options
+A summary of available options.
+
+*-?*, *-h* or *-help*::
+  Display the help screen and exit.
+*-v*, *-ver* or *-version*::
+  Display the version information and exit.
+*-fullscreen*, *-fs*::
+  Start dosbox-x in fullscreen mode.
+*-machine* _machinetype_::
+  Start dosbox-x with a specific machine type.  Valid choices are:
++
+--
+* *mda*
++
+IBM Monochrome Display Adapter (text only)
++
+* *hercules*
++
+Hercules Graphics Card (monochrome)
++
+* *cga*
++
+IBM Color Graphics Adapter, with automatic RGB/Composite switching.
++
+* *cga_mono*
++
+IBM CGA attached to a monochrome display
++
+* *cga_rgb*
++
+IBM CGA attached to an RGB monitor
++
+* *cga_composite*
++
+IBM CGA (early revision) attached to an NTSC TV
++
+* *cga_composite2*
++
+IBM CGA (late revision) attached to an NTSC TV
++
+* *pcjr*
++
+IBM PCjr
++
+* *pcjr_composite*
++
+IBM PCjr (late revision) attached to NTSC TV
++
+* *pcjr_composite2*
++
+IBM PCjr (late revision) attached to NTSC TV
++
+* *tandy*
++
+Tandy 1000 Graphics Adapter
++
+* *amstrad*
++
+Amstrad PC1512 graphics mode
++
+* *ega*
++
+IBM Enhanced Graphics Adapter
++
+* *jega*
++
+Japanese Enhanced Graphics Adapter (Microsoft AX)
++
+* *mcga*
++
+IBM Multi-Color Graphics Array
++
+* *vgaonly*
++
+IBM Video Graphics Array (see below)
++
+* *svga_paradise*
++
+SVGA - Paradise Systems PVGA1A
++
+* *svga_et3000*
++
+SVGA - Tseng Labs ET3000
++
+* *svga_et4000*
++
+SVGA - Tseng Labs ET4000
++
+* *svga_s3*
++
+VESA SVGA - S3 Trio64 - VBE 2.0
++
+* *svga_s386c928*
++
+VESA SVGA - S3 86c928 - VBE 2.0 (experimental)
++
+* *svga_s3vision864*
++
+VESA SVGA - S3 Vision 864 - VBE 2.0
++
+* *svga_s3vision868*
++
+VESA SVGA - S3 Vision 868 - VBE 2.0
++
+* *svga_s3vision964*
++
+VESA SVGA - S3 Vision 964 - VBE 2.0
++
+* *svga_s3vision968*
++
+VESA SVGA - S3 Vision 968 - VBE 2.0
++
+* *svga_s3trio32*
++
+VESA SVGA - S3 Trio32 - VBE 2.0
++
+* *svga_s3trio64*
++
+VESA SVGA - S3 Trio64 - VBE 2.0 (same as *svga_s3*)
++
+* *svga_s3trio64v+*
++
+VESA SVGA - S3 Trio64V+ - VBE 2.0
++
+* *svga_s3virge*
++
+VESA SVGA - S3 ViRGE - VBE 2.0 (experimental)
++
+* *svga_s3virgevx*
++
+VESA SVGA - S3 ViRGE VX - VBE 2.0 (experimental)
++
+* *vesa_oldvbe*
++
+VESA SVGA - S3 Trio64 with VESA BIOS Extensions (VBE) 1.2
++
+* *vesa_oldvbe10*
++
+VESA SVGA - S3 Trio64 wtih VESA BIOS Extensions (VBE) 1.0
++
+* *vesa_nolfb*
++
+VESA SVGA - S3 Trio64 with VBE 2.0 with Linear Frame Buffer disabled
++
+* *pc98*
++
+Japanese NEC PC-98 emulation
++
+* *pc9801*
++
+same as *pc98*
++
+* *pc9821*
++
+same as *pc98*
++
+* *fm_towns*
++
+Japanese Fujitsu FM Towns (not implemented)
++
+--
+
+The default is *svga_s3*.
+
+For some special VGA effects the machinetype *vgaonly* can be used, note that this disables SVGA capabilities and might be slower due to the higher emulation accuracy.
+
+NOTE: The _machinetype_ affects not only the emulated video card, but may also effect the available sound cards.
+
+*-conf* _configfile_::
+Start dosbox-x with the options specified in _configfile_. This file may also have a section called _[autoexec]_ in which you can put commands you wish to execute on startup.
+Multiple *-conf* options with _configfiles_ can be specified and they will be overlayed on each other.
+*-editconf* [_editor_]::
+Open the default configuration file in a text editor. If no editor name is given, then use the program from the EDITOR environment variable.
+*-userconf*::
+Load the configuration file located in ~/.config/dosbox-x. Can be combined with the *-conf* option.
+*-printconf*::
+Prints the location of the default configuration file and exit.
+*-eraseconf*, *-resetconf*::
+Removes the default configuration file and exit.
+*-erasemapper*, *-resetmapper*::
+Removes the mapperfile configured in the clean default configuration file and exit.
+*-opencaptures* _program_::
+Calls program with as first parameter the location of the captures folder and exit.
+*-opensaves* _program_::
+Calls program with as first parameter the location of the saves folder and exit.
+*-startui*, *-startgui* or *-starttool*::
+Start DOSBox-X with GUI configuration tool.
+*-startmapper*::
+Start the internal keymapper on startup of dosbox-x. You can use it to change the keys dosbox-x uses.
+*-promptfolder*::
+Prompt for the working directory when DOSBox-X starts.
+*-nopromptfolder*::
+Do not prompt for the working directory when DOSBox-X starts.
+*-nogui* or *-nomenu*::
+Do not show the GUI menu bar when in windowed mode.
+*-showcycles*::
+Show cycles count (FPS) in the title.
+*-showrt*::
+Show emulation speed relative to realtime in the title.
+*-socket* _socketnumber_::
+Passes the TCP socket number _socketnumber_ for the nullmodem emulation.
+See the WIKI for details.
+*-savedir* _path_::
+Set path for the save slots.
+*-defaultdir* _path_::
+Set the default working path for DOSBox-X.
+*-defaultconf*::
+Use the default config settings for DOSBox-X.
+*-defaultmapper*::
+Use the default key mappings for DOSBox-X.
+*-data-host-forced*::
+Force synchronization of date and time with the host.
+*-display2* [_color_]::
+Enable both standard & monochrome dual-screen mode. The monochrome display defaults to white, but can optionally be set to _green_ or _amber_.
+*-lang* _message_file_::
+Start dosbox-x with the language specified in _message_file_.
+*-nodpiaware*::
+Ignore (do not signal) Windows DPI awareness.
+*-securemode*::
+Enable  secure mode, which is meant to prevent a DOS program potentially gaining access to files outside directories mounted in the [autoexec] section of the config file.
+It does this by running *Z:\SYSTEM\CONFIG.COM -securemode* after completing the [autoexec] section (which in turn disables any changes to how the drives are mounted "inside" dosbox-x).
+It also disables various other CONFIG.COM options that could be exploited.
+*-prerun*::
+If _FILE_ is given, run it before the AUTOEXEC.BAT config section
+*-hostrun*::
+Enable START command, CLIP$ device and long filename (LFN) support
+*-noconfig*::
+Skips the [config] section of the loaded configuration file. This is equivalent to skipping CONFIG.SYS in DOS.
+*-noautoexec*::
+Skips the [autoexec] section of the loaded configuration file. This is equivalent to skipping AUTOEXEC.BAT in DOS.
+*-exit*::
+dosbox-x will close itself when the DOS program specified by _FILE_ ends.
+*-silent*::
+Run DOSBox-X silently and exit after executing the [autoexec] section of the loaded config file.
+*-o* _option(s)_::
+Provide command-line option(s) for [_FILE_] if specified.
+*-c* _command_::
+Runs the specified command before running [_FILE_].
+Multiple commands can be specified.
+Each command should start with *-c* though.
+A command can be an Internal Program, a DOS command or an executable on a mounted drive.
+If the command requires parameters, enclose the command and its parameters in quotes.
+*-set* _section property=value_::
+Set the config option (override any config file).
+If the property contains spaces, ensure to enclose the string in quotes.
+The section is the name of a dosbox-x config section such as *[video]* without the brackets.
+Multiple *-set* commands may be specified.
+If a property is unique, the section may be omitted.
+e.g. *-set sdl output=ttf* is equivalent to *-set output=ttf*
+*-time-limit* _seconds_::
+Kill the emulator after _seconds_.
+*-fastlaunch*::
+Fast launch mode (skip the BIOS logo and welcome banner).
+*-helpdebug*::
+Show debug-related options and exit.
+
+== INTERNAL INTERPRETER COMMANDS
+*dosbox-x* Supports most of the internal DOS commands found in COMMAND.COM.
+Help text is integrated for these commands in DOSBox-X, and will not be duplicated here.
+An explanation of these commands can also be found on the DOSBox-X wiki on the Supported Commands page.
+
+*ALIAS*, *ATTRIB*, *BREAK*, *CALL*, *CD*/*CDDIR*, *CHCP*, *CHOICE*, *CLS*,
+*COPY*, *COUNTRY*, *CTTY*, *DATE*, *DEL*/*ERASE*, *DELTREE*, *ECHO*, *EXIT*,
+*DIR*, *FOR*, *GOTO*, *HELP*, *IF*, *LFNFOR*, *LH*/*LOADHIGH*, *MD*/*MKDIR*,
+*MORE*, *PATH*, *PAUSE*, *PROMPT*, *RD*/*RMDIR*, *REM*, *REN*/*RENAME*, *SET*,
+*SHIFT*, *SUBST*, *TIME*, *TRUENAME*, *TYPE*, *VER*, *VERIFY*, *VOL*
+
+== OTHER PROVIDED COMMANDS
+In addition, the following extra commands are available on the emulated Z: drive:
+
+- *Z:\4DOS*
++
+--
+*4DOS*, *4HELP*, *OPTION*, *BATCOMP*
+--
+- *Z:\BIN*
++
+--
+*EVAL*, *SHUTDOWN*, *DSXMENU*, *CWSDPMI*, *EMSMAGIC*, *UNZIP*, *ZIP*, *MPXPLAY*,
+*DOSMID*, *CDPLAY*, *DOS4GW*, *DOS32A*, *DOSIDLE*, *UTF16*, *UTF8*, *AUTOTYPE*,
+*ADDKEY*, *LS*, *TITLE*, *COLOR*, *SETCOLOR*
+--
+- *Z:\DOS*
++
+--
+*MEM*, *EDIT*, *PRINT*, *DISKCOPY*, *DEFRAG*, *FORMAT*, *FDISK*, *SYS*, *FC*,
+*COMP*, *CHKDSK*, *BUFFERS*, *DEVICE*, *APPEND*, *XCOPY*, *SORT*, *REPLACE*,
+*LASTDRIV*, *FILES*, *FCBS*, *FIND*, *MOVE*, *DEBUG*, *EDLIN*, *CHOICE*,
+*DELTREE*, *TREE*, *LABEL*, *LOADFIX*, *MOUSE*, *MODE*, *KEYB*
+--
+- *Z:\DEBUG*
++
+--
+*HEXMEM32*, *HEXMEM16*, *A20GATE*, *BIOSTEST*, *INT2FDBG*, *NMITEST*, *LOADROM*,
+*VESAMOED*, *VFRCRATE*
+--
+- *Z:\SYSTEM*
++
+--
+*PARALLEL*, *SERIAL*, *MIXER*, *CAPMOUSE*, *FLAGSAVE*, *CFGTOOL*, *RESCAN*,
+*RE-DOS*, *COUNTRY*, *CONFIG*, *BOOT*, *MOUNT*, *IMGSWAP*, *IMGMAKE*,
+*IMGMOUNT*, *INTRO*, *HELP*
+--
+- *Z:\TEXTUTIL*
++
+--
+*CGA*, *CLR*, *EGA*, *SCANRES*, *VGA*, *DCGA*, *132X25*, *132X43*, *132X50*,
+*132X60*, *80X25*, *80X50*, *80X60*
+--
+
+== SPECIAL KEYS
+*CTRL-F7*::       CGA emulation only - Switch between early and late model IBM CGA emulation.
+*CTRL-F8*::       CGA emulation only - Switch between Auto, RGBI and Composite monitor output emulation.
+*CTRL-SHIFT-F7*:: CGA emulation only - Decrease Hue
+*CTRL-SHIFT-F8*:: CGA emulation only - Increase Hue
+*CTRL-F7*::       CGA Mono and Hercules emulation only - Cycle between Green, Amber, White and Grey
+*CTRL-F8*::       CGA Mono and Hercules emulation only - Cycle between low and high brightness
+*F12-F*::         Switch between fullscreen and window mode.
+*F12-R*::         Reset the virtual machine inside DOSBox-X
+*F12-B*::         Reboot the emulated DOS (integrated DOS or guest DOS) inside DOSBox-X.
+*F12-C*::         Start DOSBox-X’s graphical configuration tool.
+*F12-M*::         Start DOSBox-X’s mapper editor.
+*F12-Esc*::       Show/hide DOSBox-X’s drop-down menu bar.
+*F12-Del*::       Send the selected special key combination (Ctrl+Alt+Del by default) to the guest system.
+*F12-{+}*::       Increase the sound volume of DOSBox-X’s emulated DOS.
+*F12-{-}*::       Decrease the sound volume of DOSBox-X’s emulated DOS.
+*F12-]*::         Increase the emulated DOS’s current speed relative to real-time.
+*F12-[*::         Decrease the emulated DOS’s current speed relative to real-time.
+*F12-{=}*::       Increase DOSBox-X’s emulation CPU cycles.
+*F12-{-}*::       Decrease DOSBox-X’s emulation CPU cycles.
+*F12-Up*::        Increase the font size for the TrueType font (TTF) output.
+*F12-Down*::      Decrease the font size for the TrueType font (TTF) output.
+*F12-Left*::      Reset the emulated DOS’s current CPU speed to the normal speed.
+*F12-Right*::     Toggle DOSBox-X’s speed lock.
+*F12-D*::         Swap between mounted CD images.
+*F12-O*::         Swap between mounted floppy images.
+*F12-P*::         Take a screenshot of the current screen in PNG format.
+*F12-I*::         Start/Stop capturing an AVI video of the current session.
+*F12-W*::         Start/Stop recording a WAV audio of the current session.  Alt+Pause Start DOSBox-X’s Debugger.
+*F12-[,]*::       Select the previous save slot to save to or load from.
+*F12-[.]*::       Select the next save slot to save to or load from.
+*F12-S*::         Save current state to the selected save slot.
+*F12-L*::         Load the state from the selected save slot.
+*F12-Pause*::     Pause emulation (press again to continue).
+*Ctrl+F5*::       Copy all text on the DOS screen to the host clipboard.
+*Ctrl+F6*::       Paste the text in the host clipboard to the DOS screen.
+*Ctrl+F9*::       Exit DOSBox-X.
+*Ctrl+F10*::      Capture the mouse for use with the emulated DOS.
+
+These are the default keybindings. They can be changed in the keymapper.
+
+Saved/recorded files can be found in current_directory/capture (can be changed in the configfile).
+The directory has to exist prior to starting dosbox-x else nothing gets saved or recorded!
+
+NOTE:  Once you increase your dosbox-x cycles beyond your computer's maximum capacity, it will produce the same effect as slowing down the emulation.
+This maximum will vary from computer to computer, there is no standard.
+
+== ENVIRONMENT
+Any configuration option can be overridden using an environment variable.
+Environment variables starting with prefix *DOSBOX* are processed and interpreted as follows: *DOSBOX_SECTIONNAME_PROPERTYNAME=value*
+
+For example, you can override the render aspect this way:
+
+*$ DOSBOX_RENDER_ASPECT=false dosbox-x*
+
+== BUGS
+To report a bug, please visit https://github.com/joncampbell123/dosbox-x/issues
+
+== Resources
+*project web site:* https://dosbox-x.com
+
+*Project Wiki:* https://dosbox-x.com/wiki

--- a/contrib/linux/dosbox-x.asciidoc
+++ b/contrib/linux/dosbox-x.asciidoc
@@ -293,6 +293,8 @@ An explanation of these commands can also be found on the DOSBox-X wiki on the S
 == OTHER PROVIDED COMMANDS
 In addition, the following extra commands are available on the emulated Z: drive:
 
+NOTE: Some commands (like NE2000) are only present in case the corresponding feature is enabled.
+
 - *Z:\4DOS*
 +
 --


### PR DESCRIPTION
Got tired of manually trying to write the manpage in troff and
converted it to asciidoc which can convert to a manpage using:

asciidoctor -b manpage dosbox-x.asciidoc

This is not part of the build process, so for now whenever the
asciidoc is updated, it needs to be converted manually.

Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

With https://github.com/joncampbell123/dosbox-x/commit/f462870dacf2cde74ec3850a1fc4598cd7c4ee86 there is now support for the `-machine` option which is missing from the manpage and bash completion. This adds the support.
