### PR TITLE
Fix TTF mode didn't switch to graphics mode on certain types of machines

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ Next:
   - Fix palette setting bugs due to SETCOLOR fix in 2023.10.06 release.
     (Issues #4510, #4511, #4534)(maron2000)
   - Fix crash when mounting floppy/ISO images with no extension (maron2000)
+  - Fix TTF mode didn't switch to graphics mode on certain types of machines
+    such as tandy/pcjr.(Issue #4559)(maron2000)
 
 2023.10.06
   - Add "VRD" debugger command to force redraw of the VGA screen.

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -699,7 +699,11 @@ static bool SetCurMode(VideoModeBlock modeblock[],uint16_t mode) {
 		else {
 			if ((!int10.vesa_oldvbe) || (ModeList_VGA[i].mode<0x120)) {
 				CurMode=&modeblock[i];
-				return true;
+#if defined(USE_TTF)
+                if(modeblock[i].type == M_TEXT) ttf_switch_on(false);
+                else ttf_switch_off(false); // Disable TTF output when switching to graphics mode
+#endif
+                return true;
 			}
 			return false;
 		}
@@ -936,7 +940,7 @@ bool INT10_SetVideoMode_OTHER(uint16_t mode,bool clearmem) {
 				LOG(LOG_INT10,LOG_ERROR)("Trying to set illegal mode %X",mode);
 				return false;
 			}
-			break;
+            break;
 		case MCH_MCGA:
 			if (!SetCurMode(ModeList_MCGA,mode)) {
 				LOG(LOG_INT10,LOG_ERROR)("Trying to set illegal mode %X",mode);


### PR DESCRIPTION
## What issue(s) does this PR address?

In certain types of machines, screen mode didn't switch from TTF to relevant modes, resulting in a black screen.
This PR fixes such issue.

Fixes #4559
