### PR TITLE
shell_cmds: Fix number overflow

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 2022.08.0
+  - Fixed DIR crashing on volumes with more than
+    999,999,999,999 bytes of free space. (Jookia)
   - Switched to year.month.patch versioning (Jookia)
   - Fix ISO image format detection to support pure
     UDF formatted images, meaning that the image

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1823,7 +1823,7 @@ static bool doDir(DOS_Shell * shell, char * args, DOS_DTA dta, char * numformat,
 
 void DOS_Shell::CMD_DIR(char * args) {
 	HELP("DIR");
-	char numformat[16];
+	char numformat[64];
 	char path[DOS_PATHLENGTH];
 	char sargs[CROSS_LEN];
 


### PR DESCRIPTION
For an output of any number of 1000GB or more 16 bytes is not enough to
represent it: "1,000,000,000,000" takes 18 bytes including the NULL
terminator. Increase the buffer size to something overkill like 64 so we
never have to think of this situation again.

Strangely this was found to crash MinGW builds on Windows but not on
other compilers or platforms. Shortening the numformat to 5 easily
reproduces the crash on my system.

Closes #3644 https://github.com/joncampbell123/dosbox-x/issues/3644

Reported-by: gkswngh05 (https://github.com/gkswngh05)
Fixes: bd7a7293194747ee9ae6492a1a5c5dec9a4b398a