### PR TITLE
Make it possible to set date in December

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1520,7 +1520,7 @@ static Bitu DOS_21Handler(void) {
                 if (reg_cx % 4 == 0 && (reg_cx % 100 != 0 || reg_cx % 400 == 0))
                     maxday[1]++;
 
-                if (reg_cx < 1980 || reg_cx > 9999 || reg_dh < 1 || reg_dh > 12 || reg_dl < 1 || reg_dl > maxday[reg_dh])
+                if (reg_cx < 1980 || reg_cx > 9999 || reg_dh < 1 || reg_dh > 12 || reg_dl < 1 || reg_dl > maxday[reg_dh - 1])
                 {
                     reg_al = 0xff;              // error!
                     break;                      // done


### PR DESCRIPTION
An off-by-one error prevented using the DATE shell command (and maybe others?) to set a date in December.

It was caused by the actual Month value (1-indexed) being used an index for for the `maxday` array. 

Edit: This also fixes setting the date to January 30th (and 29th in non-leap years) because for January the `maxdays` entry for February was used.

## What issue(s) does this PR address?

Not being able to set a date in December using the `DATE` shell command.

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

No.

## Additional information

I encountered the issue when using the `DATE` shell command but since I fixed it in the `0x2b` interrupt handler maybe there were other places where this bug popped up?