### PR TITLE
Set usescancodes=true when non-US keyboards are detected (Linux/MacOS builds)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,6 +42,8 @@ Next
     allocated block position. (maxpat78)
   - Enhanced Dynamic and Differencing VHD support #4273 (maxpat78)
   - Imported IBM Music Feature Card support from DOSBox Staging. (Allofich)
+  - Set usescancodes=true when non-US keyboards are detected (Linux builds)
+    (maron2000)
 2023.05.01
   - IMGMAKE will choose LBA partition types for 2GB or larger disk
     images, but the user can also use -chs and -lba options to override

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,8 +42,8 @@ Next
     allocated block position. (maxpat78)
   - Enhanced Dynamic and Differencing VHD support #4273 (maxpat78)
   - Imported IBM Music Feature Card support from DOSBox Staging. (Allofich)
-  - Set usescancodes=true when non-US keyboards are detected (Linux builds)
-    (maron2000)
+  - Set usescancodes=true when non-US keyboards are detected. (Linux / MacOS 
+    builds) (maron2000)
 2023.05.01
   - IMGMAKE will choose LBA partition types for 2GB or larger disk
     images, but the user can also use -chs and -lba options to override

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -10,7 +10,7 @@ enum {
     DKM_DEU,            // German keyboard layout (one concerned user, in issue tracker)
     DKM_JPN_PC98,       // Japanese PC98 keyboard layout (for PC-98 emulation)
     DKM_JPN,            // Japanese keyboard layout (one concerned user, in issue tracker, with suggestion for mapping Ro)
-
+    DKM_NON_US,         // A non-US keyboard
     DKM_MAX
 };
 

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -999,7 +999,7 @@ static SDLKey sdlkey_map[MAX_SCANCODES] = { // Convert hardware scancode (XKB = 
     SDLK_WORLD_14, //0x64 Henkan
     SDLK_WORLD_15, //0x65 Hiragana/Katakana
     SDLK_WORLD_13, //0x66 Muhenkan
-    Z,Z,Z,Z, //0x67-0x6a
+    Z,SDLK_KP_ENTER,SDLK_RCTRL,SDLK_KP_DIVIDE, //0x67-0x6a
     Z, //SDLK_PRINTSCREEN, //0x6b
     SDLK_RALT,  //0x6c
     Z, //0x6d unknown
@@ -1159,6 +1159,8 @@ static SDLKey sdlkey_map[MAX_SCANCODES] = {
 
 #undef Z
 
+unsigned int Linux_GetKeyboardLayout(void); // defined in sdlmain_linux.cpp
+
 #if !defined(C_SDL2)
 void setScanCode(Section_prop * section) {
 	usescancodes = -1;
@@ -1180,6 +1182,19 @@ void setScanCode(Section_prop * section) {
         }
     }
 #endif // defined(WIN32)
+#if defined(__linux__)
+    else {
+        if(Linux_GetKeyboardLayout() == DKM_US) { /* Locale ID: en-us */
+            usescancodes = 0;
+            LOG_MSG("SDL_mapper: US keyboard detected, set usescancodes=false");
+        }
+        else {
+            usescancodes = 1;
+            LOG_MSG("SDL_mapper: non-US keyboard detected, set usescancodes=true");
+        }
+    }
+#endif //defined(__linux__)
+
 }
 void loadScanCode();
 const char* DOS_GetLoadedLayout(void);

--- a/src/gui/sdlmain_linux.cpp
+++ b/src/gui/sdlmain_linux.cpp
@@ -240,7 +240,7 @@ void Linux_JPXKBFix(void) {
 }
 
 unsigned int Linux_GetKeyboardLayout(void) {
-    unsigned int ret = DKM_US;
+    unsigned int ret = DKM_NON_US; // a non-US keyboard
 
     SDL_SysWMinfo wminfo;
     memset(&wminfo,0,sizeof(wminfo));


### PR DESCRIPTION
With this PR, If `usescancodes=auto` (default), it is set to true when using non-US keyboards in Linux SDL1 builds.
This behavior is consistent with what is mentioned in `dosbox-x-reference.conf`, and the same is already set for Windows build in PR #4037.