### PR TITLE
configure: Prefer pkg-config for finding OpenGL libraries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 Unreleased
+  - Use pkg-config to find OpenGL (Jookia)
   - Updated Flatpak SDK and dependencies (Jookia)
   - Fixed FFMPEG 5 compatibility (Jookia)
 

--- a/configure.ac
+++ b/configure.ac
@@ -1150,7 +1150,14 @@ case "$host" in
        AC_DEFINE(C_OPENGL,1)
        ;;
     *)
-       if test x$have_gl_h = xyes -a x$have_gl_lib = xyes ; then
+       pkg-config --exists gl; RES=$?
+       if test x$RES = x0; then
+         AC_MSG_RESULT(yes)
+         CFLAGS="$CFLAGS "`pkg-config gl --cflags`
+         CPPFLAGS="$CPPFLAGS "`pkg-config gl --cflags`
+         LIBS="$LIBS "`pkg-config gl --libs`
+         AC_DEFINE(C_OPENGL,1)
+       elif test x$have_gl_h = xyes -a x$have_gl_lib = xyes ; then
          AC_MSG_RESULT(yes)
          LIBS="$LIBS -lGL"
          AC_DEFINE(C_OPENGL,1)


### PR DESCRIPTION
This fixes finding OpenGL on systems that use indirection like libglvnd.

## What issue(s) does this PR address?

Fixes #3680 

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

Maybe on other systems?

## Additional information

No