### PR TITLE
Run PC98 Magical Girl Pretty Sammy with built-in DOS

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1404,6 +1404,13 @@ static Bitu DOS_21Handler(void) {
             DOS_FCBSetRandomRecord(SegValue(ds),reg_dx);
             break;
         case 0x25:      /* Set Interrupt Vector */
+            // Magical Girl Pretty Sammy
+            // Patch sound driver bugs. Swap the order of "mov sp" and "mov ss".
+            if(IS_PC98_ARCH && reg_al == 0x60 && !strcmp(RunningProgram, "SNDCDDRV")
+              && real_readd(SegValue(ds), reg_dx + 47) == 0x0fa6268b && real_readd(SegValue(ds), reg_dx + 52) == 0x0fa4168e) {
+                real_writed(SegValue(ds), reg_dx + 47, 0x0fa4168e);
+                real_writed(SegValue(ds), reg_dx + 52, 0x0fa6268b);
+            }
             RealSetVec(reg_al, RealMakeSeg(ds, reg_dx));
             break;
         case 0x26:      /* Create new PSP */

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -2325,6 +2325,16 @@ void isoDrive :: MediaChange() {
 }
 
 void isoDrive :: EmptyCache(void) {
+	// Magical Girl Pretty Sammy installer
+	// Installer copies files found by FindFirst/FindNext with "command /c copy",
+	// this function is called at end of DOS_Shell::CMD_COPY and cache is cleared, so only one file is copied.
+	if(IS_PC98_ARCH) {
+		const char *label = GetLabel();
+		if(!strncmp(label, "SAMY_A98", 8) || !strncmp(label, "SAMY_B98", 8)) {
+			// Do not clear cache for Pretty Sammy CD-ROM
+			return;
+		}
+	}
 	enable_udf = (dos.version.major > 7 || (dos.version.major == 7 && dos.version.minor >= 10));//default
 	enable_rock_ridge = dos.version.major >= 7 || uselfn;
 	enable_joliet = dos.version.major >= 7 || uselfn;

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -8264,6 +8264,11 @@ private:
 
             // STOP interrupt or invalid opcode
             real_writed(0,0x06*4,CALLBACK_RealPointer(call_pc98_default_stop));
+
+            // Magical Girl Pretty Sammy installer
+            // Installer enters an infinite loop if lower 8 bits of the segment portion of int 7 are 0
+            real_writew(0, 7*4, real_readw(0, 7*4) - 0x10);
+            real_writew(0, 7*4+2, real_readw(0, 7*4+2) + 1);
         }
         else {
             /* Clear the vector table */


### PR DESCRIPTION
Enable EMS memory in the PCMTRN function of AVSDRV.SYS.
Check if the buffer has enough space when AVSDRV.SYS writes PCM data.
Fixed the installer seeing int 7 vectors and going into an infinite loop.
Workaround for file copy bug in installer.
Patch sound driver bug when setting vectors.
