### PR TITLE
Fix Intel macOS builds crash on startup (Issue #4438)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install libraries
         run: |
-          brew install autoconf automake nasm glfw glew sdl_net sdl2 coreutils
+          brew install autoconf automake nasm glfw glew sdl_net sdl2 coreutils sevenzip
           mkdir -p package/dosbox-x
           mkdir -p package/dosbox-x-sdl2
           cd vs/sdlnet && ./build-dosbox.sh
@@ -66,13 +66,13 @@ jobs:
           cp $top/COPYING $top/package/dosbox-x-sdl2/COPYING.txt
           cp $top/contrib/macos/readme.txt $top/package/dosbox-x-sdl2/README.txt
           cd $top/package/
-          zip -r -9 $top/dosbox-x-macosx-x86_64-${{ env.timestamp }}.zip *
+          7zz a $top/dosbox-x-macosx-x86_64-${{ env.timestamp }}.zip *
           cd $top
       - name: Upload preview package
         uses: actions/upload-artifact@v3.1.3
         with:
           name: dosbox-x-macosx-x86_64-${{ env.timestamp }}
-          path: ${{ github.workspace }}/package/
+          path: ${{ github.workspace }}/dosbox-x-macosx-x86_64-${{ env.timestamp }}.zip
       - name: Upload release package
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/Makefile.am
+++ b/Makefile.am
@@ -69,10 +69,12 @@ dosbox-x.app: $(MACOS_BINARIES) contrib/macos/dosbox.icns src/tool/mach-o-matic
 	done
 # Remove the signatures from the architecture-dependant executables, and fix their linker search paths.
 	@if [ -f dosbox-x.app/Contents/MacOS/arm64/dosbox-x ]; then \
+		export ARCHPREF=arm64
 		codesign --remove-signature dosbox-x.app/Contents/MacOS/arm64/dosbox-x || exit 1; \
 		src/tool/mach-o-matic dosbox-x.app/Contents/MacOS/arm64/dosbox-x || exit 1; \
 	fi
 	@if [ -f dosbox-x.app/Contents/MacOS/x86_64/dosbox-x ]; then \
+		export ARCHPREF=x86_64
 		codesign --remove-signature dosbox-x.app/Contents/MacOS/x86_64/dosbox-x || exit 1; \
 		src/tool/mach-o-matic dosbox-x.app/Contents/MacOS/x86_64/dosbox-x || exit 1; \
 	fi

--- a/Makefile.am
+++ b/Makefile.am
@@ -69,12 +69,12 @@ dosbox-x.app: $(MACOS_BINARIES) contrib/macos/dosbox.icns src/tool/mach-o-matic
 	done
 # Remove the signatures from the architecture-dependant executables, and fix their linker search paths.
 	@if [ -f dosbox-x.app/Contents/MacOS/arm64/dosbox-x ]; then \
-		export ARCHPREF=arm64
+		export ARCHPREF=arm64; \
 		codesign --remove-signature dosbox-x.app/Contents/MacOS/arm64/dosbox-x || exit 1; \
 		src/tool/mach-o-matic dosbox-x.app/Contents/MacOS/arm64/dosbox-x || exit 1; \
 	fi
 	@if [ -f dosbox-x.app/Contents/MacOS/x86_64/dosbox-x ]; then \
-		export ARCHPREF=x86_64
+		export ARCHPREF=x86_64; \
 		codesign --remove-signature dosbox-x.app/Contents/MacOS/x86_64/dosbox-x || exit 1; \
 		src/tool/mach-o-matic dosbox-x.app/Contents/MacOS/x86_64/dosbox-x || exit 1; \
 	fi


### PR DESCRIPTION
Recent Intel macOS development builds crashed on startup due to incorrect links to the attached dynamic libraries.
This PR fixes the links.
Also, the development builds are affected by a well-known un-fixed bug of github that executable permission gets lost, so changed the compressing tool to 7-zip as a workaround.

## What issue(s) does this PR address?
Fixes #4438

