### PR TITLE
Update appveyor.yml configuration to Visual Studio 2022 image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 #    environment configuration    #
 #---------------------------------#
 
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 init:
   - git config --global core.autocrlf true


### PR DESCRIPTION
## What issue(s) does this PR address?

Right now AppVeyor will fail to build because the appveyor.yml file uses a Visual Studio 2019 image, while the DOSBox-X Visual Studio solution has been changed to require Visual Studio 2022.

This updates the appveyor.yml file to use a Visual Studio 2022 image. Confirmed to build successfully.