### PR TITLE
Don't trim volume names like 8.3 filenames.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -179,6 +179,8 @@ Next
     a game that sets up EGA 640x200 16-color mode then
     suddenly switches on the 2bpp CGA mode as a way to
     do 16-color dithered graphics. (joncampbell123).
+  - Fix installers for Dynamix games not working.
+    (Allofich & halcyon00)
 
 2022.12.26
   - Allow more than 640KB of conventional memory,

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -234,7 +234,7 @@ bool DOS_CreateTempFile(char * const name,uint16_t * entry);
 bool DOS_FileExists(char const * const name);
 
 /* Helper Functions */
-bool DOS_MakeName(char const * const name,char * const fullname,uint8_t * drive);
+bool DOS_MakeName(char const * const name,char * const fullname,uint8_t * drive,bool isVolume = false);
 /* Drive Handing Routines */
 uint8_t DOS_GetDefaultDrive(void);
 void DOS_SetDefaultDrive(uint8_t drive);

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -427,6 +427,9 @@ void DOS_DTA::SetupSearch(uint8_t _sdrive,uint8_t _sattr,char * pattern) {
 	} else {
 		MEM_BlockWrite(pt+offsetof(sDTA,spname),pattern,(strlen(pattern) > 8) ? 8 : (Bitu)strlen(pattern));
 	}
+    if(_sattr & DOS_ATTR_VOLUME) {
+        MEM_BlockWrite(pt+offsetof(sDTA, spext),&pattern[8],3);
+    }
 }
 
 void DOS_DTA::SetResult(const char * _name, const char * _lname, uint32_t _size,uint32_t _hsize,uint16_t _date,uint16_t _time,uint8_t _attr) {
@@ -502,9 +505,16 @@ void DOS_DTA::GetSearchParams(uint8_t & attr,char * pattern, bool lfn) {
         char temp[11];
         MEM_BlockRead(pt+offsetof(sDTA,spname),temp,11);
         for (int i=0;i<13;i++) pattern[i]=0;
+        if(attr & DOS_ATTR_VOLUME)
+        {
+            memcpy(pattern, temp, 11);
+        }
+        else
+        {
             memcpy(pattern,temp,8);
             pattern[strlen(pattern)]='.';
             memcpy(&pattern[strlen(pattern)],&temp[8],3);
+        }
     }
 }
 

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -94,7 +94,7 @@ void DOS_SetDefaultDrive(uint8_t drive) {
 	if (drive<DOS_DRIVES && ((drive<2) || Drives[drive])) {dos.current_drive = drive; DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).SetDrive(drive);}
 }
 
-bool DOS_MakeName(char const * const name,char * const fullname,uint8_t * drive) {
+bool DOS_MakeName(char const * const name,char * const fullname,uint8_t * drive,bool isVolume) {
 	if(!name || *name == 0 || *name == ' ' || *name == '\n' || *name == ':') {
 		/* Both \0 and space are separators and
 		 * empty filenames report file not found */
@@ -104,7 +104,17 @@ bool DOS_MakeName(char const * const name,char * const fullname,uint8_t * drive)
 	char names[LFN_NAMELENGTH];
 	strcpy(names,name);
 	char * name_int = names;
-	if (strlen(names)==14 && name_int[1]==':' && name_int[2]!='\\' && name_int[9]==' ' && name_int[10]=='.') {
+    if (isVolume)
+    {
+        if(name_int[10] == '.') // Remove extension dot
+        {
+                name_int[10] = name_int[11];
+                name_int[11] = name_int[12];
+                name_int[12] = name_int[13];
+                name_int[13] = 32;
+        }
+	}
+	else if (strlen(names)==14 && name_int[1]==':' && name_int[2]!='\\' && name_int[9]==' ' && name_int[10]=='.') {
 		for (unsigned int i=0;i<strlen(names);i++)
 			if (i<10 && name_int[i]==32) {
 				name_int[i]='.';
@@ -150,6 +160,13 @@ bool DOS_MakeName(char const * const name,char * const fullname,uint8_t * drive)
 		DOS_SetError(DOSERR_PATH_NOT_FOUND);
 		return false; 
 	}
+
+    if(isVolume) // Don't process any further
+    {
+        strcpy(fullname, name_int);
+        return true;
+    }
+
 	r=0;w=0;
 	while (r<DOS_PATHLENGTH && name_int[r]!=0) {
 		uint8_t c=(uint8_t)name_int[r++];
@@ -555,9 +572,11 @@ bool DOS_FindFirst(const char * search,uint16_t attr,bool fcb_findfirst) {
 		DOS_SetError(DOSERR_NO_MORE_FILES);
 		return false;
 	}
-	if (!DOS_MakeName(search,fullsearch,&drive)) return false;
+	if (!DOS_MakeName(search,fullsearch,&drive,attr & DOS_ATTR_VOLUME)) return false;
 	//Check for devices. FindDevice checks for leading subdir as well
-	bool device = (DOS_FindDevice(search) != DOS_DEVICES);
+    bool device = false;
+    if (attr & DOS_ATTR_DEVICE)
+        device = DOS_FindDevice(search) != DOS_DEVICES;
 
 	/* Split the search in dir and pattern */
 	forcelfn = false;

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -56,6 +56,7 @@ extern char * DBCS_upcase(char * str), sfn[DOS_NAMELENGTH_ASCII];
 extern bool gbk, isDBCSCP(), isKanji1_gbk(uint8_t chr), shiftjis_lead_byte(int c);
 extern bool CodePageGuestToHostUTF16(uint16_t *d/*CROSS_LEN*/,const char *s/*CROSS_LEN*/);
 extern bool CodePageHostToGuestUTF16(char *d/*CROSS_LEN*/,const uint16_t *s/*CROSS_LEN*/);
+extern bool wild_match(const char* haystack, char* needle);
 bool systemmessagebox(char const * aTitle, char const * aMessage, char const * aDialogType, char const * aIconType, int aDefaultButton);
 
 int PC98AutoChoose_FAT(const std::vector<_PC98RawPartition> &parts,imageDisk *loadedDisk) {
@@ -2444,11 +2445,18 @@ nextfile:
 	}
 	memset(find_name,0,DOS_NAMELENGTH_ASCII);
 	memset(extension,0,4);
-	memcpy(find_name,&sectbuf[entryoffset].entryname[0],8);
+
+    if (sectbuf[entryoffset].attrib & DOS_ATTR_VOLUME)
+        memcpy(find_name, &sectbuf[entryoffset].entryname[0], 11);
+    else
+    {
+        memcpy(find_name, &sectbuf[entryoffset].entryname[0], 8);
+        memcpy(extension, &sectbuf[entryoffset].entryname[8], 3);
+    }
+
 	// recover the SFN initial E5, which was converted to 05
 	// to distinguish with a free directory entry
 	if (find_name[0] == 0x05) find_name[0] = 0xe5;
-    memcpy(extension,&sectbuf[entryoffset].entryname[8],3);
 
     if (!(sectbuf[entryoffset].attrib & DOS_ATTR_VOLUME)) {
         trimString(&find_name[0]);
@@ -2456,14 +2464,9 @@ nextfile:
     }
 
 	if (extension[0]!=0) {
-		if (!(sectbuf[entryoffset].attrib & DOS_ATTR_VOLUME)) {
-			strcat(find_name, ".");
-		}
+		strcat(find_name, ".");
 		strcat(find_name, extension);
 	}
-
-	if (sectbuf[entryoffset].attrib & DOS_ATTR_VOLUME)
-        trimString(find_name);
 
     /* Compare attributes to search attributes */
 
@@ -2601,12 +2604,19 @@ nextfile:
 	}
 
 	/* Compare name to search pattern. Skip long filename match if no long filename given. */
-	if (!(WildFileCmp(find_name,srch_pattern) || (lfn_max_ord != 0 && lfind_name[0] != 0 && LWildFileCmp(lfind_name,srch_pattern)))) {
+    if(attrs & DOS_ATTR_VOLUME) {
+        if (!(wild_match(find_name, srch_pattern)))
+            goto nextfile;
+    }
+	else if (!(WildFileCmp(find_name,srch_pattern) || (lfn_max_ord != 0 && lfind_name[0] != 0 && LWildFileCmp(lfind_name,srch_pattern)))) {
 		lfind_name[0] = 0; /* LFN code will memset() it in full upon next dirent */
 		lfn_max_ord = 0;
 		lfnRange.clear();
 		goto nextfile;
 	}
+
+    if(sectbuf[entryoffset].attrib & DOS_ATTR_VOLUME)
+        trimString(find_name);
 
 	// Drive emulation does not need to require a LFN in case there is no corresponding 8.3 names.
 	if (lfind_name[0] == 0) strcpy(lfind_name,find_name);


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

Fixes #3175. Fixes #3187. Fixes #4031.

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

Don't know of any.

## Additional information

The main problem to be fixed was identified by @halcyon00. (See comments in the linked bug reports.) This is my attempt to fix it.

This PR is for three issues about game installers, all for games from Dynamix.

The disk labels for the first disk of the three games are "WILLY 1", "STELLAR7 1" and "NOVA 1".
The installers use INT 21h AH=11h to search for "WILLY ?", "STELLAR7 ??" and "NOVA ?"  with an attribute value of 8 (volume attribute). The call needs to succeed for the installer option to show. 

In DOSBox-X, when handling INT 21h AH=11h the search strings are passed into `DOS_MakeName` as

"A:WILLY ? .   "
"A:STELLAR7. ??"
"A:NOVA ?  .   "

In `DOS_MakeName`, names with a space in index 9 (before the ".") are iterated through from the left, trimming the 8-char part of the 8.3 name at the first space found. The "." and any non-space characters from the 3-char part of the 8.3 name are placed next. The resulting strings (with the "A:" trimmed off as well) are:

"WILLY."
"STELLAR7.??" 
"NOVA."

The WILLY and NOVA results don't work to show the installer option. The STELLAR7 one works to show the installer option.
When the Stellar 7 installer option is selected, the installer then searches for "STELLAR7 1". This is passed in as

"A:STELLAR7. 1 "

and trimmed to "STELLAR7.1", which fails.

This PR modifies the trimming if the volume attribute is set. In this case, the "." that has been added by that point is removed, and the space padding from after the last non-space character is trimmed. I also kept the logic to convert to uppercase, though I don't know if it is necessary. This gives "WILLY ?", "STELLAR7 ??" and "NOVA ?" for the first searches, and "STELLAR7 1" for the Stellar 7 installation string, allowing the installers to work. I also tested another unrelated installer and using the mkdir command, which worked fine.

I also added a condition on a second call to `DOS_MakeName` that was always happening for devices to only happen if the device attribute is set. I don't know if this is correct, but it seems like `DOS_MakeName` is being needlessly done twice on every search.