### PR TITLE
Fixed command+Q not working when IME ON in macOS.

### DIFF
--- a/vs/sdl/src/video/quartz/SDL_QuartzEvents.m
+++ b/vs/sdl/src/video/quartz/SDL_QuartzEvents.m
@@ -356,10 +356,12 @@ static void QZ_DoKey (_THIS, int state, NSEvent *event) {
         the scancode/keysym.
     */
     if (state == SDL_PRESSED && GetEnableIME()) {
-        [field_edit interpretKeyEvents:[NSArray arrayWithObject:event]];
-        chars = [ event characters ];
-        numChars = [ chars length ];
-        return;
+        if(!(SDL_GetModState() & (KMOD_LMETA | KMOD_RMETA)) || [event keyCode] != 12) {
+            [field_edit interpretKeyEvents:[NSArray arrayWithObject:event]];
+            chars = [ event characters ];
+            numChars = [ chars length ];
+            return;
+        }
     } else {
         numChars = 0;
     }


### PR DESCRIPTION
Fixed command+Q not working when IME ON in macOS.
SDL2 version seems to work, so only SDL1 version is fixed.