### PR TITLE
Fix Opl3! Duo and Opl2 Audio board audio playback on unix

### DIFF
--- a/src/hardware/opl2board/opl2board.cpp
+++ b/src/hardware/opl2board/opl2board.cpp
@@ -8,12 +8,17 @@ OPL2AudioBoard::OPL2AudioBoard() {
 void OPL2AudioBoard::connect(const char* port) {
 	printf("OPL2 Audio Board: Connecting to port %s... ", port);
 
-	comport = 0;
+	comport = nullptr;
 	if (SERIAL_open(port, &comport)) {
 		SERIAL_setCommParameters(comport, 115200, 'n', SERIAL_1STOP, 8);
-		printf("OK\n");
+#if !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
+		resetBuffer();
+		stopThread = false;
+		thread = std::thread(&OPL2AudioBoard::writeBuffer, this);
+#endif
+		printf("OPL2 Audio Board: COM Port OK.\n");
 	} else {
-		printf("FAIL\n");
+		printf("OPL2 Audio Board: Unable to open COM port Failed. Error %d: %s\n", errno, strerror(errno));
 	}
 }
 
@@ -21,7 +26,16 @@ void OPL2AudioBoard::disconnect() {
 	#if OPL2_AUDIO_BOARD_DEBUG
 		printf("OPL2 Audio Board: Disconnect");
 	#endif
-
+#if !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
+	// Stop buffer thread after resetting the board.
+	if(thread.joinable()) {
+		reset();
+		stopThread = true;
+		thread.join();
+	}
+#else
+	reset();
+#endif
 	if (comport) {
 		SERIAL_close(comport);
 	}
@@ -32,6 +46,8 @@ void OPL2AudioBoard::reset() {
 		printf("OPL2 Audio Board: Reset\n");
 	#endif
 
+	resetBuffer();
+
 	for (uint8_t i = 0x00; i < 0xFF; i++) {
 		if (i >= 0x40 && i <= 0x55) {
 			// Set channel volumes to minimum.
@@ -41,14 +57,46 @@ void OPL2AudioBoard::reset() {
 		}
 	}
 }
+void OPL2AudioBoard::resetBuffer()
+{
+	sendBuffer = {};
+}
+void OPL2AudioBoard::writeBuffer()
+{
+#if !defined(MACOS)
+	/* Note:(josephillips85) This is a workaround to fix the thread stop issue presented on MacOS
+	 Probably hitting this BUG https://github.com/apple/darwin-libpthread/blob/main/src/pthread.c#L2177
+	 Already tested on MacOS Big Sur 11.2.1 */
+	while(!stopThread) {
+		if (!sendBuffer.empty()) {
+			if (SERIAL_sendchar(comport, sendBuffer.front())) {
+				sendBuffer.pop();
+			}
+		}
+	}
+#else
 
+	do {
+		while(!sendBuffer.empty()) {
+			if(SERIAL_sendchar(comport, sendBuffer.front())) {
+				sendBuffer.pop();
+			};
+		}
+	} while(!stopThread);
+
+#endif
+}
 void OPL2AudioBoard::write(uint8_t reg, uint8_t val) {
 	if (comport) {
 		#if OPL2_AUDIO_BOARD_DEBUG
 			printf("OPL2 Audio Board: Write %d --> %d\n", val, reg);
 		#endif
-
+#if !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
+		sendBuffer.push(reg);
+		sendBuffer.push(val);
+#else
 		SERIAL_sendchar(comport, reg);
 		SERIAL_sendchar(comport, val);
+#endif
 	}
 }

--- a/src/hardware/opl2board/opl2board.cpp
+++ b/src/hardware/opl2board/opl2board.cpp
@@ -6,7 +6,7 @@ OPL2AudioBoard::OPL2AudioBoard() {
 }
 
 void OPL2AudioBoard::connect(const char* port) {
-	printf("OPL2 Audio Board: Connecting to port %s... ", port);
+	printf("OPL2 Audio Board: Connecting to port %s... \n", port);
 
 	comport = nullptr;
 	if (SERIAL_open(port, &comport)) {
@@ -59,7 +59,7 @@ void OPL2AudioBoard::reset() {
 }
 void OPL2AudioBoard::resetBuffer()
 {
-	sendBuffer = {};
+	sendBuffer = std::queue<uint8_t>();
 }
 void OPL2AudioBoard::writeBuffer()
 {
@@ -89,7 +89,7 @@ void OPL2AudioBoard::writeBuffer()
 void OPL2AudioBoard::write(uint8_t reg, uint8_t val) {
 	if (comport) {
 		#if OPL2_AUDIO_BOARD_DEBUG
-			printf("OPL2 Audio Board: Write %d --> %d\n", val, reg);
+			printf("OPL2 Audio Board: Write %d --> %d | buffer size %d\n", val, reg, sendBuffer.size());
 		#endif
 #if !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
 		sendBuffer.push(reg);

--- a/src/hardware/opl2board/opl2board.cpp
+++ b/src/hardware/opl2board/opl2board.cpp
@@ -63,26 +63,28 @@ void OPL2AudioBoard::resetBuffer()
 }
 void OPL2AudioBoard::writeBuffer()
 {
-#if !defined(MACOS)
-	/* Note:(josephillips85) This is a workaround to fix the thread stop issue presented on MacOS
-	 Probably hitting this BUG https://github.com/apple/darwin-libpthread/blob/main/src/pthread.c#L2177
-	 Already tested on MacOS Big Sur 11.2.1 */
-	while(!stopThread) {
-		if (!sendBuffer.empty()) {
-			if (SERIAL_sendchar(comport, sendBuffer.front())) {
-				sendBuffer.pop();
+#if !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
+
+	#if !defined(MACOS)
+		/* Note:(josephillips85) This is a workaround to fix the thread stop issue presented on MacOS
+		 Probably hitting this BUG https://github.com/apple/darwin-libpthread/blob/main/src/pthread.c#L2177
+		 Already tested on MacOS Big Sur 11.2.1 */
+		while(!stopThread) {
+			if (!sendBuffer.empty()) {
+				if (SERIAL_sendchar(comport, sendBuffer.front())) {
+					sendBuffer.pop();
+				}
 			}
 		}
-	}
-#else
-
-	do {
-		while(!sendBuffer.empty()) {
-			if(SERIAL_sendchar(comport, sendBuffer.front())) {
-				sendBuffer.pop();
-			};
-		}
-	} while(!stopThread);
+	#else
+		do {
+			while(!sendBuffer.empty()) {
+				if(SERIAL_sendchar(comport, sendBuffer.front())) {
+					sendBuffer.pop();
+				};
+			}
+		} while(!stopThread);
+	#endif
 
 #endif
 }

--- a/src/hardware/opl2board/opl2board.h
+++ b/src/hardware/opl2board/opl2board.h
@@ -1,4 +1,8 @@
+#if !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
+  #include <thread>
+#endif
 #include "../serialport/libserial.h"
+#include <queue>
 
 #ifndef OPL2_AUDIO_BOARD
 	#define OPL2_AUDIO_BOARD
@@ -15,6 +19,14 @@
 			void write(uint8_t reg, uint8_t val);
 
 		private:
+			void resetBuffer();
+			void writeBuffer();
+
+#if !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
+			std::thread thread;
+			bool stopThread = false;
+#endif
 			COMPORT comport;
+			std::queue<uint8_t> sendBuffer;
 	};
 #endif

--- a/src/hardware/opl3duoboard/opl3duoboard.cpp
+++ b/src/hardware/opl3duoboard/opl3duoboard.cpp
@@ -12,15 +12,14 @@ void Opl3DuoBoard::connect(const char* port) {
 	comport = 0;
 	if (SERIAL_open(port, &comport)) {
 		SERIAL_setCommParameters(comport, 115200, 'n', SERIAL_1STOP, 8);
-		printf("OPL3 Duo! Board: COM Port OK.\n");
-            
 #if !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
-        resetBuffer();
-        stopOPL3DuoThread = false;
-        thread = std::thread(&Opl3DuoBoard::writeBuffer,this);
+		resetBuffer();
+		stopOPL3DuoThread = false;
+		thread = std::thread(&Opl3DuoBoard::writeBuffer,this);
 #endif
+		printf("OPL3 Duo! Board: COM Port OK.\n");
 	} else {
-		printf("OPL3 Duo! Board: Unable to open COM port Failed.\n");
+		printf("OPL3 Duo! Board: Unable to open COM port Failed.  Error %d: %s\\n", errno, strerror(errno));
 	}
 }
 
@@ -68,26 +67,22 @@ void Opl3DuoBoard::reset() {
 }
 
 void Opl3DuoBoard::resetBuffer() {
-    bufferWrPos = 0;
-    bufferRdPos = 0;
+	sendBuffer = {};
 }
 
 void Opl3DuoBoard::write(uint32_t reg, uint8_t val) {
 	if (comport) {
 		#if OPL3_DUO_BOARD_DEBUG
-			printf("OPL3 Duo! Board: Write %d --> %d\n", val, reg);
+			printf("OPL3 Duo! Board: Write %d --> %d | buffer size %d\n", val, reg, sendBuffer.size());
 		#endif
-
 #if !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
-		sendBuffer[bufferWrPos] = (reg >> 6) | 0x80;
-		sendBuffer[bufferWrPos + 1] = ((reg & 0x3f) << 1) | (val >> 7);
-		sendBuffer[bufferWrPos + 2] = (val & 0x7f);
-    bufferWrPos = (bufferWrPos + 3) % OPL3_DUO_BUFFER_SIZE;
-#else    
-
-        SERIAL_sendchar(comport, (reg >> 6) | 0x80);
-        SERIAL_sendchar(comport, ((reg & 0x3f) << 1) | (val >> 7));
-        SERIAL_sendchar(comport, val & 0x7f);
+		sendBuffer.push((reg >> 6) | 0x80);
+		sendBuffer.push(((reg & 0x3f) << 1) | (val >> 7));
+		sendBuffer.push((val & 0x7f));
+#else
+		SERIAL_sendchar(comport, (reg >> 6) | 0x80);
+		SERIAL_sendchar(comport, ((reg & 0x3f) << 1) | (val >> 7));
+		SERIAL_sendchar(comport, val & 0x7f);
 #endif
 
 	}
@@ -96,27 +91,25 @@ void Opl3DuoBoard::write(uint32_t reg, uint8_t val) {
 void Opl3DuoBoard::writeBuffer() {
 #if !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
 
-    #if !defined(MACOS)
-    /* Note:(josephillips85) This is a workaround to fix the thread stop issue presented on MacOS
-     Probably hitting this BUG https://github.com/apple/darwin-libpthread/blob/main/src/pthread.c#L2177 
-     Already tested on MacOS Big Sur 11.2.1 */
-
-        while(!stopOPL3DuoThread) {        
-            if (bufferRdPos != bufferWrPos){
-            SERIAL_sendchar(comport, sendBuffer[bufferRdPos]);
-            bufferRdPos = (bufferRdPos + 1) % OPL3_DUO_BUFFER_SIZE;
-
-            }
-        }
-   #else
-
-   do {
-        while(bufferRdPos != bufferWrPos) {
-            SERIAL_sendchar(comport, sendBuffer[bufferRdPos]);
-            bufferRdPos = (bufferRdPos + 1) % OPL3_DUO_BUFFER_SIZE;
-        }
-    } while(!stopOPL3DuoThread);
-
-  #endif
+	#if !defined(MACOS)
+	/* Note:(josephillips85) This is a workaround to fix the thread stop issue presented on MacOS
+	 Probably hitting this BUG https://github.com/apple/darwin-libpthread/blob/main/src/pthread.c#L2177
+	 Already tested on MacOS Big Sur 11.2.1 */
+		while(!stopOPL3DuoThread) {
+			if (!sendBuffer.empty()) {
+				if (SERIAL_sendchar(comport, sendBuffer.front())) {
+					sendBuffer.pop();
+				}
+			}
+		}
+	#else
+	do {
+		while(!sendBuffer.empty()) {
+			if(SERIAL_sendchar(comport, sendBuffer.front())) {
+				sendBuffer.pop();
+			};
+		}
+	} while(!stopOPL3DuoThread);
+	#endif
 #endif
 }

--- a/src/hardware/opl3duoboard/opl3duoboard.cpp
+++ b/src/hardware/opl3duoboard/opl3duoboard.cpp
@@ -67,7 +67,7 @@ void Opl3DuoBoard::reset() {
 }
 
 void Opl3DuoBoard::resetBuffer() {
-	sendBuffer = {};
+	sendBuffer = std::queue<uint8_t>();
 }
 
 void Opl3DuoBoard::write(uint32_t reg, uint8_t val) {

--- a/src/hardware/opl3duoboard/opl3duoboard.h
+++ b/src/hardware/opl3duoboard/opl3duoboard.h
@@ -2,11 +2,11 @@
 #include <thread>
 #endif
 #include "../serialport/libserial.h"
+#include <queue>
 
 #ifndef OPL3_DUO_BOARD
 	#define OPL3_DUO_BOARD
-    #define OPL3_DUO_BUFFER_SIZE 9000
-   
+
 
 	// Output debug information to the DosBox console if set to 1
 	#define OPL3_DUO_BOARD_DEBUG 0
@@ -20,17 +20,14 @@
 			void write(uint32_t reg, uint8_t val);
 
 		private:
-            void resetBuffer();
-            void writeBuffer();
+			void resetBuffer();
+			void writeBuffer();
 
 #if !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
-            std::thread thread;
-            bool stopOPL3DuoThread = false;
-		
+			std::thread thread;
+			bool stopOPL3DuoThread = false;
 #endif
-            COMPORT comport;
-            uint8_t sendBuffer[OPL3_DUO_BUFFER_SIZE];
-            uint16_t bufferRdPos = 0;
-            uint16_t bufferWrPos = 0;
+			COMPORT comport;
+			std::queue<uint8_t> sendBuffer;
 	};
 #endif


### PR DESCRIPTION
On unix, OPL2 Audio and OPL3 Duo! boards stutter and play audio wrongly.
This is due to the fact that those boards do not account for non blocking IO mode on unix serials, losing packets when port is not ready to accept data.

With this PR, boards will wait for port readyness on a separate thread, buffering writes and flushing them when serial is ready. This should not block the emulator since waiting happens on a separate thread.

While OPL3duoboard.cpp does use a thread already, it doesn't wait properly on serial readyness.
opl2board.cpp just doesn't use a thread at all.
What I did is to merge those 2 implementations into one and put a proper write wait mechanic.

## What issue(s) does this PR address?

Fixes #3694
Fixes #2995 

## Does this PR introduce new feature(s)?
No

## Does this PR introduce any breaking change(s)?
No

## Additional information
Tested on Linux and Windows.

I should note that now those two boards are so similar that can be merged into one class, since they differ only in the protocol used to communicate through serial. Opl3 duo! board can itself use 2 different communication protocols if its firmware was compiled with different defines.