### PR TITLE
DOS_Int21_71a6(): Report correct file size on win32 when file is open.

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -5352,6 +5352,19 @@ void DOS_Int21_71a6(const char *name1, const char *name2) {
 			if(status.st_mode & S_IFDIR) st = DOS_ATTR_DIRECTORY;
 			else st = DOS_ATTR_ARCHIVE;
 
+			/* Win32 stat() will not return the correct file size of a file open for writing */
+#if defined (WIN32)
+			if (Files[handle]->IsOpen())
+			{
+				Files[handle]->Flush();
+				uint32_t oldPos = Files[handle]->GetSeekPos();
+				uint32_t newPos = 0;
+				Files[handle]->Seek(&newPos, DOS_SEEK_END);
+				status.st_size = Files[handle]->GetSeekPos();
+				Files[handle]->Seek(&oldPos, DOS_SEEK_SET);
+			}
+#endif
+
 			memset(buf, 0, 52);
 			set_dword(buf, st);
 			// 116444736000000000LL = FILETIME 1970/01/01 00:00:00


### PR DESCRIPTION
When a file is being written to on win32, a `stat()` call to it will report its length as 0.

This is different from [Int 21/AX=71A6h](http://www.ctyme.com/intr/rb-3216.htm), which should return the current file size.

So I wrote a quick workaround in DOS_Int21_71a6().

I tested this using djgpp, which uses Int 21/AX=71A6h, and a simple hello world C program.  With dos version set to 7.10 before applying this patch, djgpp would not generate a usable executable.  With this patch, it does.

I have no idea if the `stat()` problem is win32 specific or just mingw specific, so this PR could probably use a bit of testing.