### PR TITLE
Attempt fix for macOS CI fail following PR#4054

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,9 +3,17 @@
 EXTRA_DIST = autogen.sh
 SUBDIRS = src include
 
+if MACOSX
+if MACOS_UNIVERSAL
+MACOS_BINARIES=src/dosbox-x-arm64 src/dosbox-x-x86_64
+else
+MACOS_BINARIES=src/dosbox-x-$(shell uname -m)
+endif
+endif
+
 .PHONY: dosbox-x.app
 
-dosbox-x.app: src/dosbox-x-arm64 src/dosbox-x-x86_64 contrib/macos/dosbox.icns src/tool/mach-o-matic
+dosbox-x.app: $(MACOS_BINARIES) contrib/macos/dosbox.icns src/tool/mach-o-matic
 	rm -Rfv dosbox-x.app
 	mkdir dosbox-x.app
 	mkdir dosbox-x.app/Contents
@@ -33,18 +41,21 @@ dosbox-x.app: src/dosbox-x-arm64 src/dosbox-x-x86_64 contrib/macos/dosbox.icns s
 # this is where it gets ugly
 # Find dependent libraries and copy them into the app bundle separated by architecture
 	for exe in dosbox-x.app/Contents/MacOS/arm64/dosbox-x dosbox-x.app/Contents/MacOS/x86_64/dosbox-x; do \
-		[ -f "$$exe" ] && otool -L "$$exe" | grep -E '/usr/local/lib|/usr/local/opt|/usr/local/Cellar|/usr/local/Homebrew|/opt/homebrew/' | while read X; do Y=`echo "$$X" | sed -E '/^ +/s///' | cut -d ' ' -f 1`; \
-			dylib=`basename $$Y`; \
-			if echo $$Y | grep -Eq '/opt/homebrew'; then \
-				cp -v $$Y dosbox-x.app/Contents/MacOS/arm64/; \
-				codesign --remove-signature "dosbox-x.app/Contents/MacOS/arm64/$$dylib" || exit 1; \
-				chmod 0755 "dosbox-x.app/Contents/MacOS/arm64/$$dylib" || exit 1; \
-			else \
-				cp -v $$Y dosbox-x.app/Contents/MacOS/x86_64/; \
-				codesign --remove-signature "dosbox-x.app/Contents/MacOS/x86_64/$$dylib" || exit 1; \
-				chmod 0755 "dosbox-x.app/Contents/MacOS/x86_64/$$dylib" || exit 1; \
-			fi; \
-		done; \
+		if [ -f "$$exe" ]; then \
+			otool -L "$$exe" | grep -E '/usr/local/lib|/usr/local/opt|/usr/local/Cellar|/usr/local/Homebrew|/opt/homebrew/' | while read X; do Y=`echo "$$X" | sed -E '/^ +/s///' | cut -d ' ' -f 1`; \
+				dylib=`basename $$Y`; \
+				echo "Copying $$dylib"; \
+				if echo $$Y | grep -Eq '/opt/homebrew'; then \
+					cp -v $$Y dosbox-x.app/Contents/MacOS/arm64/; \
+					codesign --remove-signature "dosbox-x.app/Contents/MacOS/arm64/$$dylib" || exit 1; \
+					chmod 0755 "dosbox-x.app/Contents/MacOS/arm64/$$dylib" || exit 1; \
+				else \
+					cp -v $$Y dosbox-x.app/Contents/MacOS/x86_64/; \
+					codesign --remove-signature "dosbox-x.app/Contents/MacOS/x86_64/$$dylib" || exit 1; \
+					chmod 0755 "dosbox-x.app/Contents/MacOS/x86_64/$$dylib" || exit 1; \
+				fi; \
+			done; \
+		fi; \
 	done
 # Find all the libraries we copied and copy any libraries they depend on
 # separated by architecture, and remove their signatures, too.

--- a/build-macos
+++ b/build-macos
@@ -17,13 +17,20 @@ orig_LDFLAGS="$LDFLAGS"
 orig_CPPFLAGS="$CPPFLAGS"
 orig_CXXFLAGS="$CXXFLAGS"
 
+# Ensure sdl2 isn't detected as we aren't going to use it, and the presence of
+# this folder will cause the build to fail.
+rm -rf vs/sdl2/linux-host vs/sdl2/linux-build
+
+# Remove our temporary copies of dosbox-x executable before rebuilding
+rm -f src/dosbox-x-arm64 src/dosbox-x-x86_64
+
 do_cleanup() {
     rm -rf vs/sdl/linux-host vs/sdl/linux-build
     rm -rf vs/sdlnet/linux-host vs/sdlnet/linux-build
     rm -rf vs/zlib/linux-host vs/zlib/linux-build
     rm -rf vs/libpng/linux-host vs/libpng/linux-build
     rm -rf vs/freetype/linux-host vs/freetype/linux-build
-    [ -e Makefile ] && make distclean
+    [ -e Makefile ] && make clean
 }
 
 universal=0
@@ -132,6 +139,10 @@ for arch in $architectures; do
         export CPPFLAGS="$CPPFLAGS$new"
         export CXXFLAGS="$CXXFLAGS$new"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(${!brew_cmd} --prefix)/lib/pkgconfig"
+    fi
+
+    if [ "$universal" = 1 ]; then
+        opts="$opts --enable-universal"
     fi
 
     # now compile ourself

--- a/build-macos-sdl2
+++ b/build-macos-sdl2
@@ -17,12 +17,15 @@ orig_LDFLAGS="$LDFLAGS"
 orig_CPPFLAGS="$CPPFLAGS"
 orig_CXXFLAGS="$CXXFLAGS"
 
+# Remove our temporary copies of dosbox-x executable before rebuilding
+rm -f src/dosbox-x-arm64 src/dosbox-x-x86_64
+
 do_cleanup() {
     rm -rf vs/sdl2/linux-host vs/sdl2/linux-build
     rm -rf vs/zlib/linux-host vs/zlib/linux-build
     rm -rf vs/libpng/linux-host vs/libpng/linux-build
     rm -rf vs/freetype/linux-host vs/freetype/linux-build
-    [ -e Makefile ] && make distclean
+    [ -e Makefile ] && make clean
 }
 
 universal=0
@@ -127,6 +130,10 @@ for arch in $architectures; do
         export CPPFLAGS="$CPPFLAGS$new"
         export CXXFLAGS="$CXXFLAGS$new"
         export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(${!brew_cmd} --prefix)/lib/pkgconfig"
+    fi
+
+    if [ "$universal" = 1 ]; then
+        opts="$opts --enable-universal"
     fi
 
     # now compile ourself

--- a/configure.ac
+++ b/configure.ac
@@ -1235,6 +1235,15 @@ case "$host" in
 esac
 fi
 
+dnl BUILD: whether to enable universal binary support
+if test x"$macosx" = x"1" && test x"$host_cpu" = x"arm"; then
+  AC_ARG_ENABLE(MACOS_UNIVERSAL,AC_HELP_STRING([--enable-universal],[Enable macOS universal binary support]),
+    [enable_universal=$enableval],
+    [enable_universal=no])
+else
+  AM_CONDITIONAL(MACOS_UNIVERSAL, false)
+fi
+
 AC_CONFIG_FILES([ 
 Makefile
 src/Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -75,4 +75,6 @@ endif
 
 EXTRA_DIST = winres.rc ../contrib/icons/dosbox-x.ico
 
-
+# Ensure the macOS universal executables are correctly removed when cleaning
+distclean-local:
+	rm -f dosbox-x-arm64 dosbox-x-x86_64


### PR DESCRIPTION
PR #4054 broke the macOS CI for pull requests and the nightly builds. As a follow-up requested in the PR this is an attempt to fix it.

## What issue(s) does this PR address?

Regression in CI from PR #4054

## Does this PR introduce new feature(s)?

It adds an optional \`./configure --enable-universal\` parameter to define a variable for use in the `Makefile` when executing `make dosbox-x.app`. This is to allow us to determine which architecture executables to depend upon in the \`dosbox-x.app\` rule in the \`Makefile\`.

## Does this PR introduce any breaking change(s)?

I do not believe so.

## Additional information

Changes are:

* Add a parameter to `configure.am` to define a build-time variable for use in `Makefile.am` to specify the executables we will be depending upon for the `dosbox-x.app` rule.
* Fix an issue in the first library scan section of the `dosbox-x.app` rule in the `Makefile` causing a failure to build on an Apple Silicon mac when there is no `x86_64` binary present.
* Fix failure to build SDL1 variant after a previous SDL2 build attempt by deleting `vs/sdl2/linux-host` before attempting the SDL1 build.
* Use `make clean` instead of `make distclean` in the build scripts' `do_cleanup` function to not clean absolutely everything.
* Make sure we remove the achitecture-specific copies we create of the `dosbox-x` executable before building, as these are meant to be used for the universal binary creation with `lipo` and the presence of an old copy will cause the `dosbox-x.app` bundle to potentially contain mismatched copies for each architecture, or contain an architecture that is not intended to be included.
* Add a `distclean-local` rule to `src/Makefile.am` to remove the architecture-specific temporary copies of the `dosbox-x` executable when running `distclean` as these shouldn't remain in the tree.
