### PR TITLE
Bump tinyfiledialog to v3.13.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -45,8 +45,9 @@ Next
   - Fix IMGMAKE large size image error on MinGW builds (maron2000) 
   - Set usescancodes=true when non-US keyboards are detected. (Linux / MacOS 
     builds) (maron2000)
-  - Fix day of week detection (INT 21h 0x2Ah). (maron2000)
+  - Fix day of week detection (INT 21h function 0x2Ah). (maron2000)
   - Refine KEYB and CHCP command (maron2000)
+  - Bump tinyfiledialog to ver 3.13.3 (maron2000)
 2023.05.01
   - IMGMAKE will choose LBA partition types for 2GB or larger disk
     images, but the user can also use -chs and -lba options to override

--- a/src/libs/tinyfiledialogs/tinyfiledialogs.c
+++ b/src/libs/tinyfiledialogs/tinyfiledialogs.c
@@ -3261,6 +3261,14 @@ int tfd_isDarwin(void)
         return lsIsDarwin ;
 }
 
+int tdf_isHaikuOS(void)
+{
+#if defined(__HAIKU__)
+    return 1;
+#else
+    return 0;
+#endif
+}
 
 static int dirExists( char const * aDirPath )
 {
@@ -3623,7 +3631,7 @@ static int whiptailPresent(void)
 static int graphicMode(void)
 {
         return !( tinyfd_forceConsole && (isTerminalRunning() || terminalName()) )
-			&& ( getenvDISPLAY()
+			&& ( getenvDISPLAY() || tdf_isHaikuOS()
 			|| (tfd_isDarwin() && (!getenv("SSH_TTY") || getenvDISPLAY() ) ) ) ;
 }
 

--- a/src/libs/tinyfiledialogs/tinyfiledialogs.c
+++ b/src/libs/tinyfiledialogs/tinyfiledialogs.c
@@ -1,11 +1,12 @@
-/* this file can be renamed with extension ".cpp" and compiled as C++.
-The code is 100% compatible C C++
-(just comment out << extern "C" >> in the header file) */
+/* SPDX-License-Identifier: ZLIB
 
-/*_________
- /         \ tinyfiledialogs.c v3.8.5 [Jan 17, 2021] zlib licence
+this file can be renamed with extension ".cpp" and compiled as C++.
+The code is 100% compatible C C++
+(just comment out << extern "C" >> in the header file)
+  _________
+ /         \ tinyfiledialogs.c v3.13.3 [Jul 2, 2023] zlib licence
  |tiny file| Unique code file created [November 9, 2014]
- | dialogs | Copyright (c) 2014 - 2021 Guillaume Vareille http://ysengrin.com
+ | dialogs | Copyright (c) 2014 - 2023 Guillaume Vareille http://ysengrin.com
  \____  ___/ http://tinyfiledialogs.sourceforge.net
       \|     git clone http://git.code.sf.net/p/tinyfiledialogs/code tinyfd
               ____________________________________________
@@ -99,7 +100,7 @@ Thanks for contributions, bug corrections & thorough testing to:
 #endif
 #define LOW_MULTIPLE_FILES 32
 
-char tinyfd_version[8] = "3.8.5";
+char tinyfd_version[8] = "3.13.3";
 
 /******************************************************************************************************/
 /**************************************** UTF-8 on Windows ********************************************/
@@ -138,9 +139,9 @@ but and return 0 for console mode, 1 for graphic mode.
 tinyfd_response is then filled with the retain solution.
 possible values for tinyfd_response are (all lowercase)
 for graphic mode:
-  windows_wchar windows applescript kdialog zenity zenity3 matedialog
-  shellementary qarma yad python2-tkinter python3-tkinter python-dbus
-  perl-dbus gxmessage gmessage xmessage xdialog gdialog
+  windows_wchar windows applescript kdialog zenity zenity3 yad matedialog
+  shellementary qarma python2-tkinter python3-tkinter python-dbus
+  perl-dbus gxmessage gmessage xmessage xdialog gdialog dunst
 for console mode:
   dialog whiptail basicinput no_solution */
 
@@ -157,7 +158,7 @@ char tinyfd_needs[] = "\
       \\|\
 \ntiny file dialogs on Windows needs:\
 \n   a graphic display\
-\nor dialog.exe (curses console mode)\
+\nor dialog.exe (curses console mode  ** Disabled by default **)\
 \nor a console for basic input";
 #else
 char tinyfd_needs[] = "\
@@ -171,9 +172,11 @@ char tinyfd_needs[] = "\
 \n   applescript or kdialog or yad or Xdialog\
 \nor zenity (or matedialog or shellementary or qarma)\
 \nor python (2 or 3) + tkinter + python-dbus (optional)\
-\nor dialog (opens console if needed)\
+\nor dialog (opens console if needed) ** Disabled by default **\
 \nor xterm + bash (opens console for basic input)\
-\nor existing console for basic input";
+\nor existing console for basic input\
+\nand the command 'which' to detect any of the above.";
+
 #endif
 
 #ifdef _MSC_VER
@@ -463,10 +466,9 @@ int tinyfd_setGlobalInt(char const * aIntVariableName, int aValue) /* to be call
 }
 
 
-
 #ifdef _WIN32
 static int powershellPresent(void)
-{
+{ /*only on vista and above (or installed on xp)*/
     static int lPowershellPresent = -1;
     char lBuff[MAX_PATH_OR_CMD];
     FILE* lIn;
@@ -499,11 +501,10 @@ static int powershellPresent(void)
     return lPowershellPresent;
 }
 
-
 static int windowsVersion(void)
 {
-#ifndef __MINGW32__
-    typedef LONG NTSTATUS;
+#if !defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR)
+    typedef LONG NTSTATUS  ;
     typedef NTSTATUS(WINAPI* RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
     HMODULE hMod;
     RtlGetVersionPtr lFxPtr;
@@ -521,9 +522,8 @@ static int windowsVersion(void)
             }
         }
     }
-#else
-    if ( powershellPresent() ) return 6; /*minimum is vista*/
 #endif
+    if (powershellPresent()) return 6; /*minimum is vista or installed on xp*/
     return 0;
 }
 
@@ -580,6 +580,24 @@ static int sizeMbcs(wchar_t const * aMbcsString)
 }
 
 
+wchar_t* tinyfd_mbcsTo16(char const* aMbcsString)
+{
+    static wchar_t* lMbcsString = NULL;
+    int lSize;
+
+    free(lMbcsString);
+    if (!aMbcsString) { lMbcsString = NULL; return NULL; }
+    lSize = sizeUtf16FromMbcs(aMbcsString);
+    if (lSize)
+    {
+        lMbcsString = (wchar_t*)malloc(lSize * sizeof(wchar_t));
+        lSize = MultiByteToWideChar(CP_ACP, 0, aMbcsString, -1, lMbcsString, lSize);
+    }
+    else wcscpy(lMbcsString, L"");
+    return lMbcsString;
+}
+
+
 wchar_t * tinyfd_utf8to16(char const * aUtf8string)
 {
 	static wchar_t * lUtf16string = NULL;
@@ -588,15 +606,19 @@ wchar_t * tinyfd_utf8to16(char const * aUtf8string)
 	free(lUtf16string);
 	if (!aUtf8string) {lUtf16string = NULL; return NULL;}
 	lSize = sizeUtf16From8(aUtf8string);
-	lUtf16string = (wchar_t *)malloc(lSize * sizeof(wchar_t));
-	lSize = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
-		aUtf8string, -1, lUtf16string, lSize);
-	if (lSize == 0)
-	{
-		free(lUtf16string);
-		lUtf16string = NULL;
-	}
-	return lUtf16string;
+    if (lSize)
+    {
+        lUtf16string = (wchar_t*)malloc(lSize * sizeof(wchar_t));
+        lSize = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+            aUtf8string, -1, lUtf16string, lSize);
+        return lUtf16string;
+    }
+    else
+    {
+        /* let's try mbcs anyway */
+        lUtf16string = NULL;
+        return tinyfd_mbcsTo16(aUtf8string);
+    }
 }
 
 
@@ -608,14 +630,12 @@ char * tinyfd_utf16toMbcs(wchar_t const * aUtf16string)
 	free(lMbcsString);
 	if (!aUtf16string) { lMbcsString = NULL; return NULL; }
 	lSize = sizeMbcs(aUtf16string);
-	lMbcsString = (char *)malloc(lSize);
-	lSize = WideCharToMultiByte(CP_ACP, 0,
-		aUtf16string, -1, lMbcsString, lSize, NULL, NULL);
-	if (lSize == 0)
-	{
-		free(lMbcsString);
-		lMbcsString = NULL;
-	}
+    if (lSize)
+    {
+        lMbcsString = (char*)malloc(lSize);
+        lSize = WideCharToMultiByte(CP_ACP, 0, aUtf16string, -1, lMbcsString, lSize, NULL, NULL);
+    }
+    else strcpy(lMbcsString, "");
 	return lMbcsString;
 }
 
@@ -627,25 +647,6 @@ char * tinyfd_utf8toMbcs(char const * aUtf8string)
 	return tinyfd_utf16toMbcs(lUtf16string);
 }
 
-wchar_t * tinyfd_mbcsTo16(char const * aMbcsString)
-{
-	static wchar_t * lMbcsString = NULL;
-	int lSize;
-
-	free(lMbcsString);
-	if (!aMbcsString) { lMbcsString = NULL; return NULL; }
-	lSize = sizeUtf16FromMbcs(aMbcsString);
-	lMbcsString = (wchar_t *)malloc(lSize * sizeof(wchar_t));
-	lSize = MultiByteToWideChar(CP_ACP, 0,
-		aMbcsString, -1, lMbcsString, lSize);
-	if (lSize == 0)
-	{
-		free(lMbcsString);
-		lMbcsString = NULL;
-	}
-	return lMbcsString;
-}
-
 
 char * tinyfd_utf16to8(wchar_t const * aUtf16string)
 {
@@ -655,14 +656,12 @@ char * tinyfd_utf16to8(wchar_t const * aUtf16string)
 	free(lUtf8string);
 	if (!aUtf16string) { lUtf8string = NULL; return NULL; }
 	lSize = sizeUtf8(aUtf16string);
-	lUtf8string = (char *)malloc(lSize);
-	lSize = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS,
-		aUtf16string, -1, lUtf8string, lSize, NULL, NULL);
-	if (lSize == 0)
-	{
-		free(lUtf8string);
-		lUtf8string = NULL;
-	}
+    if (lSize)
+    {
+        lUtf8string = (char*)malloc(lSize);
+        lSize = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, aUtf16string, -1, lUtf8string, lSize, NULL, NULL);
+    }
+    else strcpy(lUtf8string, "");
 	return lUtf8string;
 }
 
@@ -678,17 +677,21 @@ char * tinyfd_mbcsTo8(char const * aMbcsString)
 void tinyfd_beep(void)
 {
     if (windowsVersion() > 5) Beep(440, 300);
-    else MessageBeep(-1);
+    else MessageBeep(MB_OK);
 }
 
 
 static void wipefileW(wchar_t const * aFilename)
 {
         int i;
-        struct _stat st;
         FILE * lIn;
-
+#if defined(__MINGW32_MAJOR_VERSION) && !defined(__MINGW64__) && (__MINGW32_MAJOR_VERSION <= 3)
+        struct _stat st;
         if (_wstat(aFilename, &st) == 0)
+#else
+        struct __stat64 st;
+        if (_wstat64(aFilename, &st) == 0)
+#endif
         {
                 if ((lIn = _wfopen(aFilename, L"w")))
                 {
@@ -819,7 +822,11 @@ static void RGB2HexW( unsigned char const aRGB[3], wchar_t aoResultHexRGB[8])
 
 static int dirExists(char const * aDirPath)
 {
-        struct _stat lInfo;
+#if defined(__MINGW32_MAJOR_VERSION) && !defined(__MINGW64__) && (__MINGW32_MAJOR_VERSION <= 3)
+    struct _stat lInfo;
+#else
+    struct __stat64 lInfo;
+#endif
         wchar_t * lTmpWChar;
         int lStatRet;
 		size_t lDirLen;
@@ -835,7 +842,11 @@ static int dirExists(char const * aDirPath)
         if (tinyfd_winUtf8)
         {
 			lTmpWChar = tinyfd_utf8to16(aDirPath);
+#if defined(__MINGW32_MAJOR_VERSION) && !defined(__MINGW64__) && (__MINGW32_MAJOR_VERSION <= 3)
             lStatRet = _wstat(lTmpWChar, &lInfo);
+#else
+            lStatRet = _wstat64(lTmpWChar, &lInfo);
+#endif
             if (lStatRet != 0)
                     return 0;
             else if (lInfo.st_mode & S_IFDIR)
@@ -843,7 +854,11 @@ static int dirExists(char const * aDirPath)
             else
                         return 0;
         }
+#if defined(__MINGW32_MAJOR_VERSION) && !defined(__MINGW64__) && (__MINGW32_MAJOR_VERSION <= 3)
         else if (_stat(aDirPath, &lInfo) != 0)
+#else
+        else if (_stat64(aDirPath, &lInfo) != 0)
+#endif
                 return 0;
         else if (lInfo.st_mode & S_IFDIR)
                 return 1;
@@ -854,7 +869,11 @@ static int dirExists(char const * aDirPath)
 
 static int fileExists(char const * aFilePathAndName)
 {
-        struct _stat lInfo;
+#if defined(__MINGW32_MAJOR_VERSION) && !defined(__MINGW64__) && (__MINGW32_MAJOR_VERSION <= 3)
+    struct _stat lInfo;
+#else
+    struct __stat64 lInfo;
+#endif
         wchar_t * lTmpWChar;
         int lStatRet;
         FILE * lIn;
@@ -867,7 +886,12 @@ static int fileExists(char const * aFilePathAndName)
         if (tinyfd_winUtf8)
         {
 			lTmpWChar = tinyfd_utf8to16(aFilePathAndName);
+#if defined(__MINGW32_MAJOR_VERSION) && !defined(__MINGW64__) && (__MINGW32_MAJOR_VERSION <= 3)
             lStatRet = _wstat(lTmpWChar, &lInfo);
+#else
+            lStatRet = _wstat64(lTmpWChar, &lInfo);
+#endif
+
             if (lStatRet != 0)
                     return 0;
             else if (lInfo.st_mode & _S_IFREG)
@@ -990,9 +1014,12 @@ static char * ensureFilesExist(char * aDestination,
 static int __stdcall EnumThreadWndProc(HWND hwnd, LPARAM lParam)
 {
         wchar_t lTitleName[MAX_PATH];
+        wchar_t const* lDialogTitle = (wchar_t const *) lParam;
+
         GetWindowTextW(hwnd, lTitleName, MAX_PATH);
         /* wprintf(L"lTitleName %ls \n", lTitleName);  */
-        if (wcscmp(L"tinyfiledialogsTopWindow", lTitleName) == 0)
+
+        if (wcscmp(lDialogTitle, lTitleName) == 0)
         {
                 SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
                 return 0;
@@ -1023,8 +1050,7 @@ static void hiddenConsoleW(wchar_t const * aString, wchar_t const * aDialogTitle
         WaitForInputIdle(ProcessInfo.hProcess, INFINITE);
         if (aInFront)
         {
-                while (EnumWindows(EnumThreadWndProc, (LPARAM)NULL)) {}
-                SetWindowTextW(GetForegroundWindow(), aDialogTitle);
+                while (EnumWindows(EnumThreadWndProc, (LPARAM)aDialogTitle)) {}
         }
         WaitForSingleObject(ProcessInfo.hProcess, INFINITE);
         CloseHandle(ProcessInfo.hThread);
@@ -1045,7 +1071,7 @@ int tinyfd_messageBoxW(
         if (aTitle&&!wcscmp(aTitle, L"tinyfd_query")){ strcpy(tinyfd_response, "windows_wchar"); return 1; }
 
 		if (quoteDetectedW(aTitle)) return tinyfd_messageBoxW(L"INVALID TITLE WITH QUOTES", aMessage, aDialogType, aIconType, aDefaultButton);
-		//if (quoteDetectedW(aMessage)) return tinyfd_messageBoxW(aTitle, L"INVALID MESSAGE WITH QUOTES", aDialogType, aIconType, aDefaultButton);
+		if (quoteDetectedW(aMessage)) return tinyfd_messageBoxW(aTitle, L"INVALID MESSAGE WITH QUOTES", aDialogType, aIconType, aDefaultButton);
 
         if (aIconType && !wcscmp(L"warning", aIconType))
         {
@@ -1080,6 +1106,22 @@ int tinyfd_messageBoxW(
                         aCode += MB_DEFBUTTON2;
                 }
         }
+        else if (aDialogType && !wcscmp(L"yesnocancel", aDialogType))
+        {
+            aCode += MB_YESNOCANCEL;
+            if (aDefaultButton == 1)
+            {
+                aCode += MB_DEFBUTTON1;
+            }
+            else if (aDefaultButton == 2)
+            {
+                aCode += MB_DEFBUTTON2;
+            }
+            else
+            {
+                aCode += MB_DEFBUTTON3;
+            }
+        }
         else
         {
                 aCode += MB_OK;
@@ -1088,17 +1130,18 @@ int tinyfd_messageBoxW(
         aCode += MB_TOPMOST;
 
         lBoxReturnValue = MessageBoxW(GetForegroundWindow(), aMessage, aTitle, aCode);
-        if (((aDialogType
-                && wcscmp(L"okcancel", aDialogType)
-                && wcscmp(L"yesno", aDialogType)))
-                || (lBoxReturnValue == IDOK)
-                || (lBoxReturnValue == IDYES))
+
+        if ( (lBoxReturnValue == IDNO) && (aDialogType && !wcscmp(L"yesnocancel", aDialogType)) )
         {
-                return 1;
+            return 2;
+        }
+        else if ( (lBoxReturnValue == IDOK) || (lBoxReturnValue == IDYES) )
+        {
+            return 1;
         }
         else
         {
-                return 0;
+            return 0;
         }
 }
 
@@ -1115,9 +1158,9 @@ int tinyfd_notifyPopupW(
         size_t lDialogStringLen;
 
         if (aTitle && !wcscmp(aTitle, L"tinyfd_query")) { strcpy(tinyfd_response, "windows_wchar"); return 1; }
-        
+
         if (quoteDetectedW(aTitle)) return tinyfd_notifyPopupW(L"INVALID TITLE WITH QUOTES", aMessage, aIconType);
-		//if (quoteDetectedW(aMessage)) return tinyfd_notifyPopupW(aTitle, L"INVALID MESSAGE WITH QUOTES", aIconType);
+		if (quoteDetectedW(aMessage)) return tinyfd_notifyPopupW(aTitle, L"INVALID MESSAGE WITH QUOTES", aIconType);
 
         lTitleLen = aTitle ? wcslen(aTitle) : 0;
         lMessageLen = aMessage ? wcslen(aMessage) : 0;
@@ -1193,7 +1236,7 @@ wchar_t * tinyfd_inputBoxW(
         if (aTitle&&!wcscmp(aTitle, L"tinyfd_query")){ strcpy(tinyfd_response, "windows_wchar"); return (wchar_t *)1; }
 
 		if (quoteDetectedW(aTitle)) return tinyfd_inputBoxW(L"INVALID TITLE WITH QUOTES", aMessage, aDefaultInput);
-		//if (quoteDetectedW(aMessage)) return tinyfd_inputBoxW(aTitle, L"INVALID MESSAGE WITH QUOTES", aDefaultInput);
+		if (quoteDetectedW(aMessage)) return tinyfd_inputBoxW(aTitle, L"INVALID MESSAGE WITH QUOTES", aDefaultInput);
 		if (quoteDetectedW(aDefaultInput)) return tinyfd_inputBoxW(aTitle, aMessage, L"INVALID DEFAULT_INPUT WITH QUOTES");
 
         lTitleLen =  aTitle ? wcslen(aTitle) : 0 ;
@@ -1233,7 +1276,10 @@ wchar_t * tinyfd_inputBoxW(
 					replaceWchar(lBuff, L'\n', L' ');
 					wcscat(lDialogString, lBuff);
                 }
-                wcscat(lDialogString, L"\",\"tinyfiledialogsTopWindow\",\"");
+                wcscat(lDialogString, L"\",\"");
+                if (aTitle) wcscat(lDialogString, aTitle);
+                wcscat(lDialogString, L"\",\"");
+
                 if (aDefaultInput && wcslen(aDefaultInput))
                 {
 					wcscpy(lBuff, aDefaultInput);
@@ -1249,8 +1295,7 @@ wchar_t * tinyfd_inputBoxW(
 <html>\n\
 <head>\n\
 <title>");
-
-                wcscat(lDialogString, L"tinyfiledialogsTopWindow");
+                if (aTitle) wcscat(lDialogString, aTitle);
                 wcscat(lDialogString, L"</title>\n\
 <HTA:APPLICATION\n\
 ID = 'tinyfdHTA'\n\
@@ -1927,7 +1972,7 @@ static int notifyWinGui(
 		if (tinyfd_winUtf8) lTmpWChar = tinyfd_utf8to16(aMessage);
 		else lTmpWChar = tinyfd_mbcsTo16(aMessage);
 		lMessage = (wchar_t *) malloc((wcslen(lTmpWChar) + 1)* sizeof(wchar_t));
-      if (lMessage) wcscpy(lMessage, lTmpWChar);
+        if (lMessage) wcscpy(lMessage, lTmpWChar);
 	}
 	if (aIconType)
 	{
@@ -2672,7 +2717,7 @@ int tinyfd_messageBox(
 	UINT lOriginalOutputCP = 0;
 
 	if (tfd_quoteDetected(aTitle)) return tinyfd_messageBox("INVALID TITLE WITH QUOTES", aMessage, aDialogType, aIconType, aDefaultButton);
-	//if (tfd_quoteDetected(aMessage)) return tinyfd_messageBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDialogType, aIconType, aDefaultButton);
+	if (tfd_quoteDetected(aMessage)) return tinyfd_messageBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDialogType, aIconType, aDefaultButton);
 
 	if ((!tinyfd_forceConsole || !(GetConsoleWindow() || dialogPresent()))
 		&& (!getenv("SSH_CLIENT") || getenvDISPLAY()))
@@ -2787,9 +2832,9 @@ int tinyfd_notifyPopup(
         char const * aIconType ) /* "info" "warning" "error" */
 {
 	if (tfd_quoteDetected(aTitle)) return tinyfd_notifyPopup("INVALID TITLE WITH QUOTES", aMessage, aIconType);
-	//if (tfd_quoteDetected(aMessage)) return tinyfd_notifyPopup(aTitle, "INVALID MESSAGE WITH QUOTES", aIconType);
+	if (tfd_quoteDetected(aMessage)) return tinyfd_notifyPopup(aTitle, "INVALID MESSAGE WITH QUOTES", aIconType);
 
-    if ( (windowsVersion() > 5) && (!tinyfd_forceConsole || !(
+    if ( powershellPresent() && (!tinyfd_forceConsole || !(
             GetConsoleWindow() ||
             dialogPresent()))
 			&& (!getenv("SSH_CLIENT") || getenvDISPLAY()))
@@ -2825,7 +2870,7 @@ char * tinyfd_inputBox(
 	if (!aTitle && !aMessage && !aDefaultInput) return lBuff; /* now I can fill lBuff from outside */
 
 	if (tfd_quoteDetected(aTitle)) return tinyfd_inputBox("INVALID TITLE WITH QUOTES", aMessage, aDefaultInput);
-	//if (tfd_quoteDetected(aMessage)) return tinyfd_inputBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDefaultInput);
+	if (tfd_quoteDetected(aMessage)) return tinyfd_inputBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDefaultInput);
 	if (tfd_quoteDetected(aDefaultInput)) return tinyfd_inputBox(aTitle, aMessage, "INVALID DEFAULT_INPUT WITH QUOTES");
 
     mode = 0;
@@ -2956,6 +3001,7 @@ char * tinyfd_saveFileDialog(
 
         lBuff[0]='\0';
 
+        if ( ! aFilterPatterns ) aNumOfFilterPatterns = 0 ;
 		if (tfd_quoteDetected(aTitle)) return tinyfd_saveFileDialog("INVALID TITLE WITH QUOTES", aDefaultPathAndFile, aNumOfFilterPatterns, aFilterPatterns, aSingleFilterDescription);
 		if (tfd_quoteDetected(aDefaultPathAndFile)) return tinyfd_saveFileDialog(aTitle, "INVALID DEFAULT_PATH WITH QUOTES", aNumOfFilterPatterns, aFilterPatterns, aSingleFilterDescription);
 		if (tfd_quoteDetected(aSingleFilterDescription)) return tinyfd_saveFileDialog(aTitle, aDefaultPathAndFile, aNumOfFilterPatterns, aFilterPatterns, "INVALID FILTER_DESCRIPTION WITH QUOTES");
@@ -3018,12 +3064,13 @@ char * tinyfd_openFileDialog(
 	char const * aSingleFilterDescription, /* NULL or "image files" */
     int aAllowMultipleSelects ) /* 0 or 1 */
 {
-	char lString[MAX_PATH_OR_CMD];
-	char lBuff[MAX_PATH_OR_CMD];
+    static char lBuff[MAX_PATH_OR_CMD];
+    char lString[MAX_PATH_OR_CMD];
 	char * p;
 	char * lPointerInputBox;
 	int i;
 
+    if ( ! aFilterPatterns ) aNumOfFilterPatterns = 0 ;
 	if (tfd_quoteDetected(aTitle)) return tinyfd_openFileDialog("INVALID TITLE WITH QUOTES", aDefaultPathAndFile, aNumOfFilterPatterns, aFilterPatterns, aSingleFilterDescription, aAllowMultipleSelects);
 	if (tfd_quoteDetected(aDefaultPathAndFile)) return tinyfd_openFileDialog(aTitle, "INVALID DEFAULT_PATH WITH QUOTES", aNumOfFilterPatterns, aFilterPatterns, aSingleFilterDescription, aAllowMultipleSelects);
 	if (tfd_quoteDetected(aSingleFilterDescription)) return tinyfd_openFileDialog(aTitle, aDefaultPathAndFile, aNumOfFilterPatterns, aFilterPatterns, "INVALID FILTER_DESCRIPTION WITH QUOTES", aAllowMultipleSelects);
@@ -3119,13 +3166,14 @@ char * tinyfd_selectFolderDialog(
 }
 
 
+/* aDefaultRGB is used only if aDefaultHexRGB is absent */
+/* aDefaultRGB and aoResultRGB can be the same array */
+/* returns NULL on cancel */
 /* returns the hexcolor as a string "#FF0000" */
 /* aoResultRGB also contains the result */
-/* aDefaultRGB is used only if aDefaultHexRGB is NULL */
-/* aDefaultRGB and aoResultRGB can be the same array */
 char * tinyfd_colorChooser(
         char const * aTitle, /* NULL or "" */
-        char const * aDefaultHexRGB, /* NULL or "#FF0000"*/
+        char const * aDefaultHexRGB, /* NULL or "" or "#FF0000"*/
         unsigned char const aDefaultRGB[3], /* { 0 , 255 , 255 } */
         unsigned char aoResultRGB[3]) /* { 0 , 0 , 0 } */
 {
@@ -3145,8 +3193,12 @@ char * tinyfd_colorChooser(
     {
 		if (aTitle&&!strcmp(aTitle,"tinyfd_query")){strcpy(tinyfd_response,"windows");return (char *)1;}
 		p = colorChooserWinGui(aTitle, aDefaultHexRGB, aDefaultRGB, aoResultRGB);
-		strcpy(lDefaultHexRGB, p);
-		return lDefaultHexRGB;
+        if (p)
+        {
+            strcpy(lDefaultHexRGB, p);
+            return lDefaultHexRGB;
+        }
+        return NULL;
     }
 	else if (dialogPresent())
 	{
@@ -3157,7 +3209,7 @@ char * tinyfd_colorChooser(
 		if (aTitle&&!strcmp(aTitle, "tinyfd_query")){ strcpy(tinyfd_response, "basicinput"); return (char *)0; }
 	}
 
-	if (aDefaultHexRGB)
+	if (aDefaultHexRGB && (strlen(aDefaultHexRGB)==7) )
 	{
 		strncpy(lDefaultHexRGB, aDefaultHexRGB,7);
 		lDefaultHexRGB[7]='\0';
@@ -3207,16 +3259,6 @@ int tfd_isDarwin(void)
                 lsIsDarwin = !uname(&lUtsname) && !strcmp(lUtsname.sysname,"Darwin") ;
         }
         return lsIsDarwin ;
-}
-
-
-int tdf_isHaikuOS(void)
-{
-#if defined(__HAIKU__)
-    return 1;
-#else
-    return 0;
-#endif
 }
 
 
@@ -3292,7 +3334,7 @@ static char * getVersion( char const * aExecutable ) /*version must be first num
         pclose( lIn ) ;
 
 	lTmp += strcspn(lTmp,"0123456789");
-	/* printf("lTmp:%s\n", lTmp); */
+	 /* printf("lTmp:%s\n", lTmp); */
 	return lTmp ;
 }
 
@@ -3532,7 +3574,7 @@ static char * terminalName(void)
                 {
                         strcpy(lTerminalName , "" ) ;
                 }
-                /* bad: koi rxterm guake tilda vala-terminal qterminal
+                /* bad: koi rxterm guake tilda vala-terminal qterminal kgx
                 aterm Terminal terminology sakura lilyterm weston-terminal
                 roxterm termit xvt rxvt mrxvt urxvt */
         }
@@ -3581,7 +3623,7 @@ static int whiptailPresent(void)
 static int graphicMode(void)
 {
         return !( tinyfd_forceConsole && (isTerminalRunning() || terminalName()) )
-			&& ( getenvDISPLAY() || tdf_isHaikuOS()
+			&& ( getenvDISPLAY()
 			|| (tfd_isDarwin() && (!getenv("SSH_TTY") || getenvDISPLAY() ) ) ) ;
 }
 
@@ -3767,6 +3809,55 @@ static int osascriptPresent(void)
 }
 
 
+static int dunstifyPresent(void)
+{
+    static int lDunstifyPresent = -1 ;
+	static char lBuff[MAX_PATH_OR_CMD] ;
+	FILE * lIn ;
+	char * lTmp ;
+
+    if ( lDunstifyPresent < 0 )
+    {
+        lDunstifyPresent = detectPresence( "dunstify" ) ;
+        if ( lDunstifyPresent )
+        {
+            lIn = popen( "dunstify -s" , "r" ) ;
+            lTmp = fgets( lBuff , sizeof( lBuff ) , lIn ) ;
+            pclose( lIn ) ;
+            /* printf("lTmp:%s\n", lTmp); */
+            lDunstifyPresent = strstr(lTmp,"name:dunst\n") ? 1 : 0 ;
+            if (tinyfd_verbose) printf("lDunstifyPresent %d\n", lDunstifyPresent);
+        }
+    }
+    return lDunstifyPresent && graphicMode( ) ;
+}
+
+
+static int dunstPresent(void)
+{
+    static int lDunstPresent = -1 ;
+	static char lBuff[MAX_PATH_OR_CMD] ;
+	FILE * lIn ;
+	char * lTmp ;
+
+    if ( lDunstPresent < 0 )
+    {
+        lDunstPresent = detectPresence( "dunst" ) ;
+        if ( lDunstPresent )
+        {
+            lIn = popen( "ps -e | grep dunst | grep -v grep" , "r" ) ; /* add "| wc -l" to receive the number of lines */
+            lTmp = fgets( lBuff , sizeof( lBuff ) , lIn ) ;
+            pclose( lIn ) ;
+            /* if ( lTmp ) printf("lTmp:%s\n", lTmp); */
+            if ( lTmp ) lDunstPresent = 1 ;
+            else lDunstPresent = 0 ;
+            if (tinyfd_verbose) printf("lDunstPresent %d\n", lDunstPresent);
+        }
+    }
+    return lDunstPresent && graphicMode( ) ;
+}
+
+
 int tfd_qarmaPresent(void)
 {
         static int lQarmaPresent = -1 ;
@@ -3938,6 +4029,7 @@ static int osx9orBetter(void)
         {
                 lOsx9orBetter = 0 ;
                 lIn = popen( "osascript -e 'set osver to system version of (system info)'" , "r" ) ;
+                V = 0 ;
                 if ( ( fgets( lBuff , sizeof( lBuff ) , lIn ) != NULL )
                         && ( 2 == sscanf(lBuff, "%d.%d", &V, &v) ) )
                 {
@@ -3986,14 +4078,13 @@ static int python3Present(void)
 static int python2Present(void)
 {
 	static int lPython2Present = -1 ;
-	int i;
 
 	if ( lPython2Present < 0 )
 	{
 		lPython2Present = 0 ;
 		strcpy(gPython2Name , "python2" ) ;
 		if ( detectPresence(gPython2Name) ) lPython2Present = 1;
-		else
+		/*else
 		{
 			for ( i = 9 ; i >= 0 ; i -- )
 			{
@@ -4004,7 +4095,7 @@ static int python2Present(void)
 					break;
 				}
 			}
-		}
+		}*/
 		if (tinyfd_verbose) printf("lPython2Present %d\n", lPython2Present) ;
 		if (tinyfd_verbose) printf("gPython2Name %s\n", gPython2Name) ;
 	}
@@ -4048,7 +4139,7 @@ static int tkinter2Present(void)
 			sprintf( lPythonCommand , "%s %s" , gPython2Name , lPythonParams ) ;
 			lTkinter2Present = tryCommand(lPythonCommand) ;
 		}
-		if (tinyfd_verbose) printf("lTkinter2Present %d\n", lTkinter2Present) ;
+		if (tinyfd_verbose) printf("lTkinter2Present %d graphicMode %d \n", lTkinter2Present, graphicMode() ) ;
 	}
 	return lTkinter2Present && graphicMode() && !(tfd_isDarwin() && getenv("SSH_TTY") );
 }
@@ -4122,7 +4213,7 @@ void tinyfd_beep(void)
         else if ( speakertestPresent() )
         {
                 /*strcpy( lDialogString , "timeout -k .3 .3 speaker-test --frequency 440 --test sine > /dev/tty" ) ;*/
-                strcpy( lDialogString , "( speaker-test -t sine -f 440 > /dev/tty )& pid=$!;sleep .4; kill -9 $pid" ) ; /*.3 was too short for mac g3*/
+                strcpy( lDialogString , "( speaker-test -t sine -f 440 > /dev/tty )& pid=$!;sleep .5; kill -9 $pid" ) ; /*.3 was too short for mac g3*/
         }
         else if (beepexePresent())
         {
@@ -4178,7 +4269,7 @@ int tinyfd_messageBox(
         lBuff[0]='\0';
 
 		if (tfd_quoteDetected(aTitle)) return tinyfd_messageBox("INVALID TITLE WITH QUOTES", aMessage, aDialogType, aIconType, aDefaultButton);
-		//if (tfd_quoteDetected(aMessage)) return tinyfd_messageBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDialogType, aIconType, aDefaultButton);
+		if (tfd_quoteDetected(aMessage)) return tinyfd_messageBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDialogType, aIconType, aDefaultButton);
 
         lTitleLen =  aTitle ? strlen(aTitle) : 0 ;
         lMessageLen =  aMessage ? strlen(aMessage) : 0 ;
@@ -4392,19 +4483,17 @@ int tinyfd_messageBox(
                 {
                     strcat( lDialogString , "info" ) ;
                 }
-                if ( aTitle && strlen(aTitle) )
-                {
-                        strcat(lDialogString, " --title=\"") ;
-                        strcat(lDialogString, aTitle) ;
-                        strcat(lDialogString, "\"") ;
-                }
-                if ( aMessage && strlen(aMessage) )
-                {
-                  if (strcmp("yesnocancel", aDialogType)) strcat(lDialogString, " --no-wrap");
-                  strcat(lDialogString, " --text=\"") ;
-                  strcat(lDialogString, aMessage) ;
-                  strcat(lDialogString, "\"") ;
-                }
+
+                strcat(lDialogString, " --title=\"");
+                if ( aTitle && strlen(aTitle) ) strcat(lDialogString, aTitle) ;
+                strcat(lDialogString, "\"");
+
+                if (strcmp("yesnocancel", aDialogType)) strcat(lDialogString, " --no-wrap");
+
+                strcat(lDialogString, " --text=\"") ;
+                if (aMessage && strlen(aMessage)) strcat(lDialogString, aMessage) ;
+                strcat(lDialogString, "\"") ;
+
                 if ( (tfd_zenity3Present() >= 3) || (!tfd_zenityPresent() && (tfd_shellementaryPresent() || tfd_qarmaPresent()) ) )
                 {
                         strcat( lDialogString , " --icon-name=dialog-" ) ;
@@ -4478,7 +4567,7 @@ int tinyfd_messageBox(
             strcat(lDialogString, "\"");
          }
 
-         strcat(lDialogString, " --icon-name=dialog-");
+         strcat(lDialogString, " --image=dialog-");
          if (aIconType && (!strcmp("question", aIconType)
             || !strcmp("error", aIconType)
             || !strcmp("warning", aIconType)))
@@ -5057,7 +5146,7 @@ my \\$notificationsObject = \\$notificationsService->get_object('/org/freedeskto
                                         printf("\n%s\n",aMessage);
                                 }
                                 printf("y/n: "); fflush(stdout);
-                                lChar = tolower( getchar() ) ;
+                                lChar = (char) tolower( getchar() ) ;
                                 printf("\n\n");
                         }
                         while ( lChar != 'y' && lChar != 'n' );
@@ -5072,7 +5161,7 @@ my \\$notificationsObject = \\$notificationsService->get_object('/org/freedeskto
                                         printf("\n%s\n",aMessage);
                                 }
                                 printf("[O]kay/[C]ancel: "); fflush(stdout);
-                                lChar = tolower( getchar() ) ;
+                                lChar = (char) tolower( getchar() ) ;
                                 printf("\n\n");
                         }
                         while ( lChar != 'o' && lChar != 'c' );
@@ -5087,7 +5176,7 @@ my \\$notificationsObject = \\$notificationsService->get_object('/org/freedeskto
                                         printf("\n%s\n",aMessage);
                                 }
                                 printf("[Y]es/[N]o/[C]ancel: "); fflush(stdout);
-                                lChar = tolower( getchar() ) ;
+                                lChar = (char) tolower( getchar() ) ;
                                 printf("\n\n");
                         }
                         while ( lChar != 'y' && lChar != 'n' && lChar != 'c' );
@@ -5152,29 +5241,44 @@ int tinyfd_notifyPopup(
         char const * aMessage , /* NULL or ""  may contain \n and \t */
         char const * aIconType ) /* "info" "warning" "error" */
 {
-    char lBuff[MAX_PATH_OR_CMD];
+        char lBuff[MAX_PATH_OR_CMD];
         char * lDialogString = NULL ;
-    char * lpDialogString ;
+        char * lpDialogString ;
         FILE * lIn ;
         size_t lTitleLen ;
         size_t lMessageLen ;
 
 		if (tfd_quoteDetected(aTitle)) return tinyfd_notifyPopup("INVALID TITLE WITH QUOTES", aMessage, aIconType);
-		//if (tfd_quoteDetected(aMessage)) return tinyfd_notifyPopup(aTitle, "INVALID MESSAGE WITH QUOTES", aIconType);
+		if (tfd_quoteDetected(aMessage)) return tinyfd_notifyPopup(aTitle, "INVALID MESSAGE WITH QUOTES", aIconType);
 
-        if ( getenv("SSH_TTY") )
+        if ( getenv("SSH_TTY") && !dunstifyPresent() && !dunstPresent() )
         {
-                return tinyfd_messageBox(aTitle, aMessage, "ok", aIconType, 0);
+            return tinyfd_messageBox(aTitle, aMessage, "ok", aIconType, 0);
         }
 
         lTitleLen =  aTitle ? strlen(aTitle) : 0 ;
         lMessageLen =  aMessage ? strlen(aMessage) : 0 ;
         if ( !aTitle || strcmp(aTitle,"tinyfd_query") )
         {
-                lDialogString = (char *) malloc( MAX_PATH_OR_CMD + lTitleLen + lMessageLen );
+            lDialogString = (char *) malloc( MAX_PATH_OR_CMD + lTitleLen + lMessageLen );
         }
 
-        if ( osascriptPresent( ) )
+        if ( getenv("SSH_TTY") )
+        {
+            if (aTitle&&!strcmp(aTitle,"tinyfd_query")){strcpy(tinyfd_response,"dunst");return 1;}
+            strcpy( lDialogString , "notify-send \"" ) ;
+            if ( aTitle && strlen(aTitle) )
+            {
+                strcat( lDialogString , aTitle ) ;
+                strcat( lDialogString , "\" \"" ) ;
+            }
+            if ( aMessage && strlen(aMessage) )
+            {
+                strcat(lDialogString, aMessage) ;
+            }
+            strcat( lDialogString , "\"" ) ;
+        }
+        else if ( osascriptPresent( ) )
         {
                 if (aTitle&&!strcmp(aTitle,"tinyfd_query")){strcpy(tinyfd_response,"applescript");return 1;}
 
@@ -5222,48 +5326,41 @@ int tinyfd_notifyPopup(
                 }
                 strcat( lDialogString , " \" 5" ) ;
         }
-        else if ( (tfd_zenity3Present()>=5) )
+        else if ( tfd_yadPresent() )
         {
-                /* zenity 2.32 & 3.14 has the notification but with a bug: it doesnt return from it */
-                /* zenity 3.8 show the notification as an alert ok cancel box */
-                if ( tfd_zenity3Present()>=5 )
-                {
-                        if (aTitle&&!strcmp(aTitle,"tinyfd_query")){strcpy(tinyfd_response,"zenity");return 1;}
-                        strcpy( lDialogString , "zenity" ) ;
-                }
+            if (aTitle&&!strcmp(aTitle,"tinyfd_query")){strcpy(tinyfd_response,"yad");return 1;}
+            strcpy( lDialogString , "yad --notification");
 
-                strcat( lDialogString , " --notification");
+            if ( aIconType && strlen( aIconType ) )
+            {
+                    strcat( lDialogString , " --image=\"");
+                    strcat( lDialogString , aIconType ) ;
+                    strcat( lDialogString , "\"" ) ;
+            }
 
-                if ( aIconType && strlen( aIconType ) )
-                {
-                        strcat( lDialogString , " --window-icon '");
-                        strcat( lDialogString , aIconType ) ;
-                        strcat( lDialogString , "'" ) ;
-                }
-
-                strcat( lDialogString , " --text \"" ) ;
-                if ( aTitle && strlen(aTitle) )
-                {
-                        strcat(lDialogString, aTitle) ;
-                        strcat(lDialogString, "\n") ;
-                }
-                if ( aMessage && strlen( aMessage ) )
-                {
-                        strcat( lDialogString , aMessage ) ;
-                }
-                strcat( lDialogString , " \"" ) ;
+            strcat( lDialogString , " --text=\"" ) ;
+            if ( aTitle && strlen(aTitle) )
+            {
+                    strcat(lDialogString, aTitle) ;
+                    strcat(lDialogString, "\n") ;
+            }
+            if ( aMessage && strlen( aMessage ) )
+            {
+                    strcat( lDialogString , aMessage ) ;
+            }
+            strcat( lDialogString , " \"" ) ;
         }
         else if ( perlPresent() >= 2 )
         {
                 if (aTitle&&!strcmp(aTitle,"tinyfd_query")){strcpy(tinyfd_response,"perl-dbus");return 1;}
 
-				strcpy( lDialogString , "perl -e \"use Net::DBus;\
+                strcpy( lDialogString , "perl -e \"use Net::DBus;\
 my \\$sessionBus = Net::DBus->session;\
 my \\$notificationsService = \\$sessionBus->get_service('org.freedesktop.Notifications');\
 my \\$notificationsObject = \\$notificationsService->get_object('/org/freedesktop/Notifications',\
 'org.freedesktop.Notifications');");
 
-				sprintf( lDialogString + strlen(lDialogString) ,
+                sprintf( lDialogString + strlen(lDialogString) ,
 "my \\$notificationId;\\$notificationId = \\$notificationsObject->Notify(shift, 0, '%s', '%s', '%s', [], {}, -1);\" ",
 aIconType?aIconType:"", aTitle?aTitle:"", aMessage?aMessage:"" ) ;
         }
@@ -5294,32 +5391,60 @@ aIconType?aIconType:"", aTitle?aTitle:"", aMessage?aMessage:"" ) ;
         }
         else if ( notifysendPresent() )
         {
-                if (aTitle&&!strcmp(aTitle,"tinyfd_query")){strcpy(tinyfd_response,"notifysend");return 1;}
-                strcpy( lDialogString , "notify-send" ) ;
-                if ( aIconType && strlen(aIconType) )
+            if (aTitle&&!strcmp(aTitle,"tinyfd_query")){strcpy(tinyfd_response,"notifysend");return 1;}
+            strcpy( lDialogString , "notify-send" ) ;
+            if ( aIconType && strlen(aIconType) )
+            {
+                    strcat( lDialogString , " -i '" ) ;
+                    strcat( lDialogString , aIconType ) ;
+                    strcat( lDialogString , "'" ) ;
+            }
+            strcat( lDialogString , " \"" ) ;
+            if ( aTitle && strlen(aTitle) )
+            {
+                    strcat(lDialogString, aTitle) ;
+                    strcat( lDialogString , " | " ) ;
+            }
+            if ( aMessage && strlen(aMessage) )
+            {
+                tfd_replaceSubStr( aMessage , "\n\t" , " |  " , lBuff ) ;
+                tfd_replaceSubStr( aMessage , "\n" , " | " , lBuff ) ;
+                tfd_replaceSubStr( aMessage , "\t" , "  " , lBuff ) ;
+                strcat(lDialogString, lBuff) ;
+            }
+            strcat( lDialogString , "\"" ) ;
+        }
+        else if ( (tfd_zenity3Present()>=5) )
+        {
+                /* zenity 2.32 & 3.14 has the notification but with a bug: it doesnt return from it */
+                /* zenity 3.8 show the notification as an alert ok cancel box */
+                /* zenity 3.44 doesn't have the notification (3.42 has it) */
+                if (aTitle&&!strcmp(aTitle,"tinyfd_query")){strcpy(tinyfd_response,"zenity");return 1;}
+                strcpy( lDialogString , "zenity --notification");
+
+                if ( aIconType && strlen( aIconType ) )
                 {
-                        strcat( lDialogString , " -i '" ) ;
+                        strcat( lDialogString , " --window-icon '");
                         strcat( lDialogString , aIconType ) ;
                         strcat( lDialogString , "'" ) ;
                 }
-        strcat( lDialogString , " \"" ) ;
+
+                strcat( lDialogString , " --text \"" ) ;
                 if ( aTitle && strlen(aTitle) )
                 {
                         strcat(lDialogString, aTitle) ;
-                        strcat( lDialogString , " | " ) ;
+                        strcat(lDialogString, "\n") ;
                 }
-                if ( aMessage && strlen(aMessage) )
+                if ( aMessage && strlen( aMessage ) )
                 {
-            tfd_replaceSubStr( aMessage , "\n\t" , " |  " , lBuff ) ;
-            tfd_replaceSubStr( aMessage , "\n" , " | " , lBuff ) ;
-            tfd_replaceSubStr( aMessage , "\t" , "  " , lBuff ) ;
-                        strcat(lDialogString, lBuff) ;
+                        strcat( lDialogString , aMessage ) ;
                 }
-                strcat( lDialogString , "\"" ) ;
+                strcat( lDialogString , " \"" ) ;
         }
         else
         {
-                return tinyfd_messageBox(aTitle, aMessage, "ok", aIconType, 0);
+            if (lDialogString) free(lDialogString);
+            return tinyfd_messageBox(aTitle, aMessage, "ok", aIconType, 0);
         }
 
         if (tinyfd_verbose) printf( "lDialogString: %s\n" , lDialogString ) ;
@@ -5362,7 +5487,7 @@ char * tinyfd_inputBox(
         lBuff[0]='\0';
 
 		if (tfd_quoteDetected(aTitle)) return tinyfd_inputBox("INVALID TITLE WITH QUOTES", aMessage, aDefaultInput);
-		//if (tfd_quoteDetected(aMessage)) return tinyfd_inputBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDefaultInput);
+		if (tfd_quoteDetected(aMessage)) return tinyfd_inputBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDefaultInput);
 		if (tfd_quoteDetected(aDefaultInput)) return tinyfd_inputBox(aTitle, aMessage, "INVALID DEFAULT_INPUT WITH QUOTES");
 
         lTitleLen =  aTitle ? strlen(aTitle) : 0 ;
@@ -5477,19 +5602,15 @@ char * tinyfd_inputBox(
                 }
                 strcat( lDialogString ," --entry" ) ;
 
-                if ( aTitle && strlen(aTitle) )
-                {
-                        strcat(lDialogString, " --title=\"") ;
-                        strcat(lDialogString, aTitle) ;
-                        strcat(lDialogString, "\"") ;
-                }
-                if ( aMessage && strlen(aMessage) )
-                {
-                        strcat(lDialogString, " --text=\"") ;
-                        strcat(lDialogString, aMessage) ;
-                        strcat(lDialogString, "\"") ;
-                }
-                if ( aDefaultInput && strlen(aDefaultInput) )
+                strcat(lDialogString, " --title=\"") ;
+                if (aTitle && strlen(aTitle)) strcat(lDialogString, aTitle) ;
+                strcat(lDialogString, "\"") ;
+
+                strcat(lDialogString, " --text=\"") ;
+                if (aMessage && strlen(aMessage)) strcat(lDialogString, aMessage) ;
+                strcat(lDialogString, "\"") ;
+
+                if ( aDefaultInput )
                 {
                         strcat(lDialogString, " --entry-text=\"") ;
                         strcat(lDialogString, aDefaultInput) ;
@@ -5930,8 +6051,8 @@ char * tinyfd_saveFileDialog(
     char const * aTitle , /* NULL or "" */
     char const * aDefaultPathAndFile , /* NULL or "" */
     int aNumOfFilterPatterns , /* 0 */
-    char const * const * aFilterPatterns , /* NULL or {"*.jpg","*.png"} */
-    char const * aSingleFilterDescription ) /* NULL or "image files" */
+    char const * const * aFilterPatterns , /* NULL or {"*.txt","*.doc"} */
+    char const * aSingleFilterDescription ) /* NULL or "text files" */
 {
         static char lBuff[MAX_PATH_OR_CMD] ;
         char lDialogString[MAX_PATH_OR_CMD] ;
@@ -5944,6 +6065,7 @@ char * tinyfd_saveFileDialog(
         FILE * lIn ;
         lBuff[0]='\0';
 
+        if ( ! aFilterPatterns ) aNumOfFilterPatterns = 0 ;
 		if (tfd_quoteDetected(aTitle)) return tinyfd_saveFileDialog("INVALID TITLE WITH QUOTES", aDefaultPathAndFile, aNumOfFilterPatterns, aFilterPatterns, aSingleFilterDescription);
 		if (tfd_quoteDetected(aDefaultPathAndFile)) return tinyfd_saveFileDialog(aTitle, "INVALID DEFAULT_PATH WITH QUOTES", aNumOfFilterPatterns, aFilterPatterns, aSingleFilterDescription);
 		if (tfd_quoteDetected(aSingleFilterDescription)) return tinyfd_saveFileDialog(aTitle, aDefaultPathAndFile, aNumOfFilterPatterns, aFilterPatterns, "INVALID FILTER_DESCRIPTION WITH QUOTES");
@@ -6064,12 +6186,10 @@ char * tinyfd_saveFileDialog(
                 }
                 strcat(lDialogString, " --file-selection --save --confirm-overwrite" ) ;
 
-                if ( aTitle && strlen(aTitle) )
-                {
-                        strcat(lDialogString, " --title=\"") ;
-                        strcat(lDialogString, aTitle) ;
-                        strcat(lDialogString, "\"") ;
-                }
+                strcat(lDialogString, " --title=\"") ;
+                if (aTitle && strlen(aTitle)) strcat(lDialogString, aTitle) ;
+                strcat(lDialogString, "\"") ;
+
                 if ( aDefaultPathAndFile && strlen(aDefaultPathAndFile) )
                 {
                         strcat(lDialogString, " --filename=\"") ;
@@ -6096,7 +6216,7 @@ char * tinyfd_saveFileDialog(
         else if (tfd_yadPresent())
         {
            if (aTitle && !strcmp(aTitle, "tinyfd_query")) { strcpy(tinyfd_response, "yad"); return (char*)1; }
-           strcpy(lDialogString, "yad --file-selection --save --confirm-overwrite");
+           strcpy(lDialogString, "yad --file --save --confirm-overwrite");
            if (aTitle && strlen(aTitle))
            {
               strcat(lDialogString, " --title=\"");
@@ -6395,6 +6515,7 @@ char * tinyfd_openFileDialog(
       size_t lFullBuffLen ;
       static char * lBuff = NULL;
 
+        if ( ! aFilterPatterns ) aNumOfFilterPatterns = 0 ;
 		if (tfd_quoteDetected(aTitle)) return tinyfd_openFileDialog("INVALID TITLE WITH QUOTES", aDefaultPathAndFile, aNumOfFilterPatterns, aFilterPatterns, aSingleFilterDescription, aAllowMultipleSelects);
 		if (tfd_quoteDetected(aDefaultPathAndFile)) return tinyfd_openFileDialog(aTitle, "INVALID DEFAULT_PATH WITH QUOTES", aNumOfFilterPatterns, aFilterPatterns, aSingleFilterDescription, aAllowMultipleSelects);
 		if (tfd_quoteDetected(aSingleFilterDescription)) return tinyfd_openFileDialog(aTitle, aDefaultPathAndFile, aNumOfFilterPatterns, aFilterPatterns, "INVALID FILTER_DESCRIPTION WITH QUOTES", aAllowMultipleSelects);
@@ -6583,12 +6704,11 @@ char * tinyfd_openFileDialog(
                 {
                         strcat( lDialogString , " --multiple" ) ;
                 }
-                if ( aTitle && strlen(aTitle) )
-                {
-                        strcat(lDialogString, " --title=\"") ;
-                        strcat(lDialogString, aTitle) ;
-                        strcat(lDialogString, "\"") ;
-                }
+
+                strcat(lDialogString, " --title=\"") ;
+                if (aTitle && strlen(aTitle)) strcat(lDialogString, aTitle) ;
+                strcat(lDialogString, "\"") ;
+
                 if ( aDefaultPathAndFile && strlen(aDefaultPathAndFile) )
                 {
                         strcat(lDialogString, " --filename=\"") ;
@@ -6615,7 +6735,7 @@ char * tinyfd_openFileDialog(
         else if (tfd_yadPresent())
         {
            if (aTitle && !strcmp(aTitle, "tinyfd_query")) { strcpy(tinyfd_response, "yad"); return (char*)1; }
-           strcpy(lDialogString, "yad --file-selection");
+           strcpy(lDialogString, "yad --file");
            if (aAllowMultipleSelects)
            {
               strcat(lDialogString, " --multiple");
@@ -6890,11 +7010,12 @@ frontmost of process \\\"Python\\\" to true' ''');");
                 p += strlen( p );
         }
     pclose( lIn ) ;
-    if ( lBuff[strlen( lBuff ) -1] == '\n' )
+
+    if ( strlen( lBuff ) && lBuff[strlen( lBuff ) -1] == '\n' )
     {
         lBuff[strlen( lBuff ) -1] = '\0' ;
     }
-    /* printf( "lBuff: %s\n" , lBuff ) ; */
+    /* printf( "strlen lBuff: %d\n" , strlen( lBuff ) ) ; */
         if ( lWasKdialog && aAllowMultipleSelects )
         {
                 p = lBuff ;
@@ -6926,7 +7047,7 @@ frontmost of process \\\"Python\\\" to true' ''');");
 
 		lBuff = (char *)( realloc( lBuff, (strlen(lBuff)+1) * sizeof(char)));
 
-        /*printf( "lBuff3: %s\n" , lBuff ) ; */
+        /*printf( "lBuff3 [%lu]: %s\n" , strlen(lBuff) , lBuff ) ; */
 		return lBuff ;
 }
 
@@ -7034,12 +7155,10 @@ char * tinyfd_selectFolderDialog(
                 }
                 strcat( lDialogString , " --file-selection --directory" ) ;
 
-                if ( aTitle && strlen(aTitle) )
-                {
-                        strcat(lDialogString, " --title=\"") ;
-                        strcat(lDialogString, aTitle) ;
-                        strcat(lDialogString, "\"") ;
-                }
+                strcat(lDialogString, " --title=\"") ;
+                if (aTitle && strlen(aTitle)) strcat(lDialogString, aTitle) ;
+                strcat(lDialogString, "\"") ;
+
                 if ( aDefaultPath && strlen(aDefaultPath) )
                 {
                         strcat(lDialogString, " --filename=\"") ;
@@ -7051,7 +7170,7 @@ char * tinyfd_selectFolderDialog(
         else if (tfd_yadPresent())
         {
            if (aTitle && !strcmp(aTitle, "tinyfd_query")) { strcpy(tinyfd_response, "yad"); return (char*)1; }
-           strcpy(lDialogString, "yad --file-selection --directory");
+           strcpy(lDialogString, "yad --file --directory");
            if (aTitle && strlen(aTitle))
            {
               strcat(lDialogString, " --title=\"");
@@ -7232,10 +7351,11 @@ frontmost of process \\\"Python\\\" to true' ''');");
 }
 
 
+/* aDefaultRGB is used only if aDefaultHexRGB is absent */
+/* aDefaultRGB and aoResultRGB can be the same array */
+/* returns NULL on cancel */
 /* returns the hexcolor as a string "#FF0000" */
 /* aoResultRGB also contains the result */
-/* aDefaultRGB is used only if aDefaultHexRGB is NULL */
-/* aDefaultRGB and aoResultRGB can be the same array */
 char * tinyfd_colorChooser(
         char const * aTitle , /* NULL or "" */
         char const * aDefaultHexRGB , /* NULL or "#FF0000"*/
@@ -7263,17 +7383,17 @@ char * tinyfd_colorChooser(
 		if (tfd_quoteDetected(aTitle)) return tinyfd_colorChooser("INVALID TITLE WITH QUOTES", aDefaultHexRGB, aDefaultRGB, aoResultRGB);
 		if (tfd_quoteDetected(aDefaultHexRGB)) return tinyfd_colorChooser(aTitle, "INVALID DEFAULT_HEX_RGB WITH QUOTES", aDefaultRGB, aoResultRGB);
 
-		if (aDefaultHexRGB)
+		if (aDefaultHexRGB && (strlen(aDefaultHexRGB)==7) )
 		{
 			Hex2RGB(aDefaultHexRGB, lDefaultRGB);
-         strcpy(lDefaultHexRGB, aDefaultHexRGB);
+            strcpy(lDefaultHexRGB, aDefaultHexRGB);
 		}
 		else
 		{
 			lDefaultRGB[0] = aDefaultRGB[0];
 			lDefaultRGB[1] = aDefaultRGB[1];
 			lDefaultRGB[2] = aDefaultRGB[2];
-         RGB2Hex(aDefaultRGB, lDefaultHexRGB);
+            RGB2Hex(aDefaultRGB, lDefaultHexRGB);
 		}
 
         if ( osascriptPresent( ) )
@@ -7366,12 +7486,10 @@ to set mycolor to choose color default color {");
                 strcat( lDialogString , " --color-selection --show-palette" ) ;
                 sprintf( lDialogString + strlen(lDialogString), " --color=%s" , lDefaultHexRGB ) ;
 
-                if ( aTitle && strlen(aTitle) )
-                {
-                        strcat(lDialogString, " --title=\"") ;
-                        strcat(lDialogString, aTitle) ;
-                        strcat(lDialogString, "\"") ;
-                }
+                strcat(lDialogString, " --title=\"") ;
+                if (aTitle && strlen(aTitle)) strcat(lDialogString, aTitle) ;
+                strcat(lDialogString, "\"") ;
+
                 if (tinyfd_silent) strcat( lDialogString , " 2>/dev/null ");
         }
         else if (tfd_yadPresent())

--- a/src/libs/tinyfiledialogs/tinyfiledialogs.c
+++ b/src/libs/tinyfiledialogs/tinyfiledialogs.c
@@ -2717,7 +2717,7 @@ int tinyfd_messageBox(
 	UINT lOriginalOutputCP = 0;
 
 	if (tfd_quoteDetected(aTitle)) return tinyfd_messageBox("INVALID TITLE WITH QUOTES", aMessage, aDialogType, aIconType, aDefaultButton);
-	if (tfd_quoteDetected(aMessage)) return tinyfd_messageBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDialogType, aIconType, aDefaultButton);
+	//if (tfd_quoteDetected(aMessage)) return tinyfd_messageBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDialogType, aIconType, aDefaultButton);
 
 	if ((!tinyfd_forceConsole || !(GetConsoleWindow() || dialogPresent()))
 		&& (!getenv("SSH_CLIENT") || getenvDISPLAY()))
@@ -2832,7 +2832,7 @@ int tinyfd_notifyPopup(
         char const * aIconType ) /* "info" "warning" "error" */
 {
 	if (tfd_quoteDetected(aTitle)) return tinyfd_notifyPopup("INVALID TITLE WITH QUOTES", aMessage, aIconType);
-	if (tfd_quoteDetected(aMessage)) return tinyfd_notifyPopup(aTitle, "INVALID MESSAGE WITH QUOTES", aIconType);
+	//if (tfd_quoteDetected(aMessage)) return tinyfd_notifyPopup(aTitle, "INVALID MESSAGE WITH QUOTES", aIconType);
 
     if ( powershellPresent() && (!tinyfd_forceConsole || !(
             GetConsoleWindow() ||
@@ -2870,7 +2870,7 @@ char * tinyfd_inputBox(
 	if (!aTitle && !aMessage && !aDefaultInput) return lBuff; /* now I can fill lBuff from outside */
 
 	if (tfd_quoteDetected(aTitle)) return tinyfd_inputBox("INVALID TITLE WITH QUOTES", aMessage, aDefaultInput);
-	if (tfd_quoteDetected(aMessage)) return tinyfd_inputBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDefaultInput);
+	//if (tfd_quoteDetected(aMessage)) return tinyfd_inputBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDefaultInput);
 	if (tfd_quoteDetected(aDefaultInput)) return tinyfd_inputBox(aTitle, aMessage, "INVALID DEFAULT_INPUT WITH QUOTES");
 
     mode = 0;
@@ -4277,7 +4277,7 @@ int tinyfd_messageBox(
         lBuff[0]='\0';
 
 		if (tfd_quoteDetected(aTitle)) return tinyfd_messageBox("INVALID TITLE WITH QUOTES", aMessage, aDialogType, aIconType, aDefaultButton);
-		if (tfd_quoteDetected(aMessage)) return tinyfd_messageBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDialogType, aIconType, aDefaultButton);
+		//if (tfd_quoteDetected(aMessage)) return tinyfd_messageBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDialogType, aIconType, aDefaultButton);
 
         lTitleLen =  aTitle ? strlen(aTitle) : 0 ;
         lMessageLen =  aMessage ? strlen(aMessage) : 0 ;
@@ -5257,7 +5257,7 @@ int tinyfd_notifyPopup(
         size_t lMessageLen ;
 
 		if (tfd_quoteDetected(aTitle)) return tinyfd_notifyPopup("INVALID TITLE WITH QUOTES", aMessage, aIconType);
-		if (tfd_quoteDetected(aMessage)) return tinyfd_notifyPopup(aTitle, "INVALID MESSAGE WITH QUOTES", aIconType);
+		//if (tfd_quoteDetected(aMessage)) return tinyfd_notifyPopup(aTitle, "INVALID MESSAGE WITH QUOTES", aIconType);
 
         if ( getenv("SSH_TTY") && !dunstifyPresent() && !dunstPresent() )
         {
@@ -5495,7 +5495,7 @@ char * tinyfd_inputBox(
         lBuff[0]='\0';
 
 		if (tfd_quoteDetected(aTitle)) return tinyfd_inputBox("INVALID TITLE WITH QUOTES", aMessage, aDefaultInput);
-		if (tfd_quoteDetected(aMessage)) return tinyfd_inputBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDefaultInput);
+		//if (tfd_quoteDetected(aMessage)) return tinyfd_inputBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDefaultInput);
 		if (tfd_quoteDetected(aDefaultInput)) return tinyfd_inputBox(aTitle, aMessage, "INVALID DEFAULT_INPUT WITH QUOTES");
 
         lTitleLen =  aTitle ? strlen(aTitle) : 0 ;

--- a/src/libs/tinyfiledialogs/tinyfiledialogs.c
+++ b/src/libs/tinyfiledialogs/tinyfiledialogs.c
@@ -1071,7 +1071,7 @@ int tinyfd_messageBoxW(
         if (aTitle&&!wcscmp(aTitle, L"tinyfd_query")){ strcpy(tinyfd_response, "windows_wchar"); return 1; }
 
 		if (quoteDetectedW(aTitle)) return tinyfd_messageBoxW(L"INVALID TITLE WITH QUOTES", aMessage, aDialogType, aIconType, aDefaultButton);
-		if (quoteDetectedW(aMessage)) return tinyfd_messageBoxW(aTitle, L"INVALID MESSAGE WITH QUOTES", aDialogType, aIconType, aDefaultButton);
+		//if (quoteDetectedW(aMessage)) return tinyfd_messageBoxW(aTitle, L"INVALID MESSAGE WITH QUOTES", aDialogType, aIconType, aDefaultButton);
 
         if (aIconType && !wcscmp(L"warning", aIconType))
         {
@@ -1160,7 +1160,7 @@ int tinyfd_notifyPopupW(
         if (aTitle && !wcscmp(aTitle, L"tinyfd_query")) { strcpy(tinyfd_response, "windows_wchar"); return 1; }
 
         if (quoteDetectedW(aTitle)) return tinyfd_notifyPopupW(L"INVALID TITLE WITH QUOTES", aMessage, aIconType);
-		if (quoteDetectedW(aMessage)) return tinyfd_notifyPopupW(aTitle, L"INVALID MESSAGE WITH QUOTES", aIconType);
+		//if (quoteDetectedW(aMessage)) return tinyfd_notifyPopupW(aTitle, L"INVALID MESSAGE WITH QUOTES", aIconType);
 
         lTitleLen = aTitle ? wcslen(aTitle) : 0;
         lMessageLen = aMessage ? wcslen(aMessage) : 0;
@@ -1236,7 +1236,7 @@ wchar_t * tinyfd_inputBoxW(
         if (aTitle&&!wcscmp(aTitle, L"tinyfd_query")){ strcpy(tinyfd_response, "windows_wchar"); return (wchar_t *)1; }
 
 		if (quoteDetectedW(aTitle)) return tinyfd_inputBoxW(L"INVALID TITLE WITH QUOTES", aMessage, aDefaultInput);
-		if (quoteDetectedW(aMessage)) return tinyfd_inputBoxW(aTitle, L"INVALID MESSAGE WITH QUOTES", aDefaultInput);
+		//if (quoteDetectedW(aMessage)) return tinyfd_inputBoxW(aTitle, L"INVALID MESSAGE WITH QUOTES", aDefaultInput);
 		if (quoteDetectedW(aDefaultInput)) return tinyfd_inputBoxW(aTitle, aMessage, L"INVALID DEFAULT_INPUT WITH QUOTES");
 
         lTitleLen =  aTitle ? wcslen(aTitle) : 0 ;

--- a/src/libs/tinyfiledialogs/tinyfiledialogs.h
+++ b/src/libs/tinyfiledialogs/tinyfiledialogs.h
@@ -1,10 +1,12 @@
-/* If you compiled tinyfiledialogs.c (maybe renamed with an extension ".cpp")
-with a C++ compiler, then comment out << extern "C" >> bellow in this header file) */
+/* SPDX-License-Identifier: ZLIB
+Copyright (c) 2014 - 2023 Guillaume Vareille http://ysengrin.com
 
-/*_________
- /         \ tinyfiledialogs.h v3.8.5 [Jan 17, 2021] zlib licence
+If you are using a C++ compiler to compile tinyfiledialogs.c (maybe renamed with an extension ".cpp")
+then comment out << extern "C" >> bellow in this header file)
+  _________
+ /         \ tinyfiledialogs.h v3.13.3 [Jul 2, 2023]
  |tiny file| Unique header file created [November 9, 2014]
- | dialogs | Copyright (c) 2014 - 2021 Guillaume Vareille http://ysengrin.com
+ | dialogs |
  \____  ___/ http://tinyfiledialogs.sourceforge.net
       \|     git clone http://git.code.sf.net/p/tinyfiledialogs/code tinyfd
  ____________________________________________
@@ -14,11 +16,12 @@ with a C++ compiler, then comment out << extern "C" >> bellow in this header fil
  ________________________________________________________________________________
 |  ____________________________________________________________________________  |
 | |                                                                            | |
+| |  - in tinyfiledialogs, char is UTF-8 by default (since v3.6)               | |
+| |                                                                            | |
 | | on windows:                                                                | |
 | |  - for UTF-16, use the wchar_t functions at the bottom of the header file  | |
 | |  - _wfopen() requires wchar_t                                              | |
 | |                                                                            | |
-| |  - in tinyfiledialogs, char is UTF-8 by default (since v3.6)               | |
 | |  - but fopen() expects MBCS (not UTF-8)                                    | |
 | |  - if you want char to be MBCS: set tinyfd_winUtf8 to 0                    | |
 | |                                                                            | |
@@ -91,14 +94,15 @@ extern char tinyfd_needs[]; /* info about requirements */
 extern int tinyfd_verbose; /* 0 (default) or 1 : on unix, prints the command line calls */
 extern int tinyfd_silent; /* 1 (default) or 0 : on unix, hide errors and warnings from called dialogs */
 
-/* Curses dialogs are difficult to use, on windows they are only ascii and uses the unix backslah */
+/** Curses dialogs are difficult to use and counter-intuitive.
+On windows they are only ascii and still uses the unix backslash ! **/
 extern int tinyfd_allowCursesDialogs; /* 0 (default) or 1 */
 
 extern int tinyfd_forceConsole;  /* 0 (default) or 1 */
 /* for unix & windows: 0 (graphic mode) or 1 (console mode).
 0: try to use a graphic solution, if it fails then it uses console mode.
-1: forces all dialogs into console mode even when an X server is present,
-   it can use the package dialog or dialog.exe.
+1: forces all dialogs into console mode even when an X server is present.
+   if enabled, it can use the package Dialog or dialog.exe.
    on windows it only make sense for console applications */
 
 extern int tinyfd_assumeGraphicDisplay; /* 0 (default) or 1  */
@@ -112,9 +116,9 @@ but will return 0 for console mode, 1 for graphic mode.
 tinyfd_response is then filled with the retain solution.
 possible values for tinyfd_response are (all lowercase)
 for graphic mode:
-  windows_wchar windows applescript kdialog zenity zenity3 matedialog
-  shellementary qarma yad python2-tkinter python3-tkinter python-dbus
-  perl-dbus gxmessage gmessage xmessage xdialog gdialog
+  windows_wchar windows applescript kdialog zenity zenity3 yad matedialog
+  shellementary qarma python2-tkinter python3-tkinter python-dbus
+  perl-dbus gxmessage gmessage xmessage xdialog gdialog dunst
 for console mode:
   dialog whiptail basicinput no_solution */
 
@@ -137,7 +141,7 @@ int tinyfd_messageBox(
 char * tinyfd_inputBox(
 	char const * aTitle , /* NULL or "" */
 	char const * aMessage , /* NULL or "" (\n and \t have no effect) */
-	char const * aDefaultInput ) ;  /* NULL passwordBox, "" inputbox */
+	char const * aDefaultInput ) ;  /* NULL = passwordBox, "" = inputbox */
 		/* returns NULL on cancel */
 
 char * tinyfd_saveFileDialog(
@@ -165,14 +169,14 @@ char * tinyfd_selectFolderDialog(
 
 char * tinyfd_colorChooser(
 	char const * aTitle, /* NULL or "" */
-	char const * aDefaultHexRGB, /* NULL or "#FF0000" */
+	char const * aDefaultHexRGB, /* NULL or "" or "#FF0000" */
 	unsigned char const aDefaultRGB[3] , /* unsigned char lDefaultRGB[3] = { 0 , 128 , 255 }; */
 	unsigned char aoResultRGB[3] ) ; /* unsigned char lResultRGB[3]; */
-		/* returns the hexcolor as a string "#FF0000" */
-		/* aoResultRGB also contains the result */
-		/* aDefaultRGB is used only if aDefaultHexRGB is NULL */
+		/* aDefaultRGB is used only if aDefaultHexRGB is absent */
 		/* aDefaultRGB and aoResultRGB can be the same array */
 		/* returns NULL on cancel */
+		/* returns the hexcolor as a string "#FF0000" */
+		/* aoResultRGB also contains the result */
 
 
 /************ WINDOWS ONLY SECTION ************************/


### PR DESCRIPTION
Mounting large size images (4GB+) via gui menu on VS builds was silently ignored.
I found that this was due to a bug in tinyfiledialog, so bump the code to the latest at this moment.

## What issue(s) does this PR address?
Large size images are now mountable via gui menu on VS builds. (Also maybe MinGW builds as well)
Also fix #3873
