### PR TITLE
Add warnings to IMGMOUNT command

### DIFF
--- a/contrib/translations/de/de_DE.lng
+++ b/contrib/translations/de/de_DE.lng
@@ -587,6 +587,10 @@ Aktuell eingehängte Laufwerke:
 Drive not formatted. Format it before accessing the drive.
 
 .
+:PROGRAM_MOUNT_UNSUPPORTED_EXT
+Unsupported extension %s: Mounted as raw IMG image.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/contrib/translations/de/de_DE.lng
+++ b/contrib/translations/de/de_DE.lng
@@ -583,6 +583,10 @@ Laufwerk %c als %s eingehangen
 Aktuell eingehängte Laufwerke:
 
 .
+:PROGRAM_MOUNT_NOT_FORMATTED
+Drive not formatted. Format it before accessing the drive.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/contrib/translations/de/de_pc98.lng
+++ b/contrib/translations/de/de_pc98.lng
@@ -583,6 +583,10 @@ Laufwerk %c als %s eingehangen
 Aktuell eingehaengte Laufwerke:
 
 .
+:PROGRAM_MOUNT_NOT_FORMATTED
+Drive not formatted. Format it before accessing the drive.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/contrib/translations/de/de_pc98.lng
+++ b/contrib/translations/de/de_pc98.lng
@@ -587,6 +587,10 @@ Aktuell eingehaengte Laufwerke:
 Drive not formatted. Format it before accessing the drive.
 
 .
+:PROGRAM_MOUNT_UNSUPPORTED_EXT
+Unsupported extension %s: Mounted as raw IMG image.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/contrib/translations/en/en_US.lng
+++ b/contrib/translations/en/en_US.lng
@@ -458,6 +458,10 @@ The currently mounted drives are:
 Drive not formatted. Format it before accessing the drive.
 
 .
+:PROGRAM_MOUNT_UNSUPPORTED_EXT
+Unsupported extension %s: Mounted as raw IMG image.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/contrib/translations/en/en_US.lng
+++ b/contrib/translations/en/en_US.lng
@@ -454,6 +454,10 @@ Drive %c is mounted as %s
 The currently mounted drives are:
 
 .
+:PROGRAM_MOUNT_NOT_FORMATTED
+Drive not formatted. Format it before accessing the drive.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/contrib/translations/es/es_ES.lng
+++ b/contrib/translations/es/es_ES.lng
@@ -455,6 +455,10 @@ Unidad %c montada como %s
 Las unidades actualmente montadas son:
 
 .
+:PROGRAM_MOUNT_NOT_FORMATTED
+Drive not formatted. Format it before accessing the drive.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/contrib/translations/es/es_ES.lng
+++ b/contrib/translations/es/es_ES.lng
@@ -459,6 +459,10 @@ Las unidades actualmente montadas son:
 Drive not formatted. Format it before accessing the drive.
 
 .
+:PROGRAM_MOUNT_UNSUPPORTED_EXT
+Unsupported extension %s: Mounted as raw IMG image.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/contrib/translations/fr/fr_FR.lng
+++ b/contrib/translations/fr/fr_FR.lng
@@ -458,6 +458,10 @@ Les lecteurs actuellement montés sont :
 Drive not formatted. Format it before accessing the drive.
 
 .
+:PROGRAM_MOUNT_UNSUPPORTED_EXT
+Unsupported extension %s: Mounted as raw IMG image.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s %-47s %-12s %s
 

--- a/contrib/translations/fr/fr_FR.lng
+++ b/contrib/translations/fr/fr_FR.lng
@@ -454,6 +454,10 @@ Le lecteur %c est monté en tant que %s
 Les lecteurs actuellement montés sont :
 
 .
+:PROGRAM_MOUNT_NOT_FORMATTED
+Drive not formatted. Format it before accessing the drive.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s %-47s %-12s %s
 

--- a/contrib/translations/it/it_IT.lng
+++ b/contrib/translations/it/it_IT.lng
@@ -600,6 +600,10 @@ Le unità attualmente montate sono:
 Drive not formatted. Format it before accessing the drive.
 
 .
+:PROGRAM_MOUNT_UNSUPPORTED_EXT
+Unsupported extension %s: Mounted as raw IMG image.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/contrib/translations/it/it_IT.lng
+++ b/contrib/translations/it/it_IT.lng
@@ -596,6 +596,10 @@ L'unità %c è montata come %s
 Le unità attualmente montate sono:
 
 .
+:PROGRAM_MOUNT_NOT_FORMATTED
+Drive not formatted. Format it before accessing the drive.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/contrib/translations/ja/ja_JP.lng
+++ b/contrib/translations/ja/ja_JP.lng
@@ -448,6 +448,10 @@ MOUSE [/?] [/U] [/V]
 ドライブがフォーマットされてません。フォーマットしてください。
 
 .
+:PROGRAM_MOUNT_UNSUPPORTED_EXT
+サポートされてない拡張子 %s: raw IMG ファイルとしてマウントします。
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-41s  %-10s  %s
 

--- a/contrib/translations/ja/ja_JP.lng
+++ b/contrib/translations/ja/ja_JP.lng
@@ -444,6 +444,10 @@ MOUSE [/?] [/U] [/V]
 現在マウントされているドライブ:
 
 .
+:PROGRAM_MOUNT_NOT_FORMATTED
+ドライブがフォーマットされてません。フォーマットしてください。
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-41s  %-10s  %s
 

--- a/contrib/translations/ko/ko_KR.lng
+++ b/contrib/translations/ko/ko_KR.lng
@@ -454,6 +454,10 @@ MOUSE [/?] [/U] [/V]
 현재 탑재된 드라이브:
 
 .
+:PROGRAM_MOUNT_NOT_FORMATTED
+Drive not formatted. Format it before accessing the drive.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-41s  %-10s  %s
 

--- a/contrib/translations/ko/ko_KR.lng
+++ b/contrib/translations/ko/ko_KR.lng
@@ -458,6 +458,10 @@ MOUSE [/?] [/U] [/V]
 Drive not formatted. Format it before accessing the drive.
 
 .
+:PROGRAM_MOUNT_UNSUPPORTED_EXT
+Unsupported extension %s: Mounted as raw IMG image.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-41s  %-10s  %s
 

--- a/contrib/translations/nl/nl_NL.lng
+++ b/contrib/translations/nl/nl_NL.lng
@@ -458,6 +458,10 @@ De huidige gekoppelde schijven zijn:
 Drive not formatted. Format it before accessing the drive.
 
 .
+:PROGRAM_MOUNT_UNSUPPORTED_EXT
+Unsupported extension %s: Mounted as raw IMG image.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/contrib/translations/nl/nl_NL.lng
+++ b/contrib/translations/nl/nl_NL.lng
@@ -454,6 +454,10 @@ Schijf %c is gekoppeld als %s
 De huidige gekoppelde schijven zijn:
 
 .
+:PROGRAM_MOUNT_NOT_FORMATTED
+Drive not formatted. Format it before accessing the drive.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/contrib/translations/pt/pt_BR.lng
+++ b/contrib/translations/pt/pt_BR.lng
@@ -453,6 +453,10 @@ Unidade %c montada como %s
 As unidades atualmente montadas são:
 
 .
+:PROGRAM_MOUNT_NOT_FORMATTED
+Drive not formatted. Format it before accessing the drive.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/contrib/translations/pt/pt_BR.lng
+++ b/contrib/translations/pt/pt_BR.lng
@@ -457,6 +457,10 @@ As unidades atualmente montadas são:
 Drive not formatted. Format it before accessing the drive.
 
 .
+:PROGRAM_MOUNT_UNSUPPORTED_EXT
+Unsupported extension %s: Mounted as raw IMG image.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/contrib/translations/tr/tr_TR.lng
+++ b/contrib/translations/tr/tr_TR.lng
@@ -458,6 +458,10 @@ Bulunan CD-ROM'lar: %d
 Drive not formatted. Format it before accessing the drive.
 
 .
+:PROGRAM_MOUNT_UNSUPPORTED_EXT
+Unsupported extension %s: Mounted as raw IMG image.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/contrib/translations/tr/tr_TR.lng
+++ b/contrib/translations/tr/tr_TR.lng
@@ -454,6 +454,10 @@ Bulunan CD-ROM'lar: %d
 Şu anda bağlı sürücüler:
 
 .
+:PROGRAM_MOUNT_NOT_FORMATTED
+Drive not formatted. Format it before accessing the drive.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/contrib/translations/zh/zh_CN.lng
+++ b/contrib/translations/zh/zh_CN.lng
@@ -451,6 +451,10 @@ MOUSE [/?] [/U] [/V]
 当前已挂载的驱动器为:
 
 .
+:PROGRAM_MOUNT_NOT_FORMATTED
+Drive not formatted. Format it before accessing the drive.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/contrib/translations/zh/zh_CN.lng
+++ b/contrib/translations/zh/zh_CN.lng
@@ -455,6 +455,10 @@ MOUSE [/?] [/U] [/V]
 Drive not formatted. Format it before accessing the drive.
 
 .
+:PROGRAM_MOUNT_UNSUPPORTED_EXT
+Unsupported extension %s: Mounted as raw IMG image.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/contrib/translations/zh/zh_TW.lng
+++ b/contrib/translations/zh/zh_TW.lng
@@ -451,6 +451,10 @@ MOUSE [/?] [/U] [/V]
 目前已掛載的磁碟機有:
 
 .
+:PROGRAM_MOUNT_NOT_FORMATTED
+Drive not formatted. Format it before accessing the drive.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/contrib/translations/zh/zh_TW.lng
+++ b/contrib/translations/zh/zh_TW.lng
@@ -455,6 +455,10 @@ MOUSE [/?] [/U] [/V]
 Drive not formatted. Format it before accessing the drive.
 
 .
+:PROGRAM_MOUNT_UNSUPPORTED_EXT
+Unsupported extension %s: Mounted as raw IMG image.
+
+.
 :PROGRAM_IMGMOUNT_STATUS_FORMAT
 %-5s  %-47s  %-12s  %s
 

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -5828,6 +5828,7 @@ class IMGMOUNT : public Program {
 			return true;
 		}
 
+        bool unformatted = false;
 		bool MountFat(Bitu sizes[], const char drive, const bool isHardDrive, const std::string &str_size, const std::vector<std::string> &paths, const signed char ide_index, const bool ide_slave, const int reserved_cylinders, bool roflag) {
 			(void)reserved_cylinders;
 			if (Drives[drive - 'A']) {
@@ -5989,6 +5990,7 @@ class IMGMOUNT : public Program {
 						diskfiles[i]=fdrive->loadedDisk->diskimg;
 						if ((vhdImage&&ro)||roflag) fdrive->readonly=true;
 					}
+                    unformatted = fdrive->unformatted;
 				}
 				if (errorMessage) {
 					if (!qmount) WriteOut(errorMessage);
@@ -6008,7 +6010,10 @@ class IMGMOUNT : public Program {
 			}
 			lastmount = drive;
 			if (!qmount) WriteOut(MSG_Get("PROGRAM_MOUNT_STATUS_2"), drive, tmp.c_str());
-
+            if (unformatted) {
+                if(!qmount) WriteOut(MSG_Get("PROGRAM_MOUNT_NOT_FORMATTED"));
+                LOG_MSG("IMGMOUNT: Drive %c not formatted", drive);
+            }
 			unsigned char driveIndex = drive-'A';
 			if (imgDisks.size() == 1 || (imgDisks.size() > 1 && driveIndex < 2 && (swapInDisksSpecificDrive == driveIndex || swapInDisksSpecificDrive == -1))) {
 				imageDisk* image = ((fatDrive*)imgDisks[0])->loadedDisk;
@@ -9000,6 +9005,7 @@ void DOS_SetupPrograms(void) {
     MSG_Add("PROGRAM_MOUNT_STATUS_RAMDRIVE", "Drive %c is mounted as RAM drive\n");
     MSG_Add("PROGRAM_MOUNT_STATUS_2","Drive %c is mounted as %s\n");
     MSG_Add("PROGRAM_MOUNT_STATUS_1","The currently mounted drives are:\n");
+    MSG_Add("PROGRAM_MOUNT_NOT_FORMATTED","Drive not formatted. Format it before accessing the drive.\n");
     MSG_Add("PROGRAM_IMGMOUNT_STATUS_FORMAT","%-5s  %-47s  %-12s  %s\n");
     MSG_Add("PROGRAM_IMGMOUNT_STATUS_NUMBER_FORMAT","%-12s  %-40s  %-12s  %s\n");
     MSG_Add("PROGRAM_IMGMOUNT_STATUS_2","The currently mounted drive numbers are:\n");

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -206,6 +206,7 @@ void DetachFromBios(imageDisk* image) {
 }
 
 void SwitchLanguage(int oldcp, int newcp, bool confirm) {
+    (void)oldcp; //unused
     auto iterold = langcp_map.find(lastmsgcp), iternew = langcp_map.find(newcp);
     std::string langold = iterold != langcp_map.end() ? iterold->second : "", langnew = iternew != langcp_map.end() ? iternew->second : "";
     if (loadlang && langnew.size() && strcasecmp(langold.c_str(), langnew.c_str())) {
@@ -5921,7 +5922,7 @@ class IMGMOUNT : public Program {
 									return NULL;
 								}
 								QCow2Image::QCow2Header qcow2_header = QCow2Image::read_header(newDisk);
-								uint64_t sectors;
+								// uint64_t sectors; /* unused */
 								uint32_t imagesize;
 								sizes[0] = 512; // default sector size
 								if(qcow2_header.magic == QCow2Image::magic && (qcow2_header.version == 2 || qcow2_header.version == 3)) {
@@ -5930,8 +5931,8 @@ class IMGMOUNT : public Program {
 										WriteOut("Sector size must be larger than 512 bytes and evenly divide the image cluster size of %lu bytes.\n", cluster_size);
 										return 0;
 									}
-									sectors = (uint64_t)qcow2_header.size / (uint64_t)sizes[0]; //sectors
-									imagesize = (uint32_t)(qcow2_header.size / 1024L); // imagesize
+									// sectors = (uint64_t)qcow2_header.size / (uint64_t)sizes[0]; /* unused */
+									imagesize = (uint32_t)(qcow2_header.size / 1024L);
 									sizes[1] = 63; // sectors
 									sizes[2] = 16; // heads
 									sizes[3] = (uint64_t)qcow2_header.size / sizes[0] / sizes[1] / sizes[2]; // cylinders
@@ -7300,7 +7301,7 @@ void UTF8::Run()
         WriteOut("No input text found.\n");
         return;
     }
-    int cp=dos.loaded_codepage;
+    // int cp=dos.loaded_codepage; /* unused */
     char target[11] = "CP437";
     if (dos.loaded_codepage==808) strcpy(target, "CP866");
     else if (dos.loaded_codepage==859) strcpy(target, "CP858");
@@ -7837,7 +7838,7 @@ uint64_t VHDMAKE::ssizetou64(const char* s_size) {
 void VHDMAKE::Run()
 {
     bool bOverwrite = false;
-    bool bExists = false;
+    // bool bExists = false; /* unused */
     uint32_t ret;
     char basename[256], filename[256];
 
@@ -7876,7 +7877,7 @@ void VHDMAKE::Run()
             imageDiskVHD::VHDInfo* p = info->parentInfo;
             while(p != NULL) {
                 index++;
-                for(int i = 0; i < index; i++) WriteOut(" ");
+                for(uint32_t i = 0; i < index; i++) WriteOut(" ");
                 WriteOut("child of \"%s\" (%s)", p->diskname.c_str(), vhdTypes[(int)p->vhdType]);
                 if (p->vhdType != imageDiskVHD::VHD_TYPE_FIXED)
                     WriteOut(MSG_Get("PROGRAM_VHDMAKE_BLOCKSTATS"), p->allocatedBlocks, p->totalBlocks);


### PR DESCRIPTION
This PR warns users if trying to mount an unformatted drive or image files with unsupported extensions.

![imgmount_warnings](https://github.com/joncampbell123/dosbox-x/assets/68574602/bcc2b808-11cb-4092-9f65-a7a03d738c71)
