### PR TITLE
fix crash with two configured controllers, but only one connected

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1835,6 +1835,7 @@ public:
     }
 
     CBind * CreateConfigBind(char *& buf) {
+        if (is_dummy) return 0;
         if (strncasecmp(configname,buf,strlen(configname))) return 0;
         StripWord(buf);char * type=StripWord(buf);
         CBind * bind=0;


### PR DESCRIPTION
This fixes issue https://github.com/joncampbell123/dosbox-x/issues/1122
The behavior of controller mapping is not changed.
Emulator degrades to mapping only one controller, in the same way as when no controllers are connected.