### PR TITLE
Fix missing line when printing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,8 @@ Unreleased
   - Updated mt32emu code to latest(2.7.0).(maron2000)
     Also, added config option "mt32.engage.channel1"
      (Refer to https://github.com/munt/munt for details)
+  - Fix missing line in printouts (Issue #3569)
+    (maron2000)
 
 2022.09.0 (0.84.3)
   - Updated FFMPEG video capture to use newer API,

--- a/src/hardware/parport/printer.cpp
+++ b/src/hardware/parport/printer.cpp
@@ -1308,7 +1308,8 @@ bool CPrinter::processCommandChar(uint8_t ch)
 		    }
 		    curX = leftMargin;
 		    curY += lineSpacing;
-		    if (curY > bottomMargin)
+		    //LOG_MSG("curY:%f, bottomMargin:%f",curY, bottomMargin);
+		    if (curY > bottomMargin-0.0001) // goto the next page if curY is larger or slightly smaller than bottomMargin
 			    newPage(true, false);
 		    return true;
 	    case 0x0e:		//Select double-width printing (one line) (SO)


### PR DESCRIPTION
## What issue(s) does this PR address?
When printing out text, judgement of whether to go to a new page was incorrect and some lines were printed beyond the bottom of the paper resulting in missing line(s).
This PR fixes the judgement of bottom line of the paper. 

Fixes #3569 
You can see that there are no missing lines mentioned in the issue.

![page1](https://user-images.githubusercontent.com/68574602/195345403-10ea276c-f466-4a0e-a829-2b76f82e5c0b.png)
![page2](https://user-images.githubusercontent.com/68574602/195345417-161bd38f-56cc-4021-8216-a404a118ff60.png)
![page3](https://user-images.githubusercontent.com/68574602/195345430-9a20829a-56d4-4a4b-b61e-9403cd4d474a.png)

