### PR TITLE
Fix PC-98 FAT32 HDI and ISO name bug

### DIFF
--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -43,6 +43,10 @@ extern bool CodePageHostToGuestUTF16(char *d/*CROSS_LEN*/,const uint16_t *s/*CRO
 
 using namespace std;
 
+static bool islfnchar(const char *s) {
+    return (unsigned char)*s <= 32 || (unsigned char)*s == 127 || *s == '.' || *s == '\"' || *s == '+' || *s == '=' || *s == ',' || *s == ';' || *s == ':' || *s == '<' || *s == '>' || *s == '?' || *s == '*';
+}
+
 ////////////////////////////////////
 
 /*From Linux kernel source*/
@@ -1549,7 +1553,7 @@ bool isoDrive::GetNextDirEntry(const int dirIteratorHandle, UDFFileIdentifierDes
 			const char *s = (const char*)fullname;
 			while (*s != 0) {
 				if (*s == '.') break;
-				if (*s == ' ' || *s == '\'' || *s == '\"') lfn = true;
+				if (islfnchar(s)) lfn = true;
 				nl++;
 				s++;
 			}
@@ -1564,7 +1568,7 @@ bool isoDrive::GetNextDirEntry(const int dirIteratorHandle, UDFFileIdentifierDes
 					periods++;
 					ext = s+1;
 				}
-				if (*s == ' ' || *s == '\'' || *s == '\"') lfn = true;
+				if (islfnchar(s)) lfn = true;
 				el++;
 				s++;
 			}
@@ -1592,6 +1596,8 @@ bool isoDrive::GetNextDirEntry(const int dirIteratorHandle, UDFFileIdentifierDes
                     c++;
 				} else if ((unsigned char)*s <= 32 || (unsigned char)*s == 127 || *s == '.' || *s == '\"' || *s == '+' || *s == '=' || *s == ',' || *s == ';' || *s == ':' || *s == '<' || *s == '>' || ((*s == '[' || *s == ']' || *s == '|' || *s == '\\')&&(!lead||((dos.loaded_codepage==936||IS_PDOSV)&&!gbk)))||*s=='?'||*s=='*') {
                     lead = false;
+                    *d++ = '_';
+                    c++;
                 } else if (c >= (8-tailsize)) break;
                 else {
                     lead = false;
@@ -1616,6 +1622,8 @@ bool isoDrive::GetNextDirEntry(const int dirIteratorHandle, UDFFileIdentifierDes
                             c++;
 						} else if ((unsigned char)*s <= 32 || (unsigned char)*s == 127 || *s == '.' || *s == '\"' || *s == '+' || *s == '=' || *s == ',' || *s == ';' || *s == ':' || *s == '<' || *s == '>' || ((*s == '[' || *s == ']' || *s == '|' || *s == '\\')&&(!lead||((dos.loaded_codepage==936||IS_PDOSV)&&!gbk)))||*s=='?'||*s=='*') {
                             lead = false;
+                            *d++ = '_';
+                            c++;
                         } else if (c >= 3) break;
                         else {
 							*d++ = *s;
@@ -1841,7 +1849,7 @@ int isoDrive::readDirEntry(isoDirEntry* de, const uint8_t* data,unsigned int dir
 			const char *s = (const char*)fullname;
 			while (*s != 0) {
 				if (*s == '.') break;
-				if (*s == ' ' || *s == '\'' || *s == '\"') lfn = true;
+				if (islfnchar(s)) lfn = true;
 				nl++;
 				s++;
 			}
@@ -1856,7 +1864,7 @@ int isoDrive::readDirEntry(isoDirEntry* de, const uint8_t* data,unsigned int dir
 					periods++;
 					ext = s+1;
 				}
-				if (*s == ' ' || *s == '\'' || *s == '\"') lfn = true;
+				if (islfnchar(s)) lfn = true;
 				el++;
 				s++;
 			}
@@ -1884,6 +1892,8 @@ int isoDrive::readDirEntry(isoDirEntry* de, const uint8_t* data,unsigned int dir
                     c++;
 				} else if ((unsigned char)*s <= 32 || (unsigned char)*s == 127 || *s == '.' || *s == '\"' || *s == '+' || *s == '=' || *s == ',' || *s == ';' || *s == ':' || *s == '<' || *s == '>' || ((*s == '[' || *s == ']' || *s == '|' || *s == '\\')&&(!lead||((dos.loaded_codepage==936||IS_PDOSV)&&!gbk)))||*s=='?'||*s=='*') {
                     lead = false;
+                    *d++ = '_';
+                    c++;
                 } else if (c >= (8-tailsize)) break;
                 else {
                     lead = false;
@@ -1908,6 +1918,8 @@ int isoDrive::readDirEntry(isoDirEntry* de, const uint8_t* data,unsigned int dir
                             c++;
 						} else if ((unsigned char)*s <= 32 || (unsigned char)*s == 127 || *s == '.' || *s == '\"' || *s == '+' || *s == '=' || *s == ',' || *s == ';' || *s == ':' || *s == '<' || *s == '>' || ((*s == '[' || *s == ']' || *s == '|' || *s == '\\')&&(!lead||((dos.loaded_codepage==936||IS_PDOSV)&&!gbk)))||*s=='?'||*s=='*') {
                             lead = false;
+                            *d++ = '_';
+                            c++;
                         } else if (c >= 3) break;
                         else {
 							*d++ = *s;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1795,8 +1795,8 @@ void DOSBOX_SetupConfigSections(void) {
     Pbool->SetBasic(true);
 
     Pint = secprop->Add_int("convert fat free space", Property::Changeable::WhenIdle,250);
-    Pint->Set_help("If set, auto-converted FAT images will have the specified free space in MB (except PC-98) if less than the actual free space.\n"
-                   "If set to 0, the converted disk will be read-only; if set to -1, the actual free space will be used for the converted disk.");
+    Pint->Set_help("If set, auto-converted FAT images will have the specified free space in MB (except PC-98 FAT12/16 HDI) if less than the actual free space.\n"
+                   "If set to 0, the converted disk will be read-only; if set to -1, the actual free space on host drive will be used for the converted disk.");
 
     Pbool = secprop->Add_bool("leading colon write protect image",Property::Changeable::WhenIdle,true);
     Pbool->Set_help("If set, BOOT and IMGMOUNT commands will put an image file name with a leading colon (:) in write-protect mode.");

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1472,7 +1472,7 @@ void DOS_Shell::CMD_RMDIR(char * args) {
 }
 
 static void FormatNumber(uint64_t num,char * buf) {
-	uint32_t numm,numk,numb,numg,numt;
+	uint32_t numm,numk,numb,numg,numt,nump;
 	numb=num % 1000;
 	num/=1000;
 	numk=num % 1000;
@@ -1481,7 +1481,13 @@ static void FormatNumber(uint64_t num,char * buf) {
 	num/=1000;
 	numg=num % 1000;
 	num/=1000;
-	numt=num;
+	numt=num % 1000;
+	num/=1000;
+	nump=num;
+	if (nump) {
+		sprintf(buf,"%u%c%03u%c%03u%c%03u%c%03u%c%03u",nump,dos.tables.country[7],numt,dos.tables.country[7],numg,dos.tables.country[7],numm,dos.tables.country[7],numk,dos.tables.country[7],numb);
+		return;
+	}
 	if (numt) {
 		sprintf(buf,"%u%c%03u%c%03u%c%03u%c%03u",numt,dos.tables.country[7],numg,dos.tables.country[7],numm,dos.tables.country[7],numk,dos.tables.country[7],numb);
 		return;


### PR DESCRIPTION
This fixes generation of PC-98 HDI image in FAT32 format (>2GB) and bug in ISO SFN name converted from LFN.