### PR TITLE
cpu: Display dynamic_dynrec is dynamic_x86 isn't available

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -388,6 +388,12 @@ int GetDynamicType() {
 #endif
 }
 
+#if (C_DYNAMIC_X86) && (C_DYNREC)
+#define BOTH_DYNAMIC 1
+#else
+#define BOTH_DYNAMIC 0
+#endif
+
 void menu_update_dynamic() {
 	const Section_prop * cpu_section = static_cast<Section_prop *>(control->GetSection("cpu"));
     std::string core(cpu_section->Get_string("core"));
@@ -395,7 +401,7 @@ void menu_update_dynamic() {
     size_t found = text.find_last_of(" ");
     if (found != std::string::npos && text.substr(found+1).size() && *text.substr(found+1).c_str() == '(') text = text.substr(0, found);
 #if (C_DYNREC)
-    if ((core == "dynamic" && GetDynamicType()==2) || core == "dynamic_rec" || save_dynamic_rec) {
+    if ((core == "dynamic" && GetDynamicType()==2) || core == "dynamic_rec" || save_dynamic_rec || !BOTH_DYNAMIC) {
         save_dynamic_rec = true;
         mainMenu.get_item("mapper_dynamic").set_text(text+" (dynamic_rec)");
     } else


### PR DESCRIPTION
If you compile with only the dynamic_rec then the menu shows dynamic_x86. This fixes that.

## What issue(s) does this PR address?

None

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No

## Additional information

None