### PR TITLE
Fix break keys (Windows SDL1/SDL2)

### DIFF
--- a/include/keyboard.h
+++ b/include/keyboard.h
@@ -20,23 +20,23 @@
 #define DOSBOX_KEYBOARD_H
 
 enum KBD_KEYS {
-	KBD_NONE,
-	KBD_1,	KBD_2,	KBD_3,	KBD_4,	KBD_5,	KBD_6,	KBD_7,	KBD_8,	KBD_9,	KBD_0,		
-	KBD_q,	KBD_w,	KBD_e,	KBD_r,	KBD_t,	KBD_y,	KBD_u,	KBD_i,	KBD_o,	KBD_p,	
-	KBD_a,	KBD_s,	KBD_d,	KBD_f,	KBD_g,	KBD_h,	KBD_j,	KBD_k,	KBD_l,	KBD_z,
-	KBD_x,	KBD_c,	KBD_v,	KBD_b,	KBD_n,	KBD_m,	
-	KBD_f1,	KBD_f2,	KBD_f3,	KBD_f4,	KBD_f5,	KBD_f6,	KBD_f7,	KBD_f8,	KBD_f9,	KBD_f10,KBD_f11,KBD_f12,
-	
-	/*Now the weirder keys */
+    KBD_NONE,
+    KBD_1, KBD_2, KBD_3, KBD_4, KBD_5, KBD_6, KBD_7, KBD_8, KBD_9, KBD_0,
+    KBD_q, KBD_w, KBD_e, KBD_r, KBD_t, KBD_y, KBD_u, KBD_i, KBD_o, KBD_p,
+    KBD_a, KBD_s, KBD_d, KBD_f, KBD_g, KBD_h, KBD_j, KBD_k, KBD_l, KBD_z,
+    KBD_x, KBD_c, KBD_v, KBD_b, KBD_n, KBD_m,
+    KBD_f1, KBD_f2, KBD_f3, KBD_f4, KBD_f5, KBD_f6, KBD_f7, KBD_f8, KBD_f9, KBD_f10, KBD_f11, KBD_f12,
 
-	KBD_esc,KBD_tab,KBD_backspace,KBD_enter,KBD_space,
-	KBD_leftalt,KBD_rightalt,KBD_leftctrl,KBD_rightctrl,KBD_leftshift,KBD_rightshift,
-	KBD_capslock,KBD_scrolllock,KBD_numlock,
-	
-	KBD_grave,KBD_minus,KBD_equals,KBD_backslash,KBD_leftbracket,KBD_rightbracket,
-	KBD_semicolon,KBD_quote,KBD_period,KBD_comma,KBD_slash,KBD_extra_lt_gt,
+    /*Now the weirder keys */
 
-	KBD_printscreen,KBD_pause,
+    KBD_esc, KBD_tab, KBD_backspace, KBD_enter, KBD_space,
+    KBD_leftalt, KBD_rightalt, KBD_leftctrl, KBD_rightctrl, KBD_leftshift, KBD_rightshift,
+    KBD_capslock, KBD_scrolllock, KBD_numlock,
+
+    KBD_grave, KBD_minus, KBD_equals, KBD_backslash, KBD_leftbracket, KBD_rightbracket,
+    KBD_semicolon, KBD_quote, KBD_period, KBD_comma, KBD_slash, KBD_extra_lt_gt,
+
+    KBD_printscreen, KBD_pause, KBD_break,
 	KBD_insert,KBD_home,KBD_pageup,KBD_delete,KBD_end,KBD_pagedown,
 	KBD_left,KBD_up,KBD_down,KBD_right,
 

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1256,6 +1256,8 @@ Bitu GetKeyCode(SDL_keysym keysym) {
             if(keysym.win32_vk >= 0xa6 && keysym.win32_vk <= 0xb7) return SDLK_UNKNOWN; // Ignore all media keys
 #endif
             switch(keysym.scancode) {
+            case 0x45:  // PAUSE
+                return (keysym.win32_vk == VK_CANCEL ? SDLK_BREAK : SDLK_PAUSE);
             case 0x46:  // Scroll Lock
                 // LOG_MSG("Scroll_lock scancode=%x, vk_key=%x", keysym.scancode, keysym.win32_vk);
                 return (keysym.win32_vk == VK_CANCEL ? SDLK_BREAK : SDLK_SCROLLOCK);
@@ -1267,7 +1269,6 @@ Bitu GetKeyCode(SDL_keysym keysym) {
             case 0x1d:  // CONTROL
             case 0x37:  // PRINTSCREEN
             case 0x38:  // ALT
-            case 0x45:  // PAUSE
             case 0x47:  // HOME
             case 0x48:  // cursor UP
             case 0x49:  // PAGE UP
@@ -4069,7 +4070,8 @@ static void CreateLayout(void) {
 
     AddKeyButtonEvent(PX(XO + 0), PY(YO + 0), BU(1), BV(1), "Prn", "printscreen", KBD_printscreen);
     AddKeyButtonEvent(PX(XO + 1), PY(YO + 0), BU(1), BV(1), "Scr", "scrolllock", KBD_scrolllock);
-    AddKeyButtonEvent(PX(XO + 2), PY(YO + 0), BU(1), BV(1), "Brk", "pause", KBD_pause);
+    AddKeyButtonEvent(PX(XO + 2), PY(YO + 0), BU(1), BV(1), "Pau", "pause", KBD_pause);
+    AddKeyButtonEvent(PX(XO + 3), PY(YO + 0), BU(1), BV(1), "Brk", "break", KBD_break);
 
     AddKeyButtonEvent(PX(XO + 0), PY(YO + 2), BU(1), BV(1), "Ins", "insert", KBD_insert);
     AddKeyButtonEvent(PX(XO + 1), PY(YO + 2), BU(1), BV(1), "Hom", "home", KBD_home);
@@ -4540,7 +4542,7 @@ static struct {
     {"printscreen",SDLK_PRINT},
     {"scrolllock",SDLK_SCROLLOCK},
 
-    {"pause",SDLK_PAUSE},       {"pagedown",SDLK_PAGEDOWN},
+    {"pause",SDLK_PAUSE}, {"break", SDLK_BREAK}, {"pagedown",SDLK_PAGEDOWN},
     {"pageup",SDLK_PAGEUP}, {"insert",SDLK_INSERT},     {"home",SDLK_HOME},
     {"delete",SDLK_DELETE}, {"end",SDLK_END},           {"up",SDLK_UP},
     {"left",SDLK_LEFT},     {"down",SDLK_DOWN},         {"right",SDLK_RIGHT},

--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -1419,7 +1419,6 @@ void KEYBOARD_PC98_AddKey(KBD_KEYS keytype,bool pressed) {
 
 void KEYBOARD_AddKey1(KBD_KEYS keytype,bool pressed) {
     uint8_t ret=0,ret2=0;bool extend=false;
-
     if (keyb.reset)
         return;
 
@@ -1551,8 +1550,19 @@ void KEYBOARD_AddKey1(KBD_KEYS keytype,bool pressed) {
     case KBD_f24:ret=0x2A;ret2=88;break;
 
     case KBD_numlock:ret=69;break;
-    case KBD_scrolllock:ret=70;break;
-
+    case KBD_scrolllock:
+#if defined(C_SDL2)
+        if(keyb.leftctrl_pressed ^ keyb.rightctrl_pressed) {
+            extend = true; ret = 70;
+        }
+        else {
+            ret = 70;
+        }
+#else
+        ret = 70;
+#endif
+        break;
+    case KBD_break: extend = true; ret = 70; break;
     case KBD_kp7:ret=71;break;
     case KBD_kp8:ret=72;break;
     case KBD_kp9:ret=73;break;
@@ -1592,11 +1602,11 @@ void KEYBOARD_AddKey1(KBD_KEYS keytype,bool pressed) {
     case KBD_insert:extend=true;ret=82;break;
     case KBD_delete:extend=true;ret=83;break;
     case KBD_pause:
-        if (!pressed) {
+        //if (!pressed) {
             /* keyboards send both make&break codes for this key on
                key press and nothing on key release */
-            return;
-        }
+        //    return;
+        //}
         if (!keyb.leftctrl_pressed && !keyb.rightctrl_pressed) {
             /* neither leftctrl, nor rightctrl pressed -> PAUSE key */
             KEYBOARD_AddBuffer(0xe1);
@@ -1605,7 +1615,7 @@ void KEYBOARD_AddKey1(KBD_KEYS keytype,bool pressed) {
             KEYBOARD_AddBuffer(0xe1);
             KEYBOARD_AddBuffer(29|0x80);
             KEYBOARD_AddBuffer(69|0x80);
-        } else if (!keyb.leftctrl_pressed || !keyb.rightctrl_pressed) {
+        } else if (keyb.leftctrl_pressed ^ keyb.rightctrl_pressed) {
             /* exactly one of [leftctrl, rightctrl] is pressed -> Ctrl+BREAK */
             KEYBOARD_AddBuffer(0xe0);
             KEYBOARD_AddBuffer(70);


### PR DESCRIPTION
This PR fixes Ctrl+Pause and Ctrl+Scroll Lock to work as Break key.
Tested on Windows VS builds SDL1/SDL2.
