### PR TITLE
Fix macos crash on launch when output=surface or auto (SDL2)

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3756,12 +3756,12 @@ static void GUI_StartUp() {
     else if (output == "ttf")
     {
         LOG_MSG("SDL(sdlmain.cpp): TTF activated");
-#if C_DIRECT3D
-        if(!init_output) OUTPUT_DIRECT3D_Select();
+#if defined(WIN32) && !defined(C_SDL2)
+        if(!init_output) OUTPUT_SURFACE_Select(); // Initialize screen by output=surface for Windows for SDL1
 #elif C_OPENGL
         if(!init_output) OUTPUT_OPENGL_Select(GLBilinear); // Initialize screen before switching to TTF (required for macOS builds)     
 #else
-        OUTPUT_SURFACE_Select();
+        if(!init_output) OUTPUT_SURFACE_Select();
 #endif // C_DIRECT3D || C_OPENGL
         OUTPUT_TTF_Select(0);
         init_output = true;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3756,13 +3756,9 @@ static void GUI_StartUp() {
     else if (output == "ttf")
     {
         LOG_MSG("SDL(sdlmain.cpp): TTF activated");
-#if defined(WIN32) && !defined(C_SDL2)
-        if(!init_output) OUTPUT_SURFACE_Select(); // Initialize screen by output=surface for Windows for SDL1
-#elif C_OPENGL
-        if(!init_output) OUTPUT_OPENGL_Select(GLBilinear); // Initialize screen before switching to TTF (required for macOS builds)     
-#else
-        if(!init_output) OUTPUT_SURFACE_Select();
-#endif // C_DIRECT3D || C_OPENGL
+#if ((WIN32 && !defined(C_SDL2)) || MACOSX) && C_OPENGL
+        if(!init_output) OUTPUT_OPENGL_Select(GLBilinear); // Initialize screen before switching to TTF (required for Windows & macOS builds)
+#endif
         OUTPUT_TTF_Select(0);
         init_output = true;
     }

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -160,6 +160,7 @@ extern int tryconvertcp, Reflect_Menu(void);
 #include <output/output_tools.h>
 #include <output/output_ttf.h>
 #include <output/output_tools_xbrz.h>
+static bool init_output = false;
 
 #if defined(WIN32)
 #include "resource.h"
@@ -3714,7 +3715,13 @@ static void GUI_StartUp() {
     sdl.desktop.isperfect = false; /* Reset before selection */
     if (output == "surface") 
     {
+#if C_DIRECT3D
+        if(!init_output) OUTPUT_DIRECT3D_Select();
+#elif C_OPENGL
+        if(!init_output) OUTPUT_OPENGL_Select(GLBilinear); // Initialize screen before switching to TTF (required for macOS builds)     
+#endif
         OUTPUT_SURFACE_Select();
+        init_output = true;
 #if C_OPENGL
     } 
     else if (output == "opengl" || output == "openglhq") 
@@ -3749,18 +3756,25 @@ static void GUI_StartUp() {
     else if (output == "ttf")
     {
         LOG_MSG("SDL(sdlmain.cpp): TTF activated");
-#if C_OPENGL
-        OUTPUT_OPENGL_Select(GLBilinear); // Initialize screen before switching to TTF (required for macOS builds)     
+#if C_DIRECT3D
+        if(!init_output) OUTPUT_DIRECT3D_Select();
+#elif C_OPENGL
+        if(!init_output) OUTPUT_OPENGL_Select(GLBilinear); // Initialize screen before switching to TTF (required for macOS builds)     
 #else
         OUTPUT_SURFACE_Select();
-#endif // C_OPENGL
+#endif // C_DIRECT3D || C_OPENGL
         OUTPUT_TTF_Select(0);
+        init_output = true;
     }
 #endif
     else 
     {
         LOG_MSG("SDL: Unsupported output device %s, switching back to surface",output.c_str());
+#if MACOSX && C_OPENGL
+        if(!init_output) OUTPUT_OPENGL_Select(GLBilinear); // Initialize screen before switching to surface (required for macOS builds)     
+#endif
         OUTPUT_SURFACE_Select(); // should not reach there anymore
+        init_output = true;
     }
 
     sdl.overscan_width=(unsigned int)section->Get_int("overscan");

--- a/src/output/output_ttf.cpp
+++ b/src/output/output_ttf.cpp
@@ -1392,7 +1392,10 @@ void ttf_switch_on(bool ss=true) {
 #endif
         }
         bool OpenGL_using(void), gl = OpenGL_using();
-        change_output(10);
+#if defined(WIN32) && !defined(C_SDL2)
+        change_output(3); // call OUTPUT_OPENGL_Select(GLBilinear) to initialize output before enabling TTF output on Windows builds (does nothing if OpenGL not available)
+#endif
+        change_output(10); // call OUTPUT_TTF_Select()
         SetVal("sdl", "output", "ttf");
         std::string showdbcsstr = static_cast<Section_prop *>(control->GetSection("dosv"))->Get_string("showdbcsnodosv");
         showdbcs = showdbcsstr=="true"||showdbcsstr=="1"||(showdbcsstr=="auto" && (loadlang || dbcs_sbcs));


### PR DESCRIPTION
This PR fixes macOS SDL2 version crashes on launch when output=surface.
Once DOSBox-X launches, it seems that you can select output=surface.

And added some fixes when restoring minimized window when output=ttf.
Fixes #4248
I was planning to put this fix in a different PR but github automatically included this fix in this PR.