### PR TITLE
Fix restoring minimized window on TTF output (MinGW)

### DIFF
--- a/src/output/output_ttf.cpp
+++ b/src/output/output_ttf.cpp
@@ -1393,7 +1393,7 @@ void ttf_switch_on(bool ss=true) {
         }
         bool OpenGL_using(void), gl = OpenGL_using();
 #if defined(WIN32) && !defined(C_SDL2)
-        change_output(3); // call OUTPUT_OPENGL_Select(GLBilinear) to initialize output before enabling TTF output on Windows builds (does nothing if OpenGL not available)
+        change_output(0); // call OUTPUT_SURFACE_Select() to initialize output before enabling TTF output on Windows builds
 #endif
         change_output(10); // call OUTPUT_TTF_Select()
         SetVal("sdl", "output", "ttf");


### PR DESCRIPTION
PR #4462 fixed issues of restoring minimized windows during TTF output on Windows SDL1 builds.
It works well for VS builds, but it takes time to restore the window on MinGW builds.
This PR fixes such issue.

Steps to reproduce the issue:
When in TTF mode capture video. Screen will automatically switch to non-TTF output. Stop capture and minimize the window.