### PR TITLE
- Should fix compilation of src/hardware/parport/parport.cpp with Vis…

### DIFF
--- a/src/hardware/parport/directlpt.cpp
+++ b/src/hardware/parport/directlpt.cpp
@@ -18,17 +18,8 @@
 
 #include "dosbox.h"
 
-#if C_DIRECTLPT
-/*
-  For MinGW and MinGW-w64, _M_IX86 and _M_X64 are not defined by the compiler,
-  but in a header file, which has to be (indirectly) included, usually through a
-  C (not C++) standard header file. For MinGW it is sdkddkver.h and for
-  MinGW-w64 it is _mingw_mac.h. Do not rely on constants that may not be
-  defined, depending on what was included before these lines.
-*/
-#if ((defined __i386__ || defined __x86_64__ || defined _M_IX86 || defined _M_X64) && \
-     (defined WIN32 || defined BSD || defined __CYGWIN__)) || /* WIN32 is not defined by default on Cygwin */ \
-    defined LINUX /* Linux, including non-x86 (e.g. Raspberry Pi) */
+#include "directlpt.h" // for HAS_CDIRECTLPT
+#if HAS_CDIRECTLPT
 #include <SDL.h>
 #ifdef LINUX
 #include <errno.h>
@@ -41,7 +32,6 @@
 #endif
 #include "libs/passthroughio/passthroughio.h"
 #include "callback.h"
-#include "directlpt.h"
 #include "logging.h"
 
 #define PPORT_CON_IRQ 0x10
@@ -358,5 +348,4 @@ void CDirectLPT::Write_IOSEL(Bitu val) {
 
 void CDirectLPT::handleUpperEvent(uint16_t type) { (void)type; }
 
-#endif // Win32 / BSD / Linux
-#endif // C_DIRECTLPT
+#endif // HAS_CDIRECTLPT

--- a/src/hardware/parport/directlpt.h
+++ b/src/hardware/parport/directlpt.h
@@ -34,6 +34,9 @@
     defined LINUX /* Linux, including non-x86 (e.g. Raspberry Pi) */
 #include "parport.h"
 
+// Instead of repeating the preprocessor logic above, use 1 constant in client code
+#define HAS_CDIRECTLPT 1
+
 class CDirectLPT : public CParallel {
 public:
 	CDirectLPT(Bitu nr, uint8_t initIrq, CommandLine* cmd);
@@ -64,5 +67,10 @@ private:                                // something was wrong, delete it right 
 #endif
 };
 
+#else
 #endif // Win32 / BSD / Linux
 #endif // C_DIRECTLPT
+
+#ifndef HAS_CDIRECTLPT
+#define HAS_CDIRECTLPT 0
+#endif

--- a/src/hardware/parport/parport.cpp
+++ b/src/hardware/parport/parport.cpp
@@ -138,7 +138,7 @@ static Bitu PARALLEL_Read (Bitu port, Bitu iolen) {
 			parallelPortObjects[i]->log_par(parallelPortObjects[i]->dbg_cregs,
 				"read  0x%2x from %s.",retval,dbgtext[port&3]);
 #endif
-			return retval;	
+			return retval;
 		}
 	}
 	return 0xff;
@@ -209,9 +209,9 @@ CParallel::CParallel(CommandLine* cmd, Bitu portnr, uint8_t initirq) {
 	dbg_cregs	= cmd->FindExist("dbgregs", false);
 	dbg_plainputchar = cmd->FindExist("dbgputplain", false);
 	dbg_plaindr = cmd->FindExist("dbgdataplain", false);
-	
+
 	if(cmd->FindExist("dbgall", false)) {
-		dbg_data= 
+		dbg_data=
 		dbg_putchar=
 		dbg_cregs=true;
 		dbg_plainputchar=dbg_plaindr=false;
@@ -222,7 +222,7 @@ CParallel::CParallel(CommandLine* cmd, Bitu portnr, uint8_t initirq) {
 	else debugfp=0;
 
 	if(debugfp == 0) {
-		dbg_data= 
+		dbg_data=
 		dbg_putchar=dbg_plainputchar=
 		dbg_cregs=false;
 	} else {
@@ -337,7 +337,7 @@ void BIOS_Post_register_parports() {
 			BIOS_SetLPTPort(i,(uint16_t)DISNEY_BasePort());
 	}
 }
-	
+
 class PARPORTS:public Module_base {
 	public:
 		PARPORTS (Section * configuration):Module_base (configuration) {
@@ -380,7 +380,7 @@ class PARPORTS:public Module_base {
 				if (i == 0 && DISNEY_ShouldInit())
 					continue;
 
-#if C_DIRECTLPT
+#if C_DIRECTLPT && HAS_CDIRECTLPT
 				if(str=="reallpt") {
 					CDirectLPT* cdlpt= new CDirectLPT(i, defaultirq[i],&cmd);
 					if(cdlpt->InstallationSuccessful) {
@@ -426,7 +426,7 @@ class PARPORTS:public Module_base {
 								parallelPortObjects[i] = 0;
 							}
 						} else
-#endif				
+#endif
 							if(str=="disabled") {
 								parallelPortObjects[i] = 0;
 							} else if (str == "disney") {
@@ -473,7 +473,7 @@ static PARPORTS *testParallelPortsBaseclass = NULL;
 
 static const char *parallelTypes[PARALLEL_TYPE_COUNT] = {
 	"disabled",
-#if C_DIRECTLPT
+#if C_DIRECTLPT && HAS_CDIRECTLPT
 	"reallpt",
 #endif
 	"file",
@@ -620,7 +620,7 @@ void PARALLEL::Run()
 			case PARALLEL_TYPE_DISABLED:
 				parallelPortObjects[port-1] = 0;
 				break;
-#if C_DIRECTLPT
+#if C_DIRECTLPT && HAS_CDIRECTLPT
 			case PARALLEL_TYPE_REALLPT:
 				{
 					CDirectLPT* cdlpt= new CDirectLPT(port-1, defaultirq[port-1],&cmd);


### PR DESCRIPTION
…ual Studio ARM32 and Visual Studio ARM64.

- I say should because I do not have access to Visual Studio ARM32 nor Visual Studio ARM64. As far as I can tell this is a proper fix.

## What issue(s) does this PR address?

Compilation of parport.cpp caused an error with Visual Studio ARM32 and Visual Studio ARM64, because parport.cpp was referring to the class CDirectLPT if the constant C_DIRECTLPT was non-zero. However, in my previous pull request I had made CDirectLPT only available on platforms where it can actually work. CDirectLPT cannot work on Windows/ARM32 and Windows/ARM64.
This pull request introduces the constant HAS_CDIRECTLPT that has the value 1 if the class CDirectLPT is available. Using this constant is much less error prone than repeating the preprocessor logic that determines whether CDirectLPT should be compiled.

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

No.

## Additional information

Thank you very much for accepting my previous pull request!
