### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/hxdos.yml
+++ b/.github/workflows/hxdos.yml
@@ -3,8 +3,14 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   HX_DOS_CI_build:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
     if: github.event_name == 'workflow_dispatch' || contains('joncampbell123', github.actor) == false
     runs-on: windows-latest
     defaults:
@@ -55,6 +61,9 @@ jobs:
           path: ${{ github.workspace }}/package/
 
   MinGW_lowend_CI_build:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
     if: github.event_name == 'workflow_dispatch' || contains('joncampbell123', github.actor) == false
     runs-on: windows-latest
     defaults:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,8 +3,14 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   Linux_CI_build:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
     if: github.event_name == 'workflow_dispatch' || contains('joncampbell123', github.actor) == false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,8 +3,14 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   macOS_CI_build:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
     if: github.event_name == 'workflow_dispatch' || contains('joncampbell123', github.actor) == false
     runs-on: macos-latest
     steps:

--- a/.github/workflows/mingw32.yml
+++ b/.github/workflows/mingw32.yml
@@ -3,8 +3,14 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   MinGW32_CI_build:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
     if: github.event_name == 'workflow_dispatch' || contains('joncampbell123', github.actor) == false
     runs-on: windows-latest
     defaults:

--- a/.github/workflows/mingw64.yml
+++ b/.github/workflows/mingw64.yml
@@ -3,8 +3,14 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   MinGW64_CI_build:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
     if: github.event_name == 'workflow_dispatch' || contains('joncampbell123', github.actor) == false
     runs-on: windows-latest
     defaults:

--- a/.github/workflows/vsbuild32.yml
+++ b/.github/workflows/vsbuild32.yml
@@ -3,8 +3,14 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   MSBuild32_CI_build:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
     if: github.event_name == 'workflow_dispatch' || contains('joncampbell123', github.actor) == false
     runs-on: windows-latest
     defaults:
@@ -85,6 +91,9 @@ jobs:
           path: ${{ github.workspace }}/package/
 
   MSBuild_ARM32_CI_build:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
     if: github.event_name == 'workflow_dispatch' || contains('joncampbell123', github.actor) == false
     runs-on: windows-latest
     defaults:

--- a/.github/workflows/vsbuild64.yml
+++ b/.github/workflows/vsbuild64.yml
@@ -3,8 +3,14 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   MSBuild64_CI_build:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
     if: github.event_name == 'workflow_dispatch' || contains('joncampbell123', github.actor) == false
     runs-on: windows-latest
     defaults:
@@ -85,6 +91,9 @@ jobs:
           path: ${{ github.workspace }}/package/
 
   MSBuild_ARM64_CI_build:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
     if: github.event_name == 'workflow_dispatch' || contains('joncampbell123', github.actor) == false
     runs-on: windows-latest
     defaults:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
