### PR TITLE
XADD flags

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.83.26
+  - Updates XADD instruction to set appropriate flags
+    (cimarronm)
   - Fix DBCS table initialization on reset and
     restart (cimarronm)
   - Update FLD constant FPU instructions to more

--- a/src/cpu/core_normal/prefix_0f.h
+++ b/src/cpu/core_normal/prefix_0f.h
@@ -1709,17 +1709,19 @@
 	CASE_0F_B(0xc0)												/* XADD Gb,Eb */
 		{
 			if (CPU_ArchitectureType<CPU_ARCHTYPE_486OLD) goto illegal_opcode;
-			GetRMrb;uint8_t oldrmrb=*rmrb;
-			if (rm >= 0xc0 ) {GetEArb;*rmrb=*earb;*earb+=oldrmrb;}
-			else {GetEAa;*rmrb=LoadMb(eaa);SaveMb(eaa,LoadMb(eaa)+oldrmrb);}
+			GetRMrb;auto oldrmrb=lf_var2b=*rmrb;
+			if (rm >= 0xc0 ) {GetEArb;lf_var1b=*rmrb=*earb;*earb+=oldrmrb;lf_resb=*earb;}
+			else {GetEAa;lf_var1b=*rmrb=LoadMb(eaa);SaveMb(eaa,lf_resb=*rmrb+oldrmrb);}
+			lflags.type=t_ADDb;
 			break;
 		}
 	CASE_0F_W(0xc1)												/* XADD Gw,Ew */
 		{
 			if (CPU_ArchitectureType<CPU_ARCHTYPE_486OLD) goto illegal_opcode;
-			GetRMrw;uint16_t oldrmrw=*rmrw;
-			if (rm >= 0xc0 ) {GetEArw;*rmrw=*earw;*earw+=oldrmrw;}
-			else {GetEAa;*rmrw=LoadMw(eaa);SaveMw(eaa,LoadMw(eaa)+oldrmrw);}
+			GetRMrw;auto oldrmrw=lf_var2w=*rmrw;
+			if (rm >= 0xc0 ) {GetEArw;lf_var1w=*rmrw=*earw;*earw+=oldrmrw;lf_resw=*earw;}
+			else {GetEAa;lf_var1w=*rmrw=LoadMw(eaa);SaveMw(eaa,lf_resw=*rmrw+oldrmrw);}
+			lflags.type=t_ADDw;
 			break;
 		}
 

--- a/src/cpu/core_normal/prefix_66_0f.h
+++ b/src/cpu/core_normal/prefix_66_0f.h
@@ -489,9 +489,10 @@
 	CASE_0F_D(0xc1)												/* XADD Gd,Ed */
 		{
 			if (CPU_ArchitectureType<CPU_ARCHTYPE_486OLD) goto illegal_opcode;
-			GetRMrd;uint32_t oldrmrd=*rmrd;
-			if (rm >= 0xc0 ) {GetEArd;*rmrd=*eard;*eard+=oldrmrd;}
-			else {GetEAa;*rmrd=LoadMd(eaa);SaveMd(eaa,LoadMd(eaa)+oldrmrd);}
+			GetRMrd;auto oldrmrd=lf_var2d=*rmrd;
+			if (rm >= 0xc0 ) {GetEArd;lf_var1d=*rmrd=*eard;*eard+=oldrmrd;lf_resd=*eard;}
+			else {GetEAa;lf_var1d=*rmrd=LoadMd(eaa);SaveMd(eaa,lf_resd=*rmrd+oldrmrd);}
+			lflags.type=t_ADDd;
 			break;
 		}
     CASE_0F_D(0xc7)


### PR DESCRIPTION
Updates XADD instruction decoding to update CPU flags

### Before
```
AX=0000 BX=0000 CX=0000 DX=0000 SP=FFFE BP=0000 SI=0000 DI=0000
DS=0DAB ES=0DAB SS=0DAB CS=0DAB IP=0101 NV UP EI NG NZ NA PO NC
0DAB:0101 B80100            MOV     AX,0001
-t
AX=0001 BX=0000 CX=0000 DX=0000 SP=FFFE BP=0000 SI=0000 DI=0000
DS=0DAB ES=0DAB SS=0DAB CS=0DAB IP=0104 NV UP EI NG NZ NA PO NC
0DAB:0104 BBFFFF            MOV     BX,FFFF
-t
AX=0001 BX=FFFF CX=0000 DX=0000 SP=FFFE BP=0000 SI=0000 DI=0000
DS=0DAB ES=0DAB SS=0DAB CS=0DAB IP=0107 NV UP EI NG NZ NA PO NC
0DAB:0107 0FC1D8            XADD    AX,BX
-t
AX=0000 BX=0001 CX=0000 DX=0000 SP=FFFE BP=0000 SI=0000 DI=0000
DS=0DAB ES=0DAB SS=0DAB CS=0DAB IP=010A NV UP EI NG NZ NA PO NC
0DAB:010A 0000              ADD     [BX+SI],AL                       DS:0001=20
```
### After
```
AX=0000 BX=0000 CX=0000 DX=0000 SP=FFFE BP=0000 SI=0000 DI=0000
DS=0DAB ES=0DAB SS=0DAB CS=0DAB IP=0101 NV UP EI NG NZ NA PO NC
0DAB:0101 B80100            MOV     AX,0001
-t
AX=0001 BX=0000 CX=0000 DX=0000 SP=FFFE BP=0000 SI=0000 DI=0000
DS=0DAB ES=0DAB SS=0DAB CS=0DAB IP=0104 NV UP EI NG NZ NA PO NC
0DAB:0104 BBFFFF            MOV     BX,FFFF
-t
AX=0001 BX=FFFF CX=0000 DX=0000 SP=FFFE BP=0000 SI=0000 DI=0000
DS=0DAB ES=0DAB SS=0DAB CS=0DAB IP=0107 NV UP EI NG NZ NA PO NC
0DAB:0107 0FC1D8            XADD    AX,BX
-t
AX=0000 BX=0001 CX=0000 DX=0000 SP=FFFE BP=0000 SI=0000 DI=0000
DS=0DAB ES=0DAB SS=0DAB CS=0DAB IP=010A NV UP EI PL ZR AC PE CY
0DAB:010A 0000              ADD     [BX+SI],AL                       DS:0001=20
```
![image](https://user-images.githubusercontent.com/1505899/167994309-8440f663-0c0f-48d3-b045-ee8a1ab692d4.png)

