### PR TITLE
MinGW-lowend also works under XP

### DIFF
--- a/devel-build.html
+++ b/devel-build.html
@@ -85,7 +85,7 @@ function add_ci_build_entry(workflow_id, description, page = 1) {
 document.addEventListener("DOMContentLoaded", () => {
     add_ci_build_entry("vsbuild32", "32-bit Visual Studio builds (for Vista+/ARM)");
     add_ci_build_entry("vsbuild64", "64-bit Visual Studio builds (for Vista+/ARM)");
-    add_ci_build_entry("mingw32", "32-bit MinGW builds (for 7+) and lowend builds (for Vista+)");
+    add_ci_build_entry("mingw32", "32-bit MinGW builds (for 7+) and MinGW-lowend builds (for XP+)");
     add_ci_build_entry("mingw64", "64-bit MinGW builds (for 7+)");
     add_ci_build_entry("vsbuild_xp", "32/64-bit builds for Windows XP+");	
     add_ci_build_entry("linux", "Linux (x86_64) builds");


### PR DESCRIPTION
dosbox-x-mingw-win32-lowend-20230213021958 works under WinXP. 
Most recent builds don't work (reportedly not only for XP, so hopefully that will be corrected) - #4051