### PR TITLE
Fix unexpected behavior of swapping multiple CD images

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -112,6 +112,8 @@ Unreleased
     IMGMOUNT (maron2000)
   - Increase of sprintf buffer size in Program::WriteOut()
     (caiiiycuk)
+  - Fix unexpected behavior of swapping multiple CD images
+    (maron2000)
 
 2022.09.0 (0.84.3)
   - Updated FFMPEG video capture to use newer API,

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -2329,12 +2329,12 @@ void isoDrive :: EmptyCache(void) {
 	enable_rock_ridge = dos.version.major >= 7 || uselfn;
 	enable_joliet = dos.version.major >= 7 || uselfn;
 	is_joliet = false;
-	this->fileName[0]  = '\0';
-	this->discLabel[0] = '\0';
+	//this->fileName[0]  = '\0';
+	//this->discLabel[0] = '\0';
 	nextFreeDirIterator = 0;
 	memset(dirIterators, 0, sizeof(dirIterators));
 	memset(sectorHashEntries, 0, sizeof(sectorHashEntries));
 	memset(&rootEntry, 0, sizeof(isoDirEntry));
-	safe_strncpy(this->fileName, fileName, CROSS_LEN);
+	//safe_strncpy(this->fileName, fileName, CROSS_LEN);
 	loadImage();
 }

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -2329,12 +2329,12 @@ void isoDrive :: EmptyCache(void) {
 	enable_rock_ridge = dos.version.major >= 7 || uselfn;
 	enable_joliet = dos.version.major >= 7 || uselfn;
 	is_joliet = false;
-	//this->fileName[0]  = '\0';
-	//this->discLabel[0] = '\0';
+	//this->fileName[0]  = '\0'; /* deleted to fix issue #3848. Revert this if there are any flaws */
+	//this->discLabel[0] = '\0'; /* deleted to fix issue #3848. Revert this if there are any flaws */
 	nextFreeDirIterator = 0;
 	memset(dirIterators, 0, sizeof(dirIterators));
 	memset(sectorHashEntries, 0, sizeof(sectorHashEntries));
 	memset(&rootEntry, 0, sizeof(isoDirEntry));
-	//safe_strncpy(this->fileName, fileName, CROSS_LEN);
+	//safe_strncpy(this->fileName, fileName, CROSS_LEN); /* deleted to fix issue #3848. Revert this if there are any flaws */
 	loadImage();
 }


### PR DESCRIPTION
Swapping multiple CD images works but if an image is swapped for the second time, it fails. This PR fixes such failure.

## What issue(s) does this PR address?

Fixes #3848 


