### PR TITLE
Fixed Japanese input related issues.

### DIFF
--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -812,9 +812,9 @@ bool device_CON::Read(uint8_t * data,uint16_t * size) {
 			break;
 		case 0xe0: /* Extended keys in the  int 16 0x10 case */
 #if defined(USE_TTF)
-			if((isJEGAEnabled() || IS_DOSV || ttf_dosv) && (reg_ah == 0xf0 || reg_ah == 0xf1)) {
+			if((isJEGAEnabled() || IS_PC98_ARCH || IS_DOSV || ttf_dosv) && (reg_ah == 0xf0 || reg_ah == 0xf1)) {
 #else
-			if((isJEGAEnabled() || IS_DOSV) && (reg_ah == 0xf0 || reg_ah == 0xf1)) {
+			if((isJEGAEnabled() || IS_PC98_ARCH || IS_DOSV) && (reg_ah == 0xf0 || reg_ah == 0xf1)) {
 #endif
 				data[count++]=reg_al;
 			} else if(!reg_ah) { /*extended key if reg_ah isn't 0 */

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5038,6 +5038,7 @@ static bool CheckEnableImmOnKey(SDL_KeyboardEvent key)
 #elif (defined(WIN32) && !defined(HX_DOS) || defined(MACOSX)) && defined(C_SDL2)
 static bool CheckEnableImmOnKey(SDL_KeyboardEvent key)
 {
+	if(ime_text.size() != 0) return false;
 	if(key.keysym.scancode == 0x29 ||
 #if defined(SDL_DOSBOX_X_IME)
 	(!SDL_IM_Composition(4) && (key.keysym.sym == 0x20 || (key.keysym.sym >= 0x30 && key.keysym.sym <= 0x39))) ||


### PR DESCRIPTION
Fixed a garbled character when entering a character whose second byte is 0xe0 in PC-98 mode.
For example, "も" and "金" are garbled.

Fixed a problem in the SDL2 version where the combination input with the Ctrl key to manipulate the conversion string of the IME would result in character input as it is.
For example, if Ctrl+I was entered to convert the string being typed into katakana, Ctrl+I would also be entered.
