### PR TITLE
Debugger disassembly improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -47,6 +47,9 @@ Next
     builds) (maron2000)
   - Fix day of week detection (INT 21h 0x2Ah). (maron2000)
   - Refine KEYB and CHCP command (maron2000)
+  - Use segment descriptor's big flag (if present) when disassembling code in
+    the debugger code view (cimarronm)
+  - Add decoding of rdmsr/wrmsr instructions to disassembler (cimarronm)
 2023.05.01
   - IMGMAKE will choose LBA partition types for 2GB or larger disk
     images, but the user can also use -chs and -lba options to override

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -1294,7 +1294,12 @@ static void DrawCode(void) {
 		Bitu drawsize;
 
         if (start != mem_no_address) {
-            drawsize=size=DasmI386(dline, (PhysPt)start, disEIP, cpu.code.big);
+            Descriptor desc;
+
+            if (cpu.gdt.GetDescriptor(codeViewData.useCS, desc))
+                drawsize=size=DasmI386(dline, (PhysPt)start, disEIP, desc.saved.seg.big);
+            else
+                drawsize=size=DasmI386(dline, (PhysPt)start, disEIP, cpu.code.big);
         }
         else {
             drawsize=size=1;

--- a/src/debug/debug_disasm.cpp
+++ b/src/debug/debug_disasm.cpp
@@ -290,7 +290,7 @@ static char const *second[] = {
   "%x0",              "%x0",             "%x0",            "%x0",
   "%x0",              "%x0",             "%x0",            "%x0",
 /* 3 */
-  0,                  "rdtsc",           0,                0,
+  "wrmsr",            "rdtsc",           "rdmsr",          0,
   "sysenter",         "sysexit",         0,                0,
   0,                  0,                 0,                0,
   0,                  0,                 0,                0,


### PR DESCRIPTION
## What issue(s) does this PR address?

Takes into account the `big` flag of the segment descriptor for the code disassembly being displayed if present otherwise it falls back into use the current mode of the cpu.
Adds decoding of `rdmsr`/`wrmsr` instructions to disassembler.

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No