### PR TITLE
Fix VHD fixed image geometry detection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
 Next
+  - qcow2 image support: Make image able to be mounted by
+    drive letters (experimental) (maron2000)
+  - VHD image support: Make file name check for .vhd extension
+    to be case insensitive (maron2000)
   - VHD image support: Fix auto-detection of geometry (maron2000)
   - VHD image support: If the VHD image is not a fixed type,
     say so in the log (previously it said nothing) and say

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 Next
+  - VHD image support: Fix auto-detection of geometry (maron2000)
   - VHD image support: If the VHD image is not a fixed type,
     say so in the log (previously it said nothing) and say
     what kind of image was mounted (joncampbell123).

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -3897,7 +3897,15 @@ restart_int:
                 WriteOut("WARNING: Cluster sizes >= 64KB are not compatible with MS-DOS and SCANDISK\n");
         }
         // write VHD footer if requested, largely copied from RAW2VHD program, no license was included
-        if((mediadesc == 0xF8) && (temp_line.find(".vhd")) != std::string::npos) {
+        char extension[6] = {}; // care extensions longer than 3 letters such as '.vhdd'
+        if(temp_line.find_last_of('.') != std::string::npos) {
+            for(int i = 0; i < sizeof(extension) - 1; i++) {
+                if(temp_line.find_last_of('.') + i > temp_line.length() - 1) break;
+                extension[i] = temp_line[temp_line.find_last_of('.') + i];
+            }
+            extension[sizeof(extension) - 1] = '\0'; // Terminate string just in case
+        }
+        if((mediadesc == 0xF8) && !strcasecmp(extension, ".vhd")) {
             int i;
             uint8_t footer[512];
             // basic information


### PR DESCRIPTION
It was not possible to mount VHD fixed size images without giving geometry parameters manually since auto-detection of the disk geometry was broken.
This PR fixes the auto-detection of geometry to mount VHD images. 
Edit: Also added code to mount qcow2 images by drive letters (experimental)

## What issue(s) does this PR address?
Fixes #3987
qcow2 images can now be mounted by drive letters (has to be formatted before mounting)

## Additional information
Checked mounting a fixed size VHD (test.vhd) and dynamic size VHD (dynamic.vhd).
Also checked changing the file extension from `.vhd` to `.vpc` (test.vpc)
![command_003](https://user-images.githubusercontent.com/68574602/218069261-0a2d12c4-a446-468a-8a6b-bf93716bb83b.png)
![command_000](https://user-images.githubusercontent.com/68574602/218269460-d35414d5-14a7-4280-9ed3-e4ffbafd80f8.png)
