### PR TITLE
Fixes related to DOS standard input Raw mode

### DIFF
--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -126,6 +126,7 @@ public:
 	virtual bool	Seek(uint32_t * pos,uint32_t type);
 	virtual bool	Close();
 	virtual uint16_t	GetInformation(void);
+	virtual void	SetInformation(uint16_t info);
 	virtual bool	ReadFromControlChannel(PhysPt bufptr,uint16_t size,uint16_t * retcode);
 	virtual bool	WriteToControlChannel(PhysPt bufptr,uint16_t size,uint16_t * retcode);
 	virtual uint8_t	GetStatus(bool input_flag);

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -641,6 +641,12 @@ uint16_t DOS_Device::GetInformation(void) {
 	return Devices[devnum]->GetInformation();
 }
 
+void DOS_Device::SetInformation(uint16_t info) {
+	if(Devices[devnum]->IsName("CON") && !(Devices[devnum]->GetInformation() & EXT_DEVICE_BIT)) {
+		Devices[devnum]->SetInformation(info);
+	}
+}
+
 bool DOS_Device::ReadFromControlChannel(PhysPt bufptr,uint16_t size,uint16_t * retcode) {
 	return Devices[devnum]->ReadFromControlChannel(bufptr,size,retcode);
 }

--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -646,6 +646,7 @@ bool DOS_IOCTL(void) {
 			return false;
 		} else {
 			if (Files[handle]->GetInformation() & DeviceInfoFlags::Device) {	//Check for device
+				((DOS_Device *)(Files[handle]))->SetInformation(reg_dx);
 				reg_al=(uint8_t)(Files[handle]->GetInformation() & 0xff);
 			} else {
 				DOS_SetError(DOSERR_FUNCTION_NUMBER_INVALID);


### PR DESCRIPTION
Fix #4088
Fixed to be able to set Raw mode with ax=4401h for built-in CON device.
Fixed echoing on standard input in case of Raw mode setting.
