### PR TITLE
Fixed issue with built-in command "parallel".

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,24 @@ AC_CANONICAL_BUILD
 dnl Setup for automake
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_HEADER(config.h)
+AH_BOTTOM([/*
+  Define HAS_CDIRECTLPT as 1 if C_DIRECTLPT is defined (as 1) *and* parallel
+  pass-through is available on the current platform. It is only available on
+  x86{_64} with Windows or BSD, and on Linux.
+  We cannot override the value of C_DIRECTLPT, because configure will replace
+  "#undef C_DIRECTLPT" or "#define C_DIRECTLPT 0" with "#define C_DIRECTLPT 1".
+*/
+#ifdef C_DIRECTLPT
+#if ((defined __i386__ || defined __x86_64__ || defined _M_IX86 || defined _M_X64) && \
+     (defined WIN32 || defined BSD || defined __CYGWIN__)) || \
+     /* WIN32 is not defined by default on Cygwin */ \
+    defined LINUX /* Linux, including non-x86 (e.g. Raspberry Pi) */
+#define HAS_CDIRECTLPT 1
+#endif
+#endif // C_DIRECTLPT
+#ifndef HAS_CDIRECTLPT
+#define HAS_CDIRECTLPT 0
+#endif])
 
 dnl Checks for programs.
 AC_PROG_MAKE_SET

--- a/include/parport.h
+++ b/include/parport.h
@@ -43,7 +43,7 @@ private:
 
 enum ParallelTypesE {
 	PARALLEL_TYPE_DISABLED = 0,
-#if C_DIRECTLPT
+#if HAS_CDIRECTLPT
 	PARALLEL_TYPE_REALLPT,
 #endif
 	PARALLEL_TYPE_FILE,
@@ -68,7 +68,7 @@ public:
 
 	// Constructor
 	CParallel(CommandLine* cmd, Bitu portnr, uint8_t initirq);
-	
+
 	virtual ~CParallel();
 
 	IO_ReadHandleObject ReadHandler[3];
@@ -85,7 +85,7 @@ public:
 	Bitu port_nr;
 	Bitu base;
 	Bitu irq;
-	
+
 	// read data line register
 	virtual Bitu Read_PR()=0;
 	virtual Bitu Read_COM()=0;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -9177,7 +9177,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
           Drop root privileges after they are no longer needed, which is a good
           practice if the executable is setuid root.
           dropPrivileges() is called by PARPORTS::PARPORTS() after contructing
-          CDirectLPT instances, but only if the constant C_DIRECTLPT is
+          CDirectLPT instances, but only if the constant HAS_CDIRECTLPT is
           non-zero. dropPrivileges() should be called regardless (if
           initPassthroughIO() is used anywhere else).
         */

--- a/src/hardware/parport/directlpt.cpp
+++ b/src/hardware/parport/directlpt.cpp
@@ -16,7 +16,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#include "directlpt.h" // for HAS_CDIRECTLPT
+#include "config.h"
+
 #if HAS_CDIRECTLPT
 #include <SDL.h>
 #ifdef LINUX
@@ -32,6 +33,7 @@
 #endif
 #include "libs/passthroughio/passthroughio.h"
 #include "callback.h"
+#include "directlpt.h"
 #include "logging.h"
 
 #define PPORT_CON_IRQ 0x10
@@ -105,6 +107,7 @@ CDirectLPT::CDirectLPT(Bitu nr, uint8_t initIrq, CommandLine* cmd)
 
 		if(ioctl(porthandle, PPCLAIM) == -1) {
 			LOG_MSG("parallel%d: Failed to claim parallel port. Pass-through I/O disabled.", (int)nr + 1);
+			close(porthandle);
 			return;
 		}
 

--- a/src/hardware/parport/directlpt.h
+++ b/src/hardware/parport/directlpt.h
@@ -21,21 +21,8 @@
 
 #include "config.h"
 
-#if C_DIRECTLPT
-/*
-  For MinGW and MinGW-w64, _M_IX86 and _M_X64 are not defined by the compiler,
-  but in a header file, which has to be (indirectly) included, usually through a
-  C (not C++) standard header file. For MinGW it is sdkddkver.h and for
-  MinGW-w64 it is _mingw_mac.h. Do not rely on constants that may not be
-  defined, depending on what was included before these lines.
-*/
-#if ((defined __i386__ || defined __x86_64__ || defined _M_IX86 || defined _M_X64) && \
-     (defined WIN32 || defined BSD || defined __CYGWIN__)) || /* WIN32 is not defined by default on Cygwin */ \
-    defined LINUX /* Linux, including non-x86 (e.g. Raspberry Pi) */
+#if HAS_CDIRECTLPT
 #include "parport.h"
-
-// Instead of repeating the preprocessor logic above, use 1 constant in client code
-#define HAS_CDIRECTLPT 1
 
 class CDirectLPT : public CParallel {
 public:
@@ -67,9 +54,4 @@ private:                                // something was wrong, delete it right 
 #endif
 };
 
-#endif // Win32 / BSD / Linux
-#endif // C_DIRECTLPT
-
-#ifndef HAS_CDIRECTLPT
-#define HAS_CDIRECTLPT 0
-#endif
+#endif // HAS_CDIRECTLPT

--- a/src/hardware/parport/parport.cpp
+++ b/src/hardware/parport/parport.cpp
@@ -32,7 +32,7 @@
 #include "bios.h"					// SetLPTPort(..)
 #include "hardware.h"				// OpenCaptureFile
 
-#if C_DIRECTLPT && (defined __i386__ || defined __x86_64__) && (defined BSD || defined LINUX)
+#if HAS_CDIRECTLPT && (defined __i386__ || defined __x86_64__) && (defined BSD || defined LINUX)
 #include "libs/passthroughio/passthroughio.h" // for dropPrivileges()
 #endif
 #include "parport.h"
@@ -380,7 +380,7 @@ class PARPORTS:public Module_base {
 				if (i == 0 && DISNEY_ShouldInit())
 					continue;
 
-#if C_DIRECTLPT && HAS_CDIRECTLPT
+#if HAS_CDIRECTLPT
 				if(str=="reallpt") {
 					CDirectLPT* cdlpt= new CDirectLPT(i, defaultirq[i],&cmd);
 					if(cdlpt->InstallationSuccessful) {
@@ -444,9 +444,9 @@ class PARPORTS:public Module_base {
 								parallelPortObjects[i] = 0;
 							}
 			} // for lpt 1-9
-#if C_DIRECTLPT && (defined __i386__ || defined __x86_64__) && (defined BSD || defined LINUX)
+#if HAS_CDIRECTLPT && (defined __i386__ || defined __x86_64__) && (defined BSD || defined LINUX)
 			// Drop root privileges after they are no longer needed, which is a
-			// good practice if the executable is setuid root,
+			// good practice if the executable is setuid root.
 			dropPrivileges(); // Ignore whether we could actually drop privileges.
 #endif
 		}
@@ -473,7 +473,7 @@ static PARPORTS *testParallelPortsBaseclass = NULL;
 
 static const char *parallelTypes[PARALLEL_TYPE_COUNT] = {
 	"disabled",
-#if C_DIRECTLPT && HAS_CDIRECTLPT
+#if HAS_CDIRECTLPT
 	"reallpt",
 #endif
 	"file",
@@ -620,7 +620,7 @@ void PARALLEL::Run()
 			case PARALLEL_TYPE_DISABLED:
 				parallelPortObjects[port-1] = 0;
 				break;
-#if C_DIRECTLPT && HAS_CDIRECTLPT
+#if HAS_CDIRECTLPT
 			case PARALLEL_TYPE_REALLPT:
 				{
 					CDirectLPT* cdlpt= new CDirectLPT(port-1, defaultirq[port-1],&cmd);

--- a/vs/config.h
+++ b/vs/config.h
@@ -389,5 +389,20 @@ typedef         double     Real64;
 # pragma warning(disable:4996)
 #endif
 
+/*
+  Define HAS_CDIRECTLPT as 1 if C_DIRECTLPT is defined (as 1) *and* parallel
+  pass-through is available on the current platform. It is only available on
+  x86{_64} with Windows or BSD, and on Linux.
+*/
+#ifdef C_DIRECTLPT
+#if (defined __i386__ || defined __x86_64__ || defined _M_IX86 || defined _M_X64) && \
+    defined WIN32
+#define HAS_CDIRECTLPT 1
+#endif
+#endif // C_DIRECTLPT
+#ifndef HAS_CDIRECTLPT
+#define HAS_CDIRECTLPT 0
+#endif
+
 /* Linux-side configure script will write/rewrite this file so both Windows and Linux builds carry the same information --J.C. */
 #include "config_package.h"


### PR DESCRIPTION
## What issue(s) does this PR address?

The original issue was that on systems that cannot support parallel port pass-through there was a mismatch between parallelTypes in parport.cpp and the enum ParallelTypesE in parport.h. This caused issues when using the built-in command "parallel". "parallel /?" produced incorrect output about the available parallel port types, listing (null) as a valid type. Using an unrecognized type would crash DOSBox-X.

A solution was to define PARALLEL_TYPE_REALLPT only if HAS_CDIRECTLPT was non-zero. However, HAS_CDIRECTLPT was defined in directlpt.h. The definition of HAS_CDIRECTLPT could be moved to parport.h, but since it is actually a configuration constant, config.h seemed a better place. I had hoped to be able to override C_DIRECTLPT in config.h and eliminate HAS_CDIRECTLPT, but my autotools skills are insufficient. However, now only HAS_CDIRECTLPT is used in the code instead.

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No.
