### PR TITLE
Fix turbo mode not staying enabled using "stop turbo on key = false" when toggled via keyboard

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -993,7 +993,7 @@ void DOSBOX_RealInit() {
 
     LOG(LOG_MISC,LOG_DEBUG)("DOSBOX-X RealInit: loading settings and initializing");
 
-    MAPPER_AddHandler(DOSBOX_UnlockSpeed, MK_rightarrow, MMODHOST,"speedlock","Toggle Speedlock");
+    MAPPER_AddHandler(DOSBOX_UnlockSpeed2, MK_rightarrow, MMODHOST,"speedlock","Toggle Speedlock");
     {
         MAPPER_AddHandler(DOSBOX_UnlockSpeed2, MK_nothing, 0, "speedlock2", "Turbo (Fast Forward)", &item);
         item->set_description("Toggle emulation speed, to allow running faster than realtime (fast forward)");


### PR DESCRIPTION
This makes Turbo Mode work as expected when enabling it via keyboard ( F11-Right ) and having "stop turbo on key = false" in the config. This brings it in line with how the dropdown-menu enabled Turbo Mode works. Previously it was for some reason necessary to hold down F11-Right for Turbo Mode to stay on.

## What issue(s) does this PR address?

Fixes #4485