### PR TITLE
Update DXCapture shell command to support /O for OPL capture

### DIFF
--- a/contrib/translations/en/en_US.lng
+++ b/contrib/translations/en/en_US.lng
@@ -2328,7 +2328,7 @@ Runs program with video or audio capture.
 DX-CAPTURE [/V|/-V] [/A|/-A] [/M|/-M] [command] [options]
 
 It will start video or audio capture, run program, and then automatically stop capture when the program exits.
-
+/V for video, /A for audio, /M multi-track audio and /O for OPL FM (DROv2 format).
 .
 :SHELL_CMD_DEBUGBOX_HELP
 Runs program and breaks into debugger at entry point.

--- a/contrib/translations/nl/nl_NL.lng
+++ b/contrib/translations/nl/nl_NL.lng
@@ -2324,10 +2324,11 @@ Voert programma uit met video- of audio-opname.
 
 .
 :SHELL_CMD_DXCAPTURE_HELP_LONG
-DX-CAPTURE [/V|/-V] [/A|/-A] [/M|/-M] [commando] [opties]
+DX-CAPTURE [/V|/-V] [/A|/-A] [/M|/-M] [O|/-O] [commando] [opties]
 
 Het zal video- of audio-opname starten, het programma uitvoeren en vervolgens
 automatisch stoppen met vastleggen wanneer het programma wordt afgesloten.
+/V voor video, /A voor audio, /M voor multi-track audio en /O voor OPL FM (DROv2 formaat)
 
 .
 :SHELL_CMD_DEBUGBOX_HELP

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -342,6 +342,8 @@ extern unsigned int hostkeyalt, sendkeymap;
 extern const char* RunningProgram;
 Bitu CaptureState = 0;
 
+void OPL_SaveRawEvent(bool pressed), SetGameState_Run(int value), ResolvePath(std::string& in);
+
 #define WAVE_BUF 16*1024
 #define MIDI_BUF 4*1024
 
@@ -744,6 +746,24 @@ void CAPTURE_StopMTWave(void) {
 #if !defined(C_EMSCRIPTEN)
 	if (CaptureState & CAPTURE_MULTITRACK_WAVE)
         CAPTURE_MTWaveEvent(true);
+#endif
+}
+
+#if !defined(C_EMSCRIPTEN)
+void CAPTURE_OPLEvent(bool pressed);
+#endif
+
+void CAPTURE_StartOPL(void) {
+#if !defined(C_EMSCRIPTEN)
+	if (!(CaptureState & CAPTURE_OPL))
+        OPL_SaveRawEvent(true);
+#endif
+}
+
+void CAPTURE_StopOPL(void) {
+#if !defined(C_EMSCRIPTEN)
+	if (CaptureState & CAPTURE_OPL)
+        OPL_SaveRawEvent(true);
 #endif
 }
 
@@ -2045,7 +2065,6 @@ void CAPTURE_Destroy(Section *sec) {
 bool enable_autosave = false;
 int autosave_second = 0, autosave_count = 0, autosave_start[10], autosave_end[10], autosave_last[10];
 std::string autosave_name[10];
-void OPL_SaveRawEvent(bool pressed), SetGameState_Run(int value), ResolvePath(std::string& in);
 
 void ParseAutoSaveArg(std::string arg) {
     if (arg.size()) {

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1735,7 +1735,7 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_TRUENAME_HELP","Finds the fully-expanded name for a file.\n");
 	MSG_Add("SHELL_CMD_TRUENAME_HELP_LONG","TRUENAME [/H] file\n");
 	MSG_Add("SHELL_CMD_DXCAPTURE_HELP","Runs program with video or audio capture.\n");
-	MSG_Add("SHELL_CMD_DXCAPTURE_HELP_LONG","DX-CAPTURE [/V|/-V] [/A|/-A] [/M|/-M] [command] [options]\n\nIt will start video or audio capture, run program, and then automatically stop capture when the program exits.\n");
+	MSG_Add("SHELL_CMD_DXCAPTURE_HELP_LONG","DX-CAPTURE [/V|/-V] [/A|/-A] [/M|/-M] [/O|/-O] [command] [options]\n\nIt will start video or audio capture, run program, and then automatically stop capture when the program exits.\n /V for video, /A for audio, /M multi-track audio and /O for OPL FM (DROv2 format)");
 #if C_DEBUG
 	MSG_Add("SHELL_CMD_DEBUGBOX_HELP","Runs program and breaks into debugger at entry point.\n");
 	MSG_Add("SHELL_CMD_DEBUGBOX_HELP_LONG","DEBUGBOX [command] [options]\n\nType DEBUGBOX without a parameter to start the debugger.\n");

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -4268,6 +4268,9 @@ void CAPTURE_StopWave(void);
 void CAPTURE_StartMTWave(void);
 void CAPTURE_StopMTWave(void);
 
+void CAPTURE_StartOPL(void);
+void CAPTURE_StopOPL(void);
+
 // Explanation: Start capture, run program, stop capture when program exits.
 //              Great for gameplay footage or demoscene capture.
 //
@@ -4281,6 +4284,7 @@ void DOS_Shell::CMD_DXCAPTURE(char * args) {
     bool cap_video = false;
     bool cap_audio = false;
     bool cap_mtaudio = false;
+    bool cap_opl = false;
     unsigned long post_exit_delay_ms = 3000; /* 3 sec */
 
     if (!strcmp(args,"-?")) {
@@ -4300,8 +4304,12 @@ void DOS_Shell::CMD_DXCAPTURE(char * args) {
 			cap_video = false;
 		else if (!(strcmp(arg1,"/A")))
 			cap_audio = true;
+        else if (!(strcmp(arg1,"/O")))
+			cap_opl = true;
 		else if (!(strcmp(arg1,"/-A")))
 			cap_audio = false;
+        else if (!(strcmp(arg1,"/-O")))
+			cap_opl = false;
 		else if (!(strcmp(arg1,"/M")))
 			cap_mtaudio = true;
 		else if (!(strcmp(arg1,"/-M")))
@@ -4312,7 +4320,7 @@ void DOS_Shell::CMD_DXCAPTURE(char * args) {
 		}
     }
 
-    if (!cap_video && !cap_audio && !cap_mtaudio)
+    if (!cap_video && !cap_audio && !cap_mtaudio && !cap_opl)
         cap_video = true;
 
     if (cap_video)
@@ -4321,6 +4329,8 @@ void DOS_Shell::CMD_DXCAPTURE(char * args) {
         CAPTURE_StartWave();
     if (cap_mtaudio)
         CAPTURE_StartMTWave();
+    if (cap_opl)
+        CAPTURE_StartOPL();
 
     DoCommand(args);
 
@@ -4363,6 +4373,8 @@ void DOS_Shell::CMD_DXCAPTURE(char * args) {
         CAPTURE_StopWave();
     if (cap_mtaudio)
         CAPTURE_StopMTWave();
+    if (cap_opl)
+        CAPTURE_StopOPL();
 }
 
 void DOS_Shell::CMD_CTTY(char * args) {


### PR DESCRIPTION
Add OPL capture support to DX-CAPTURE

## What issue(s) does this PR address?

It adds the option to start capturing OPL FM commands with the DX-CAPTURE shell command. Currently this can only be done by using the menu at the top.

## Does this PR introduce new feature(s)?
It adds the /O option to DX-CAPTURE shell command to capture OPL FM commands in DRO format.

## Does this PR introduce any breaking change(s)?
No, not that I'm aware of. It uses the already existing capture routines for OPL that are already present in dosbox-x.

## Additional information
I found the documentation of the parameters was missing for DX-CAPTURE. For example /M is multi-track, while I thought it was for MIDI at first. I've taken the liberty of adding this extra description to the English and Dutch translations.

## Background/context why I made this
I'm looking for a way to quickly test and validate a music player called [Adplay](https://github.com/adplug/adplay-dos) (from the creators of AdPlug). It allows you to playback many formats of OPL2/3 music. I'm working on a new version and use this new option to validate my work, since dosbox-x allows me to capture audio, video and OPL of every run. Later on I plan to make some kind of unit/integration/regression test based on this, comparing the raw OPL output between versions.