### PR TITLE
Change maximum number of joystick buttons allowed by the mapper.

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -83,7 +83,7 @@
 
 #define MAXSTICKS               8
 #define MAXACTIVE               16
-#define MAXBUTTON               32
+#define MAXBUTTON               96
 #define MAXBUTTON_CAP           16
 #define MAXAXIS                 8
 #define MAXHAT                  2


### PR DESCRIPTION
Modern sticks (particularly throttles) have more than 32 buttons. See VKB STECS and Virpil Mongoose for examples.

## What issue(s) does this PR address?

I was getting duplicate button presses when trying to map on my VKB STECS. Turns out it was wrapping after button 31.

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

Yes. Any existing mapper files which map over 32 buttons will no longer function correctly because the buttons will no longer wrap.

For example, if a user mapped button 33 before this change, this would have wrapped to button 1 (33 % 32 = 1), so it would have gotten mapped as button one. After this change, it will no longer wrap, so the existing bind won't work, they'd have to rebind it properly.

If this is objectionable, we can introduce a "max joystick buttons" config parameter which is defaulted to 32 for the old behavior. Users could then increase this value to allow for more buttons.

## Additional information

There is a performance impact as we are now polling 3x the number of button inputs. I tested this for about half an hour in Jane's ATF and any latency added was imperceptible to me on a Ryzen 7 3700X. Not sure how it would behave on something slower.

If this performance hit is objectionable, the "max joystick buttons" parameter described above can be similarly used to mitigate this too - set it to the number of buttons one actually has, and then you only incur the polling penalty for exactly that number of buttons.