### PR TITLE
improve out-of-the-box compatibility of game link mode

### DIFF
--- a/src/gamelink/README.md
+++ b/src/gamelink/README.md
@@ -35,7 +35,28 @@ gamelink master = true
 
 [render]
 scaler=xbrz
+
+[dos]
+hma                                              = false
+drive z expand path                              = false
+minimum dos initial private segment              = 0
+minimum mcb segment                              = 0
+minimum mcb free                                 = 187
+maximum environment block size on exec           = 32768
+additional environment block size on exec        = 83
+kernel allocation in umb                         = true
+shellhigh                                        = true
+
+[config]
+set path=z:\system
+set prompt=
+set comspec=z:\
 ```
+
+The [dos] and [config] sections are mandatory with exactly these settings!
+DOSBox-X has a different default memory layout than mainline DOSBox, the
+shown settings fix this. This is needed so that Game Link clients see the
+same memory content no matter which DOSBox version you use.
 
 If you use the `xbrz` scaler, you must use `windowresolution` to set the frame
 buffer size that is sent to GC. For all other scalers, the native
@@ -63,11 +84,28 @@ An example config looks like this:
 output = surface
 # ... or any other non-gamelink output
 gamelink master = true
+
+[dos]
+hma                                              = false
+drive z expand path                              = false
+minimum dos initial private segment              = 0
+minimum mcb segment                              = 0
+minimum mcb free                                 = 187
+maximum environment block size on exec           = 32768
+additional environment block size on exec        = 83
+kernel allocation in umb                         = true
+shellhigh                                        = true
+
+[config]
+set path=z:\system
+set prompt=
+set comspec=z:\
 ```
 
-Just add this single option to an existing working configuration and GC can
-track your movement through your game world. Everything else should work as
-normal.
+Add the `gamelink master` option and the shown extra settings to an existing
+working configuration and GC can track your movement through your game world.
+Everything else should work as normal. See above for an explanation why those
+extra settings are needed.
 
 
 
@@ -83,19 +121,56 @@ from game to game. See the GC web site and the web in general for details.
 Compatibility
 -------------
 
-Unfortunately, DOSBox-X loads executables at different addresses from the
-reference DOSBox-GRIDC. This breaks all game profiles. There are two
-workarounds in place to deal with this:
+... or "My game works in DOSBox-GRIDC but not in DOSBox-X!"
 
-A default offset will be added to every memory address request. This should
-work with some simple programs.
+As already mentioned above, DOSBox-X loads executables at different addresses
+from the reference DOSBox-GRIDC. The following extra settings will configure
+DOSBox-X for a memory layout that is virtually indistinguishable from
+mainline DOSBox:
 
-For all other programs, you need to find out its original load address and
-modify the GC profile to tell DOSBox this address.  This is more involved:
+```
+
+[dos]
+hma                                              = false
+drive z expand path                              = false
+minimum dos initial private segment              = 0
+minimum mcb segment                              = 0
+minimum mcb free                                 = 187
+maximum environment block size on exec           = 32768
+additional environment block size on exec        = 83
+kernel allocation in umb                         = true
+shellhigh                                        = true
+
+[config]
+set path=z:\system
+set prompt=
+set comspec=z:\
+```
+
+Note that you will not have a command prompt, unfortunately. But you can type
+commands just fine, everything should work as normal.
+
+There is one small hack in there: the COMSPEC environment variable had to be
+shortened because the default DOSBOX-X environment is bigger than mainline
+DOSBox, and there are actually games sensitive to that (e.g. Ultima 1).
+However, this setting might create problems with other games, so you can try
+to use these two values instead:
+
+```
+[dos]
+additional environment block size on exec        = 72
+
+[config]
+set comspec=z:\command.com
+```
+
+If nothing works, there is a more complicated solution. You need to find out
+the game's original load address and tell DOSBox this address. It works like
+this:
 
 
 1. You need to run the game in the original DOSBox-GRIDC together with GC
-itself.
+itself. Load a save game so that your position is detected in GC.
 
 2. Then you run the same game in DOSBox-X, which has been configured with one
 extra option:
@@ -105,32 +180,19 @@ extra option:
 gamelink snoop = true
 ```
 
-3. Load the same save game in both DOSBox instances and move to the same
-place. Once a match is detected, a popup dialog window should tell you two
-different configuration values.
+3. Load the same save game in DOSBox-X instances and move to the same
+place. Once a match is detected, a popup dialog window should tell you a
+configuration value for DOSBox-X.
 
-With these two values, you can configure Game Link in two different ways,
-whatever works best for you.
-
-The first and easiest option is to enter the first value from the dialog
-window into the DOSBox-X configuration file:
+4. Enter the setting from the dialog window into the DOSBox-X configuration
+file, for example like this:
 
 ```
 [sdl]
 gamelink load address = 6768
 ```
 
-The second option is to modify your Grid Cartographer profile:
-
-1. Find the game profile XML file and locate the `<peek>` tag near the start
-of the file. It will contain a list of hexadecimal numbers.
-
-2. Add the second value from the dialog window (the one starting with `100`)
-to the end of this list.
-
-3. Exit everything including GC, disable `gamelink snoop` and enjoy
-GC+DOSBox-X!
-
+5. Remember to turn off the `gamelink snoop` setting and enjoy your game.
 
 
 

--- a/src/gamelink/gamelink.h
+++ b/src/gamelink/gamelink.h
@@ -174,29 +174,6 @@ namespace GameLink
 	extern void InitTerminal();
 
 
-// Ugly hack: grid cartographer sends absolute addresses, but different dosbox
-// versions load executables at different addresses. 
-
-// To fix those cases, this code calculates an offset from the original and
-// the actual load address. There are two ways to configure the original load
-// address. One way is to use option "gamelink load address", the other is to
-// modify the Grid Cartographer profile:
-
-// To do so, edit the corresponding grid cartographer profile XML file, search
-// for the <peek> tag, add 0x1000_0000 to the address and put it at the end. For
-// example, if the load address is 0x1a70 the XML tag could look like:
-// <peek bytes="1299c 1299e 19c42 19c2e 19c30 19c40 19c32 17a8a 10001a70" />
-
-// To find out the original load address, run the game in dosbox-gridc and
-// connect to Grid Cartographer. Start DOSBox-X in parallel with
-// the "gamelinksnoop = true" option. Load the same game in both,
-// dosbox-gridc and DOSBox-X, load the same save game/move to the same
-// position. Console output should then contain a suggested original load
-// address.
-
-// This default offset works for some simple cases.
-#define GAMELINK_LOAD_ADDRESS_DEFAULT 0x1a70
-
 }; // namespace GameLink
 
 //==============================================================================

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -6461,7 +6461,7 @@ void SDL_SetupConfigSection() {
     Pbool->Set_help("Allow Game Link connections e.g. from Grid Cartographer; required for output=gamelink, otherwise optional.");
     Pbool = sdl_sec->Add_bool("gamelink snoop", Property::Changeable::OnlyAtStart, false);
     Pbool->Set_help("Connect to an existing Game Link session and output link data instead of sending own data. Compares memory contents to find a suitable memory offset of peeks.");
-    Pint = sdl_sec->Add_int("gamelink load address", Property::Changeable::Always, GAMELINK_LOAD_ADDRESS_DEFAULT);
+    Pint = sdl_sec->Add_int("gamelink load address", Property::Changeable::Always, 0);
     Pbool->Set_help("Configure the original load address of the software (when running in plain DOSBox) so that gamelink accesses are adjusted for different load addresses.");
 #endif
 


### PR DESCRIPTION
The previous version of the game link code was pretty awkward to use due to big changes in memory layout. I found settings that almost fix this, removing the complicated setup procedure. This patch documents the required settings for maximum compatibility in the accompanying README file.

The patch keeps the "snoop" mode just in case some game is more sensitive to the remaining minimal memory differences. It does eliminate the hackish configuration via GC XML profiles, making this feature fully self-contained, not dependent on a specific client.

## What issue(s) does this PR address?

## Does this PR introduce new feature(s)?

## Does this PR introduce any breaking change(s)?

## Additional information
