### PR TITLE
Fix overflowing info in mapper

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -52,6 +52,7 @@ Unreleased
     prevents a bug in UNLZEXE from causing a crash, and
     maybe helps other buggy programs and unusual cases.
     Use real addressing to support stack pointer wraparound.
+  - Fix overflow in mapper info on SDL2 builds (aybe)
 
 2022.09.0 (0.84.3)
   - Updated FFMPEG video capture to use newer API,

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -4370,9 +4370,9 @@ static void CreateLayout(void) {
 
     // NOTE: screen budget is really tight down there, more than that and drawing crashes
 
-    bind_but.action = new CCaptionButton(PX(8) - CX, PY(22) - CY, BU(15), BV(1), false);
-    bind_but.dbg1   = new CCaptionButton(PX(8) - CX, PY(23) - CY, BU(16), BV(1), false);
-    bind_but.dbg2   = new CCaptionButton(PX(8) - CX, PY(24) - CY, BU(16), BV(1), false);
+    bind_but.action = new CCaptionButton(PX(7), PY(22) - CY, BU(15), BV(1), false);
+    bind_but.dbg1   = new CCaptionButton(PX(7), PY(23) - CY, BU(16), BV(1), false);
+    bind_but.dbg2   = new CCaptionButton(PX(7), PY(24) - CY, BU(16), BV(1), false);
 
     bind_but.dbg1->Change("%s", "");
     bind_but.dbg2->Change("%s", "");


### PR DESCRIPTION
## What issue(s) does this PR address?

Info would overflow in SDL2 build:

Before:

![dosbox-x_yFi7JwrDVc](https://user-images.githubusercontent.com/1537591/202367782-eb01d6a6-b195-4c4b-8ae4-af6d59edd6ec.png)

After:

![dosbox-x_QWxU3J0BNW](https://user-images.githubusercontent.com/1537591/202367766-88ce76b3-42df-4f46-8c7f-2996211741e2.png)
