### PR TITLE
Set fluid.driver default to "dsound" (Win32)

### DIFF
--- a/src/gui/midi_synth.h
+++ b/src/gui/midi_synth.h
@@ -364,6 +364,10 @@ public:
 		else
 		    fluid_settings_setstr(settings, "audio.driver", "pulseaudio");
 #endif
+#if defined (WIN32)
+        else
+            fluid_settings_setstr(settings, "audio.driver", "dsound"); // Explicitly set audio driver to be dsound as default for Windows
+#endif //WIN32
 		fluid_settings_setnum(settings, "synth.sample-rate", atof(section->Get_string("fluid.samplerate")));
 		fluid_settings_setnum(settings, "synth.gain", atof(section->Get_string("fluid.gain")));
 		fluid_settings_setint(settings, "synth.polyphony", section->Get_int("fluid.polyphony"));

--- a/src/libs/fluidsynth/fluid_chorus.c
+++ b/src/libs/fluidsynth/fluid_chorus.c
@@ -86,7 +86,7 @@
  */
 #define MAX_SAMPLES_LN2 12
 
-#define MAX_SAMPLES (1 << (MAX_SAMPLES_LN2-1))
+#define MAX_SAMPLES (2^(MAX_SAMPLES_LN2))
 #define MAX_SAMPLES_ANDMASK (MAX_SAMPLES-1)
 
 
@@ -95,7 +95,7 @@
    samples
 */
 #define INTERPOLATION_SUBSAMPLES_LN2 8
-#define INTERPOLATION_SUBSAMPLES (1 << (INTERPOLATION_SUBSAMPLES_LN2-1))
+#define INTERPOLATION_SUBSAMPLES (2^INTERPOLATION_SUBSAMPLES_LN2)
 #define INTERPOLATION_SUBSAMPLES_ANDMASK (INTERPOLATION_SUBSAMPLES-1)
 
 /* Use how many samples for interpolation? Must be odd.  '7' sounds
@@ -270,7 +270,7 @@ fluid_chorus_set(fluid_chorus_t* chorus, int set, int nr, float level,
   if (chorus->speed_Hz < MIN_SPEED_HZ) {
     fluid_log(FLUID_WARN, "chorus: speed is too low (min %f)! Setting value to min.",
 	     (double) MIN_SPEED_HZ);
-    chorus->speed_Hz = MIN_SPEED_HZ;
+    chorus->speed_Hz = (float) MIN_SPEED_HZ;
   } else if (chorus->speed_Hz > MAX_SPEED_HZ) {
     fluid_log(FLUID_WARN, "chorus: speed must be below %f Hz! Setting value to max.",
 	     (double) MAX_SPEED_HZ);
@@ -289,7 +289,7 @@ fluid_chorus_set(fluid_chorus_t* chorus, int set, int nr, float level,
   } else if (chorus->level > 10) {
     fluid_log(FLUID_WARN, "chorus: level must be < 10. A reasonable level is << 1! "
 	     "Setting it to 0.1.");
-    chorus->level = 0.1;
+    chorus->level = (float) 0.1;
   }
 
   /* The modulating LFO goes through a full period every x samples: */
@@ -518,7 +518,7 @@ fluid_chorus_triangle(int *buf, int len, int depth)
 		incr = 2.0 / len * (double)depth * (double)INTERPOLATION_SUBSAMPLES;
 	
 		    /* Initialize first value */
-		val = 0. - 3. * MAX_SAMPLES * INTERPOLATION_SUBSAMPLES;
+		val = 0. - (double)3. * (double)MAX_SAMPLES * INTERPOLATION_SUBSAMPLES;
 	
 		    /* Build triangular modulation waveform */
 		while (il <= ir)

--- a/src/libs/fluidsynth/fluid_event_priv.h
+++ b/src/libs/fluidsynth/fluid_event_priv.h
@@ -79,5 +79,6 @@ fluid_evt_heap_t* _fluid_evt_heap_init(int nbEvents);
 void _fluid_evt_heap_free(fluid_evt_heap_t* heap);
 fluid_evt_entry* _fluid_seq_heap_get_free(fluid_evt_heap_t* heap);
 void _fluid_seq_heap_set_free(fluid_evt_heap_t* heap, fluid_evt_entry* evt);
+void fluid_event_key_pressure(fluid_event_t* evt, int channel, short key, short val);
 
 #endif /* _FLUID_EVENT_PRIV_H */

--- a/src/libs/fluidsynth/fluid_rev.c
+++ b/src/libs/fluidsynth/fluid_rev.c
@@ -62,7 +62,7 @@
 
 
 //#define DC_OFFSET 0
-#define DC_OFFSET 1e-8
+#define DC_OFFSET 1.0e-8f
 //#define DC_OFFSET 0.001f
 typedef struct _fluid_allpass fluid_allpass;
 typedef struct _fluid_comb fluid_comb;

--- a/src/libs/fluidsynth/fluid_sys.c
+++ b/src/libs/fluidsynth/fluid_sys.c
@@ -401,7 +401,7 @@ double fluid_utime(void) {
   }
 }
 
-unsigned int fluid_curtime(void) { return fluid_utime() * 1000; }
+unsigned int fluid_curtime(void) { return (unsigned int)(fluid_utime() * 1000); }
 
 #else /* HAVE_WINDOWS_H */
 

--- a/src/libs/fluidsynth/fluid_voice.h
+++ b/src/libs/fluidsynth/fluid_voice.h
@@ -213,9 +213,9 @@ fluid_real_t fluid_voice_gen_value(fluid_voice_t* voice, int num);
 #define fluid_voice_get_loudness(voice) (fluid_adsr_env_get_max_val(&voice->volenv))
 
 #define _GEN(_voice, _n) \
-  ((fluid_real_t)(_voice)->gen[_n].val \
-   + (fluid_real_t)(_voice)->gen[_n].mod \
-   + (fluid_real_t)(_voice)->gen[_n].nrpn)
+  ((fluid_real_t)((_voice)->gen[_n].val \
+   + (_voice)->gen[_n].mod \
+   + (_voice)->gen[_n].nrpn))
 
 /* defined in fluid_dsp_float.c */
 


### PR DESCRIPTION
## What issue(s) does this PR address?
Fix `mididevice=FluidSynth` fails to load when `fluid.driver=default` on 32bit SDL2 Windows build.

Fixes #3817
