### PR TITLE
Add M_PI definition to sblaster.cpp

### DIFF
--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -44,6 +44,8 @@
 # pragma warning(disable:4244) /* const fmath::local::uint64_t to double possible loss of data */
 # pragma warning(disable:4305) /* truncation from double to float */
 # pragma warning(disable:4065) /* switch without case */
+#define _USE_MATH_DEFINES      /* needed for M_PI definition */
+//#define M_PI       3.14159265358979323846   /* pi */
 #endif
 
 #include <assert.h>


### PR DESCRIPTION
Visual Studio builds are currently broken since definition of M_PI is missing.
This PR adds the required definition to build it successfully. 
