### PR TITLE
Only include resource.h when building for Windows

### DIFF
--- a/src/gamelink/gamelink.cpp
+++ b/src/gamelink/gamelink.cpp
@@ -17,7 +17,9 @@
 #include "gamelink.h"
 #include "logging.h"
 #include "sdlmain.h"
+#ifdef WIN32
 #include "../resource.h"
+#endif
 
 // External Dependencies
 #ifdef WIN32

--- a/src/gamelink/gamelink_term.cpp
+++ b/src/gamelink/gamelink_term.cpp
@@ -21,7 +21,9 @@
 #include "dosbox.h"
 #include "gamelink.h"
 #include "sdlmain.h"
+#ifdef WIN32
 #include "../resource.h"
+#endif
 #include <stdio.h>
 #include "mem.h"
 


### PR DESCRIPTION
## What issue(s) does this PR address?

`resource.h` is included unconditionally, but it only relevant for Windows builds. This protects the inclusion using the `WIN32` define; this avoids accidentally introducing dependencies on `resource.h` in non-Windows builds.

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

No.