### PR TITLE
SDL2 XInput: fix incorrectly mapped axes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,8 @@ Unreleased
   - Fix some NetBSD build issues
     (Jookia, with patch from Nia)
   - Fix minor graphical issues in mapper GUI (aybe)
+  - Swap SDL2 XInput axes by default for a better
+    out of the box experience (aybe)
 
 2022.09.0 (0.84.3)
   - Updated FFMPEG video capture to use newer API,

--- a/vs/sdl2/src/joystick/windows/SDL_xinputjoystick.c
+++ b/vs/sdl2/src/joystick/windows/SDL_xinputjoystick.c
@@ -408,9 +408,9 @@ UpdateXInputJoystickState(SDL_Joystick * joystick, XINPUT_STATE_EX *pXInputState
 
     SDL_PrivateJoystickAxis(joystick, 0, pXInputState->Gamepad.sThumbLX);
     SDL_PrivateJoystickAxis(joystick, 1, ~pXInputState->Gamepad.sThumbLY);
-    SDL_PrivateJoystickAxis(joystick, 2, ((int)pXInputState->Gamepad.bLeftTrigger * 257) - 32768);
-    SDL_PrivateJoystickAxis(joystick, 3, pXInputState->Gamepad.sThumbRX);
-    SDL_PrivateJoystickAxis(joystick, 4, ~pXInputState->Gamepad.sThumbRY);
+    SDL_PrivateJoystickAxis(joystick, 2, pXInputState->Gamepad.sThumbRX);
+    SDL_PrivateJoystickAxis(joystick, 3, ~pXInputState->Gamepad.sThumbRY);
+    SDL_PrivateJoystickAxis(joystick, 4, ((int)pXInputState->Gamepad.bLeftTrigger * 257) - 32768);
     SDL_PrivateJoystickAxis(joystick, 5, ((int)pXInputState->Gamepad.bRightTrigger * 257) - 32768);
 
     for (button = 0; button < SDL_arraysize(s_XInputButtons); ++button) {


### PR DESCRIPTION
## What issue(s) does this PR address?

Pretty much the same as #3747 but for SDL2, however, it's a completely different fix.

For some weird reason, the axes were mapped in a weird way:

- thumb lx
- thumb ly
- trigger l
- thumb rx
- thumb ry
- trigger r

By ordering them in a way that makes more sense, it immediately fixes the trigger issues without having to fiddle with the configuration and provides a better out of the box experience:

- thumb lx
- thumb ly
- thumb rx
- thumb ry
- trigger l
- trigger r