### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -647,6 +647,11 @@ dnl LIBRARY TEST: libiconv
 dnl This may be provided by glibc itself, -liconv may not be needed.
 AC_CHECK_HEADER(iconv.h,have_iconv_h=yes,)
 AC_CHECK_LIB(iconv, libiconv_open, have_iconv_lib=yes, ,-liconv)
+case "$host" in
+  *-*-openbsd*)
+    LIBS="$LIBS -liconv"
+    ;;
+esac
 
 dnl LIBRARY TEST: SDLnet
 AC_CHECK_HEADER(SDL_net.h,have_sdl_net_h=yes,)

--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -3837,10 +3837,10 @@ public:
 			if (s != NULL && *s != 0) {
 				const char *os = s;
 
-				while (*s != NULL && o < 12) cpu_custom_cpuid[o++] = *s++;
+				while (*s != 0 && o < 12) cpu_custom_cpuid[o++] = *s++;
 				while (o < 12) cpu_custom_cpuid[o++] = ' ';
 
-				if (*s != NULL && o == 12)
+				if (*s != 0 && o == 12)
 					LOG_MSG("WARNING: CPUID string '%s' truncated. Maximum 12 characters",os);
 			}
 		}

--- a/src/gui/whereami.c
+++ b/src/gui/whereami.c
@@ -12,6 +12,15 @@
 extern "C" {
 #endif
 
+#if defined(__linux__) || defined(__CYGWIN__)
+#undef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE
+#elif defined(__APPLE__)
+#undef _DARWIN_C_SOURCE
+#define _DARWIN_C_SOURCE
+#define _DARWIN_BETTER_REALPATH
+#endif
+
 #if !defined(WAI_MALLOC) || !defined(WAI_FREE) || !defined(WAI_REALLOC)
 #include <stdlib.h>
 #endif
@@ -59,6 +68,7 @@ extern "C" {
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
+#include <stdbool.h>
 
 static int WAI_PREFIX(getModulePath_)(HMODULE module, char* out, int capacity, int* dirname_length)
 {
@@ -66,8 +76,9 @@ static int WAI_PREFIX(getModulePath_)(HMODULE module, char* out, int capacity, i
   wchar_t buffer2[MAX_PATH];
   wchar_t* path = NULL;
   int length = -1;
+  bool ok;
 
-  for (;;)
+  for (ok = false; !ok; ok = true)
   {
     DWORD size;
     int length_, length__;
@@ -123,14 +134,12 @@ static int WAI_PREFIX(getModulePath_)(HMODULE module, char* out, int capacity, i
     }
 
     length = length__;
-
-    break;
   }
 
   if (path != buffer1)
     WAI_FREE(path);
 
-  return length;
+  return ok ? length : -1;
 }
 
 WAI_NOINLINE WAI_FUNCSPEC
@@ -160,7 +169,7 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
   return length;
 }
 
-#elif defined(__linux__) || defined(__CYGWIN__) || defined(__sun) || defined(EMSCRIPTEN) || defined(WAI_USE_PROC_SELF_EXE)
+#elif defined(__linux__) || defined(__CYGWIN__) || defined(__sun) || defined(WAI_USE_PROC_SELF_EXE)
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -174,6 +183,7 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
 #define __STDC_FORMAT_MACROS
 #endif
 #include <inttypes.h>
+#include <stdbool.h>
 
 #if !defined(WAI_PROC_SELF_EXE)
 #if defined(__sun)
@@ -189,8 +199,9 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
   char buffer[PATH_MAX];
   char* resolved = NULL;
   int length = -1;
+  bool ok;
 
-  for (;;)
+  for (ok = false; !ok; ok = true)
   {
     resolved = realpath(WAI_PROC_SELF_EXE, buffer);
     if (!resolved)
@@ -215,11 +226,9 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
         }
       }
     }
-
-    break;
   }
 
-  return length;
+  return ok ? length : -1;
 }
 
 #if !defined(WAI_PROC_SELF_MAPS_RETRY)
@@ -239,6 +248,7 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
 #include <sys/mman.h>
 #include <unistd.h>
 #endif
+#include <stdbool.h>
 
 WAI_NOINLINE WAI_FUNCSPEC
 int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
@@ -265,11 +275,7 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
       if (!fgets(buffer, sizeof(buffer), maps))
         break;
 
-#if !defined(PRIx64)
-#define PRIx64 "lx"
-#endif
-      std::string format = std::string("%") + PRIx64 + std::string("-%") + PRIx64 + std::string(" %s %") + PRIx64 + std::string(" %x:%x %u %s\n");
-      if (sscanf(buffer, format.c_str(), &low, &high, perms, &offset, &major, &minor, &inode, path) == 8)
+      if (sscanf(buffer, "%" PRIx64 "-%" PRIx64 " %s %" PRIx64 " %x:%x %u %s\n", &low, &high, perms, &offset, &major, &minor, &inode, path) == 8)
       {
         uint64_t addr = (uintptr_t)WAI_RETURN_ADDRESS();
         if (low <= addr && addr <= high)
@@ -358,20 +364,17 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
       break;
   }
 
-  if (maps)
-    fclose(maps);
-
   return length;
 }
 
 #elif defined(__APPLE__)
 
-#define _DARWIN_BETTER_REALPATH
 #include <mach-o/dyld.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <dlfcn.h>
+#include <stdbool.h>
 
 WAI_FUNCSPEC
 int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
@@ -381,8 +384,9 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
   char* path = buffer1;
   char* resolved = NULL;
   int length = -1;
+  bool ok;
 
-  for (;;)
+  for (ok = false; !ok; ok = true)
   {
     uint32_t size = (uint32_t)sizeof(buffer1);
     if (_NSGetExecutablePath(path, &size) == -1)
@@ -415,14 +419,12 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
         }
       }
     }
-
-    break;
   }
 
   if (path != buffer1)
     WAI_FREE(path);
 
-  return length;
+  return ok ? length : -1;
 }
 
 WAI_NOINLINE WAI_FUNCSPEC
@@ -476,6 +478,7 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
 #include <stdlib.h>
 #include <string.h>
 #include <dlfcn.h>
+#include <stdbool.h>
 
 #if !defined(WAI_PROC_SELF_EXE)
 #define WAI_PROC_SELF_EXE "/proc/self/exefile"
@@ -489,8 +492,9 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
   char* resolved = NULL;
   FILE* self_exe = NULL;
   int length = -1;
+  bool ok;
 
-  for (;;)
+  for (ok = false; !ok; ok = true)
   {
     self_exe = fopen(WAI_PROC_SELF_EXE, "r");
     if (!self_exe)
@@ -522,13 +526,11 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
         }
       }
     }
-
-    break;
   }
 
   fclose(self_exe);
 
-  return length;
+  return ok ? length : -1;
 }
 
 WAI_FUNCSPEC
@@ -576,7 +578,7 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
 }
 
 #elif defined(__DragonFly__) || defined(__FreeBSD__) || \
-      defined(__FreeBSD_kernel__) || defined(__NetBSD__)
+      defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__OpenBSD__)
 
 #include <limits.h>
 #include <stdlib.h>
@@ -584,6 +586,116 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #include <dlfcn.h>
+#include <stdbool.h>
+
+#if defined(__OpenBSD__)
+
+#include <unistd.h>
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer1[4096];
+  char buffer2[PATH_MAX];
+  char buffer3[PATH_MAX];
+  char** argv = (char**)buffer1;
+  char* resolved = NULL;
+  int length = -1;
+  bool ok;
+
+  for (ok = false; !ok; ok = true)
+  {
+    int mib[4] = { CTL_KERN, KERN_PROC_ARGS, getpid(), KERN_PROC_ARGV };
+    size_t size;
+
+    if (sysctl(mib, 4, NULL, &size, NULL, 0) != 0)
+        break;
+
+    if (size > sizeof(buffer1))
+    {
+      argv = (char**)WAI_MALLOC(size);
+      if (!argv)
+        break;
+    }
+
+    if (sysctl(mib, 4, argv, &size, NULL, 0) != 0)
+        break;
+
+    if (strchr(argv[0], '/'))
+    {
+      resolved = realpath(argv[0], buffer2);
+      if (!resolved)
+        break;
+    }
+    else
+    {
+      const char* PATH = getenv("PATH");
+      if (!PATH)
+        break;
+
+      size_t argv0_length = strlen(argv[0]);
+
+      const char* begin = PATH;
+      while (1)
+      {
+        const char* separator = strchr(begin, ':');
+        const char* end = separator ? separator : begin + strlen(begin);
+
+        if (end - begin > 0)
+        {
+          if (*(end -1) == '/')
+            --end;
+
+          if (((end - begin) + 1 + argv0_length + 1) <= sizeof(buffer2))
+          {
+            memcpy(buffer2, begin, end - begin);
+            buffer2[end - begin] = '/';
+            memcpy(buffer2 + (end - begin) + 1, argv[0], argv0_length + 1);
+
+            resolved = realpath(buffer2, buffer3);
+            if (resolved)
+              break;
+          }
+        }
+
+        if (!separator)
+          break;
+
+        begin = ++separator;
+      }
+
+      if (!resolved)
+        break;
+    }
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  if (argv != (char**)buffer1)
+    WAI_FREE(argv);
+
+  return ok ? length : -1;
+}
+
+#else
 
 WAI_FUNCSPEC
 int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
@@ -593,8 +705,9 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
   char* path = buffer1;
   char* resolved = NULL;
   int length = -1;
+  bool ok;
 
-  for (;;)
+  for (ok = false; !ok; ok = true)
   {
 #if defined(__NetBSD__)
     int mib[4] = { CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME };
@@ -603,7 +716,7 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
 #endif
     size_t size = sizeof(buffer1);
 
-    if (sysctl(mib, (u_int)(sizeof(mib) / sizeof(mib[0])), path, &size, NULL, 0) != 0)
+    if (sysctl(mib, 4, path, &size, NULL, 0) != 0)
         break;
 
     resolved = realpath(path, buffer2);
@@ -629,15 +742,12 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
         }
       }
     }
-
-    break;
   }
 
-  if (path != buffer1)
-    WAI_FREE(path);
-
-  return length;
+  return ok ? length : -1;
 }
+
+#endif
 
 WAI_NOINLINE WAI_FUNCSPEC
 int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -1325,7 +1325,7 @@ OPL_Mode Module::oplmode=OPL_none;
 }	//Adlib Namespace
 
 std::string getoplmode() {
-#if !defined(__FreeBSD__)
+#if !defined(__FreeBSD__) && !defined(__OpenBSD__)
 	// Todo: is this needed at all? opmode cannot be null...
 	if (Adlib::Module::oplmode == NULL || Adlib::Module::oplmode == OPL_none) return "None";
 #else

--- a/src/hardware/voodoo_opengl.cpp
+++ b/src/hardware/voodoo_opengl.cpp
@@ -549,7 +549,7 @@ void voodoo_ogl_invalidate_paltex(void) {
 }
 
 
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 GLhandleARB m_hProgramObject   = (GLhandleARB)0;
 #else
 GLhandleARB m_hProgramObject   = (GLhandleARB)NULL;

--- a/src/misc/regionalloctracking.cpp
+++ b/src/misc/regionalloctracking.cpp
@@ -22,7 +22,7 @@
 #include "regionalloctracking.h"
 #include "parport.h"
 #include <time.h>
-#if !defined(ANDROID) && !defined(__ANDROID__)
+#if !defined(ANDROID) && !defined(__ANDROID__) && !defined(__OpenBSD__)
 /* Newer NDKs doesn't have this header.
    It doesn't matter anyway */
 #include <sys/timeb.h>

--- a/src/misc/savestates.cpp
+++ b/src/misc/savestates.cpp
@@ -17,7 +17,7 @@
 #ifdef WIN32
 #include "direct.h"
 #endif
-#if defined (__APPLE__)
+#if defined (__OpenBSD__) || defined (__APPLE__)
 #else
 #include <malloc.h>
 #endif

--- a/src/output/output_surface.cpp
+++ b/src/output/output_surface.cpp
@@ -19,7 +19,7 @@ void X11_ErrorHandlerInstall(void);
 
 void OUTPUT_SURFACE_Initialize()
 {
-#if C_X11
+#if C_X11 && defined(LINUX)
     // Apparently if the window size changes rapidly enough, SDL2 can be tricked into
     // blitting the wrong dimensions to the window and trigger an X11 BadValue error.
     // Set up an error handler that prints the error to STDERR and then returns,


### PR DESCRIPTION
Hello, this change will fix the build of DosBox-X on OpenBSD.
- Update `whereami` to its latest version.
- Change `configure.ac` to always link with `iconv` on OpenBSD.
- Fix some `NULL` issues for OpenBSD.
- Only call `X11_ErrorHandlerInstall` on Linux.