### PR TITLE
Use == to check for volume attribute bit

### DIFF
--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -427,7 +427,7 @@ void DOS_DTA::SetupSearch(uint8_t _sdrive,uint8_t _sattr,char * pattern) {
 	} else {
 		MEM_BlockWrite(pt+offsetof(sDTA,spname),pattern,(strlen(pattern) > 8) ? 8 : (Bitu)strlen(pattern));
 	}
-    if(_sattr & DOS_ATTR_VOLUME) {
+    if(_sattr == DOS_ATTR_VOLUME) {
         MEM_BlockWrite(pt+offsetof(sDTA, spext),&pattern[8],3);
     }
 }
@@ -505,7 +505,7 @@ void DOS_DTA::GetSearchParams(uint8_t & attr,char * pattern, bool lfn) {
         char temp[11];
         MEM_BlockRead(pt+offsetof(sDTA,spname),temp,11);
         for (int i=0;i<13;i++) pattern[i]=0;
-        if(attr & DOS_ATTR_VOLUME)
+        if(attr == DOS_ATTR_VOLUME)
         {
             memcpy(pattern, temp, 11);
         }

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -572,7 +572,7 @@ bool DOS_FindFirst(const char * search,uint16_t attr,bool fcb_findfirst) {
 		DOS_SetError(DOSERR_NO_MORE_FILES);
 		return false;
 	}
-	if (!DOS_MakeName(search,fullsearch,&drive,attr & DOS_ATTR_VOLUME)) return false;
+	if (!DOS_MakeName(search,fullsearch,&drive,attr == DOS_ATTR_VOLUME)) return false;
 	//Check for devices. FindDevice checks for leading subdir as well
     bool device = false;
     if (attr & DOS_ATTR_DEVICE)

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -871,7 +871,7 @@ nextfile:
 		if (sectbuf[entryoffset].entryname[0] == 0xe5)
 			goto nextfile;
 
-		if (sectbuf[entryoffset].attrib & DOS_ATTR_VOLUME) {
+		if (sectbuf[entryoffset].attrib == DOS_ATTR_VOLUME) {
 			/* TODO: There needs to be a way for FCB delete to erase the volume label by name instead
 			 *       of just picking the first one */
 			/* found one */
@@ -2604,7 +2604,7 @@ nextfile:
 	}
 
 	/* Compare name to search pattern. Skip long filename match if no long filename given. */
-    if(attrs & DOS_ATTR_VOLUME) {
+    if(attrs == DOS_ATTR_VOLUME) {
         if (!(wild_match(find_name, srch_pattern)))
             goto nextfile;
     }
@@ -2615,7 +2615,7 @@ nextfile:
 		goto nextfile;
 	}
 
-    if(sectbuf[entryoffset].attrib & DOS_ATTR_VOLUME)
+    if(sectbuf[entryoffset].attrib == DOS_ATTR_VOLUME)
         trimString(find_name);
 
 	// Drive emulation does not need to require a LFN in case there is no corresponding 8.3 names.


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

Fixes the regression caused by https://github.com/joncampbell123/dosbox-x/pull/4045 that made Quake replace its config file with a default one on every run.

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

No.

## Additional information

There is other DOSBox-X code unrelated to that PR that checks for the volume attribute bit by using "&". Perhaps it should also be using "=="?
