### PR TITLE
Update drive_physfs.cpp to support overlay files in place of .zip files

### DIFF
--- a/src/dos/drive_physfs.cpp
+++ b/src/dos/drive_physfs.cpp
@@ -368,7 +368,7 @@ bool physfsDrive::setOverlaydir(const char * name) {
         return false;
 	} else {
         if (oldwrite) PHYSFS_unmount(oldwrite);
-        PHYSFS_mount(newname, NULL, 1);
+        PHYSFS_mount(newname, NULL, 0);
         dirCache.EmptyCache();
     }
 	if (oldwrite) free((char *)oldwrite);

--- a/src/dos/drive_physfs.cpp
+++ b/src/dos/drive_physfs.cpp
@@ -743,7 +743,7 @@ bool physfsFile::Seek(uint32_t * pos,uint32_t type) {
 	switch (type) {
 	case DOS_SEEK_SET:break;
 	case DOS_SEEK_CUR:mypos += PHYSFS_tell(fhandle); break;
-	case DOS_SEEK_END:mypos += PHYSFS_fileLength(fhandle)-mypos; break;
+	case DOS_SEEK_END:mypos += PHYSFS_fileLength(fhandle); -mypos; break;
 	default:
 	//TODO Give some doserrorcode;
 		return false;//ERROR


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

Permits overlay contents to be used in place of .zip contents. Replaces missing ; that causes some .zips to not work.

## What issue(s) does this PR address?

Per joncampbell123/dosbox-x#3535, joncampbell123/dosbox-x#3355 and icculus/physfs#18 this fixes contents of overlay directory not superseding the original .zip contents, for example: changing a config file or testing a patch.  

This should have uses for many people, adding/removing files from the .zip could risk breaking the game or program or corrupt the file. With this in place you can edit existing files and use the overlay version in place of the .zip original. If it breaks something you can delete the overlay and go back to the stock version. Another use could be be multiple overlays with one base .zip for testing CGA, EGA, TANDY versions without needing to duplicate the base .zip (for NTFS users you can then use folder compression so the overlays take even less space).

There is also the missing ; before -mypos on line 746 discussed in joncampbell123/dosbox-x#3535 which breaks .zip functionality with some software. Restoring this fixes a lot of games that did not behave with it removed.

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

Not that I am aware of, @grapeli and myself have tested it in #3535 and seems to behave as expected.

## Additional information

My first Pull Request 😁
