### PR TITLE
Limit "port 61 bit 6" change to early PC types

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,9 @@ Unreleased
      (Refer to https://github.com/munt/munt for details)
   - Fix missing line in printouts (Issue #3569)
     (maron2000)
+  - Limit the "always return bit 6 of port 61h as set
+    for PC" change to only apply to early PC types
+    (MDA, CGA or Hercules). (Allofich)
 
 2022.09.0 (0.84.3)
   - Updated FFMPEG video capture to use newer API,

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -679,10 +679,10 @@ static Bitu read_p61(Bitu, Bitu) {
         ((TIMER_GetOutput2() || (port_61_data&1) == 0)? 0x20:0) | // NTS: Timer 2 doesn't cycle if Port 61 gate turned off, and it becomes '1' when turned off
         ((fmod(PIC_FullIndex(),0.030) > 0.015)? 0x10:0));
 
-    // Always return bit 6 as set for a PC and as cleared for PCjr or Tandy. See https://www.vogons.org/viewtopic.php?t=50417.
+    // Always return bit 6 as set for early PCs and as cleared for PCjr or Tandy. See https://www.vogons.org/viewtopic.php?t=50417.
     if(machine == MCH_PCJR || machine == MCH_TANDY)
         dbg &= 0xBF;
-    else
+    else if(machine == MCH_CGA || machine == MCH_HERC || machine == MCH_MDA)
         dbg |= 0x40;
 
     return dbg;


### PR DESCRIPTION
## What issue(s) does this PR address?

Fixes keyboard input not working in Bust-A-Move 2: Arcade Edition (Puzzle Bobble 2)
https://github.com/joncampbell123/dosbox-x/issues/3638

## Additional information

This change https://github.com/joncampbell123/dosbox-x/commit/ce936e801685e7e20af18908785ef3c1d2d72c91, while allowing the game Zaxxon to successfully detect a PC and run in PC mode, caused unresponsive keyboard controls in Bust-A-Move 2: Arcade Edition. That change was based off of this VOGONS post:

https://www.vogons.org/viewtopic.php?t=50417

I followed the suggestion of the poster there literally that "Bit 6 will always be set on a PC" for https://github.com/joncampbell123/dosbox-x/commit/ce936e801685e7e20af18908785ef3c1d2d72c91, but looking at their proposed patch, they limit it to MCH_CGA and MCH_HERC there, so I think they may have meant "Bit 6 will always be set on a PC of that time" (Zaxxon is a 1984 release).

This PR limits the bit 6 change to MCH_CGA and MCH_HERC, and since DOSBox-X also has MCH_MDA, that as well. DOSBox-X also has MCH_MCGA, which is not in mainline, but I don't know if that would be appropriate to apply the behavior to or not, so I'm leaving it out.

Closes #3638.