### PR TITLE
Add Win32 'Debug/Clear logging console' menu item

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -52,7 +52,9 @@ Unreleased
     prevents a bug in UNLZEXE from causing a crash, and
     maybe helps other buggy programs and unusual cases.
     Use real addressing to support stack pointer wraparound.
-  - Add Win32 'Debug/Clear logging console' menu item (aybe)
+  - Win32 logging console (aybe)
+    - add 'Debug/Clear logging console' menu entry
+    - ensure main window stays above it when shown
 
 2022.09.0 (0.84.3)
   - Updated FFMPEG video capture to use newer API,

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -52,6 +52,7 @@ Unreleased
     prevents a bug in UNLZEXE from causing a crash, and
     maybe helps other buggy programs and unusual cases.
     Use real addressing to support stack pointer wraparound.
+  - Add Win32 'Debug/Clear logging console' menu item (aybe)
 
 2022.09.0 (0.84.3)
   - Updated FFMPEG video capture to use newer API,

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -589,6 +589,7 @@ void DEBUG_FlushInput(void) {
 
 void DBGUI_StartUp(void) {
 	mainMenu.get_item("show_console").check(true).enable(false).refresh_item(mainMenu);
+	mainMenu.get_item("clear_console").check(false).enable(false).refresh_item(mainMenu);
 
 	LOG(LOG_MISC,LOG_DEBUG)("DEBUG GUI startup");
 	/* Start the main window */

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -812,6 +812,7 @@ static const char* def_menu_debug[] =
     "save_logas",
     "--",
     "show_console",
+    "clear_console",
     "disable_logging",
     "wait_on_error",
     "--",

--- a/src/gui/menu_callback.cpp
+++ b/src/gui/menu_callback.cpp
@@ -2306,6 +2306,8 @@ bool show_console_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const
     if (DEBUG_IsDebuggerConsoleVisible())
         return true;
 #endif
+    auto window = GetForegroundWindow();
+
     auto console = GetConsoleWindow();
 
     if (console == nullptr)
@@ -2314,7 +2316,9 @@ bool show_console_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const
     auto visible = IsWindowVisible(console);
 
     ShowWindow(console, visible ? SW_HIDE : SW_SHOW);
-    
+
+    SetForegroundWindow(window);
+
     if (console == nullptr)
         console = GetConsoleWindow();
 

--- a/src/gui/menu_callback.cpp
+++ b/src/gui/menu_callback.cpp
@@ -2306,19 +2306,19 @@ bool show_console_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const
     if (DEBUG_IsDebuggerConsoleVisible())
         return true;
 #endif
-    HWND hwnd = GetConsoleWindow();
+    auto console = GetConsoleWindow();
 
-    if (hwnd == nullptr)
+    if (console == nullptr)
         DOSBox_ShowConsole();
 
-    BOOL visible = IsWindowVisible(hwnd);
+    auto visible = IsWindowVisible(console);
 
-    ShowWindow(hwnd, visible ? SW_HIDE : SW_SHOW);
+    ShowWindow(console, visible ? SW_HIDE : SW_SHOW);
     
-    if (hwnd == nullptr)
-        hwnd = GetConsoleWindow();
+    if (console == nullptr)
+        console = GetConsoleWindow();
 
-    visible = IsWindowVisible(hwnd);
+    visible = IsWindowVisible(console);
 
     mainMenu.get_item("show_console").check(visible).refresh_item(mainMenu);
     mainMenu.get_item("clear_console").check(false).enable(visible).refresh_item(mainMenu);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8970,6 +8970,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 
 #if !defined(C_EMSCRIPTEN)
         mainMenu.get_item("show_console").check(showconsole_init).refresh_item(mainMenu);
+        mainMenu.get_item("clear_console").check(false).enable(false).refresh_item(mainMenu);
         if (control->opt_display2) {
             mainMenu.get_item("show_console").enable(false).refresh_item(mainMenu);
             mainMenu.get_item("wait_on_error").enable(false).refresh_item(mainMenu);


### PR DESCRIPTION
## Does this PR introduce new feature(s)?

Added a new menu item to clear console.

Also, user-friendly, the console does not appear in front of main window anymore but behind it.

![dosbox-x_j1rZRXgoLo](https://user-images.githubusercontent.com/1537591/202377158-36a02997-a461-4648-8848-bb8fcc3e1029.png)

![dosbox-x_KXrzO3pyQf](https://user-images.githubusercontent.com/1537591/202377395-4baff91b-80c3-45b1-8e05-c368c49198d7.png)

