### PR TITLE
replace sOffset (use offsetof)

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -390,7 +390,7 @@ static INLINE uint16_t DOS_PackDate(uint16_t year,uint16_t mon,uint16_t day) {
 
 
 /* Remains some classes used to access certain things */
-#define sOffset(s,m) ((char*)&(((s*)NULL)->m)-(char*)NULL)
+#define sOffset(s,m) offsetof(s,m)
 #define sGet(s,m) GetIt(sizeof(((s *)&pt)->m),(PhysPt)sOffset(s,m))
 #define sSave(s,m,val) SaveIt(sizeof(((s *)&pt)->m),(PhysPt)sOffset(s,m),val)
 


### PR DESCRIPTION
Building DOSBox-X on OpenBSD/amd64 (clang-13), I see many -Wnull-pointer-subtracion warnings like this:

```
../../include/dos_inc.h:542:35: warning: performing pointer subtraction with a null pointer may have undefined behavior [-Wnull-pointer-subtraction]
        void SetBootDrive(uint8_t drv) { sSave(sDIB,bootDrive,drv); }
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~
../../include/dos_inc.h:395:61: note: expanded from macro 'sSave'
#define sSave(s,m,val) SaveIt(sizeof(((s *)&pt)->m),(PhysPt)sOffset(s,m),val)
                                                            ^~~~~~~~~~~~
../../include/dos_inc.h:393:46: note: expanded from macro 'sOffset'
#define sOffset(s,m) ((char*)&(((s*)NULL)->m)-(char*)NULL)
                                             ^~~~~~~~~~~~
```
I think sOffset() in dos_inc.h can be replaced with offsetof() and it can reduce this warning. Is there any historical reason to keep this code?

(in OpenBSD's stddef.h, offsetof() is defined like this)
```
#if __GNUC_PREREQ__(4, 0)
#define offsetof(type, member)  __builtin_offsetof(type, member)
#else
#define offsetof(type, member)  ((size_t)(&((type *)0)->member))
#endif

```