### PR TITLE
Enable debugger function for MinGW builds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -54,6 +54,9 @@ Next
   - Fix memory limits on expand-down segment descriptors (cimarronm)
   - Bump tinyfiledialog to ver 3.13.3 (maron2000)
   - Fix mouse column limit on text mode (issue #4353) (maron2000)
+  - Fix Blocek launching failure (issue #4385) (maron2000)
+  - Bump in-tree FreeType library to ver 2.13.1 (maron2000)
+  - Enable debugger function for MinGW builds (maron2000)
 2023.05.01
   - IMGMAKE will choose LBA partition types for 2GB or larger disk
     images, but the user can also use -chs and -lba options to override

--- a/build-mingw
+++ b/build-mingw
@@ -62,11 +62,15 @@ CXXFLAGS="${new}${CXXFLAGS}"
 INTERNAL_FREETYPE=1
 export CFLAGS LDFLAGS CPPFLAGS CXXFLAGS INTERNAL_FREETYPE
 
-pacman -S --needed --noconfirm mingw-w64-x86_64-libslirp &>/dev/null
+#pacman -S --needed --noconfirm mingw-w64-x86_64-libslirp &>/dev/null
+
+CXXFLAGS="$CXXFLAGS -DNCURSES_STATIC "
+CPPFLAGS="$CPPFLAGS -DNCURSES_STATIC "
+CFLAGS="$CFLAGS -DNCURSES_STATIC "
+export CFLAGS CPPFLAGS CXXFLAGS
 
 # now compile ourself
 echo "Compiling DOSBox-X"
 chmod +x configure
-# FIXME: I would like MinGW builds to enable the debugger, eventually
-./configure --enable-d3d9 --enable-d3d-shaders --disable-libfluidsynth --prefix=/usr "${@}" || exit 1
+./configure --enable-debug --disable-avcodec --enable-d3d9 --enable-d3d-shaders --disable-libfluidsynth --prefix=/usr "${@}" || exit 1
 make -j3 || exit 1

--- a/build-mingw-sdl2
+++ b/build-mingw-sdl2
@@ -15,8 +15,8 @@ chmod +x vs/sdl/build-scripts/strip_fPIC.sh
 # prefer to compile against our own copy of SDL 2.x IF the system does not provide one
 x=$(which sdl2-config)
 if test -z "${x}" ; then
-    echo "Compiling our internal SDL 2.x"
-    (cd vs/sdl2 && ./build-dosbox.sh) || exit 1
+   echo "Compiling our internal SDL 2.x"
+   (cd vs/sdl2 && ./build-dosbox.sh) || exit 1
 fi
 
 # prefer to compile against our own copy of SDLnet 1.x
@@ -60,11 +60,15 @@ CXXFLAGS="${new}${CXXFLAGS}"
 INTERNAL_FREETYPE=1
 export CFLAGS LDFLAGS CPPFLAGS CXXFLAGS INTERNAL_FREETYPE
 
-pacman -S --needed --noconfirm mingw-w64-x86_64-libslirp &>/dev/null
+# pacman -S --needed --noconfirm mingw-w64-x86_64-libslirp &>/dev/null
+
+CXXFLAGS="$CXXFLAGS -DNCURSES_STATIC "
+CPPFLAGS="$CPPFLAGS -DNCURSES_STATIC "
+CFLAGS="$CFLAGS -DNCURSES_STATIC "
+export CFLAGS CPPFLAGS CXXFLAGS
 
 # now compile ourself
 echo "Compiling DOSBox-X"
 chmod +x configure
-# FIXME: I would like MinGW builds to enable the debugger, eventually
-./configure --enable-d3d9 --enable-d3d-shaders --disable-libfluidsynth --prefix=/usr --enable-sdl2 "${@}" || exit 1
+./configure --enable-debug --disable-avcodec --enable-d3d9 --enable-d3d-shaders --disable-libfluidsynth --enable-sdl2 --prefix=/usr "${@}" || exit 1
 make -j3 || exit 1

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8712,7 +8712,9 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
             sdl_version.major, sdl_version.minor, sdl_version.patch,
             SDL_GetCurrentVideoDriver(), SDL_GetCurrentAudioDriver());
 #endif //defined (C_SDL2)
-
+#if defined(__MINGW32__) && defined(C_DEBUG)
+        LOG_MSG("EXPERIMENTAL: Debugger enabled for MinGW build, DOSBox-X crashes depending on the terminal software you use. Launching from command prompt (cmd.exe) is recommended.");
+#endif
         /* -- -- decide whether to show menu in GUI */
         if (control->opt_nogui || menu.compatible)
             menu.gui=false;


### PR DESCRIPTION
This PR introduces the debugger function to MinGW builds (excl. lowend build).
There is a known limitation due to the `ncurses` library, that debugger will crash DOSBox-X if launched from MSYS2 MinGW64 terminal.
Such crash can be avoided by either launching DOSBox-X by double-clicking the .exe file or launch from Command prompt (cmd.exe)
For MSYS2 MinGW64 terminal, you need to enter `unset TERM` command before launching DOSBox-X in order to use the debugger.

Refer to the following page for some more information.
https://stackoverflow.com/questions/75350336/ncurses-program-using-mingw-w64-fails-with-error-opening-terminal-xterm

![mingw_debugger](https://github.com/joncampbell123/dosbox-x/assets/68574602/ba188db6-4d3d-4373-b62a-5954d9f6d7dd)
