### PR TITLE
Fix an assertion when reboot in guest os if mount a directory as CD-ROM before `boot`

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2591,6 +2591,7 @@ public:
                         imageDisk *imagedrv = new imageDisk(Drives[drv], drv, (convertro || Drives[drv]->readonly || (od && od->ovlreadonly)) ? 0 : freeMB, timeout);
                         if (imagedrv && imagedrv->ffdd) {
                             imageDiskList[nextdrv] = imagedrv;
+                            imagedrv->Addref();
                             bool ide_slave = false;
                             signed char ide_index = -1;
                             IDE_Auto(ide_index,ide_slave);


### PR DESCRIPTION
When booting guest os, if i previous attach an directory as CD-ROM, it will be remounted as a FAT drive.
But when I reboot inside the guest os, there will be a `WARNING: imageDisk Release() changed refcount to -1` message and then `abort`.
https://github.com/joncampbell123/dosbox-x/blob/7ff35831766dcd3838b16ebe8b8be6edecd85ef5/include/bios_disk.h#L107
It seems that the FAT drive missing an `Addref` so I add it.
Can be reproduced in last the release version.

## What issue(s) does this PR address?

None

## Does this PR introduce new feature(s)?

None

## Does this PR introduce any breaking change(s)?

None

## Additional information
