### PR TITLE
Fix crash on switching to fullscreen when output=opengl (Intel macOS)

### DIFF
--- a/src/output/output_gamelink.cpp
+++ b/src/output/output_gamelink.cpp
@@ -16,7 +16,8 @@
 #include "mixer.h"
 #include "mapper.h"
 #include "../gamelink/scancodes_windows.h"
-#include "../output/output_surface.h"
+#include "output/output_surface.h"
+#include "output/output_opengl.h"
 #include <output/output_tools_xbrz.h>
 
 using namespace std;
@@ -36,9 +37,14 @@ void OUTPUT_GAMELINK_Select()
         MessageBoxA( NULL, "ERROR: Game Link output disabled.",
                                 "DOSBox \"Game Link\" Error", MB_OK | MB_ICONSTOP );
 #else // WIN32
+#if defined(MACOSX) && !defined(__arm64__) && C_OPENGL
+        LOG_MSG( "OUTPUT_GAMELINK: Not enabled via `gamelink master = true`, falling back to `output=opengl`." );
+        OUTPUT_OPENGL_Select(GLBilinear);
+#else // MACOSX
         LOG_MSG( "OUTPUT_GAMELINK: Not enabled via `gamelink master = true`, falling back to `output=surface`." );
-#endif // WIN32
         OUTPUT_SURFACE_Select();
+#endif //!MACOSX
+#endif
         return;
     }
 

--- a/src/output/output_tools.cpp
+++ b/src/output/output_tools.cpp
@@ -80,7 +80,7 @@ std::string GetDefaultOutput() {
 # else
     output = "surface";
 # endif
-#elif defined(C_OPENGL) && !(defined(LINUX) && !defined(C_SDL2)) && !(defined(MACOSX) && defined(C_SDL2))
+#elif defined(C_OPENGL) && (!(defined(LINUX) && !defined(C_SDL2)) || (defined(MACOSX) && !defined(__arm64__)))
     /* NTS: Lately, especially on Macbooks with Retina displays, OpenGL gives better performance
             than the CG bitmap-based "surface" output.
 

--- a/src/output/output_ttf.cpp
+++ b/src/output/output_ttf.cpp
@@ -601,7 +601,7 @@ void GFX_SelectFontByPoints(int ptsize) {
 
 void SetOutputSwitch(const char *outputstr) {
 #if C_DIRECT3D
-        if (!strcasecmp(outputstr, "direct3d"))
+        if (!strcasecmp(outputstr, "direct3d") || !strcasecmp(outputstr, "auto"))
             switchoutput = 6;
         else
 #endif
@@ -610,7 +610,7 @@ void SetOutputSwitch(const char *outputstr) {
             switchoutput = 5;
         else if (!strcasecmp(outputstr, "openglnb"))
             switchoutput = 4;
-        else if (!strcasecmp(outputstr, "opengl")||!strcasecmp(outputstr, "openglnq"))
+        else if (!strcasecmp(outputstr, "opengl")||!strcasecmp(outputstr, "openglnq") || !strcasecmp(outputstr, "auto"))
             switchoutput = 3;
         else
 #endif
@@ -624,7 +624,7 @@ void OUTPUT_TTF_Select(int fsize) {
     if (!initttf&&TTF_Init()) {											// Init SDL-TTF
         std::string message = "Could not init SDL-TTF: " + std::string(SDL_GetError());
         systemmessagebox("Error", message.c_str(), "ok","error", 1);
-        sdl.desktop.want_type = SCREEN_SURFACE;
+        change_output(switchoutput == -1 ? 0 : switchoutput);
         return;
     }
     int fontSize = 0;


### PR DESCRIPTION
On macOS, DOSBox-X crashes when switching to fullscreen when output=opengl.
The crash occurs when output is switched from surface (default) to opengl, and then switched to fullscreen.
This PR makes opengl to be the default to avoid such crash.
I can't test Arm macs, but since there are no bug reports, I leave default output of arm mac to be surface.

Tested on MacOS Monterey 12.7.1 and ArchLinux (SDL1 & SDL2).

Fixes https://github.com/joncampbell123/dosbox-x/issues/4567
(PR #4568 tried to do the same but reverted unwanted replacements of line-feed code etc.)