### PR TITLE
Fix build on Haiku and MinGW

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -524,7 +524,7 @@ case "$host" in
        AC_DEFINE(HAIKU, 1, [Compiling on Haiku])
        dnl FEATURE: Whether to support direct serial port passthrough
        AC_DEFINE(C_DIRECTSERIAL, 1, [ Define to 1 if you want serial passthrough support (Win32, Posix and OS/2).])
-       LIBS="$LIBS -lnetwork -lbsd"
+       LIBS="$LIBS -lnetwork -lbsd -lbe"
        ;;
     *-*-freebsd* | *-*-dragonfly* | *-*-netbsd* | *-*-openbsd*)
        dnl Disabled directserial for now. It doesn't do anything without

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -19,7 +19,6 @@
  *  With major works from joncampbell123 and Wengier
  */
 
-#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -31,9 +30,6 @@
 #define _DARWIN_C_SOURCE
 #endif
 #ifndef WIN32
-#if defined(EMSCRIPTEN) || defined(HAIKU)
-#include <fcntl.h>
-#endif
 #include <utime.h>
 #include <sys/file.h>
 #else
@@ -55,6 +51,10 @@
 #include "timer.h"
 #include "render.h"
 #include "jfont.h"
+
+#if defined(EMSCRIPTEN) || defined(HAIKU)
+#include <fcntl.h>
+#endif
 
 #include "cp437_uni.h"
 #include "cp737_uni.h"


### PR DESCRIPTION
This addresses https://github.com/joncampbell123/dosbox-x/issues/3537#issuecomment-1420876666 and should fix the regression introduced on MinGW builds

The failures on MSBuild already existed on master and should be unrelated