### PR TITLE
HX-DOS fix pre-upload testing failure

### DIFF
--- a/.github/workflows/hxdos.yml
+++ b/.github/workflows/hxdos.yml
@@ -82,9 +82,10 @@ jobs:
           $top/vs/tool/zip.exe -r -9 $top/dosbox-x-mingw-hx-dos-${{ env.timestamp }}.zip *
           cd $top
       - name: Wait for VS 32bit build to finish (Release only)
+        if: startsWith(github.ref, 'refs/tags/')
         shell: bash
         run: |
-          sleep 30m
+          sleep 40m
       - name: Download Windows build
         uses: robinraju/release-downloader@v1.8
         with:

--- a/.github/workflows/hxdos.yml
+++ b/.github/workflows/hxdos.yml
@@ -81,6 +81,10 @@ jobs:
           cd $top/package/
           $top/vs/tool/zip.exe -r -9 $top/dosbox-x-mingw-hx-dos-${{ env.timestamp }}.zip *
           cd $top
+      - name: Wait for VS 32bit build to finish (Release only)
+        shell: bash
+        run: |
+          sleep 30m
       - name: Download Windows build
         uses: robinraju/release-downloader@v1.8
         with:


### PR DESCRIPTION
HX-DOS builds tests itself by running it on VS builds before Release/Development builds are uploaded.
Upon building release versions, test may fail because VS release builds are yet to be built and missing, therefore wait for sometime to finish building it.