### PR TITLE
Fix issue #3820: START command only ever opens first file.

### DIFF
--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -2007,7 +2007,8 @@ std::string localDrive::GetHostName(const char * name) {
 	dirCache.ExpandName(newname);
 	const host_cnv_char_t* host_name = CodePageGuestToHost(newname);
 	ht_stat_t temp_stat;
-	static std::string hostname = host_name != NULL && ht_stat(host_name,&temp_stat)==0 ? newname : "";
+	static std::string hostname;
+    hostname = host_name != NULL && ht_stat(host_name,&temp_stat)==0 ? newname : "";
 	return hostname;
 }
 

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -2007,8 +2007,7 @@ std::string localDrive::GetHostName(const char * name) {
 	dirCache.ExpandName(newname);
 	const host_cnv_char_t* host_name = CodePageGuestToHost(newname);
 	ht_stat_t temp_stat;
-	static std::string hostname;
-    hostname = host_name != NULL && ht_stat(host_name,&temp_stat)==0 ? newname : "";
+	static std::string hostname; hostname = host_name != NULL && ht_stat(host_name,&temp_stat)==0 ? newname : "";
 	return hostname;
 }
 


### PR DESCRIPTION
There is an issue when using the `START` command in DosBox-X, it will open the first file ok but requests to open subsequent files only open the first file. Based on suggestions by @darac-10 and @aybe this has now been fixed. Requested files now open as they should.

## What issue(s) does this PR address?

Fixes and closes #3820 

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

Nothing appears to be broken in testing

## Additional information

I've added the pull on behalf of @darac-10 to fix and close the above issue. Tested by both of us and resolves issue as described.
