### PR TITLE
Fix 'colors' option flaws (Issue #4579 & #3318)

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -8151,7 +8151,8 @@ static void COLOR_ProgramStart(Program * * make) {
     *make=new COLOR;
 }
 
-alt_rgb altBGR[16]={0}, altBGR0[16]={0}, *rgbcolors = (alt_rgb*)render.pal.rgb;
+alt_rgb altBGR[16], altBGR0[16], *rgbcolors = (alt_rgb*)render.pal.rgb;
+bool init_altBGR = false,init_altBGR0 = false;
 
 bool setVGAColor(const char *colorArray, int j) {
     if (!IS_VGA_ARCH||!CurMode) return false;


### PR DESCRIPTION
This PR fixes the following issues.

- TTF output was black screen when `colors` option is specified with '+' option. (issue #4579)
- With the above mentioned '+' option, colors of TTF output didn't reset to preset value when switched from another output option (or from graphics mode to TTF mode). (A regression of Issue #3318)

Fixes #4579
