### PR TITLE
configure: Remove version setting hack

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1275,6 +1275,3 @@ AC_OUTPUT
 
 # HACK: it's a script...
 chmod +x make-rpm.sh
-
-# HACK: Write all PACKAGE defines to vs/config_package.h so Windows builds are kept in sync
-grep -E 'PACKAGE|VERSION' config.h > $srcdir/vs/config_package.h


### PR DESCRIPTION
update-version-number does this for us.

## What issue(s) does this PR address?

This removes churn of the vs config file whenever a Linux build is done.

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No

## Additional information