### PR TITLE
IME input support in SDL1 version of macOS

### DIFF
--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -166,6 +166,9 @@ struct SDL_Block {
     uint32_t focus_ticks = 0;
     uint32_t ime_ticks;
 #endif
+#if defined(MACOSX)
+	uint32_t ime_ticks;
+#endif
     // state of alt-keys for certain special handlings
     uint16_t laltstate = 0, raltstate = 0;
     uint16_t lctrlstate = 0, rctrlstate = 0;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -941,7 +941,7 @@ void SetCyclesCount_mapper_shortcut(bool pressed) {
 }
 
 void SetIME() {
-#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
+#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11 || defined(MACOSX)) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
     if (enableime && !control->opt_silent) {
         dos.im_enable_flag = true;
         SDL_SetIMValues(SDL_IM_ENABLE, 1, NULL);

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -890,7 +890,7 @@ static SDLKey sdlkey_map[]={
     /*52-57*/ SDLK_KP0, SDLK_KP1, SDLK_KP2, SDLK_KP3, SDLK_KP4, SDLK_KP5, 
     /*58-5C*/ SDLK_KP6, SDLK_KP7, Z, SDLK_KP8, SDLK_KP9, 
 
-    /*5D-5F*/ Z, Z, SDLK_a,
+	/*5D-5F*/ SDLK_WORLD_1, SDLK_UNDERSCORE, SDLK_a,
     
     /* Function keys and cursor blocks (F13 not supported, F14 =>
      * PRINT[SCREEN], F15 => SCROLLOCK, F16 => PAUSE, HELP => INSERT) */
@@ -4567,11 +4567,16 @@ static struct {
     // TODO??
 #else
 #ifdef SDL_DOSBOX_X_SPECIAL
+#if defined(MACOSX)
+    {"jp_bckslash",SDLK_UNDERSCORE},
+    {"jp_yen",SDLK_WORLD_1 },
+#else
     /* hack for Japanese keyboards with \ and _ */
     {"jp_bckslash",SDLK_JP_RO}, // Same difference
     {"jp_ro",SDLK_JP_RO}, // DOSBox proprietary
     /* hack for Japanese keyboards with Yen and | */
     {"jp_yen",SDLK_JP_YEN },
+#endif
 #endif
     /* more */
     {"jp_hankaku", SDLK_WORLD_12 },

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -5829,7 +5829,7 @@ static Bitu INT8_Handler(void) {
     mem_writed(BIOS_TIMER,value);
 
 	if(bootdrive>=0) {
-#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11 || defined(MACOSX) && defined(SDL_DOSBOX_X_IME)) && (defined(C_SDL2) || defined(SDL_DOSBOX_X_SPECIAL))
+#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11 || defined(MACOSX)) && (defined(C_SDL2) || defined(SDL_DOSBOX_X_SPECIAL))
         SetIMPosition();
 #endif
     } else if (IS_DOSV && DOSV_CheckCJKVideoMode()) {
@@ -5837,7 +5837,7 @@ static Bitu INT8_Handler(void) {
     } else if(J3_IsJapanese()) {
         INT8_J3();
     } else if (IS_DOS_CJK) {
-#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11 || defined(MACOSX) && defined(SDL_DOSBOX_X_IME)) && (defined(C_SDL2) || defined(SDL_DOSBOX_X_SPECIAL))
+#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11 || defined(MACOSX)) && (defined(C_SDL2) || defined(SDL_DOSBOX_X_SPECIAL))
         SetIMPosition();
 #endif
     }

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -1306,7 +1306,7 @@ Bitu INT16_Handler(void) {
                  (mem_readb(BIOS_KEYBOARD_FLAGS3)&0x0c);    // Right Ctrl/Alt pressed, bits 2,3
         break;
     case 0x13:
-#if defined(WIN32) && !defined(HX_DOS) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
+#if (defined(WIN32) && !defined(HX_DOS) || defined(MACOSX)) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
 #if defined(USE_TTF)
         if((IS_DOSV || ttf_dosv) && IS_DOS_CJK && (DOSV_GetFepCtrl() & DOSV_FEP_CTRL_IAS)) {
 #else

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -2372,15 +2372,17 @@ extern void IME_SetFontSize(int size);
 void AdjustIMEFontSize()
 {
 	int cheight = CurMode->cheight;
+#if !defined(MACOSX)
 	if(IS_DOSV && cheight == 19) {
 		cheight = 16;
 	}
+#endif
 #if defined(USE_TTF)
 	if(dos.im_enable_flag && ttf.inUse) {
 		cheight = TTF_FontAscent(ttf.SDL_font);
 	}
 #endif
-#if defined(WIN32) && !defined(HX_DOS) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
+#if (defined(WIN32) && !defined(HX_DOS) || defined(MACOSX)) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
 	SDL_SetIMValues(SDL_IM_FONT_SIZE, cheight, NULL);
 #elif defined(WIN32) && !defined(HX_DOS) && defined(C_SDL2)
 	IME_SetFontSize(cheight);

--- a/src/ints/int_dosv.cpp
+++ b/src/ints/int_dosv.cpp
@@ -1832,7 +1832,7 @@ static Bitu mskanji_api(void)
 		real_writeb(kk_seg, kk_off + 5, 0);
 		reg_ax = 0;
 	} else if(func == 5) {
-#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
+#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11 || defined(MACOSX)) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
 		if(mode & 0x8000) {
 			if(mode & 0x0001)
 				SDL_SetIMValues(SDL_IM_ONOFF, 0, NULL);
@@ -2065,7 +2065,7 @@ uint8_t GetKanjiAttr()
 
 void INT8_DOSV()
 {
-#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11 || defined(MACOSX) && defined(SDL_DOSBOX_X_IME)) && (defined(C_SDL2) || defined(SDL_DOSBOX_X_SPECIAL))
+#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11 || defined(MACOSX)) && (defined(C_SDL2) || defined(SDL_DOSBOX_X_SPECIAL))
 	SetIMPosition();
 #endif
 	if(!CheckAnotherDisplayDriver() && real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE) != 0x72 && real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE) != 0x12) {
@@ -2291,14 +2291,14 @@ Bitu INT6F_Handler(void)
 	case 0x03:
 	case 0x04:
 	case 0x05:
-#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
+#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11 || defined(MACOSX)) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
 		SDL_SetIMValues(SDL_IM_ONOFF, 1, NULL);
 #elif (defined(WIN32) && !defined(HX_DOS) || defined(MACOSX)) && defined(C_SDL2)
 		IME_SetEnable(TRUE);
 #endif
 		break;
 	case 0x0b:
-#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
+#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11 || defined(MACOSX)) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
 		SDL_SetIMValues(SDL_IM_ONOFF, 0, NULL);
 #elif (defined(WIN32) && !defined(HX_DOS) || defined(MACOSX)) && defined(C_SDL2)
 		IME_SetEnable(FALSE);
@@ -2307,7 +2307,7 @@ Bitu INT6F_Handler(void)
 	case 0x66:
 		{
 			reg_al = 0x00;
-#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
+#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11 || defined(MACOSX)) && !defined(C_SDL2) && defined(SDL_DOSBOX_X_SPECIAL)
 			int onoff;
 			if(SDL_GetIMValues(SDL_IM_ONOFF, &onoff, NULL) == NULL) {
 				if(onoff) {
@@ -2534,7 +2534,7 @@ void J3_OffCursor()
 
 void INT8_J3()
 {
-#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11 || defined(MACOSX) && defined(SDL_DOSBOX_X_IME)) && (defined(C_SDL2) || defined(SDL_DOSBOX_X_SPECIAL))
+#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11 || defined(MACOSX)) && (defined(C_SDL2) || defined(SDL_DOSBOX_X_SPECIAL))
 	SetIMPosition();
 #endif
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -992,7 +992,7 @@ void DOS_Shell::Prepare(void) {
         initcodepagefont();
         dos.loaded_codepage=cp;
     }
-#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11 || defined(MACOSX) && defined(SDL_DOSBOX_X_IME)) && (defined(C_SDL2) || defined(SDL_DOSBOX_X_SPECIAL))
+#if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11 || defined(MACOSX)) && (defined(C_SDL2) || defined(SDL_DOSBOX_X_SPECIAL))
     if (enableime) SetIMPosition();
 #endif
 }

--- a/vs/sdl/include/SDL_platform.h
+++ b/vs/sdl/include/SDL_platform.h
@@ -71,6 +71,7 @@
 #if defined(__APPLE__)
 #undef __MACOSX__
 #define __MACOSX__	1
+#define ENABLE_IM_EVENT 1
 #elif defined(macintosh)
 #undef __MACOS__
 #define __MACOS__	1

--- a/vs/sdl/include/SDL_platform.h.default
+++ b/vs/sdl/include/SDL_platform.h.default
@@ -71,6 +71,7 @@
 #if defined(__APPLE__)
 #undef __MACOSX__
 #define __MACOSX__	1
+#define ENABLE_IM_EVENT 1
 #elif defined(macintosh)
 #undef __MACOS__
 #define __MACOS__	1

--- a/vs/sdl/include/SDL_syswm.h
+++ b/vs/sdl/include/SDL_syswm.h
@@ -226,6 +226,11 @@ typedef struct SDL_SysWMinfo {
 	int data;
 } SDL_SysWMinfo;
 
+#ifdef ENABLE_IM_EVENT
+struct SDL_SysIMinfo;
+typedef struct SDL_SysIMinfo SDL_SysIMinfo;
+#endif
+
 #endif /* video driver type */
 
 #endif /* SDL_PROTOTYPES_ONLY */

--- a/vs/sdl/src/video/quartz/SDL_QuartzVideo.h
+++ b/vs/sdl/src/video/quartz/SDL_QuartzVideo.h
@@ -88,6 +88,7 @@
 /* use this to get the CGLContext; it handles Cocoa interface changes. */
 CGLContextObj QZ_GetCGLContextObj(NSOpenGLContext *nsctx);
 
+@class SDLTranslatorResponder;
 
 /* Main driver structure to store required state information */
 typedef struct SDL_PrivateVideoData {
@@ -114,7 +115,7 @@ typedef struct SDL_PrivateVideoData {
     SDL_Rect           **client_mode_list; /* resolution list to pass back to client */
     SDLKey             keymap[256];        /* Mac OS X to SDL key mapping */
     Uint32             current_mods;       /* current keyboard modifiers, to track modifier state */
-    NSText             *field_edit;        /* a field editor for keyboard composition processing */
+    SDLTranslatorResponder *field_edit;        /* a field editor for keyboard composition processing */
     Uint32             last_virtual_button;/* last virtual mouse button pressed */
     io_connect_t       power_connection;   /* used with IOKit to detect wake from sleep */
     Uint8              expect_mouse_up;    /* used to determine when to send mouse up events */
@@ -129,6 +130,7 @@ typedef struct SDL_PrivateVideoData {
     BOOL               quit_thread;        /* used to quit the async blitting thread */
     SInt32             system_version;     /* used to dis-/enable workarounds depending on the system version */
 
+    BOOL               ime_enable;
     void *opengl_library;    /* dynamically loaded OpenGL library. */
 } SDL_PrivateVideoData;
 
@@ -173,6 +175,7 @@ typedef struct SDL_PrivateVideoData {
 #define quit_thread (this->hidden->quit_thread)
 #define system_version (this->hidden->system_version)
 #define opengl_library (this->hidden->opengl_library)
+#define ime_enable (this->hidden->ime_enable)
 
 /* grab states - the input is in one of these states */
 enum {
@@ -234,3 +237,9 @@ void         QZ_PrivateCocoaToSDL (_THIS, NSPoint *p);
 BOOL         QZ_IsMouseInWindow (_THIS);
 void         QZ_DoActivate (_THIS);
 void         QZ_DoDeactivate (_THIS);
+
+int QZ_SetIMPosition(_THIS, int x, int y);
+char *QZ_SetIMValues(_THIS, SDL_imvalue value, int alt);
+char *QZ_GetIMValues(_THIS, SDL_imvalue value, int *alt);
+int QZ_FlushIMString(_THIS, void *buffer);
+


### PR DESCRIPTION
Modified to support IME input on SDL1 version of macOS.
Fixed SDL1 version of macOS for input of yen and underscore.
