### PR TITLE
Machine_type -> Machine_Type in savestates.cpp

### DIFF
--- a/src/misc/savestates.cpp
+++ b/src/misc/savestates.cpp
@@ -1217,7 +1217,7 @@ void SaveState::save(size_t slot) { //throw (Error)
 			}
 
 			if(!create_machinetype) {
-				std::string tempname = temp+"Machine_type";
+				std::string tempname = temp+"Machine_Type";
 				std::ofstream machinetype (tempname.c_str(), std::ofstream::binary);
 				machinetype << getType();
 				create_machinetype=true;


### PR DESCRIPTION
The `Machine_type` should be `Machine_Type` otherwise it breaks save/load feature in browser (maybe also on *nix)