### PR TITLE
Sync dh fpu state with normal fpu

### DIFF
--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -315,7 +315,7 @@ Bits CPU_Core_Dyn_X86_Run(void) {
 			fpu.sw = dyn_dh_fpu.state.sw;
 			const uint8_t* buffer = &dyn_dh_fpu.state.st_reg[0][0];
 			for(Bitu i = 0;i < 8;i++){
-				memcpy(&fpu.p_regs[STV(i)], buffer + i * 10, 10);
+				memcpy(&fpu.p_regs[i], buffer + i * 10, 10);
 			}
 		}
 		~auto_fpu_sync () {
@@ -324,7 +324,7 @@ Bits CPU_Core_Dyn_X86_Run(void) {
 			dyn_dh_fpu.state.sw = fpu.sw;
 			uint8_t* buffer = &dyn_dh_fpu.state.st_reg[0][0];
 			for(Bitu i = 0;i < 8;i++){
-				memcpy(buffer + i * 10, &fpu.p_regs[STV(i)], 10);
+				memcpy(buffer + i * 10, &fpu.p_regs[i], 10);
 			}
 		}
 	};

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -313,20 +313,18 @@ Bits CPU_Core_Dyn_X86_Run(void) {
 			FPU_SetTag(dyn_dh_fpu.state.tag);
 			fpu.cw = dyn_dh_fpu.state.cw;
 			fpu.sw = dyn_dh_fpu.state.sw;
+			const uint8_t* buffer = &dyn_dh_fpu.state.st_reg[0][0];
 			for(Bitu i = 0;i < 8;i++){
-				fpu.p_regs[STV(i)].m1 = *((uint32_t*)(dyn_dh_fpu.state.st_reg[i]+0));
-				fpu.p_regs[STV(i)].m2 = *((uint32_t*)(dyn_dh_fpu.state.st_reg[i]+4));
-				fpu.p_regs[STV(i)].m3 = *((uint16_t*)(dyn_dh_fpu.state.st_reg[i]+8));
+				memcpy(&fpu.p_regs[STV(i)], buffer + i * 10, 10);
 			}
 		}
 		~auto_fpu_sync () {
 			dyn_dh_fpu.state.tag = FPU_GetTag();
 			dyn_dh_fpu.state.cw = fpu.cw;
 			dyn_dh_fpu.state.sw = fpu.sw;
+			uint8_t* buffer = &dyn_dh_fpu.state.st_reg[0][0];
 			for(Bitu i = 0;i < 8;i++){
-				*((uint32_t*)(dyn_dh_fpu.state.st_reg[i]+0)) = fpu.p_regs[STV(i)].m1;
-				*((uint32_t*)(dyn_dh_fpu.state.st_reg[i]+4)) = fpu.p_regs[STV(i)].m2;
-				*((uint16_t*)(dyn_dh_fpu.state.st_reg[i]+8)) = fpu.p_regs[STV(i)].m3;
+				memcpy(buffer + i * 10, &fpu.p_regs[STV(i)], 10);
 			}
 		}
 	};


### PR DESCRIPTION
## What issue(s) does this PR address?

This is the same change as in https://github.com/dosbox-staging/dosbox-staging/pull/2248

Basically this fixes the fpu state out of sync problem when dynamic core calls normal core to handle self modification code.

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No

## Additional information

I tested this with dos navigator:

* Set core to dynamic
* Run Dos Navigator
* Type some rubbish on the command line and press enter
* Repeat the above step
* After several times, dos navigator will crash (the entire dosbox app will crash in other dosbox versions but in dosbox-x I guess it has better error handling so only the program in it crashes).

I used mingw build because the visual studio build uses 64-bit floats and won't run dos navigator.
