### PR TITLE
Fix various packager bugs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ Unreleased
     for some reason. (joncampbell123)
   - Fix setcap on systems with split /usr (Jookia)
   - Fix building with --disable-core-inline (Jookia)
+  - Fix building not finding fluidsynth (Jookia)
 
 2022.09.0 (0.84.3)
   - Updated FFMPEG video capture to use newer API,

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,8 @@ Unreleased
   - Fix setcap on systems with split /usr (Jookia)
   - Fix building with --disable-core-inline (Jookia)
   - Fix building not finding fluidsynth (Jookia)
+  - Fix some NetBSD build issues
+    (Jookia, with patch from Nia)
 
 2022.09.0 (0.84.3)
   - Updated FFMPEG video capture to use newer API,

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ Unreleased
   - Fixed FFMPEG 5 compatibility (Jookia)
   - Fix FFMPEG crash if FFMPEG fails to write header
     for some reason. (joncampbell123)
+  - Fix setcap on systems with split /usr (Jookia)
 
 2022.09.0 (0.84.3)
   - Updated FFMPEG video capture to use newer API,

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Unreleased
   - Fix FFMPEG crash if FFMPEG fails to write header
     for some reason. (joncampbell123)
   - Fix setcap on systems with split /usr (Jookia)
+  - Fix building with --disable-core-inline (Jookia)
 
 2022.09.0 (0.84.3)
   - Updated FFMPEG video capture to use newer API,

--- a/Makefile.am
+++ b/Makefile.am
@@ -132,11 +132,11 @@ install: src/dosbox-x
 	install -m 644 $(srcdir)/contrib/linux/dosbox-x.1 $(DESTDIR)$(mandir)/man1
 	mkdir -p $(DESTDIR)$(prefix)/share/bash-completion/completions
 	install -m 644 $(srcdir)/contrib/linux/dosbox-x $(DESTDIR)$(prefix)/share/bash-completion/completions
-	-test -x /usr/sbin/setcap && setcap cap_net_raw=ep $(DESTDIR)$(bindir)/dosbox-x
+	-command -v setcap >/dev/null && setcap cap_net_raw=ep $(DESTDIR)$(bindir)/dosbox-x || true
 
 install_strip: src/dosbox-x install
 	install -m 755 -s src/dosbox-x $(DESTDIR)$(bindir)
-	-test -x /usr/sbin/setcap && setcap cap_net_raw=ep $(DESTDIR)$(bindir)/dosbox-x
+	-command -v setcap >/dev/null && setcap cap_net_raw=ep $(DESTDIR)$(bindir)/dosbox-x || true
 
 uninstall:
 	rm -f $(DESTDIR)$(bindir)/dosbox-x

--- a/configure.ac
+++ b/configure.ac
@@ -429,6 +429,43 @@ else
   fi
 fi
 
+dnl FEATURE: Whether to use OpenGL
+AH_TEMPLATE(C_OPENGL,[Define to 1 to use opengl display output support])
+AC_ARG_ENABLE(opengl,AC_HELP_STRING([--disable-opengl],[Disable opengl support]),enable_opengl=$enableval,enable_opengl=yes)
+AC_MSG_CHECKING(whether opengl display output will be enabled)
+
+# We need to do this before any other AC_CHECK_LIB runs just to make sure
+# linking doesn't fail if SDL is using OpenGL
+if test x$enable_opengl = xyes; then
+case "$host" in
+    *-*-darwin*)
+       AC_MSG_RESULT(yes)
+       LIBS="$LIBS -framework OpenGL"
+       AC_DEFINE(C_OPENGL,1)
+       ;;
+    *)
+       pkg-config --exists gl; RES=$?
+       if test x$RES = x0; then
+         AC_MSG_RESULT(yes)
+         CFLAGS="$CFLAGS "`pkg-config gl --cflags`
+         CPPFLAGS="$CPPFLAGS "`pkg-config gl --cflags`
+         LIBS="$LIBS "`pkg-config gl --libs`
+         AC_DEFINE(C_OPENGL,1)
+       elif test x$have_gl_h = xyes -a x$have_gl_lib = xyes ; then
+         AC_MSG_RESULT(yes)
+         LIBS="$LIBS -lGL"
+         AC_DEFINE(C_OPENGL,1)
+       elif test x$have_gl_h = xyes -a x$have_opengl32_lib = xyes ; then
+         AC_MSG_RESULT(yes)
+         LIBS="$LIBS -lopengl32"
+         AC_DEFINE(C_OPENGL,1)
+       else
+         AC_MSG_RESULT(no)
+       fi
+       ;;
+esac
+fi
+
 # FIXME: Arrggh we need the WHOLE PATH
 pwd=`realpath $srcdir`
 if [[ -z "$pwd" ]]; then pwd=`pwd`; fi
@@ -586,6 +623,7 @@ case "$host" in
        WINDRES=":"
     ;;
 esac
+
 
 dnl LIBRARY TEST: ncurses
 AC_CHECK_HEADER(curses.h,have_curses_h=yes,)
@@ -1134,42 +1172,6 @@ if test x$enable_ffmpeg = xyes; then
             AC_DEFINE(C_AVCODEC,1)
         fi
     fi
-fi
-
-dnl FEATURE: Whether to use OpenGL
-AH_TEMPLATE(C_OPENGL,[Define to 1 to use opengl display output support])
-AC_ARG_ENABLE(opengl,AC_HELP_STRING([--disable-opengl],[Disable opengl support]),enable_opengl=$enableval,enable_opengl=yes)
-AC_MSG_CHECKING(whether opengl display output will be enabled)
-
-# test
-if test x$enable_opengl = xyes; then
-case "$host" in
-    *-*-darwin*)
-       AC_MSG_RESULT(yes)
-       LIBS="$LIBS -framework OpenGL"
-       AC_DEFINE(C_OPENGL,1)
-       ;;
-    *)
-       pkg-config --exists gl; RES=$?
-       if test x$RES = x0; then
-         AC_MSG_RESULT(yes)
-         CFLAGS="$CFLAGS "`pkg-config gl --cflags`
-         CPPFLAGS="$CPPFLAGS "`pkg-config gl --cflags`
-         LIBS="$LIBS "`pkg-config gl --libs`
-         AC_DEFINE(C_OPENGL,1)
-       elif test x$have_gl_h = xyes -a x$have_gl_lib = xyes ; then
-         AC_MSG_RESULT(yes)
-         LIBS="$LIBS -lGL"
-         AC_DEFINE(C_OPENGL,1)
-       elif test x$have_gl_h = xyes -a x$have_opengl32_lib = xyes ; then
-         AC_MSG_RESULT(yes)
-         LIBS="$LIBS -lopengl32"
-         AC_DEFINE(C_OPENGL,1)
-       else
-         AC_MSG_RESULT(no)
-       fi
-       ;;
-esac
 fi
 
 dnl FEATURE: Whether to use Direct3D 9 output

--- a/configure.ac
+++ b/configure.ac
@@ -1029,7 +1029,7 @@ esac
 dnl FEATURE: Whether to use libslirp, and enable userspace TCP/IP emulation
 AH_TEMPLATE(C_SLIRP, [Define to 1 to enable userspace TCP/IP emulation, requires libslirp])
 AC_ARG_ENABLE(libslirp,AC_HELP_STRING([--disable-libslirp],[Disable libslirp support]),enable_libslirp=$enableval,enable_libslirp=yes)
-if test x$enable_libslirp == xyes ; then
+if test x$enable_libslirp = xyes ; then
   case "$host" in
     *-*-cygwin* | *-*-mingw32*)
        if test x$have_slirp_h = xyes; then

--- a/configure.ac
+++ b/configure.ac
@@ -543,7 +543,7 @@ case "$host_cpu" in
     c_targetcpu="arm"
     c_unalignedmemory=yes
     ;;
-   armv6l)
+   armv6*)
     AC_DEFINE(C_TARGETCPU,ARMV4LE)
     AC_MSG_RESULT(ARMv6 Little Endian)
     c_targetcpu="arm"

--- a/src/cpu/core_normal.cpp
+++ b/src/cpu/core_normal.cpp
@@ -51,7 +51,6 @@ extern bool ignore_opcode_63;
 #define SaveMd(off,val)	mem_writed(off,val)
 #define SaveMq(off,val) {mem_writed(off,val&0xffffffff);mem_writed(off+4,(val>>32)&0xffffffff);}
 #else 
-#include "paging.h"
 #define LoadMb(off) mem_readb_inline(off)
 #define LoadMw(off) mem_readw_inline(off)
 #define LoadMd(off) mem_readd_inline(off)

--- a/src/cpu/core_normal_286.cpp
+++ b/src/cpu/core_normal_286.cpp
@@ -21,6 +21,7 @@
 #include "cpu.h"
 #include "lazyflags.h"
 #include "callback.h"
+#include "paging.h"
 #include "pic.h"
 #include "fpu.h"
 
@@ -63,7 +64,6 @@ extern bool mustCompleteInstruction;
 #define SaveMd(off,val)	mem_writed(off,val)
 #define SaveMq(off,val) {mem_writed(off,val&0xffffffff);mem_writed(off+4,(val>>32)&0xffffffff);}
 #else 
-#include "paging.h"
 #define LoadMb(off) mem_readb_inline(off)
 #define LoadMw(off) mem_readw_inline(off)
 #define LoadMd(off) mem_readd_inline(off)

--- a/src/cpu/core_normal_8086.cpp
+++ b/src/cpu/core_normal_8086.cpp
@@ -19,6 +19,7 @@
 #include "cpu.h"
 #include "lazyflags.h"
 #include "callback.h"
+#include "paging.h"
 #include "pic.h"
 #include "fpu.h"
 
@@ -74,8 +75,6 @@ static void SaveMw(Bitu off,Bitu val) {
 #define SaveMd(off,val)	mem_writed(off,val)
 
 #else 
-
-#include "paging.h"
 
 #define LoadMb(off) mem_readb_inline(off)
 

--- a/src/cpu/core_prefetch.cpp
+++ b/src/cpu/core_prefetch.cpp
@@ -22,6 +22,7 @@
 #include "cpu.h"
 #include "lazyflags.h"
 #include "callback.h"
+#include "paging.h"
 #include "pic.h"
 #include "fpu.h"
 
@@ -49,7 +50,6 @@ extern bool ignore_opcode_63;
 #define SaveMd(off,val)	mem_writed(off,val)
 #define SaveMq(off,val) {mem_writed(off,val&0xffffffff);mem_writed(off+4,(val>>32)&0xffffffff);}
 #else 
-#include "paging.h"
 #define LoadMb(off) mem_readb_inline(off)
 #define LoadMw(off) mem_readw_inline(off)
 #define LoadMd(off) mem_readd_inline(off)

--- a/src/cpu/core_prefetch_286.cpp
+++ b/src/cpu/core_prefetch_286.cpp
@@ -22,6 +22,7 @@
 #include "cpu.h"
 #include "lazyflags.h"
 #include "callback.h"
+#include "paging.h"
 #include "pic.h"
 #include "fpu.h"
 
@@ -65,7 +66,6 @@ extern bool ignore_opcode_63;
 #define SaveMd(off,val)	mem_writed(off,val)
 #define SaveMq(off,val) {mem_writed(off,val&0xffffffff);mem_writed(off+4,(val>>32)&0xffffffff);}
 #else 
-#include "paging.h"
 #define LoadMb(off) mem_readb_inline(off)
 #define LoadMw(off) mem_readw_inline(off)
 #define LoadMd(off) mem_readd_inline(off)

--- a/src/cpu/core_prefetch_8086.cpp
+++ b/src/cpu/core_prefetch_8086.cpp
@@ -22,6 +22,7 @@
 #include "cpu.h"
 #include "lazyflags.h"
 #include "callback.h"
+#include "paging.h"
 #include "pic.h"
 #include "fpu.h"
 
@@ -78,8 +79,6 @@ static void SaveMw(Bitu off,Bitu val) {
 #define SaveMd(off,val)	mem_writed(off,val)
 
 #else 
-
-#include "paging.h"
 
 #define LoadMb(off) mem_readb_inline(off)
 

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -6935,11 +6935,7 @@ bool AUTOTYPE::ReadDoubleArg(const std::string &name,
 	if (cmd->FindString(flag, str_value, true)) {
 		// Can the user's value be parsed?
 		const double user_value = to_finite<double>(str_value);
-#if defined(__FreeBSD__) || defined(MACOSX) || defined(EMSCRIPTEN) || ((defined(ANDROID) || defined(__ANDROID__)) && defined(__clang__))
-		if (isfinite(user_value)) { /* *sigh* Really, clang, really? */
-#else
-		if (std::isfinite(user_value)) {
-#endif
+		if (isfinite(user_value)) {
 			result = true;
 
 			// Clamp the user's value if needed

--- a/src/libs/physfs/physfs_platform_unix.c
+++ b/src/libs/physfs/physfs_platform_unix.c
@@ -53,10 +53,14 @@
 #include <sys/mnttab.h>
 #endif
 
-#ifdef PHYSFS_PLATFORM_FREEBSD
+#if defined(PHYSFS_PLATFORM_FREEBSD) || defined(__NetBSD__)
 #include <sys/sysctl.h>
 #endif
 
+#ifdef __NetBSD__
+#include <sys/statvfs.h>
+#define statfs statvfs
+#endif
 
 #include "physfs_internal.h"
 
@@ -258,6 +262,14 @@ char *__PHYSFS_platformCalcBaseDir(const char *argv0)
         char fullpath[PATH_MAX];
         size_t buflen = sizeof (fullpath);
         int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
+        if (sysctl(mib, 4, fullpath, &buflen, NULL, 0) != -1)
+            retval = __PHYSFS_strdup(fullpath);
+    }
+    #elif defined(__NetBSD__)
+    {
+        char fullpath[PATH_MAX];
+        size_t buflen = sizeof (fullpath);
+        int mib[4] = { CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME };
         if (sysctl(mib, 4, fullpath, &buflen, NULL, 0) != -1)
             retval = __PHYSFS_strdup(fullpath);
     }


### PR DESCRIPTION
I surveyed various packages of DOSBox-X to see what downstreams have been dealing with and fixed them or incorporated patches (I added one of @alarixnia 's)

## What issue(s) does this PR address?

Fixes #1552

## Does this PR introduce new feature(s)?

Less bugs

## Does this PR introduce any breaking change(s)?

GCC below 6 is no longer supported. I checked around and modern systems don't seem to bother with this.

## Additional information

There's still some major bugs that need to be fixed for non-x86 and BSD platforms.
I specifically didn't take the NetBSD iconv patch as NetBSD has to patch a dozen other programs to support this and it's fixed in NetBSD 10.