### PR TITLE
VHD geometry patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ messages in such languages. Language files can be found in the `languages` direc
 |Chinese (Traditional)|[contrib/translations/zh/zh_TW.lng](https://github.com/joncampbell123/dosbox-x/blob/master/contrib/translations/zh/zh_TW.lng)|
 |French|[contrib/translations/fr/fr_FR.lng](https://github.com/joncampbell123/dosbox-x/blob/master/contrib/translations/fr/fr_FR.lng)|
 |German|[contrib/translations/de/de_DE.lng](https://github.com/joncampbell123/dosbox-x/blob/master/contrib/translations/de/de_DE.lng)|
+|Italian|[contrib/translations/it/it_IT.lng](https://github.com/joncampbell123/dosbox-x/blob/master/contrib/translations/it/it_IT.lng)|
 |Japanese|[contrib/translations/ja/ja_JP.lng](https://github.com/joncampbell123/dosbox-x/blob/master/contrib/translations/ja/ja_JP.lng)|
 |Korean|[contrib/translations/ko/ko_KR.lng](https://github.com/joncampbell123/dosbox-x/blob/master/contrib/translations/ko/ko_KR.lng)|
 |Portuguese (Brazilian)|[contrib/translations/pt/pt_BR.lng](https://github.com/joncampbell123/dosbox-x/blob/master/contrib/translations/pt/pt_BR.lng)|

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -344,6 +344,8 @@ public:
     static uint32_t CreateDynamic(const char* filename, uint64_t size);
     static uint32_t CreateDifferencing(const char* filename, const char* basename);
     uint32_t CreateSnapshot();
+    void DetectGeometry(Bitu sizes[]);
+    static uint64_t scanMBR(uint8_t* mbr, Bitu sizes[], uint64_t disksize=0);
     bool MergeSnapshot(uint32_t* totalSectorsMerged, uint32_t* totalBlocksUpdated);
     static void SizeToCHS(uint64_t size, uint16_t* c, uint8_t* h, uint8_t* s);
     bool UpdateUUID();

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -3515,12 +3515,6 @@ restart_int:
             }
             extension[sizeof(extension) - 1] = '\0'; // Terminate string just in case
         }
-        //avoids IMGMOUNT issues, since VHD psuedo-CHS != BPB algorithm (above)
-        //Windows 11 actually does NOT complain, other utilities can
-        if(disktype == "vhd" || !strcasecmp(extension, ".vhd")) {
-            imageDiskVHD::SizeToCHS(size, (uint16_t*) &c, (uint8_t*) &h, (uint8_t*) &s);
-            LOG_MSG("VHD geometry reset conforming to VHD specification");
-        }
         if (!dos_kernel_disabled) WriteOut(MSG_Get("PROGRAM_IMGMAKE_PRINT_CHS"),temp_line.c_str(),c,h,s);
         LOG_MSG(MSG_Get("PROGRAM_IMGMAKE_PRINT_CHS"),temp_line.c_str(),c,h,s);
 
@@ -6163,6 +6157,9 @@ class IMGMOUNT : public Program {
 			fseeko64(diskfile, 0L, SEEK_END);
 			uint32_t fcsize = (uint32_t)(ftello64(diskfile) / 512L);
 			uint8_t buf[512];
+#if 0       // VHD pseudo geometry should be avoided always!
+            // New VHD driver is capable of MBR/BPB analysis.
+
 			// check for vhd signature
 			fseeko64(diskfile, -512, SEEK_CUR);
 			if (fread(buf, sizeof(uint8_t), 512, diskfile)<512) {
@@ -6194,7 +6191,7 @@ class IMGMOUNT : public Program {
 				if (sizes[3]>1023) LOG_MSG("WARNING: cylinders>1023, INT13 will not work unless extensions are used");
 				yet_detected = true;
 			}
-
+#endif
 			fseeko64(diskfile, 0L, SEEK_SET);
 			if (fread(buf, sizeof(uint8_t), 512, diskfile)<512) {
 				fclose(diskfile);


### PR DESCRIPTION
- bios_vhd.cpp now detects real MBR/BPB geometry or, at least, returns a default C/255/63 one coherent with IMGMAKE; calcDiskSize is dropped in favor of footer.currentSize (a VHD can reach 2040GB, while pseudo-CHS geometry is limited to 127GB)

- IMGMAKE/IMGMOUNT behavior is reverted back to "old" (pre-May 2023) DosBox-X default

Fixes #4589 and probably #4541
