### PR TITLE
Fixed to discard marked text when IME is turned off on macOS

### DIFF
--- a/vs/sdl/src/video/quartz/SDL_QuartzEvents.m
+++ b/vs/sdl/src/video/quartz/SDL_QuartzEvents.m
@@ -334,7 +334,7 @@ void     QZ_InitOSKeymap (_THIS) {
     keymap[QZ_KP_ENTER] = SDLK_KP_ENTER;
 }
 
-static int GetEnableIME()
+int GetEnableIME()
 {
     TISInputSourceRef is = TISCopyCurrentKeyboardInputSource();
     CFBooleanRef ret = (CFBooleanRef)TISGetInputSourceProperty(is, kTISPropertyInputSourceIsASCIICapable);

--- a/vs/sdl/src/video/quartz/SDL_QuartzVideo.m
+++ b/vs/sdl/src/video/quartz/SDL_QuartzVideo.m
@@ -242,6 +242,16 @@ static inline void QZ_SetFrame(_THIS, NSScreen *nsscreen, NSRect frame)
     [_markedLabel setHidden:YES];
 }
 
+extern int GetEnableIME();
+
+- (void)keyboardInputSourceChanged:(NSNotification *)notification
+{
+    if(!GetEnableIME()) {
+        [_markedLabel setHidden:YES];
+        [[NSTextInputContext currentInputContext] discardMarkedText];
+    }
+}
+
 - (NSRect)firstRectForCharacterRange:(NSRange)aRange actualRange:(NSRangePointer)actualRange
 {
     NSWindow *window = [self window];
@@ -265,8 +275,11 @@ static inline void QZ_SetFrame(_THIS, NSScreen *nsscreen, NSRect frame)
 
     if(_markedLabel == nil) {
         _markedLabel = [[IMETextView alloc] initWithFrame: NSMakeRect(0.0, 0.0, 0.0, 0.0)];
-        //NSWindow *window = [self window];
         [[[self window] contentView] addSubview:_markedLabel];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(keyboardInputSourceChanged:)
+                                                     name:NSTextInputContextKeyboardSelectionDidChangeNotification
+                                                   object:nil];
     }
     [_markedLabel setFrameOrigin: NSMakePoint(_inputRect.x, windowHeight - _inputRect.y)];
 


### PR DESCRIPTION
Fixed an issue where the display remained when the IME was turned off while marked text (composition string) was being entered, causing subsequent input to become incorrect.