### PR TITLE
Automatically mount directories 'drive[c-y]' found in DOSBox-X executable directory

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -114,6 +114,8 @@ Next:
     DOSBox-X is never going to compile for a C standard that old.
     Furthermore this check is preventing compilation on ARM-based
     Macbooks for some reason, though not Intel based Macbooks.
+  - Automatically mount directories found in DOSBox-X's executable
+    directory with naming scheme 'drive[drive letter]'. (aybe)
 
 2023.03.31
   - "mount -t overlay" will now print a message on the console to

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -8468,6 +8468,31 @@ static void FLAGSAVE_ProgramStart(Program** make)
     *make = new FLAGSAVE;
 }
 
+/**
+ * \brief Mounts directories 'drive[c-z]' found in DOSBox-X directory.
+ */
+void Add_Existing_Drive_Directories()
+{
+    for(char drive = 'C'; drive < 'Z'; drive++)
+    {
+        std::string name = "drive";
+        std::string path = ".";
+
+        name += drive;
+        path += CROSS_FILESPLIT;
+        path += name;
+
+        getdrivezpath(path, name);
+
+        if (path == "")
+            continue;
+
+        LOG_MSG("Mounting directory 'drive%c' found in DOSBox-X directory as drive %c.\n", (char)(drive + 32), drive);
+
+        MountHelper(drive, path.c_str(), "LOCAL");
+    }
+}
+
 void Add_VFiles(bool usecp) {
     VFILE_Register("TEXTUTIL", 0, 0, "/");
     VFILE_Register("SYSTEM", 0, 0, "/");
@@ -9155,4 +9180,6 @@ void DOS_SetupPrograms(void) {
 
     /*regular setup*/
     Add_VFiles(false);
+
+    Add_Existing_Drive_Directories();
 }


### PR DESCRIPTION
## What issue(s) does this PR address?

Nothing.

## Does this PR introduce new feature(s)?

Looks for existing directories named `drivec` and up to `drivey` in DOSBox-X's executable directory.

If these do exist they will be mounted as local drives.

Basically, this allows a user to simply create such directories and they will be immediately mounted without further action.

## Does this PR introduce any breaking change(s)?

Probably none.

## Additional information

