### PR TITLE
MIDI: set minimum sysex delay when enabled

### DIFF
--- a/include/midi.h
+++ b/include/midi.h
@@ -47,6 +47,7 @@ struct DB_Midi {
         uint8_t buf[SYSEX_SIZE] = {};
 		Bitu used = 0;
 		Bitu delay = 0;
+		bool extra_delay = false;
 		uint32_t start = 0;
 
 		midi_state_sysex_t() {}

--- a/src/gui/midi.cpp
+++ b/src/gui/midi.cpp
@@ -540,7 +540,12 @@ void MIDI_RawOutByte(uint8_t data) {
 						midi.sysex.delay = 145; // Viking Child
 					} else if (midi.sysex.buf[5] == 0x10 && midi.sysex.buf[6] == 0x00 && midi.sysex.buf[7] == 0x01) {
 						midi.sysex.delay = 30; // Dark Sun 1
-					} else midi.sysex.delay = (Bitu)(((float)(midi.sysex.used) * 1.25f) * 1000.0f / 3125.0f) + 2;
+					} else {
+						midi.sysex.delay = (Bitu)(((float)(midi.sysex.used) * 1.25f) * 1000.0f / 3125.0f) + 2;
+						if (midi.sysex.extra_delay && midi.sysex.delay < 40) {
+							midi.sysex.delay = 40;
+						}
+					}
 					midi.sysex.start = GetTicks();
 				}
 			}
@@ -602,6 +607,7 @@ public:
 			midi.sysex.start = GetTicks();
 			fullconf.erase(fullconf.find("delaysysex"));
 			LOG(LOG_MISC,LOG_DEBUG)("MIDI:Using delayed SysEx processing");
+			midi.sysex.extra_delay = true;
 		}
 		trim(fullconf);
 		const char * conf = fullconf.c_str();


### PR DESCRIPTION
## What issue(s) does this PR address?

Fixes #4506.

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No

## Additional information

A real rev.0 MT-32 is the main system that needs the sysex delay, and it needs about 40ms between sysex commands to work properly. 40ms is documented in a few blogs online and is the delay used universally by ScummVM. In testing, a sub-40 value appeared to work sometimes but always using 40 should be safest.

Reviewing the [original delaysysex patch](https://sourceforge.net/p/dosbox/patches/241/), the case that's leading to incorrect timing here is a new case in the if statement that wasn't in the original patch. It's possible this bug was introduced later, or that the patch as merged wasn't entirely comprehensive enough.

Tested with MEdit, which was written for LAPC-I/CL-32L; with this patch, loading problematic songs (such as One Step Beyond's `INGAME1.RLD`) now works, whereas they reliably triggered a buffer overflow before.
