### PR TITLE
Fixed to display IME marked text in SDL2 version on macOS

### DIFF
--- a/src/gui/menu_macos.mm
+++ b/src/gui/menu_macos.mm
@@ -53,6 +53,29 @@ bool IME_GetEnable() {
     CFBooleanRef ret = (CFBooleanRef)TISGetInputSourceProperty(is, kTISPropertyInputSourceIsASCIICapable);
     return !CFBooleanGetValue(ret);
 }
+
+void IME_SetEnable(int state) {
+    if(state) {
+        NSString *locale;
+        NSArray *languages = [NSLocale preferredLanguages];
+        if (languages != nil) {
+            locale = [languages objectAtIndex:0];
+        } else {
+            locale = [[NSLocale currentLocale] objectForKey:NSLocaleLanguageCode];
+        }
+        TISInputSourceRef source = TISCopyInputSourceForLanguage((CFStringRef)locale);
+        if (source) {
+            TISSelectInputSource(source);
+        }
+    } else {
+        NSArray *source_list = CFBridgingRelease(TISCreateASCIICapableInputSourceList());
+        TISInputSourceRef source;
+        source = (__bridge TISInputSourceRef)([source_list firstObject]);
+        if (source) {
+            TISSelectInputSource(source);
+        }
+    }
+}
 #endif
 
 extern int pause_menu_item_tag;

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -4465,8 +4465,10 @@ static struct {
     /* Is that the extra backslash key ("less than" key) */
     /* on some keyboards with the 102-keys layout??      */
     {"lessthan",SDL_SCANCODE_NONUSBACKSLASH},
-#if !defined(MACOSX)
-#if (defined (WIN32) || defined (__linux__))
+#if defined(MACOSX)
+    {"jp_bckslash",SDL_SCANCODE_INTERNATIONAL1},
+    {"jp_yen",SDL_SCANCODE_INTERNATIONAL3},
+#elif (defined (WIN32) || defined (__linux__))
     /* Special handling for JP Keyboards */
     {"jp_bckslash",SDL_SCANCODE_INTERNATIONAL1}, // SDL2 returns same code as SDL_SCANCODE_NONUSBACKSLASH?
     {"jp_yen",SDL_SCANCODE_INTERNATIONAL3},
@@ -4474,7 +4476,6 @@ static struct {
     {"jp_henkan", SDL_SCANCODE_INTERNATIONAL4},
     {"jp_hiragana", SDL_SCANCODE_INTERNATIONAL2},
 #endif //(defined (WIN32) || defined (__linux__))
-#endif //!defined(MACOSX)
 #if 0
 #ifdef SDL_DOSBOX_X_SPECIAL
     /* hack for Japanese keyboards with \ and _ */

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5092,10 +5092,14 @@ void SetIMPosition() {
         uint8_t height = IS_PC98_ARCH?16:real_readb(BIOSMEM_SEG, BIOSMEM_CHAR_HEIGHT);
         uint8_t width = CurMode && DOSV_CheckCJKVideoMode() ? CurMode->cwidth : (height / 2);
         SDL_Rect rect;
+        rect.h = 0;
 #if defined(USE_TTF)
         if (ttf.inUse) {
             rect.x = x * ttf.width;
             rect.y = y * ttf.height + (ttf.height - TTF_FontAscent(ttf.SDL_font)) / 2;
+#if defined(MACOSX)
+            rect.h = ttf.height;
+#endif
         } else {
 #endif
             double sx = sdl.clip.w>0&&sdl.draw.width>0?((double)sdl.clip.w/sdl.draw.width):1, sy = sdl.clip.h>0&&sdl.draw.height>0?((double)sdl.clip.h/sdl.draw.height):1;
@@ -5104,6 +5108,9 @@ void SetIMPosition() {
 #if DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW /* SDL drawn menus */
             rect.y += mainMenu.menuBarHeight;
 #endif
+#if defined(MACOSX)
+            rect.h = height;
+#endif
 #if defined(USE_TTF)
         }
 #endif
@@ -5111,7 +5118,6 @@ void SetIMPosition() {
             rect.y--;
 #if defined(C_SDL2)
         rect.w = 0;
-        rect.h = 0;
         SDL_SetTextInputRect(&rect);
 #else
         SDL_SetIMPosition(rect.x, rect.y);

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -1166,6 +1166,16 @@ static bool IsEnhancedKey(uint16_t &key) {
 extern void IME_SetEnable(BOOL state);
 extern bool IME_GetEnable();
 #endif
+#if defined(MACOSX) && defined(C_SDL2) && defined(SDL_DOSBOX_X_IME)
+extern bool IME_GetEnable();
+extern void IME_SetEnable(int state);
+#ifndef TRUE
+#define TRUE 1
+#endif
+#ifndef FALSE
+#define FALSE 0
+#endif
+#endif
 
 extern bool DOS_BreakFlag;
 extern bool DOS_BreakConioFlag;
@@ -1316,7 +1326,7 @@ Bitu INT16_Handler(void) {
                 }
             }
         }
-#elif defined(WIN32) && !defined(HX_DOS) && defined(C_SDL2)
+#elif (defined(WIN32) && !defined(HX_DOS) || defined(MACOSX)) && defined(C_SDL2)
 #if defined(USE_TTF)
         if((IS_DOSV || ttf_dosv) && IS_DOS_CJK && (DOSV_GetFepCtrl() & DOSV_FEP_CTRL_IAS)) {
 #else

--- a/src/ints/int_dosv.cpp
+++ b/src/ints/int_dosv.cpp
@@ -1799,6 +1799,16 @@ static Bitu write_font24x24(void)
 	return CBRET_NONE;
 }
 
+#if defined(MACOSX) && defined(C_SDL2) && defined(SDL_DOSBOX_X_IME)
+extern bool IME_GetEnable();
+extern void IME_SetEnable(int state);
+#ifndef TRUE
+#define TRUE 1
+#endif
+#ifndef FALSE
+#define FALSE 0
+#endif
+#endif
 
 static Bitu mskanji_api(void)
 {
@@ -1837,14 +1847,14 @@ static Bitu mskanji_api(void)
 					real_writew(param_seg, param_off + 2, 0x0009);
 			}
 		}
-#elif defined(WIN32) && !defined(HX_DOS) && defined(C_SDL2)
+#elif (defined(WIN32) && !defined(HX_DOS) || defined(MACOSX)) && defined(C_SDL2)
 		if(mode & 0x8000) {
 			if(mode & 0x0001)
 				IME_SetEnable(FALSE);
 			else if(mode & 0x0002)
 				IME_SetEnable(TRUE);
 		} else {
-			if(IME_GetEnable() == NULL)
+			if(IME_GetEnable())
 				real_writew(param_seg, param_off + 2, 0x000a);
 			else
 				real_writew(param_seg, param_off + 2, 0x0009);
@@ -2283,14 +2293,14 @@ Bitu INT6F_Handler(void)
 	case 0x05:
 #if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
 		SDL_SetIMValues(SDL_IM_ONOFF, 1, NULL);
-#elif defined(WIN32) && !defined(HX_DOS) && defined(C_SDL2)
+#elif (defined(WIN32) && !defined(HX_DOS) || defined(MACOSX)) && defined(C_SDL2)
 		IME_SetEnable(TRUE);
 #endif
 		break;
 	case 0x0b:
 #if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
 		SDL_SetIMValues(SDL_IM_ONOFF, 0, NULL);
-#elif defined(WIN32) && !defined(HX_DOS) && defined(C_SDL2)
+#elif (defined(WIN32) && !defined(HX_DOS) || defined(MACOSX)) && defined(C_SDL2)
 		IME_SetEnable(FALSE);
 #endif
 		break;
@@ -2304,7 +2314,7 @@ Bitu INT6F_Handler(void)
 					reg_al = 0x01;
 				}
 			}
-#elif defined(WIN32) && !defined(HX_DOS) && defined(C_SDL2)
+#elif (defined(WIN32) && !defined(HX_DOS) || defined(MACOSX)) && defined(C_SDL2)
 			if(IME_GetEnable()) {
 				reg_al = 0x01;
 			}


### PR DESCRIPTION
Fixed display of IME marked text on macOS.
Marked text in macOS is described as a composition string in Windows.
![macime](https://user-images.githubusercontent.com/42603716/202832894-287082eb-0962-4a00-a76a-89e35512cdad.png)
"漢字の入力" above the conversion candidates is the marked text.
Fixed to be able to turn on/off IME with $IAS and MS-KANJI API on macOS.
Fixed to be able to input yen and underscore with Japanese keyboard on macOS.

The mac I got was an old Intel machine, so please check if it works with ARM machine and the latest OS.
