### PR TITLE
Commit #3678 broke commit #3347

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1980,15 +1980,17 @@ static Bitu DOS_21Handler(void) {
                 else if(Files[handle]->GetInformation() & EXT_DEVICE_BIT) {
                     fRead = !(((DOS_ExtDevice*)Files[handle])->CallDeviceFunction(4, 26, SegValue(ds), reg_dx, toread) & 0x8000);
 #if defined(USE_TTF)
-                    fRead &= ttf.inUse && reg_bx == WPvga512CHMhandle;
+                    if(fRead && ttf.inUse && reg_bx == WPvga512CHMhandle)
+                        MEM_BlockRead(SegPhys(ds) + reg_dx, dos_copybuf, toread);
 #endif
                 }
-                else {
-                   fRead = DOS_ReadFile(reg_bx, dos_copybuf, &toread);
+                else
+                {
+                    if(fRead = DOS_ReadFile(reg_bx, dos_copybuf, &toread))
+                        MEM_BlockWrite(SegPhys(ds) + reg_dx, dos_copybuf, toread);
                 }
 
                 if (fRead) {
-                    MEM_BlockWrite(SegPhys(ds) + reg_dx, dos_copybuf, toread);
                     reg_ax=toread;
 #if defined(USE_TTF)
                     if (ttf.inUse && reg_bx == WPvga512CHMhandle) {


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

Commit #3678 broke commit #3347, reverting breaking changes to get #3347 working again (MEM_BlockWrite MUSTN'T be called on ext device, otherwise it overwrites buffer which causes malfunction)

## Does this PR introduce any breaking change(s)?

Maybe it breaks ZIP dirve functionality again which #3678 is meant to fix? I don't know, how to easily test this, so possibly please check it before merging.
