### PR TITLE
DBCS Initialization Fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.83.26
+  - Fix DBCS table initialization on reset and
+    restart (cimarronm)
   - Update FLD constant FPU instructions to more
     accurately match FPU implementations (cimarronm)
 0.83.25

--- a/src/dos/dos_tables.cpp
+++ b/src/dos/dos_tables.cpp
@@ -326,6 +326,7 @@ void DOS_SetupTables(void) {
 	dos_infoblock.SetCurDirStruct(RealMake(seg,0));
 
     /* Allocate DBCS DOUBLE BYTE CHARACTER SET LEAD-BYTE TABLE */
+    dos.tables.dbcs = 0;
     SetupDBCSTable();
 
 	/* FILENAME CHARACTER TABLE */


### PR DESCRIPTION
This properly initializes the DBCS tables in the case of a restart/reset.

## What issue(s) does this PR address?

Fixes issue #3003 

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No

## Additional information

If dos.tables.dbcs pointer is already set (as in the case of a restart or reset), then DOS initialization will not allocate memory for the DBCS tables in `SetupDBCSTable`