### PR TITLE
Adds internationalization support to Int 21h:6523 ("[Y]es/[N]o chars" patch)

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -2744,9 +2744,9 @@ static Bitu DOS_21Handler(void) {
                             else
                                 c = reg_dl; // SBCS
 
-                            if (tolower(c) == 'y')
+                            if (tolower(c) == MSG_Get("INT21_6523_YESNO_CHARS")[0])
                                 reg_ax = 1;/*yes*/
-                            else if (tolower(c) == 'n')
+                            else if (tolower(c) == MSG_Get("INT21_6523_YESNO_CHARS")[1])
                                 reg_ax = 0;/*no*/
                             else
                                 reg_ax = 2;/*neither*/

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -9438,6 +9438,7 @@ void DOS_SetupPrograms(void) {
     MSG_Add("PROGRAM_KEYB_INVALIDFILE","Keyboard file %s invalid\n");
     MSG_Add("PROGRAM_KEYB_LAYOUTNOTFOUND","No layout in %s for codepage %i\n");
     MSG_Add("PROGRAM_KEYB_INVCPFILE","None or invalid codepage file for layout %s\n\n");
+    MSG_Add("INT21_6523_YESNO_CHARS", "yn");
     MSG_Add("PROGRAM_MODE_USAGE","Configures system devices.\n\n"
             "\033[34;1mMODE\033[0m display-type       :display-type codes are "
             "\033[1mCO80\033[0m, \033[1mBW80\033[0m, \033[1mCO40\033[0m, \033[1mBW40\033[0m, or \033[1mMONO\033[0m\n"


### PR DESCRIPTION
When a DOS program relies on INT 21h to get a yes/no keyboard character from the user, DOSBox-X now allows specifying such characters in the language file.

Fixes #4477