### PR TITLE
Add ABNT C2 support and Mac F16-19 key support (SDL1)

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -866,39 +866,37 @@ static uint8_t scancode_map[MAX_SDLKEYS];
 static SDLKey sdlkey_map[]={
     /* Main block printables */
     /*00-05*/ Z, SDLK_s, SDLK_d, SDLK_f, SDLK_h, SDLK_g,
-    /*06-0B*/ SDLK_z, SDLK_x, SDLK_c, SDLK_v, SDLK_WORLD_0, SDLK_b,
+    /*06-0B*/ SDLK_z, SDLK_x, SDLK_c, SDLK_v, SDLK_BACKQUOTE /* 'Section' key */, SDLK_b,
     /*0C-11*/ SDLK_q, SDLK_w, SDLK_e, SDLK_r, SDLK_y, SDLK_t, 
     /*12-17*/ SDLK_1, SDLK_2, SDLK_3, SDLK_4, SDLK_6, SDLK_5, 
     /*18-1D*/ SDLK_EQUALS, SDLK_9, SDLK_7, SDLK_MINUS, SDLK_8, SDLK_0, 
     /*1E-21*/ SDLK_RIGHTBRACKET, SDLK_o, SDLK_u, SDLK_LEFTBRACKET, 
     /*22-23*/ SDLK_i, SDLK_p,
     /*24-29*/ SDLK_RETURN, SDLK_l, SDLK_j, SDLK_QUOTE, SDLK_k, SDLK_SEMICOLON, 
-    /*2A-29*/ SDLK_BACKSLASH, SDLK_COMMA, SDLK_SLASH, SDLK_n, SDLK_m, 
-    /*2F-2F*/ SDLK_PERIOD,
+    /*2A-2F*/ SDLK_BACKSLASH, SDLK_COMMA, SDLK_SLASH, SDLK_n, SDLK_m, SDLK_PERIOD,
 
     /* Spaces, controls, modifiers (dosbox uses LMETA only for
      * hotkeys, it's not really mapped to an emulated key) */
     /*30-33*/ SDLK_TAB, SDLK_SPACE, SDLK_BACKQUOTE, SDLK_BACKSPACE,
-    /*34-37*/ Z, SDLK_ESCAPE, Z, SDLK_LMETA,
+    /*34-37*/ Z, SDLK_ESCAPE, SDLK_RSUPER, SDLK_LSUPER,
     /*38-3B*/ SDLK_LSHIFT, SDLK_CAPSLOCK, SDLK_LALT, SDLK_LCTRL,
-
-    /*3C-40*/ Z, Z, Z, Z, Z,
+    /*3C-40*/ SDLK_RSHIFT, SDLK_RALT, SDLK_RCTRL, Z, SDLK_F17,
 
     /* Keypad (KP_EQUALS not supported, NUMLOCK used on what is CLEAR
      * in Mac OS X) */
     /*41-46*/ SDLK_KP_PERIOD, Z, SDLK_KP_MULTIPLY, Z, SDLK_KP_PLUS, Z,
     /*47-4A*/ SDLK_NUMLOCK /*==SDLK_CLEAR*/, Z, Z, Z,
     /*4B-4D*/ SDLK_KP_DIVIDE, SDLK_KP_ENTER, Z,
-    /*4E-51*/ SDLK_KP_MINUS, Z, Z, SDLK_KP_EQUALS,
+    /*4E-51*/ SDLK_KP_MINUS, SDLK_F18, SDLK_F19, SDLK_KP_EQUALS,
     /*52-57*/ SDLK_KP0, SDLK_KP1, SDLK_KP2, SDLK_KP3, SDLK_KP4, SDLK_KP5, 
     /*58-5C*/ SDLK_KP6, SDLK_KP7, Z, SDLK_KP8, SDLK_KP9, 
 
-	/*5D-5F*/ SDLK_WORLD_1, SDLK_UNDERSCORE, SDLK_a,
+	/*5D-5F*/ SDLK_JP_YEN, SDLK_JP_RO, SDLK_KP_COMMA,
     
     /* Function keys and cursor blocks (F13 not supported, F14 =>
      * PRINT[SCREEN], F15 => SCROLLOCK, F16 => PAUSE, HELP => INSERT) */
     /*60-64*/ SDLK_F5, SDLK_F6, SDLK_F7, SDLK_F3, SDLK_F8,
-    /*65-6A*/ SDLK_F9, Z, SDLK_F11, Z, SDLK_F13, SDLK_PAUSE /*==SDLK_F16*/,
+    /*65-6A*/ SDLK_F9, SDLK_WORLD_17, SDLK_F11, SDLK_WORLD_18, SDLK_F13, SDLK_PAUSE /*==SDLK_F16*/,
     /*6B-70*/ SDLK_PRINT /*==SDLK_F14*/, Z, SDLK_F10, Z, SDLK_F12, Z,
     /*71-72*/ SDLK_SCROLLOCK /*==SDLK_F15*/, SDLK_INSERT /*==SDLK_HELP*/, 
     /*73-77*/ SDLK_HOME, SDLK_PAGEUP, SDLK_DELETE, SDLK_F4, SDLK_END,
@@ -4583,8 +4581,8 @@ static struct {
 #else
 #ifdef SDL_DOSBOX_X_SPECIAL
 #if defined(MACOSX)
-    {"jp_bckslash",SDLK_UNDERSCORE},
-    {"jp_yen",SDLK_WORLD_1 },
+    {"jp_bckslash",SDLK_JP_RO},
+    {"jp_yen",SDLK_JP_YEN },
 #else
     /* hack for Japanese keyboards with \ and _ */
     {"jp_bckslash",SDLK_JP_RO}, // Same difference
@@ -5739,7 +5737,7 @@ void loadScanCode() {
             sdlkey_map[0x67]=SDLK_PRINT;
             sdlkey_map[0x69]=SDLK_RALT;
         }
-#else
+#else //defined(WIN32) Is this really required?
         sdlkey_map[0xc8]=SDLK_UP;
         sdlkey_map[0xd0]=SDLK_DOWN;
         sdlkey_map[0xcb]=SDLK_LEFT;

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1115,7 +1115,7 @@ static SDLKey sdlkey_map[MAX_SCANCODES] = {
 	SDLK_LESS, //0x56 Non-US \ and |
 	SDLK_F11, //0x57
 	SDLK_F12, //0x58
-	Z, //0x59 Keypad =
+	SDLK_KP_EQUALS, //0x59 Keypad =
 	Z, Z, //0x5a-0x5b unknown
 	Z, //0x5c Keyboard International6
 	Z, Z, Z, //0x5d-0x5f unknown
@@ -1137,7 +1137,7 @@ static SDLKey sdlkey_map[MAX_SCANCODES] = {
 	SDLK_WORLD_13, //0x7b Keyboard International5 Muhenkan
 	Z, //0x7c unknown
 	SDLK_JP_YEN, //0x7d Keyboard International3 \ and |
-	Z, //0x7e Keypad Comma
+	SDLK_KP_COMMA, //0x7e Keypad Comma
 	Z, //0x7f unknown
 	/* 0x80-0x8f unknown */
 	Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
@@ -4091,8 +4091,10 @@ static void CreateLayout(void) {
 #define XO 19
 #define YO 2
 
-    AddKeyButtonEvent(PX(XO + 3) - 3, PY(YO - 1), BU(1) - 1, BV(1), "Neq", "kp_equals", KBD_kpequals);
-
+    AddKeyButtonEvent(PX(XO + 3) - 3, PY(YO - 1), BU(1) - 1, BV(1), "KP=", "kp_equals", KBD_kpequals);
+    if(!IS_PC98_ARCH) {
+        AddKeyButtonEvent(PX(XO + 2) - 3, PY(YO - 1), BU(1) - 1, BV(1), "KP,", "kp_comma", KBD_kpcomma);
+    }
     num_lock_event =
     AddKeyButtonEvent(PX(XO + 0) - 0, PY(YO + 0), BU(1) - 1, BV(1), "Num", "numlock", KBD_numlock);
     AddKeyButtonEvent(PX(XO + 1) - 1, PY(YO + 0), BU(1) - 1, BV(1), "/", "kp_divide", KBD_kpdivide);
@@ -4472,6 +4474,7 @@ static struct {
     {"kp_divide",SDL_SCANCODE_KP_DIVIDE},   {"kp_multiply",SDL_SCANCODE_KP_MULTIPLY},
     {"kp_minus",SDL_SCANCODE_KP_MINUS},     {"kp_plus",SDL_SCANCODE_KP_PLUS},
     {"kp_period",SDL_SCANCODE_KP_PERIOD},   {"kp_enter",SDL_SCANCODE_KP_ENTER},
+    {"kp_equals",SDL_SCANCODE_KP_EQUALS},   {"kp_comma",SDL_SCANCODE_KP_COMMA},
 
     /* Is that the extra backslash key ("less than" key) */
     /* on some keyboards with the 102-keys layout??      */
@@ -4557,6 +4560,7 @@ static struct {
      *      This default assignment should allow Apple Mac users (who's keyboards DO have one)
      *      to use theirs as a normal equals sign. */
     {"kp_equals",SDLK_KP_EQUALS},
+    {"kp_comma", SDLK_KP_COMMA},
 
 #if defined(C_SDL2)
     // TODO??
@@ -4584,7 +4588,7 @@ static struct {
 #else
     /* hack for Japanese keyboards with \ and _ */
     {"jp_bckslash",SDLK_JP_RO}, // Same difference
-    {"jp_ro",SDLK_JP_RO}, // DOSBox proprietary
+    //{"jp_ro",SDLK_JP_RO}, // DOSBox proprietary
     /* hack for Japanese keyboards with Yen and | */
     {"jp_yen",SDLK_JP_YEN },
 #endif

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -1449,6 +1449,7 @@ void KEYBOARD_AddKey1(KBD_KEYS keytype,bool pressed) {
     case KBD_minus:ret=12;break;
     case KBD_equals:ret=13;break;
     case KBD_kpequals:ret=0x59;break; /* According to Battler */
+    case KBD_kpcomma: ret=0x7e;break; /* Keypad comma and ABNT C2 (Brazilian KP period)*/
     case KBD_backspace:ret=14;break;
     case KBD_tab:ret=15;break;
 
@@ -1631,7 +1632,7 @@ void KEYBOARD_AddKey1(KBD_KEYS keytype,bool pressed) {
     case KBD_jp_muhenkan:ret=0x7B;break;
     case KBD_jp_henkan:ret=0x79;break;
     case KBD_jp_hiragana:ret=0x70;break;/*also Katakana */
-    case KBD_jp_backslash:ret=0x73;break;/*JP 106-key: _ \ or ろ (ro)  <-- WARNING: UTF-8 unicode */
+    case KBD_jp_backslash:ret=0x73;break;/*JP 106-key: _ \ or ろ (ro)  <-- WARNING: UTF-8 unicode also ABNT C1(Brazilian /)*/
     case KBD_jp_yen:ret=0x7d;break;/*JP 106-key: | ¥ (yen) or ー (prolonged sound mark)  <-- WARNING: UTF-8 unicode */
 	case KBD_colon:if (!pc98_force_ibm_layout) {ret = 0x28; break;} /*JP106-key : or * same position with Quote key */
 	case KBD_caret:if (!pc98_force_ibm_layout) {ret = 0x0d; break;} /*JP106-key ^ or ~ same position with Equals key */

--- a/vs/sdl/include/SDL_keysym.h
+++ b/vs/sdl/include/SDL_keysym.h
@@ -299,7 +299,7 @@ typedef enum {
         /*@}*/
 
 	/* Add any other keys here */
-
+    SDLK_KP_COMMA   = 323,
 	SDLK_LAST
 } SDLKey;
 

--- a/vs/sdl/include/SDL_keysym.h
+++ b/vs/sdl/include/SDL_keysym.h
@@ -132,8 +132,8 @@ typedef enum {
 	SDLK_WORLD_14		= 174,		// HACK : JP Keyboard Henkan
 	SDLK_WORLD_15		= 175,		// HACK : JP Keyboard Hiragana
 	SDLK_WORLD_16		= 176,
-	SDLK_WORLD_17		= 177,
-	SDLK_WORLD_18		= 178,
+	SDLK_WORLD_17		= 177,      // HACK : JP Eisu (Mac)
+	SDLK_WORLD_18		= 178,      // HACK : JP Kana (Mac)
 	SDLK_WORLD_19		= 179,
 	SDLK_WORLD_20		= 180,
 	SDLK_JP_RO			= 180,		// HACK : SDLK_JP_RO == SDLK_WORLD_20
@@ -269,9 +269,9 @@ typedef enum {
 
 	/** @name Key state modifier keys */
         /*@{*/
-	SDLK_NUMLOCK		= 300,
-	SDLK_CAPSLOCK		= 301,
-	SDLK_SCROLLOCK		= 302,
+	SDLK_NUMLOCK    = 300,
+	SDLK_CAPSLOCK   = 301,
+	SDLK_SCROLLOCK  = 302,
 	SDLK_RSHIFT		= 303,
 	SDLK_LSHIFT		= 304,
 	SDLK_RCTRL		= 305,
@@ -283,7 +283,7 @@ typedef enum {
 	SDLK_LSUPER		= 311,		/**< Left "Windows" key */
 	SDLK_RSUPER		= 312,		/**< Right "Windows" key */
 	SDLK_MODE		= 313,		/**< "Alt Gr" key */
-	SDLK_COMPOSE		= 314,		/**< Multi-key compose key */
+	SDLK_COMPOSE    = 314,		/**< Multi-key compose key */
         /*@}*/
 
 	/** @name Miscellaneous function keys */
@@ -300,6 +300,11 @@ typedef enum {
 
 	/* Add any other keys here */
     SDLK_KP_COMMA   = 323,
+    SDLK_F16        = 324, /* Mac keyboards with keypad have F13-F19 keys */
+    SDLK_F17        = 325,
+    SDLK_F18        = 326,
+    SDLK_F19        = 327,
+
 	SDLK_LAST
 } SDLKey;
 

--- a/vs/sdl/src/events/SDL_keyboard.c
+++ b/vs/sdl/src/events/SDL_keyboard.c
@@ -181,8 +181,8 @@ int SDL_KeyboardInit(void)
 	keynames[SDLK_WORLD_14] = "JP Henkan/Int'l 4";
 	keynames[SDLK_WORLD_15] = "JP Kata&Hira/Int'l 2";
 	keynames[SDLK_WORLD_16] = "world 16";
-	keynames[SDLK_WORLD_17] = "world 17";
-	keynames[SDLK_WORLD_18] = "world 18";
+	keynames[SDLK_WORLD_17] = "JP Eisu";
+	keynames[SDLK_WORLD_18] = "JP Kana";
 	keynames[SDLK_WORLD_19] = "world 19";
 	keynames[SDLK_WORLD_20] = "JP ro/Int'l 6";
 	keynames[SDLK_WORLD_21] = "world 21";

--- a/vs/sdl/src/events/SDL_keyboard.c
+++ b/vs/sdl/src/events/SDL_keyboard.c
@@ -175,16 +175,16 @@ int SDL_KeyboardInit(void)
 	keynames[SDLK_WORLD_8] = "world 8";
 	keynames[SDLK_WORLD_9] = "world 9";
 	keynames[SDLK_WORLD_10] = "world 10";
-	keynames[SDLK_WORLD_11] = "world 11";
-	keynames[SDLK_WORLD_12] = "world 12";
-	keynames[SDLK_WORLD_13] = "world 13";
-	keynames[SDLK_WORLD_14] = "world 14";
-	keynames[SDLK_WORLD_15] = "world 15";
+	keynames[SDLK_WORLD_11] = "JP Yen/Int'l 3";
+	keynames[SDLK_WORLD_12] = "JP Hankaku/Lang 5";
+	keynames[SDLK_WORLD_13] = "JP Muhenkan/Int'l 5";
+	keynames[SDLK_WORLD_14] = "JP Henkan/Int'l 4";
+	keynames[SDLK_WORLD_15] = "JP Kata&Hira/Int'l 2";
 	keynames[SDLK_WORLD_16] = "world 16";
 	keynames[SDLK_WORLD_17] = "world 17";
 	keynames[SDLK_WORLD_18] = "world 18";
 	keynames[SDLK_WORLD_19] = "world 19";
-	keynames[SDLK_WORLD_20] = "world 20";
+	keynames[SDLK_WORLD_20] = "JP ro/Int'l 6";
 	keynames[SDLK_WORLD_21] = "world 21";
 	keynames[SDLK_WORLD_22] = "world 22";
 	keynames[SDLK_WORLD_23] = "world 23";
@@ -277,7 +277,8 @@ int SDL_KeyboardInit(void)
 	keynames[SDLK_KP_MINUS] = "[-]";
 	keynames[SDLK_KP_PLUS] = "[+]";
 	keynames[SDLK_KP_ENTER] = "enter";
-	keynames[SDLK_KP_EQUALS] = "equals";
+	keynames[SDLK_KP_EQUALS] = "[=]";
+    keynames[SDLK_KP_COMMA] = "[,]";
 
 	keynames[SDLK_UP] = "up";
 	keynames[SDLK_DOWN] = "down";


### PR DESCRIPTION
This PR adds support for the following keys.

Keypad comma/ABNT C2(.) (Windows/Mac)
Keypad equals (Windows)
'Section' key ('@' key for French AZERTY) (Mac)
F17, F18, F19 keys (Mac: no keys assigned as default so you can assign one you desire)
JP Ro/ABNT C1, JP yen (Mac: Change to be as same as Windows)
JP Eisu and JP Kana (Mac: no keys assigned as default so you can assign one you desire)
