### PR TITLE
Fix INT13h AH=02 broken conditional branch

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 Next
+  - Fix INT13h AH=02 broken conditional branch which prevents
+    installer of game "Inherit the Earth: Quest for the Orb"
+    to obtain free space of hard drive (maron2000)
   - qcow2 image support: Make image able to be mounted by
     drive letters (experimental) (maron2000)
   - VHD image support: Make file name check for .vhd extension

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -1866,7 +1866,7 @@ static Bitu INT13_DiskHandler(void) {
             CALLBACK_SCF(true);
             return CBRET_NONE;
         }
-        if (drivenum >= MAX_DISK_IMAGES && imageDiskList[drivenum] == NULL) {
+        if (drivenum >= MAX_DISK_IMAGES || imageDiskList[drivenum] == NULL) {
             if (drivenum >= DOS_DRIVES || !Drives[drivenum] || Drives[drivenum]->isRemovable()) {
                 reg_ah = 0x01;
                 CALLBACK_SCF(true);


### PR DESCRIPTION
This PR fixes the INT13h AH=02 broken conditional branch which prevents installer of game "Inherit the Earth: Quest for the Orb" to obtain free space of hard drives

## What issue(s) does this PR address?
Fixes #4012 