### PR TITLE
Debugger fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -47,6 +47,8 @@ Next
     builds) (maron2000)
   - Fix day of week detection (INT 21h 0x2Ah). (maron2000)
   - Refine KEYB and CHCP command (maron2000)
+  - Fix disassembly for far jmp/call decoding (cimarronm)
+  - Fix memory limits on expand-down segment descriptors (cimarronm)
 2023.05.01
   - IMGMAKE will choose LBA partition types for 2GB or larger disk
     images, but the user can also use -chs and -lba options to override

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -391,7 +391,8 @@ uint64_t LinMakeProt(uint16_t selector, uint32_t offset)
 
     if (cpu.gdt.GetDescriptor(selector,desc)) {
         if (selector >= 8 && desc.Type() != 0) {
-            if (offset <= desc.GetLimit())
+            if ( (!desc.GetExpandDown() && offset <= desc.GetLimit()) ||
+                 ( desc.GetExpandDown() && offset >  desc.GetLimit()) )
                 return desc.GetBase()+(uint64_t)offset;
         }
     }

--- a/src/debug/debug_disasm.cpp
+++ b/src/debug/debug_disasm.cpp
@@ -1046,7 +1046,7 @@ static void percent(char type, char subtype)
 
   switch (type) {
   case 'A':                          /* direct address */
-       outhex(subtype, extend, 0, addrsize, 0);
+       outhex(subtype, extend, 0, opsize, 0);
        break;
 
   case 'C':                          /* reg(r/m) picks control reg */


### PR DESCRIPTION
Fixes in debug disassembly and segment descriptor limits

## What issue(s) does this PR address?

1. Fixes far direct jmp/call disassembly to use operand-size prefix instead of address-size prefix

### Reference from DOS debug
```
A:\> debug test.com
-u 100
0827:0100 66EABC9A78563412  JMP     1234:56789ABC
0827:0108 0000              ADD     [BX+SI],AL
0827:010A 0000              ADD     [BX+SI],AL
0827:010C 0000              ADD     [BX+SI],AL
0827:010E 0000              ADD     [BX+SI],AL
0827:0110 0000              ADD     [BX+SI],AL
0827:0112 0000              ADD     [BX+SI],AL
0827:0114 0000              ADD     [BX+SI],AL
0827:0116 0000              ADD     [BX+SI],AL
0827:0118 0000              ADD     [BX+SI],AL
0827:011A 0000              ADD     [BX+SI],AL
0827:011C 0000              ADD     [BX+SI],AL
0827:011E 0000              ADD     [BX+SI],AL
``` 

### dosbox's debugger
#### before fix
```
⎺⎺⎺⎺Code Overview⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
0827:00000100 66EABC9A7856        jmp  5678:9ABC
0827:00000106 3412                xor  al,12
0827:00000108 0000                add  [bx+si],al             ds:[3378]=626F
0827:0000010A 0000                add  [bx+si],al             ds:[3378]=626F
...
```

#### after fix
```
⎺⎺⎺Code Overview⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺⎺
0827:00000100 66EABC9A78563412    jmp  1234:56789ABC
0827:00000108 0000                add  [bx+si],al             ds:[3378]=626F
0827:0000010A 0000                add  [bx+si],al             ds:[3378]=626F
...
```

2. Fixes segment descriptor limits on expand-down segments

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No