### PR TITLE
make-flatpak: Run with --user to avoid system conflicts

### DIFF
--- a/make-flatpak.sh
+++ b/make-flatpak.sh
@@ -20,7 +20,7 @@ if [ $? -eq 0 ]; then
 	echo  flatpak --user install myrepo com.dosbox_x.DOSBox-X
 	echo
 	echo You can then run the flatpak as follows:
-	echo  flatpak run com.dosbox_x.DOSBox-X
+	echo  flatpak --user run com.dosbox_x.DOSBox-X
 	echo
 	echo Or you can test it without installing by running:
 	echo  flatpak-builder --run build-flatpak contrib/linux/com.dosbox_x.DOSBox-X.yaml dosbox-x


### PR DESCRIPTION
If you have DOSBox-X already installed using the system Flatpak then without --user you will run the old version.

## What issue(s) does this PR address?

N/A

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No

## Additional information

Add any additional information here.
