### PR TITLE
FPU instructions with operand size prefix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.83.26
+  - Updates to FPU to handle opcode size prefix (66h)
+    on FSTENV/FLDENV/FSAVE/FRSTOR instructions (cimarronm)
   - Fix DBCS table initialization on reset and
     restart (cimarronm)
   - Update FLD constant FPU instructions to more

--- a/include/fpu.h
+++ b/include/fpu.h
@@ -28,7 +28,7 @@
 void FPU_ESC0_Normal(Bitu rm);
 void FPU_ESC0_EA(Bitu rm,PhysPt addr);
 void FPU_ESC1_Normal(Bitu rm);
-void FPU_ESC1_EA(Bitu rm,PhysPt addr);
+void FPU_ESC1_EA(Bitu rm,PhysPt addr, bool op16);
 void FPU_ESC2_Normal(Bitu rm);
 void FPU_ESC2_EA(Bitu rm,PhysPt addr);
 void FPU_ESC3_Normal(Bitu rm);
@@ -36,7 +36,7 @@ void FPU_ESC3_EA(Bitu rm,PhysPt addr);
 void FPU_ESC4_Normal(Bitu rm);
 void FPU_ESC4_EA(Bitu rm,PhysPt addr);
 void FPU_ESC5_Normal(Bitu rm);
-void FPU_ESC5_EA(Bitu rm,PhysPt addr);
+void FPU_ESC5_EA(Bitu rm,PhysPt addr, bool op16);
 void FPU_ESC6_Normal(Bitu rm);
 void FPU_ESC6_EA(Bitu rm,PhysPt addr);
 void FPU_ESC7_Normal(Bitu rm);

--- a/src/cpu/core_dyn_x86/dyn_fpu.h
+++ b/src/cpu/core_dyn_x86/dyn_fpu.h
@@ -311,13 +311,13 @@ static void dyn_fpu_esc1(){
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;
 		case 0x04: /* FLDENV */
-			dyn_call_function_pagefault_check((void*)&FPU_FLDENV,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FLDENV,"%Drd%Ib", DREG(EA), !decode.big_op);
 			break;
 		case 0x05: /* FLDCW */
 			dyn_call_function_pagefault_check((void *)&FPU_FLDCW,"%Drd",DREG(EA));
 			break;
 		case 0x06: /* FSTENV */
-			dyn_call_function_pagefault_check((void *)&FPU_FSTENV,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void *)&FPU_FSTENV,"%Drd%Ib", DREG(EA), !decode.big_op);
 			break;
 		case 0x07:  /* FNSTCW*/
 			dyn_call_function_pagefault_check((void *)&FPU_FNSTCW,"%Drd",DREG(EA));
@@ -528,10 +528,10 @@ static void dyn_fpu_esc5(){
 			gen_call_function((void*)&FPU_FPOP,"");
 			break;
 		case 0x04:	/* FRSTOR */
-			dyn_call_function_pagefault_check((void*)&FPU_FRSTOR,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FRSTOR, "%Drd%Ib", DREG(EA), !decode.big_op);
 			break;
 		case 0x06:	/* FSAVE */
-			dyn_call_function_pagefault_check((void*)&FPU_FSAVE,"%Drd",DREG(EA));
+			dyn_call_function_pagefault_check((void*)&FPU_FSAVE, "%Drd%Ib", DREG(EA), !decode.big_op);
 			break;
 		case 0x07:   /*FNSTSW */
 			gen_protectflags(); 

--- a/src/cpu/core_dyn_x86/risc_x64.h
+++ b/src/cpu/core_dyn_x86/risc_x64.h
@@ -1162,7 +1162,7 @@ static void gen_fill_branch(uint8_t * data,uint8_t * from=cache.pos) {
 	Bits len=from-data-1;
 	if (len<0) len=~len;
 	if (len>127)
-		LOG_MSG("Big jump %d",len);
+		LOG_MSG("Big jump %ld",len);
 #endif
 	*data=(uint8_t)(from-data-1);
 }
@@ -1198,7 +1198,7 @@ static void gen_fill_short_jump(uint8_t * data, uint8_t * to=cache.pos) {
 	Bits len=to-data-1;
 	if (len<0) len=~len;
 	if (len>127)
-		LOG_MSG("Big jump %d",len);
+		LOG_MSG("Big jump %ld",len);
 #endif
 	data[0] = (uint8_t)(to-data-1);
 }

--- a/src/cpu/core_dynrec/dyn_fpu.h
+++ b/src/cpu/core_dynrec/dyn_fpu.h
@@ -313,7 +313,7 @@ static void dyn_fpu_esc1(){
 			break;
 		case 0x04: /* FLDENV */
 			dyn_fill_ea(FC_ADDR);
-			gen_call_function_R(FPU_FLDENV,FC_ADDR);
+			gen_call_function_RI(FPU_FLDENV, FC_ADDR, !decode.big_op);
 			break;
 		case 0x05: /* FLDCW */
 			dyn_fill_ea(FC_ADDR);
@@ -321,7 +321,7 @@ static void dyn_fpu_esc1(){
 			break;
 		case 0x06: /* FSTENV */
 			dyn_fill_ea(FC_ADDR);
-			gen_call_function_R(FPU_FSTENV,FC_ADDR);
+			gen_call_function_RI(FPU_FSTENV, FC_ADDR, !decode.big_op);
 			break;
 		case 0x07:  /* FNSTCW*/
 			dyn_fill_ea(FC_ADDR);
@@ -533,11 +533,11 @@ static void dyn_fpu_esc5(){
 			break;
 		case 0x04:	/* FRSTOR */
 			dyn_fill_ea(FC_ADDR); 
-			gen_call_function_R(FPU_FRSTOR,FC_ADDR);
+			gen_call_function_RI(FPU_FRSTOR, FC_ADDR, !decode.big_op);
 			break;
 		case 0x06:	/* FSAVE */
 			dyn_fill_ea(FC_ADDR); 
-			gen_call_function_R(FPU_FSAVE,FC_ADDR);
+			gen_call_function_RI(FPU_FSAVE, FC_ADDR, !decode.big_op);
 			break;
 		case 0x07:   /*FNSTSW */
 			dyn_fill_ea(FC_OP1); 

--- a/src/cpu/core_full/op.h
+++ b/src/cpu/core_full/op.h
@@ -627,11 +627,11 @@ switch (inst.code.op) {
 #if C_FPU
 		switch (((inst.rm>=0xc0) << 3) | inst.code.save) {
 		case 0x00:	FPU_ESC0_EA(inst.rm,inst.rm_eaa);break;
-		case 0x01:	FPU_ESC1_EA(inst.rm,inst.rm_eaa);break;
+		case 0x01:	FPU_ESC1_EA(inst.rm,inst.rm_eaa,inst.code.extra);break;
 		case 0x02:	FPU_ESC2_EA(inst.rm,inst.rm_eaa);break;
 		case 0x03:	FPU_ESC3_EA(inst.rm,inst.rm_eaa);break;
 		case 0x04:	FPU_ESC4_EA(inst.rm,inst.rm_eaa);break;
-		case 0x05:	FPU_ESC5_EA(inst.rm,inst.rm_eaa);break;
+		case 0x05:	FPU_ESC5_EA(inst.rm,inst.rm_eaa,inst.code.extra);break;
 		case 0x06:	FPU_ESC6_EA(inst.rm,inst.rm_eaa);break;
 		case 0x07:	FPU_ESC7_EA(inst.rm,inst.rm_eaa);break;
 

--- a/src/cpu/core_full/optable.h
+++ b/src/cpu/core_full/optable.h
@@ -172,10 +172,10 @@ static OpCode OpCodeTable[1024]={
 {D_SETALC	,0			,0		,0		},{D_XLAT	,0			,0		,0		},
 //TODO FPU
 /* 0xd8 - 0xdf */
-{L_MODRM	,O_FPU		,0		,0		},{L_MODRM	,O_FPU		,1		,0		},
-{L_MODRM	,O_FPU		,2		,0		},{L_MODRM	,O_FPU		,3		,0		},
-{L_MODRM	,O_FPU		,4		,0		},{L_MODRM	,O_FPU		,5		,0		},
-{L_MODRM	,O_FPU		,6		,0		},{L_MODRM	,O_FPU		,7		,0		},
+{L_MODRM	,O_FPU		,0		,true   },{L_MODRM	,O_FPU		,1		,true   },
+{L_MODRM	,O_FPU		,2		,true   },{L_MODRM	,O_FPU		,3		,true   },
+{L_MODRM	,O_FPU		,4		,true   },{L_MODRM	,O_FPU		,5		,true   },
+{L_MODRM	,O_FPU		,6		,true   },{L_MODRM	,O_FPU		,7		,true   },
 
 /* 0xe0 - 0xe7 */
 {L_Ibx		,O_LOOPNZ	,S_AIPw	,0		},{L_Ibx	,O_LOOPZ	,S_AIPw	,0		},
@@ -527,10 +527,10 @@ static OpCode OpCodeTable[1024]={
 {L_Ib		,O_AAM		,0		,0		},{L_Ib		,O_AAD		,0		,0		},
 {D_SETALC	,0			,0		,0		},{D_XLAT	,0			,0		,0		},
 /* 0x2d8 - 0x2df */
-{L_MODRM	,O_FPU		,0		,0		},{L_MODRM	,O_FPU		,1		,0		},
-{L_MODRM	,O_FPU		,2		,0		},{L_MODRM	,O_FPU		,3		,0		},
-{L_MODRM	,O_FPU		,4		,0		},{L_MODRM	,O_FPU		,5		,0		},
-{L_MODRM	,O_FPU		,6		,0		},{L_MODRM	,O_FPU		,7		,0		},
+{L_MODRM	,O_FPU		,0		,false  },{L_MODRM	,O_FPU		,1		,false  },
+{L_MODRM	,O_FPU		,2		,false  },{L_MODRM	,O_FPU		,3		,false  },
+{L_MODRM	,O_FPU		,4		,false  },{L_MODRM	,O_FPU		,5		,false  },
+{L_MODRM	,O_FPU		,6		,false  },{L_MODRM	,O_FPU		,7		,false  },
 
 /* 0x2e0 - 0x2e7 */
 {L_Ibx		,O_LOOPNZ	,S_AIPd	,0		},{L_Ibx	,O_LOOPZ	,S_AIPd	,0		},

--- a/src/cpu/core_normal/helpers.h
+++ b/src/cpu/core_normal/helpers.h
@@ -140,12 +140,22 @@
 #define EAXId(inst)															\
 	{ inst(reg_eax,Fetchd(),LoadRd,SaveRd);}
 
+
 #define FPU_ESC(code) {														\
 	uint8_t rm=Fetchb();														\
 	if (rm >= 0xc0) {															\
 		FPU_ESC ## code ## _Normal(rm);										\
 	} else {																\
 		GetEAa;FPU_ESC ## code ## _EA(rm,eaa);								\
+	}																		\
+}
+
+#define FPU_ESC_SIZE(code, op16) {														\
+	uint8_t rm=Fetchb();														\
+	if (rm >= 0xc0) {															\
+		FPU_ESC ## code ## _Normal(rm);										\
+	} else {																\
+		GetEAa;FPU_ESC ## code ## _EA(rm,eaa,op16);								\
 	}																		\
 }
 

--- a/src/cpu/core_normal/prefix_none.h
+++ b/src/cpu/core_normal/prefix_none.h
@@ -1084,7 +1084,7 @@
 		break;
 	CASE_B(0xd9)												/* FPU ESC 1 */
 		if (enable_fpu) {
-			FPU_ESC(1);
+			FPU_ESC_SIZE(1, !(core.opcode_index&OPCODE_SIZE));
 		}
 		else {
 			uint8_t rm=Fetchb();
@@ -1120,7 +1120,7 @@
 		break;
 	CASE_B(0xdd)												/* FPU ESC 5 */
 		if (enable_fpu) {
-			FPU_ESC(5);
+			FPU_ESC_SIZE(5, !(core.opcode_index&OPCODE_SIZE));
 		}
 		else {
 			uint8_t rm=Fetchb();

--- a/src/fpu/fpu.cpp
+++ b/src/fpu/fpu.cpp
@@ -127,7 +127,7 @@ void FPU_ESC0_Normal(Bitu rm) {
 	}
 }
 
-void FPU_ESC1_EA(Bitu rm,PhysPt addr) {
+void FPU_ESC1_EA(Bitu rm,PhysPt addr, bool op16) {
 // floats
 	Bitu group=(rm >> 3) & 7;
 	Bitu sub=(rm & 7);
@@ -158,13 +158,13 @@ void FPU_ESC1_EA(Bitu rm,PhysPt addr) {
 		FPU_FPOP();
 		break;
 	case 0x04: /* FLDENV */
-		FPU_FLDENV(addr);
+		FPU_FLDENV(addr, op16);
 		break;
 	case 0x05: /* FLDCW */
 		FPU_FLDCW(addr);
 		break;
 	case 0x06: /* FSTENV */
-		FPU_FSTENV(addr);
+		FPU_FSTENV(addr, op16);
 		break;
 	case 0x07:  /* FNSTCW*/
 		mem_writew(addr,fpu.cw);
@@ -517,7 +517,7 @@ void FPU_ESC4_Normal(Bitu rm) {
 	}
 }
 
-void FPU_ESC5_EA(Bitu rm,PhysPt addr) {
+void FPU_ESC5_EA(Bitu rm,PhysPt addr, bool op16) {
 	Bitu group=(rm >> 3) & 7;
 	Bitu sub=(rm & 7);
 	switch(group){
@@ -553,10 +553,10 @@ void FPU_ESC5_EA(Bitu rm,PhysPt addr) {
 		FPU_FPOP();
 		break;
 	case 0x04:	/* FRSTOR */
-		FPU_FRSTOR(addr);
+		FPU_FRSTOR(addr, op16);
 		break;
 	case 0x06:	/* FSAVE */
-		FPU_FSAVE(addr);
+		FPU_FSAVE(addr, op16);
 		break;
 	case 0x07:   /*FNSTSW    NG DISAGREES ON THIS*/
 		mem_writew(addr,fpu.sw);

--- a/src/fpu/fpu_instructions.h
+++ b/src/fpu/fpu_instructions.h
@@ -634,8 +634,8 @@ static void FPU_FSCALE(void){
 	return; //2^x where x is chopped.
 }
 
-static void FPU_FSTENV(PhysPt addr){
-	if(!cpu.code.big) {
+static void FPU_FSTENV(PhysPt addr, bool op16){
+	if (op16) {
 		mem_writew(addr+0,static_cast<uint16_t>(fpu.cw));
 		mem_writew(addr+2,static_cast<uint16_t>(fpu.sw));
 		mem_writew(addr+4,static_cast<uint16_t>(FPU_GetTag()));
@@ -646,27 +646,23 @@ static void FPU_FSTENV(PhysPt addr){
 	}
 }
 
-static void FPU_FLDENV(PhysPt addr){
+static void FPU_FLDENV(PhysPt addr, bool op16){
 	uint16_t tag;
-	uint32_t tagbig;
-	Bitu cw;
-	if(!cpu.code.big) {
-		cw     = mem_readw(addr+0);
+	if (op16) {
+		fpu.cw = mem_readw(addr+0);
 		fpu.sw = mem_readw(addr+2);
 		tag    = mem_readw(addr+4);
 	} else { 
-		cw     = mem_readd(addr+0);
-		fpu.sw = (uint16_t)mem_readd(addr+4);
-		tagbig = mem_readd(addr+8);
-		tag    = static_cast<uint16_t>(tagbig);
+		fpu.cw = static_cast<uint16_t>(mem_readd(addr+0));
+		fpu.sw = static_cast<uint16_t>(mem_readd(addr+4));
+		tag    = static_cast<uint16_t>(mem_readd(addr+8));
 	}
 	FPU_SetTag(tag);
-	fpu.cw = cw;
 }
 
-static void FPU_FSAVE(PhysPt addr){
-	FPU_FSTENV(addr);
-	uint8_t start = (cpu.code.big?28:14);
+static void FPU_FSAVE(PhysPt addr, bool op16){
+	FPU_FSTENV(addr, op16);
+	uint8_t start = op16 ? 14:28;
 	for(uint8_t i = 0;i < 8;i++){
 		FPU_ST80(addr+start,STV(i),/*&*/fpu.regs_80[STV(i)],fpu.use80[STV(i)]);
 		start += 10;
@@ -674,9 +670,9 @@ static void FPU_FSAVE(PhysPt addr){
 	FPU_FINIT();
 }
 
-static void FPU_FRSTOR(PhysPt addr){
-	FPU_FLDENV(addr);
-	uint8_t start = (cpu.code.big?28:14);
+static void FPU_FRSTOR(PhysPt addr, bool op16){
+	FPU_FLDENV(addr, op16);
+	uint8_t start = op16 ? 14:28;
 	for(uint8_t i = 0;i < 8;i++){
 		fpu.regs[STV(i)].d = FPU_FLD80(addr+start,/*&*/fpu.regs_80[STV(i)]);
 		fpu.use80[STV(i)] = true;

--- a/src/fpu/fpu_instructions_longdouble.h
+++ b/src/fpu/fpu_instructions_longdouble.h
@@ -537,8 +537,8 @@ static void FPU_FSCALE(void){
 	return; //2^x where x is chopped.
 }
 
-static void FPU_FSTENV(PhysPt addr){
-	if(!cpu.code.big) {
+static void FPU_FSTENV(PhysPt addr, bool op16){
+	if (op16) {
 		mem_writew(addr+0,static_cast<uint16_t>(fpu.cw));
 		mem_writew(addr+2,static_cast<uint16_t>(fpu.sw));
 		mem_writew(addr+4,static_cast<uint16_t>(FPU_GetTag()));
@@ -549,28 +549,24 @@ static void FPU_FSTENV(PhysPt addr){
 	}
 }
 
-static void FPU_FLDENV(PhysPt addr){
+static void FPU_FLDENV(PhysPt addr, bool op16){
 	uint16_t tag;
-	uint32_t tagbig;
-	Bitu cw;
-	if(!cpu.code.big) {
-		cw     = mem_readw(addr+0);
+	if (op16) {
+		fpu.cw = mem_readw(addr+0);
 		fpu.sw = mem_readw(addr+2);
 		tag    = mem_readw(addr+4);
 	} else { 
-		cw     = mem_readd(addr+0);
-		fpu.sw = (uint16_t)mem_readd(addr+4);
-		tagbig = mem_readd(addr+8);
-		tag    = static_cast<uint16_t>(tagbig);
+		fpu.cw = static_cast<uint16_t>(mem_readd(addr+0));
+		fpu.sw = static_cast<uint16_t>(mem_readd(addr+4));
+		tag    = static_cast<uint16_t>(mem_readd(addr+8));
 	}
 	FPU_SetTag(tag);
-	fpu.cw = cw;
     FPU_SyncCW();
 }
 
-static void FPU_FSAVE(PhysPt addr){
-	FPU_FSTENV(addr);
-	Bitu start = (cpu.code.big?28:14);
+static void FPU_FSAVE(PhysPt addr, bool op16){
+	FPU_FSTENV(addr, op16);
+	Bitu start = op16 ? 14:28;
 	for(Bitu i = 0;i < 8;i++){
 		FPU_ST80(addr+start,STV(i));
 		start += 10;
@@ -578,9 +574,9 @@ static void FPU_FSAVE(PhysPt addr){
 	FPU_FINIT();
 }
 
-static void FPU_FRSTOR(PhysPt addr){
-	FPU_FLDENV(addr);
-	Bitu start = (cpu.code.big?28:14);
+static void FPU_FRSTOR(PhysPt addr, bool op16){
+	FPU_FLDENV(addr, op16);
+	Bitu start = op16 ? 14:28;
 	for(Bitu i = 0;i < 8;i++){
 		fpu.regs_80[STV(i)].v = FPU_FLD80(addr+start);
 		start += 10;

--- a/src/fpu/fpu_instructions_x86.h
+++ b/src/fpu/fpu_instructions_x86.h
@@ -1356,8 +1356,8 @@ static void FPU_FSCALE(void){
 }
 
 
-static void FPU_FSTENV(PhysPt addr){
-	if(!cpu.code.big) {
+static void FPU_FSTENV(PhysPt addr, bool op16){
+	if (op16) {
 		mem_writew(addr+0,static_cast<uint16_t>(fpu.cw));
 		mem_writew(addr+2,static_cast<uint16_t>(fpu.sw));
 		mem_writew(addr+4,static_cast<uint16_t>(FPU_GetTag()));
@@ -1368,27 +1368,24 @@ static void FPU_FSTENV(PhysPt addr){
 	}
 }
 
-static void FPU_FLDENV(PhysPt addr){
+static void FPU_FLDENV(PhysPt addr, bool op16){
 	uint16_t tag;
-	Bitu cw;
-	if(!cpu.code.big) {
-		cw     = mem_readw(addr+0);
+	if (op16) {
+		fpu.cw = mem_readw(addr+0);
 		fpu.sw = mem_readw(addr+2);
 		tag    = mem_readw(addr+4);
 	} else { 
-		cw     = mem_readd(addr+0);
-		fpu.sw = (uint16_t)mem_readd(addr+4);
-		uint32_t tagbig = mem_readd(addr+8);
-		tag    = static_cast<uint16_t>(tagbig);
+		fpu.cw = static_cast<uint16_t>(mem_readd(addr+0));
+		fpu.sw = static_cast<uint16_t>(mem_readd(addr+4));
+		tag    = static_cast<uint16_t>(mem_readd(addr+8));
 	}
 	FPU_SetTag(tag);
-	fpu.cw = cw;
 }
 
-static void FPU_FSAVE(PhysPt addr){
-	FPU_FSTENV(addr);
-	Bitu start=(cpu.code.big?28:14);
-	for(Bitu i=0;i<8;i++){
+static void FPU_FSAVE(PhysPt addr, bool op16){
+	FPU_FSTENV(addr, op16);
+	PhysPt start = op16 ? 14:28;
+	for(unsigned i=0;i<8;i++){
 		mem_writed(addr+start,fpu.p_regs[STV(i)].m1);
 		mem_writed(addr+start+4,fpu.p_regs[STV(i)].m2);
 		mem_writew(addr+start+8,fpu.p_regs[STV(i)].m3);
@@ -1397,10 +1394,10 @@ static void FPU_FSAVE(PhysPt addr){
 	FPU_FINIT();
 }
 
-static void FPU_FRSTOR(PhysPt addr){
-	FPU_FLDENV(addr);
-	Bitu start=(cpu.code.big?28:14);
-	for(Bitu i=0;i<8;i++){
+static void FPU_FRSTOR(PhysPt addr, bool op16){
+	FPU_FLDENV(addr, op16);
+	PhysPt start = op16 ? 14:28;
+	for(unsigned i=0;i<8;i++){
 		fpu.p_regs[STV(i)].m1 = mem_readd(addr+start);
 		fpu.p_regs[STV(i)].m2 = mem_readd(addr+start+4);
 		fpu.p_regs[STV(i)].m3 = mem_readw(addr+start+8);


### PR DESCRIPTION
Updates the various cores to handle the operand size prefix (66h) on fldenv/fstenv/fsave/frstor instructions.

## What issue(s) does this PR address?

Addresses issue #3440

## Does this PR introduce new feature(s)?

Adds special operand handling for FPU instructions on all the cores

## Does this PR introduce any breaking change(s)?

No