### PR TITLE
ci(macos): update runner to macos-12

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ jobs:
       actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
       contents: read  # for actions/checkout to fetch code
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.11.0


### PR DESCRIPTION
Right now macos-10.15 support is deprecated on the homebrew side (we only support most three recent versions, i.e. `11`, `12`, `13`), thus updating the runner to macos-12, aka macOS monterey.

Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

Just github action runner update.

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

I dont think so

## Additional information

Maintain CI builds

---

relates to https://github.com/actions/runner-images/pull/5842