### PR TITLE
Proper redirect stdout and stderr. Fixes joncampbell123/dosbox-x#3968

### DIFF
--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -17,6 +17,8 @@
  */
 
 
+#include <iostream>
+
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>
@@ -686,6 +688,13 @@ bool DOS_WriteFile(uint16_t entry,const uint8_t * data,uint16_t * amount,bool fc
 	uint16_t towrite=*amount;
 	bool ret=Files[handle]->Write(data,&towrite);
 	*amount=towrite;
+
+    if (entry == STDOUT) {
+        std::cout.write(reinterpret_cast<const char *>(data), *amount);
+    } else if (entry == STDERR) {
+        std::cerr.write(reinterpret_cast<const char *>(data), *amount);
+    }
+
 	return ret;
 }
 


### PR DESCRIPTION
Fixes #3968.

It misses some single characters (not `0x21/0x02`), but it is still better than nothing.

## What issue(s) does this PR address?

If there are any related issues, reference them here. Ex. #1234, Fixes #1234, Closes #1234, etc.
<!-- (For more information on using keywords like in above, read this document: https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) -->

## Does this PR introduce new feature(s)?

If yes, describe the feature(s) introduced.

## Does this PR introduce any breaking change(s)?

If yes, describe the breaking change(s) in detail.

## Additional information

Add any additional information here.
