### PR TITLE
Fix config.h include location in the resource file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -961,7 +961,7 @@ AH_TEMPLATE(C_IPX,[Define to 1 to enable IPX over Internet networking, requires 
 
 case "$host" in
   *-*-cygwin* | *-*-mingw32*)
-    if test x$have_sdl_net_h = xyes -a x$enable_hx = xno; then
+    if test x$have_sdl_net_h = xyes -a x$enable_hx != xyes; then
       have_sdl_net_lib=yes
     fi
   ;;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,7 +17,7 @@ ico_stuff = winres.rc
 endif
 
 .rc.o:
-	$(WINDRES) -DMINGW -o $@ $<
+	$(WINDRES) -o $@ $<
 
 dosbox_x_SOURCES = dosbox.cpp $(ico_stuff)
 dosbox_x_LDADD = debug/libdebug.a dos/libdos.a shell/libshell.a builtin/libbuiltin.a \

--- a/src/winres.rc
+++ b/src/winres.rc
@@ -1,15 +1,9 @@
 
 #include "winresrc.h"
 #include "../include/resource.h"
+#include "../vs/config_package.h"
 
 #define VERSION_NUMBER 0,83,25,0
-#define FLUIDINC
-
-#ifdef MINGW
-# include "../config.h"
-#else
-# include "./config.h"
-#endif
 
 // icon resource
 dosbox_ico ICON "../contrib/icons/dosbox-x.ico"


### PR DESCRIPTION
This fixes the resource file to use the config_package.h header file so that it will build in different Windows platforms, as mentioned in #3444. Along with a minor fix in the configure.ac script for MinGW builds.