### PR TITLE
Fix issue #3814 Enable OpenGL output in MinGW builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,15 @@ AC_DEFUN([AC_CHECK_CPPFLAGS],
         [AC_MSG_RESULT([no]); CPPFLAGS="${temp_check_cppflags}"])
 ])# AC_CHECK_CPPFLAGS
 
+dnl LIBRARY TEST: OpenGL support
+AC_CHECK_LIB(GL, main, have_gl_lib=yes, have_gl_lib=no , )
+AC_CHECK_LIB(opengl32, main, have_opengl32_lib=yes,have_opengl32_lib=no , )
+AC_CHECK_HEADER(GL/gl.h, have_gl_h=yes , have_gl_h=no , )
+
+dnl LIBRARY TEST: Direct3D 9 header support
+AC_CHECK_HEADER(d3d9.h, have_d3d9_h=yes , have_d3d9_h=no , )
+AC_CHECK_HEADER(d3dx9math.h, have_d3dx9math_h=yes , have_d3dx9math_h=no , )
+
 dnl Utility function ============================
 
 # AC_CHECK_CXXFLAGS(ADDITIONAL-CXXFLAGS, ACTION-IF-FOUND, ACTION-IF-NOT-FOUND)


### PR DESCRIPTION
## What issue(s) does this PR address?
Fix OpenGL output is disabled in MinGW development builds.
Fixes #3814
