### PR TITLE
Disable imfc logging function

### DIFF
--- a/src/hardware/imfc.cpp
+++ b/src/hardware/imfc.cpp
@@ -95,9 +95,9 @@ SDL_mutex* m_loggerMutex;
 template <typename... Args>
 void IMF_LOG(std::string format, Args const&... args)
 {
-	SDL_LockMutex(m_loggerMutex);
-	printf((format + "\n").c_str(), args...);
-	SDL_UnlockMutex(m_loggerMutex);
+	/*SDL_LockMutex(m_loggerMutex);
+	printf((format + "\n").c_str(), args...); // Causes "error: format not a string literal and no format arguments [-Werror=format-security]" on GCC 13.1.1
+	SDL_UnlockMutex(m_loggerMutex);*/
 }
 
 inline uint8_t leftRotate8(uint8_t n)


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

Fixes #4237.

## Does this PR introduce any breaking change(s)?

The IMFC logging will no longer be output by printf, but they weren't appearing in the DOSBox-X log anyway. If they are desired, maybe they can be converted to use the DOSBox-X logging style or something.