### PR TITLE
Minor fixes to CMOS RTC register range checking

### DIFF
--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -36,26 +36,6 @@
 #include "sys/time.h"
 #endif
 
-// sigh... Windows doesn't know gettimeofday
-#if defined (WIN32) && !defined (__MINGW32__)
-typedef Bitu suseconds_t;
-
-struct timeval {
-    time_t tv_sec;
-    suseconds_t tv_usec;
-};
-
-static void gettimeofday (timeval* ptime, void* pdummy) {
-    (void)pdummy;
-    struct _timeb thetime;
-    _ftime(&thetime);
-
-    ptime->tv_sec = thetime.time;
-    ptime->tv_usec = (Bitu)thetime.millitm;
-}
-
-#endif
-
 static struct {
     uint8_t regs[0x40];
     bool nmi;
@@ -247,9 +227,9 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
             // other checks for valid values are done in case-switch
 
             // convert pm hours differently (bcd 81-92 corresponds to hex 81-8c)
-            if (cmos.reg == 0x04 && val >= 0x80)
+            if ((cmos.reg == 0x04 || cmos.reg == 0x05) && val >= 0x80)
             {
-                val = (val < 90) ? 0x80 : 0x8a + (val & 0x0f);
+                val = 0x8a + (val & 0x0f);
             }
             else
             {

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -240,58 +240,60 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
 
     switch (cmos.reg) {
         case 0x00:      /* Seconds */
-            if (val > 59) return;       // invalid seconds value
+            if (val > 59) { LOG(LOG_BIOS, LOG_ERROR)("CMOS:Tried to write invalid second value %d for clock.", val); return; }       // invalid second value
             cmos.clock.sec = val; break;
         case 0x01:      /* Seconds, alarm */
-            if (val > 59) return;       // invalid seconds value
+            if (val > 59) { LOG(LOG_BIOS, LOG_ERROR)("CMOS:Tried to write invalid second value %d for alarm.", val); return; }       // invalid second value
             cmos.alarm.sec = val; break;
         case 0x02:      /* Minutes */
-            if (val > 59) return;       // invalid minutes value
+            if (val > 59) { LOG(LOG_BIOS, LOG_ERROR)("CMOS:Tried to write invalid minute value %d for clock.", val); return; }       // invalid minute value
             cmos.clock.min = val; break;
         case 0x03:      /* Minutes, alarm */
-            if (val > 59) return;       // invalid minutes value
+            if (val > 59) { LOG(LOG_BIOS, LOG_ERROR)("CMOS:Tried to write invalid minute value %d for alarm.", val); return; }       // invalid minute value
             cmos.alarm.min = val; break;
         case 0x04:      /* Hours */
             if (cmos.ampm)              // 12h am/pm mode
             {
-                if (val < 1 || (val > 12 && val < 0x81) || val > 0x8c) return; // invalid hour value
+                if (val < 1 || (val > 12 && val < 0x81) || val > 0x8c)
+                    { LOG(LOG_BIOS, LOG_ERROR)("CMOS:Tried to write invalid hour value %d for clock.", val); return; }               // invalid hour value
                 if (val > 12) val -= (0x80-12);         // convert pm to 24h
             }
             else                        // 24h mode
             {
-                if (val > 23) return;                               // invalid hour value
+                if (val > 23) { LOG(LOG_BIOS, LOG_ERROR)("CMOS:Tried to write invalid hour value %d for clock.", val); return; }     // invalid hour value
             }
 
             cmos.clock.hour = val; break;
         case 0x05:      /* Hours, alarm */
             if (cmos.ampm)              // 12h am/pm mode
             {
-                if (val < 1 || (val > 12 && val < 0x81) || val > 0x8c) return; // invalid hour value
+                if (val < 1 || (val > 12 && val < 0x81) || val > 0x8c)
+                    { LOG(LOG_BIOS, LOG_ERROR)("CMOS:Tried to write invalid hour value %d for alarm.", val); return; }               // invalid hour value
                 if (val > 12) val -= (0x80-12);         // convert pm to 24h
             }
             else                        // 24h mode
             {
-                if (val > 23) return;                               // invalid hour value
+                if (val > 23) { LOG(LOG_BIOS, LOG_ERROR)("CMOS:Tried to write invalid hour value %d for alarm.", val); return; }     // invalid hour value
             }
 
             cmos.alarm.hour = val; break;
         case 0x06:      /* Day of week */
-            if (val < 1 || val > 7) return;                // invalid day of week value
+            if (val < 1 || val > 7) { LOG(LOG_BIOS, LOG_ERROR)("CMOS:Tried to write invalid day of week value %d.", val); return; }  // invalid day of week value
             cmos.clock.weekday = val; break;
-        case 0x07:      /* Date of month */
-            if (val < 1 || val > 31) return;               // invalid date value (mktime() should catch the rest)
+        case 0x07:      /* Day of month */
+            if (val < 1 || val > 31) { LOG(LOG_BIOS, LOG_ERROR)("CMOS:Tried to write invalid day of month value %d.", val); return; } // invalid day of month value
             cmos.clock.day = val; break;
         case 0x08:      /* Month */
-            if (val < 1 || val > 12) return;               // invalid month value
+            if (val < 1 || val > 12) { LOG(LOG_BIOS, LOG_ERROR)("CMOS:Tried to write invalid month value %d.", val); return; }       // invalid month value
             cmos.clock.month = val; break;
         case 0x09:      /* Year */
-            if (val > 99) return;                          // invalid year value
+            if (val > 99) { LOG(LOG_BIOS, LOG_ERROR)("CMOS:Tried to write invalid year value %d.", val); return; }                   // invalid year value
             cmos.clock.year -= cmos.clock.year % 100;
             cmos.clock.year += val;
             break;
         case 0x32:      /* Century */
         case 0x37:      /* Century (alternate used by Windows NT/2000/XP) */
-            if (val < 19) return;               // invalid century value?
+            if (val < 19) { LOG(LOG_BIOS, LOG_ERROR)("CMOS:Tried to write invalid century value %d.", val); return; }                // invalid century value
             cmos.clock.year %= 100;
             cmos.clock.year += val * 100;
             break;

--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -274,7 +274,7 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
         case 0x04:      /* Hours */
             if (cmos.ampm)              // 12h am/pm mode
             {
-                if ((val > 12 && val < 0x81) || val > 0x8c) return; // invalid hour value
+                if (val < 1 || (val > 12 && val < 0x81) || val > 0x8c) return; // invalid hour value
                 if (val > 12) val -= (0x80-12);         // convert pm to 24h
             }
             else                        // 24h mode
@@ -286,7 +286,7 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
         case 0x05:      /* Hours, alarm */
             if (cmos.ampm)              // 12h am/pm mode
             {
-                if ((val > 12 && val < 0x81) || val > 0x8c) return; // invalid hour value
+                if (val < 1 || (val > 12 && val < 0x81) || val > 0x8c) return; // invalid hour value
                 if (val > 12) val -= (0x80-12);         // convert pm to 24h
             }
             else                        // 24h mode
@@ -296,14 +296,16 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
 
             cmos.alarm.hour = val; break;
         case 0x06:      /* Day of week */
+            if (val < 1 || val > 7) return;                // invalid day of week value
             cmos.clock.weekday = val; break;
         case 0x07:      /* Date of month */
-            if (val > 31) return;               // invalid date value (mktime() should catch the rest)
+            if (val < 1 || val > 31) return;               // invalid date value (mktime() should catch the rest)
             cmos.clock.day = val; break;
         case 0x08:      /* Month */
             if (val < 1 || val > 12) return;               // invalid month value
             cmos.clock.month = val; break;
         case 0x09:      /* Year */
+            if (val > 99) return;                          // invalid year value
             cmos.clock.year -= cmos.clock.year % 100;
             cmos.clock.year += val;
             break;


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

Some range checking to match documentation, cleanup and error logging.

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

No.

## Additional information

1. Added some range checking to the RTC register writes according to documentation.
According to http://philipstorr.id.au/pcbook/book5/cmoslist.htm and https://www.ti.com/lit/ds/symlink/bq3285.pdf, the valid ranges for the registers are:
00h Seconds   		(BCD 00-59, Hex 00-3B) Note: Bit 7 is read only      
01h Second Alarm  	(BCD 00-59, Hex 00-3B)      
02h Minutes       	(BCD 00-59, Hex 00-3B))         
03h Minute Alarm  	(BCD 00-59, Hex 00-3B)       
04h Hours         	(BCD 00-23, Hex 00-17 if 24 hr mode)
                   		(BCD 01-12, Hex 01-0C if 12 hr am)
                   		(BCD 81-92. Hex 81-8C if 12 hr pm)         
05h Hour Alarm    	(same as hours)     
06h Day of Week   	(01-07 Sunday=1)    
07h Date of Month 	(BCD 01-31, Hex 01-1F)    
08h Month         	(BCD 01-12, Hex 01-0C)         
09h Year          	(BCD 00-99, Hex 00-63)

2. Added error logs instead of silent returns when out-of-range values are written.
3. Removed unused Windows-only function and redundant comparison.
4. Applied the BCD conversion for PM values that was done for REG 4 (hours, clock) case to the REG 5 (hours, alarm) case as well, since I assume it should get the same treatment.

That said, the conversion, which I left untouched save for adding a < 1 check to match the documentation, doesn't make sense to me. It seems to be forcing the "BCD" values 90 to 92 to convert to hex values 8a to 8c, I guess to match the documentation, but I wonder if the documentation is mistaken. The BCD values from the documentation seem to just be decimal values, at least for the other cases. For example in the minutes cases, BCD 59 is shown to be equivalent to Hex 3B, like how decimal 59 is equivalent to Hex 3B. From what I understand of BCD (which I admittedly was not familiar with and just looked up for this), the BCD value 59 would be the binary representation of 5 (0101) and the binary representation of 9 (1001) put together, so 01011001, or 59 in hexadecimal, not 3B, so it seems like the BCD values given in the documentation are decimal values, not BCD.

Then there is the PM hours case, the "BCD" values 81-92 are said by the documentation to correspond to hex 81-8C. If these BCD values are really BCD (as I understand BCD), then the conversion to hexadecimal works for 81 through 89, but not for 90 through 92. The conversion code in DOSBox-X `val = 0x8a + (val & 0x0f);` seems to force the conversion to work for 90 through 92, but I wonder if the documentation is wrong. If the "BCD" values for the PM hours case are also actually decimal, then the hexadecimal equivalents would be 51-5C. Maybe the person writing the documentation mistakenly read the hexadecimal as 51-5C and put the "BCD" (decimal) values as 81-92? Or maybe they saw that the hexadecimal had 0x80 added to it compared to the AM case and just added 80 to the "BCD" (decimal) as well? Anyway it makes sense that the hexadecimal PM case would just be the AM case with bit 7 set, making it 81-8C, so I wonder if the real "BCD" value here should just be the decimal equivalent of 81-8C, that being 129-140?

Anyway, sorry if I am misunderstanding something, such as how BCD works, but I thought I would bring it to your attention. As I wrote above, I left the conversion as is, except for removing a redundant comparison and adding a check for < 1.