### PR TITLE
Work-around for issue in InpOut32/InpOutx64 v1.…

### DIFF
--- a/src/hardware/parport/directlpt.cpp
+++ b/src/hardware/parport/directlpt.cpp
@@ -16,8 +16,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#include "dosbox.h"
-
 #include "directlpt.h" // for HAS_CDIRECTLPT
 #if HAS_CDIRECTLPT
 #include <SDL.h>
@@ -29,6 +27,8 @@
 #include <linux/parport.h>
 #include <linux/ppdev.h>
 #include <sys/ioctl.h>
+#elif defined BSD
+#include <unistd.h>
 #endif
 #include "libs/passthroughio/passthroughio.h"
 #include "callback.h"
@@ -103,7 +103,7 @@ CDirectLPT::CDirectLPT(Bitu nr, uint8_t initIrq, CommandLine* cmd)
 			return;
 		}
 
-		if(ioctl(porthandle, PPCLAIM, NULL) == -1) {
+		if(ioctl(porthandle, PPCLAIM) == -1) {
 			LOG_MSG("parallel%d: Failed to claim parallel port. Pass-through I/O disabled.", (int)nr + 1);
 			return;
 		}

--- a/src/hardware/parport/directlpt.h
+++ b/src/hardware/parport/directlpt.h
@@ -67,7 +67,6 @@ private:                                // something was wrong, delete it right 
 #endif
 };
 
-#else
 #endif // Win32 / BSD / Linux
 #endif // C_DIRECTLPT
 

--- a/src/libs/passthroughio/passthroughio.cpp
+++ b/src/libs/passthroughio/passthroughio.cpp
@@ -199,7 +199,16 @@ static uint16_t dlportio_input_word(uint16_t port) { return DlPortReadPortUshort
 static void dlportio_output_word(uint16_t port, uint16_t value) { DlPortWritePortUshort(port, value); }
 
 static uint32_t dlportio_input_dword(uint16_t port) { return DlPortReadPortUlong(port); }
-static void dlportio_output_dword(uint16_t port, uint32_t value) { DlPortWritePortUlong(port, value); }
+static void dlportio_output_dword(uint16_t port, uint32_t value) {
+#if 0
+	// DlPortWritePortUlong() in InpOut32/InpOutx64 v1.5.0.1 is broken. See
+	// InpOutInterfaceDriver.zip, hwinterfacedrv.c, line 172.
+	DlPortWritePortUlong(port, value);
+#else
+	DlPortWritePortUshort(port, (USHORT)value);
+	DlPortWritePortUshort(port + 2, (USHORT)(value >> 16));
+#endif
+}
 
 #ifdef __CYGWIN__
 static void ioSignalHandler(int signum, siginfo_t* info, void* ctx) {
@@ -392,7 +401,6 @@ bool initPassthroughIO(void) {
 #ifndef __ANDROID__
 #include <sys/io.h>
 #endif
-#include <sys/types.h>
 #elif defined __OpenBSD__ || defined __NetBSD__
 #include <machine/sysarch.h>
 #include <sys/types.h>


### PR DESCRIPTION
…5.0.1.

Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

- Removed redundant includes in directlpt.cpp and passthroughio.cpp.
- Added missing include of <unistd.h> in directlpt.cpp for the BSDs.
- Removed stray #else in directlpt.h.
- Added work-around for broken (but currently unused) DlPortWritePortUlong() in InpOut32/InpOutx64 v1.5.0.1.

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

No.
