### PR TITLE
Fix warning C5208

### DIFF
--- a/include/vga.h
+++ b/include/vga.h
@@ -628,7 +628,7 @@ enum {
 };
 
 // optimization tracking, the "complexity" of the arrangement.
-typedef union {
+typedef struct VGA_Complexity_t {
 	unsigned int	flags = 0;
 
 	INLINE unsigned int setf(unsigned int flag) {


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

Fixes Visual Studio warning C5208: "unnamed class used in typedef name cannot declare members other than non-static data members, member enumerations, or member classes"