### PR TITLE
Fix IMGMAKE error message

### DIFF
--- a/contrib/translations/de/de_DE.lng
+++ b/contrib/translations/de/de_DE.lng
@@ -1198,7 +1198,7 @@ In Datei "%s" kann nicht geschrieben werden.
 .
 :PROGRAM_IMGMAKE_NOT_ENOUGH_SPACE
 Für das Image ist nicht genug Speicher verfügbar.
-%u Byte benötigt.
+%llu Byte benötigt.
 
 .
 :PROGRAM_IMGMAKE_PRINT_CHS

--- a/contrib/translations/de/de_pc98.lng
+++ b/contrib/translations/de/de_pc98.lng
@@ -1198,7 +1198,7 @@ In Datei "%s" kann nicht geschrieben werden.
 .
 :PROGRAM_IMGMAKE_NOT_ENOUGH_SPACE
 Fuer das Image ist nicht genug Speicher verfuegbar.
-%u Byte benoetigt.
+%llu Byte benoetigt.
 
 .
 :PROGRAM_IMGMAKE_PRINT_CHS

--- a/contrib/translations/en/en_US.lng
+++ b/contrib/translations/en/en_US.lng
@@ -1183,7 +1183,7 @@ The file "%s" cannot be opened for writing.
 
 .
 :PROGRAM_IMGMAKE_NOT_ENOUGH_SPACE
-Not enough space available for the image file. Need %u bytes.
+Not enough space available for the image file. Need %llu bytes.
 
 .
 :PROGRAM_IMGMAKE_PRINT_CHS

--- a/contrib/translations/es/es_ES.lng
+++ b/contrib/translations/es/es_ES.lng
@@ -1185,7 +1185,7 @@ El archivo "%s" no se puede abrir para escritura.
 
 .
 :PROGRAM_IMGMAKE_NOT_ENOUGH_SPACE
-Espacio insuficiente para archivo imagen. Necesitas %u bytes
+Espacio insuficiente para archivo imagen. Necesitas %llu bytes
 
 .
 :PROGRAM_IMGMAKE_PRINT_CHS

--- a/contrib/translations/fr/fr_FR.lng
+++ b/contrib/translations/fr/fr_FR.lng
@@ -1182,7 +1182,7 @@ Le fichier "%s" ne peut pas être ouvert en écriture.
 
 .
 :PROGRAM_IMGMAKE_NOT_ENOUGH_SPACE
-Pas assez d'espace disponible pour le fichier image. Besoin de %u octets.
+Pas assez d'espace disponible pour le fichier image. Besoin de %llu octets.
 
 .
 :PROGRAM_IMGMAKE_PRINT_CHS

--- a/contrib/translations/ja/ja_JP.lng
+++ b/contrib/translations/ja/ja_JP.lng
@@ -1179,7 +1179,8 @@ IMGMAKE の使用例:
 
 .
 :PROGRAM_IMGMAKE_NOT_ENOUGH_SPACE
-イメージファイルを作成するのに必要な空き容量が %llu バイト足りません。
+イメージファイルを作成するのにディスクの空き容量が不足しています。
+%llu バイト必要です。
 
 .
 :PROGRAM_IMGMAKE_PRINT_CHS

--- a/contrib/translations/ja/ja_JP.lng
+++ b/contrib/translations/ja/ja_JP.lng
@@ -1179,7 +1179,7 @@ IMGMAKE の使用例:
 
 .
 :PROGRAM_IMGMAKE_NOT_ENOUGH_SPACE
-イメージファイルを作成するのに必要な空き容量が %u バイト足りません。
+イメージファイルを作成するのに必要な空き容量が %llu バイト足りません。
 
 .
 :PROGRAM_IMGMAKE_PRINT_CHS

--- a/contrib/translations/ko/ko_KR.lng
+++ b/contrib/translations/ko/ko_KR.lng
@@ -1190,7 +1190,7 @@ IMGMAKE의 몇 가지 사용 예:
 
 .
 :PROGRAM_IMGMAKE_NOT_ENOUGH_SPACE
-이미지 파일을 만드는 데 필요한 여유 공간이 %u바이트가 부족합니다.
+이미지 파일을 만드는 데 필요한 여유 공간이 %llu바이트가 부족합니다.
 
 .
 :PROGRAM_IMGMAKE_PRINT_CHS

--- a/contrib/translations/nl/nl_NL.lng
+++ b/contrib/translations/nl/nl_NL.lng
@@ -1182,7 +1182,7 @@ Het bestand "%s" kan niet worden geopend om te schrijven.
 
 .
 :PROGRAM_IMGMAKE_NOT_ENOUGH_SPACE
-Onvoldoende ruimte beschikbaar voor het imagebestand. %u bytes nodig.
+Onvoldoende ruimte beschikbaar voor het imagebestand. %llu bytes nodig.
 
 .
 :PROGRAM_IMGMAKE_PRINT_CHS

--- a/contrib/translations/pt/pt_BR.lng
+++ b/contrib/translations/pt/pt_BR.lng
@@ -1188,7 +1188,7 @@ O arquivo "%s" não pode ser aberto para escrita.
 
 .
 :PROGRAM_IMGMAKE_NOT_ENOUGH_SPACE
-Espaço insuficiente para o arquivo de imagem. Precisa de %u bytes.
+Espaço insuficiente para o arquivo de imagem. Precisa de %llu bytes.
 
 .
 :PROGRAM_IMGMAKE_PRINT_CHS

--- a/contrib/translations/tr/tr_TR.lng
+++ b/contrib/translations/tr/tr_TR.lng
@@ -1182,7 +1182,7 @@ Disk geometrisi: %d silindir, %d kafa, %d sektör, %d kilobayt
 
 .
 :PROGRAM_IMGMAKE_NOT_ENOUGH_SPACE
-Kalıp dosyası için yeterli boş alan yok. %u bayt daha gerekli.
+Kalıp dosyası için yeterli boş alan yok. %llu bayt daha gerekli.
 
 .
 :PROGRAM_IMGMAKE_PRINT_CHS

--- a/contrib/translations/zh/zh_CN.lng
+++ b/contrib/translations/zh/zh_CN.lng
@@ -1171,7 +1171,7 @@ BIOSTEST 镜像文件
 
 .
 :PROGRAM_IMGMAKE_NOT_ENOUGH_SPACE
-没有足够的空间生成镜像文件. 需要 %u 字节.
+没有足够的空间生成镜像文件. 需要 %llu 字节.
 
 .
 :PROGRAM_IMGMAKE_PRINT_CHS

--- a/contrib/translations/zh/zh_TW.lng
+++ b/contrib/translations/zh/zh_TW.lng
@@ -1176,7 +1176,7 @@ BIOSTEST 映像檔
 
 .
 :PROGRAM_IMGMAKE_NOT_ENOUGH_SPACE
-沒有足夠的空間產生映像檔. 需要 %u 位元組.
+沒有足夠的空間產生映像檔. 需要 %llu 位元組.
 
 .
 :PROGRAM_IMGMAKE_PRINT_CHS

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -9392,7 +9392,7 @@ void DOS_SetupPrograms(void) {
 #endif
     MSG_Add("PROGRAM_IMGMAKE_FILE_EXISTS","The file \"%s\" already exists. You can specify \"-force\" to overwrite.\n");
     MSG_Add("PROGRAM_IMGMAKE_CANNOT_WRITE","The file \"%s\" cannot be opened for writing.\n");
-    MSG_Add("PROGRAM_IMGMAKE_NOT_ENOUGH_SPACE","Not enough space available for the image file. Need %lld bytes.\n");
+    MSG_Add("PROGRAM_IMGMAKE_NOT_ENOUGH_SPACE","Not enough space available for the image file. Need %llu bytes.\n");
     MSG_Add("PROGRAM_IMGMAKE_PRINT_CHS","Creating image file \"%s\" with %u cylinders, %u heads and %u sectors\n");
     MSG_Add("PROGRAM_IMGMAKE_CANT_READ_FLOPPY","\n\nUnable to read floppy.");
     MSG_Add("PROGRAM_IMGMAKE_BADSIZE","Wrong -size or -chs arguments.\n");


### PR DESCRIPTION
Error message regarding not enough free space was fixed in #4357, but was only for English messages.
This PR fixes the same for other languages as well.
