### PR TITLE
Update bios_vhd.cpp

### DIFF
--- a/src/ints/bios_vhd.cpp
+++ b/src/ints/bios_vhd.cpp
@@ -326,8 +326,10 @@ uint8_t imageDiskVHD::Read_AbsoluteSector(uint32_t sectnum, void * data) {
 
 bool is_zeroed_sector(const void* data) {
     uint32_t *p = (uint32_t*) data;
-    while(*p++ == 0);
-    if((uint8_t*)p < ((uint8_t*)data + 512)) return false;
+    uint8_t* q = ((uint8_t*)data + 512);
+    while((void*)p < (void*)q && *p++ == 0);
+    if((void*)p < (void*)q)
+        return false;
     return true;
 }
 

--- a/src/ints/bios_vhd.cpp
+++ b/src/ints/bios_vhd.cpp
@@ -324,11 +324,21 @@ uint8_t imageDiskVHD::Read_AbsoluteSector(uint32_t sectnum, void * data) {
 	}
 }
 
+bool is_zeroed_sector(const void* data) {
+    uint32_t *p = (uint32_t*) data;
+    while(*p++ == 0);
+    if((uint8_t*)p < ((uint8_t*)data + 512)) return false;
+    return true;
+}
+
 uint8_t imageDiskVHD::Write_AbsoluteSector(uint32_t sectnum, const void * data) {
 	uint32_t blockNumber = sectnum / sectorsPerBlock;
 	uint32_t sectorOffset = sectnum % sectorsPerBlock;
 	if (!loadBlock(blockNumber)) return 0x05; //can't load block
 	if (!currentBlockAllocated) {
+        //an unallocated block is kept virtualized until zeroed
+        if(is_zeroed_sector(data)) return 0;
+
 		if (!copiedFooter) {
 			//write backup of footer at start of file (should already exist, but we never checked to be sure it is readable or matches the footer we used)
 			if (fseeko64(diskimg, (off_t)0, SEEK_SET)) return 0x05;


### PR DESCRIPTION
Blocks are kept virtual until they are zeroed, so saving space

## Does this PR introduce new feature(s)?

Enhanced compatibility with Windows 1x VHD writer. Avoids zeroed block are written to disk wasting space.
