### PR TITLE
Fix flatpak properly

### DIFF
--- a/contrib/linux/com.dosbox_x.DOSBox-X.yaml
+++ b/contrib/linux/com.dosbox_x.DOSBox-X.yaml
@@ -31,7 +31,7 @@ modules:
       - --disable-static
     sources:
       - type: archive
-        url: https://mesa.freedesktop.org/archive/glu/glu-9.0.2.tar.xz
+        url: https://ftp.osuosl.org/pub/blfs/conglomeration/glu/glu-9.0.2.tar.xz
         sha256: 6e7280ff585c6a1d9dfcdf2fca489251634b3377bfc33c29e4002466a38d02d4
     cleanup:
       - /include

--- a/make-flatpak.sh
+++ b/make-flatpak.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-if [[ ! $(flatpak list|grep org.flatpak.Builder|wc -l) -ge 1 ]]; then 
-	echo Please ensure the flatpak builder is installed by running:
-	echo flatpak install flathub org.flatpak.Builder
+if [[ ! -x $(which flatpak-builder) ]]; then
+	echo Please install flatpak-builder
 	exit
 fi
 
@@ -12,7 +11,7 @@ if [[ ! $(flatpak list|grep org.freedesktop.Sdk|wc -l) -ge 1 ]]; then
 	exit
 fi
 
-flatpak run org.flatpak.Builder --repo=myrepo --force-clean build-flatpak contrib/linux/com.dosbox_x.DOSBox-X.yaml
+flatpak-builder --repo=myrepo --force-clean build-flatpak contrib/linux/com.dosbox_x.DOSBox-X.yaml
 if [ $? -eq 0 ]; then
 	echo
 	echo You can now install the flatpak by running the following commands:
@@ -24,5 +23,5 @@ if [ $? -eq 0 ]; then
 	echo  flatpak run com.dosbox_x.DOSBox-X
 	echo
 	echo Or you can test it without installing by running:
-	echo  flatpak run org.flatpak.Builder --run build-flatpak contrib/linux/com.dosbox_x.DOSBox-X.yaml dosbox-x
+	echo  flatpak-builder --run build-flatpak contrib/linux/com.dosbox_x.DOSBox-X.yaml dosbox-x
 fi


### PR DESCRIPTION
This commit reverts the change to using the Flatpak version of Flatpak builder and instead fixes the core issue stopping Debian builds by switching the GLU archive to a working mirror.

## What issue(s) does this PR address?

See talk after #3401 was merged.
GnuTLS bug is at https://gitlab.com/gnutls/gnutls/-/issues/1335

I've also opened various other bugs online:
https://github.com/flatpak/flatpak-builder/issues/468
https://gitlab.com/gnutls/gnutls/-/issues/1357

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No