### PR TITLE
Temporary fix of HX-DOS CI build

### DIFF
--- a/.github/workflows/hxdos.yml
+++ b/.github/workflows/hxdos.yml
@@ -91,7 +91,8 @@ jobs:
         shell: bash
         run: |
           top=`pwd`
-          $top/vs/tool/unzip.exe -o dosbox-x-vsbuild-win32-*.zip bin/Win32/Release/dosbox-x.*
+          #$top/vs/tool/unzip.exe -o dosbox-x-vsbuild-win32-*.zip bin/Win32/Release/dosbox-x.*
+          $top/vs/tool/unzip.exe -o dosbox-x-vsbuild-win32-20230401005056.zip bin/Win32/Release/dosbox-x.*
           cp $top/package/dosbox-x.ref $top/hxdos.cfg
           echo mount b ..>>$top/hxdos.cfg
           echo "echo success>b:\SUCCESS.TXT">>$top/hxdos.cfg


### PR DESCRIPTION
For some reason, CI build for HX-DOS since release 2023.3.31 fails due to error in unpacking test environment.
This PR temporary fixes it, and it may be reverted in the coming release.

Fixes #4137