### PR TITLE
Fix porttalk compilation error on Android

### DIFF
--- a/src/libs/porttalk/porttalk.cpp
+++ b/src/libs/porttalk/porttalk.cpp
@@ -237,7 +237,7 @@ bool setPermissionList() {
 #endif
 
 #ifdef LINUX
-# if defined(__i386__) || defined(__amd64__) || defined(__x86_64__)
+# if (defined(__i386__) || defined(__amd64__) || defined(__x86_64__)) && !(defined(ANDROID) || defined(__ANDROID__)) // ioperm is unavaliable on Android
 // This Linux ioperm only works up to port 0x3FF
 #include <sys/perm.h>
 // For musl-libc based toolchain, use <sys/io.h> instead of <sys/perm.h>
@@ -255,7 +255,17 @@ void addIOPermission(uint16_t port) {
 bool setPermissionList() {
     return true;
 }
+# else
+// Placeholders
+bool initPorttalk() {
+    return false;
+}
+ 
+void addIOPermission(uint16_t port) {}
 
+bool setPermissionList() {
+    return false;
+}
 # endif
 #endif
 


### PR DESCRIPTION
This fixes compilation for Android, specifically under builds for x86/x86_64 IIRC.

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

None as I see.
