### PR TITLE
Various spelling fixes

### DIFF
--- a/contrib/translations/en/en_US.lng
+++ b/contrib/translations/en/en_US.lng
@@ -1280,7 +1280,7 @@ You'll have to manually rename the newly created VHD image.
 
 .
 :PROGRAM_VHDMAKE_SUCCESS
-New VHD image succesfully created. You can mount it with ←[34;1mIMGMOUNT←[0m.
+New VHD image successfully created. You can mount it with ←[34;1mIMGMOUNT←[0m.
 
 .
 :PROGRAM_VHDMAKE_ERROPEN
@@ -1357,7 +1357,7 @@ into Fixed VHD.
  -l | -link     create a new Differencing VHD new.vhd and link it to the
                 pre-existing parent image parent.vhd
  -f | -force    force overwriting a pre-existing image file
- -i | -info     show useful informations about a.vhd image
+ -i | -info     show useful information about a.vhd image
  -m | -merge    merge differencing delta.vhd to its parent
  new.vhd        name of the new Dynamic VHD image to create
  size           disk size (eventually with size unit, Bytes is implicit)

--- a/contrib/translations/es/es_ES.lng
+++ b/contrib/translations/es/es_ES.lng
@@ -1282,7 +1282,7 @@ You'll have to manually rename the newly created VHD image.
 
 .
 :PROGRAM_VHDMAKE_SUCCESS
-New VHD image succesfully created. You can mount it with ←[34;1mIMGMOUNT←[0m.
+New VHD image successfully created. You can mount it with ←[34;1mIMGMOUNT←[0m.
 
 .
 :PROGRAM_VHDMAKE_ERROPEN
@@ -1359,7 +1359,7 @@ into Fixed VHD.
  -l | -link     create a new Differencing VHD new.vhd and link it to the
                 pre-existing parent image parent.vhd
  -f | -force    force overwriting a pre-existing image file
- -i | -info     show useful informations about a.vhd image
+ -i | -info     show useful information about a.vhd image
  -m | -merge    merge differencing delta.vhd to its parent
  new.vhd        name of the new Dynamic VHD image to create
  size           disk size (eventually with size unit, Bytes is implicit)

--- a/contrib/translations/fr/fr_FR.lng
+++ b/contrib/translations/fr/fr_FR.lng
@@ -1278,7 +1278,7 @@ You'll have to manually rename the newly created VHD image.
 
 .
 :PROGRAM_VHDMAKE_SUCCESS
-New VHD image succesfully created. You can mount it with ←[34;1mIMGMOUNT←[0m.
+New VHD image successfully created. You can mount it with ←[34;1mIMGMOUNT←[0m.
 
 .
 :PROGRAM_VHDMAKE_ERROPEN
@@ -1355,7 +1355,7 @@ into Fixed VHD.
  -l | -link     create a new Differencing VHD new.vhd and link it to the
                 pre-existing parent image parent.vhd
  -f | -force    force overwriting a pre-existing image file
- -i | -info     show useful informations about a.vhd image
+ -i | -info     show useful information about a.vhd image
  -m | -merge    merge differencing delta.vhd to its parent
  new.vhd        name of the new Dynamic VHD image to create
  size           disk size (eventually with size unit, Bytes is implicit)

--- a/contrib/translations/ko/ko_KR.lng
+++ b/contrib/translations/ko/ko_KR.lng
@@ -1286,7 +1286,7 @@ You'll have to manually rename the newly created VHD image.
 
 .
 :PROGRAM_VHDMAKE_SUCCESS
-New VHD image succesfully created. You can mount it with [34;1mIMGMOUNT[0m.
+New VHD image successfully created. You can mount it with [34;1mIMGMOUNT[0m.
 
 .
 :PROGRAM_VHDMAKE_ERROPEN
@@ -1363,7 +1363,7 @@ into Fixed VHD.
  -l | -link     create a new Differencing VHD new.vhd and link it to the
                 pre-existing parent image parent.vhd
  -f | -force    force overwriting a pre-existing image file
- -i | -info     show useful informations about a.vhd image
+ -i | -info     show useful information about a.vhd image
  -m | -merge    merge differencing delta.vhd to its parent
  new.vhd        name of the new Dynamic VHD image to create
  size           disk size (eventually with size unit, Bytes is implicit)

--- a/contrib/translations/nl/nl_NL.lng
+++ b/contrib/translations/nl/nl_NL.lng
@@ -1278,7 +1278,7 @@ You'll have to manually rename the newly created VHD image.
 
 .
 :PROGRAM_VHDMAKE_SUCCESS
-New VHD image succesfully created. You can mount it with ←[34;1mIMGMOUNT←[0m.
+New VHD image successfully created. You can mount it with ←[34;1mIMGMOUNT←[0m.
 
 .
 :PROGRAM_VHDMAKE_ERROPEN
@@ -1355,7 +1355,7 @@ into Fixed VHD.
  -l | -link     create a new Differencing VHD new.vhd and link it to the
                 pre-existing parent image parent.vhd
  -f | -force    force overwriting a pre-existing image file
- -i | -info     show useful informations about a.vhd image
+ -i | -info     show useful information about a.vhd image
  -m | -merge    merge differencing delta.vhd to its parent
  new.vhd        name of the new Dynamic VHD image to create
  size           disk size (eventually with size unit, Bytes is implicit)

--- a/contrib/translations/pt/pt_BR.lng
+++ b/contrib/translations/pt/pt_BR.lng
@@ -1286,7 +1286,7 @@ You'll have to manually rename the newly created VHD image.
 
 .
 :PROGRAM_VHDMAKE_SUCCESS
-New VHD image succesfully created. You can mount it with [34;1mIMGMOUNT[0m.
+New VHD image successfully created. You can mount it with [34;1mIMGMOUNT[0m.
 
 .
 :PROGRAM_VHDMAKE_ERROPEN
@@ -1363,7 +1363,7 @@ into Fixed VHD.
  -l | -link     create a new Differencing VHD new.vhd and link it to the
                 pre-existing parent image parent.vhd
  -f | -force    force overwriting a pre-existing image file
- -i | -info     show useful informations about a.vhd image
+ -i | -info     show useful information about a.vhd image
  -m | -merge    merge differencing delta.vhd to its parent
  new.vhd        name of the new Dynamic VHD image to create
  size           disk size (eventually with size unit, Bytes is implicit)

--- a/contrib/translations/tr/tr_TR.lng
+++ b/contrib/translations/tr/tr_TR.lng
@@ -1279,7 +1279,7 @@ You'll have to manually rename the newly created VHD image.
 
 .
 :PROGRAM_VHDMAKE_SUCCESS
-New VHD image succesfully created. You can mount it with ←[34;1mIMGMOUNT←[0m.
+New VHD image successfully created. You can mount it with ←[34;1mIMGMOUNT←[0m.
 
 .
 :PROGRAM_VHDMAKE_ERROPEN
@@ -1356,7 +1356,7 @@ into Fixed VHD.
  -l | -link     create a new Differencing VHD new.vhd and link it to the
                 pre-existing parent image parent.vhd
  -f | -force    force overwriting a pre-existing image file
- -i | -info     show useful informations about a.vhd image
+ -i | -info     show useful information about a.vhd image
  -m | -merge    merge differencing delta.vhd to its parent
  new.vhd        name of the new Dynamic VHD image to create
  size           disk size (eventually with size unit, Bytes is implicit)

--- a/contrib/translations/zh/zh_CN.lng
+++ b/contrib/translations/zh/zh_CN.lng
@@ -1267,7 +1267,7 @@ You'll have to manually rename the newly created VHD image.
 
 .
 :PROGRAM_VHDMAKE_SUCCESS
-New VHD image succesfully created. You can mount it with [34;1mIMGMOUNT[0m.
+New VHD image successfully created. You can mount it with [34;1mIMGMOUNT[0m.
 
 .
 :PROGRAM_VHDMAKE_ERROPEN
@@ -1344,7 +1344,7 @@ into Fixed VHD.
  -l | -link     create a new Differencing VHD new.vhd and link it to the
                 pre-existing parent image parent.vhd
  -f | -force    force overwriting a pre-existing image file
- -i | -info     show useful informations about a.vhd image
+ -i | -info     show useful information about a.vhd image
  -m | -merge    merge differencing delta.vhd to its parent
  new.vhd        name of the new Dynamic VHD image to create
  size           disk size (eventually with size unit, Bytes is implicit)

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -9524,7 +9524,7 @@ void DOS_SetupPrograms(void) {
     MSG_Add("PROGRAM_VHDMAKE_WRITERR", "Could not write to new VHD image \"%s\", aborting.\n");
     MSG_Add("PROGRAM_VHDMAKE_REMOVEERR", "Could not erase file \"%s\"\n");
     MSG_Add("PROGRAM_VHDMAKE_RENAME", "You'll have to manually rename the newly created VHD image.\n");
-    MSG_Add("PROGRAM_VHDMAKE_SUCCESS", "New VHD image succesfully created. You can mount it with \033[34;1mIMGMOUNT\033[0m.\n");
+    MSG_Add("PROGRAM_VHDMAKE_SUCCESS", "New VHD image successfully created. You can mount it with \033[34;1mIMGMOUNT\033[0m.\n");
     MSG_Add("PROGRAM_VHDMAKE_ERROPEN", "Error, could not open image file \"%s\".\n");
     MSG_Add("PROGRAM_VHDMAKE_BADSIZE", "Bad VHD size specified, aborting!\n");
     MSG_Add("PROGRAM_VHDMAKE_FNEEDED", "A pre-existing VHD image can't be silently overwritten without -f option!\n");
@@ -9542,7 +9542,7 @@ void DOS_SetupPrograms(void) {
     MSG_Add("PROGRAM_VHDMAKE_ABSPATH_UX", "ERROR: an absolute path to parent inhibits portability.\nUse a path relative to differencing image file!\n");
     MSG_Add("PROGRAM_VHDMAKE_HELP",
         "Creates Dynamic or Differencing VHD images, converts raw images into Fixed VHD,\n"
-        "shows informations about VHD images and merges them.\n"
+        "shows information about VHD images and merges them.\n"
         "\033[32;1mVHDMAKE\033[0m [-f] new.vhd size[BKMGT]\n"
         "\033[32;1mVHDMAKE\033[0m \033[34;1m-convert\033[0m raw.hdd new.vhd\n"
         "\033[32;1mVHDMAKE\033[0m [-f] \033[34;1m-link\033[0m parent.vhd new.vhd\n"
@@ -9552,7 +9552,7 @@ void DOS_SetupPrograms(void) {
         " -l | -link     create a new Differencing VHD new.vhd and link it to the\n"
         "                pre-existing parent image parent.vhd\n"
         " -f | -force    force overwriting a pre-existing image file\n"
-        " -i | -info     show useful informations about a.vhd image\n"
+        " -i | -info     show useful information about a.vhd image\n"
         " -m | -merge    merge differencing delta.vhd to its parent\n"
         " new.vhd        name of the new Dynamic VHD image to create\n"
         " size           disk size (eventually with size unit, Bytes is implicit)\n"

--- a/src/ints/bios_vhd.cpp
+++ b/src/ints/bios_vhd.cpp
@@ -948,7 +948,7 @@ bool imageDiskVHD::MergeSnapshot(uint32_t* totalSectorsMerged, uint32_t* totalBl
     }
     LOG_MSG("Merged %d sectors in %d blocks", *totalSectorsMerged, *totalBlocksUpdated);
     if (! ((imageDiskVHD*)parentDisk)->UpdateUUID() )
-        LOG_MSG("Warning: parent UUID not updated, invalid childs could exist around!");
+        LOG_MSG("Warning: parent UUID not updated, invalid children might remain!");
     return true;
 }
 


### PR DESCRIPTION
These were flagged by Debian's QA tools:

* childs -> children (I rephrased the surrounding text)
* informations -> information (except in French)
* succesfully -> successfully