### PR TITLE
Warning fixes

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -779,10 +779,10 @@ struct DOS_Block {
     DOS_Version version = {};
     uint16_t firstMCB = 0;
     uint16_t errorcode = 0;
-    uint16_t psp();//{return DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).GetPSP();};
-    void psp(uint16_t _seg);//{ DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).SetPSP(_seg);};
-    RealPt dta();//{return DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).GetDTA();};
-    void dta(RealPt _dta);//{DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).SetDTA(_dta);};
+    uint16_t psp() const;//{return DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).GetPSP();};
+    void psp(uint16_t _seg) const;//{ DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).SetPSP(_seg);};
+    RealPt dta() const;//{return DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).GetDTA();};
+    void dta(RealPt _dta) const;//{DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).SetDTA(_dta);};
     uint8_t return_code = 0, return_mode = 0;
 
     uint8_t current_drive = 0;

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -192,7 +192,7 @@ public:
 	uint32_t GetSeekPos(void);
 	FILE * fhandle;
 private:
-	bool read_only_medium;
+	bool read_only_medium = false;
 	enum { NONE,READ,WRITE } last_action;
 };
 

--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -87,7 +87,7 @@ public:
 	virtual bool	UpdateDateTimeFromHost()	{ return true; }
 	virtual uint32_t	GetSeekPos()	{ return 0xffffffff; }
 	void SetDrive(uint8_t drv) { hdrive=drv;}
-	uint8_t GetDrive(void) { return hdrive;}
+	uint8_t GetDrive(void) const { return hdrive;}
 	virtual void 	SaveState( std::ostream& stream );
 	virtual void 	LoadState( std::istream& stream, bool pop );
     virtual void    Flush(void) { }

--- a/include/mapper.h
+++ b/include/mapper.h
@@ -46,6 +46,7 @@ union SDL_Event;
 void MAPPER_CheckEvent(SDL_Event *);
 
 std::string mapper_event_keybind_string(const std::string &x);
+std::map<std::string, std::string> get_event_map();
 
 #define MMOD1 0x1
 #define MMOD2 0x2

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -238,6 +238,7 @@ void DoKillSwitch();
 void ResetSystem(bool pressed);
 void PauseDOSBox(bool pressed);
 bool systemmessagebox(char const * aTitle, char const * aMessage, char const * aDialogType, char const * aIconType, int aDefaultButton);
+int GetNumScreen();
 
 #if defined(C_SDL2)
 SDL_Window* GFX_SetSDLWindowMode(uint16_t width, uint16_t height, SCREEN_TYPES screenType);

--- a/include/shell.h
+++ b/include/shell.h
@@ -388,4 +388,6 @@ private:
 	void CreateAutoexec(void);
 };
 
+size_t GetPauseCount();
+
 #endif

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -346,8 +346,8 @@ public:
 	//! \brief Indicate whether the image has a data track
 	bool	ReadSector              (uint8_t *buffer, bool raw, unsigned long sector);
 	//! \brief Indicate whether the image has a data track
-	bool	HasDataTrack            (void);
-	bool	HasAudioTrack           (void);
+	bool	HasDataTrack            (void) const;
+	bool	HasAudioTrack           (void) const;
     //! \brief Flag to track if images have been initialized
     //!
     //! \description Whether images[] has been initialized.
@@ -388,17 +388,17 @@ private:
 	// Private utility functions
 	void  ClearTracks();
 	bool  LoadIsoFile(char *filename);
-	bool  CanReadPVD(TrackFile *file, int sectorSize, bool mode2);
+	bool  CanReadPVD(TrackFile *file, int sectorSize, bool mode2) const;
 	int	  GetTrack(unsigned long sector);
 	static void CDAudioCallBack (Bitu len);
 
 	// Private functions for cue sheet processing
 	bool  LoadCueSheet(char *cuefile);
 	bool  LoadChdFile(char* chdfile);
-	bool  GetRealFileName(std::string& filename, std::string& pathname);
-	bool  GetCueKeyword(std::string &keyword, std::istream &in);
-	bool  GetCueFrame(int &frames, std::istream &in);
-	bool  GetCueString(std::string &str, std::istream &in);
+	bool  GetRealFileName(std::string& filename, std::string& pathname) const;
+	bool  GetCueKeyword(std::string &keyword, std::istream &in) const;
+	bool  GetCueFrame(int &frames, std::istream &in) const;
+	bool  GetCueString(std::string &str, std::istream &in) const;
 	bool  AddTrack(Track &curr, int &shift, int prestart, int &totalPregap, int currPregap);
 	// member variables
 	std::vector<Track>   tracks;

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -1355,7 +1355,7 @@ bool CDROM_Interface_Image::AddTrack(Track &curr, int &shift, int prestart, int 
 	// frames between index 0(prestart) and 1(curr.start) must be skipped
 	int skip;
 	if (prestart >= 0) {
-		if (prestart > curr.start) return false;
+		if ((unsigned int)prestart > curr.start) return false;
 		skip = curr.start - prestart;
         //LOG_MSG("CDROM Addtrack skip=%d prestart=%d curr.start=%d", skip, prestart, curr.start);
 	} else skip = 0;

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -1014,7 +1014,7 @@ bool CDROM_Interface_Image::LoadIsoFile(char* filename)
 	return true;
 }
 
-bool CDROM_Interface_Image::CanReadPVD(TrackFile *file, int sectorSize, bool mode2)
+bool CDROM_Interface_Image::CanReadPVD(TrackFile *file, int sectorSize, bool mode2) const
 {
 	uint8_t pvd[COOKED_SECTOR_SIZE];
 	int seek = 16 * sectorSize;	// first vd is located at sector 16
@@ -1362,7 +1362,7 @@ bool CDROM_Interface_Image::AddTrack(Track &curr, int &shift, int prestart, int 
 
 	// first track (track number must be 1)
 	if (tracks.empty()) {
-		if (curr.number != 1) return false;
+        if(curr.number != 1) return false;
         curr.pregap = 0; // first track starts from sector zero, right?
         curr.skip = skip * curr.sectorSize; //
 		curr.start += currPregap;
@@ -1416,7 +1416,7 @@ bool CDROM_Interface_Image::AddTrack(Track &curr, int &shift, int prestart, int 
 	return true;
 }
 
-bool CDROM_Interface_Image::HasDataTrack(void)
+bool CDROM_Interface_Image::HasDataTrack(void) const
 {
 	//Data track has attribute 0x40
 	for (const auto &track : tracks) {
@@ -1427,7 +1427,7 @@ bool CDROM_Interface_Image::HasDataTrack(void)
 	return false;
 }
 
-bool CDROM_Interface_Image::HasAudioTrack(void)
+bool CDROM_Interface_Image::HasAudioTrack(void) const
 {
 	//Audio track has attribute 0x00
 	for (const auto &track : tracks) {
@@ -1438,7 +1438,7 @@ bool CDROM_Interface_Image::HasAudioTrack(void)
 	return false;
 }
 
-bool CDROM_Interface_Image::GetRealFileName(string &filename, string &pathname)
+bool CDROM_Interface_Image::GetRealFileName(string &filename, string &pathname) const
 {
 	// check if file exists
 	struct stat test;
@@ -1496,7 +1496,7 @@ bool CDROM_Interface_Image::GetRealFileName(string &filename, string &pathname)
 	return false;
 }
 
-bool CDROM_Interface_Image::GetCueKeyword(string &keyword, istream &in)
+bool CDROM_Interface_Image::GetCueKeyword(string &keyword, istream &in) const
 {
 	in >> keyword;
 	for (Bitu i = 0; i < keyword.size(); i++) {
@@ -1505,7 +1505,7 @@ bool CDROM_Interface_Image::GetCueKeyword(string &keyword, istream &in)
 	return true;
 }
 
-bool CDROM_Interface_Image::GetCueFrame(int &frames, istream &in)
+bool CDROM_Interface_Image::GetCueFrame(int &frames, istream &in) const
 {
 	string msf;
 	in >> msf;
@@ -1515,7 +1515,7 @@ bool CDROM_Interface_Image::GetCueFrame(int &frames, istream &in)
 	return success;
 }
 
-bool CDROM_Interface_Image::GetCueString(string &str, istream &in)
+bool CDROM_Interface_Image::GetCueString(string &str, istream &in) const
 {
 	int pos = (int)in.tellg();
 	in >> str;

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -257,7 +257,7 @@ DOS_InfoBlock dos_infoblock;
 extern int bootdrive;
 extern bool force_sfn, dos_kernel_disabled;
 
-uint16_t DOS_Block::psp() {
+uint16_t DOS_Block::psp() const {
 	if (dos_kernel_disabled) {
 		LOG_MSG("BUG: DOS kernel is disabled (booting a guest OS), and yet somebody is still asking for DOS's current PSP segment\n");
 		return 0x0000;
@@ -266,7 +266,7 @@ uint16_t DOS_Block::psp() {
 	return DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).GetPSP();
 }
 
-void DOS_Block::psp(uint16_t _seg) {
+void DOS_Block::psp(uint16_t _seg) const {
 	if (dos_kernel_disabled) {
 		LOG_MSG("BUG: DOS kernel is disabled (booting a guest OS), and yet somebody is still attempting to change DOS's current PSP segment\n");
 		return;
@@ -275,7 +275,7 @@ void DOS_Block::psp(uint16_t _seg) {
 	DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).SetPSP(_seg);
 }
 
-RealPt DOS_Block::dta() {
+RealPt DOS_Block::dta() const {
 	if (dos_kernel_disabled) {
 		LOG_MSG("BUG: DOS kernel is disabled (booting a guest OS), and yet somebody is still asking for DOS's DTA (disk transfer address)\n");
 		return 0;
@@ -284,7 +284,7 @@ RealPt DOS_Block::dta() {
 	return DOS_SDA(DOS_SDA_SEG,DOS_SDA_OFS).GetDTA();
 }
 
-void DOS_Block::dta(RealPt _dta) {
+void DOS_Block::dta(RealPt _dta) const {
 	if (dos_kernel_disabled) {
 		LOG_MSG("BUG: DOS kernel is disabled (booting a guest OS), and yet somebody is still attempting to change DOS's DTA (disk transfer address)\n");
 		return;

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -2734,7 +2734,7 @@ static Bitu DOS_21Handler(void) {
                         else len = mem_strlen(data); /* Is limited to 1024 */
 
                         if(len > DOS_COPYBUFSIZE - 1) E_Exit("DOS:0x65 Buffer overflow");
-                        if(len) {
+                        else if(len) {
                             MEM_BlockRead(data,dos_copybuf,len);
                             dos_copybuf[len] = 0;
                             //No upcase as String(0x21) might be multiple asciz strings

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -3910,7 +3910,7 @@ restart_int:
         // write VHD footer if requested, largely copied from RAW2VHD program, no license was included
         char extension[6] = {}; // care extensions longer than 3 letters such as '.vhdd'
         if(temp_line.find_last_of('.') != std::string::npos) {
-            for(int i = 0; i < sizeof(extension) - 1; i++) {
+            for(unsigned int i = 0; i < sizeof(extension) - 1; i++) {
                 if(temp_line.find_last_of('.') + i > temp_line.length() - 1) break;
                 extension[i] = temp_line[temp_line.find_last_of('.') + i];
             }
@@ -4068,7 +4068,7 @@ public:
             return;
         }
         if (cmd->FindCommand(2,temp_line)) {
-            unsigned int swap=atoi(temp_line.c_str());
+            int swap=atoi(temp_line.c_str());
             if (swap<1||swap>DriveManager::GetDisksSize(d)) {
                 WriteOut(MSG_Get("PROGRAM_IMGSWAP_ERROR"), DriveManager::GetDisksSize(d));
                 return;

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -60,6 +60,7 @@
 #include "mouse.h"
 #include "../ints/int10.h"
 #include "../output/output_opengl.h"
+#include "paging.h"
 #if !defined(HX_DOS)
 #include "../libs/tinyfiledialogs/tinyfiledialogs.c"
 #endif
@@ -73,7 +74,6 @@ host_cnv_char_t *CodePageGuestToHost(const char *s);
 #if !defined(S_ISREG)
 # define S_ISREG(x) ((x & S_IFREG) == S_IFREG)
 #endif
-#include "../dos/cdrom.h"
 #include <ShlObj.h>
 #else
 #include <libgen.h>
@@ -110,7 +110,7 @@ extern int toSetCodePage(DOS_Shell *shell, int newCP, int opt);
 void MSG_Init(), JFONT_Init(), InitFontHandle(), ShutFontHandle(), DOSBox_SetSysMenu(), Load_Language(std::string name);
 void DOS_EnableDriveMenu(char drv), GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused), UpdateSDLDrawTexture();
 void runBoot(const char *str), runMount(const char *str), runImgmount(const char *str), runRescan(const char *str), show_prompt(), ttf_reset(void);
-void getdrivezpath(std::string &path, std::string dirname), drivezRegister(std::string path, std::string dir, bool usecp), UpdateDefaultPrinterFont(void);
+void getdrivezpath(std::string &path, std::string const& dirname), drivezRegister(std::string const& path, std::string const& dir, bool usecp), UpdateDefaultPrinterFont(void);
 std::string GetDOSBoxXPath(bool withexe=false);
 FILE *testLoadLangFile(const char *fname);
 
@@ -480,8 +480,8 @@ void MenuMountDrive(char drive, const char drive2[DOS_PATHLENGTH]) {
 	Drives[drive-'A']=newdrive;
 	DOS_EnableDriveMenu(drive);
 	mem_writeb(Real2Phys(dos.tables.mediaid)+(drive-'A')*2,mediaid);
-	if(type==DRIVE_CDROM) LOG_MSG("GUI: Drive %c is mounted as CD-ROM %c:\\",drive,drive);
-	else LOG_MSG("GUI: Drive %c is mounted as local directory %c:\\",drive,drive);
+    if(type == DRIVE_CDROM) LOG_MSG("GUI: Drive %c is mounted as CD-ROM %c:\\", drive, drive);
+    else LOG_MSG("GUI: Drive %c is mounted as local directory %c:\\", drive, drive);
     if(drive == drive2[0] && strlen(drive2) == 3) {
         // automatic mount
     } else {
@@ -691,10 +691,10 @@ void MenuBrowseImageFile(char drive, bool arc, bool boot, bool multiple) {
 		strcat(mountstring,temp_str);
 		if (!multiple) strcat(mountstring,"\"");
 		strcat(mountstring,files.size()?files.c_str():fname.c_str());
-		if (!multiple) strcat(mountstring,"\"");
-		if (mountiro[drive-'A']) strcat(mountstring," -ro");
-		if (boot) strcat(mountstring," -u");
-        if (arc) {
+        if(!multiple) strcat(mountstring, "\"");
+        if(mountiro[drive - 'A']) strcat(mountstring, " -ro");
+        if(boot) strcat(mountstring, " -u");
+        if(arc) {
             strcat(mountstring," -q");
             runMount(mountstring);
         } else {
@@ -1157,7 +1157,7 @@ public:
 					uint16_t numc=type=="cdrom"?1:32;
                     uint32_t total_size_cyl=32765;
 					uint32_t tmp=(uint32_t)freesize*1024*1024/(type=="cdrom"?2048*1:512*32);
-					if (tmp>65534) numc=type=="cdrom"?(tmp+65535)/65536:64;
+                    if(tmp > 65534) numc = type == "cdrom" ? (tmp + 65535) / 65536 : 64;
                     uint32_t free_size_cyl=(uint32_t)freesize*1024*1024/(numc*(type=="cdrom"?2048:512));
                     if (free_size_cyl>65534) free_size_cyl=65534;
                     if (total_size_cyl<free_size_cyl) total_size_cyl=free_size_cyl+10;
@@ -1207,9 +1207,9 @@ public:
 			if (cmd->FindExist("-u",true)) {
                 bool curdrv = toupper(i_drive)-'A' == DOS_GetDefaultDrive();
                 const char *msg=UnmountHelper(i_drive);
-				if (!quiet) WriteOut(msg, toupper(i_drive));
-				if (!cmd->FindCommand(2,temp_line)||!temp_line.size()) return;
-                if (curdrv && toupper(i_drive)-'A' != DOS_GetDefaultDrive()) removed = true;
+                if(!quiet) WriteOut(msg, toupper(i_drive));
+                if(!cmd->FindCommand(2, temp_line) || !temp_line.size()) return;
+                if(curdrv && toupper(i_drive) - 'A' != DOS_GetDefaultDrive()) removed = true;
 			}
             drive = static_cast<char>(i_drive);
             if (type == "overlay") {
@@ -1301,7 +1301,7 @@ public:
             /* Removing trailing backslash if not root dir so stat will succeed */
             if(temp_line.size() > 3 && temp_line[temp_line.size()-1]=='\\') temp_line.erase(temp_line.size()-1,1);
             if(temp_line.size() == 2 && toupper(temp_line[0])>='A' && toupper(temp_line[0])<='Z' && temp_line[1]==':') temp_line.append("\\");
-			if(temp_line.size() > 4 && temp_line[0]=='\\' && temp_line[1]=='\\' && temp_line[2]!='\\' && std::count(temp_line.begin()+3, temp_line.end(), '\\')==1) temp_line.append("\\");
+            if(temp_line.size() > 4 && temp_line[0] == '\\' && temp_line[1] == '\\' && temp_line[2] != '\\' && std::count(temp_line.begin() + 3, temp_line.end(), '\\') == 1) temp_line.append("\\");
             notrycp = true;
             const host_cnv_char_t* host_name = CodePageGuestToHost(temp_line.c_str());
             notrycp = false;
@@ -1446,17 +1446,17 @@ public:
                 else
                     newdrive  = new cdromDrive(drive,temp_line.c_str(),sizes[0],bit8size,sizes[2],sizes[3],mediaid,error,options);
                 // Check Mscdex, if it worked out...
-                if (!quiet)
-                switch (error) {
-                    case 0  :   WriteOut(MSG_Get("MSCDEX_SUCCESS"));                break;
-                    case 1  :   WriteOut(MSG_Get("MSCDEX_ERROR_MULTIPLE_CDROMS"));  break;
-                    case 2  :   WriteOut(MSG_Get("MSCDEX_ERROR_NOT_SUPPORTED"));    break;
-                    case 3  :   WriteOut(MSG_Get("MSCDEX_ERROR_PATH"));             break;
-                    case 4  :   WriteOut(MSG_Get("MSCDEX_TOO_MANY_DRIVES"));        break;
-                    case 5  :   WriteOut(MSG_Get("MSCDEX_LIMITED_SUPPORT"));        break;
-                    case 10 :   WriteOut(MSG_Get("PROGRAM_MOUNT_PHYSFS_ERROR"));WriteOut(MSG_Get("PROGRAM_MOUNT_IMGMOUNT"));break;
-                    default :   WriteOut(MSG_Get("MSCDEX_UNKNOWN_ERROR"));          break;
-                }
+                if(!quiet)
+                    switch(error) {
+                    case 0:   WriteOut(MSG_Get("MSCDEX_SUCCESS"));                break;
+                    case 1:   WriteOut(MSG_Get("MSCDEX_ERROR_MULTIPLE_CDROMS"));  break;
+                    case 2:   WriteOut(MSG_Get("MSCDEX_ERROR_NOT_SUPPORTED"));    break;
+                    case 3:   WriteOut(MSG_Get("MSCDEX_ERROR_PATH"));             break;
+                    case 4:   WriteOut(MSG_Get("MSCDEX_TOO_MANY_DRIVES"));        break;
+                    case 5:   WriteOut(MSG_Get("MSCDEX_LIMITED_SUPPORT"));        break;
+                    case 10:   WriteOut(MSG_Get("PROGRAM_MOUNT_PHYSFS_ERROR")); WriteOut(MSG_Get("PROGRAM_MOUNT_IMGMOUNT")); break;
+                    default:   WriteOut(MSG_Get("MSCDEX_UNKNOWN_ERROR"));          break;
+                    }
                 if (error && error!=5) {
                     delete newdrive;
                     return;
@@ -1492,8 +1492,8 @@ public:
                   }
                   localDrive* ldp = dynamic_cast<localDrive*>(Drives[drive-'A']);
                   cdromDrive* cdp = dynamic_cast<cdromDrive*>(Drives[drive-'A']);
-                  if (!ldp || cdp || pcdp) {
-					  if (!quiet) WriteOut(MSG_Get("PROGRAM_MOUNT_OVERLAY_INCOMPAT_BASE"));
+                  if(!ldp || cdp || pcdp) {
+                      if(!quiet) WriteOut(MSG_Get("PROGRAM_MOUNT_OVERLAY_INCOMPAT_BASE"));
                       return;
                   }
                   std::string base = ldp->getBasedir();
@@ -1630,9 +1630,6 @@ void SBLASTER_DOS_Shutdown();
 unsigned char PC98_ITF_ROM[0x8000];
 bool PC98_ITF_ROM_init = false;
 unsigned char PC98_BANK_Select = 0x12;
-
-#include "mem.h"
-#include "paging.h"
 
 class PC98ITFPageHandler : public PageHandler {
 public:
@@ -2082,8 +2079,8 @@ public:
 			}
 		}
 
-		if (!bootbyDrive)
-		while(i<cmd->GetCount()) {
+        if(!bootbyDrive)
+            while(i < cmd->GetCount()) {
             if(cmd->FindCommand((unsigned int)(i+1), temp_line)) {
 				if ((temp_line == "/?") || (temp_line == "-?")) {
 					printError();
@@ -3056,7 +3053,7 @@ const uint8_t freedos_mbr[] = {
 class IMGMAKE : public Program {
 public:
 #ifdef WIN32
-    bool OpenDisk(HANDLE* f, OVERLAPPED* o, uint8_t* name) {
+    bool OpenDisk(HANDLE* f, OVERLAPPED* o, uint8_t* name) const {
         o->hEvent = INVALID_HANDLE_VALUE;
         *f = CreateFile( (LPCSTR)name, GENERIC_READ | GENERIC_WRITE,
             0,    // exclusive access 
@@ -3081,12 +3078,12 @@ public:
         return true;
     }
 
-    void CloseDisk(HANDLE f, OVERLAPPED* o) {
+    void CloseDisk(HANDLE f, OVERLAPPED* o) const {
         if(f != INVALID_HANDLE_VALUE) CloseHandle(f);
         if(o->hEvent != INVALID_HANDLE_VALUE) CloseHandle(o->hEvent);
     }
 
-    bool StartReadDisk(HANDLE f, OVERLAPPED* o, uint8_t* buffer, Bitu offset, Bitu size) { 
+    bool StartReadDisk(HANDLE f, OVERLAPPED* o, uint8_t* buffer, Bitu offset, Bitu size) const { 
         o->Offset = (DWORD)offset;
         if (!ReadFile(f, buffer, (DWORD)size, NULL, o) &&
             (GetLastError()==ERROR_IO_PENDING)) return true;
@@ -3094,7 +3091,7 @@ public:
     }
 
     // 0=still waiting, 1=catastrophic failure, 2=success, 3=sector not found, 4=crc error
-    Bitu CheckDiskReadComplete(HANDLE f, OVERLAPPED* o) {
+    Bitu CheckDiskReadComplete(HANDLE f, OVERLAPPED* o) const {
         DWORD numret;
         BOOL b = GetOverlappedResult( f, o, &numret,false); 
         if(b) return 2;
@@ -4452,7 +4449,7 @@ public:
     void DisplayMenuCursorEnd(void) { WriteOut("\033[0m\n"); }
     void DisplayMenuNone(void) { WriteOut("\033[44m\033[K\033[0m\n"); }
 
-    bool CON_IN(uint8_t * data) {
+    bool CON_IN(uint8_t * data) const {
         uint8_t c;
         uint16_t n=1;
 
@@ -4508,7 +4505,11 @@ public:
             return;
         }
 
-        if(cmd->FindExist("usage",false)) {DisplayUsage(); if (attr) DOS_SetAnsiAttr(attr); return; }
+        if(cmd->FindExist("usage", false)) {
+            DisplayUsage();
+            if(attr) DOS_SetAnsiAttr(attr);
+            return;
+        }
         uint8_t c;uint16_t n=1;
 
 #define CURSOR(option) \
@@ -4953,7 +4954,7 @@ public:
 
         //look for -el-torito parameter and remove it from the command line
         cmd->FindString("-el-torito",el_torito,true);
-		if (el_torito == "") cmd->FindString("-bootcd",el_torito,true);
+        if(el_torito == "") cmd->FindString("-bootcd", el_torito, true);
         if (el_torito != "") {
             //get el-torito floppy from cdrom mounted at drive letter el_torito_cd_drive
             el_torito_cd_drive = toupper(el_torito[0]);
@@ -6023,12 +6024,12 @@ private:
         return true;
     }
 
-    void AddToDriveManager(const char drive, DOS_Drive* imgDisk, const uint8_t mediaid) {
+    void AddToDriveManager(const char drive, DOS_Drive* imgDisk, const uint8_t mediaid) const {
         std::vector<DOS_Drive*> imgDisks = { imgDisk };
         AddToDriveManager(drive, imgDisks, mediaid);
     }
 
-    void AddToDriveManager(const char drive, const std::vector<DOS_Drive*> &imgDisks, const uint8_t mediaid) {
+    void AddToDriveManager(const char drive, const std::vector<DOS_Drive*> &imgDisks, const uint8_t mediaid) const {
         std::vector<DOS_Drive*>::size_type ct;
 
         // Update DriveManager
@@ -6193,7 +6194,7 @@ private:
         }
     }
 
-    bool DetectMFMsectorPartition(uint8_t buf[], uint32_t fcsize, Bitu sizes[]) {
+    bool DetectMFMsectorPartition(uint8_t buf[], uint32_t fcsize, Bitu sizes[]) const {
         // This is used for plain MFM sector format as created by IMGMAKE
         // It tries to find the first partition. Addressing is in CHS format.
         /* Offset   | Length    | Description
@@ -6256,7 +6257,7 @@ private:
         return false;
     }
     
-    bool DetectBximagePartition(uint32_t fcsize, Bitu sizes[]) {
+    bool DetectBximagePartition(uint32_t fcsize, Bitu sizes[]) const {
         // Try bximage disk geometry
         uint32_t cylinders = fcsize / (16 * 63);
         // Int13 only supports up to 1023 cylinders
@@ -6284,17 +6285,17 @@ private:
             int error = -1;
             DOS_Drive* newDrive = new isoDrive(drive, wpcolon&&paths[i].length()>1&&paths[i].c_str()[0]==':'?paths[i].c_str()+1:paths[i].c_str(), mediaid, error, options);
             isoDisks.push_back(newDrive);
-            if (!qmount)
-            switch (error) {
-            case 0: break;
-            case 1: WriteOut(MSG_Get("MSCDEX_ERROR_MULTIPLE_CDROMS"));  break;
-            case 2: WriteOut(MSG_Get("MSCDEX_ERROR_NOT_SUPPORTED"));    break;
-            case 3: WriteOut(MSG_Get("MSCDEX_ERROR_OPEN"));             break;
-            case 4: WriteOut(MSG_Get("MSCDEX_TOO_MANY_DRIVES"));        break;
-            case 5: WriteOut(MSG_Get("MSCDEX_LIMITED_SUPPORT"));        break;
-            case 6: WriteOut(MSG_Get("MSCDEX_INVALID_FILEFORMAT"));     break;
-            default: WriteOut(MSG_Get("MSCDEX_UNKNOWN_ERROR"));         break;
-            }
+            if(!qmount)
+                switch(error) {
+                case 0: break;
+                case 1: WriteOut(MSG_Get("MSCDEX_ERROR_MULTIPLE_CDROMS"));  break;
+                case 2: WriteOut(MSG_Get("MSCDEX_ERROR_NOT_SUPPORTED"));    break;
+                case 3: WriteOut(MSG_Get("MSCDEX_ERROR_OPEN"));             break;
+                case 4: WriteOut(MSG_Get("MSCDEX_TOO_MANY_DRIVES"));        break;
+                case 5: WriteOut(MSG_Get("MSCDEX_LIMITED_SUPPORT"));        break;
+                case 6: WriteOut(MSG_Get("MSCDEX_INVALID_FILEFORMAT"));     break;
+                default: WriteOut(MSG_Get("MSCDEX_UNKNOWN_ERROR"));         break;
+                }
             // error: clean up and leave
             if (error) {
                 for (ct = 0; ct < isoDisks.size(); ct++) {
@@ -6620,9 +6621,9 @@ private:
 	void PrintStatus() {
         WriteOut("Status for device CON:\n----------------------\nColumns=%d\nLines=%d\n", COLS, LINES);
 #if defined(USE_TTF)
-        if (!ttf.inUse)
+        if(!ttf.inUse)
 #endif
-        WriteOut("\nCode page operation not supported on this device\n");
+            WriteOut("\nCode page operation not supported on this device\n");
 	}
     int LINES = 25, COLS = 80;
 };

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -783,8 +783,8 @@ uint64_t isoDrive::UDFextent_seek(struct UDFextents &ex,uint64_t ofs) {
 	return (uint64_t)ex.extofs + (uint64_t)ex.relofs;
 }
 
-int isoDrive::UDFextent_read(struct UDFextents &ex,unsigned char *buf,size_t count) {
-	int rd = 0;
+unsigned int isoDrive::UDFextent_read(struct UDFextents &ex,unsigned char *buf,size_t count) {
+	unsigned int rd = 0;
 
 	if (ex.is_indata) {
 		assert(ex.relofs <= (uint32_t)ex.indata.size());

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -115,7 +115,7 @@ void UDFTagId::parse(const unsigned int sz,const unsigned char *b) {
 	}
 }
 
-bool UDFTagId::tagChecksumOK(const unsigned int sz,const unsigned char *b) {
+bool UDFTagId::tagChecksumOK(const unsigned int sz,const unsigned char *b) const {
 	uint8_t chksum = 0;
 
 	if (sz < 16)
@@ -132,7 +132,7 @@ bool UDFTagId::tagChecksumOK(const unsigned int sz,const unsigned char *b) {
 	return true;
 }
 
-bool UDFTagId::dataChecksumOK(const unsigned int sz,const unsigned char *b) {
+bool UDFTagId::dataChecksumOK(const unsigned int sz,const unsigned char *b) const {
 	if (DescriptorCRCLength != 0) {
 		if ((DescriptorCRCLength+16u) > sz)
 			return false;
@@ -696,8 +696,7 @@ UDFlong_ad::UDFlong_ad() {
 UDFextent::UDFextent() {
 }
 
-UDFextent::UDFextent(const struct UDFextent_ad &s) {
-	ex = s;
+UDFextent::UDFextent(const struct UDFextent_ad &s) : ex(s) {
 }
 
 ////////////////////////////////////
@@ -711,7 +710,7 @@ UDFextents::UDFextents(const struct UDFextent_ad &s) {
 
 ////////////////////////////////////
 
-void isoDrive::UDFFileEntryToExtents(UDFextents &ex,UDFFileEntry &fe) {
+void isoDrive::UDFFileEntryToExtents(UDFextents &ex,UDFFileEntry &fe) const {
 	ex.xl.clear();
 	ex.indata.clear();
 	ex.is_indata = false;
@@ -739,7 +738,7 @@ void isoDrive::UDFFileEntryToExtents(UDFextents &ex,UDFFileEntry &fe) {
 
 ////////////////////////////////////
 
-void isoDrive::UDFextent_rewind(struct UDFextents &ex) {
+void isoDrive::UDFextent_rewind(struct UDFextents &ex) const {
 	ex.relofs = 0;
 	ex.extent = 0;
 	ex.extofs = 0;
@@ -755,7 +754,7 @@ uint64_t isoDrive::UDFtotalsize(struct UDFextents &ex) const {
         return total;
 }
 
-uint64_t isoDrive::UDFextent_seek(struct UDFextents &ex,uint64_t ofs) {
+uint64_t isoDrive::UDFextent_seek(struct UDFextents &ex,uint64_t ofs) const {
 	UDFextent_rewind(ex);
 
 	if (ex.is_indata) {
@@ -783,7 +782,7 @@ uint64_t isoDrive::UDFextent_seek(struct UDFextents &ex,uint64_t ofs) {
 	return (uint64_t)ex.extofs + (uint64_t)ex.relofs;
 }
 
-unsigned int isoDrive::UDFextent_read(struct UDFextents &ex,unsigned char *buf,size_t count) {
+unsigned int isoDrive::UDFextent_read(struct UDFextents &ex,unsigned char *buf,size_t count) const {
 	unsigned int rd = 0;
 
 	if (ex.is_indata) {
@@ -975,9 +974,6 @@ isoDrive::isoDrive(char driveLetter, const char* fileName, uint8_t mediaid, int&
     enable_udf = (dos.version.major > 7 || (dos.version.major == 7 && dos.version.minor >= 10));//default
     enable_rock_ridge = (dos.version.major >= 7 || uselfn);//default
     enable_joliet = (dos.version.major >= 7 || uselfn);//default
-    is_rock_ridge = false;
-    is_joliet = false;
-    is_udf = false;
     for (const auto &opt : options) {
         size_t equ = opt.find_first_of('=');
         std::string name,value;
@@ -1590,7 +1586,7 @@ bool isoDrive::GetNextDirEntry(const int dirIteratorHandle, UDFFileIdentifierDes
 			while (*s == '.'||*s == ' ') s++;
 			bool lead = false;
 			while (*s != 0) {
-				if (s == ext) break; // doesn't match if ext == NULL, so no harm in that case
+                if(s == ext) break; // doesn't match if ext == NULL, so no harm in that case
                 if (!lead && ((IS_PC98_ARCH && shiftjis_lead_byte(*s & 0xFF)) || (isDBCSCP() && isKanji1_gbk(*s & 0xFF)))) {
                     if (c >= (7-tailsize)) break;
                     lead = true;
@@ -1713,11 +1709,11 @@ bool isoDrive::ReadCachedSector(uint8_t** buffer, const uint32_t sector) {
 	return true;
 }
 
-inline bool isoDrive :: readSector(uint8_t *buffer, uint32_t sector) {
+inline bool isoDrive :: readSector(uint8_t *buffer, uint32_t sector) const {
 	return CDROM_Interface_Image::images[subUnit]->ReadSector(buffer, false, sector);
 }
 
-int isoDrive::readDirEntry(isoDirEntry* de, const uint8_t* data,unsigned int dirIteratorIndex) {
+int isoDrive::readDirEntry(isoDirEntry* de, const uint8_t* data,unsigned int dirIteratorIndex) const {
 	// This code is NOT for UDF filesystem access!
 	if (is_udf) return -1;
 
@@ -1890,7 +1886,7 @@ int isoDrive::readDirEntry(isoDirEntry* de, const uint8_t* data,unsigned int dir
 			while (*s == '.'||*s == ' ') s++;
 			bool lead = false;
 			while (*s != 0) {
-				if (s == ext) break; // doesn't match if ext == NULL, so no harm in that case
+                if(s == ext) break; // doesn't match if ext == NULL, so no harm in that case
                 if (!lead && ((IS_PC98_ARCH && shiftjis_lead_byte(*s & 0xFF)) || (isDBCSCP() && isKanji1_gbk(*s & 0xFF)))) {
                     if (c >= (7-tailsize)) break;
                     lead = true;
@@ -1955,7 +1951,7 @@ static bool escape_is_joliet(const unsigned char *esc) {
 	return false;
 }
 
-bool isoDrive :: loadImageUDFAnchorVolumePointer(UDFAnchorVolumeDescriptorPointer &avdp,uint8_t pvd[COOKED_SECTOR_SIZE],uint32_t sector) {
+bool isoDrive :: loadImageUDFAnchorVolumePointer(UDFAnchorVolumeDescriptorPointer &avdp,uint8_t pvd[COOKED_SECTOR_SIZE],uint32_t sector) const {
 	UDFTagId aid;
 
 	if (!aid.get(COOKED_SECTOR_SIZE,pvd)) return false;

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -2784,7 +2784,7 @@ bool localFile::Seek(uint32_t * pos,uint32_t type) {
 #if defined(WIN32)
     if (file_access_tries>0) {
         HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(fhandle));
-        int32_t dwPtr = SetFilePointer(hFile, *pos, NULL, type);
+        DWORD dwPtr = SetFilePointer(hFile, *pos, NULL, type);
         if (dwPtr == INVALID_SET_FILE_POINTER && !strcmp(RunningProgram, "BTHORNE"))	// Fix for Black Thorne
             dwPtr = SetFilePointer(hFile, 0, NULL, DOS_SEEK_END);
         if (dwPtr != INVALID_SET_FILE_POINTER) {										// If success

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -96,6 +96,12 @@
 #include "cp1258_uni.h"
 #include "cp3021_uni.h"
 
+#if defined (WIN32)
+#include <Shellapi.h>
+#else
+#include <glob.h>
+#endif
+
 #if defined(PATH_MAX) && !defined(MAX_PATH)
 #define MAX_PATH PATH_MAX
 #endif
@@ -1090,7 +1096,7 @@ int FileDirExistUTF8(std::string &localname, const char *name) {
 extern uint16_t fztime, fzdate;
 extern bool force_conversion, InitCodePage();
 std::string GetDOSBoxXPath(bool withexe=false);
-void getdrivezpath(std::string &path, std::string dirname) {
+void getdrivezpath(std::string &path, std::string const& dirname) {
     const host_cnv_char_t* host_name = CodePageGuestToHost(path.c_str());
     if (host_name == NULL) {path = "";return;}
     struct stat cstat;
@@ -1126,7 +1132,7 @@ void getdrivezpath(std::string &path, std::string dirname) {
     }
 }
 
-void drivezRegister(std::string path, std::string dir, bool usecp) {
+void drivezRegister(std::string const& path, std::string const& dir, bool usecp) {
     int cp = dos.loaded_codepage;
     if (!usecp || !cp) {
         force_conversion = true;
@@ -1494,13 +1500,13 @@ bool localDrive::FileOpen(DOS_File * * file,const char * name,uint32_t flags) {
 			break;
 		}
 	}
-	if (!dos_kernel_disabled)
-	for (i=0;i<DOS_FILES;i++) {
-		if (Files[i] && Files[i]->IsOpen() && Files[i]->GetDrive()==drive && Files[i]->IsName(name)) {
-			lfp=dynamic_cast<localFile*>(Files[i]);
-			if (lfp) lfp->Flush();
-		}
-	}
+    if(!dos_kernel_disabled)
+        for(i = 0; i < DOS_FILES; i++) {
+            if(Files[i] && Files[i]->IsOpen() && Files[i]->GetDrive() == drive && Files[i]->IsName(name)) {
+                lfp = dynamic_cast<localFile*>(Files[i]);
+                if(lfp) lfp->Flush();
+            }
+        }
 
     // guest to host code page translation
     const host_cnv_char_t* host_name = CodePageGuestToHost(newname);
@@ -1612,11 +1618,6 @@ bool localDrive::GetSystemFilename(char *sysName, char const * const dosName) {
 #endif
 }
 
-#if defined (WIN32)
-#include <Shellapi.h>
-#else
-#include <glob.h>
-#endif
 bool localDrive::FileUnlink(const char * name) {
     if (readonly) {
         DOS_SetError(DOSERR_WRITE_PROTECTED);
@@ -2888,14 +2889,12 @@ uint32_t localFile::GetSeekPos() {
 
 localFile::localFile() {}
 
-localFile::localFile(const char* _name, FILE * handle) {
-	fhandle=handle;
+localFile::localFile(const char* _name, FILE* handle) : fhandle(handle) {
 	open=true;
 	localFile::UpdateDateTimeFromHost();
 
 	attr=DOS_ATTR_ARCHIVE;
 	last_action=NONE;
-	read_only_medium=false;
 
 	name=0;
 	SetName(_name);
@@ -2982,15 +2981,12 @@ bool MSCDEX_HasMediaChanged(uint8_t subUnit);
 bool MSCDEX_GetVolumeName(uint8_t subUnit, char* name);
 
 cdromDrive::cdromDrive(const char driveLetter, const char * startdir,uint16_t _bytes_sector,uint8_t _sectors_cluster,uint16_t _total_clusters,uint16_t _free_clusters,uint8_t _mediaid, int& error, std::vector<std::string> &options)
-		   :localDrive(startdir,_bytes_sector,_sectors_cluster,_total_clusters,_free_clusters,_mediaid,options),
-		    subUnit(0),
-		    driveLetter('\0')
+		   :localDrive(startdir,_bytes_sector,_sectors_cluster,_total_clusters,_free_clusters,_mediaid,options), driveLetter(driveLetter)
 {
 	// Init mscdex
 	error = MSCDEX_AddDrive(driveLetter,startdir,subUnit);
 	strcpy(info, "CDRom ");
 	strcat(info, startdir);
-	this->driveLetter = driveLetter;
 	// Get Volume Label
 	char name[32];
 	if (MSCDEX_GetVolumeName(subUnit,name)) dirCache.SetLabel(name,true,true);

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -101,7 +101,7 @@ public:
 	virtual bool add_special_file_to_disk(const char* dosname, const char* operation, uint16_t value, bool isdir);
 	virtual void EmptyCache(void) { dirCache.EmptyCache(); };
 	virtual void MediaChange() {};
-	const char* getBasedir() {return basedir;};
+	const char* getBasedir() const {return basedir;};
 	struct {
 		uint16_t bytes_sector;
 		uint8_t sectors_cluster;
@@ -537,7 +537,7 @@ public:
 	virtual bool isRemote(void);
 	virtual bool isRemovable(void);virtual Bits UnMount(void);
 private:
-	uint8_t subUnit;	char driveLetter;
+	uint8_t subUnit = 0;	char driveLetter = '\0';
 };
 
 class physfscdromDrive : public physfsDrive
@@ -688,8 +688,8 @@ struct UDFTagId { /* ECMA-167 7.2.1 */
 
 	bool					get(const unsigned int sz,const unsigned char *b);
 	void					parse(const unsigned int sz,const unsigned char *b);
-	bool					tagChecksumOK(const unsigned int sz,const unsigned char *b);
-	bool					dataChecksumOK(const unsigned int sz,const unsigned char *b);
+	bool					tagChecksumOK(const unsigned int sz,const unsigned char *b) const;
+	bool					dataChecksumOK(const unsigned int sz,const unsigned char *b) const;
 	bool					checksumOK(const unsigned int sz,const unsigned char *b);
 						UDFTagId(const unsigned int sz,const unsigned char *b);
 						UDFTagId();
@@ -1059,13 +1059,13 @@ public:
 	virtual Bits UnMount(void);
 	bool loadImage();
 	bool loadImageUDF();
-	bool loadImageUDFAnchorVolumePointer(UDFAnchorVolumeDescriptorPointer &avdp,uint8_t *pvd/*COOKED_SECTOR_SIZE*/,uint32_t sector);
-	bool readSector(uint8_t *buffer, uint32_t sector);
+	bool loadImageUDFAnchorVolumePointer(UDFAnchorVolumeDescriptorPointer &avdp,uint8_t *pvd/*COOKED_SECTOR_SIZE*/,uint32_t sector) const;
+	bool readSector(uint8_t *buffer, uint32_t sector) const;
 	void setFileName(const char* fileName);
 	virtual char const* GetLabel(void) {return discLabel;};
 	virtual void Activate(void);
 private:
-    int  readDirEntry(isoDirEntry* de, const uint8_t* data, unsigned int direntindex);
+    int  readDirEntry(isoDirEntry* de, const uint8_t* data, unsigned int direntindex) const;
 	bool lookup(isoDirEntry *de, const char *path);
 	bool lookup(UDFFileIdentifierDescriptor &fid, UDFFileEntry &fe, const char *path);
 	int  UpdateMscdex(char driveLetter, const char* path, uint8_t& subUnit);
@@ -1114,10 +1114,10 @@ private:
 	UDFFileSetDescriptor						fsetd;
 	UDFPartitionDescriptor						partd;
 public:
-	void UDFextent_rewind(struct UDFextents &ex);
-	void UDFFileEntryToExtents(UDFextents &ex,UDFFileEntry &fe);
-	uint64_t UDFextent_seek(struct UDFextents &ex,uint64_t ofs);
-	unsigned int UDFextent_read(struct UDFextents &ex,unsigned char *buf,size_t count);
+	void UDFextent_rewind(struct UDFextents &ex) const;
+	void UDFFileEntryToExtents(UDFextents &ex,UDFFileEntry &fe) const;
+	uint64_t UDFextent_seek(struct UDFextents &ex,uint64_t ofs) const;
+	unsigned int UDFextent_read(struct UDFextents &ex,unsigned char *buf,size_t count) const;
 	uint64_t UDFtotalsize(struct UDFextents &ex) const;
 private:
 	struct DirIterator {
@@ -1190,7 +1190,7 @@ public:
 	virtual bool TestDir(const char * dir);
 	virtual bool RemoveDir(const char * dir);
 	virtual bool MakeDir(const char * dir);
-	const char* getOverlaydir() {return overlaydir;};
+	const char* getOverlaydir() const {return overlaydir;};
 	bool ovlnocachedir = false;
 	bool ovlreadonly = false;
 private:

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -1117,7 +1117,7 @@ public:
 	void UDFextent_rewind(struct UDFextents &ex);
 	void UDFFileEntryToExtents(UDFextents &ex,UDFFileEntry &fe);
 	uint64_t UDFextent_seek(struct UDFextents &ex,uint64_t ofs);
-	int UDFextent_read(struct UDFextents &ex,unsigned char *buf,size_t count);
+	unsigned int UDFextent_read(struct UDFextents &ex,unsigned char *buf,size_t count);
 	uint64_t UDFtotalsize(struct UDFextents &ex) const;
 private:
 	struct DirIterator {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -301,7 +301,6 @@ void resetFontSize(), increaseFontSize(), decreaseFontSize();
 void GetMaxWidthHeight(unsigned int *pmaxWidth, unsigned int *pmaxHeight);
 void MAPPER_CheckEvent(SDL_Event * event), MAPPER_CheckKeyboardLayout(), MAPPER_ReleaseAllKeys();
 bool isDBCSCP(), InitCodePage();
-int GetNumScreen();
 
 SDL_Block sdl;
 Bitu frames = 0;
@@ -945,7 +944,7 @@ void GFX_SetIcon(void)
 bool IsDebuggerActive(void);
 #endif
 
-extern std::string dosbox_title, GetDefaultOutput();
+extern std::string dosbox_title;
 
 void GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused) {
     (void)frameskip;//UNUSED

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -30,12 +30,13 @@
 #include "setup.h"
 #include "cross.h" //fmod on certain platforms
 #include "control.h"
-bool date_host_forced=false;
 #if defined (WIN32) && !defined (__MINGW32__)
 #include "sys/timeb.h"
 #else
 #include "sys/time.h"
 #endif
+
+bool date_host_forced = false;
 
 // sigh... Windows doesn't know gettimeofday
 #if defined (WIN32) && !defined (__MINGW32__)
@@ -47,6 +48,7 @@ struct timeval {
 };
 
 static void gettimeofday (timeval* ptime, void* pdummy) {
+    (void)pdummy;
     struct _timeb thetime;
     _ftime(&thetime);
 
@@ -456,7 +458,7 @@ static Bitu cmos_readreg(Bitu port,Bitu iolen) {
         drive_b = 0;
         if(imageDiskList[0] != NULL) drive_a = imageDiskList[0]->GetBiosType();
         if(imageDiskList[1] != NULL) drive_b = imageDiskList[1]->GetBiosType();
-        return ((drive_a << 4) | (drive_b));
+        return ((drive_a << 4) | drive_b);
     /* First harddrive info */
     case 0x12:
         /* NTS: DOSBox 0.74 mainline has these backwards: the upper nibble is the first hard disk,
@@ -480,8 +482,6 @@ static Bitu cmos_readreg(Bitu port,Bitu iolen) {
         if(imageDiskList[2] != NULL) return (imageDiskList[2]->heads);
         return 0;
     case 0x1e:
-        if(imageDiskList[2] != NULL) return 0xff;
-        return 0;
     case 0x1f:
         if(imageDiskList[2] != NULL) return 0xff;
         return 0;
@@ -511,8 +511,6 @@ static Bitu cmos_readreg(Bitu port,Bitu iolen) {
         if(imageDiskList[3] != NULL) return (imageDiskList[3]->heads);
         return 0;
     case 0x27:
-        if(imageDiskList[3] != NULL) return 0xff;
-        return 0;
     case 0x28:
         if(imageDiskList[3] != NULL) return 0xff;
         return 0;

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -53,10 +53,10 @@ static MEM_Callout_t lfb_mmio_cb = MEM_Callout_t_none;
 
 class MEM_callout_vector : public std::vector<MEM_CalloutObject> {
 public:
-    MEM_callout_vector() : std::vector<MEM_CalloutObject>(), getcounter(0), alloc_from(0) { };
+    MEM_callout_vector() : std::vector<MEM_CalloutObject>() { };
 public:
-    unsigned int getcounter;
-    unsigned int alloc_from;
+    unsigned int getcounter = 0;
+    unsigned int alloc_from = 0;
 };
 
 static MEM_callout_vector MEM_callouts[MEM_callouts_max];
@@ -76,13 +76,11 @@ extern bool VIDEO_BIOS_always_carry_14_high_font;
 extern bool VIDEO_BIOS_always_carry_16_high_font;
 
 static struct MemoryBlock {
-    MemoryBlock() : pages(0), handler_pages(0), reported_pages(0), phandlers(NULL), mhandles(NULL), mem_alias_pagemask(0), mem_alias_pagemask_active(0), address_bits(0) { }
-
-    Bitu pages;
-    Bitu handler_pages;
-    Bitu reported_pages;
-    PageHandler * * phandlers;
-    MemHandle * mhandles;
+    Bitu pages = 0;
+    Bitu handler_pages = 0;
+    Bitu reported_pages = 0;
+    PageHandler * * phandlers = NULL;
+    MemHandle * mhandles = NULL;
     struct {
         Bitu        start_page;
         Bitu        end_page;
@@ -99,9 +97,9 @@ static struct MemoryBlock {
         bool enabled;
         uint8_t controlport;
     } a20 = {};
-    uint32_t mem_alias_pagemask;
-    uint32_t mem_alias_pagemask_active;
-    uint32_t address_bits;
+    uint32_t mem_alias_pagemask = 0;
+    uint32_t mem_alias_pagemask_active = 0;
+    uint32_t address_bits = 0;
 } memory;
 
 uint32_t MEM_get_address_bits() {

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -3565,6 +3565,45 @@ class ViBRA_PnP : public ISAPnPDevice {
 bool JOYSTICK_IsEnabled(Bitu which);
 extern void HARDOPL_Init(Bitu hardwareaddr, Bitu sbbase, bool isCMS);
 
+std::string GetSBtype() {
+    switch (sb.type) {
+        case SBT_NONE:
+            return "None";
+        case SBT_1:
+            return "SB1";
+        case SBT_PRO1:
+            return "SBPro";
+        case SBT_2:
+            return "SB2";
+        case SBT_PRO2:
+            return "SBPro 2";
+        case SBT_16:
+            return "SB16";
+        case SBT_GB:
+            return "GB";
+        default:
+            return "Unknown";
+    }
+}
+
+std::string GetSBbase() {
+    std::stringstream ss;
+    ss << std::hex << sb.hw.base;
+    return ss.str();
+}
+
+std::string GetSBirq() {
+    return sb.hw.irq==0xff?"None":std::to_string(sb.hw.irq);
+}
+
+std::string GetSBldma() {
+    return sb.hw.dma8==0xff?"None":std::to_string((int)sb.hw.dma8);
+}
+
+std::string GetSBhdma() {
+    return sb.hw.dma16==0xff?"None":std::to_string((int)sb.hw.dma16);
+}
+
 class SBLASTER: public Module_base {
 private:
     /* Data */
@@ -3793,7 +3832,7 @@ public:
 
         Find_Type_And_Opl(section,sb.type,oplmode);
         if (sb.hw.irq == 0) {
-            std::string GetSBtype(), sbtype=GetSBtype();
+            std::string sbtype=GetSBtype();
             sb.hw.irq=sbtype=="SBPro 2"||sbtype=="SB16"||IS_PC98_ARCH?5:7;
         }
 
@@ -4132,45 +4171,6 @@ ASP>
         DSP_Reset(); // Stop everything
     }
 }; //End of SBLASTER class
-
-std::string GetSBtype() {
-    switch (sb.type) {
-        case SBT_NONE:
-            return "None";
-        case SBT_1:
-            return "SB1";
-        case SBT_PRO1:
-            return "SBPro";
-        case SBT_2:
-            return "SB2";
-        case SBT_PRO2:
-            return "SBPro 2";
-        case SBT_16:
-            return "SB16";
-        case SBT_GB:
-            return "GB";
-        default:
-            return "Unknown";
-    }
-}
-
-std::string GetSBbase() {
-    std::stringstream ss;
-    ss << std::hex << sb.hw.base;
-    return ss.str();
-}
-
-std::string GetSBirq() {
-    return sb.hw.irq==0xff?"None":std::to_string(sb.hw.irq);
-}
-
-std::string GetSBldma() {
-    return sb.hw.dma8==0xff?"None":std::to_string((int)sb.hw.dma8);
-}
-
-std::string GetSBhdma() {
-    return sb.hw.dma16==0xff?"None":std::to_string((int)sb.hw.dma16);
-}
 
 extern void HWOPL_Cleanup();
 

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -3614,7 +3614,7 @@ private:
     OPL_Mode oplmode;
 
     /* Support Functions */
-    void Find_Type_And_Opl(Section_prop* config,SB_TYPES& type, OPL_Mode& opl_mode){
+    void Find_Type_And_Opl(Section_prop* config,SB_TYPES& type, OPL_Mode& opl_mode) const {
         sb.vibra = false;
         sb.ess_type = ESS_NONE;
         sb.reveal_sc_type = RSC_NONE;

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -30,6 +30,7 @@
 #include "shell.h"
 #include "menu.h"
 #include "jfont.h"
+#include "mapper.h"
 #include <map>
 #include <list>
 #include <string>
@@ -442,7 +443,7 @@ bool MSG_Write(const char * location, const char * name) {
                 fprintf(out,":MENU:%s\n%s\n.\n",idname.c_str(),temp);
         }
 	}
-    std::map<std::string,std::string> get_event_map(), event_map = get_event_map();
+    std::map<std::string,std::string> event_map = get_event_map();
     for (auto it=event_map.begin();it!=event_map.end();++it) {
         if (mainMenu.item_exists("mapper_"+it->first) && mainMenu.get_item("mapper_"+it->first).get_text() == it->second) continue;
         if (!CodePageGuestToHostUTF8(temp,it->second.c_str()))

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -733,7 +733,6 @@ void ApplySetting(std::string pvar, std::string inputline, bool quiet) {
                     } else if (GFX_IsFullscreen()) {GFX_LosingFocus();GFX_SwitchFullScreen();}
                 }
                 if (!strcasecmp(inputline.substr(0, 7).c_str(), "output=")) {
-                    std::string GetDefaultOutput();
                     std::string output=section->Get_string("output");
                     if (output == "default") output=GetDefaultOutput();
                     GFX_LosingFocus();
@@ -775,7 +774,6 @@ void ApplySetting(std::string pvar, std::string inputline, bool quiet) {
 #endif
                 if (!strcasecmp(inputline.substr(0, 8).c_str(), "display=")) {
                     void SetDisplayNumber(int display);
-                    int GetNumScreen();
                     int numscreen = GetNumScreen();
                     const int display = section->Get_int("display");
                     if (display >= 0 && display <= numscreen)

--- a/src/output/output_tools.h
+++ b/src/output/output_tools.h
@@ -73,4 +73,6 @@ inline void aspectCorrectFitClip(volatile WH &clipW, volatile WH &clipH, volatil
 //    assert((sdl.clip.y + sdl.clip.h) <= sdl.desktop.full.height);
 }
 
+std::string GetDefaultOutput();
+
 #endif

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -962,7 +962,6 @@ void DOS_Shell::InputCommand(char * line) {
                         ++w_count;
                         if (w_count % col == 0) {p_count++;WriteOut_NoParsing("\n");lastcr=true;}
                     }
-                    size_t GetPauseCount();
                     if (p_count>GetPauseCount()) {
                         WriteOut(MSG_Get("SHELL_CMD_PAUSE"));
                         lastcr=false;


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

Fixes some compiler warnings and static analysis warnings.

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

No.

## Additional information

Fixes are for the following compiler warnings:
-vexing parse (a function declaration like `Foo()` made in a file in order to have access to that function. Fixed by removing such declarations and using an included .h file that has the function signature, or for `GetSBtype()`, moving the function definition earlier in the file so that the vexing parse declaration is no longer needed)
 
-sign compare (comparison of signed and unsigned values)

And the following static analysis warnings:
-member function that doesn't mutate its object not labeled const
-invalid memory access
-include directive not at top of file
-duplicate switch cases
-redundant parentheses
-ambiguous if statement scope due to formatting (generally caused by an if statement in a tab-indented line being followed by a statement indented with spaces. Fixed by running auto-format on these lines, so some spacing was also changed) 
-not using in-class initialization when possible
-unused parameters (these were probably also compiler warnings)
-not passing expensive object by const reference (string objects)
-initializing in constructor when using class initialization or initialization list possible (class initialization preferred)