### PR TITLE
configure.ac: Fix error in setpriority test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -322,7 +322,7 @@ AH_TEMPLATE(C_SET_PRIORITY,[Define to 1 if you have setpriority support])
 AC_MSG_CHECKING(for setpriority support)
 AC_LINK_IFELSE([AC_LANG_SOURCE([
 #include <sys/resource.h>
-int main(int argc,char * argv[]) {
+int main(int argc,char **argv) {
 	return setpriority (PRIO_PROCESS, 0,PRIO_MIN+PRIO_MAX);
 };
 ])],AC_MSG_RESULT(yes);AC_DEFINE(C_SET_PRIORITY,1),AC_MSG_RESULT(no))


### PR DESCRIPTION
On some compilers this error would happen:

> conftest.c:39:5: error: second parameter of 'main' (argument array) must be of type 'char **'
> int main(int argc,char * argv) {
>     ^

This is absurd because the test clearly has argv[] in it, but it's
getting dropped for some reason. Just avoid this by writing char**

## What issue(s) does this PR address?

Some weird configure bug?

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

Not sure

## Additional information

I noticed this in #3433 . I will need @brunocastello to test this and send me or upload their config.log if they can.