### PR TITLE
FPU 32-bit VS build fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 0.83.26
+  - Fix FPU operations using the top of stack on
+    32-bit VS builds (cimarronm)
   - Add IDE ATAPI command MECHANISM STATUS for
     Windows NT 4.0 because that system seems
     to want to know if your CD-ROM drive is a


### PR DESCRIPTION
Fixes the 32-bit visual studio builds which were not reading the FPU top of stack index correctly

## What issue(s) does this PR address?

Addresses PR #3521 

## Does this PR introduce new feature(s)?

No