### PR TITLE
Fix issues 3535 (dosbox-x hang on zip-mounted drives) and 3347 (minor bug fix and related)

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1941,30 +1941,24 @@ static Bitu DOS_21Handler(void) {
                 }
 
                 dos.echo=true;
-
-                if(handle >= DOS_FILES) {
+                if(handle >= DOS_FILES || !Files[handle] || !Files[handle]->IsOpen()) {
                     DOS_SetError(DOSERR_INVALID_HANDLE);
-                } else 
-                if(!Files[handle] || !Files[handle]->IsOpen())
-                    DOS_SetError(DOSERR_INVALID_HANDLE);
-                else if(Files[handle]->GetInformation() & EXT_DEVICE_BIT)
-                {
+                }
+                else if(Files[handle]->GetInformation() & EXT_DEVICE_BIT) {
                     fRead = !(((DOS_ExtDevice*)Files[handle])->CallDeviceFunction(4, 26, SegValue(ds), reg_dx, toread) & 0x8000);
 #if defined(USE_TTF)
-                    if(fRead && ttf.inUse && reg_bx == WPvga512CHMhandle)
-                        MEM_BlockRead(SegPhys(ds) + reg_dx, dos_copybuf, toread);
+                    fRead &= ttf.inUse && reg_bx == WPvga512CHMhandle;
 #endif
                 }
-                else
-                {
-                    if((fRead = DOS_ReadFile(reg_bx, dos_copybuf, &toread)))
-                        MEM_BlockWrite(SegPhys(ds) + reg_dx, dos_copybuf, toread);
+                else {
+                   fRead = DOS_ReadFile(reg_bx, dos_copybuf, &toread);
                 }
 
                 if (fRead) {
+                    MEM_BlockWrite(SegPhys(ds) + reg_dx, dos_copybuf, toread);
                     reg_ax=toread;
 #if defined(USE_TTF)
-                    if (ttf.inUse && reg_bx == WPvga512CHMhandle){
+                    if (ttf.inUse && reg_bx == WPvga512CHMhandle) {
                         if (toread == 26 || toread == 2) {
                             if (toread == 2)
                                 WP5chars = *(uint16_t*)dos_copybuf;
@@ -2033,17 +2027,15 @@ static Bitu DOS_21Handler(void) {
                 {
                     uint32_t handle = RealHandle(reg_bx);
 
-                    if(handle >= DOS_FILES) {
+                    if(handle >= DOS_FILES || !Files[handle] || !Files[handle]->IsOpen()) {
                         DOS_SetError(DOSERR_INVALID_HANDLE);
                     }
-                    else
-                        if(!Files[handle] || !Files[handle]->IsOpen())
-                            DOS_SetError(DOSERR_INVALID_HANDLE);
-                        else if(Files[handle]->GetInformation() & EXT_DEVICE_BIT)
-                        {
-                            fWritten = !(((DOS_ExtDevice*)Files[handle])->CallDeviceFunction(8, 26, SegValue(ds), reg_dx, towrite) & 0x8000);
-                        }
-                        else fWritten = DOS_WriteFile(reg_bx, dos_copybuf, &towrite);
+                    else if(Files[handle]->GetInformation() & EXT_DEVICE_BIT) {
+                        fWritten = !(((DOS_ExtDevice*)Files[handle])->CallDeviceFunction(8, 26, SegValue(ds), reg_dx, towrite) & 0x8000);
+                    }
+                    else {
+                        fWritten = DOS_WriteFile(reg_bx, dos_copybuf, &towrite);
+                    }
                 }
                 if (fWritten) {
                     reg_ax=towrite;

--- a/src/dos/drive_physfs.cpp
+++ b/src/dos/drive_physfs.cpp
@@ -407,7 +407,7 @@ bool physfsDrive::FileOpen(DOS_File * * file,const char * name,uint32_t flags) {
 		return false;
 	}
 
-	*file=new physfsFile(name,hand,0x202,newname,false);
+	*file=new physfsFile(name,hand,0x2,newname,false);
 	(*file)->flags=flags;  //for the inheritance flag and maybe check for others.
 	return true;
 }
@@ -447,7 +447,7 @@ bool physfsDrive::FileCreate(DOS_File * * file,const char * name,uint16_t attrib
 	}
 
 	/* Make the 16 bit device information */
-	*file=new physfsFile(name,hand,0x202,newname,true);
+	*file=new physfsFile(name,hand,0x2,newname,true);
 	(*file)->flags=OPEN_READWRITE;
 	if(!existing_file) {
 		strcpy(newname,basedir);


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

This PR proposes a fix for issue #3535 and some code fixes/cleanup for the merged #3347.

### Longer explanation

I was trying to work with a ZIP file mounted as drive in read-only, with an overlay mount on top for changes. In order to collect the contents of the ZIP, I first used a regular folder mount as drive, testing all the programs inside of the drive, and making sure everything worked (which was the case). However, putting the same contents in a ZIP file (and mounting as described) makes dosbox-x crash with a "ERROR CPU:Illegal Unhandled Interrupt Called 6" when running the same content (DOS programs that worked fine under a regular folder mount).

Even a simple "edit bla.txt" produces the same hang of dosbox-x (when bla.txt is in a ZIP mounted drive).

I saw that #3535 described this problem, and the comments say that the temporary solution is to revert #3347 and rebuild. Digging deeper into this, I think I found two bugs:

1) In the code that was merged by #3347, there seems to be a mistake in the 0x3f code (DOS File read). This code now calls MEM_BlockRead instead of MEM_BlockWrite in one of the possible paths (actually in the added path for DOS file I/O device drivers). And, in certain true conditions MEM_BlockWrite is not called at all. To me, it seems to be a minor mistake. So, this PR fixes this and cleans up the code a little bit.

2) The issue described in #3535 seems to be caused by the PhysFS code that sets the EXT_DEVICE_BIT (0x200) on the file handle objects for files in a ZIP (when doing open or create file). I believe this bit should NOT be set, as the files are just regular DOS files (not special device files). This bit causes the #3347 code to think it needs the file I/O device driver path to be called when instead it's just reading or writing regular files.

### Disclaimer

Now, I'm not (yet) familiar with the inner workings of dosbox and dosbox-x, so it's perfectly possible that this PR is completely wrong. If that is the case, then my apologies and just reject the PR (maybe let me know why). At least, for me it seems this PR solves the issue in #3535.

## Does this PR introduce any breaking change(s)?

I hope not. Please review.