### PR TITLE
Enhanced Dynamic and Differencing VHD support

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -299,9 +299,9 @@ public:
 	static VHDTypes GetVHDType(const char* fileName);
 	VHDTypes GetVHDType(void) const;
 	virtual ~imageDiskVHD();
-	uint32_t mk_crc(uint8_t* s, uint32_t size);
-	void mk_chs(uint64_t size, char* chs);
-	uint32_t CreateDynamic(char* filename, uint64_t size);
+	static uint32_t mk_crc(uint8_t* s, uint32_t size);
+	static void mk_chs(uint64_t size, char* chs);
+	static uint32_t CreateDynamic(char* filename, uint64_t size);
 
 private:
 	struct Geometry {

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -278,6 +278,8 @@ public:
 		INVALID_MATCH = 4,
 		INVALID_DATE = 5,
 		UNSUPPORTED_WRITE = 6,
+        UNSUPPORTED_SIZE = 7,
+        ERROR_WRITING = 8,
 		PARENT_ERROR = 0x10,
 		ERROR_OPENING_PARENT = 0x11,
 		PARENT_INVALID_DATA = 0x12,
@@ -298,9 +300,12 @@ public:
 	static ErrorCodes Open(const char* fileName, const bool readOnly, imageDisk** disk);
 	static VHDTypes GetVHDType(const char* fileName);
 	VHDTypes GetVHDType(void) const;
-	virtual ~imageDiskVHD();
-	static uint32_t CreateDynamic(const char* filename, uint64_t size);
+    static uint32_t CreateFixed(const char* filename, uint64_t size);
+    static uint32_t ConvertFixed(const char* filename);
+    static uint32_t CreateDynamic(const char* filename, uint64_t size);
 	static uint32_t CreateDifferencing(const char* filename, const char* basename);
+    static void PseudoCHSFromSize(uint64_t size, uint32_t* c, uint32_t* h, uint32_t* s);
+    virtual ~imageDiskVHD();
 
 private:
 	struct Geometry {
@@ -363,7 +368,6 @@ private:
 	virtual bool loadBlock(const uint32_t blockNumber);
 	static bool convert_UTF16_for_fopen(std::string &string, const void* data, const uint32_t dataLength);
     static uint32_t mk_crc(uint8_t* s, uint32_t size);
-    static void mk_chs(uint64_t size, char* chs);
 
     imageDisk* parentDisk = NULL;
 	uint64_t footerPosition = 0;

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -299,6 +299,9 @@ public:
 	static VHDTypes GetVHDType(const char* fileName);
 	VHDTypes GetVHDType(void) const;
 	virtual ~imageDiskVHD();
+	uint32_t mk_crc(uint8_t* s, uint32_t size);
+	void mk_chs(uint64_t size, char* chs);
+	uint32_t CreateDynamic(char* filename, uint64_t size);
 
 private:
 	struct Geometry {

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -299,9 +299,8 @@ public:
 	static VHDTypes GetVHDType(const char* fileName);
 	VHDTypes GetVHDType(void) const;
 	virtual ~imageDiskVHD();
-	static uint32_t mk_crc(uint8_t* s, uint32_t size);
-	static void mk_chs(uint64_t size, char* chs);
-	static uint32_t CreateDynamic(char* filename, uint64_t size);
+	static uint32_t CreateDynamic(const char* filename, uint64_t size);
+	static uint32_t CreateDifferencing(const char* filename, const char* basename);
 
 private:
 	struct Geometry {
@@ -363,6 +362,8 @@ private:
 	static ErrorCodes Open(const char* fileName, const bool readOnly, imageDisk** disk, const uint8_t* matchUniqueId);
 	virtual bool loadBlock(const uint32_t blockNumber);
 	static bool convert_UTF16_for_fopen(std::string &string, const void* data, const uint32_t dataLength);
+    static uint32_t mk_crc(uint8_t* s, uint32_t size);
+    static void mk_chs(uint64_t size, char* chs);
 
     imageDisk* parentDisk = NULL;
 	uint64_t footerPosition = 0;

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -3496,6 +3496,20 @@ restart_int:
                 return;
             }
         }
+        char extension[6] = {}; // care extensions longer than 3 letters such as '.vhdd'
+        if(temp_line.find_last_of('.') != std::string::npos) {
+            for(unsigned int i = 0; i < sizeof(extension) - 1; i++) {
+                if(temp_line.find_last_of('.') + i > temp_line.length() - 1) break;
+                extension[i] = temp_line[temp_line.find_last_of('.') + i];
+            }
+            extension[sizeof(extension) - 1] = '\0'; // Terminate string just in case
+        }
+        //avoids IMGMOUNT issues, since VHD psuedo-CHS != BPB algorithm (above)
+        //Windows 11 actually does NOT complain, other utilities (i.e. 7-zip) CAN!
+        if(disktype == "vhd" || !strcasecmp(extension, ".vhd")) {
+            imageDiskVHD::PseudoCHSFromSize(size, &c, &h, &s);
+            LOG_MSG("VHD geometry reset conforming to VHD specification");
+        }
         if (!dos_kernel_disabled) WriteOut(MSG_Get("PROGRAM_IMGMAKE_PRINT_CHS"),temp_line.c_str(),c,h,s);
         LOG_MSG(MSG_Get("PROGRAM_IMGMAKE_PRINT_CHS"),temp_line.c_str(),c,h,s);
 
@@ -3506,25 +3520,17 @@ restart_int:
         if(disktype == "vhd") {
             uint32_t ret = imageDiskVHD::CreateDynamic(temp_line.c_str(), size);
             switch(ret) {
-            case 3:
-                WriteOut(MSG_Get("PROGRAM_IMGMAKE_VHD_ERR3"));
+            case imageDiskVHD::ERROR_OPENING:
+                WriteOut(MSG_Get("PROGRAM_VHDMAKE_ERROPEN"), temp_line.c_str());
                 return;
-            case 4:
-                WriteOut(MSG_Get("PROGRAM_IMGMAKE_VHD_ERR4"), temp_line.c_str());
-                return;
-            case 5:
-                WriteOut(MSG_Get("PROGRAM_IMGMAKE_VHD_ERR5"), temp_line.c_str());
+            case imageDiskVHD::ERROR_WRITING:
+                WriteOut(MSG_Get("PROGRAM_VHDMAKE_WRITERR"), temp_line.c_str());
                 return;
             }
-            if(imageDiskVHD::Open(temp_line.c_str(), false, (imageDisk**) &vhd) != imageDiskVHD::OPEN_SUCCESS)
+            if(imageDiskVHD::Open(temp_line.c_str(), false, (imageDisk**)&vhd) != imageDiskVHD::OPEN_SUCCESS) {
+                WriteOut(MSG_Get("PROGRAM_VHDMAKE_ERROPEN"), temp_line.c_str());
                 return;
-            // Reset these according to VHD pseudo-CHS geometry, avoiding IMGMOUNT issues!
-            // VHD psuedo-CHS algorithm != BPB algorithm (above)
-            c = vhd->cylinders > 1023? 1023 : vhd->cylinders;
-            h = vhd->heads;
-            s = vhd->sectors;
-            if(!dos_kernel_disabled) WriteOut(MSG_Get("PROGRAM_IMGMAKE_PRINT_CHS"), temp_line.c_str(), c, h, s);
-            LOG_MSG(MSG_Get("PROGRAM_IMGMAKE_PRINT_CHS"), temp_line.c_str(), c, h, s);
+            }
         }
         else {
             f = fopen64(temp_line.c_str(), "wb+");
@@ -3966,14 +3972,6 @@ restart_int:
                 WriteOut("WARNING: Cluster sizes >= 64KB are not compatible with MS-DOS and SCANDISK\n");
         }
         // write VHD footer if requested, largely copied from RAW2VHD program, no license was included
-        char extension[6] = {}; // care extensions longer than 3 letters such as '.vhdd'
-        if(temp_line.find_last_of('.') != std::string::npos) {
-            for(unsigned int i = 0; i < sizeof(extension) - 1; i++) {
-                if(temp_line.find_last_of('.') + i > temp_line.length() - 1) break;
-                extension[i] = temp_line[temp_line.find_last_of('.') + i];
-            }
-            extension[sizeof(extension) - 1] = '\0'; // Terminate string just in case
-        }
         if((mediadesc == 0xF8) && disktype != "vhd" && !strcasecmp(extension, ".vhd")) {
             int i;
             uint8_t footer[512];
@@ -3991,9 +3989,6 @@ restart_int:
 #endif
             // size and geometry
             *(uint64_t*)(footer+0x30) = *(uint64_t*)(footer+0x28) = SDL_SwapBE64(size);
-            // WARNING: CHS geometry calculated by IMGMAKE differs from
-            // pseudo CHS geometry described in VHD spec: Windows 11 actually does
-            // NOT complain, other utilities (i.e. 7zFM) CAN!
             *(uint16_t*)(footer+0x38) = SDL_SwapBE16(c);
             *(uint8_t*)( footer+0x3A) = h;
             *(uint8_t*)( footer+0x3B) = s;
@@ -7823,6 +7818,9 @@ uint64_t VHDMAKE::ssizetou64(const char* s_size) {
 void VHDMAKE::Run()
 {
     bool bOverwrite = false;
+    bool bExists = false;
+    uint32_t ret;
+    char basename[256], filename[256];
 
 	// Hack To allow long commandlines
 	ChangeToLongCmd();
@@ -7836,14 +7834,39 @@ void VHDMAKE::Run()
     if(cmd->FindExist("-f", true))
         bOverwrite = true;
 
-    if(cmd->FindExist("-l", true)) {
-        char basename[256], newname[256];
+    if(cmd->FindExist("-c", true)) {
+        if(cmd->GetCount() > 2) {
+            PrintUsage();
+            return;
+        }
+        cmd->FindCommand(1, temp_line);
+        safe_strcpy(filename, temp_line.c_str()); // image to convert
+        cmd->FindCommand(2, temp_line);
+        safe_strcpy(basename, temp_line.c_str()); // resulting VHD (after renaming)
+        if(access(basename, 0) == 0) {
+            if(!bOverwrite) {
+                WriteOut(MSG_Get("PROGRAM_VHDMAKE_FNEEDED"));
+                return;
+            }
+            if(remove(basename)) {
+                WriteOut(MSG_Get("PROGRAM_VHDMAKE_REMOVEERR"), basename);
+            }
+        }
+        ret = imageDiskVHD::ConvertFixed(filename);
+        if(ret == imageDiskVHD::OPEN_SUCCESS) {
+            if (rename(filename, basename))
+                WriteOut(MSG_Get("PROGRAM_VHDMAKE_RENAME"));
+        }
+    }
+    else if(cmd->FindExist("-l", true)) {
+        if(cmd->GetCount() > 2) {
+            PrintUsage();
+            return;
+        }
         cmd->FindCommand(1, temp_line);
         safe_strcpy(basename, temp_line.c_str());
-
         cmd->FindCommand(2, temp_line);
-        safe_strcpy(newname, temp_line.c_str());
-
+        safe_strcpy(filename, temp_line.c_str());
 #ifdef WIN32
         if(basename[1] == ':')
             WriteOut(MSG_Get("PROGRAM_VHDMAKE_ABSPATH_WIN"));
@@ -7853,66 +7876,50 @@ void VHDMAKE::Run()
             return;
         }
 #endif
-        if(! bOverwrite && access(newname, 0) == 0) {
+        if(! bOverwrite && access(filename, 0) == 0) {
             WriteOut(MSG_Get("PROGRAM_VHDMAKE_FNEEDED"));
             return;
         }
-
-        uint32_t ret = imageDiskVHD::CreateDifferencing(newname, basename);
-        switch(ret) {
-        case 3:
-            WriteOut(MSG_Get("PROGRAM_VHDMAKE_BADPARENT"), basename);
-            break;
-        case 4:
-            WriteOut(MSG_Get("PROGRAM_IMGMAKE_VHD_ERR4"), basename);
-            break;
-        case 5:
-            WriteOut(MSG_Get("PROGRAM_IMGMAKE_VHD_ERR5"), basename);
-            break;
-        case 0:
-            WriteOut(MSG_Get("PROGRAM_VHDMAKE_SUCCESS"));
-            break;
-        }
-
+        ret = imageDiskVHD::CreateDifferencing(filename, basename);
     }
     else {
-        char filename[256], size[16];
+        if(cmd->GetCount() > 2) {
+            PrintUsage();
+            return;
+        }
+        char size[16];
         cmd->FindCommand(1, temp_line);
         safe_strcpy(filename, temp_line.c_str());
-
         cmd->FindCommand(2, temp_line);
         safe_strcpy(size, temp_line.c_str());
-
         uint64_t vhd_size = ssizetou64(size);
-        if(!vhd_size) {
+        if(!vhd_size || vhd_size < 3145728 || vhd_size > 2190433320960) {
             WriteOut(MSG_Get("PROGRAM_VHDMAKE_BADSIZE"));
             return;
         }
-
         if(!bOverwrite && access(filename, 0) == 0) {
             WriteOut(MSG_Get("PROGRAM_VHDMAKE_FNEEDED"));
             return;
         }
+        ret = imageDiskVHD::CreateDynamic(filename, vhd_size);
+    }
 
-        uint32_t ret = imageDiskVHD::CreateDynamic(filename, vhd_size);
-
-        switch(ret) {
-        case 2:
-            WriteOut(MSG_Get("PROGRAM_VHDMAKE_VHD_ERR2"));
-            break;
-        case 3:
-            WriteOut(MSG_Get("PROGRAM_IMGMAKE_VHD_ERR3"));
-            break;
-        case 4:
-            WriteOut(MSG_Get("PROGRAM_IMGMAKE_VHD_ERR4"), filename);
-            break;
-        case 5:
-            WriteOut(MSG_Get("PROGRAM_IMGMAKE_VHD_ERR5"), filename);
-            break;
-        default:
-            WriteOut(MSG_Get("PROGRAM_VHDMAKE_SUCCESS"));
-            break;
-        }
+    switch(ret) {
+    case imageDiskVHD::UNSUPPORTED_SIZE:
+        WriteOut(MSG_Get("PROGRAM_VHDMAKE_BADSIZE"));
+        break;
+    case imageDiskVHD::ERROR_OPENING:
+        WriteOut(MSG_Get("PROGRAM_VHDMAKE_ERROPEN"), filename);
+        break;
+    case imageDiskVHD::ERROR_OPENING_PARENT:
+        WriteOut(MSG_Get("PROGRAM_VHDMAKE_BADPARENT"), filename);
+        break;
+    case imageDiskVHD::ERROR_WRITING:
+        WriteOut(MSG_Get("PROGRAM_VHDMAKE_WRITERR"), filename);
+        break;
+    case imageDiskVHD::OPEN_SUCCESS:
+        WriteOut(MSG_Get("PROGRAM_VHDMAKE_SUCCESS"));
+        break;
     }
 }
 
@@ -9298,6 +9305,7 @@ void DOS_SetupPrograms(void) {
         "  \033[32;1mIMGMAKE -t fd\033[0m                   - create a 1.44MB floppy image \033[33;1mIMGMAKE.IMG\033[0m\n"
         "  \033[32;1mIMGMAKE -t fd_1440 -force\033[0m       - force to create a floppy image \033[33;1mIMGMAKE.IMG\033[0m\n"
         "  \033[32;1mIMGMAKE dos.img -t fd_2880\033[0m      - create a 2.88MB floppy image named dos.img\n"
+        "  \033[32;1mIMGMAKE new.vhd -t vhd -size 520\033[0m- create a 520MB Dynamic VHD named new.vhd\n"
 #ifdef WIN32
         "  \033[32;1mIMGMAKE c:\\disk.img -t hd -size 50\033[0m      - create a 50MB HDD image c:\\disk.img\n"
         "  \033[32;1mIMGMAKE c:\\disk.img -t hd_520 -nofs\033[0m     - create a 520MB blank HDD image\n"
@@ -9351,28 +9359,32 @@ void DOS_SetupPrograms(void) {
             "\033[34;1mMODE CON RATE=\033[0mr \033[34;1mDELAY=\033[0md :typematic rates, r=1-32 (32=fastest), d=1-4 (1=lowest)\n");
     MSG_Add("PROGRAM_MODE_INVALID_PARAMETERS","Invalid parameter(s).\n");
     MSG_Add("PROGRAM_PORT_INVALID_NUMBER","Must specify a port number between 1 and 9.\n");
-    MSG_Add("PROGRAM_IMGMAKE_VHD_ERR2", "Can't create a VHD <3 MB!\n");
-    MSG_Add("PROGRAM_IMGMAKE_VHD_ERR3", "Can't create a VHD >2040 GB!\n");
-    MSG_Add("PROGRAM_IMGMAKE_VHD_ERR4", "Error, could not open image file \"%s\" for writing.\n");
-    MSG_Add("PROGRAM_IMGMAKE_VHD_ERR5", "Could not write to new VHD image \"%s\", aborting.\n");
+    MSG_Add("PROGRAM_VHDMAKE_WRITERR", "Could not write to new VHD image \"%s\", aborting.\n");
+    MSG_Add("PROGRAM_VHDMAKE_REMOVEERR", "Could not erase file \"%s\"\n");
+    MSG_Add("PROGRAM_VHDMAKE_RENAME", "You'll have to manually rename the newly created VHD image.\n");
     MSG_Add("PROGRAM_VHDMAKE_SUCCESS", "New VHD image succesfully created. You can mount it with \033[34;1mIMGMOUNT\033[0m.\n");
+    MSG_Add("PROGRAM_VHDMAKE_ERROPEN", "Error, could not open image file \"%s\".\n");
     MSG_Add("PROGRAM_VHDMAKE_BADSIZE", "Bad VHD size specified, aborting!\n");
     MSG_Add("PROGRAM_VHDMAKE_FNEEDED", "A pre-existing VHD image can't be silently overwritten without -f option!\n");
     MSG_Add("PROGRAM_VHDMAKE_BADPARENT", "The parent VHD image \"%s\" can't be opened for linking, aborting!\n");
     MSG_Add("PROGRAM_VHDMAKE_ABSPATH_WIN", "Warning: an absolute path to parent limits portability to Windows.\nPlease prefer a path relative to differencing image file!\n");
     MSG_Add("PROGRAM_VHDMAKE_ABSPATH_UX", "ERROR: an absolute path to parent inhibits portability.\nUse a path relative to differencing image file!\n");
     MSG_Add("PROGRAM_VHDMAKE_HELP",
-        "Creates a new VHD image.\n\n"
-        "VHDMAKE [-f] new.vhd nnn[BKMGT]\n"
-        "VHDMAKE [-f] -l parent.vhd new.vhd\n\n"
-        " -f         Force overwriting a file\n"
-        " -l         Links to a parent VHD image\n"
-        " filename   Specifies the name of the new VHD image file\n"
-        " nnn        Specifies the disk size(eventually with size unit)\n"
-        "            (B)ytes is implicit\n"
-        " parent.vhd Specifies the base VHD to link the new differencing VHD to\n"
-        " new.vhd    Specifies the new differencing VHD to make\n\n"
-        "Default VHD image type is Dynamic.\n\n");
+        "Creates Dynamic or Differencing VHD images, or converts raw images\ninto Fixed VHD.\n"
+        "\033[32;1mVHDMAKE\033[0m \033[34;1m-c\033[0m raw.hdd new.vhd\n"
+        "\033[32;1mVHDMAKE\033[0m [-f] new.vhd size[BKMGT]\n"
+        "\033[32;1mVHDMAKE\033[0m [-f] \033[34;1m-l\033[0m parent.vhd new.vhd\n"
+        " -c         convert a raw hd image to Fixed VHD, renaming it to new.vhd\n"
+        " -l         create a new Differencing VHD new.vhd and link it to the\n"
+        "            pre-existing parent image parent.vhd\n"
+        " -f         force overwriting a pre-existing image file\n"
+        " new.vhd    name of the new Dynamic VHD image to create\n"
+        " size       disk size (eventually with size unit, Bytes is implicit)\n"
+        "When converting a raw disk image to Fixed VHD, it has to be partitioned with\n"
+        "MBR scheme and formatted with FAT format.\n"
+        "When creating a Dynamic VHD, its size must be >=3MB and <=2040GB.\n"
+        "The Dynamic VHD created is not partitioned nor formatted: to directly mount to\n"
+        "a drive letter with \033[34;1mIMGMOUNT\033[0m, please consider using \033[34;1mIMGMAKE\033[0m instead.");
 
     const Section_prop * dos_section=static_cast<Section_prop *>(control->GetSection("dos"));
     hidefiles = dos_section->Get_string("drive z hide files");

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -3514,6 +3514,11 @@ restart_int:
             }
             if(imageDiskVHD::Open(temp_line.c_str(), false, (imageDisk**) &vhd) != imageDiskVHD::OPEN_SUCCESS)
                 return;
+            // Resets these according to VHD pseudo-CHS geometry, avoiding IMGMOUNT issues!
+            // VHD psuedo-CHS algorithm != BPB algorithm (above)
+            c = vhd->cylinders > 1023? 1023 : vhd->cylinders;
+            h = vhd->heads;
+            s = vhd->sectors;
         }
         else {
             f = fopen64(temp_line.c_str(), "wb+");

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -7737,9 +7737,9 @@ private:
 	void PrintUsage() {
         constexpr const char* msg =
             "Creates a new Dynamic or Differencing VHD image.\n\n"
-            "VHDMAKE [-F] new.vhd nnn[BKMGT]\n"
-            "VHDMAKE [-F] -l parent.vhd new.vhd\n\n"
-            "  -F         Force overwriting a file\n"
+            "VHDMAKE [-f] new.vhd nnn[BKMGT]\n"
+            "VHDMAKE [-f] -l parent.vhd new.vhd\n\n"
+            "  -f         Force overwriting a file\n"
             "  -l         Links to a parent VHD image\n"
             "  filename   Specifies the name of the new VHD image file\n"
             "  nnn        Specifies the disk size (eventually with size unit)\n"
@@ -7783,7 +7783,7 @@ void VHDMAKE::Run()
         return;
     }
 
-    if(cmd->FindExist("-F", true))
+    if(cmd->FindExist("-f", true))
         bOverwrite = true;
 
     if(cmd->FindExist("-l", true)) {
@@ -7816,8 +7816,11 @@ void VHDMAKE::Run()
         case 4:
             WriteOut("Couldn't create new differencing image \"%s\", aborting!\n", newname);
             break;
+        case 5:
+            WriteOut("Couldn't write to differencing image \"%s\", aborting!\n", newname);
+            break;
         case 0:
-            WriteOut("New Differencing VHD image succesfully created. You can mount it with \033[34;1mIMGMOUNT\033[0m.\n");
+            WriteOut("New Differencing VHD succesfully created. You can mount it with \033[34;1mIMGMOUNT\033[0m.\n");
             break;
         }
 
@@ -7853,13 +7856,15 @@ void VHDMAKE::Run()
         case 4:
             WriteOut("Error, could not open %s for writing", filename);
             break;
+        case 5:
+            WriteOut("Couldn't write to new VHD image \"%s\", aborting!\n", filename);
+            break;
         default:
             WriteOut("New Dynamic VHD image succesfully created. You can mount it with \033[34;1mIMGMOUNT\033[0m.\n");
             break;
         }
     }
 }
-
 
 static void VHDMAKE_ProgramStart(Program * * make) {
     *make=new VHDMAKE;

--- a/src/ints/bios_vhd.cpp
+++ b/src/ints/bios_vhd.cpp
@@ -595,8 +595,13 @@ uint32_t imageDiskVHD::CreateDynamic(char* filename, uint64_t size) {
     memset(Footer, 0, 1536);
     memcpy(Footer, footer_head, sizeof(footer_head));
     memcpy(Header, dyn_head, sizeof(dyn_head));
-
+#ifdef _MSC_VER
     _time32((__time32_t*)&Footer + 24);
+#else
+    time_t T;
+    time(&T);
+    *((uint32_t*)(Footer+24)) = (uint32_t)T;
+#endif
     *((uint32_t*)(Footer + 24)) -= 946681200;
     *((uint32_t*)(Footer + 24)) = SDL_SwapBE32(*(uint32_t*)(Footer + 24));
 

--- a/src/ints/bios_vhd.cpp
+++ b/src/ints/bios_vhd.cpp
@@ -596,9 +596,9 @@ uint32_t imageDiskVHD::CreateDynamic(const char* filename, uint64_t size) {
     memcpy(Footer, footer_head, sizeof(footer_head));
     memcpy(Header, dyn_head, sizeof(dyn_head));
 
-    time((time_t*)(Footer + 24));
-    *((uint32_t*)(Footer + 24)) -= 946681200;
-    *((uint32_t*)(Footer + 24)) = SDL_SwapBE32(*(uint32_t*)(Footer + 24));
+    time_t T;
+    time(&T);
+    *((uint32_t*)(Footer + 24)) = SDL_SwapBE32((uint32_t)T - 946681200);
 
     srand(time(NULL));
 
@@ -670,9 +670,9 @@ uint32_t imageDiskVHD::CreateDifferencing(const char* filename, const char* base
 
     *((uint32_t*)(Footer + 0x3C)) = SDL_SwapBE32(4); // dwDiskType
 
-    time((time_t*)(Footer + 24));             // dwTimestamp
-    *((uint32_t*)(Footer + 24)) -= 946681200;
-    *((uint32_t*)(Footer + 24)) = SDL_SwapBE32(*(uint32_t*)(Footer + 24));
+    time_t T;
+    time(&T);
+    *((uint32_t*)(Footer + 24)) = SDL_SwapBE32((uint32_t)T - 946681200);
 
     srand(time(NULL));
     *((uint16_t*)(Footer + 68)) = rand(); // UUID

--- a/src/ints/bios_vhd.cpp
+++ b/src/ints/bios_vhd.cpp
@@ -718,7 +718,8 @@ uint32_t imageDiskVHD::CreateDifferencing(const char* filename, const char* base
     wchar_t* w_basename = (wchar_t*)malloc(platsize);
     memset(w_basename, 0, platsize);
     for(uint32_t i = 0; i < l_basename; i++)
-        w_basename[i] = SDL_SwapLE16((uint16_t)basename[i]); // dirty hack to quickly convert ASCII -> UTF-16 *LE*
+        // dirty hack to quickly convert ASCII -> UTF-16 *LE* and fix slashes
+        w_basename[i] = SDL_SwapLE16(basename[i]=='/'? (uint16_t)'\\' : (uint16_t)basename[i]);
     fwrite(w_basename, platsize, 1, vhd);
  
     // Footer copy


### PR DESCRIPTION
DOSBox-X is enhanced with the ability to create Dynamic and Differencing VHD images (and to convert raw hd images into Fixed VHD) to play with IMGMOUNT and share data with Windows easily.

## Does this PR introduce new feature(s)?
- extends imageDiskVHD in bios_vhd.cpp to create Fixed, Dynamic and Differencing VHD on the fly;
- adds a VHDMAKE.COM virtual program to access new functionalities;
- patches IMGMAKE to create both Dynamic and Fixed VHD, already partitioned and formatted.

New IMGMAKE syntax:
  `IMGMAKE new_dynamic.vhd -t vhd -size XX` creates a Dynamic VHD.
  `IMGMAKE new_fixed.vhd -t hd -size XX` creates a Fixed VHD.
