### PR TITLE
Fix allocation of IDE slots when mounting images by IMGMOUNT

### DIFF
--- a/include/ide.h
+++ b/include/ide.h
@@ -17,5 +17,6 @@ void IDE_CDROM_Detach_Ret(signed char &indexret,bool &slaveret,unsigned char dri
 void IDE_Hard_Disk_Attach(signed char index,bool slave,unsigned char bios_disk_index);
 void IDE_Hard_Disk_Detach(unsigned char bios_disk_index);
 void IDE_ResetDiskByBIOS(unsigned char disk);
+bool IDE_controller_occupied(signed char index, bool slave);
 
 #endif

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -4893,6 +4893,7 @@ public:
         std::string el_torito;
         std::string ideattach="auto";
         std::string type="hdd";
+        uint8_t tdr;
 	std::string bdisk;
 	int bdisk_number=-1;
 
@@ -4903,7 +4904,7 @@ public:
             ((temp_line.size()>1) && (temp_line[1]!=':'))) {
             // drive not valid
         } else {
-            uint8_t tdr = toupper(temp_line[0]);
+            tdr = toupper(temp_line[0]);
             if(tdr=='A'||tdr=='B'||tdr=='0'||tdr=='1') type="floppy";
         }
 
@@ -4975,12 +4976,18 @@ public:
         cmd->FindString("-ide",ideattach,true);
 		std::transform(ideattach.begin(), ideattach.end(), ideattach.begin(), ::tolower);
 
-        if (ideattach == "auto") {
-            if (type != "floppy") {
-                IDE_Auto(ide_index,ide_slave);
+        if(ideattach == "auto") {
+            //LOG_MSG("IDE: attach=auto type=%s", type);
+            if(type != "floppy") {
+                if(type == "iso") {
+                    if(!IDE_controller_occupied(1, false)) { // CD-ROMS default to secondary master if not occupied
+                        ide_index = 1;
+                        ide_slave = false;
+                    }
+                }
+                if (ide_index < 0) IDE_Auto(ide_index, ide_slave);
+                LOG_MSG("IDE: index %d slave=%d", ide_index, ide_slave ? 1 : 0);
             }
-                
-            LOG_MSG("IDE: index %d slave=%d",ide_index,ide_slave?1:0);
         }
         else if (ideattach != "none" && isdigit(ideattach[0]) && ideattach[0] > '0') { /* takes the form [controller]<m/s> such as: 1m for primary master */
             ide_index = ideattach[0] - '1';
@@ -5072,6 +5079,14 @@ public:
 				if (!strcasecmp(ext, ".iso")||!strcasecmp(ext, ".cue")||!strcasecmp(ext, ".bin")||!strcasecmp(ext, ".chd")||!strcasecmp(ext, ".mdf")||!strcasecmp(ext, ".gog")||!strcasecmp(ext, ".ins")) {
 					type="iso";
 					fstype="iso";
+                    if(ide_index < 0 || ideattach == "auto") {
+                        if(!IDE_controller_occupied(1, false)) { // check if secondary master is already occupied
+                            ide_index = 1;
+                            ide_slave = false;
+                        }
+                        else IDE_Auto(ide_index, ide_slave);
+                        LOG_MSG("IDE: index %d slave=%d", ide_index, ide_slave ? 1 : 0);
+                    }
 				} else if (!strcasecmp(ext, ".ima")) {
 					type="floppy";
 					ideattach="none";

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -4976,7 +4976,11 @@ public:
         cmd->FindString("-ide",ideattach,true);
 		std::transform(ideattach.begin(), ideattach.end(), ideattach.begin(), ::tolower);
 
-        if(ideattach == "auto") {
+        if(isdigit(tdr) && tdr - '0' >= 2) { //Allocate to respective slots if drive number is specified
+            ide_index = (tdr - '2') / 2;     // Drive number 2 = 1m (index=0, slave=false), 3 = 1s (index=0, slave=true), ...
+            ide_slave = (tdr - '2') & 1 ? true : false;
+            LOG_MSG("IDE: index %d slave=%d", ide_index, ide_slave ? 1 : 0);
+        } else if(ideattach == "auto") {
             //LOG_MSG("IDE: attach=auto type=%s", type);
             if(type != "floppy") {
                 if(type == "iso") {

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -2648,7 +2648,7 @@ void IDE_Auto(signed char &index,bool &slave) {
     slave = false;
     for (i=0;i < MAX_IDE_CONTROLLERS;i++) {
         IDEController* c;
-        if ((c=idecontroller[i]) == NULL) continue;
+        if((c = idecontroller[i]) == NULL) continue;
         index = (signed char)i;
 
         if (c->device[0] == NULL) {
@@ -2659,6 +2659,16 @@ void IDE_Auto(signed char &index,bool &slave) {
             slave = true;
             break;
         }
+    }
+}
+
+bool IDE_controller_occupied(signed char index, bool slave) { // Return true if specified slot is occupied 
+    const uint8_t ide_device = slave ? 1 : 0;
+    if(idecontroller[index]->device[ide_device] == NULL) {
+        return false;
+    }
+    else {
+        return true;
     }
 }
 


### PR DESCRIPTION
## What issue(s) does this PR address?
When mounting CD images on Windows, there are many cases that it isn't recognized due to the IDE slot it is mounted. (The default is currently the first available slot starting from Primary-Master).
This PR makes CD images to be mounted to Secondary - Master if it is not occupied, which is known to work quite well.
It maybe also worth mentioned that PC-98 mostly assume that IDE CD-ROM drive is connected to Secondary-Master.

Also, according to the Wiki, the slot to be mounted when device number is specified is fixed.
This PR allocates the slot accordingly to what it is mentioned in the Wiki.

https://github.com/joncampbell123/dosbox-x/wiki/Guide:Managing-image-files-in-DOSBox%E2%80%90X#mounting-harddisk-images

Fixes #3418
Fixes #3739 
## Additional information

I personally tested on Windows VS and MinGW builds.