### PR TITLE
Revert pcap read timeout change on non-macOS

### DIFF
--- a/src/misc/ethernet_pcap.cpp
+++ b/src/misc/ethernet_pcap.cpp
@@ -214,7 +214,7 @@ bool PcapEthernetConnection::Initialize(Section* config)
 #ifdef MACOSX
             timeout = 3000; // For macOS, use 3000ms as it does not appear to support -1
 #else
-            timeout = -1; // For other platform, use -1 which should mean "non-blocking mode"
+            timeout = -1; // For other platforms, use -1 which should mean "non-blocking mode"
 #endif
         } else
             timeout = strtoul(timeoutstr,&end,10);

--- a/src/misc/ethernet_pcap.cpp
+++ b/src/misc/ethernet_pcap.cpp
@@ -211,10 +211,10 @@ bool PcapEthernetConnection::Initialize(Section* config)
         char *end;
         int timeout = -1;
         if (!strlen(timeoutstr)||timeoutstr[0]!='-'&&!isdigit(timeoutstr[0])) { // Default timeout values
-#ifdef WIN32
-            timeout = -1; // For Windows, use -1 which appears to be specific to WinPCap and means "non-blocking mode"
+#ifdef MACOSX
+            timeout = 3000; // For macOS, use 3000ms as it does not appear to support -1
 #else
-            timeout = 3000; // For other platforms, use 3000ms as the timeout which should work for platforms like macOS
+            timeout = -1; // For other platform, use -1 which should mean "non-blocking mode"
 #endif
         } else
             timeout = strtoul(timeoutstr,&end,10);


### PR DESCRIPTION
Commit https://github.com/joncampbell123/dosbox-x/commit/af3e81ed400b6fd331cfdbd77304c05b66afe5e3 by @Jookia which was meant to fix PCAP on macOS, broke PCAP on Linux.

With this change in place, a lot of packets end up getting dropped. So much that TCP/IP communication pretty much stops functioning.

A later partial revert already restored the original -1 value for Windows systems, but left the 3000ms value in place for all other systems.

This change inverses the logic, instead of setting a timeout of -1 only for Windows and using 3000ms for everyone else, it uses 3000ms exclusively for macOS, and -1 for everyone else.

## What issue(s) does this PR address?
Fixes #2998

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

Cannot vouch for BSD systems, but if libpcap on Linux works with -1, I would expect the same to be true for the BSDs.

## Additional information

