### PR TITLE
Fix DBCS draw function

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,6 +39,8 @@
     in non-TTF outputs. (Wengier)
   - Fixed IME input not working in MinGW builds, and
     FluidSynth in MinGW-lowend builds. (Wengier)
+  - Fixed commands "CHOICE /N /C:123" and "MIXER /GUI"
+    not working properly in previous version. (Wengier)
   - Integrated commits from mainline (Allofich)
     - Disable leading directory validity check in
     DOS_FindDevice.

--- a/contrib/translations/en/en_US.lng
+++ b/contrib/translations/en/en_US.lng
@@ -1,6 +1,6 @@
 :DOSBOX-X:LANGUAGE:English (United States)
 :DOSBOX-X:CODEPAGE:437
-:DOSBOX-X:VERSION:0.83.25
+:DOSBOX-X:VERSION:0.83.26
 :DOSBOX-X:REMARK:
 :AUTOEXEC_CONFIGFILE_HELP
 Lines in this section will be run at startup.
@@ -223,17 +223,11 @@ Empty slot
 :SLOT
 Slot
 .
-:PREVIOUS_PAGE
-< Previous Page
-.
-:NEXT_PAGE
-    Next Page >
-.
 :SELECT_EVENT
 Select an event to change.
 .
 :SELECT_DIFFERENT_EVENT
-Select a different event or hit the Add/Del/Next buttons.
+Select an event or press Add/Del/Next buttons.
 .
 :PRESS_JOYSTICK_KEY
 Press a key/joystick button or move the joystick.
@@ -3453,15 +3447,6 @@ Quick launch program
 .
 :MAPPER:reboot
 Reboot DOS system
-.
-:MAPPER:recmtwave
-Record to M.T. AVI
-.
-:MAPPER:recvoldown
-Decrease rec. volume
-.
-:MAPPER:recvolup
-Increase rec. volume
 .
 :MAPPER:rescanall
 Rescan drives

--- a/contrib/translations/es/es_ES.lng
+++ b/contrib/translations/es/es_ES.lng
@@ -1,6 +1,6 @@
 :DOSBOX-X:LANGUAGE:Spanish (Spain)
 :DOSBOX-X:CODEPAGE:858
-:DOSBOX-X:VERSION:0.83.25
+:DOSBOX-X:VERSION:0.83.26
 :DOSBOX-X:REMARK:
 :AUTOEXEC_CONFIGFILE_HELP
 Las líneas de esta sección se iniciarán al inicio.
@@ -225,12 +225,6 @@ Slot vacío
 .
 :SLOT
 Slot
-.
-:PREVIOUS_PAGE
-< Pág anterior
-.
-:NEXT_PAGE
-Pág siguiente >
 .
 :SELECT_EVENT
 Elige evento a cambiar.

--- a/contrib/translations/fr/fr_FR.lng
+++ b/contrib/translations/fr/fr_FR.lng
@@ -1,6 +1,6 @@
 :DOSBOX-X:LANGUAGE:French (France)
 :DOSBOX-X:CODEPAGE:858
-:DOSBOX-X:VERSION:0.83.25
+:DOSBOX-X:VERSION:0.83.26
 :DOSBOX-X:REMARK:
 :AUTOEXEC_CONFIGFILE_HELP
 Les lignes de cette section seront exécutées au démarrage.
@@ -223,12 +223,6 @@ Emplacement vide
 .
 :SLOT
 Emplacement
-.
-:PREVIOUS_PAGE
-< Page préc.
-.
-:NEXT_PAGE
-Page suivante >
 .
 :SELECT_EVENT
 Sélectionnez un événement à modifier.
@@ -2308,10 +2302,10 @@ Basculer plein écran
 Réinit. taille fenêtre
 .
 :MENU:mapper_dbcssbcs
-CJK : Commutation entre les modes DBCS/SBCS
+CJK: Commutation entre les modes DBCS/SBCS
 .
 :MENU:mapper_autoboxdraw
-CJK : Détection automatique des caractères de type "box-drawing".
+CJK: Détection auto. des caractères de boîte dessin
 .
 :MENU:mapper_incsize
 Augmenter taille police
@@ -2741,10 +2735,10 @@ Afficher le texte de droite à gauche
 Utiliser la police actuelle pour l'impression
 .
 :MENU:ttf_halfwidthkana
-CJK : Autoriser les Katakana japonais en demi-largeur
+CJK: Autoriser les Katakana japonais en demi-largeur
 .
 :MENU:ttf_extcharset
-CJK : Activer le jeu de caractères chinois étendu
+CJK: Activer le jeu de caractères chinois étendu
 .
 :MENU:VideoPC98Menu
 PC-98

--- a/contrib/translations/ja/ja_JP.lng
+++ b/contrib/translations/ja/ja_JP.lng
@@ -1,6 +1,6 @@
 :DOSBOX-X:LANGUAGE:Japanese
 :DOSBOX-X:CODEPAGE:932
-:DOSBOX-X:VERSION:0.83.25
+:DOSBOX-X:VERSION:0.83.26
 :DOSBOX-X:REMARK:PC-98, JEGA, DOS/V エミュレーション、または とコード ページ 932 の日本語フォントを使用して、日本語の表示と印刷を直接サポートします
 :AUTOEXEC_CONFIGFILE_HELP
 このセクションに記載の行は起動時に実行されます。
@@ -221,12 +221,6 @@ IDE ポジション
 .
 :SLOT
 スロット
-.
-:PREVIOUS_PAGE
-< 前のページ
-.
-:NEXT_PAGE
-   次のページ >
 .
 :SELECT_EVENT
 設定変更するイベントを選択

--- a/contrib/translations/ko/ko_KR.lng
+++ b/contrib/translations/ko/ko_KR.lng
@@ -461,11 +461,11 @@ MOUSE [/?] [/U] [/V]
 
 .
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
-%-5s %-41s %-10s %s
+%-5s  %-41s  %-10s  %s
 
 .
 :PROGRAM_IMGMOUNT_STATUS_NUMBER_FORMAT
-%-12s %-33s %-10s %s
+%-12s  %-36s  %-10s  %s
 
 .
 :PROGRAM_IMGMOUNT_STATUS_2

--- a/contrib/translations/ko/ko_KR.lng
+++ b/contrib/translations/ko/ko_KR.lng
@@ -1,6 +1,6 @@
 :DOSBOX-X:LANGUAGE:Korean
 :DOSBOX-X:CODEPAGE:949
-:DOSBOX-X:VERSION:0.83.25
+:DOSBOX-X:VERSION:0.83.26
 :DOSBOX-X:REMARK:DOS/V 에뮬레이션 또는 코드 페이지 949의 한국어 글꼴을 사용하여 한국어 표시 및 인쇄를 직접 지원합니다.
 :AUTOEXEC_CONFIGFILE_HELP
 이 섹션에 나열된 줄은 시작할 때 실행됩니다.
@@ -222,12 +222,6 @@ IDE 위치
 .
 :SLOT
 슬롯
-.
-:PREVIOUS_PAGE
-< 앞 페이지
-.
-:NEXT_PAGE
-    다음 페이지 >
 .
 :SELECT_EVENT
 설정 변경할 이벤트를 선택

--- a/contrib/translations/pt/pt_BR.lng
+++ b/contrib/translations/pt/pt_BR.lng
@@ -1,6 +1,6 @@
 :DOSBOX-X:LANGUAGE:Portuguese (Brazil)
 :DOSBOX-X:CODEPAGE:860
-:DOSBOX-X:VERSION:0.83.25
+:DOSBOX-X:VERSION:0.83.26
 :DOSBOX-X:REMARK:
 :AUTOEXEC_CONFIGFILE_HELP
 As linhas nesta seção serão sempre executadas ao se iniciar o DOSBox-X.
@@ -222,12 +222,6 @@ Compartimento vazio
 .
 :SLOT
 Compartimento
-.
-:PREVIOUS_PAGE
-< Pág. anterior
-.
-:NEXT_PAGE
-Próx. página >
 .
 :SELECT_EVENT
 Selecionar evento para alterar.

--- a/contrib/translations/tr/tr_TR.lng
+++ b/contrib/translations/tr/tr_TR.lng
@@ -1,6 +1,6 @@
 :DOSBOX-X:LANGUAGE:Turkish (Turkey)
 :DOSBOX-X:CODEPAGE:857
-:DOSBOX-X:VERSION:0.83.25
+:DOSBOX-X:VERSION:0.83.26
 :DOSBOX-X:REMARK:
 :AUTOEXEC_CONFIGFILE_HELP
 Lines in this section will be run at startup.
@@ -222,12 +222,6 @@ Boş slot
 .
 :SLOT
 Slot
-.
-:PREVIOUS_PAGE
-< Önceki sayfa
-.
-:NEXT_PAGE
-Sonraki sayfa >
 .
 :SELECT_EVENT
 Değiştirilecek olayı seçin.

--- a/contrib/translations/zh/zh_CN.lng
+++ b/contrib/translations/zh/zh_CN.lng
@@ -1,6 +1,6 @@
 :DOSBOX-X:LANGUAGE:Simplified Chinese
 :DOSBOX-X:CODEPAGE:936
-:DOSBOX-X:VERSION:0.83.25
+:DOSBOX-X:VERSION:0.83.26
 :DOSBOX-X:REMARK:建议将国家和代码页设为 86,936 并搭配中文字体; 或使用 chs 或 cn 中文 DOS/V 模式以直接支持中文显示和打印
 :AUTOEXEC_CONFIGFILE_HELP
 Lines in this section will be run at startup.
@@ -220,12 +220,6 @@ IDE 位置
 .
 :SLOT
 存档
-.
-:PREVIOUS_PAGE
-< 上一页
-.
-:NEXT_PAGE
-       下一页 >
 .
 :SELECT_EVENT
 选择要修改的事件.

--- a/contrib/translations/zh/zh_TW.lng
+++ b/contrib/translations/zh/zh_TW.lng
@@ -1,6 +1,6 @@
 :DOSBOX-X:LANGUAGE:Traditional Chinese
 :DOSBOX-X:CODEPAGE:950
-:DOSBOX-X:VERSION:0.83.25
+:DOSBOX-X:VERSION:0.83.26
 :DOSBOX-X:REMARK:建議將國家和字碼頁設為 886,950 並搭配中文字型; 或使用 cht 或 tw 中文 DOS/V 模式以直接支援中文顯示和列印
 :AUTOEXEC_CONFIGFILE_HELP
 段落中的指令行會在啟動時執行.
@@ -220,12 +220,6 @@ IDE 位置
 .
 :SLOT
 位置
-.
-:PREVIOUS_PAGE
-< 上一頁
-.
-:NEXT_PAGE
-       下一頁 >
 .
 :SELECT_EVENT
 選擇要修改的事件.

--- a/contrib/windows/installer/DOSBox-X-setup.iss
+++ b/contrib/windows/installer/DOSBox-X-setup.iss
@@ -1,5 +1,5 @@
 ﻿#define MyAppName "DOSBox-X"
-#define MyAppVersion "0.83.25"
+#define MyAppVersion "0.83.26"
 #define MyAppBit "(32-bit)"
 #define MyAppPublisher "joncampbell123 [DOSBox-X Team]"
 #define MyAppURL "https://dosbox-x.com/"

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -2056,7 +2056,7 @@ void CAPTURE_Init() {
 	MAPPER_AddHandler(CAPTURE_WaveEvent,MK_w,MMODHOST,"recwave","Record audio to WAV", &item);
 	item->set_text("Record audio to WAV");
 
-	MAPPER_AddHandler(CAPTURE_MTWaveEvent,MK_nothing,0,"recmtwave","Record to M.T. AVI", &item);
+	MAPPER_AddHandler(CAPTURE_MTWaveEvent,MK_nothing,0,"recmtwave","Record to multi-track AVI", &item);
 	item->set_text("Record audio to multi-track AVI");
 
 	MAPPER_AddHandler(CAPTURE_MidiEvent,MK_nothing,0,"caprawmidi","Record MIDI output", &item);

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -40,6 +40,9 @@
 #endif
 
 struct IDEEventPack {
+#if defined(HX_DOS) || defined(__MINGW32__)
+	IDEEventPack() = default;
+#endif
 	IDEEventPack(const unsigned int interface,const unsigned int device) : v(pack(interface,device)) {
 	}
 	IDEEventPack(const unsigned int nv) : v(nv) {

--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -1149,16 +1149,16 @@ void MAPPER_RecVolumeDown(bool pressed) {
 void MIXER_Controls_Init() {
     DOSBoxMenu::item *item;
 
-    MAPPER_AddHandler(MAPPER_VolumeUp  ,MK_kpplus, MMODHOST,"volup","Increase volume",&item);
+    MAPPER_AddHandler(MAPPER_VolumeUp,MK_kpplus, MMODHOST,"volup","Increase volume",&item);
     item->set_text("Increase volume");
     
     MAPPER_AddHandler(MAPPER_VolumeDown,MK_kpminus,MMODHOST,"voldown","Decrease volume",&item);
     item->set_text("Decrease volume");
 
-    MAPPER_AddHandler(MAPPER_RecVolumeUp  ,MK_nothing, 0,"recvolup","Increase rec. volume",&item);
+    MAPPER_AddHandler(MAPPER_RecVolumeUp,MK_nothing, 0,"recvolup","Increase recording volume",&item);
     item->set_text("Increase recording volume");
 
-    MAPPER_AddHandler(MAPPER_RecVolumeDown,MK_nothing, 0,"recvoldown","Decrease rec. volume",&item);
+    MAPPER_AddHandler(MAPPER_RecVolumeDown,MK_nothing, 0,"recvoldown","Decrease recording volume",&item);
     item->set_text("Decrease recording volume");
 }
 

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -2213,84 +2213,6 @@ struct first_equal {
 };
 
 template <const unsigned int card,typename templine_type_t> static inline uint8_t* EGAVGA_TEXT_Combined_Draw_Line(Bitu vidstart,Bitu line) {
-	// keep it aligned:
-	templine_type_t* draw = ((templine_type_t*)TempLine) + 16 - vga.draw.panning;
-	const uint32_t* vidmem = VGA_Planar_Memwrap(vidstart); // pointer to chars+attribs
-	Bitu blocks = vga.draw.blocks;
-	if (vga.draw.panning) blocks++; // if the text is panned part of an
-	// additional character becomes visible
-	VGA_Latch pixels;
-
-	while (blocks--) {
-		pixels.d = *vidmem;
-
-		Bitu chr = pixels.b[0];
-		Bitu attr = pixels.b[1];
-		// the font pattern
-		Bitu font = vga.draw.font_tables[(attr >> 3)&1][(chr<<5)+line];
-		Bitu background = attr >> 4u;
-
-		// if blinking is enabled bit7 is not mapped to attributes
-		if (vga.draw.blinking) background &= ~0x8u;
-
-		// choose foreground color if blinking not set for this cell or blink on
-		Bitu foreground = (vga.draw.blink || (!(attr&0x80)))?
-			(attr&0xf):background;
-
-		// underline: all foreground [freevga: 0x77, previous 0x7]
-		if (GCC_UNLIKELY(((attr&0x77) == 0x01) && (vga.crtc.underline_location&0x1f)==line))
-			background = foreground;
-
-		if (vga.draw.char9dot) {
-			font <<=1; // 9 pixels
-
-			// extend to the 9th pixel if needed
-			if ((font&0x2) && (vga.attr.mode_control&0x04) && (chr>=0xc0) && (chr<=0xdf)) font |= 1;
-
-			for (Bitu n = 0; n < 9; n++) {
-				if (card == MCH_VGA)
-					*draw++ = vga.dac.xlat32[(font&0x100)? foreground:background];
-				else /*MCH_EGA*/
-					*draw++ = vga.attr.palette[(font&0x100)? foreground:background];
-
-				font <<= 1;
-			}
-		} else {
-			for (Bitu n = 0; n < 8; n++) {
-				if (card == MCH_VGA)
-					*draw++ = vga.dac.xlat32[(font&0x80)? foreground:background];
-				else /*MCH_EGA*/
-					*draw++ = vga.attr.palette[(font&0x80)? foreground:background];
-
-				font <<= 1;
-			}
-		}
-
-		vidmem += (uintptr_t)1U << (uintptr_t)vga.config.addr_shift;
-	}
-
-	// draw the text mode cursor if needed
-	if ((vga.draw.cursor.count&0x8) && (line >= vga.draw.cursor.sline) && (line <= vga.draw.cursor.eline) && vga.draw.cursor.enabled) {
-		// the address of the attribute that makes up the cell the cursor is in
-		Bits attr_addr = ((Bits)vga.draw.cursor.address - (Bits)vidstart) >> (Bits)vga.config.addr_shift; /* <- FIXME: This right? */
-		if (attr_addr >= 0 && attr_addr < (Bits)vga.draw.blocks) {
-			Bitu index = (Bitu)attr_addr * (vga.draw.char9dot ? 9u : 8u);
-			draw = (((templine_type_t*)TempLine) + index) + 16 - vga.draw.panning;
-
-			Bitu foreground = vga.tandy.draw_base[(vga.draw.cursor.address<<2ul)+1] & 0xf;
-			for (Bitu i = 0; i < 8; i++) {
-				if (card == MCH_VGA)
-					*draw++ = vga.dac.xlat32[foreground];
-				else /*MCH_EGA*/
-					*draw++ = vga.attr.palette[foreground];
-			}
-		}
-	}
-
-	return TempLine+(16*sizeof(templine_type_t));
-}
-
-template <const unsigned int card,typename templine_type_t> static inline uint8_t* EGAVGA_TEXT_DBCS_Combined_Draw_Line(Bitu vidstart,Bitu line) {
     // keep it aligned:
     templine_type_t* draw = ((templine_type_t*)TempLine) + 16 - vga.draw.panning;
     const uint32_t* vidmem = VGA_Planar_Memwrap(vidstart); // pointer to chars+attribs
@@ -2300,13 +2222,18 @@ template <const unsigned int card,typename templine_type_t> static inline uint8_
     Bitu background = 0, foreground = 0;
     Bitu chr, chr_left = 0, p3 = 0, attr, bsattr;
     bool chr_wide = false;
+    bool usedbcs = (isJEGAEnabled() || (isDBCSCP()
+#if defined(USE_TTF)
+                   && dbcs_sbcs
+#endif
+                   && showdbcs) && CurMode && CurMode->type == M_TEXT && !dos_kernel_disabled && strcmp(RunningProgram, "LOADLIN"));
 
-    if (vga.draw.height < 16u || vga.draw.width < 8u) return TempLine;
+    if (usedbcs && (vga.draw.height < 16u || vga.draw.width < 8u)) return TempLine;
 
     unsigned int row = (vidstart - vga.config.real_start - vga.draw.bytes_skip) / vga.draw.address_add, col = 0;
-    unsigned int rows = (vga.draw.height / 16u) - 1u, cols = (vga.draw.width / 8u) - 1u;
+    unsigned int rows = (vga.draw.height / 16u) - 1u, cols = (vga.draw.address_add / 2u) - 1u;
 
-    if (line == 1) {
+    if (usedbcs && line == 1) {
         if (!jtbs.empty()) jtbs.erase(std::remove_if(jtbs.begin(), jtbs.end(), first_equal(row)), jtbs.end());
         if (!dbox.empty()) dbox.erase(std::remove_if(dbox.begin(), dbox.end(), first_equal(row)), dbox.end());
     }
@@ -2314,8 +2241,7 @@ template <const unsigned int card,typename templine_type_t> static inline uint8_
     VGA_Latch pixeln1, pixeln2, pixeln3, pixelp1, pixelp2, pixelp3;
     while (blocks--) {
         if (!col) p3 = 0;
-
-        {
+        if (usedbcs) { // DBCS case
             VGA_Latch pixels;
             pixels.d = *vidmem;
             chr = pixels.b[0];
@@ -2500,6 +2426,48 @@ template <const unsigned int card,typename templine_type_t> static inline uint8_
             pixelp2.d = *(vidmem - 2 * ((uintptr_t)1U << (uintptr_t)vga.config.addr_shift));
             p3 = col>2?pixelp2.b[0]:0;
             col++;
+        } else { // SBCS case
+            VGA_Latch pixels;
+
+            pixels.d = *vidmem;
+
+            Bitu chr = pixels.b[0];
+            Bitu attr = pixels.b[1];
+            // the font pattern
+            Bitu font = vga.draw.font_tables[(attr >> 3)&1][(chr<<5)+line];
+            Bitu background = attr >> 4u;
+            // if blinking is enabled bit7 is not mapped to attributes
+            if (vga.draw.blinking) background &= ~0x8u;
+            // choose foreground color if blinking not set for this cell or blink on
+            Bitu foreground = (vga.draw.blink || (!(attr&0x80)))?
+                (attr&0xf):background;
+            // underline: all foreground [freevga: 0x77, previous 0x7]
+            if (GCC_UNLIKELY(((attr&0x77) == 0x01) &&
+                (vga.crtc.underline_location&0x1f)==line))
+                    background = foreground;
+            if (vga.draw.char9dot) {
+                font <<=1; // 9 pixels
+                // extend to the 9th pixel if needed
+                if ((font&0x2) && (vga.attr.mode_control&0x04) &&
+                    (chr>=0xc0) && (chr<=0xdf)) font |= 1;
+                for (Bitu n = 0; n < 9; n++) {
+                    if (card == MCH_VGA)
+                        *draw++ = vga.dac.xlat32[(font&0x100)? foreground:background];
+                    else /*MCH_EGA*/
+                        *draw++ = vga.attr.palette[(font&0x100)? foreground:background];
+
+                    font <<= 1;
+                }
+            } else {
+                for (Bitu n = 0; n < 8; n++) {
+                    if (card == MCH_VGA)
+                        *draw++ = vga.dac.xlat32[(font&0x80)? foreground:background];
+                    else /*MCH_EGA*/
+                        *draw++ = vga.attr.palette[(font&0x80)? foreground:background];
+
+                    font <<= 1;
+                }
+            }
         }
         vidmem += (uintptr_t)1U << (uintptr_t)vga.config.addr_shift;
     }
@@ -2533,16 +2501,6 @@ static uint8_t* EGA_TEXT_Xlat8_Draw_Line(Bitu vidstart, Bitu line) {
 // combined 8/9-dot wide text mode 16bpp line drawing function
 static uint8_t* VGA_TEXT_Xlat32_Draw_Line(Bitu vidstart, Bitu line) {
     return EGAVGA_TEXT_Combined_Draw_Line<MCH_VGA,uint32_t>(vidstart,line);
-}
-
-// combined 8/9-dot wide text mode 16bpp line drawing function with JEGA/DBCS
-static uint8_t* EGA_TEXT_DBCS_Xlat8_Draw_Line(Bitu vidstart, Bitu line) {
-    return EGAVGA_TEXT_DBCS_Combined_Draw_Line<MCH_EGA,uint8_t>(vidstart,line);
-}
-
-// combined 8/9-dot wide text mode 16bpp line drawing function with JEGA/DBCS
-static uint8_t* VGA_TEXT_DBCS_Xlat32_Draw_Line(Bitu vidstart, Bitu line) {
-    return EGAVGA_TEXT_DBCS_Combined_Draw_Line<MCH_VGA,uint32_t>(vidstart,line);
 }
 
 template <const unsigned int card,typename templine_type_t,const unsigned int pixels> static inline void Alt_EGAVGA_TEXT_Combined_Draw_Line_RenderBMP(templine_type_t* &draw,unsigned int font,const unsigned char foreground,const unsigned char background) {
@@ -5416,24 +5374,17 @@ void VGA_SetupDrawing(Bitu /*val*/) {
             vga.draw.char9dot = true;
         }
 
-        if (IS_JEGA_ARCH) {
-            /* Wengier connected the JEGA case to EGA emulation, and EGA emulation renders bpp == 8 */
-            VGA_DrawLine = EGA_TEXT_DBCS_Xlat8_Draw_Line;
-            bpp = 8;
-        }
-        else if (IS_EGA_ARCH) {
-            if (vga_alt_new_mode)
+        /* FIXME: This is still peeking into DOS state, which should be turned into an INT 10h call or some such
+         *        when KEYB or other utility changes code page, but it does not involve reading guest memory */
+        if (IS_EGA_ARCH) {
+            if (vga_alt_new_mode && !IS_JEGA_ARCH)
                 VGA_DrawLine = Alt_EGA_TEXT_Xlat8_Draw_Line;
             else
                 VGA_DrawLine = EGA_TEXT_Xlat8_Draw_Line;
             bpp = 8;
         }
         else {
-            /* FIXME: This is still peeking into DOS state, which should be turned into an INT 10h call or some such
-	     *        when KEYB or other utility changes code page, but it does not involve reading guest memory */
-            if (showdbcs && !dos_kernel_disabled && isDBCSCP())
-                VGA_DrawLine = VGA_TEXT_DBCS_Xlat32_Draw_Line;
-            else if (vga_alt_new_mode)
+            if (vga_alt_new_mode)
                 VGA_DrawLine = Alt_VGA_TEXT_Xlat32_Draw_Line;
             else
                 VGA_DrawLine = VGA_TEXT_Xlat32_Draw_Line;

--- a/src/hardware/voodoo_opengl.cpp
+++ b/src/hardware/voodoo_opengl.cpp
@@ -1745,8 +1745,14 @@ void voodoo_ogl_reset_videomode(void) {
     GFX_ReleaseMouse();
     GFX_ForceFullscreenExit();
 
-	/*if (new_height<v->fbi.height) */new_height = v->fbi.height;
-	/*if (new_width < v->fbi.width) */new_width = v->fbi.width;
+#if DOSBOXMENU_TYPE != DOSBOXMENU_SDLDRAW
+	if (new_height<v->fbi.height)
+#endif
+		new_height = v->fbi.height;
+#if DOSBOXMENU_TYPE != DOSBOXMENU_SDLDRAW
+	if (new_width < v->fbi.width)
+#endif
+		new_width = v->fbi.width;
 
 	if (GFX_LazyFullscreenRequested()) GFX_SwitchFullscreenNoReset();
 

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -185,8 +185,6 @@ void AddMessages() {
     MSG_Add("SWAP_SLOT","Swap slot");
     MSG_Add("EMPTY_SLOT","Empty slot");
     MSG_Add("SLOT","Slot");
-    MSG_Add("PREVIOUS_PAGE","<-");
-    MSG_Add("NEXT_PAGE","->");
     MSG_Add("SELECT_EVENT", "Select an event to change.");
     MSG_Add("SELECT_DIFFERENT_EVENT", "Select an event or press Add/Del/Next buttons.");
     MSG_Add("PRESS_JOYSTICK_KEY", "Press a key/joystick button or move the joystick.");


### PR DESCRIPTION
This fixes the DBCS draw function, so that it will function as in the previous release, but with fixes applied such as to avoid using CPU calls as discussed in Discord.

Also updated the translations in response to PR #3514. For example, for "Previous pages" and "next pages" buttons, I updated the languages to use "<-" and "->" for all languages in response to PR https://github.com/joncampbell123/dosbox-x/pull/3514.