### PR TITLE
Fix to PC-98

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2599,10 +2599,10 @@ public:
 
             if (IS_PC98_ARCH) {
                 for(i=0;i<bootsize;i++) real_writeb((uint16_t)load_seg, (uint16_t)i, bootarea.rawdata[i]);
-                if (CPU_ArchitectureType >= CPU_ARCHTYPE_386) {
+                if (CPU_ArchitectureType >= CPU_ARCHTYPE_286) {
                     uint64_t address = 0x480;
                     PageHandler *ph = MEM_GetPageHandler((Bitu)(address>>12));
-                    if (ph->flags & PFLAG_WRITEABLE) host_writeb(ph->GetHostWritePt((Bitu)(address>>12)) + (address&0xFFF), 3);
+                    if (ph->flags & PFLAG_WRITEABLE) host_writeb(ph->GetHostWritePt((Bitu)(address>>12)) + (address&0xFFF), CPU_ArchitectureType >= CPU_ARCHTYPE_386 ? 3 : 1);
                 }
             }
             else {

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -9102,7 +9102,7 @@ private:
         32
 #endif
         , SDL_STRING);
-        sprintf(logostr[6], "|  Version %7s  |", VERSION);
+        sprintf(logostr[6], "| Version %9s |", VERSION);
         strcpy(logostr[7], "+-------------------+");
 startfunction:
         int logo_x,logo_y,x=2,y=2,rowheight=8;

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -703,6 +703,7 @@ struct fatFromDOSDrive
                 sasi.cylinders = 615;
             }
             tsize = BYTESPERSECTOR * sasi.sectors * sasi.surfaces * sasi.cylinders;
+            if (tsize < sum.used_bytes) readOnly = true;
             addFreeMB = readOnly ? 0 :((std::ceil)((double)tsize - sum.used_bytes) / (1024 * 1024) + 1);
         } else
             addFreeMB = (readOnly ? 0 : freeSpaceMB);


### PR DESCRIPTION
This fixes bugs in the PC-98 subsystem including the x86 CPU check and overflow bugs. The CPU check fix for example allows Windows 9x boot disk to run in PC-98 mode, as reported in latter part of issue #1279.