### PR TITLE
Add macOS Universal Binary build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -320,8 +320,8 @@ __pycache__/
 ###############################################################################
 
 *~
-dosbox.app/
-dosbox.app/*
+dosbox-x.app/
+dosbox-x.app/*
 dosbox.icns
 dosbox.iconset/
 dosbox.iconset/*
@@ -351,6 +351,10 @@ Makefile
 config.h
 config.status
 stamp-h1
+
+# macOS Universal Binary intermediates
+/src/dosbox-x-arm64
+/src/dosbox-x-x86_64
 
 doxygen
 doxygen/*
@@ -410,6 +414,9 @@ vs/libpng/linux-build/*
 /vs/libpdcurses/wincon/firework.exe
 .vscode/settings.json
 vs/freetype/objs
+
+# Ignore mach-o-matic
+/src/tool/mach-o-matic
 
 # Ignore flatpak stuff
 .flatpak-builder/

--- a/BUILD.md
+++ b/BUILD.md
@@ -18,7 +18,7 @@ The four major operating systems and platforms of DOSBox-X are:
 
 2. Linux (with X11) 64-bit x86/x64, and on a Raspberry Pi 3/4
 
-3. macOS (Mac OS X) recent version, 64-bit Intel and ARM-based
+3. macOS (Mac OS X) recent version, 64-bit Intel, ARM-based, and Universal
 
 4. DOS (MS-DOS 5.0+ or compatible)
 
@@ -28,7 +28,10 @@ of Visual Studio 2017 to Visual Studio 2022 and the DirectX 2010 SDK.
 Linux and MinGW Windows builds are expected to compile with the GNU autotools.
 
 macOS builds are expected to compile on the terminal using GNU autotools and
-the LLVM/Clang compiler provided by XCode.
+the LLVM/Clang compiler provided by XCode. Universal macOS builds are only
+possible when building on a host machine powered by an Apple Silicon CPU, due to
+requiring parallel Homebrew installations running natively *and* under
+Rosetta 2.
 
 In all cases, the code requires a C++ compiler that can support the C++11
 standard.
@@ -73,14 +76,32 @@ sudo make install
 ```
 
 * macOS compile (SDL1)
-```
-./build-macos
-```
+  * Build natively for the host architecture
+    ```
+    ./build-macos
+    ```
+  * Build a Universal Binary on an Apple Silicon CPU (will *not* work on Intel)
+    ```
+    ./build-macos universal
+    ````
+    You can build an App Bundle from the result of this build with
+    ```
+    make dosbox-x.app
+    ```
 
 * macOS compile (SDL2)
-```
-./build-macos-sdl2
-```
+  * Build natively for the host architecture
+    ```
+    ./build-macos-sdl2
+    ```
+  * Build a Universal Binary on an Apple Silicon CPU (will *not* work on Intel)
+    ```
+    ./build-macos-sdl2 universal
+    ````
+    You can build an App Bundle from the result of this build with
+    ```
+    make dosbox-x.app
+    ```
 
 * MinGW compile (using MinGW-w64) for Windows Vista/7 or later (SDL1)
 ```

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,11 +5,13 @@ SUBDIRS = src include
 
 .PHONY: dosbox-x.app
 
-dosbox-x.app: src/dosbox-x contrib/macos/dosbox.icns src/tool/mach-o-matic
+dosbox-x.app: src/dosbox-x-arm64 src/dosbox-x-x86_64 contrib/macos/dosbox.icns src/tool/mach-o-matic
 	rm -Rfv dosbox-x.app
 	mkdir dosbox-x.app
 	mkdir dosbox-x.app/Contents
 	mkdir dosbox-x.app/Contents/MacOS
+	mkdir dosbox-x.app/Contents/MacOS/arm64
+	mkdir dosbox-x.app/Contents/MacOS/x86_64
 	mkdir dosbox-x.app/Contents/Resources
 	mkdir dosbox-x.app/Contents/Resources/drivez
 	mkdir dosbox-x.app/Contents/Resources/glshaders
@@ -26,35 +28,74 @@ dosbox-x.app: src/dosbox-x contrib/macos/dosbox.icns src/tool/mach-o-matic
 	cp -v contrib/translations/*/*.lng dosbox-x.app/Contents/Resources/languages/
 	cp -v dosbox-x.reference.conf dosbox-x.app/Contents/Resources/
 	cp -v dosbox-x.reference.full.conf dosbox-x.app/Contents/Resources/
-	cp -v src/dosbox-x dosbox-x.app/Contents/MacOS/dosbox-x
+	if [ -f src/dosbox-x-arm64 ]; then cp -v src/dosbox-x-arm64 dosbox-x.app/Contents/MacOS/arm64/dosbox-x; fi
+	if [ -f src/dosbox-x-x86_64 ]; then cp -v src/dosbox-x-x86_64 dosbox-x.app/Contents/MacOS/x86_64/dosbox-x; fi
 # this is where it gets ugly
-	codesign --remove-signature dosbox-x.app/Contents/MacOS/dosbox-x
-	otool -L dosbox-x.app/Contents/MacOS/dosbox-x | grep -E '/usr/local/lib|/usr/local/opt|/usr/local/Cellar|/opt/homebrew/' | while read X; do Y=`echo "$$X" | sed -E '/^ +/s///' | cut -d ' ' -f 1`; \
-		dylib=`basename $$Y`; \
-		cp -v $$Y dosbox-x.app/Contents/MacOS/; \
-		codesign --remove-signature "dosbox-x.app/Contents/MacOS/$$dylib" || exit 1; \
-		chmod 0755 "dosbox-x.app/Contents/MacOS/$$dylib" || exit 1; \
-	done
-# and the libs too. NTS: Cannot use install_name_tool anymore to change anything about dylib files because that invalidates code signing of those files
-	for pass in 1 2 3 4 5; do \
-		for dolib in dosbox-x.app/Contents/MacOS/*.dylib; do \
-			XB=`otool -L "$$dolib" | grep -E '/usr/local/lib|/usr/local/opt|/usr/local/Cellar|/opt/homebrew/' | sed -E '/^ +/s///' | cut -d ' ' -f 1`; \
-			for Y in $$XB; do \
-				dylib=`basename $$Y`; \
-				if [ -f "dosbox-x.app/Contents/MacOS/$$dylib" ]; then true; else \
-					cp -vn $$Y dosbox-x.app/Contents/MacOS/; \
-					codesign --remove-signature "dosbox-x.app/Contents/MacOS/$$dylib" || exit 1; \
-					chmod 0755 "dosbox-x.app/Contents/MacOS/$$dylib" || exit 1; \
-				fi; \
-			done; \
+# Find dependent libraries and copy them into the app bundle separated by architecture
+	for exe in dosbox-x.app/Contents/MacOS/arm64/dosbox-x dosbox-x.app/Contents/MacOS/x86_64/dosbox-x; do \
+		[ -f "$$exe" ] && otool -L "$$exe" | grep -E '/usr/local/lib|/usr/local/opt|/usr/local/Cellar|/usr/local/Homebrew|/opt/homebrew/' | while read X; do Y=`echo "$$X" | sed -E '/^ +/s///' | cut -d ' ' -f 1`; \
+			dylib=`basename $$Y`; \
+			if echo $$Y | grep -Eq '/opt/homebrew'; then \
+				cp -v $$Y dosbox-x.app/Contents/MacOS/arm64/; \
+				codesign --remove-signature "dosbox-x.app/Contents/MacOS/arm64/$$dylib" || exit 1; \
+				chmod 0755 "dosbox-x.app/Contents/MacOS/arm64/$$dylib" || exit 1; \
+			else \
+				cp -v $$Y dosbox-x.app/Contents/MacOS/x86_64/; \
+				codesign --remove-signature "dosbox-x.app/Contents/MacOS/x86_64/$$dylib" || exit 1; \
+				chmod 0755 "dosbox-x.app/Contents/MacOS/x86_64/$$dylib" || exit 1; \
+			fi; \
 		done; \
-	done; \
-	for dylib in dosbox-x.app/Contents/MacOS/*.dylib; do \
-		if [ -f "$$dylib" ]; then \
-	        src/tool/mach-o-matic "$$dylib" || exit 1; \
+	done
+# Find all the libraries we copied and copy any libraries they depend on
+# separated by architecture, and remove their signatures, too.
+	for pass in 1 2 3 4 5; do \
+		for dir in dosbox-x.app/Contents/MacOS/arm64 dosbox-x.app/Contents/MacOS/x86_64; do \
+			if [ `ls  $$dir/*.dylib 2>/dev/null | wc -l` -gt 0 ]; then \
+				for dolib in $$dir/*.dylib; do \
+					XB=`otool -L "$$dolib" | grep -E '/usr/local/lib|/usr/local/opt|/usr/local/Cellar|/usr/local/Homebrew|/opt/homebrew/' | sed -E '/^ +/s///' | cut -d ' ' -f 1`; \
+					for Y in $$XB; do \
+						dylib=`basename $$Y`; \
+						if echo $$Y | grep -Eq '/opt/homebrew'; then \
+							cp -v $$Y dosbox-x.app/Contents/MacOS/arm64/; \
+							codesign --remove-signature "dosbox-x.app/Contents/MacOS/arm64/$$dylib" || exit 1; \
+							chmod 0755 "dosbox-x.app/Contents/MacOS/arm64/$$dylib" || exit 1; \
+						else \
+							cp -v $$Y dosbox-x.app/Contents/MacOS/x86_64/; \
+							codesign --remove-signature "dosbox-x.app/Contents/MacOS/x86_64/$$dylib" || exit 1; \
+							chmod 0755 "dosbox-x.app/Contents/MacOS/x86_64/$$dylib" || exit 1; \
+						fi; \
+					done; \
+				done; \
+			fi; \
+		done; \
+	done
+# Fix the linker search paths of the libraries we copied
+	for dir in dosbox-x.app/Contents/MacOS/arm64 dosbox-x.app/Contents/MacOS/x86_64; do \
+		if [ `ls  $$dir/*.dylib 2>/dev/null | wc -l` -gt 0 ]; then \
+			for dylib in $$dir/*.dylib; do \
+				[ -f "$$dylib" ] && src/tool/mach-o-matic "$$dylib" || exit 1; \
+			done; \
 		fi; \
-	done; \
-	src/tool/mach-o-matic dosbox-x.app/Contents/MacOS/dosbox-x || exit 1; \
+	done
+# Remove the signatures from the architecture-dependant executables, and fix their linker search paths.
+	if [ -f dosbox-x.app/Contents/MacOS/arm64/dosbox-x ]; then \
+		codesign --remove-signature dosbox-x.app/Contents/MacOS/arm64/dosbox-x || exit 1; \
+		src/tool/mach-o-matic dosbox-x.app/Contents/MacOS/arm64/dosbox-x || exit 1; \
+	fi
+	if [ -f dosbox-x.app/Contents/MacOS/x86_64/dosbox-x ]; then \
+		codesign --remove-signature dosbox-x.app/Contents/MacOS/x86_64/dosbox-x || exit 1; \
+		src/tool/mach-o-matic dosbox-x.app/Contents/MacOS/x86_64/dosbox-x || exit 1; \
+	fi
+# Create universal binary executable if both architectures are present or just move the one we have
+	if [ -f dosbox-x.app/Contents/MacOS/arm64/dosbox-x ] && [ -f dosbox-x.app/Contents/MacOS/x86_64/dosbox-x ]; then \
+		lipo -create dosbox-x.app/Contents/MacOS/arm64/dosbox-x dosbox-x.app/Contents/MacOS/x86_64/dosbox-x -output dosbox-x.app/Contents/MacOS/dosbox-x; \
+		rm -f dosbox-x.app/Contents/MacOS/arm64/dosbox-x dosbox-x.app/Contents/MacOS/x86_64/dosbox-x; \
+	elif [ -f dosbox-x.app/Contents/MacOS/arm64/dosbox-x ]; then \
+		mv -f dosbox-x.app/Contents/MacOS/arm64/dosbox-x dosbox-x.app/Contents/MacOS/dosbox-x; \
+	elif [ -f dosbox-x.app/Contents/MacOS/x86_64/dosbox-x ]; then \
+		mv -f dosbox-x.app/Contents/MacOS/x86_64/dosbox-x dosbox-x.app/Contents/MacOS/dosbox-x; \
+	fi
+# Re-sign the universal binary executable and all the libraries
 	codesign --deep -s - dosbox-x.app/Contents/MacOS/dosbox-x || exit 1
 
 debug-dosbox-x-app:

--- a/build-macos
+++ b/build-macos
@@ -12,73 +12,133 @@ if test -z "$top" ; then exit 1; fi
 # fix
 chmod +x vs/sdl/build-scripts/strip_fPIC.sh
 
-# prefer to compile against our own copy of SDL 1.x
-echo Compiling our internal SDL 1.x
-(cd vs/sdl && ./build-dosbox.sh) || exit 1
-new="-I$top/vs/sdl/linux-host/include "
-nld="-L$top/vs/sdl/linux-host/lib "
-export CFLAGS="$new$CFLAGS"
-export LDFLAGS="$nld$LDFLAGS"
-export CPPFLAGS="$new$CPPFLAGS"
-export CXXFLAGS="$new$CXXFLAGS"
+orig_CFLAGS="$CFLAGS"
+orig_LDFLAGS="$LDFLAGS"
+orig_CPPFLAGS="$CPPFLAGS"
+orig_CXXFLAGS="$CXXFLAGS"
 
-# prefer to compile against our own copy of SDLnet 1.x
-echo Compiling our internal SDLnet 1.x
-(cd vs/sdlnet && ./build-dosbox.sh) || exit 1
+do_cleanup() {
+    rm -rf vs/sdl/linux-host vs/sdl/linux-build
+    rm -rf vs/sdlnet/linux-host vs/sdlnet/linux-build
+    rm -rf vs/zlib/linux-host vs/zlib/linux-build
+    rm -rf vs/libpng/linux-host vs/libpng/linux-build
+    rm -rf vs/freetype/linux-host vs/freetype/linux-build
+    [ -e Makefile ] && make distclean
+}
 
-# prefer to compile against our own zlib
-echo Compiling our internal zlib
-(cd vs/zlib && ./build-dosbox.sh) || exit 1
-new="-I$top/vs/zlib/linux-host/include "
-nld="-L$top/vs/zlib/linux-host/lib "
-export CFLAGS="$new$CFLAGS"
-export LDFLAGS="$nld$LDFLAGS"
-export CPPFLAGS="$new$CPPFLAGS"
-export CXXFLAGS="$new$CXXFLAGS"
+universal=0
+architectures="$(uname -m)"
+if [ "$1" = "universal" ]; then
+    shift
+    if [ "$architectures" = "arm64" ]; then
+        # We can only build universal binaries on an arm64 host because we
+        # need homebrew functional under both architectures.
+        universal=1
+        architectures="arm64 x86_64"
+    fi
+fi
 
-# prefer to compile against our own libpng (comment this out to disable)
-echo Compiling our internal libpng
-(cd vs/libpng && ./build-dosbox.sh) || exit 1
-new="-I$top/vs/libpng/linux-host/include "
-nld="-L$top/vs/libpng/linux-host/lib "
-export CFLAGS="$new$CFLAGS"
-export LDFLAGS="$nld$LDFLAGS"
-export CPPFLAGS="$new$CPPFLAGS"
-export CXXFLAGS="$new$CXXFLAGS"
+arm64_brew_cmd=""
+x86_64_brew_cmd=""
+# arm64 native Homebrew
+if [ -x /opt/homebrew/bin/brew ]; then
+    arm64_brew_cmd="/opt/homebrew/bin/brew"
+fi
 
-# prefer to compile against our own freetype
-echo Compiling our internal freetype
-(cd vs/freetype && ./build-dosbox.sh) || exit 1
-new="-I$top/vs/freetype/linux-host/include/freetype2 "
-nld="-L$top/vs/freetype/linux-host/lib -lfreetype "
-export CFLAGS="$new$CFLAGS"
-export LDFLAGS="$nld$LDFLAGS"
-export CPPFLAGS="$new$CPPFLAGS"
-export CXXFLAGS="$new$CXXFLAGS"
-export INTERNAL_FREETYPE=1
+# x86_64 Homebrew
+if [ -x /usr/local/bin/brew ]; then
+    # old homebrew
+    x86_64_brew_cmd="/usr/local/bin/brew"
+elif [ -x /usr/local/Homebrew/bin/brew ]; then
+    # new homebrew
+    x86_64_brew_cmd="/usr/local/Homebrew/bin/brew"
+fi
 
-brew list fluid-synth &>/dev/null || brew install fluid-synth
-brew list libslirp &>/dev/null || brew install libslirp
-brew list pkg-config &>/dev/null || brew install pkg-config
+# x86_64 on arm64 for universal builds if x86_64 Homebrew is installed
+if [ -n "$x86_64_brew_cmd" ] && [ "$universal" -eq 1 ]; then
+    x86_64_brew_cmd="/usr/bin/arch -x86_64 $x86_64_brew_cmd"
+fi
 
-opts=
+for arch in $architectures; do
+    declare brew_cmd="${arch}_brew_cmd"
+    if [ -n "${!brew_cmd}" ]; then
+        ${!brew_cmd} list fluid-synth &>/dev/null || ${!brew_cmd} install fluid-synth
+        ${!brew_cmd} list libslirp &>/dev/null || ${!brew_cmd} install libslirp
+        ${!brew_cmd} list pkg-config &>/dev/null || ${!brew_cmd} install pkg-config
+    fi
 
-# if Brew has installed packages, try to use those too
-brew="/opt/homebrew"
-if [[ -d "$brew" && -d "$brew/include" && -d "$brew/lib" ]]; then
-    echo "Brew is installed, I'm going to use it's libraries too"
-    new=" -I$brew/include"
-    nld=" -L$brew/lib"
+    do_cleanup
+
+    arch_flags="-arch $arch -mmacosx-version-min=10.12 " 
+    export CFLAGS="$arch_flags$orig_CFLAGS"
+    export LDFLAGS="$arch_flags$orig_LDFLAGS"
+    export CPPFLAGS="$arch_flags$orig_CPPFLAGS"
+    export CXXFLAGS="$arch_flags$orig_CXXFLAGS"
+
+    # prefer to compile against our own copy of SDL 1.x
+    echo Compiling our internal SDL 1.x
+    (cd vs/sdl && ./build-dosbox.sh) || exit 1
+    new=" -I$top/vs/sdl/linux-host/include"
+    nld=" -L$top/vs/sdl/linux-host/lib"
     export CFLAGS="$CFLAGS$new"
     export LDFLAGS="$LDFLAGS$nld"
     export CPPFLAGS="$CPPFLAGS$new"
     export CXXFLAGS="$CXXFLAGS$new"
-    export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$brew/lib/pkgconfig"
-fi
 
-# now compile ourself
-echo Compiling DOSBox-X
-chmod +x configure
-./configure --enable-debug=heavy --prefix=/usr $opts "$@" || exit 1
-make -j3 || exit 1
+    # prefer to compile against our own copy of SDLnet 1.x
+    echo Compiling our internal SDLnet 1.x
+    (cd vs/sdlnet && ./build-dosbox.sh) || exit 1
 
+    # prefer to compile against our own zlib
+    echo Compiling our internal zlib
+    (cd vs/zlib && ./build-dosbox.sh) || exit 1
+    new=" -I$top/vs/zlib/linux-host/include"
+    nld=" -L$top/vs/zlib/linux-host/lib"
+    export CFLAGS="$CFLAGS$new"
+    export LDFLAGS="$LDFLAGS$nld"
+    export CPPFLAGS="$CPPFLAGS$new"
+    export CXXFLAGS="$CXXFLAGS$new"
+
+    # prefer to compile against our own libpng (comment this out to disable)
+    echo Compiling our internal libpng
+    (cd vs/libpng && ./build-dosbox.sh) || exit 1
+    new=" -I$top/vs/libpng/linux-host/include"
+    nld=" -L$top/vs/libpng/linux-host/lib"
+    export CFLAGS="$CFLAGS$new"
+    export LDFLAGS="$LDFLAGS$nld"
+    export CPPFLAGS="$CPPFLAGS$new"
+    export CXXFLAGS="$CXXFLAGS$new"
+
+    # prefer to compile against our own freetype
+    echo Compiling our internal freetype
+    (cd vs/freetype && ./build-dosbox.sh) || exit 1
+    new=" -I$top/vs/freetype/linux-host/include/freetype2"
+    nld=" -L$top/vs/freetype/linux-host/lib -lfreetype"
+    export CFLAGS="$CFLAGS$new"
+    export LDFLAGS="$LDFLAGS$nld"
+    export CPPFLAGS="$CPPFLAGS$new"
+    export CXXFLAGS="$CXXFLAGS$new"
+    export INTERNAL_FREETYPE=1
+
+    opts=
+
+    # if Brew has installed packages, try to use those too
+    if [ -n "${!brew_cmd}" ]; then
+        echo "Brew is installed, I'm going to use it's libraries too"
+        new=" -I$(${!brew_cmd} --prefix)/include"
+        nld=" -L$(${!brew_cmd} --prefix)/lib"
+        export CFLAGS="$CFLAGS$new"
+        export LDFLAGS="$LDFLAGS$nld"
+        export CPPFLAGS="$CPPFLAGS$new"
+        export CXXFLAGS="$CXXFLAGS$new"
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(${!brew_cmd} --prefix)/lib/pkgconfig"
+    fi
+
+    # now compile ourself
+    echo Compiling DOSBox-X
+    chmod +x configure
+    ./configure --enable-debug=heavy --prefix=/usr $opts "$@" || exit 1
+    make -j3 || exit 1
+
+    cp src/dosbox-x src/dosbox-x-$arch
+done

--- a/build-macos-sdl2
+++ b/build-macos-sdl2
@@ -12,69 +12,128 @@ if test -z "$top" ; then exit 1; fi
 # fix
 chmod +x vs/sdl/build-scripts/strip_fPIC.sh
 
-# prefer to compile against our own copy of SDL 2.x IF the system does not provide one
-echo Compiling our internal SDL 2.x
-(cd vs/sdl2 && ./build-dosbox.sh) || exit 1
-new="-I$top/vs/sdl2/linux-host/include "
-nld="-L$top/vs/sdl2/linux-host/lib "
-export CFLAGS="$new$CFLAGS"
-export LDFLAGS="$nld$LDFLAGS"
-export CPPFLAGS="$new$CPPFLAGS"
-export CXXFLAGS="$new$CXXFLAGS"
+orig_CFLAGS="$CFLAGS"
+orig_LDFLAGS="$LDFLAGS"
+orig_CPPFLAGS="$CPPFLAGS"
+orig_CXXFLAGS="$CXXFLAGS"
 
-# prefer to compile against our own zlib
-echo Compiling our internal zlib
-(cd vs/zlib && ./build-dosbox.sh) || exit 1
-new="-I$top/vs/zlib/linux-host/include "
-nld="-L$top/vs/zlib/linux-host/lib "
-export CFLAGS="$new$CFLAGS"
-export LDFLAGS="$nld$LDFLAGS"
-export CPPFLAGS="$new$CPPFLAGS"
-export CXXFLAGS="$new$CXXFLAGS"
+do_cleanup() {
+    rm -rf vs/sdl2/linux-host vs/sdl2/linux-build
+    rm -rf vs/zlib/linux-host vs/zlib/linux-build
+    rm -rf vs/libpng/linux-host vs/libpng/linux-build
+    rm -rf vs/freetype/linux-host vs/freetype/linux-build
+    [ -e Makefile ] && make distclean
+}
 
-# prefer to compile against our own libpng (comment this out to disable)
-echo Compiling our internal libpng
-(cd vs/libpng && ./build-dosbox.sh) || exit 1
-new="-I$top/vs/libpng/linux-host/include "
-nld="-L$top/vs/libpng/linux-host/lib "
-export CFLAGS="$new$CFLAGS"
-export LDFLAGS="$nld$LDFLAGS"
-export CPPFLAGS="$new$CPPFLAGS"
-export CXXFLAGS="$new$CXXFLAGS"
+universal=0
+architectures="$(uname -m)"
+if [ "$1" = "universal" ]; then
+    shift
+    if [ "$architectures" = "arm64" ]; then
+        # We can only build universal binaries on an arm64 host because we
+        # need homebrew functional under both architectures.
+        universal=1
+        architectures="arm64 x86_64"
+    fi
+fi
 
-# prefer to compile against our own freetype
-echo Compiling our internal freetype
-(cd vs/freetype && ./build-dosbox.sh) || exit 1
-new="-I$top/vs/freetype/linux-host/include/freetype2 "
-nld="-L$top/vs/freetype/linux-host/lib -lfreetype "
-export CFLAGS="$new$CFLAGS"
-export LDFLAGS="$nld$LDFLAGS"
-export CPPFLAGS="$new$CPPFLAGS"
-export CXXFLAGS="$new$CXXFLAGS"
-export INTERNAL_FREETYPE=1
+arm64_brew_cmd=""
+x86_64_brew_cmd=""
+# arm64 native Homebrew
+if [ -x /opt/homebrew/bin/brew ]; then
+    arm64_brew_cmd="/opt/homebrew/bin/brew"
+fi
 
-brew list fluid-synth &>/dev/null || brew install fluid-synth
-brew list libslirp &>/dev/null || brew install libslirp
-brew list pkg-config &>/dev/null || brew install pkg-config
+# x86_64 Homebrew
+if [ -x /usr/local/bin/brew ]; then
+    # old homebrew
+    x86_64_brew_cmd="/usr/local/bin/brew"
+elif [ -x /usr/local/Homebrew/bin/brew ]; then
+    # new homebrew
+    x86_64_brew_cmd="/usr/local/Homebrew/bin/brew"
+fi
 
-opts=
+# x86_64 on arm64 for universal builds if x86_64 Homebrew is installed
+if [ -n "$x86_64_brew_cmd" ] && [ "$universal" -eq 1 ]; then
+    x86_64_brew_cmd="/usr/bin/arch -x86_64 $x86_64_brew_cmd"
+fi
 
-# if Brew has installed packages, try to use those too
-brew="/opt/homebrew"
-if [[ -d "$brew" && -d "$brew/include" && -d "$brew/lib" ]]; then
-    echo "Brew is installed, I'm going to use it's libraries too"
-    new=" -I$brew/include"
-    nld=" -L$brew/lib"
+for arch in $architectures; do
+    declare brew_cmd="${arch}_brew_cmd"
+    if [ -n "${!brew_cmd}" ]; then
+        ${!brew_cmd} list fluid-synth &>/dev/null || ${!brew_cmd} install fluid-synth
+        ${!brew_cmd} list libslirp &>/dev/null || ${!brew_cmd} install libslirp
+        ${!brew_cmd} list pkg-config &>/dev/null || ${!brew_cmd} install pkg-config
+    fi
+
+    do_cleanup
+
+    arch_flags="-arch $arch -mmacosx-version-min=10.12 " 
+    export CFLAGS="$arch_flags$orig_CFLAGS"
+    export LDFLAGS="$arch_flags$orig_LDFLAGS"
+    export CPPFLAGS="$arch_flags$orig_CPPFLAGS"
+    export CXXFLAGS="$arch_flags$orig_CXXFLAGS"
+
+    # prefer to compile against our own copy of SDL 2.x IF the system does not provide one
+    echo Compiling our internal SDL 2.x
+    (cd vs/sdl2 && ./build-dosbox.sh) || exit 1
+    new="-I$top/vs/sdl2/linux-host/include "
+    nld="-L$top/vs/sdl2/linux-host/lib "
     export CFLAGS="$CFLAGS$new"
     export LDFLAGS="$LDFLAGS$nld"
     export CPPFLAGS="$CPPFLAGS$new"
     export CXXFLAGS="$CXXFLAGS$new"
-    export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$brew/lib/pkgconfig"
-fi
 
-# now compile ourself
-echo Compiling DOSBox-X
-chmod +x configure
-./configure --enable-debug=heavy --prefix=/usr --enable-sdl2 $opts "$@" || exit 1
-make -j3 || exit 1
+    # prefer to compile against our own zlib
+    echo Compiling our internal zlib
+    (cd vs/zlib && ./build-dosbox.sh) || exit 1
+    new="-I$top/vs/zlib/linux-host/include "
+    nld="-L$top/vs/zlib/linux-host/lib "
+    export CFLAGS="$CFLAGS$new"
+    export LDFLAGS="$LDFLAGS$nld"
+    export CPPFLAGS="$CPPFLAGS$new"
+    export CXXFLAGS="$CXXFLAGS$new"
 
+    # prefer to compile against our own libpng (comment this out to disable)
+    echo Compiling our internal libpng
+    (cd vs/libpng && ./build-dosbox.sh) || exit 1
+    new="-I$top/vs/libpng/linux-host/include "
+    nld="-L$top/vs/libpng/linux-host/lib "
+    export CFLAGS="$CFLAGS$new"
+    export LDFLAGS="$LDFLAGS$nld"
+    export CPPFLAGS="$CPPFLAGS$new"
+    export CXXFLAGS="$CXXFLAGS$new"
+
+    # prefer to compile against our own freetype
+    echo Compiling our internal freetype
+    (cd vs/freetype && ./build-dosbox.sh) || exit 1
+    new="-I$top/vs/freetype/linux-host/include/freetype2 "
+    nld="-L$top/vs/freetype/linux-host/lib -lfreetype "
+    export CFLAGS="$CFLAGS$new"
+    export LDFLAGS="$LDFLAGS$nld"
+    export CPPFLAGS="$CPPFLAGS$new"
+    export CXXFLAGS="$CXXFLAGS$new"
+    export INTERNAL_FREETYPE=1
+
+    opts=
+
+    # if Brew has installed packages, try to use those too
+    if [ -n "${!brew_cmd}" ]; then
+        echo "Brew is installed, I'm going to use it's libraries too"
+        new=" -I$(${!brew_cmd} --prefix)/include"
+        nld=" -L$(${!brew_cmd} --prefix)/lib"
+        export CFLAGS="$CFLAGS$new"
+        export LDFLAGS="$LDFLAGS$nld"
+        export CPPFLAGS="$CPPFLAGS$new"
+        export CXXFLAGS="$CXXFLAGS$new"
+        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(${!brew_cmd} --prefix)/lib/pkgconfig"
+    fi
+
+    # now compile ourself
+    echo Compiling DOSBox-X
+    chmod +x configure
+    ./configure --enable-debug=heavy --prefix=/usr --enable-sdl2 $opts "$@" || exit 1
+    make -j3 || exit 1
+
+    cp src/dosbox-x src/dosbox-x-$arch
+done

--- a/src/tool/mach-o-matic.cpp
+++ b/src/tool/mach-o-matic.cpp
@@ -40,13 +40,15 @@ string dylib_replace(string path) {
         fn = s;
 
     if (str_startswith(s,"/opt/homebrew/"))
-        return string("@executable_path/") + fn;
+        return string("@executable_path/arm64/") + fn;
+    if (str_startswith(s,"/usr/local/Homebrew/"))
+        return string("@executable_path/x86_64/") + fn;
     if (str_startswith(s,"/usr/local/lib/"))
-        return string("@executable_path/") + fn;
+        return string("@executable_path/x86_64/") + fn;
     if (str_startswith(s,"/usr/local/opt/"))
-        return string("@executable_path/") + fn;
+        return string("@executable_path/x86_64/") + fn;
     if (str_startswith(s,"/usr/local/Cellar/"))
-        return string("@executable_path/") + fn;
+        return string("@executable_path/x86_64/") + fn;
 
     return path;
 }

--- a/vs/sdl2/build-dosbox.sh
+++ b/vs/sdl2/build-dosbox.sh
@@ -35,13 +35,12 @@ sys=`uname -s`
 
 if [ "$sys" == "Darwin" ]; then
 opts="--disable-video-x11"
+elif [ "$sys" != "Linux" ]; then
+# These are supported on BSDs but the SDL2 code assumes Linux
+opts="--disable-video-wayland --disable-libudev"
 fi
 if [ "$1" == "hx-dos" ]; then
 opts="--disable-video-opengl"
-fi
-if [ "$sys" != "Linux" ]; then
-# These are supported on BSDs but the SDL2 code assumes Linux
-opts="--disable-video-wayland --disable-libudev"
 fi
 
 ac_cv_header_iconv_h=no ac_cv_func_iconv=no ac_cv_lib_iconv_libiconv_open=no ../configure "--srcdir=$srcdir" "--prefix=$instdir" --enable-static --disable-shared --disable-x11-shared --disable-video-x11-xrandr --disable-video-x11-vm --disable-video-x11-xv $opts || exit 1


### PR DESCRIPTION
Add support to build both Intel and arm64 executables on an Apple Silicon Mac and combine them into a single App Bundle to simplify distribution of macOS builds.

## What issue(s) does this PR address?

Fixes #3237

## Does this PR introduce new feature(s)?

No new features within DosBox-X itself, but does bring the new build-time feature to be able to create a Universal Binary with both Intel and Apple Silicon supported by a single App Bundle.

## Does this PR introduce any breaking change(s)?

I do not believe it does. The changes are to the build scripts only, so the functionality of DosBox-X *should* be identical.

However, I have only been able to test the Intel portion of the Universal Binaries I have produced by running through Rosetta 2 as I only have one Mac, which has an m1 CPU.

Running through Rosetta 2 required that I set the CPU configuration option `core` to `normal` at runtime otherwise it would crash with a Segmentation Fault when starting DOOM (my test game) - I suspect this is a byproduct of running through Rosetta 2, but this needs to be verified by testing on an Intel-based Mac.

## Additional information

I have uploaded my built App Bundle of an SDL2 build to Google Drive (because it is too big to attach to this PR) so that somebody can test on a native Intel Mac: [dosbox-x.app.zip](https://drive.google.com/open?id=13udgs5YoLVJlWxazADRXf68bR3Go7wsP&authuser=diddledanillew%40gmail.com&usp=drive_fs)

The Universal build method will *only* succeed on an Apple Silicon Mac. If you build on an Intel Mac you will receive a single-architecture build for Intel only due to the requirement for a working arm64 Homebrew prefix for the build process.

You need to have both an arm64 *and* Intel prefix of Homebrew for a Universal build, because we need the Homebrew-provided shared libraries for both architectures.

The build process for a Universal Binary App Bundle is as follows...

For SDL2:

```bash
$ ./build-macos-sdl2 universal
$ make dosbox-x.app
```

Or for SDL1:

```bash
$ ./build-macos universal
$ make dosbox-x.app
```

The `build-macos` and `build-macos-sdl2` scripts will *only* build both architectures on an Apple Silicon Mac. You *must* add the `universal` parameter to trigger them to build both architectures even when you are on an Apple Silicon system. *Without* the `universal` parameter the scripts should build the same way they did before this PR so that potential breaking of anyone packaging elsewhere is minimised :-)