### PR TITLE
acinclude: Enable SDL2 by default

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -8,7 +8,7 @@ AC_ARG_WITH(sdl2-exec-prefix,[  --with-sdl2-exec-prefix=PFX Exec prefix where SD
 AC_ARG_ENABLE(sdl2test, [  --disable-sdl2test      Do not try to compile and run a test SDL program],
 		    enable_sdl2test=no, enable_sdl2test=yes)
 AC_ARG_ENABLE(sdl2,     [  --enable-sdl2           Enable SDL 2.x],
-		    enable_sdl2enable=$enableval, enable_sdl2enable=no)
+		    enable_sdl2enable=$enableval, enable_sdl2enable=yes)
 
   AH_TEMPLATE(C_SDL2,[Set to 1 to enable SDL 2.x support])
 
@@ -63,7 +63,7 @@ AC_ARG_WITH(sdl-exec-prefix,[  --with-sdl-exec-prefix=PFX Exec prefix where SDL 
 AC_ARG_ENABLE(sdltest,      [  --disable-sdltest       Do not try to compile and run a test SDL program],
 		    enable_sdltest=no, enable_sdltest=yes)
 AC_ARG_ENABLE(sdl, [  --enable-sdl            Enable SDL 1.x],
-		    enable_sdlenable=$enableval, enable_sdlenable=yes)
+		    enable_sdlenable=$enableval, enable_sdlenable=no)
 
   AH_TEMPLATE(C_SDL1,[Set to 1 to enable SDL 1.x support])
 

--- a/build
+++ b/build
@@ -19,6 +19,6 @@ echo Compiling our internal SDLnet 1.x
 # now compile ourself
 echo Compiling DOSBox-X
 chmod +x configure
-./configure --enable-core-inline --disable-debug --prefix=/usr "$@" || exit 1
+./configure --enable-core-inline --disable-debug --enable-sdl --prefix=/usr "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-debug
+++ b/build-debug
@@ -37,6 +37,6 @@ echo Compiling our internal SDLnet 1.x
 # now compile ourself
 echo Compiling DOSBox-X
 chmod +x configure
-./configure --enable-core-inline --enable-debug=heavy --prefix=/usr "$@" $opt || exit 1
+./configure --enable-core-inline --enable-debug=heavy --enable-sdl --prefix=/usr "$@" $opt || exit 1
 make -j3 || exit 1
 

--- a/build-debug-g3
+++ b/build-debug-g3
@@ -31,6 +31,6 @@ echo Compiling our internal SDLnet 1.x
 # now compile ourself
 echo Compiling DOSBox-X
 # NTS: --disable-dynamic-core is needed. the dynamic core doesn't work properly with the CFLAGS given above
-./configure --enable-core-inline --enable-debug=heavy --prefix=/usr --disable-dynamic-core "$@" || exit 1
+./configure --enable-core-inline --enable-debug=heavy --enable-sdl --prefix=/usr --disable-dynamic-core "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-debug-g3-sdl2
+++ b/build-debug-g3-sdl2
@@ -36,6 +36,6 @@ echo Compiling our internal SDLnet 1.x
 (cd vs/sdlnet && ./build-dosbox.sh) || exit 1
 
 # NTS: --disable-dynamic-core is needed. the dynamic core doesn't work properly with the CFLAGS given above
-./configure --enable-core-inline --enable-debug=heavy --prefix=/usr --disable-dynamic-core --enable-sdl2 "$@" || exit 1
+./configure --enable-core-inline --enable-debug=heavy --prefix=/usr --disable-dynamic-core "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-debug-gcc-prof
+++ b/build-debug-gcc-prof
@@ -30,6 +30,6 @@ echo Compiling our internal SDLnet 1.x
 # now compile ourself
 echo Compiling DOSBox-X
 chmod +x configure
-./configure --enable-core-inline --enable-debug=heavy --prefix=/usr "$@" $opt || exit 1
+./configure --enable-core-inline --enable-debug=heavy --enable-sdl --prefix=/usr "$@" $opt || exit 1
 make -j3 || exit 1
 

--- a/build-debug-macosx
+++ b/build-debug-macosx
@@ -57,6 +57,6 @@ export INTERNAL_FREETYPE=1
 echo Compiling DOSBox-X
 
 chmod +x configure
-./configure --enable-core-inline --enable-debug=heavy --prefix=/usr --disable-libfluidsynth --disable-libslirp --disable-avcodec "$@" || exit 1
+./configure --enable-core-inline --enable-debug=heavy --enable-sdl --prefix=/usr --disable-libfluidsynth --disable-libslirp --disable-avcodec "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-debug-macosx-sdl2
+++ b/build-debug-macosx-sdl2
@@ -57,6 +57,6 @@ brew list pkg-config &>/dev/null || brew install pkg-config
 # now compile ourself
 echo Compiling DOSBox-X
 chmod +x configure
-./configure --enable-core-inline --enable-debug=heavy --prefix=/usr --enable-sdl2 --disable-avcodec "$@" || exit 1
+./configure --enable-core-inline --enable-debug=heavy --prefix=/usr --disable-avcodec "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-debug-sdl2
+++ b/build-debug-sdl2
@@ -33,6 +33,6 @@ echo Compiling our internal SDLnet 1.x
 (cd vs/sdlnet && ./build-dosbox.sh) || exit 1
 
 chmod +x configure
-./configure --enable-core-inline --enable-debug=heavy --prefix=/usr --enable-sdl2 "$@" $opt || exit 1
+./configure --enable-core-inline --enable-debug=heavy --prefix=/usr "$@" $opt || exit 1
 make -j3 || exit 1
 

--- a/build-debug-with-clang
+++ b/build-debug-with-clang
@@ -32,6 +32,6 @@ echo Compiling our internal SDLnet 1.x
 # now compile ourself
 echo Compiling DOSBox-X
 chmod +x configure
-./configure --enable-core-inline --enable-debug=heavy --prefix=/usr "$@" $opt || exit 1
+./configure --enable-core-inline --enable-debug=heavy --enable-sdl --prefix=/usr "$@" $opt || exit 1
 make -j3 || exit 1
 

--- a/build-emscripten-sdl2
+++ b/build-emscripten-sdl2
@@ -30,7 +30,7 @@ chmod +x configure
 # build command borrowed from Yksoft1 vanilla DOSBox-X port with modifications
 ./configure \
     --host=x86_64-linux --disable-fpu-x86 --disable-dynamic-core \
-    --enable-sdl2 --with-sdl-prefix=$EMSDK/upstream/emscripten/system \
+    --with-sdl-prefix=$EMSDK/upstream/emscripten/system \
     --disable-opengl --disable-mt32 --enable-emscripten --enable-force-menu-sdldraw --disable-x11 \
     --disable-directserial "$@"
 make -j6 || exit 1

--- a/build-macosx
+++ b/build-macosx
@@ -75,6 +75,6 @@ fi
 # now compile ourself
 echo Compiling DOSBox-X
 chmod +x configure
-./configure --enable-core-inline --enable-debug=heavy --prefix=/usr $opts "$@" || exit 1
+./configure --enable-core-inline --enable-sdl --enable-debug=heavy --prefix=/usr $opts "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-macosx-sdl2
+++ b/build-macosx-sdl2
@@ -72,6 +72,6 @@ fi
 # now compile ourself
 echo Compiling DOSBox-X
 chmod +x configure
-./configure --enable-core-inline --enable-debug=heavy --prefix=/usr --enable-sdl2 $opts "$@" || exit 1
+./configure --enable-core-inline --enable-debug=heavy --prefix=/usr $opts "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-mingw
+++ b/build-mingw
@@ -65,6 +65,6 @@ pacman -S --needed --noconfirm mingw-w64-x86_64-libslirp &>/dev/null
 echo Compiling DOSBox-X
 chmod +x configure
 # FIXME: I would like MinGW builds to enable the debugger, eventually
-./configure --enable-core-inline --enable-d3d9 --enable-d3d-shaders --disable-libfluidsynth --prefix=/usr "$@" || exit 1
+./configure --enable-core-inline --enable-sdl --enable-d3d9 --enable-d3d-shaders --disable-libfluidsynth --prefix=/usr "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-mingw-hx-dos
+++ b/build-mingw-hx-dos
@@ -54,6 +54,6 @@ export INTERNAL_FREETYPE=1
 echo Compiling DOSBox-X
 chmod +x configure
 # FIXME: I would like MinGW builds to enable the debugger, eventually
-./configure --enable-core-inline --disable-mt32 --disable-opengl --enable-hx-dos --prefix=/usr "$@" || exit 1
+./configure --enable-core-inline --disable-mt32 --disable-opengl --enable-hx-dos --enable-sdl --prefix=/usr "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-mingw-lowend
+++ b/build-mingw-lowend
@@ -58,6 +58,6 @@ export INTERNAL_FREETYPE=1
 echo Compiling DOSBox-X
 chmod +x configure
 # FIXME: I would like MinGW builds to enable the debugger, eventually
-./configure --enable-core-inline --disable-libfluidsynth --disable-libslirp --enable-d3d9 --enable-d3d-shaders --prefix=/usr "$@" || exit 1
+./configure --enable-core-inline --disable-libfluidsynth --disable-libslirp --enable-d3d9 --enable-d3d-shaders --enable-sdl --prefix=/usr "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-mingw-sdl2
+++ b/build-mingw-sdl2
@@ -63,6 +63,6 @@ pacman -S --needed --noconfirm mingw-w64-x86_64-libslirp &>/dev/null
 echo Compiling DOSBox-X
 chmod +x configure
 # FIXME: I would like MinGW builds to enable the debugger, eventually
-./configure --enable-core-inline --enable-d3d9 --enable-d3d-shaders --disable-libfluidsynth --prefix=/usr --enable-sdl2 "$@" || exit 1
+./configure --enable-core-inline --enable-d3d9 --enable-d3d-shaders --disable-libfluidsynth --prefix=/usr "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-mingw-sdldraw
+++ b/build-mingw-sdldraw
@@ -60,6 +60,6 @@ pacman -S --needed --noconfirm mingw-w64-x86_64-libslirp &>/dev/null
 echo Compiling DOSBox-X
 chmod +x configure
 # FIXME: I would like MinGW builds to enable the debugger, eventually
-./configure --enable-core-inline --enable-force-menu-sdldraw --enable-d3d9 --enable-d3d-shaders --disable-libfluidsynth --prefix=/usr "$@" || exit 1
+./configure --enable-core-inline --enable-force-menu-sdldraw --enable-d3d9 --enable-d3d-shaders --disable-libfluidsynth --enable-sdl --prefix=/usr "$@" || exit 1
 make -j3 || exit 1
 

--- a/build-riscos
+++ b/build-riscos
@@ -13,7 +13,7 @@ export PATH=$GCCSDK_INSTALL_ENV/bin:$PATH
 export CPPFLAGS=-I$GCCSDK_INSTALL_ENV/include
 export LDFLAGS="-L$GCCSDK_INSTALL_ENV/lib -static"
 
-./configure --host=arm-unknown-riscos --enable-core-inline "$@"
+./configure --host=arm-unknown-riscos --enable-sdl --enable-core-inline "$@"
 make -j3 || exit 1
 elf2aif src/dosbox-x !DosBox-X/dosbox-x,ff8
 cp contrib/fonts/FREECG98.BMP !DosBox-X/resources/freecg98.bmp,69c

--- a/contrib/linux/com.dosbox_x.DOSBox-X.yaml
+++ b/contrib/linux/com.dosbox_x.DOSBox-X.yaml
@@ -77,7 +77,6 @@ modules:
     config-opts:
       - --enable-core-inline
       - --enable-debug=heavy
-      - --enable-sdl2
     sources:
       - type: dir
         path: ../..

--- a/contrib/linux/dosbox-x.spec.in
+++ b/contrib/linux/dosbox-x.spec.in
@@ -62,7 +62,7 @@ options and features.
 
 %build
 ./autogen.sh
-%configure --enable-core-inline --enable-debug=heavy --enable-sdl2
+%configure --enable-core-inline --enable-debug=heavy
 %make_build
 
 %install


### PR DESCRIPTION
This sets configure to have --enable-sdl2 enabled by default

## What issue(s) does this PR address?

Issues like #3433 show that having SDL2 installed isn't enough for configure to build with it, --enable-sdl2 needs to be set by default too.

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

Yes: Builds now use SDL2 by default. This breaks every non-SDL2 build script.
However, this is not my doing: The code in configure.ac prefers SDL2 if it is available already, this just enables finding SDL2.

I'm putting this PR in draft status to figure out what to do about that. @joncampbell123 and @Wengier have experience with building the actual application so I'd really enjoy the feedback.

It might be worth flipping things around and disabling SDL1 by default and updating build scripts so they pass --disable-sdl1.

## Additional information

