### PR TITLE
Support ATAPI raw sector reading with READ CD command

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -65,7 +65,7 @@ class imageDisk {
 		virtual void Get_Geometry(uint32_t * getHeads, uint32_t *getCyl, uint32_t *getSect, uint32_t *getSectSize);
 		virtual uint8_t GetBiosType(void);
 		virtual uint32_t getSectSize(void);
-		imageDisk(class DOS_Drive *useDrive);
+		imageDisk(class DOS_Drive *useDrive, bool readonly);
 		imageDisk(FILE *imgFile, const char *imgName, uint32_t imgSizeK, bool isHardDisk);
 		imageDisk(FILE* diskimg, const char* diskName, uint32_t cylinders, uint32_t heads, uint32_t sectors, uint32_t sector_size, bool hardDrive);
 		virtual ~imageDisk();

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -651,8 +651,16 @@ bool keyboard_layout::map_key(Bitu key, uint16_t layouted_key, bool is_command, 
 	return false;
 }
 
+uint16_t GetDefaultCP() {
+    if (IS_PC98_ARCH||IS_JEGA_ARCH||IS_JDOSV) return 932;
+    else if (IS_KDOSV) return 949;
+    else if (IS_PDOSV) return 936;
+    else if (IS_TDOSV) return 950;
+    return 437;
+}
+
 uint16_t keyboard_layout::extract_codepage(const char* keyboard_file_name) {
-	if (!strcmp(keyboard_file_name,"none")) return (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+	if (!strcmp(keyboard_file_name,"none")) return GetDefaultCP();
 
 	uint32_t read_buf_size;
 	static uint8_t read_buf[65535];
@@ -714,7 +722,7 @@ uint16_t keyboard_layout::extract_codepage(const char* keyboard_file_name) {
 		} else {
 			start_pos=0;
 			LOG(LOG_BIOS,LOG_ERROR)("Keyboard layout file %s not found",keyboard_file_name);
-			return (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+			return GetDefaultCP();
 		}
 		if (tempfile) {
 			fseek(tempfile, long(start_pos+2), SEEK_SET);
@@ -727,7 +735,7 @@ uint16_t keyboard_layout::extract_codepage(const char* keyboard_file_name) {
 		uint32_t dr=(uint32_t)fread(read_buf, sizeof(uint8_t), 4, tempfile);
 		if ((dr<4) || (read_buf[0]!=0x4b) || (read_buf[1]!=0x4c) || (read_buf[2]!=0x46)) {
 			LOG(LOG_BIOS,LOG_ERROR)("Invalid keyboard layout file %s",keyboard_file_name);
-			return (IS_PC98_ARCH || IS_JEGA_ARCH ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+			return GetDefaultCP();
 		}
 
 		fseek(tempfile, 0, SEEK_SET);
@@ -751,7 +759,7 @@ uint16_t keyboard_layout::extract_codepage(const char* keyboard_file_name) {
 
 		if (submap_cp!=0) return submap_cp;
 	}
-	return (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+	return GetDefaultCP();
 }
 
 static uint8_t cpi_buf[65536];
@@ -1396,7 +1404,7 @@ public:
 	DOS_KeyboardLayout(Section* configuration):Module_base(configuration){
         const Section_prop* section = static_cast<Section_prop*>(configuration);
 		const char * layoutname=section->Get_string("keyboardlayout");
-		dos.loaded_codepage=(IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));	// US codepage already initialized
+		dos.loaded_codepage = GetDefaultCP();	// default codepage already initialized
         int tocp=!strcmp(layoutname, "jp")||IS_JDOSV?932:(!strcmp(layoutname, "ko")||IS_KDOSV?949:(!strcmp(layoutname, "tw")||!strcmp(layoutname, "hk")||!strcmp(layoutname, "zht")||IS_TDOSV?950:(!strcmp(layoutname, "cn")||!strcmp(layoutname, "zh")||!strcmp(layoutname, "zhs")||IS_PDOSV?936:(!strcmp(layoutname, "us")?437:0))));
         if (tocp) layoutname="us";
 
@@ -1441,12 +1449,12 @@ public:
 					break;
 				case 1031: // Germany, CP 850, Alt CP 437
 					layoutname = "gr";
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 1033: // US, CP 437
 #if defined(HX_DOS)
                     layoutname = "us";
-                    wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+                    wants_dos_codepage = GetDefaultCP();
                     break;
 #endif
 					return;
@@ -1455,15 +1463,15 @@ public:
 					break;
 				case 1034: // Spain, CP 850, Alt CP 437
 					layoutname = "sp";
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 1035: // Finland, CP 850, Alt CP 437
 					layoutname = "su";
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 1036: // France, CP 850, Alt CP 437
 					layoutname = "fr";
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 1038: // Hungary, CP 852, Alt CP 850
 					if (cur_kb_subID==1) layoutname = "hu";
@@ -1474,11 +1482,11 @@ public:
 					break;
 				case 1040: // Italy, CP 850, Alt CP 437
 					layoutname = "it";
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 1043: // Netherlands, CP 850, Alt CP 437
 					layoutname = "nl";
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 1044: // Norway, CP 850, Alt CP 865
 					layoutname = "no";
@@ -1488,14 +1496,14 @@ public:
 					break;
 				case 1046: // Brazil, CP 850, Alt CP 437
 					layoutname = "br";
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 /*				case 1048: // Romania, CP  852, Alt CP 850
 					layoutname = "ro446";
 					break; */
 				case 1049: // Russia, CP  866, Alt CP 915
 					layoutname = "ru";
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 1050: // Croatia, CP 852, Alt CP 850
 					layoutname = "hr";
@@ -1508,14 +1516,14 @@ public:
 					break; */
 				case 1053: // Sweden, CP 850, Alt CP 437
 					layoutname = "sv";
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 1055: // Turkey, CP 857
 					layoutname = "tr";
 					break;
 				case 1058: // Ukraine, CP 848?
 					layoutname = "ur";
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 1059: // Belarus, CP 849?
 					layoutname = "bl";
@@ -1543,62 +1551,62 @@ public:
 					break; */
 				case 2055: // Swiss-German, CP 850, Alt CP 437
 					layoutname = "sg";
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 2057: // UK, CP 850, Alt CP 437
 					layoutname = "uk"; 
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 2060: // Belgium-French, CP 850, Alt CP 437
 					layoutname = "be";
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 2064: // Swiss-Italian, CP 850, Alt CP 437
 					layoutname = "sf"; // Uses Swiss-French
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 2067: // Belgium-Dutch, CP 850, Alt CP 437
 					layoutname = "be";
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 2070: // Portugal, CP 850, Alt CP 860
 					layoutname = "po";
 					break;
 				case 3081: // Australia, CP 850, Alt CP 437
 					layoutname = "us"; 
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 3184: // Canada-French, CP 850, Alt CP 863
 					layoutname = "cf";
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 4103: // Luxembourg-German, CP 850, Alt CP 437
 					layoutname = "sf"; // Official, but BE and DE are also common
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 4105: // Canada-English, CP 850, Alt CP 437
 					layoutname = "ca";
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 4108: // Swiss-French, CP 850, Alt CP 437
 					layoutname = "sf";
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 4127: // Liechtenstein, CP 850, Alt CP 437
 					layoutname = "sg"; // Uses Swiss-German
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 5129: // New-Zealand, CP 850, Alt CP 437
 					layoutname = "us"; 
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 5132: // Luxembourg-French, CP 840, Alt CP 437
 					layoutname = "sf"; // Official, but BE and DE are also common
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 6153: // Ireland, CP 850, Alt CP 437
 					layoutname = "uk"; 
-					wants_dos_codepage = (IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));
+					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 1041: // Japan, CP 943, Alt CP 942
 					layoutname = "jp";
@@ -1651,9 +1659,9 @@ public:
 	}
 
 	~DOS_KeyboardLayout(){
-		if ((dos.loaded_codepage!=(IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))))) && (CurMode->type==M_TEXT)) {
+		if ((dos.loaded_codepage!=GetDefaultCP()) && (CurMode->type==M_TEXT)) {
 			INT10_ReloadRomFonts();
-			dos.loaded_codepage=(IS_PC98_ARCH || IS_JEGA_ARCH || IS_JDOSV ? 932 : (IS_KDOSV ? 949 : (IS_PDOSV ? 936 : (IS_TDOSV ? 950 : 437))));	// US codepage
+			dos.loaded_codepage=GetDefaultCP();	// default codepage
 		}
 		if (loaded_layout) {
 			delete loaded_layout;

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1839,6 +1839,7 @@ public:
         bool pc98_show_graphics = false;
         bool bios_boot = false;
         bool swaponedrive = false;
+        bool convertro = false;
         bool force = false;
         int convimg = -1;
         int quiet = 0;
@@ -1868,6 +1869,11 @@ public:
 
         if (cmd->FindExist("-force",true))
             force = true;
+
+        if (cmd->FindExist("-convertfatro",true)) {
+            convimg = 1;
+            convertro = true;
+        }
 
         if (cmd->FindExist("-convertfat",true))
             convimg = 1;
@@ -2520,7 +2526,8 @@ public:
                                 *msg = 0;
                             }
                         }
-                        imageDisk *imagedrv = new imageDisk(Drives[drv]);
+                        Overlay_Drive *od = dynamic_cast<Overlay_Drive*>(Drives[drv]);
+                        imageDisk *imagedrv = new imageDisk(Drives[drv], convertro || Drives[drv]->readonly || (od && od->ovlreadonly));
                         if (imagedrv && imagedrv->ffdd) {
                             imageDiskList[nextdrv] = imagedrv;
                             bool ide_slave = false;

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -1002,7 +1002,7 @@ int FileDirExistCP(const char *name) {
 int FileDirExistUTF8(std::string &localname, const char *name) {
     int cp = dos.loaded_codepage;
 #ifdef WIN32
-    dos.loaded_codepage = GetOEMCP();
+    dos.loaded_codepage = GetACP();
 #else
     return 0;
 #endif

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -241,9 +241,11 @@ bool Overlay_Drive::MakeDir(const char * dir) {
 				host_name = CodePageGuestToHost(pdir);
 				if (host_name!=NULL) {
 #if defined (WIN32)
-					temp=_wmkdir_p(host_name);
+					temp=_wmkdir(host_name);
+					if (temp) temp=_wmkdir_p(host_name);
 #else
-					temp=mkdir_p(host_name,0775);
+					temp=mkdir(host_name,0775);
+					if (temp) temp=mkdir_p(host_name,0775);
 #endif
 					if (temp==0) madepdir=true;
 				}
@@ -254,9 +256,11 @@ bool Overlay_Drive::MakeDir(const char * dir) {
 	host_name = CodePageGuestToHost(newdir);
 	if (host_name!=NULL) {
 #if defined (WIN32)
-		temp=_wmkdir_p(host_name);
+		temp=_wmkdir(host_name);
+		if (temp) temp=_wmkdir_p(host_name);
 #else
-		temp=mkdir_p(host_name,0775);
+		temp=mkdir(host_name,0775);
+		if (temp) temp=mkdir_p(host_name,0775);
 #endif
 	}
 	if (temp==0) {

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -315,7 +315,7 @@ struct fatFromDOSDrive
 			if (df) { df->Close(); delete df; }
 	}
 
-	fatFromDOSDrive(DOS_Drive* drv) : drive(drv)
+	fatFromDOSDrive(DOS_Drive* drv, bool ro) : drive(drv)
 	{
 		cacheSectorNumber[0] = 1; // must not state that sector 0 is already cached
 		memset(&cacheSectorNumber[1], 0, sizeof(cacheSectorNumber) - sizeof(cacheSectorNumber[0]));
@@ -549,7 +549,7 @@ struct fatFromDOSDrive
         freeSpaceMB = freeSpace / (1024*1024);
         rsize=false;
         tomany=false;
-        readOnly = (free_clusters == 0);
+        readOnly = ro || free_clusters == 0;
         if (!DriveFileIterator(drv, Iter::SumFileSize, (Bitu)&sum)) return;
 
 		const uint32_t addFreeMB = (readOnly ? 0 : freeSpaceMB), totalMB = (uint32_t)(sum.used_bytes / (1024*1024)) + addFreeMB + 1;
@@ -1498,9 +1498,9 @@ imageDisk::imageDisk(FILE* imgFile, const char* imgName, uint32_t imgSizeK, bool
     }
 }
 
-imageDisk::imageDisk(class DOS_Drive *useDrive)
+imageDisk::imageDisk(class DOS_Drive *useDrive, bool readonly)
 {
-	ffdd = new fatFromDOSDrive(useDrive);
+	ffdd = new fatFromDOSDrive(useDrive, readonly);
 	if (!ffdd->success) {
 		LOG_MSG("FAT conversion failed");
 		delete ffdd;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -414,8 +414,6 @@ public:
 	virtual bool WriteToControlChannel(PhysPt bufptr,uint16_t size,uint16_t * retcode) { (void)bufptr; (void)size; (void)retcode; return false; }
 };
 
-bool intmpdev = false;
-DOS_Device * tmpdev = NULL;
 void DOS_Shell::ParseLine(char * line) {
 	LOG(LOG_EXEC,LOG_DEBUG)("Parsing command line: %s",line);
 	/* Check for a leading @ */
@@ -468,7 +466,7 @@ void DOS_Shell::ParseLine(char * line) {
 				sprintf(pipetmp, "pipe%d.tmp", rand()%10000);
 		}
 	}
-	tmpdev = NULL;
+	DOS_Device *tmpdev = NULL;
 	if (out||toc) {
 		if (out&&toc)
 			WriteOut(!*out?"Duplicate redirection\n":"Duplicate redirection - %s\n", out);
@@ -495,7 +493,8 @@ void DOS_Shell::ParseLine(char * line) {
 				fail=true;
 			status = device?false:DOS_OpenFileExtended(toc&&!fail?pipetmp:out,OPEN_READWRITE,DOS_ATTR_ARCHIVE,0x12,&dummy,&dummy2);
 			if (toc&&(fail||!status)&&!strchr(pipetmp,'\\')) {
-                if (Drives[0]||Drives[2]) {
+                Overlay_Drive *da = Drives[0] ? (Overlay_Drive *)Drives[0] : NULL, *dc = Drives[2] ? (Overlay_Drive *)Drives[2] : NULL;
+                if ((Drives[0]&&!Drives[0]->readonly&&!(da&&da->ovlreadonly))||(Drives[2]&&!Drives[2]->readonly&&!(dc&&dc->ovlreadonly))) {
                     int len = (int)strlen(pipetmp);
                     if (len > 266) {
                         len = 266;


### PR DESCRIPTION
This PR contains 2 fixes for the ATAPI IDE emulation regarding the READ CD command.

## What issue(s) does this PR address?

Maybe #585? It was the only one that came up with my searches.

Together with the PR #3623 it partially addresses #211.

## Does this PR introduce new feature(s)?

1. Fix the ATAPI READ CD (0xBE) command by adding a missing break statement. Without it, it would accidentally fall through into the next case which would then overwrite `TransferLength` with an invalid value which then can cause memory corruption in the following call to `on_atapi_busy_time` by calling `ReadSectorsHost` with a `TransferLength` that fills the 64k `sector` buffer past its length.

2. Add support for reading raw and CDDA sectors of size 2352 bytes. It does so by passing `true` for the `raw` argument of the `ReadSectorsHost` function which is already equipped to read 2352 bytes that way. Implementations for other transfer types and lengths are not part of this PR.

## Does this PR introduce any breaking change(s)?

No, it only adds new functionality where otherwise "Unsupported sector type" warnings would have been logged.

## Additional information

To fully comply with the READ CD command described in the ATAPI standard, ide.cpp would need to know more about the track layout of the CD. For example information if it's a MODE2 track or track boundaries to refuse when requested to read across them. 

Maybe it would make more sense to change `ReadSectorsHost` to something like `ReadSectorsATAPI` which gets called with all the information (`TransferSectorType`, `TransferSectorSize`, `TransferLength`) and have the `CDROM_Interface` implementation comply with the request in a manner that matches the standard.