### PR TITLE
Fixed space key input when IME ON in SDL2 version

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -5744,7 +5744,7 @@ void GFX_Events() {
             if (event.type == SDL_KEYDOWN && isModifierApplied())
                 ClipKeySelect(event.key.keysym.sym);
             if(dos.im_enable_flag) {
-#if defined (WIN32) && !defined(HX_DOS) || defined(MACOSX)
+#if defined(MACOSX)
                 if(event.type == SDL_KEYDOWN && IME_GetEnable()) {
                     // Enter, BS, TAB, <-, ->
                     if(event.key.keysym.sym == 0x0d || event.key.keysym.sym == 0x08 || event.key.keysym.sym == 0x09 || (event.key.keysym.scancode >= 0x4f && event.key.keysym.scancode <= 0x52)) {
@@ -5752,16 +5752,14 @@ void GFX_Events() {
                             break;
                         }
                     } else {
-                        if((event.key.keysym.mod & 0x03) == 0 && event.key.keysym.scancode == 0x2c && ime_text.size() == 0 && dos.loaded_codepage == 932) {
-                            // Zenkaku space
-                            BIOS_AddKeyToBuffer(0xf100 | 0x81);
-                            BIOS_AddKeyToBuffer(0xf000 | 0x40);
-                            break;
-                        }
-#if defined(WIN32)
-                        else if(ime_text.size() != 0)
-#endif
-                            break;
+                        if(event.key.keysym.scancode == 0x2c && ime_text.size() == 0 && dos.loaded_codepage == 932) {
+                            if((event.key.keysym.mod & 0x03) == 0) {
+                                // Zenkaku space
+                                BIOS_AddKeyToBuffer(0xf100 | 0x81);
+                                BIOS_AddKeyToBuffer(0xf000 | 0x40);
+                                break;
+                            }
+                        } else break;
                     }
                 }
 #endif

--- a/vs/sdl2/src/video/windows/SDL_windowsevents.c
+++ b/vs/sdl2/src/video/windows/SDL_windowsevents.c
@@ -636,7 +636,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
                     SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_CLOSE, 0, 0);
                 }
             }
-            if ((wParam != VK_PROCESSKEY || (lParam >> 16) == 0x39) && code != SDL_SCANCODE_UNKNOWN) {
+            if (wParam != VK_PROCESSKEY && code != SDL_SCANCODE_UNKNOWN) {
                 SDL_SendKeyboardKey(SDL_PRESSED, code);
             }
         }

--- a/vs/sdl2/src/video/windows/SDL_windowskeyboard.c
+++ b/vs/sdl2/src/video/windows/SDL_windowskeyboard.c
@@ -892,6 +892,16 @@ IME_HandleMessage(HWND hwnd, UINT msg, WPARAM wParam, LPARAM *lParam, SDL_VideoD
         IME_InputLangChanged(videodata);
         break;
     case WM_IME_CHAR:
+        if(wParam == 0x20) {
+            // enable IME input space
+            PostMessage(hwnd, WM_KEYDOWN, 0x20, 0x390001);
+        } else if(wParam == 0x3000) {
+            // input Zenkaku space
+            videodata->ime_composition[0] = 0x3000;
+            videodata->ime_composition[1] = 0;
+            IME_SendEditingEvent(videodata);
+            IME_SendInputEvent(videodata);
+        }
         trap = SDL_TRUE;
         break;
     case WM_IME_SETCONTEXT:


### PR DESCRIPTION
Fixed a space being entered when the space key is pressed in the guess candidate display in ChangJie IME.
Fixed that half-width space is not input when pressing space key while holding down Shift when IME is on in macOS.
