### PR TITLE
Mention W9x builds in devel-build.html

### DIFF
--- a/devel-build.html
+++ b/devel-build.html
@@ -47,7 +47,7 @@ title: DOSBox-X Development Builds
         add_ci_build_entry(REPO, "vsbuild_xp", "32/64-bit installers and builds for Windows XP+");
         add_ci_build_entry(REPO, "vsbuild32", "32-bit Visual Studio portable builds (for Vista+/ARM)");
         add_ci_build_entry(REPO, "vsbuild64", "64-bit Visual Studio portable builds (for Vista+/ARM)");
-        add_ci_build_entry(REPO, "mingw32", "32-bit MinGW (for 7+) and MinGW-lowend (for XP+, W9x) portable builds");
+        add_ci_build_entry(REPO, "mingw32", "32-bit MinGW (for 7+) and MinGW-lowend (for XP+, W9x/NT4+) portable builds");
         add_ci_build_entry(REPO, "mingw64", "64-bit MinGW portable builds (for 7+)");
         add_ci_build_entry(REPO, "linux", "Linux (x86_64) builds");
         add_ci_build_entry(REPO, "macos", "macOS (x86_64) builds");

--- a/devel-build.html
+++ b/devel-build.html
@@ -43,12 +43,12 @@ title: DOSBox-X Development Builds
 <script type="text/javascript">
     const REPO = "joncampbell123/dosbox-x";
     document.addEventListener("DOMContentLoaded", () => {
-        add_ci_build_entry(REPO, "vsbuild32", "32-bit Visual Studio builds (for Vista+/ARM)");
-        add_ci_build_entry(REPO, "vsbuild64", "64-bit Visual Studio builds (for Vista+/ARM)");
-        add_ci_build_entry(REPO, "mingw32", "32-bit MinGW builds (for 7+) and MinGW-lowend builds (for XP+)");
-        add_ci_build_entry(REPO, "mingw64", "64-bit MinGW builds (for 7+)");
-        add_ci_build_entry(REPO, "vsbuild_xp", "32/64-bit installers and builds for Windows XP+");
         add_ci_build_entry(REPO, "windows-installers", "32/64-bit installers and builds for Vista+");
+        add_ci_build_entry(REPO, "vsbuild_xp", "32/64-bit installers and builds for Windows XP+");
+        add_ci_build_entry(REPO, "vsbuild32", "32-bit Visual Studio portable builds (for Vista+/ARM)");
+        add_ci_build_entry(REPO, "vsbuild64", "64-bit Visual Studio portable builds (for Vista+/ARM)");
+        add_ci_build_entry(REPO, "mingw32", "32-bit MinGW (for 7+) and MinGW-lowend (for XP+, W9x) portable builds");
+        add_ci_build_entry(REPO, "mingw64", "64-bit MinGW portable builds (for 7+)");
         add_ci_build_entry(REPO, "linux", "Linux (x86_64) builds");
         add_ci_build_entry(REPO, "macos", "macOS (x86_64) builds");
         add_ci_build_entry(REPO, "hxdos", "HX-DOS (x86) build");


### PR DESCRIPTION
We now have W9x builds by CI workflow, so mention that in development builds webpage.
Also put the Windows installers before portable builds, since installers are recommended over portable builds.