### PR TITLE
Fix 6-bit VGA to 8-bit RGB palette conversion

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -48,6 +48,7 @@ Unreleased
     prevents a bug in UNLZEXE from causing a crash, and
     maybe helps other buggy programs and unusual cases.
     Use real addressing to support stack pointer wraparound.
+  - Fix 6-bit VGA to 8-bit RGB palette conversion (maron2000)
 
 2022.09.0 (0.84.3)
   - Updated FFMPEG video capture to use newer API,

--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,15 @@ AC_DEFUN([AC_CHECK_CPPFLAGS],
         [AC_MSG_RESULT([no]); CPPFLAGS="${temp_check_cppflags}"])
 ])# AC_CHECK_CPPFLAGS
 
+dnl LIBRARY TEST: OpenGL support
+AC_CHECK_LIB(GL, main, have_gl_lib=yes, have_gl_lib=no , )
+AC_CHECK_LIB(opengl32, main, have_opengl32_lib=yes,have_opengl32_lib=no , )
+AC_CHECK_HEADER(GL/gl.h, have_gl_h=yes , have_gl_h=no , )
+
+dnl LIBRARY TEST: Direct3D 9 header support
+AC_CHECK_HEADER(d3d9.h, have_d3d9_h=yes , have_d3d9_h=no , )
+AC_CHECK_HEADER(d3dx9math.h, have_d3dx9math_h=yes , have_d3dx9math_h=no , )
+
 dnl Utility function ============================
 
 # AC_CHECK_CXXFLAGS(ADDITIONAL-CXXFLAGS, ACTION-IF-FOUND, ACTION-IF-NOT-FOUND)

--- a/src/hardware/vga_dac.cpp
+++ b/src/hardware/vga_dac.cpp
@@ -56,9 +56,10 @@ enum {DAC_READ,DAC_WRITE};
 
 static void VGA_DAC_SendColor( Bitu index, Bitu src ) {
     const uint8_t dacshift = vga_8bit_dac ? 0u : 2u;
-    const uint8_t red = vga.dac.rgb[src].red << dacshift;
-    const uint8_t green = vga.dac.rgb[src].green << dacshift;
-    const uint8_t blue = vga.dac.rgb[src].blue << dacshift;
+    /* convert 6bit VGA palette to 8bit RGB */
+    uint8_t red = (vga.dac.rgb[src].red << dacshift | vga.dac.rgb[src].red >> (dacshift * 2));
+    uint8_t green = (vga.dac.rgb[src].green << dacshift | vga.dac.rgb[src].green >> (dacshift * 2));
+    uint8_t blue = (vga.dac.rgb[src].blue << dacshift | vga.dac.rgb[src].blue >> (dacshift * 2));
 
     /* FIXME: CGA composite mode calls RENDER_SetPal itself, which conflicts with this code */
     if (vga.mode == M_CGA16)


### PR DESCRIPTION
Fix 8-bit RGB value is slightly darker than expected when converted from 6-bit VGA.
Also, fixed issue that OpenGL output was disabled in MinGW development builds, due to inappropriate order of testing existence of OpenGL library.

## What issue(s) does this PR address?
Fixes #3804
Fixes #3814

## Additional information
Reference https://moddingwiki.shikadi.net/wiki/VGA_Palette
