### PR TITLE
FAT SFN quirk when the path starts with 0xe5

### DIFF
--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -292,6 +292,11 @@ static void convToDirFile(const char *filename, char *filearray) {
                 if(charidx >= 11) break;
                 if(filename[i] != '.') {
                         filearray[charidx] = filename[i];
+                        if (charidx == 0 && filearray[0] == (char)0xe5) {
+                                // SFNs beginning with E5 gets stored as 05
+                                // to distinguish with a free directory entry
+                                filearray[0] = 0x05;
+                        }
                         charidx++;
                 } else {
                         charidx = 8;
@@ -2410,6 +2415,9 @@ nextfile:
 	memset(find_name,0,DOS_NAMELENGTH_ASCII);
 	memset(extension,0,4);
 	memcpy(find_name,&sectbuf[entryoffset].entryname[0],8);
+	// recover the SFN initial E5, which was converted to 05
+	// to distinguish with a free directory entry
+	if (find_name[0] == 0x05) find_name[0] = 0xe5;
     memcpy(extension,&sectbuf[entryoffset].entryname[8],3);
 
     if (!(sectbuf[entryoffset].attrib & DOS_ATTR_VOLUME)) {

--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -27,6 +27,8 @@
 #include "control.h"
 #include "ide.h"
 
+char *DBCS_upcase(char *);
+
 bool wildmount = false;
 
 bool wild_match(const char *haystack, char *needle) {
@@ -286,11 +288,14 @@ void Set_Label(char const * const input, char * const output, bool cdrom) {
         Bitu togo     = 11;
         Bitu vnamePos = 0;
         Bitu labelPos = 0;
+        char upcasebuf[12] = {0};
+        strncpy(upcasebuf, input, 11);
+        DBCS_upcase(upcasebuf);
 
         while (togo > 0) {
-            if (input[vnamePos]==0) break;
+            if (upcasebuf[vnamePos]==0) break;
             //Another mscdex quirk. Label is not always uppercase. (Daggerfall)
-            output[labelPos] = toupper(input[vnamePos]);
+            output[labelPos] = upcasebuf[vnamePos];
             labelPos++;
             vnamePos++;
             togo--;


### PR DESCRIPTION
This checks if the short filename starts with 0xe5, replaces it with 0x05 before storing, and vice versa when reading back from disk.

## What issue(s) does this PR address?

I recently found out a quirk of FAT short file names, where if the first character happens to be 0xe5 it has to be replaced with 0x05 due to clashing with the value to mark the dirent as free[0]. In CP932 this corresponds to Kuten codepoints row 73 and 74[1] which are mostly fairly obscure Level 2 Kanji characters, but an example is 蜃 (E5 87), which means that current DOSBox-x refuses to create a file named 蜃気楼.TXT (mirage, haze) in IMGMOUNTed filesystems[2].

mtools cannot handle this either, but Linux[3] and FreeBSD[4] seem to do.

This patch blindly translates initial 0x05 in dirent to 0xe5 and vice versa, just like in FreeBSD and Linux.

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

I do not believe so, but considering that introducing a bug in filesystem implementation can be catastrophic, it might be necessary to treat this patch carefully.

## Additional information
### Example disk image
[e5sfn.hd4.gz](https://github.com/joncampbell123/dosbox-x/files/8907307/e5sfn.hd4.gz)
This is a 1.44MB raw floppy image that contains a SFN-only 蜃気楼.txt in CP932.
Confirmed on MS-DOS 6.2/V, MS-DOS 5.0A NEC, MS-DOS 6.2 EPSON, FreeDOS(98), Mac OS J1-9.2.1, Windows 2000 JPN, Linux, US English MS-DOS 6.22 (shows 蜃 as σç instead of ♣ç)
### References
[0]: MS FAT spec: https://download.microsoft.com/download/1/6/1/161ba512-40e2-4cc9-843a-923143f3456c/fatgen103.doc
[1]: JIS codepoint table: https://en.wiktionary.org/wiki/Appendix:Japanese_kanji_by_JIS_X_0208_kuten_code#Row_73
[2]: FAT guide by elm chan: http://elm-chan.org/docs/fat_e.html#dir_struct
[3]: Linux: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/fat/namei_msdos.c?h=v5.18#n56
[4]: FreeBSD: http://fxr.watson.org/fxr/source/fs/msdosfs/msdosfs_conv.c?v=FREEBSD-12-STABLE#L504