### PR TITLE
Spell out 5.0 as the auto/unset/default DOS version

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -4323,7 +4323,7 @@ void DOSBOX_SetupConfigSections(void) {
 
     Pstring = secprop->Add_string("ver",Property::Changeable::WhenIdle,"");
     Pstring->Set_help("Set DOS version. Specify as major.minor format. A single number is treated as the major version (compatible with LFN support). Common settings are:\n"
-            "auto (or unset)                  Pick a DOS kernel version automatically\n"
+            "auto (or unset)                  Pick DOS kernel version 5.0 (DOSBox default)\n"
             "3.3                              MS-DOS 3.3 emulation (not tested!)\n"
             "5.0                              MS-DOS 5.0 emulation (recommended for DOS gaming)\n"
             "6.22                             MS-DOS 6.22 emulation\n"


### PR DESCRIPTION
```ini
[dos]
#                                              ver: Set DOS version. Specify as major.minor format. A single number is treated as the major version (compatible with LFN support). Common settings are:
#                                                     auto (or unset)                  Pick a DOS kernel version automatically
#                                                     3.3                              MS-DOS 3.3 emulation (not tested!)
#                                                     5.0                              MS-DOS 5.0 emulation (recommended for DOS gaming)
#                                                     6.22                             MS-DOS 6.22 emulation
#                                                     7.0                              MS-DOS 7.0 (or Windows 95 pure DOS mode) emulation
#                                                     7.1                              MS-DOS 7.1 (or Windows 98 pure DOS mode) emulation
#                                                     Long filename (LFN) support will be enabled with a reported DOS version of 7.0 or higher with "lfn=auto" (default).
#                                                     Similarly, FAT32 disk images will be supported with a reported DOS version of 7.1 or higher.
ver                                              =
```

It can be somewhat misleading. But if you leave it blank, it will choose DOS version 5.0

_Originally posted by @rderooy in https://github.com/joncampbell123/dosbox-x/issues/3998#issuecomment-1426391565_

PR changes the first setting to
`auto (or unset)                  Pick DOS kernel version 5.0 (DOSBox default)`

## What issue(s) does this PR address?

Fixes #3998

## Does this PR introduce new feature(s)?

No, only .conf comment clarification

## Does this PR introduce any breaking change(s)?

should not

## Additional information
