### PR TITLE
Fixed crash on the BSDs when reallpt is specified without either real…

### DIFF
--- a/src/hardware/parport/directlpt.cpp
+++ b/src/hardware/parport/directlpt.cpp
@@ -85,6 +85,10 @@ CDirectLPT::CDirectLPT(Bitu nr, uint8_t initIrq, CommandLine* cmd)
 			LOG_MSG("parallel%d: ecpbase (raw I/O) requires root privileges. Pass-through I/O disabled.", (int)nr + 1);
 			return;
 		}
+#ifdef BSD
+		LOG_MSG("parallel%d: Raw I/O requires root privileges. Pass-through I/O disabled.", (int)nr + 1);
+		return;
+#endif
 	}
 #endif
 #endif // x86{_64}


### PR DESCRIPTION
…base or ecpbase and running as regular user (not setuid root).

## What issue(s) does this PR address?

As stated in the title.

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

No.

## Additional information

If either realbase or ecpbase is specified, the log states that DOSBox-X requires root privileges. So, running as root or making the DOSBox-X binary setuid root will work as expected.
