### PR TITLE
Fixed extra characters in Chinese input

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5108,7 +5108,7 @@ static bool CheckEnableImmOnKey(SDL_KeyboardEvent key)
 	  #if defined(SDL_DOSBOX_X_IME) && !defined(MACOSX)
 	  !SDL_IM_Composition() &&
 	  #endif
-	  (key.keysym.sym == 0x08 || key.keysym.sym == 0x09 || (!IS_JDOSV && !IS_PC98_ARCH && key.keysym.sym >= 0x20 && key.keysym.sym <= 0x7F) || (key.keysym.sym >= 0x100 && key.keysym.sym <= 0x119) || key.keysym.sym == 0x12C || key.keysym.sym == 0x12D) || (strPasteBuffer.length() && key.keysym.sym >= 0x80))
+	  (key.keysym.sym == 0x08 || key.keysym.sym == 0x09 || (!dos.im_enable_flag && key.keysym.sym >= 0x20 && key.keysym.sym <= 0x7F) || (key.keysym.sym >= 0x100 && key.keysym.sym <= 0x119) || key.keysym.sym == 0x12C || key.keysym.sym == 0x12D) || (strPasteBuffer.length() && key.keysym.sym >= 0x80))
 	) {
 		// BS, <-, ->, PgUp, PgDn, etc.
 		return true;
@@ -5138,7 +5138,7 @@ static bool CheckEnableImmOnKey(SDL_KeyboardEvent key)
 	if(key.keysym.scancode == 0x29 ||
 #if defined(SDL_DOSBOX_X_IME)
 	(!SDL_IM_Composition(4) && (key.keysym.sym == 0x20 || (key.keysym.sym >= 0x30 && key.keysym.sym <= 0x39))) ||
-	(!SDL_IM_Composition(1) && (key.keysym.sym == 0x08 || key.keysym.sym == 0x09 || (!IS_JDOSV && !IS_PC98_ARCH && key.keysym.sym > 0x20 && key.keysym.sym <= 0x2F) || (!IS_JDOSV && !IS_PC98_ARCH && key.keysym.sym > 0x3A && key.keysym.sym <= 0x7F) || key.keysym.scancode == 0x39 || (key.keysym.scancode >= 0x53 && key.keysym.scancode <= 0x63))) ||
+	(!SDL_IM_Composition(1) && (key.keysym.sym == 0x08 || key.keysym.sym == 0x09 || (!dos.im_enable_flag && key.keysym.sym > 0x20 && key.keysym.sym <= 0x2F) || (!dos.im_enable_flag && key.keysym.sym > 0x3A && key.keysym.sym <= 0x7F) || key.keysym.scancode == 0x39 || (key.keysym.scancode >= 0x53 && key.keysym.scancode <= 0x63))) ||
 #endif
 	(key.keysym.scancode >= 0x49 && key.keysym.scancode <= 0x52) || (key.keysym.scancode >= 0xe0 && key.keysym.scancode <= 0xe6) || (strPasteBuffer.length() && key.keysym.sym >= 0x20)) {
 		// ESC, shift, control, alt, PgUp, PgDn, etc.


### PR DESCRIPTION
Fixed #4227.
Fixed extra characters in input when IME is enabled by setting codepage in [dos] country instead of [dosv] dosv setting.
