### PR TITLE
Fix MinGW-32 build

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,14 +1,6 @@
 0.83.25
   - XGA: Do not register XGA I/O ports unless emulating
-    the S3 chipset (such as machine=svga_s3) (joncampbell123).
-  - Add stub INT 10h handler at F000:F065 if
-    machine=vgaonly and using a VGA ROM BIOS image.
-    The IBM VGA ROM BIOS image points INT 42h at that
-    fixed address and calls it for any function it does
-    not understand. (joncampbell123)
-  - Fix extra INT 10h call during BIOS screen. The
-    extra call caused crashes when combined with a ROM
-    image of the stock IBM VGA BIOS. (joncampbell123)
+    S3 chipset (such as machine=svga_s3) (joncampbell123)
   - Menu options "Force scaler" and "Print text screen"
     can now be assigned to keyboard shortcuts from the
     Mapper Editor. (Wengier)
@@ -47,6 +39,11 @@
   - Added Korean language option in Windows installer.
     Also, language option page will be shown regardless
     of the output option selected. (Wengier)
+  - Add stub INT 10h handler at F000:F065 if
+    machine=vgaonly and using a VGA ROM BIOS image.
+    The IBM VGA ROM BIOS image points INT 42h at that
+    fixed address and calls it for any function it does
+    not understand. (joncampbell123)
   - Set int33 event status bit 8 when passing absolute
     mouse coordinates, which is useful in emulation or
     virtualization environments where the mouse may be
@@ -64,6 +61,9 @@
   - Fixed lockup in classic Jumpman. (maron2000)
   - Fixed color in some modes under x86-64 macOS SDL2
     builds. (myon98)
+  - Fixed extra INT 10h call during BIOS screen. The
+    extra call caused crashes when combined with a ROM
+    image of the stock IBM VGA BIOS. (joncampbell123)
   - Fixed fscale FPU operation and updated FPU status
     word. Also fixed FPU stack value log messages on
     x86-based builds. (cimarronm)
@@ -78,6 +78,7 @@
     menu when dynamic_x86 is also available. Also fixed
     the dynamic_rec core may not be displayed correctly
     in the menu when a language file is used. (Wengier)
+  - Fixed Windows resource information. (Wengier)
   - Fixed a buffer overflow when launching a program.
     (Jookia)
   - Fixed bug where DOS IOCTL would call device control

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -50,6 +50,10 @@ Once Flatpak support is enabled on your Linux system you can install the DOSBox-
 
 ``flatpak install flathub com.dosbox_x.DOSBox-X``
 
+Alternatively, you can install the DOSBox-X Flatpak locally if you downloaded the ``com.dosbox_x.DOSBox-X.flatpakref`` file to your computer:
+
+``flatpak install --from com.dosbox_x.DOSBox-X.flatpakref``
+
 After it is installed, it can be run with:
 
 ``flatpak run com.dosbox_x.DOSBox-X``

--- a/configure.ac
+++ b/configure.ac
@@ -959,14 +959,14 @@ AH_TEMPLATE(C_SDL_NET,[Indicate whether SDL_net is present])
 AH_TEMPLATE(C_MODEM,[Define to 1 to enable internal modem support, requires SDL_net])
 AH_TEMPLATE(C_IPX,[Define to 1 to enable IPX over Internet networking, requires SDL_net])
 
-dnl enable SDL2 net if SDL2
 case "$host" in
   *-*-cygwin* | *-*-mingw32*)
-     if test x$have_sdl_net_h = xyes; then
-       have_sdl_net_lib=yes
-     fi
+    if test x$have_sdl_net_h = xyes -a x$enable_hx = xno; then
+      have_sdl_net_lib=yes
+    fi
   ;;
 esac
+dnl enable SDL2 net if SDL2
 if test -n "$SDL2_LIBS"; then
  if test x$have_sdl2_net_lib = xyes -a x$have_sdl_net_h = xyes ; then
   LIBS="$LIBS -lSDL2_net"

--- a/configure.ac
+++ b/configure.ac
@@ -1066,6 +1066,12 @@ if test x$enable_libslirp == xyes ; then
        fi
     ;;
   esac
+else
+  case "$host" in
+    *-*-cygwin* | *-*-mingw32*)
+      LIBS="$LIBS -liconv"
+    ;;
+  esac
 fi
 
 if test x$enable_x11 != xno; then

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -6674,10 +6674,7 @@ bool DOSBOX_parse_argv() {
             fprintf(stderr,"  -securemode                             Enable secure mode (no drive mounting etc)\n");
             fprintf(stderr,"  -prerun                                 If [name] is given, run it before AUTOEXEC.BAT config section\n");
 #if defined(WIN32) && !defined(HX_DOS) || defined(MACOSX) || defined(LINUX)
-            fprintf(stderr,"  -hostrun                                Enable START command, CLIP$ device and long filename support\n");
-#endif
-#if defined(WIN32) && !defined(HX_DOS)
-            fprintf(stderr,"                                          Windows programs can be launched directly to run on the host\n");
+            fprintf(stderr,"  -hostrun                                Enable running host program via START command and LFN support\n");
 #endif
             fprintf(stderr,"  -noconfig                               Do not execute CONFIG.SYS config section\n");
             fprintf(stderr,"  -noautoexec                             Do not execute AUTOEXEC.BAT config section\n");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5091,8 +5091,9 @@ void SetIMPosition() {
             rect.y = y * ttf.height + (ttf.height - TTF_FontAscent(ttf.SDL_font)) / 2;
         } else {
 #endif
-            rect.x = x * width;
-            rect.y = y * height - (J3_IsJapanese()?2:(IS_DOSV?-1:(DOSV_CheckCJKVideoMode()?2:0)));
+            double sx = sdl.clip.w>0&&sdl.draw.width>0?((double)sdl.clip.w/sdl.draw.width):1, sy = sdl.clip.h>0&&sdl.draw.height>0?((double)sdl.clip.h/sdl.draw.height):1;
+            rect.x = x * width * sx;
+            rect.y = y * height * sy - (J3_IsJapanese()?2:(IS_DOSV?-1:(DOSV_CheckCJKVideoMode()?2:0)));
 #if DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW /* SDL drawn menus */
             rect.y += mainMenu.menuBarHeight;
 #endif

--- a/src/hardware/serialport/misc_util.cpp
+++ b/src/hardware/serialport/misc_util.cpp
@@ -26,8 +26,10 @@
 /*****************************************************************************/
 // C++ SDLnet wrapper
 
+#if !defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR)
 #define ENET_IMPLEMENTATION
 #include "enet.h"
+#endif
 #include "ipx.h"
 #include "logging.h"
 #include "misc_util.h"
@@ -84,7 +86,9 @@ NETClientSocket *NETClientSocket::NETClientFactory(SocketTypesE socketType,
 	switch (socketType) {
 	case SOCKET_TYPE_TCP: return new TCPClientSocket(destination, port);
 
+#if !defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR)
 	case SOCKET_TYPE_ENET: return new ENETClientSocket(destination, port);
+#endif
 
 	default: return nullptr;
 	}
@@ -141,7 +145,9 @@ NETServerSocket *NETServerSocket::NETServerFactory(SocketTypesE socketType,
 	switch (socketType) {
 	case SOCKET_TYPE_TCP: return new TCPServerSocket(port);
 
+#if !defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR)
 	case SOCKET_TYPE_ENET: return new ENETServerSocket(port);
+#endif
 
 	default: return nullptr;
 	}
@@ -150,6 +156,7 @@ NETServerSocket *NETServerSocket::NETServerFactory(SocketTypesE socketType,
 
 // --- ENet UDP NET INTERFACE ------------------------------------------------
 
+#if !defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR)
 class enet_manager_t {
 public:
 	enet_manager_t()
@@ -522,6 +529,7 @@ void ENETClientSocket::updateState()
 	}
 #endif
 }
+#endif
 
 // --- TCP NET INTERFACE -----------------------------------------------------
 

--- a/src/hardware/serialport/misc_util.h
+++ b/src/hardware/serialport/misc_util.h
@@ -66,7 +66,9 @@
 
 #include <SDL_net.h>
 
+#if !defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR)
 #include "enet.h"
+#endif
 
 uint32_t Netwrapper_GetCapabilities();
 
@@ -131,6 +133,7 @@ public:
 
 // --- ENET UDP NET INTERFACE ------------------------------------------------
 
+#if !defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR)
 class ENETServerSocket : public NETServerSocket {
 public:
 	ENETServerSocket(uint16_t port);
@@ -174,6 +177,7 @@ private:
 	ENetAddress          address       = {};
 	std::queue<uint8_t>  receiveBuffer = {};
 };
+#endif
 
 // --- TCP NET INTERFACE -----------------------------------------------------
 

--- a/src/winres.rc
+++ b/src/winres.rc
@@ -1,5 +1,5 @@
 
-#include "winres.h"
+#include "winresrc.h"
 #include "../include/resource.h"
 
 // icon resource
@@ -22,15 +22,15 @@ BEGIN
     BEGIN
 		BLOCK "040904b0"
 		BEGIN
-		    VALUE "Comments", "(C) 2002-2018 TheGreatCodeholio, a fork of the DOSBox project, published under GNU GPL"
-		    VALUE "CompanyName", "DOSBox-X"
+		    VALUE "Comments", "Project maintainer: joncampbell123 (TheGreatCodeholio)"
+		    VALUE "CompanyName", "DOSBox-X Project"
 		    VALUE "FileDescription", "DOSBox-X DOS Emulator"
-		    VALUE "FileVersion", "0, 74, 0, 0"
+		    VALUE "FileVersion", "0, 83, 25, 0"
 		    VALUE "InternalName", "DOSBox-X"
-		    VALUE "LegalCopyright", "Copyright ?2002-2018 TheGreatCodeholio"
+		    VALUE "LegalCopyright", "Copyright 2011-2022 The DOSBox-X Team (joncampbell123), published under GNU GPL"
 		    VALUE "OriginalFilename", "dosbox-x.exe"
 		    VALUE "ProductName", "DOSBox-X DOS Emulator"
-		    VALUE "ProductVersion", "0, 74, 0, 0"
+		    VALUE "ProductVersion", "0, 83, 25, 0"
 		END
     END
     BLOCK "VarFileInfo"

--- a/src/winres.rc
+++ b/src/winres.rc
@@ -1,6 +1,8 @@
 
 #include "winresrc.h"
 #include "../include/resource.h"
+
+#define VERSION_NUMBER 0,83,25,0
 #define FLUIDINC
 #include "../config.h"
 
@@ -9,8 +11,6 @@ dosbox_ico ICON "../contrib/icons/dosbox-x.ico"
 IDI_MAPPER ICON "../contrib/icons/mapper.ico"
 IDI_CFG_GUI ICON "../contrib/icons/cfggui.ico"
 IDI_PAUSE ICON "../contrib/icons/pause.ico"
-
-#define VERSION_NUMBER 0,83,25,0
 
 // version resource
 VS_VERSION_INFO VERSIONINFO

--- a/src/winres.rc
+++ b/src/winres.rc
@@ -1,6 +1,8 @@
 
 #include "winresrc.h"
 #include "../include/resource.h"
+#define FLUIDINC
+#include "../config.h"
 
 // icon resource
 dosbox_ico ICON "../contrib/icons/dosbox-x.ico"
@@ -8,10 +10,12 @@ IDI_MAPPER ICON "../contrib/icons/mapper.ico"
 IDI_CFG_GUI ICON "../contrib/icons/cfggui.ico"
 IDI_PAUSE ICON "../contrib/icons/pause.ico"
 
+#define VERSION_NUMBER 0,83,25,0
+
 // version resource
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 0,74,0,0
- PRODUCTVERSION 0,74,0,0
+ FILEVERSION VERSION_NUMBER
+ PRODUCTVERSION VERSION_NUMBER
  FILEFLAGSMASK 0x3fL
  FILEFLAGS 0x0L
  FILEOS 0x40004L
@@ -25,12 +29,12 @@ BEGIN
 		    VALUE "Comments", "Project maintainer: joncampbell123 (TheGreatCodeholio)"
 		    VALUE "CompanyName", "DOSBox-X Project"
 		    VALUE "FileDescription", "DOSBox-X DOS Emulator"
-		    VALUE "FileVersion", "0, 83, 25, 0"
+		    VALUE "FileVersion", PACKAGE_VERSION
 		    VALUE "InternalName", "DOSBox-X"
 		    VALUE "LegalCopyright", "Copyright 2011-2022 The DOSBox-X Team (joncampbell123), published under GNU GPL"
 		    VALUE "OriginalFilename", "dosbox-x.exe"
 		    VALUE "ProductName", "DOSBox-X DOS Emulator"
-		    VALUE "ProductVersion", "0, 83, 25, 0"
+		    VALUE "ProductVersion", PACKAGE_VERSION
 		END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
This fixes the code compile issue on MinGW-32 (not MinGW-w64) due to Modem support, by disabling ENET function for such builds so that the code will compile as expected in this platform.