### PR TITLE
Debugger - FPU log improvements

### DIFF
--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -4736,9 +4736,9 @@ static void LogFPUInfo(void) {
         unsigned int adj = STV(i);
 
 #if C_FPU_X86
-        DEBUG_ShowMsg(" st(%u): %s val=%.20Lf", i, FPU_tag(fpu.tags[adj]), reinterpret_cast<long double&>(fpu.p_regs[adj]));
+        DEBUG_ShowMsg(" st(%u): %s val=%.20Lg", i, FPU_tag(fpu.tags[adj]), reinterpret_cast<long double&>(fpu.p_regs[adj]));
 #elif defined(HAS_LONG_DOUBLE)//probably shouldn't allow struct to change size based on this
-        DEBUG_ShowMsg(" st(%u): %s val=%.9f",i,FPU_tag(fpu.tags[adj]),(double)fpu.regs_80[adj].v);
+        DEBUG_ShowMsg(" st(%u): %s val=%.20Lg",i,FPU_tag(fpu.tags[adj]), fpu.regs_80[adj].v);
 #else
         DEBUG_ShowMsg(" st(%u): %s use80=%u val=%.9f",i,FPU_tag(fpu.tags[adj]),fpu.use80[adj],fpu.regs[adj].d);
 #endif

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -4735,12 +4735,19 @@ static void LogFPUInfo(void) {
     for (unsigned int i=0;i < 8;i++) {
         unsigned int adj = STV(i);
 
-#if C_FPU_X86
-        DEBUG_ShowMsg(" st(%u): %s val=%.20Lg", i, FPU_tag(fpu.tags[adj]), reinterpret_cast<long double&>(fpu.p_regs[adj]));
-#elif defined(HAS_LONG_DOUBLE)//probably shouldn't allow struct to change size based on this
-        DEBUG_ShowMsg(" st(%u): %s val=%.20Lg",i,FPU_tag(fpu.tags[adj]), fpu.regs_80[adj].v);
+#if C_FPU_X86 && HAS_LONG_DOUBLE
+        DEBUG_ShowMsg(" st(%u): %s val=%.20Lg (0x%04x%08x%08x)", i, FPU_tag(fpu.tags[adj]),
+                      reinterpret_cast<long double&>(fpu.p_regs[adj]), fpu.p_regs[adj].m3,
+                      fpu.p_regs[adj].m2, fpu.p_regs[adj].m1);
+#elif C_FPU_X86
+        DEBUG_ShowMsg(" st(%u): %s val=0x%04x%08x%08x", i, FPU_tag(fpu.tags[adj]),
+                      fpu.p_regs[adj].m3, fpu.p_regs[adj].m2, fpu.p_regs[adj].m1);
+#elif HAS_LONG_DOUBLE
+        DEBUG_ShowMsg(" st(%u): %s val=%.20Lg (0x%04x%016llx)", i, FPU_tag(fpu.tags[adj]),
+                      fpu.regs_80[adj].v, fpu.regs_80[adj].raw.h, fpu.regs_80[adj].raw.l);
 #else
-        DEBUG_ShowMsg(" st(%u): %s use80=%u val=%.9f",i,FPU_tag(fpu.tags[adj]),fpu.use80[adj],fpu.regs[adj].d);
+        DEBUG_ShowMsg(" st(%u): %s use80=%u val=%.16g (0x%016llx)", i, FPU_tag(fpu.tags[adj]),
+                      fpu.use80[adj], fpu.regs[adj].d, fpu.regs[adj].ll);
 #endif
     }
 


### PR DESCRIPTION
Makes a few improvements to the FPU log output:
1. Change %f to %g on floating-point values which handles very small or large numbers much better (e.g. 0.00000000000000000000 vs 5.958329803226850769e-261)
2. Handle the special case in 32-bit visual studio builds where it is using the x87 instructions with long double but the compiler itself and stdlib do not support a long double type
3. Output the raw hex value in addition to the decimal values

Example:
```
I-> fpu
status: B=0 C3-C0=1000 ES=0 SF=0 PE=1 UE=0 OE=0 ZE=0 DE=0 IE=0 TOP=7
 st(0): Valid val=5.958329803226850769e-261 (0x3c9ebb9ee659bf54ee56)
 st(1): Empty val=3.1415926535897932385 (0x4000c90fdaa22168c235)
 st(2): Empty val=-4.5842876944787566461 (0xc00192b27c1b67ba5d4a)
 st(3): Empty val=3.1415926535897932387 (0x4000c90fdaa22168c236)
 st(4): Empty val=-4.5842876944787566461 (0xc00192b27c1b67ba5d4a)
 st(5): Empty val=3.1415926535897932387 (0x4000c90fdaa22168c236)
 st(6): Empty val=-4.5842876944787566461 (0xc00192b27c1b67ba5d4a)
 st(7): Empty val=0.3010299956639811952 (0x3ffd9a209a84fbcff798)
```