### PR TITLE
Rename CD-ROM due to SafeDisc2 DRM

### DIFF
--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -1460,7 +1460,7 @@ IDEATAPICDROMDevice::IDEATAPICDROMDevice(IDEController *c,unsigned char drive_in
 
     /* INQUIRY strings */
     id_mmc_vendor_id = "DOSBox-X";
-    id_mmc_product_id = "Virtual CD-ROM";
+    id_mmc_product_id = "Virt. CD-ROM";
     id_mmc_product_rev = "0.83-X";
 }
 

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -1461,7 +1461,7 @@ IDEATAPICDROMDevice::IDEATAPICDROMDevice(IDEController *c,unsigned char drive_in
     /* INQUIRY strings */
     id_mmc_vendor_id = "DOSBox-X";
     /* SafeDisc 2 DRM checks for the keyword "virtual" and will refuse to run. */
-    id_mmc_product_id = "Virt. CD-ROM";
+    id_mmc_product_id = "ATAPI CD-ROM";
     id_mmc_product_rev = "0.83-X";
 }
 

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -1460,6 +1460,7 @@ IDEATAPICDROMDevice::IDEATAPICDROMDevice(IDEController *c,unsigned char drive_in
 
     /* INQUIRY strings */
     id_mmc_vendor_id = "DOSBox-X";
+    /* SafeDisc 2 DRM checks for the keyword "virtual" and will refuse to run. */
     id_mmc_product_id = "Virt. CD-ROM";
     id_mmc_product_rev = "0.83-X";
 }


### PR DESCRIPTION
This changes the CD-ROM device name. Apparently SafeDisc 2 DRM checks if the device name contains the word "virtual".

Prior to this change, Red Alert 2 will fail to install. The installer will ask to insert the CD-ROM while it is already present.

However, after installation, Red Alert 2 still fails on launch, so more work is needed.

I am open to any other suggestions as to how to name the device.

## What issue(s) does this PR address?
It partly addresses https://github.com/joncampbell123/dosbox-x/issues/211

