### PR TITLE
Fixed keyboardlayout=jp to be Japanese keyboard layout.

### DIFF
--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -1712,7 +1712,7 @@ public:
 			}
 		}
         if (tocp && !IS_PC98_ARCH) {
-            if(dos.loaded_codepage == 932 && !strcmp(layoutname, "jp106")) loaded_layout->read_keyboard_file(layoutname, dos.loaded_codepage);
+            if((dos.loaded_codepage == 932 || tocp == 932) && (!strcmp(layoutname, "jp106") || !strcmp(layoutname, "jp"))) loaded_layout->read_keyboard_file(layoutname, 932);
 
             uint16_t cpbak = dos.loaded_codepage;
 #if defined(USE_TTF)


### PR DESCRIPTION
Fixed [dos] keyboardlayout=jp in dosbox-x.conf to use Japanese keyboard layout.