### PR TITLE
Fix Sid Meier's Civilization crash (Issue #4511)

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -8214,9 +8214,11 @@ void SETCOLOR::Run()
             altBGR0[i].red = rgbcolors[i].red;
             altBGR0[i].green = rgbcolors[i].green;
             altBGR0[i].blue = rgbcolors[i].blue;
+#ifdef USE_TTF
             altBGR1[i].red = rgbcolors[i].red;
             altBGR1[i].green = rgbcolors[i].green;
             altBGR1[i].blue = rgbcolors[i].blue;
+#endif
             get_pal = true;
         }
     }

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -8149,39 +8149,39 @@ static void COLOR_ProgramStart(Program * * make) {
     *make=new COLOR;
 }
 
-alt_rgb altBGR[16], *rgbcolors = (alt_rgb*)render.pal.rgb;
+alt_rgb altBGR[16]={0}, altBGR0[16]={0}, *rgbcolors = (alt_rgb*)render.pal.rgb;
+
 bool setVGAColor(const char *colorArray, int j) {
     if (!IS_VGA_ARCH||!CurMode) return false;
     const char * nextRGB = colorArray;
-    uint8_t rgbVal[3] = {0};
-    int32_t red, green, blue;
-    int32_t nextRGB_val = -1;
-    if (sscanf(nextRGB, " ( %d , %d , %d)", (int32_t*)&red, (int32_t*)&green, (int32_t*)&blue) == 3) {
-        if(red >= 0) rgbVal[0] = (uint8_t)(red & 0xFF);
-        if(green >= 0) rgbVal[1] = (uint8_t)(green & 0xFF);
-        if(blue >= 0) rgbVal[2] = (uint8_t)(blue & 0xFF);
-    } else if (sscanf(nextRGB, " #%6x", (uint32_t*)&nextRGB_val) == 1) {
-        if (nextRGB_val < 0)
+    int32_t rgbVal[4] = {-1,-1,-1,-1};
+    if (sscanf(nextRGB, " ( %d , %d , %d)", &rgbVal[0], &rgbVal[1], &rgbVal[2]) == 3) {
+        for (int i = 0; i< 3; i++) {
+            if (rgbVal[i] < 0 || rgbVal[i] > 255)
+                return false;
+        }
+    } else if (sscanf(nextRGB, " #%6x", (unsigned int*)(&rgbVal[3])) == 1) {
+        if (rgbVal[3] < 0 || rgbVal[3] > 0xFFFFFF)
             return false;
         for (int i = 2; i >= 0; i--) {
-            rgbVal[i] = nextRGB_val&255;
-            nextRGB_val >>= 8;
+            rgbVal[i] = rgbVal[3]&255;
+            rgbVal[3] >>= 8;
         }
     } else
         return false;
-
-    for(int i = j > -1 ? j : 0; i < (j > -1 ? j + 1 : 16); i++) {
-        IO_ReadB(mem_readw(BIOS_VIDEO_PORT) + 6);
-        IO_WriteB(VGAREG_ACTL_ADDRESS, i + 32);
-        uint8_t imap = IO_ReadB(VGAREG_ACTL_READ_DATA);
-        IO_WriteB(VGAREG_DAC_WRITE_ADDRESS, imap);
-        IO_WriteB(VGAREG_DAC_DATA, rgbVal[0] >> 2);
-        IO_WriteB(VGAREG_DAC_DATA, rgbVal[1] >> 2);
-        IO_WriteB(VGAREG_DAC_DATA, rgbVal[2] >> 2);
-        rgbcolors[j].red = rgbVal[0];
-        rgbcolors[j].green = rgbVal[1];
-        rgbcolors[j].blue = rgbVal[2];
-    }
+    IO_ReadB(mem_readw(BIOS_VIDEO_PORT)+6);
+    IO_WriteB(VGAREG_ACTL_ADDRESS, j+32);
+    uint8_t imap=IO_ReadB(VGAREG_ACTL_READ_DATA);
+    IO_WriteB(VGAREG_DAC_WRITE_ADDRESS, imap);
+    IO_WriteB(VGAREG_DAC_DATA, rgbVal[0] >> 2);
+    IO_WriteB(VGAREG_DAC_DATA, rgbVal[1] >> 2);
+    IO_WriteB(VGAREG_DAC_DATA, rgbVal[2] >> 2);
+    rgbcolors[j].red = rgbVal[0] & 0xFF;
+    rgbcolors[j].green = rgbVal[1] & 0xFF;
+    rgbcolors[j].blue = rgbVal[2] & 0xFF;
+    altBGR0[j].red = rgbVal[0];
+    altBGR0[j].green = rgbVal[1];
+    altBGR0[j].blue = rgbVal[2];
     return true;
 }
 
@@ -8192,6 +8192,7 @@ bool setColors(const char *colorArray, int n);
 void resetFontSize();
 #endif
 
+bool get_pal = false;
 class SETCOLOR : public Program {
 public:
     void Run(void);
@@ -8207,6 +8208,18 @@ void SETCOLOR::Run()
 {
 	// Hack To allow long commandlines
 	ChangeToLongCmd();
+
+    if (!get_pal){
+        for (uint8_t i=0; i<16; i++){
+            altBGR0[i].red = rgbcolors[i].red;
+            altBGR0[i].green = rgbcolors[i].green;
+            altBGR0[i].blue = rgbcolors[i].blue;
+            altBGR1[i].red = rgbcolors[i].red;
+            altBGR1[i].green = rgbcolors[i].green;
+            altBGR1[i].blue = rgbcolors[i].blue;
+            get_pal = true;
+        }
+    }
 
 	// Usage
 	if (cmd->FindExist("-?", false) || cmd->FindExist("/?", false)) {
@@ -8235,13 +8248,10 @@ void SETCOLOR::Run()
 			if (p==NULL) {
 #if defined(USE_TTF)
                 bool colornul = staycolors || (IS_VGA_ARCH && (altBGR1[i].red > 4 || altBGR1[i].green > 4 || altBGR1[i].blue > 4) && rgbcolors[i].red < 5 && rgbcolors[i].green < 5 && rgbcolors[i].blue < 5);
-                rgbcolors[i].red = colornul||(colorChanged&&!IS_VGA_ARCH)?altBGR1[i].red:rgbcolors[i].red;
-                rgbcolors[i].green = colornul||(colorChanged&&!IS_VGA_ARCH)?altBGR1[i].green:rgbcolors[i].green;
-                rgbcolors[i].blue = colornul||(colorChanged&&!IS_VGA_ARCH)?altBGR1[i].blue:rgbcolors[i].blue;
-                altBGR[i].red = rgbcolors[i].red;
-                altBGR[i].green = rgbcolors[i].green;
-                altBGR[i].blue = rgbcolors[i].blue;
-                WriteOut("Color %d: (%d,%d,%d) or #%02x%02x%02x\n",i,altBGR[i].red,altBGR[i].green,altBGR[i].blue,altBGR[i].red,altBGR[i].green,altBGR[i].blue);
+                altBGR[i].red = colornul||(colorChanged&&!IS_VGA_ARCH)?altBGR1[i].red:rgbcolors[i].red;
+                altBGR[i].green = colornul||(colorChanged&&!IS_VGA_ARCH)?altBGR1[i].green:rgbcolors[i].green;
+                altBGR[i].blue = colornul||(colorChanged&&!IS_VGA_ARCH)?altBGR1[i].blue:rgbcolors[i].blue;
+                WriteOut("Color %d: (%d,%d,%d) or #%02x%02x%02x\n",i,altBGR0[i].red,altBGR0[i].green,altBGR0[i].blue,altBGR0[i].red,altBGR0[i].green,altBGR0[i].blue);
 #else
                 WriteOut("Color %d: (%d,%d,%d) or #%02x%02x%02x\n",i,rgbcolors[i].red,rgbcolors[i].green,rgbcolors[i].blue,rgbcolors[i].red,rgbcolors[i].green,rgbcolors[i].blue);
 #endif
@@ -8283,21 +8293,18 @@ void SETCOLOR::Run()
                 if (!IS_VGA_ARCH)
                     WriteOut("Changing color scheme is not supported for the current video mode.\n");
                 else if (setVGAColor(value, i))
-                    WriteOut("Color %d: (%d,%d,%d) or #%02x%02x%02x\n",i,rgbcolors[i].red,rgbcolors[i].green,rgbcolors[i].blue,rgbcolors[i].red,rgbcolors[i].green,rgbcolors[i].blue);
+                    //WriteOut("Color %d: (%d,%d,%d) or #%02x%02x%02x\n",i,rgbcolors[i].red,rgbcolors[i].green,rgbcolors[i].blue,rgbcolors[i].red,rgbcolors[i].green,rgbcolors[i].blue);
+                    WriteOut("Color %d: (%d,%d,%d) or #%02x%02x%02x\n",i,altBGR0[i].red,altBGR0[i].green,altBGR0[i].blue,altBGR0[i].red,altBGR0[i].green,altBGR0[i].blue);
                 else
                     WriteOut("Invalid color value - %s\n",value);
 #if defined(USE_TTF)
 			} else if (setColors(value,i)) {
                 bool colornul = staycolors || (IS_VGA_ARCH && (altBGR1[i].red > 4 || altBGR1[i].green > 4 || altBGR1[i].blue > 4) && rgbcolors[i].red < 5 && rgbcolors[i].green < 5 && rgbcolors[i].blue < 5);
-                rgbcolors[i].red = (colornul || (colorChanged && !IS_VGA_ARCH)) ? altBGR1[i].red : rgbcolors[i].red;
-                rgbcolors[i].green = (colornul || (colorChanged && !IS_VGA_ARCH)) ? altBGR1[i].green : rgbcolors[i].green;
-                rgbcolors[i].blue = (colornul || (colorChanged && !IS_VGA_ARCH)) ? altBGR1[i].blue : rgbcolors[i].blue;
-                altBGR[i].red = rgbcolors[i].red;
-                altBGR[i].green = rgbcolors[i].green;
-                altBGR[i].blue = rgbcolors[i].blue;
-				WriteOut("Color %d => (%d,%d,%d) or #%02x%02x%02x\n",i, rgbcolors[i].red, rgbcolors[i].green, rgbcolors[i].blue, rgbcolors[i].red, rgbcolors[i].green, rgbcolors[i].blue);
+                altBGR[i].red = (colornul||(colorChanged&&!IS_VGA_ARCH))?altBGR1[i].red:rgbcolors[i].red;
+                altBGR[i].green = (colornul||(colorChanged&&!IS_VGA_ARCH))?altBGR1[i].green:rgbcolors[i].green;
+                altBGR[i].blue = (colornul||(colorChanged&&!IS_VGA_ARCH))?altBGR1[i].blue:rgbcolors[i].blue;
+				WriteOut("Color %d => (%d,%d,%d) or #%02x%02x%02x\n",i,altBGR[i].red,altBGR[i].green,altBGR[i].blue,altBGR[i].red,altBGR[i].green,altBGR[i].blue);
 				resetFontSize();
-                setVGAColor(value, i); // also change pallette value for non-TTF output
 			} else
 				WriteOut("Invalid color value - %s\n",value);
 #endif
@@ -8307,13 +8314,10 @@ void SETCOLOR::Run()
 		for (int i = 0; i < 16; i++) {
 #if defined(USE_TTF)
             bool colornul = staycolors || (IS_VGA_ARCH && (altBGR1[i].red > 4 || altBGR1[i].green > 4 || altBGR1[i].blue > 4) && rgbcolors[i].red < 5 && rgbcolors[i].green < 5 && rgbcolors[i].blue < 5);
-            rgbcolors[i].red = colornul || (colorChanged && !IS_VGA_ARCH) ? altBGR1[i].red : rgbcolors[i].red;
-            rgbcolors[i].green = colornul || (colorChanged && !IS_VGA_ARCH) ? altBGR1[i].green : rgbcolors[i].green;
-            rgbcolors[i].blue = colornul || (colorChanged && !IS_VGA_ARCH) ? altBGR1[i].blue : rgbcolors[i].blue;
-            altBGR[i].red = rgbcolors[i].red;
-            altBGR[i].green = rgbcolors[i].green;
-            altBGR[i].blue = rgbcolors[i].blue;
-			WriteOut("Color %d: (%d,%d,%d) or #%02x%02x%02x\n",i, rgbcolors[i].red, rgbcolors[i].green, rgbcolors[i].blue, rgbcolors[i].red, rgbcolors[i].green, rgbcolors[i].blue);
+            altBGR[i].red = colornul||(colorChanged&&!IS_VGA_ARCH)?altBGR1[i].red:rgbcolors[i].red;
+            altBGR[i].green = colornul||(colorChanged&&!IS_VGA_ARCH)?altBGR1[i].green:rgbcolors[i].green;
+            altBGR[i].blue = colornul||(colorChanged&&!IS_VGA_ARCH)?altBGR1[i].blue:rgbcolors[i].blue;
+			WriteOut("Color %d: (%d,%d,%d) or #%02x%02x%02x\n",i,altBGR[i].red,altBGR[i].green,altBGR[i].blue,altBGR[i].red,altBGR[i].green,altBGR[i].blue);
 #else
 			WriteOut("Color %d: (%d,%d,%d) or #%02x%02x%02x\n",i,rgbcolors[i].red,rgbcolors[i].green,rgbcolors[i].blue,rgbcolors[i].red,rgbcolors[i].green,rgbcolors[i].blue);
 #endif

--- a/src/ints/int10_pal.cpp
+++ b/src/ints/int10_pal.cpp
@@ -29,7 +29,6 @@
 void GFX_EndTextLines(bool force);
 bool setColors(const char *colorArray, int n);
 #endif
-bool setVGAColor(const char* colorArray, int j);
 static INLINE void ResetACTL(void) {
 	IO_Read(real_readw(BIOSMEM_SEG,BIOSMEM_CRTC_ADDRESS) + 6u);
 }
@@ -242,7 +241,6 @@ void INT10_SetSingleDACRegister(uint8_t index,uint8_t red,uint8_t green,uint8_t 
     }
     setColors(value,imap[index]);
     if (ttf.inUse) GFX_EndTextLines(true);
-    if (ttf.inUse) setVGAColor(value, imap[index]);
 #endif
 }
 
@@ -291,20 +289,18 @@ void INT10_SetDACBlock(uint16_t index,uint16_t count,PhysPt data) {
 			IO_Write(VGAREG_DAC_DATA,ic);
 #if defined(USE_TTF)
             if (start==16) {
-                sprintf(value,"(%d,%d,%d)", (red << 2 | red >> 4), (green << 2 | green >> 4), (blue << 2 | blue >> 4));
+                sprintf(value,"(%d,%d,%d)",(red<<2|red>>4), (green<<2|green>>4), (blue<<2|blue>>4));
                 str+=std::string(value);
             }
 #endif
 		}
 	}
-
-    if(str.size()) {
 #if defined(USE_TTF)
-        setColors(str.c_str(), -1);
-        if(ttf.inUse) GFX_EndTextLines(true);
-        if(ttf.inUse) setVGAColor(str.c_str(), -1);
-#endif
+    if (str.size()) {
+        setColors(str.c_str(),-1);
+        if (ttf.inUse) GFX_EndTextLines(true);
     }
+#endif
 }
 
 void INT10_GetDACBlock(uint16_t index,uint16_t count,PhysPt data) {

--- a/src/output/output_ttf.cpp
+++ b/src/output/output_ttf.cpp
@@ -112,7 +112,8 @@ static SDL_Rect ttf_textClip = {0, 0, 0, 0};
 ttf_cell curAttrChar[txtMaxLins*txtMaxCols];					// currently displayed textpage
 ttf_cell newAttrChar[txtMaxLins*txtMaxCols];					// to be replaced by
 
-alt_rgb altBGR0[16], altBGR1[16];
+extern alt_rgb altBGR0[16];
+alt_rgb altBGR1[16] = {0};
 int blinkCursor = -1;
 static int prev_sline = -1;
 static int charSet = 0;
@@ -124,7 +125,6 @@ int menuwidth_atleast(int width), FileDirExistCP(const char *name), FileDirExist
 void AdjustIMEFontSize(void),refreshExtChar(void), initcodepagefont(void), change_output(int output), drawmenu(Bitu val), KEYBOARD_Clear(void), RENDER_Reset(void), DOSBox_SetSysMenu(void), GetMaxWidthHeight(unsigned int *pmaxWidth, unsigned int *pmaxHeight), SetWindowTransparency(int trans), resetFontSize(void), RENDER_CallBack( GFX_CallBackFunctions_t function );
 bool isDBCSCP(void), InitCodePage(void), CodePageGuestToHostUTF16(uint16_t *d/*CROSS_LEN*/,const char *s/*CROSS_LEN*/), systemmessagebox(char const * aTitle, char const * aMessage, char const * aDialogType, char const * aIconType, int aDefaultButton);
 std::string GetDOSBoxXPath(bool withexe=false);
-bool setVGAColor(const char* colorArray, int i);
 
 #if defined(C_SDL2)
 void GFX_SetResizeable(bool enable);
@@ -243,9 +243,9 @@ void setVGADAC() {
             IO_WriteB(VGAREG_ACTL_ADDRESS, i+32);
             imap[i]=IO_ReadB(VGAREG_ACTL_READ_DATA);
             IO_WriteB(VGAREG_DAC_WRITE_ADDRESS, imap[i]);
-            IO_WriteB(VGAREG_DAC_DATA, rgbColors[i].red>>2);
-            IO_WriteB(VGAREG_DAC_DATA, rgbColors[i].green>>2);
-            IO_WriteB(VGAREG_DAC_DATA, rgbColors[i].blue>>2);
+            IO_WriteB(VGAREG_DAC_DATA, altBGR0[i].red>>2);
+            IO_WriteB(VGAREG_DAC_DATA, altBGR0[i].green>>2);
+            IO_WriteB(VGAREG_DAC_DATA, altBGR0[i].blue>>2);
         }
     }
 }
@@ -258,14 +258,16 @@ bool setColors(const char *colorArray, int n) {
             altBGR1[i].red=rgbColors[i].red;
             altBGR1[i].green=rgbColors[i].green;
             altBGR1[i].blue=rgbColors[i].blue;
+            altBGR0[i].red=rgbColors[i].red;
+            altBGR0[i].green=rgbColors[i].green;
+            altBGR0[i].blue=rgbColors[i].blue;
         }
     staycolors = strlen(colorArray) && *colorArray == '+';
     const char* nextRGB = colorArray + (staycolors?1:0);
 	uint8_t * altPtr = (uint8_t *)altBGR1;
-	int8_t rgbVal[3] = {-1,-1,-1};
-    int32_t nextRGB_val = -1;
+	int32_t rgbVal[4] = {-1,-1,-1,-1};
 	for (int colNo = n>-1?n:0; colNo < (n>-1?n+1:16); colNo++) {
-		if (sscanf(nextRGB, " ( %d , %d , %d)", (int32_t*)&rgbVal[0], (int32_t*)&rgbVal[1], (int32_t*)&rgbVal[2]) == 3) {	// Decimal: (red,green,blue)
+		if (sscanf(nextRGB, " ( %d , %d , %d)", &rgbVal[0], &rgbVal[1], &rgbVal[2]) == 3) {	// Decimal: (red,green,blue)
 			for (int i = 0; i< 3; i++) {
 				if (rgbVal[i] < 0 || rgbVal[i] > 255)
 					return false;
@@ -273,8 +275,8 @@ bool setColors(const char *colorArray, int n) {
 			while (*nextRGB != ')')
 				nextRGB++;
 			nextRGB++;
-		} else if (sscanf(nextRGB, " #%6x", (uint32_t*)&nextRGB_val) == 1) {							// Hexadecimal
-			if (nextRGB_val < 0)
+		} else if (sscanf(nextRGB, " #%6x", ((uint32_t*)(&rgbVal[3]))) == 1) {							// Hexadecimal
+			if (rgbVal[3] < 0 || rgbVal[3] > 0xFFFFF)
 				return false;
 			for (int i = 2; i >= 0; i--) {
 				rgbVal[i] = nextRGB_val&255;
@@ -283,11 +285,9 @@ bool setColors(const char *colorArray, int n) {
 			nextRGB = strchr(nextRGB, '#') + 7;
 		} else
 			return false;
-        for(int i = n > -1 ? n : 0; i < (n > -1 ? n + 1 : 16); i++) {
-            altBGR0[i].red = rgbColors[i].red;
-            altBGR0[i].green = rgbColors[i].green;
-            altBGR0[i].blue = rgbColors[i].blue;
-        }
+        altBGR0[colNo].blue = rgbVal[2];
+        altBGR0[colNo].green = rgbVal[1];
+        altBGR0[colNo].red = rgbVal[0];
         rgbColors[colNo].blue = (uint8_t)rgbVal[2];
         rgbColors[colNo].green = (uint8_t)rgbVal[1];
         rgbColors[colNo].red = (uint8_t)rgbVal[0];
@@ -696,9 +696,8 @@ void OUTPUT_TTF_Select(int fsize) {
                 str+=std::string(value)+" ";
             }
             if (str.size()) {
-                colorChanged = justChanged = false;
-                setColors(str.c_str(), -1);
-                //setColors("#000000 #0000aa #00aa00 #00aaaa #aa0000 #aa00aa #aa5500 #aaaaaa #555555 #5555ff #55ff55 #55ffff #ff5555 #ff55ff #ffff55 #ffffff",-1);
+                setColors(str.c_str(),-1);
+                colorChanged=justChanged=false;
             }
         }
         SetBlinkRate(ttf_section);
@@ -1332,6 +1331,7 @@ void AutoBoxDraw_mapper_shortcut(bool pressed) {
     if (ttf.inUse) resetFontSize();
 }
 
+bool setVGAColor(const char *colorArray, int i);
 void ttf_reset_colors() {
     if (ttf.inUse) {
         SetVal("ttf", "colors", "");

--- a/src/output/output_ttf.cpp
+++ b/src/output/output_ttf.cpp
@@ -279,8 +279,8 @@ bool setColors(const char *colorArray, int n) {
 			if (rgbVal[3] < 0 || rgbVal[3] > 0xFFFFF)
 				return false;
 			for (int i = 2; i >= 0; i--) {
-				rgbVal[i] = nextRGB_val&255;
-				nextRGB_val >>= 8;
+				rgbVal[i] = rgbVal[3]&255;
+				rgbVal[3] >>= 8;
 			}
 			nextRGB = strchr(nextRGB, '#') + 7;
 		} else

--- a/src/output/output_ttf.cpp
+++ b/src/output/output_ttf.cpp
@@ -276,7 +276,7 @@ bool setColors(const char *colorArray, int n) {
 				nextRGB++;
 			nextRGB++;
 		} else if (sscanf(nextRGB, " #%6x", ((uint32_t*)(&rgbVal[3]))) == 1) {							// Hexadecimal
-			if (rgbVal[3] < 0 || rgbVal[3] > 0xFFFFF)
+			if (rgbVal[3] < 0 || rgbVal[3] > 0xFFFFFF)
 				return false;
 			for (int i = 2; i >= 0; i--) {
 				rgbVal[i] = rgbVal[3]&255;


### PR DESCRIPTION
PR #4505 made Sid Meier's Civilization on Linux to crash as mentioned in Issue #4511.
This PR fixes the crash, and confirmed that it doesn't crash and goes to the next step.
![civ_000](https://github.com/joncampbell123/dosbox-x/assets/68574602/f09de888-5ea1-449b-a169-a9493537cc6d)

Tried on Windows VS x64 build and Arch Linux SDL2 builds.

## What issue(s) does this PR address?
Fixes #4511

## Additional information
Confirmed that this doesn't affect Chess Master 3000 as mentioned in Issue #4510. 

https://github.com/joncampbell123/dosbox-x/assets/68574602/863b771a-ef82-41fa-bea8-1758d245788d

And SETCOLOR command working as expected.
![command_000](https://github.com/joncampbell123/dosbox-x/assets/68574602/a0a02d74-abe0-41f3-a6d9-675047667ee7)
