### PR TITLE
Fix OPL2 Board and OPL3Duo Board Drop audio on Intel/ARM Macs 

### DIFF
--- a/src/hardware/opl2board/opl2board.cpp
+++ b/src/hardware/opl2board/opl2board.cpp
@@ -1,3 +1,9 @@
+/*
+OPL2 Board Driver
+note:(josephillips85) To perform changes please peform for the specific target platform
+Ex. MacOS , Windows , Linux
+Don't change the behaivor of the target platform if you don't have the way to test it.
+*/ 
 #include "../serialport/libserial.h"
 #include "setup.h"
 #include "opl2board.h"
@@ -11,6 +17,7 @@ void OPL2AudioBoard::connect(const char* port) {
 	comport = nullptr;
 	if (SERIAL_open(port, &comport)) {
 		SERIAL_setCommParameters(comport, 115200, 'n', SERIAL_1STOP, 8);
+
 #if !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
 		resetBuffer();
 		stopThread = false;
@@ -93,12 +100,16 @@ void OPL2AudioBoard::write(uint8_t reg, uint8_t val) {
 		#if OPL2_AUDIO_BOARD_DEBUG
 			printf("OPL2 Audio Board: Write %d --> %d | buffer size %d\n", val, reg, sendBuffer.size());
 		#endif
-#if !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
-		sendBuffer.push(reg);
-		sendBuffer.push(val);
+#if !defined(MACOS)
+    SERIAL_sendchar(comport, reg);
+    SERIAL_sendchar(comport, val);       
+
+#elif !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
+	sendBuffer.push(reg);
+	sendBuffer.push(val);
 #else
-		SERIAL_sendchar(comport, reg);
-		SERIAL_sendchar(comport, val);
+	SERIAL_sendchar(comport, reg);
+	SERIAL_sendchar(comport, val);
 #endif
 	}
 }

--- a/src/hardware/opl3duoboard/opl3duoboard.cpp
+++ b/src/hardware/opl3duoboard/opl3duoboard.cpp
@@ -1,3 +1,9 @@
+/*
+OPL3Duo Board Driver
+note:(josephillips85) To perform changes please peform for the specific target platform
+Ex. MacOS , Windows , Linux
+Don't change the behaivor of the target platform if you don't have the way to test it.
+*/   
 #include "../serialport/libserial.h"
 #include "setup.h"
 #include "opl3duoboard.h"
@@ -75,21 +81,27 @@ void Opl3DuoBoard::write(uint32_t reg, uint8_t val) {
 		#if OPL3_DUO_BOARD_DEBUG
 			printf("OPL3 Duo! Board: Write %d --> %d | buffer size %d\n", val, reg, sendBuffer.size());
 		#endif
-#if !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
-		sendBuffer.push((reg >> 6) | 0x80);
-		sendBuffer.push(((reg & 0x3f) << 1) | (val >> 7));
-		sendBuffer.push((val & 0x7f));
+
+ 
+#if !defined(MACOS)
+    SERIAL_sendchar(comport, (reg >> 6) | 0x80);
+	SERIAL_sendchar(comport, ((reg & 0x3f) << 1) | (val >> 7));
+	SERIAL_sendchar(comport, val & 0x7f);
+#elif !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
+	sendBuffer.push((reg >> 6) | 0x80);
+	sendBuffer.push(((reg & 0x3f) << 1) | (val >> 7));
+	sendBuffer.push((val & 0x7f));
 #else
-		SERIAL_sendchar(comport, (reg >> 6) | 0x80);
-		SERIAL_sendchar(comport, ((reg & 0x3f) << 1) | (val >> 7));
-		SERIAL_sendchar(comport, val & 0x7f);
+	SERIAL_sendchar(comport, (reg >> 6) | 0x80);
+	SERIAL_sendchar(comport, ((reg & 0x3f) << 1) | (val >> 7));
+	SERIAL_sendchar(comport, val & 0x7f);
 #endif
 
 	}
 }
 
 void Opl3DuoBoard::writeBuffer() {
-#if !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
+#if !defined(HX_DOS) && !(defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)) 
 
 	#if !defined(MACOS)
 	/* Note:(josephillips85) This is a workaround to fix the thread stop issue presented on MacOS


### PR DESCRIPTION
This fix will allow recover the use of OPL2 Board and OPL3Duo audio on MacOS computers Intel or ARM Based Macs caused by PR#3808 on Mac Computers

## What issue(s) does this PR address?
Closes #4180

## Does this PR introduce new feature(s)?
No
If yes, describe the feature(s) introduced.

## Does this PR introduce any breaking change(s)?
No
If yes, describe the breaking change(s) in detail.
No
## Additional information

Is recommended that futures fixes or changes only affect the target system and not the whole implementation without a way to test it on another targets platform.
