### PR TITLE
Fix class-memaccess warnings

### DIFF
--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -418,7 +418,6 @@ private:
 class CDROM_Interface_Aspi : public CDROM_Interface
 {
 public:
-	CDROM_Interface_Aspi		(void);
 	virtual ~CDROM_Interface_Aspi(void);
 
 	bool	SetDevice			(char* path, int forceCD);
@@ -452,16 +451,16 @@ private:
 	bool	GetVendor			(BYTE HA_num, BYTE SCSI_Id, BYTE SCSI_Lun, char* szBuffer);
 		
 	// ASPI stuff
-	BYTE	haId;
-	BYTE	target;
-	BYTE	lun;
-	char	letter;
+	BYTE	haId = 0;
+	BYTE	target = 0;
+	BYTE	lun = 0;
+	char	letter = 0;
 
 	// Windows stuff
-	HINSTANCE	hASPI;
-	HANDLE		hEvent;											// global event
-	DWORD		(*pGetASPI32SupportInfo)	(void);             // ptrs to aspi funcs
-	DWORD		(*pSendASPI32Command)		(LPSRB);
+	HINSTANCE	hASPI = NULL;
+	HANDLE		hEvent = NULL;											// global event
+	DWORD		(*pGetASPI32SupportInfo)	(void) = NULL;             // ptrs to aspi funcs
+	DWORD		(*pSendASPI32Command)		(LPSRB) = NULL;
     TMSF        oldLeadOut = {};
 };
 

--- a/src/dos/cdrom_aspi_win32.cpp
+++ b/src/dos/cdrom_aspi_win32.cpp
@@ -61,15 +61,6 @@ typedef union {
 // Windows ASPI functions (should work for all WIN with ASPI layer)
 // *****************************************************************
 
-CDROM_Interface_Aspi::CDROM_Interface_Aspi(void)
-{
-	hASPI					= NULL;
-	hEvent					= NULL;
-	pGetASPI32SupportInfo	= NULL;
-	pSendASPI32Command		= NULL;
-	memset(&oldLeadOut,0,sizeof(oldLeadOut));
-};
-
 CDROM_Interface_Aspi::~CDROM_Interface_Aspi(void)
 {
 	// Stop Audio

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -2338,7 +2338,10 @@ void isoDrive :: EmptyCache(void) {
 	//this->fileName[0]  = '\0'; /* deleted to fix issue #3848. Revert this if there are any flaws */
 	//this->discLabel[0] = '\0'; /* deleted to fix issue #3848. Revert this if there are any flaws */
 	nextFreeDirIterator = 0;
-	memset(dirIterators, 0, sizeof(dirIterators));
+    size_t dirIteratorsSize = sizeof(dirIterators);
+    for(std::size_t i = 0; i < dirIteratorsSize; ++i) {
+        dirIterators[i] = isoDrive::DirIterator{};
+    }
 	memset(sectorHashEntries, 0, sizeof(sectorHashEntries));
 	memset(&rootEntry, 0, sizeof(isoDirEntry));
 	//safe_strncpy(this->fileName, fileName, CROSS_LEN); /* deleted to fix issue #3848. Revert this if there are any flaws */


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

Fixes 2 remaining "clearing an object of non-trivial type, use assignment or value-initialization instead [-Wclass-memaccess]" warnings. Also assigned 0 values to uninitialized members in the CDROM_Interface_Aspi class and moved it all to in-class initialization, removing the need for the constructor.