### PR TITLE
Fix issue #3650

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,6 +46,8 @@
   - SDL_Net support is available for HX-DOS builds,
     similar to other builds. Packet driver is needed
     for network capability in DOS. (Wengier)
+  - Fixed line endings when copying to shared clipboard
+    (e.g. CLIP$) in non-Windows platforms. (Wengier)
   - Fixed problems with SDL1 Windows builds in which
     the user had to type the Fullscreen mapper shortcut
     twice. It seems a SDL1 library function that is

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -438,7 +438,11 @@ private:
 						break;
 					case 10:															// Linefeed (combination)
 					case 13:
+#if defined(WIN32)
 						fwrite("\x0d\x00\x0a\x00", 1, 4, fh);
+#else
+						fwrite("x0a\x00", 1, 2, fh);
+#endif
 						if (i < rawdata.size() -1 && textChar == 23-rawdata[i+1])
 							i++;
 						break;
@@ -481,6 +485,7 @@ private:
             std::string result="";
             std::istringstream iss(contents.c_str());
             for (std::string token; std::getline(iss, token); ) {
+                if (token.size() && token.back() == 13) token.pop_back();
                 char* uname = CodePageGuestToHost(token.c_str());
                 result+=(uname!=NULL?std::string(uname):token)+std::string(1, 10);
             }

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -39,6 +39,10 @@ bool ANSI_SYS_installed();
 #if defined(MACOSX)
 bool SetClipboard(std::string value);
 #endif
+#if (!defined(WIN32) && defined(C_SDL2)) || defined(MACOSX)
+typedef char host_cnv_char_t;
+host_cnv_char_t *CodePageGuestToHost(const char *s);
+#endif
 
 extern bool enable_share_exe, enable_network_redirector;
 
@@ -469,8 +473,7 @@ static bool DOS_MultiplexFunctions(void) {
             std::istringstream iss(text);
             std::string result="";
             for (std::string token; std::getline(iss, token); ) {
-                typedef char host_cnv_char_t;
-                host_cnv_char_t *CodePageGuestToHost(const char *s);
+                if (token.size() && token.back() == 13) token.pop_back();
                 char* uname = CodePageGuestToHost(token.c_str());
                 result+=(uname!=NULL?std::string(uname):token)+std::string(1, 10);
             }

--- a/src/misc/clipboard.cpp
+++ b/src/misc/clipboard.cpp
@@ -771,6 +771,7 @@ void CopyClipboard(int all) {
     morelen=true;
     baselen=0;
     for (std::string token; std::getline(iss, token); ) {
+        if (token.size() && token.back() == 13) token.pop_back();
         if (CodePageGuestToHostUTF8(temp,token.c_str()))
             result+=temp;
         else


### PR DESCRIPTION
This fixes line endings when copying to the macOS clipboard.

## What issue(s) does this PR address?

#3650

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No