### PR TITLE
mt32 disabled for aarch64 by default fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -858,6 +858,10 @@ if test x$enable_mt32 = xyes ; then
       AC_MSG_RESULT(yes)
       AC_DEFINE(C_MT32,1)
       ;;
+    aarch64)
+      AC_MSG_RESULT(yes)
+      AC_DEFINE(C_MT32,1)
+      ;;
     *)
       enable_mt32=no
       AC_MSG_RESULT(no)


### PR DESCRIPTION
## What issue(s) does this PR address?

mt32 is disabled by default for aarch64 architecture, which works fine on this architecture

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No

## Additional information
https://github.com/joncampbell123/dosbox-x/issues/2056
