### PR TITLE
DOS/V Extended CGA text mode support

### DIFF
--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -74,14 +74,17 @@ Bitu INT10_Handler(void) {
 	case 0x00:								/* Set VideoMode */
 		Mouse_BeforeNewVideoMode(true);
 		SetTrueVideoMode(reg_al);
-		if(IS_DOSV && IS_DOS_CJK && (reg_al == 0x03 || reg_al == 0x70 || reg_al == 0x72 || reg_al == 0x78)) {
-			uint8_t mode = reg_al;
-			if(reg_al == 0x03 || reg_al == 0x72) {
+		if(IS_DOSV && IS_DOS_CJK && (reg_al == 0x03 || (reg_al >= 0x70 && reg_al <= 0x73) || reg_al == 0x78)) {
+			uint8_t mode = 0x03;
+			if(reg_al == 0x03 || reg_al == 0x72 || reg_al == 0x73) {
 				INT10_SetVideoMode(0x12);
 				INT10_SetDOSVModeVtext(mode, DOSV_VGA);
-			} else if(reg_al == 0x70 || reg_al == 0x78) {
+				if(reg_al == 0x72 || reg_al == 0x73) {
+					real_writeb(BIOSMEM_SEG, BIOSMEM_CURRENT_MODE, reg_al);
+				}
+			} else if(reg_al == 0x70 || reg_al == 0x71 || reg_al == 0x78) {
 				mode = 0x70;
-				enum DOSV_VTEXT_MODE vtext_mode = DOSV_GetVtextMode((reg_al == 0x70) ? 0 : 1);
+				enum DOSV_VTEXT_MODE vtext_mode = DOSV_GetVtextMode((reg_al == 0x78) ? 1 : 0);
 				if(vtext_mode == DOSV_VTEXT_XGA || vtext_mode == DOSV_VTEXT_XGA_24) {
 					if(svgaCard == SVGA_TsengET4K) {
 						INT10_SetVideoMode(0x37);
@@ -102,6 +105,9 @@ Bitu INT10_Handler(void) {
 				} else {
 					INT10_SetVideoMode(0x12);
 					INT10_SetDOSVModeVtext(mode, DOSV_VTEXT_VGA);
+				}
+				if(reg_al == 0x71) {
+					real_writeb(BIOSMEM_SEG, BIOSMEM_CURRENT_MODE, reg_al);
 				}
 			}
 			DOSV_FillScreen();

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -2318,7 +2318,6 @@ VideoModeBlock ModeList_DOSV[]={
 /* mode  ,type     ,sw  ,sh  ,tw ,th ,cw,ch ,pt,pstart  ,plength,htot,vtot,hde,vde special flags */
 { 0x003  ,M_EGA    ,640 ,480 ,80 ,25 ,8 ,19 ,1 ,0xA0000 ,0xA000 ,100 ,525 ,80 ,480 ,0	},
 { 0x070  ,M_EGA    ,640 ,480 ,80 ,30 ,8 ,16 ,1 ,0xA0000 ,0xA000 ,100 ,525 ,80 ,480 ,0	},
-{ 0x072  ,M_EGA    ,640 ,480 ,80 ,25 ,8 ,19 ,1 ,0xA0000 ,0xA000 ,100 ,525 ,80 ,480 ,0	},
 };
 
 VideoModeBlock ModeList_DOSV_SVGA[]={

--- a/src/ints/int_dosv.cpp
+++ b/src/ints/int_dosv.cpp
@@ -1701,7 +1701,7 @@ void SetTrueVideoMode(uint8_t mode)
 
 bool DOSV_CheckJapaneseVideoMode()
 {
-	if(IS_DOS_JAPANESE && (TrueVideoMode == 0x03 || TrueVideoMode == 0x12 || TrueVideoMode == 0x70 || TrueVideoMode == 0x72 || TrueVideoMode == 0x78)) {
+	if(IS_DOS_JAPANESE && (TrueVideoMode == 0x03 || TrueVideoMode == 0x12 || (TrueVideoMode >= 0x70 && TrueVideoMode <= 0x73) || TrueVideoMode == 0x78)) {
 		return true;
 	}
 	return false;
@@ -1709,7 +1709,7 @@ bool DOSV_CheckJapaneseVideoMode()
 
 bool DOSV_CheckCJKVideoMode()
 {
-	if(IS_DOS_CJK && (TrueVideoMode == 0x03 || TrueVideoMode == 0x12 || TrueVideoMode == 0x70 || TrueVideoMode == 0x72 || TrueVideoMode == 0x78)) {
+	if(IS_DOS_CJK && (TrueVideoMode == 0x03 || TrueVideoMode == 0x12 || (TrueVideoMode >= 0x70 && TrueVideoMode <= 0x73) || TrueVideoMode == 0x78)) {
 		return true;
 	}
 	return false;
@@ -1956,11 +1956,31 @@ void DOSV_CursorXor(Bitu x, Bitu y)
 			DOSV_CursorXor24(x, y, start, end);
 			return;
 		} else if(height == 19) {
-			if(start < 8) start = dosv_cursor_19[start];
-			if(end < 8) end = dosv_cursor_19[end];
+			if(end == 28) {
+				end = 18;
+				if(start >= 26) {
+					start -= 11;
+					end--;
+				} else if(start >= 3) {
+					start = 10;
+				}
+			} else {
+				if(start < 8) start = dosv_cursor_19[start];
+				if(end < 8) end = dosv_cursor_19[end];
+			}
 		} else if(height == 16) {
-			if(start < 8) start = dosv_cursor_16[start];
-			if(end < 8) end = dosv_cursor_16[end];
+			if(end == 28) {
+				end = 15;
+				if(start >= 26) {
+					start -= 14;
+					end--;
+				} else if(start >= 3) {
+					start = 8;
+				}
+			} else {
+				if(start < 8) start = dosv_cursor_16[start];
+				if(end < 8) end = dosv_cursor_16[end];
+			}
 		}
 		IO_Write(0x3ce, 0x05); IO_Write(0x3cf, 0x03);
 		IO_Write(0x3ce, 0x00); IO_Write(0x3cf, 0x0f);


### PR DESCRIPTION
Extended CGA text mode 0x73,0x71 is now supported.
V-Text's extended CGA text mode 0x71 uses [dosv] vtext1 setting.
Also, fixed a wrong cursor display in the editor attached to PC-DOS/V.
