### PR TITLE
Fix compilation error in sdl_mapper.cpp (std::max)

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2621,7 +2621,7 @@ protected:
         if(centered)
         {
             const auto size = data.size();
-            const auto xPos = std::max(x, x + dx / 2 - size * 8 / 2);
+            const auto xPos = std::max(x, (Bitu) (x + dx / 2 - size * 8 / 2));
             const auto yPos = std::max(y, y + dy / 2 - 14 / 2);
             DrawText(1 + xPos, yPos, data.c_str(), foreground, background);
         }


### PR DESCRIPTION
Hi. 

## What issue(s) does this PR address?

I tried to compile dosbox-x on macos, and have following error:
```
/Volumes/macext/caiiiycuk/js-dos/emulators/native/dosbox-x/src/gui/sdl_mapper.cpp:2624:31: error: no matching function for call to 'max'
            const auto xPos = std::max(x,  (x + dx / 2 - size * 8 / 2));
                              ^~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__algorithm/max.h:39:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('unsigned int' vs. 'unsigned long')
max(const _Tp& __a, const _Tp& __b)
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__algorithm/max.h:50:1: note: candidate template ignored: could not match 'initializer_list<type-parameter-0-0>' against 'unsigned int'
max(initializer_list<_Tp> __t, _Compare __comp)
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__algorithm/max.h:59:1: note: candidate function template not viable: requires single argument '__t', but 2 arguments were provided
max(initializer_list<_Tp> __t)
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/c++/v1/__algorithm/max.h:30:1: note: candidate function template not viable: requires 3 arguments, but 2 were provided
max(const _Tp& __a, const _Tp& __b, _Compare __comp)
^
1 error generated.
ninja: build stopped: subcommand failed.

```

I thik it's because x, dx have type Bitu,but size is a size_t type. So it results into std::max(Bitu, size_t).

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No

