### PR TITLE
Add link for XP installer on the website

### DIFF
--- a/_data/latest_version.yml
+++ b/_data/latest_version.yml
@@ -6,8 +6,19 @@ version: 2022.12.26
 # the version
 git_tag: dosbox-x-v2022.12.26
 
-win32_setup_file: dosbox-x-win32-2022.12.26-setup.exe
-win64_setup_file: dosbox-x-win64-2022.12.26-setup.exe
+#Original
+#win32_setup_file: dosbox-x-win32-2022.12.26-setup.exe
+#win64_setup_file: dosbox-x-win64-2022.12.26-setup.exe
+#winXP_setup_file: dosbox-x-winXP-2022.12.26-setup.exe
+
+# Change link to portable files to at least avoid 404 error,
+# since 2022.12.26 installers are not available.
+# Installers should be available in the next release, and the linked to them.
+win32_setup_file: dosbox-x-vsbuild-win32-20221226190454.zip
+win64_setup_file: dosbox-x-vsbuild-win64-20221226190454.zip
+#not yet available
+winXP_setup_file: dosbox-x-winXP-2022.12.26-setup.exe
+
 
 macos_intel_file: dosbox-x-macosx-x86_64-20221226190321.zip
 macos_arm_file: dosbox-x-macosx-arm64-20221226183221.zip

--- a/_data/latest_version.yml
+++ b/_data/latest_version.yml
@@ -11,7 +11,7 @@ git_tag: dosbox-x-v2022.12.26
 #win64_setup_file: dosbox-x-win64-2022.12.26-setup.exe
 #winXP_setup_file: dosbox-x-winXP-2022.12.26-setup.exe
 
-# Change link to portable files to at least avoid 404 error,
+# Linking to the portable packages to at least avoid a 404 error,
 # since 2022.12.26 installers are not available.
 # The actual installers should be linked in the next release,
 # where they are available.

--- a/_data/latest_version.yml
+++ b/_data/latest_version.yml
@@ -13,7 +13,8 @@ git_tag: dosbox-x-v2022.12.26
 
 # Change link to portable files to at least avoid 404 error,
 # since 2022.12.26 installers are not available.
-# Installers should be available in the next release, and the linked to them.
+# The actual installers should be linked in the next release,
+# where they are available.
 win32_setup_file: dosbox-x-vsbuild-win32-20221226190454.zip
 win64_setup_file: dosbox-x-vsbuild-win64-20221226190454.zip
 #not yet available

--- a/_data/latest_version.yml
+++ b/_data/latest_version.yml
@@ -12,7 +12,7 @@ git_tag: dosbox-x-v2022.12.26
 #winXP_setup_file: dosbox-x-winXP-2022.12.26-setup.exe
 
 # Linking to the portable packages to at least avoid a 404 error,
-# since 2022.12.26 installers are not available.
+# since installers are not released for 2022.12.26.
 # The actual installers should be linked in the next release,
 # where they are available.
 win32_setup_file: dosbox-x-vsbuild-win32-20221226190454.zip

--- a/_includes/version.html
+++ b/_includes/version.html
@@ -26,7 +26,7 @@
   |
   <a href="{{ latest_version_release_link }}/{{ version.win64_setup_file }}">64-bit Setup (7+)</a>
 </h5>
-<h5><a href="{{ latest_version_release_link }}/{{ version.winXP_setup_file }}">32/64-bit Setup (XP+)(temporary not released)</a></h5>
+<h5><a href="{{ latest_version_release_link }}/{{ version.winXP_setup_file }}">32/64-bit Setup (XP+) (currently not released)</a></h5>
 <h5><a href="https://github.com/joncampbell123/dosbox-x/blob/master/INSTALL.md#windows-packages-installer-or-portable">More options including portable packages</a></h5>
 
 <h4>Linux version:</h4>

--- a/_includes/version.html
+++ b/_includes/version.html
@@ -22,10 +22,11 @@
 <h4>Windows version:</h4>
 <h5 class="subtitle-mute">(Windows XP and later versions supported)</h5>
 <h5>
-  <a href="{{ latest_version_release_link }}/{{ version.win32_setup_file }}">32-bit Setup (XP+)</a>
+  <a href="{{ latest_version_release_link }}/{{ version.win32_setup_file }}">32-bit Setup (Vista+)</a>
   |
-  <a href="{{ latest_version_release_link }}/{{ version.win64_setup_file }}">64-bit Setup (Vista+)</a>
+  <a href="{{ latest_version_release_link }}/{{ version.win64_setup_file }}">64-bit Setup (7+)</a>
 </h5>
+<h5><a href="{{ latest_version_release_link }}/{{ version.winXP_setup_file }}">32/64-bit Setup (XP+)</a></h5>
 <h5><a href="https://github.com/joncampbell123/dosbox-x/blob/master/INSTALL.md#windows-packages-installer-or-portable">More options including portable packages</a></h5>
 
 <h4>Linux version:</h4>

--- a/_includes/version.html
+++ b/_includes/version.html
@@ -26,7 +26,7 @@
   |
   <a href="{{ latest_version_release_link }}/{{ version.win64_setup_file }}">64-bit Setup (7+)</a>
 </h5>
-<h5><a href="{{ latest_version_release_link }}/{{ version.winXP_setup_file }}">32/64-bit Setup (XP+)</a></h5>
+<h5><a href="{{ latest_version_release_link }}/{{ version.winXP_setup_file }}">32/64-bit Setup (XP+)(temporary not released)</a></h5>
 <h5><a href="https://github.com/joncampbell123/dosbox-x/blob/master/INSTALL.md#windows-packages-installer-or-portable">More options including portable packages</a></h5>
 
 <h4>Linux version:</h4>


### PR DESCRIPTION
Hopefully the Windows installers are available in the coming release.
Added link for the XP installers (for now, you get 404 error since it is not yet released)
And since the installer for 2022.12.26 release is not available, tentatively linked to Visual Studio portable zips.
(and reflected the fact that the 64bit installer doesn't work on Vista now)

## Additional information
![update_webpage](https://user-images.githubusercontent.com/68574602/216895577-4d544251-9a98-4525-bc25-efa04dc2ef7b.png)
