### PR TITLE
Fixes related to Japanese Shift JIS folder names

### DIFF
--- a/include/support.h
+++ b/include/support.h
@@ -50,6 +50,7 @@ char * ScanCMDRemain(char * cmd);
 char * StripWord(char *&line);
 Bits ConvDecWord(char * word);
 Bits ConvHexWord(char * word);
+bool check_last_split_char(const char *name, size_t len, char split);
 
 enum {
 	UTF8ERR_INVALID=-1,

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -300,7 +300,7 @@ bool DOS_GetSFNPath(char const * const path,char * SFNPath,bool LFN) {
 	int fbak=lfn_filefind_handle;
     for (char *s = strchr_dbcs(p,'\\'); s != NULL; s = strchr_dbcs(p,'\\')) {
 		*s = 0;
-		if (SFNPath[strlen(SFNPath)-1]=='\\')
+		if (check_last_split_char(SFNPath, strlen(SFNPath), '\\'))
 			sprintf(pdir,"\"%s%s\"",SFNPath,p);
 		else
 			sprintf(pdir,"\"%s\\%s\"",SFNPath,p);
@@ -393,7 +393,7 @@ bool DOS_ChangeDir(char const * const dir) {
 		return false;
 	}
 	if (!DOS_MakeName(dir,fulldir,&drive)) return false;
-	if (strlen(fulldir) && testdir[len-1]=='\\') {
+	if (strlen(fulldir) && check_last_split_char(testdir, len, '\\')) {
 		DOS_SetError(DOSERR_PATH_NOT_FOUND);
 		return false;
 	}
@@ -410,7 +410,7 @@ bool DOS_ChangeDir(char const * const dir) {
 bool DOS_MakeDir(char const * const dir) {
 	uint8_t drive;char fulldir[DOS_PATHLENGTH];
 	size_t len = strlen(dir);
-	if(!len || dir[len-1] == '\\') {
+	if(!len || check_last_split_char(dir, len, '\\')) {
 		DOS_SetError(DOSERR_PATH_NOT_FOUND);
 		return false;
 	}
@@ -550,7 +550,7 @@ bool DOS_FindFirst(const char * search,uint16_t attr,bool fcb_findfirst) {
 	uint8_t drive;char fullsearch[DOS_PATHLENGTH];
 	char dir[DOS_PATHLENGTH];char pattern[DOS_PATHLENGTH];
 	size_t len = strlen(search);
-	if(len && search[len - 1] == '\\' && !( (len > 2) && (search[len - 2] == ':') && (attr == DOS_ATTR_VOLUME) )) { 
+	if(len && check_last_split_char(search, len, '\\') && !( (len > 2) && (search[len - 2] == ':') && (attr == DOS_ATTR_VOLUME) )) { 
 		//Dark Forces installer, but c:\ is alright for volume labels(exclusively set)
 		DOS_SetError(DOSERR_NO_MORE_FILES);
 		return false;
@@ -1307,7 +1307,7 @@ bool DOS_CreateTempFile(char * const name,uint16_t * entry) {
 		tempname[0]='\\';
 		tempname++;
 	} else {
-		if ((name[namelen-1]!='\\') && (name[namelen-1]!='/')) {
+		if (!check_last_split_char(name, namelen, '\\') && (name[namelen-1]!='/')) {
 			tempname[0]='\\';
 			tempname++;
 		}

--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -198,9 +198,9 @@ char* DOS_Drive_Cache::GetExpandName(const char* path) {
         size_t len = strlen(work);
 #if defined (WIN32)
 //What about OS/2
-        if((work[len-1] == CROSS_FILESPLIT ) && (len >= 2) && (work[len-2] != ':')) {
+		if(check_last_split_char(work, len, CROSS_FILESPLIT) && (len >= 2) && (work[len-2] != ':')) {
 #else
-        if((len > 1) && (work[len-1] == CROSS_FILESPLIT )) {
+		if((len > 1) && check_last_split_char(work, len, CROSS_FILESPLIT)) {
 #endif       
             work[len-1] = 0; // Remove trailing slashes except when in root
         }

--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -1011,7 +1011,7 @@ bool Overlay_Drive::FindNext(DOS_DTA & dta) {
 	char full_name[CROSS_LEN], lfull_name[LFN_NAMELENGTH+1];
 	char dir_entcopy[CROSS_LEN], ldir_entcopy[CROSS_LEN];
 
-	uint8_t srch_attr;char srch_pattern[DOS_NAMELENGTH_ASCII];
+	uint8_t srch_attr;char srch_pattern[LFN_NAMELENGTH+1];
 	uint8_t find_attr;
 
 	dta.GetSearchParams(srch_attr,srch_pattern,false);

--- a/src/dos/drive_physfs.cpp
+++ b/src/dos/drive_physfs.cpp
@@ -617,7 +617,7 @@ bool physfsDrive::FindNext(DOS_DTA & dta) {
 	char * dir_ent, *ldir_ent;
 	char full_name[CROSS_LEN], lfull_name[LFN_NAMELENGTH+1];
 
-	uint8_t srch_attr;char srch_pattern[DOS_NAMELENGTH_ASCII];
+	uint8_t srch_attr;char srch_pattern[LFN_NAMELENGTH+1];
 	uint8_t find_attr;
 
     dta.GetSearchParams(srch_attr,srch_pattern,false);

--- a/src/misc/support.cpp
+++ b/src/misc/support.cpp
@@ -115,6 +115,22 @@ char *strtok_dbcs(char *s, const char *d) {
     return result;
 }
 
+bool check_last_split_char(const char *name, size_t len, char split)
+{
+	bool tail = false;
+	if((IS_PC98_ARCH || isDBCSCP()) && split == '\\') {
+		bool lead = false;
+		for(size_t pos = 0 ; pos < len ; pos++) {
+			if(lead) lead = false;
+        	else if ((IS_PC98_ARCH && shiftjis_lead_byte(name[pos])) || (isDBCSCP() && isKanji1(name[pos]))) lead = true;
+			else if(pos == len - 1 && name[pos] == split) tail = true;
+		}
+	} else if(len > 0) {
+		if(name[len - 1] == split) tail = true;
+	}
+	return tail;
+}
+
 /* 
 	Ripped some source from freedos for this one.
 

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -1981,14 +1981,9 @@ void DOS_Shell::CMD_DIR(char * args) {
 	if (argLen == 0) {
 		strcpy(args,"*.*"); //no arguments.
 	} else {
-		switch (args[argLen-1])
-		{
-		case '\\':	// handle \, C:\, etc.
-		case ':' :	// handle C:, etc.
+		// handle \, C:\, etc.                          handle C:, etc.
+		if(check_last_split_char(args, argLen, '\\') || args[argLen-1] == ':') {
 			strcat(args,"*.*");
-			break;
-		default:
-			break;
 		}
 	}
 	args = ExpandDot(args,buffer,CROSS_LEN,!uselfn);


### PR DESCRIPTION
Fixed a bug for folders with Japanese names that have 0x5c at the end.
Fixed a bug that a list of files in a folder with Japanese name which has 0x5c,0x61-0x7a at the second byte of the character could not be referred to.
Fixed the problem of out-of-buffer writing when using LFN.
