### PR TITLE
Fix internal sdlnet build on macOS, enables nullmodem/modem support on macOS for SDL1 builds

### DIFF
--- a/build-debug-macos
+++ b/build-debug-macos
@@ -16,11 +16,9 @@ chmod +x vs/sdl/build-scripts/strip_fPIC.sh
 echo Compiling our internal SDL 1.x
 (cd vs/sdl && ./build-dosbox.sh) || exit 1
 
-# FIXME: SDLnet will compile a static library that targets a foreign architecture,
-#        and then ld will complain about it????????
 # prefer to compile against our own copy of SDLnet 1.x
-#echo Compiling our internal SDLnet 1.x
-#(cd vs/sdlnet && ./build-dosbox.sh) || exit 1
+echo Compiling our internal SDLnet 1.x
+(cd vs/sdlnet && ./build-dosbox.sh) || exit 1
 
 # prefer to compile against our own zlib
 echo Compiling our internal zlib

--- a/build-macos
+++ b/build-macos
@@ -22,11 +22,9 @@ export LDFLAGS="$nld$LDFLAGS"
 export CPPFLAGS="$new$CPPFLAGS"
 export CXXFLAGS="$new$CXXFLAGS"
 
-# FIXME: SDLnet will compile a static library that targets a foreign architecture,
-#        and then ld will complain about it????????
 # prefer to compile against our own copy of SDLnet 1.x
-#echo Compiling our internal SDLnet 1.x
-#(cd vs/sdlnet && ./build-dosbox.sh) || exit 1
+echo Compiling our internal SDLnet 1.x
+(cd vs/sdlnet && ./build-dosbox.sh) || exit 1
 
 # prefer to compile against our own zlib
 echo Compiling our internal zlib

--- a/vs/sdlnet/build-dosbox.sh
+++ b/vs/sdlnet/build-dosbox.sh
@@ -51,3 +51,7 @@ if [ "$1" == "hx-dos" ]; then
     cp SDLnet.c.default SDLnet.c || exit 1
 fi
 
+# Delete libSDLmain.a and libSDL.a from archive file
+# otherwise linking will fail on macOS
+ar dv linux-host/lib/libSDL_net.a libSDLmain.a || true
+ar dv linux-host/lib/libSDL_net.a libSDL.a || true


### PR DESCRIPTION
Fix internal sdlnet build on macOS, which re-enables support for nullmodem and modem on macOS for SDL1 builds.

## What issue(s) does this PR address?

See #3534, on macOS, SDL1 builds do not link in sdlnet, and thus modem support is disabled.

The problem was that the sdlnet build produces a `libSDL_net.a` file that not only contains the object files, but also `libSDL.a` and `libSDLmain.a`. This leads to issues down the line, when linking against `libSDL_net.a`, producing non-sensical linker error messages like `building for macOS-x86_64 but attempting to link with file built for macOS-x86_64`.

I have not found a way to prevent the addition of those files. The fix is thus simply deleting them from the `.a` file right after `libSDL_net.a` has finished building.

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

No.
