### PR TITLE
Fix launching Blocek issue (#4385)

### DIFF
--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -575,7 +575,7 @@ bool DOS_FindFirst(const char * search,uint16_t attr,bool fcb_findfirst) {
 	if (!DOS_MakeName(search,fullsearch,&drive,attr == DOS_ATTR_VOLUME)) return false;
 	//Check for devices. FindDevice checks for leading subdir as well
     bool device = false;
-    if (attr & DOS_ATTR_DEVICE)
+    //if (attr & DOS_ATTR_DEVICE) /* FIX_ME: This line deleted to fix launching Blocek editor (Issue #4385), revert this if this induces other errors */
         device = DOS_FindDevice(search) != DOS_DEVICES;
 
     /* Split the search in dir and pattern */


### PR DESCRIPTION
A conditional branch added in commit 79cca9d prevents Blocek editor from launching.
Since it was confirmed that the line is not essential, remove the line to enable Blocek to be launchable.

## What issue(s) does this PR address?
Fixes #4385 
