### PR TITLE
Maxpat78 patch 2 [wip]

### DIFF
--- a/include/dos_system.h
+++ b/include/dos_system.h
@@ -318,6 +318,7 @@ public:
 	virtual bool AllocationInfo32(uint32_t * _bytes_sector,uint32_t * _sectors_cluster,uint32_t * _total_clusters,uint32_t * _free_clusters) { (void)_bytes_sector; (void)_sectors_cluster; (void)_total_clusters; (void)_free_clusters; return false; }
 	virtual bool FileExists(const char* name)=0;
 	virtual bool FileStat(const char* name, FileStat_Block * const stat_block)=0;
+   	virtual bool GetDiskSize64(uint64_t * _disk_size64) { (void) _disk_size64; return false; }
 	virtual uint8_t GetMediaByte(void)=0;
 	virtual void SetDir(const char* path) { strcpy(curdir,path); };
 //	virtual void EmptyCache(void) { dirCache.EmptyCache(); };

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -2241,6 +2241,14 @@ bool localDrive::Rename(const char * oldname,const char * newname) {
 
 }
 
+bool localDrive::GetDiskSize64(uint64_t * _disk_size64) { 
+#ifdef WIN32
+    return GetDiskFreeSpaceEx(basedir, (PULARGE_INTEGER) _disk_size64, NULL, NULL); // fills lpFreeBytesAvailableToCaller
+#else
+    return false;
+#endif
+}
+
 #if !defined(WIN32)
 #include <sys/statvfs.h>
 #endif

--- a/src/dos/drives.h
+++ b/src/dos/drives.h
@@ -74,6 +74,7 @@ public:
 	virtual bool FindFirst(const char * _dir,DOS_DTA & dta,bool fcb_findfirst=false);
 	virtual bool FindNext(DOS_DTA & dta);
 	virtual bool SetFileAttr(const char * name,uint16_t attr);
+    virtual bool GetDiskSize64(uint64_t * _disk_size64);
 	virtual bool GetFileAttr(const char * name,uint16_t * attr);
 	virtual bool GetFileAttrEx(char* name, struct stat *status);
 	std::string GetHostName(const char * name);

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -133,8 +133,10 @@ static void cmos_timerevent(Bitu val) {
             cmos.last.ended -= fmod(cmos.last.ended,1000);
             cmos.last.ended += 1000;
 
-            cmos_tick();
-            if (cmos.regs[0xb] & 0x20/*AIE*/) cmos_checkalarm();
+            if (!cmos.lock) {
+                cmos_tick();
+                if (cmos.regs[0xb] & 0x20/*AIE*/) cmos_checkalarm();
+            }
 
             // Update-Ended Interrupt Flag (UF)
             if (cmos.regs[0xb] & 0x10) cmos.regs[0xc] |= 0x10;
@@ -269,6 +271,7 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
                 cmos.ampm = !(val & 0x02);
                 cmos.bcd = !(val & 0x04);
                 cmos.lock = (val & 0x80) != 0;
+                if (cmos.lock) val &= ~0x10; /* Setting bit 7 clears bit 4 (UEI) */
                 cmos.regs[cmos.reg] = (uint8_t)val;
                 cmos_checktimer();
             }


### PR DESCRIPTION
This patch provides a new GetDiskSize64 member in DOS_Drive, and implements it in localDrive class so that internal shell's DIR command can know proper disk size of a (network) drive >2TB.

## What issue(s) does this PR address?
Fixes #4258 

## Does this PR introduce new feature(s)?

DOS_Drive::GetDiskSize64 
localDrive::GetDiskSize64 

## Does this PR introduce any breaking change(s)?

If yes, describe the breaking change(s) in detail.

## Additional information

Add any additional information here.
