### PR TITLE
SDL2_net now available for EPEL8 and 9

### DIFF
--- a/contrib/linux/dosbox-x.spec.in
+++ b/contrib/linux/dosbox-x.spec.in
@@ -25,12 +25,7 @@ BuildRequires: mesa-libGL-devel
 BuildRequires: ncurses-devel
 BuildRequires: pulseaudio-libs-devel
 BuildRequires: SDL2-devel
-
-# Does not exist on RHEL8 EPEL for some reason
-%if 0%{?fedora} || 0%{?el7}
 BuildRequires: SDL2_net-devel
-%endif
-
 BuildRequires: zlib-devel
 
 Requires:      fluid-soundfont-gm


### PR DESCRIPTION
Exclusion no longer required as SDL2_net is finally available for EPEL8 and EPEL9.