### PR TITLE
Fix too deep subdirectories in XP VS build release

### DIFF
--- a/.github/workflows/vsbuild_xp.yml
+++ b/.github/workflows/vsbuild_xp.yml
@@ -97,7 +97,9 @@ jobs:
           cp $top/contrib/glshaders/* $top/package/glshaders/
           cp $top/contrib/translations/*/*.lng $top/package/languages/
           cp $top/COPYING $top/package/COPYING
-          '${{ github.workspace }}/vs/tool/zip.exe' -r -9 '${{ github.workspace }}/dosbox-x-vsbuild-XP-${{ env.timestamp }}.zip' '${{ github.workspace }}/package/*'
+          cd $top/package/
+          $top/vs/tool/zip.exe -r -9 $top/dosbox-x-vsbuild-XP-${{ env.timestamp }}.zip *
+          cd $top
       - name: Upload preview package
         uses: actions/upload-artifact@v3.1.3
         with:


### PR DESCRIPTION
The release portable VS build package for Windows XP somehow packed the directory structure in absolute path resulting that the files are saved in a deep subdirectory.
This PR changes it to relative path so you don't have to dig in the directories to find the executable.

The nightly build package is okay, and is not affected by this PR.

Fixes #4625 