### PR TITLE
Don't use NULL where 0 is appropriate

### DIFF
--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -1325,12 +1325,7 @@ OPL_Mode Module::oplmode=OPL_none;
 }	//Adlib Namespace
 
 std::string getoplmode() {
-#if !defined(__FreeBSD__) && !defined(__OpenBSD__)
-	// Todo: is this needed at all? opmode cannot be null...
-	if (Adlib::Module::oplmode == NULL || Adlib::Module::oplmode == OPL_none) return "None";
-#else
-	if (Adlib::Module::oplmode == 0 || Adlib::Module::oplmode == OPL_none) return "None";
-#endif
+    if (Adlib::Module::oplmode == OPL_none) return "None";
     else if (Adlib::Module::oplmode == OPL_cms) return "CMS";
     else if (Adlib::Module::oplmode == OPL_opl2) return "OPL2";
     else if (Adlib::Module::oplmode == OPL_dualopl2) return "Dual OPL2";

--- a/src/hardware/voodoo_opengl.cpp
+++ b/src/hardware/voodoo_opengl.cpp
@@ -548,13 +548,7 @@ void voodoo_ogl_invalidate_paltex(void) {
 	}
 }
 
-
-#if defined(__FreeBSD__) || defined(__OpenBSD__)
-GLhandleARB m_hProgramObject   = (GLhandleARB)0;
-#else
-GLhandleARB m_hProgramObject   = (GLhandleARB)NULL;
-#endif
-
+GLhandleARB m_hProgramObject = 0;
 
 void ogl_printInfoLog(GLhandleARB obj)
 {


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

Corrects a few usages of `NULL` when a value of `0` is expected. According to https://github.com/joncampbell123/dosbox-x/issues/3819#issuecomment-1315033434 this may be needed for compiling in Alpine.

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

No.

## Additional information

The removed "todo" says that the oplmode cannot be "null", but if null here means "0", it can be, by setting it an oplmode of none in the .conf file, so I removed that todo comment.
