### PR TITLE
Fix PIC_AddEvent() interval (timer.cpp)

### DIFF
--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -324,7 +324,11 @@ static void PIT0_Event(Bitu /*val*/) {
 			LOG_MSG("PIT0_Event timing error %.6fms",err);
 #endif
 
-		PIC_AddEvent(PIT0_Event,pit[0].delay - (err * 0.05));
+        if(pit[0].delay - (err * 0.05) <= 0) {
+            err = 0;
+            //LOG_MSG("PIT0_Event delay value negative, reset to 0", err);
+        }
+        PIC_AddEvent(PIT0_Event,pit[0].delay - (err * 0.05));
 	}
 }
 


### PR DESCRIPTION
The game Days of Thunder is causing Dosbox-X to freeze after it exits.
This is due to that the interval of PIC_AddEvent() is negative, and this PR fixes it.
However, this does not fix the root cause to make the interval negative value, so further fix may be required.

## What issue(s) does this PR address?
Fixes #3916
