### PR TITLE
CHANGELOG - FFMPEG update moved from 2022.09.0 to 2022.12.26

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -633,12 +633,12 @@
   - Fix unexpected behavior of swapping multiple CD images
     (maron2000)
   - Fixed build on NetBSD and FreeBSD (Jookia)
-
-2022.09.0 (0.84.3)
   - Updated FFMPEG video capture to use newer API,
     fix memory leaks, and fix use-after-free bug that
     may have been responsible for occasional crashes
     when using the function. (joncampbell123)
+
+2022.09.0 (0.84.3)
   - Added 86PCM support for PC-98 emulation. (nanshiki)
   - Added German language translation. (Link-Mario)
   - Added code page 867 (compatible with Hebrew DOS


### PR DESCRIPTION
To address #3702 along with PR #4413