### PR TITLE
Fixed Chinese input bug again

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5105,10 +5105,10 @@ bool GFX_IsFullscreen(void) {
 static bool CheckEnableImmOnKey(SDL_KeyboardEvent key)
 {
 	if(key.keysym.sym == 0 || (
-	  #if defined(SDL_DOSBOX_X_IME) && !defined(MACOSX)
+	  #if defined(WIN32)
 	  !SDL_IM_Composition() &&
 	  #endif
-	  (key.keysym.sym == 0x08 || key.keysym.sym == 0x09 || (!dos.im_enable_flag && key.keysym.sym >= 0x20 && key.keysym.sym <= 0x7F) || (key.keysym.sym >= 0x100 && key.keysym.sym <= 0x119) || key.keysym.sym == 0x12C || key.keysym.sym == 0x12D) || (strPasteBuffer.length() && key.keysym.sym >= 0x80))
+	  (key.keysym.sym == 0x08 || key.keysym.sym == 0x09 || (key.keysym.sym >= 0x20 && key.keysym.sym <= 0x7F) || (key.keysym.sym >= 0x100 && key.keysym.sym <= 0x119) || key.keysym.sym == 0x12C || key.keysym.sym == 0x12D) || (strPasteBuffer.length() && key.keysym.sym >= 0x80))
 	) {
 		// BS, <-, ->, PgUp, PgDn, etc.
 		return true;
@@ -5138,7 +5138,7 @@ static bool CheckEnableImmOnKey(SDL_KeyboardEvent key)
 	if(key.keysym.scancode == 0x29 ||
 #if defined(SDL_DOSBOX_X_IME)
 	(!SDL_IM_Composition(4) && (key.keysym.sym == 0x20 || (key.keysym.sym >= 0x30 && key.keysym.sym <= 0x39))) ||
-	(!SDL_IM_Composition(1) && (key.keysym.sym == 0x08 || key.keysym.sym == 0x09 || (!dos.im_enable_flag && key.keysym.sym > 0x20 && key.keysym.sym <= 0x2F) || (!dos.im_enable_flag && key.keysym.sym > 0x3A && key.keysym.sym <= 0x7F) || key.keysym.scancode == 0x39 || (key.keysym.scancode >= 0x53 && key.keysym.scancode <= 0x63))) ||
+	(!SDL_IM_Composition(1) && (key.keysym.sym == 0x08 || key.keysym.sym == 0x09 || (dos.loaded_codepage != 932 && key.keysym.sym > 0x20 && key.keysym.sym <= 0x2F) || (dos.loaded_codepage != 932 && key.keysym.sym > 0x3A && key.keysym.sym <= 0x7F) || key.keysym.scancode == 0x39 || (key.keysym.scancode >= 0x53 && key.keysym.scancode <= 0x63))) ||
 #endif
 	(key.keysym.scancode >= 0x49 && key.keysym.scancode <= 0x52) || (key.keysym.scancode >= 0xe0 && key.keysym.scancode <= 0xe6) || (strPasteBuffer.length() && key.keysym.sym >= 0x20)) {
 		// ESC, shift, control, alt, PgUp, PgDn, etc.


### PR DESCRIPTION
Fix #4253 still had problems, so I fixed it again.
Fixed the problem that it was not possible to input English characters in Chinese input.