### PR TITLE
More dynamic FPU fixes

### DIFF
--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -315,7 +315,7 @@ Bits CPU_Core_Dyn_X86_Run(void) {
 			fpu.sw = dyn_dh_fpu.state.sw;
 			const uint8_t* buffer = &dyn_dh_fpu.state.st_reg[0][0];
 			for(Bitu i = 0;i < 8;i++){
-				memcpy(&fpu.p_regs[STV(i)], buffer + i * 10, 10);
+				memcpy(&fpu.p_regs[i], buffer + i * 10, 10);
 			}
 		}
 		~auto_fpu_sync () {
@@ -324,7 +324,7 @@ Bits CPU_Core_Dyn_X86_Run(void) {
 			dyn_dh_fpu.state.sw = fpu.sw;
 			uint8_t* buffer = &dyn_dh_fpu.state.st_reg[0][0];
 			for(Bitu i = 0;i < 8;i++){
-				memcpy(buffer + i * 10, &fpu.p_regs[STV(i)], 10);
+				memcpy(buffer + i * 10, &fpu.p_regs[i], 10);
 			}
 		}
 	};

--- a/src/cpu/core_dyn_x86.cpp
+++ b/src/cpu/core_dyn_x86.cpp
@@ -315,7 +315,7 @@ Bits CPU_Core_Dyn_X86_Run(void) {
 			fpu.sw = dyn_dh_fpu.state.sw;
 			const uint8_t* buffer = &dyn_dh_fpu.state.st_reg[0][0];
 			for(Bitu i = 0;i < 8;i++){
-				memcpy(&fpu.p_regs[i], buffer + i * 10, 10);
+				memcpy(&fpu.p_regs[STV(i)], buffer + i * 10, 10);
 			}
 		}
 		~auto_fpu_sync () {
@@ -324,7 +324,7 @@ Bits CPU_Core_Dyn_X86_Run(void) {
 			dyn_dh_fpu.state.sw = fpu.sw;
 			uint8_t* buffer = &dyn_dh_fpu.state.st_reg[0][0];
 			for(Bitu i = 0;i < 8;i++){
-				memcpy(buffer + i * 10, &fpu.p_regs[i], 10);
+				memcpy(buffer + i * 10, &fpu.p_regs[STV(i)], 10);
 			}
 		}
 	};


### PR DESCRIPTION
After some testing, I believe the memory layout that I assumed on fnsave was incorrect.  This fixes it. 

This also adds protection to all the other instances where CPU_Core_Normal_Run() is called in the x86 dynamic core.  After this Turbo Debugger is able to correctly display FPU updates on the dynamic core.

An optimization is added to avoid most of the copies.