### PR TITLE
cpu: Don't crash if no dynamic cores are available

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -389,6 +389,7 @@ int GetDynamicType() {
 }
 
 void menu_update_dynamic() {
+#if (C_DYNAMIC_X86) || (C_DYNREC)
 	const Section_prop * cpu_section = static_cast<Section_prop *>(control->GetSection("cpu"));
     std::string core(cpu_section->Get_string("core"));
     std::string text = mainMenu.get_item("mapper_dynamic").get_text();
@@ -404,6 +405,7 @@ void menu_update_dynamic() {
         save_dynamic_rec = false;
         mainMenu.get_item("mapper_dynamic").set_text(text+" (dynamic_x86)");
     }
+#endif
 }
 
 void menu_update_core(void) {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -9151,7 +9151,9 @@ fresh_boot:
             if (!strcmp(RunningProgram, "LOADLIN") && core == "auto") {
                 cpudecoder=&CPU_Core_Normal_Run;
                 mainMenu.get_item("mapper_normal").check(true).refresh_item(mainMenu);
+#if (C_DYNAMIC_X86) || (C_DYNREC)
                 mainMenu.get_item("mapper_dynamic").check(false).refresh_item(mainMenu);
+#endif
             }
 
             /* new code: fire event */


### PR DESCRIPTION
If --disable-dynrec and --disable-dynamic are both passed to configure, DOSBox-X will crash trying to get the menu options.

## What issue(s) does this PR address?

None

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No

## Additional information

Found while testing something else.
