### PR TITLE
Fix crash when mounting floppy image with no extension

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -5169,21 +5169,23 @@ class IMGMOUNT : public Program {
 				}
 				if (!rtype&&!rfstype&&fstype!="none"&&paths[0].length()>4) {
 					const char *ext = strrchr(paths[0].c_str(), '.');
-					if (!strcasecmp(ext, ".iso")||!strcasecmp(ext, ".cue")||!strcasecmp(ext, ".bin")||!strcasecmp(ext, ".chd")||!strcasecmp(ext, ".mdf")||!strcasecmp(ext, ".gog")||!strcasecmp(ext, ".ins")) {
-						type="iso";
-						fstype="iso";
-						if(ide_index < 0 || ideattach == "auto") {
-							if(!IDE_controller_occupied(1, false)) { // check if secondary master is already occupied
-								ide_index = 1;
-								ide_slave = false;
-							}
-							else IDE_Auto(ide_index, ide_slave);
-							LOG_MSG("IDE: index %d slave=%d", ide_index, ide_slave ? 1 : 0);
-						}
-					} else if (!strcasecmp(ext, ".ima")) {
-						type="floppy";
-						ideattach="none";
-					}
+					if (ext != NULL) {
+                        if (!strcasecmp(ext, ".iso")||!strcasecmp(ext, ".cue")||!strcasecmp(ext, ".bin")||!strcasecmp(ext, ".chd")||!strcasecmp(ext, ".mdf")||!strcasecmp(ext, ".gog")||!strcasecmp(ext, ".ins")) {
+                            type="iso";
+                            fstype="iso";
+                            if(ide_index < 0 || ideattach == "auto") {
+                                if(!IDE_controller_occupied(1, false)) { // check if secondary master is already occupied
+                                    ide_index = 1;
+                                    ide_slave = false;
+                                }
+                                else IDE_Auto(ide_index, ide_slave);
+                                LOG_MSG("IDE: index %d slave=%d", ide_index, ide_slave ? 1 : 0);
+                            }
+                        } else if (!strcasecmp(ext, ".ima")) {
+                            type="floppy";
+                            ideattach="none";
+                        }
+                    }
 				}
 			}
 


### PR DESCRIPTION
DOSBox-X crashed when mounting a floppy image with extension missing.
This PR will ignore detecting the type of image from its extension in such case.

![floppy](https://github.com/joncampbell123/dosbox-x/assets/68574602/b7a48608-7bea-4e32-9029-814163a86acb)
