### PR TITLE
Fix oversight in clearing of dirIterators

### DIFF
--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -2338,8 +2338,8 @@ void isoDrive :: EmptyCache(void) {
 	//this->fileName[0]  = '\0'; /* deleted to fix issue #3848. Revert this if there are any flaws */
 	//this->discLabel[0] = '\0'; /* deleted to fix issue #3848. Revert this if there are any flaws */
 	nextFreeDirIterator = 0;
-    size_t dirIteratorsSize = sizeof(dirIterators);
-    for(std::size_t i = 0; i < dirIteratorsSize; ++i) {
+    size_t numberOfDirIterators = sizeof(dirIterators) / sizeof(dirIterators[0]);
+    for(std::size_t i = 0; i < numberOfDirIterators; ++i) {
         dirIterators[i] = isoDrive::DirIterator{};
     }
 	memset(sectorHashEntries, 0, sizeof(sectorHashEntries));


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

Should fix #4291. Maybe also #4233.

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

Should not.

## Additional information

Thanks to @maron2000. I don't actually have a setup where the crash occurs to test for 100% that this fixes the crash, but it looks correct.
