### PR TITLE
Fix day of week detection (INT 21h 0x2Ah)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,6 +42,7 @@ Next
     allocated block position. (maxpat78)
   - Enhanced Dynamic and Differencing VHD support #4273 (maxpat78)
   - Imported IBM Music Feature Card support from DOSBox Staging. (Allofich)
+  - Fix day of week detection (INT 21h 0x2Ah). (maron2000)
 2023.05.01
   - IMGMAKE will choose LBA partition types for 2GB or larger disk
     images, but the user can also use -chs and -lba options to override

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1500,11 +1500,13 @@ static Bitu DOS_21Handler(void) {
                 // calculate day of week (we could of course read it from CMOS, but never mind)
                 /* Use Zeller's congruence */
                 uint16_t year = reg_cx, month = reg_dh, day = reg_dl;
+                int8_t weekday;
                 if(month <= 2) {
                     year--;
                     month += 12;
                 }
-                reg_al = (year + year / 4u  - year / 100u + year / 400u + (13u * month + 8u) / 5u + day + 7) % 7;
+                weekday = (year + year / 4u  - year / 100u + year / 400u + (13u * month + 8u) / 5u + day) % 7;
+                reg_al = weekday < 0 ? weekday + 7 : weekday;
                 /* Sunday=0, Monday=1, ... */
             }
             break;

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1504,7 +1504,7 @@ static Bitu DOS_21Handler(void) {
                     year--;
                     month += 12;
                 }
-                reg_al = (year + year / 4u  - year / 100u + year / 400u + (13u * month + 8u) / 5u + day) % 7;
+                reg_al = (year + year / 4u  - year / 100u + year / 400u + (13u * month + 8u) / 5u + day + 7) % 7;
                 /* Sunday=0, Monday=1, ... */
             }
             break;

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1498,10 +1498,14 @@ static Bitu DOS_21Handler(void) {
                 reg_dl = dos.date.day;
 
                 // calculate day of week (we could of course read it from CMOS, but never mind)
-                unsigned int a = (14u - reg_dh) / 12u;
-                unsigned int y = reg_cl - a;
-                unsigned int m = reg_dh + 12u * a - 2u;
-                reg_al = (reg_dl + y + (y / 4u) - (y / 100u) + (y / 400u) + (31u * m) / 12u) % 7u;
+                /* Use Zeller's congruence */
+                uint16_t year = reg_cx, month = reg_dh, day = reg_dl;
+                if(month <= 2) {
+                    year--;
+                    month += 12;
+                }
+                reg_al = (year + year / 4u  - year / 100u + year / 400u + (13u * month + 8u) / 5u + day) % 7;
+                /* Sunday=0, Monday=1, ... */
             }
             break;
         case 0x2b:      /* Set System Date */


### PR DESCRIPTION
This PR fixes the issue that DOS reports wrong day of the week, as reported in issue #4329.

## What issue(s) does this PR address?
Fixes #4329 

## Additional information
![4dos_000](https://github.com/joncampbell123/dosbox-x/assets/68574602/aff6b717-c70f-4938-a2aa-bd6d2ae9daee)