### PR TITLE
Fix mouse column limit on text mode (issue #4353)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -53,6 +53,7 @@ Next
   - Fix disassembly for far jmp/call decoding (cimarronm)
   - Fix memory limits on expand-down segment descriptors (cimarronm)
   - Bump tinyfiledialog to ver 3.13.3 (maron2000)
+  - Fix mouse column limit on text mode (issue #4353) (maron2000)
 2023.05.01
   - IMGMAKE will choose LBA partition types for 2GB or larger disk
     images, but the user can also use -chs and -lba options to override

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -1289,6 +1289,7 @@ void Mouse_AfterNewVideoMode(bool setmode) {
             if ((rows == 0) || (rows > 250)) rows = 25 - 1;
             mouse.max_y = 8*(rows+1) - 1;
             uint16_t cols = real_readb(BIOSMEM_SEG, BIOSMEM_NB_COLS);
+            if((cols == 0) || (cols > 250)) cols = 80;
             mouse.max_x = cols * 8 - 1;
         }
         break;

--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -1288,6 +1288,8 @@ void Mouse_AfterNewVideoMode(bool setmode) {
             Bitu rows = IS_EGAVGA_ARCH?real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS):24;
             if ((rows == 0) || (rows > 250)) rows = 25 - 1;
             mouse.max_y = 8*(rows+1) - 1;
+            uint16_t cols = real_readb(BIOSMEM_SEG, BIOSMEM_NB_COLS);
+            mouse.max_x = cols * 8 - 1;
         }
         break;
     }


### PR DESCRIPTION
Refering to the fix on dosbox-staging, fix issue which moving mouse cursor past 80th column was not possible.
I personally tested dos navigator 6.4.0 (mentioned in #4353) on Visual Studio x64 build. 

## What issue(s) does this PR address?
Fixes #4353

