### PR TITLE
Log SDL2 version

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8707,6 +8707,13 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
             sdl.inited = true;
         else
             E_Exit("Can't init SDL %s",SDL_GetError());
+#if defined(C_SDL2)
+        SDL_version sdl_version;
+        SDL_GetVersion(&sdl_version);
+        LOG_MSG("SDL: version %d.%d.%d, Video %s, Audio %s)",
+            sdl_version.major, sdl_version.minor, sdl_version.patch,
+            SDL_GetCurrentVideoDriver(), SDL_GetCurrentAudioDriver());
+#endif //defined (C_SDL2)
 
         /* -- -- decide whether to show menu in GUI */
         if (control->opt_nogui || menu.compatible)


### PR DESCRIPTION
Some DOSBox-X builds seems to be built using system installed SDL2 library rather than the in-tree one.
Therefore, show SDL2 version in log to easily confirm which version it is running on.