### PR TITLE
output_ttf: Don't initialize code page fonts with a disabled DOS kernel

### DIFF
--- a/src/output/output_ttf.cpp
+++ b/src/output/output_ttf.cpp
@@ -523,7 +523,8 @@ int setTTFCodePage() {
             }
         if (eurAscii != -1 && TTF_GlyphIsProvided(ttf.SDL_font, 0x20ac))
             cpMap[eurAscii] = 0x20ac;
-        initcodepagefont();
+        if (!dos_kernel_disabled)
+            initcodepagefont();
 #if defined(WIN32) && !defined(HX_DOS)
         DOSBox_SetSysMenu();
 #endif


### PR DESCRIPTION
This fixes some buggy TTF behaviour.

## What issue(s) does this PR address?

Switching to TTF output when ELKS (or a non-DOS kernel) will corrupt the VM. See #3463

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No

## Additional information

Unsure if this is the right approach. I get the implication that as initcodepagefonts runs DOS commands it's not meant to run here.

Strangely enough it doesn't crash FreeDOS. I guess it implements enough of a DOS kernel to work.