### PR TITLE
Add C++11 build test to CI workflow

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -81,3 +81,42 @@ jobs:
         with:
           name: dosbox-x-linux-x86_64-${{ env.timestamp }}
           path: ${{ github.workspace }}/src/bin/
+  Test_cxx11:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
+    if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.12.0
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '14'
+      - name: Install libraries
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y nasm fluidsynth libfluidsynth-dev libpcap-dev libslirp-dev libsdl-net1.2-dev libsdl2-net-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev
+          mkdir src/bin
+      - name: Build Linux SDL1
+        run: |
+          top=`pwd`
+          ./build-debug  --enable-force-cxx11
+          strip -s $top/src/dosbox-x
+          cp $top/src/dosbox-x $top/src/bin/dosbox-x-sdl1
+      - name: Build Linux SDL2
+        run: |
+          top=`pwd`
+          ./build-debug-sdl2  --enable-force-cxx11
+          strip -s $top/src/dosbox-x
+          cp $top/src/dosbox-x $top/src/bin/dosbox-x-sdl2
+      - name: Unit testing
+        run: |
+          top=`pwd`
+          chmod +x $top/src/bin/dosbox-x-sdl1 $top/src/bin/dosbox-x-sdl2
+          $top/src/bin/dosbox-x-sdl1 -tests
+          $top/src/bin/dosbox-x-sdl2 -tests
+

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@ Next:
     means off for IBM compatible mode and on for PC-9821 compatible mode.
     This should allow some DOS games that depend on the linear framebuffer
     to work properly even if memsize=16 or higher.
+  - MIDI: set minimum sysex delay when enabled (mistydemeo)
+  - International support in LABEL, COPY, DEL builtin commands (maxpat)
   - Fix palette setting bugs due to SETCOLOR fix in 2023.10.06 release. (maron2000)
       Graphical glitches in Ultima VI(#4507), Chessmaster 3000(#4510), Wizardry VII(#4534) 
       Crash Sid Meyer's Civilization I (#4511)     
@@ -13,8 +15,22 @@ Next:
     (Issue #4438)(maron2000) 
   - Fix TTF mode didn't switch to graphics mode on certain types of machines
     such as tandy/pcjr.(Issue #4559)(maron2000)
+  - Fix crash on switching to fullscreen when output=opengl (Intel macOS) (maron2000)
+  - Update DXCapture shell command to support /O for OPL capture (AranVink)
   - Fix floppy images lock bug (maxpat78)
+  - Fix type of return value at bool MountFat() (jg1uaa)
   - Fix VHD geometry bugs by performing MBR analysis (maxpat78)
+  - Change maximum number of joystick buttons allowed by the mapper (mattcaron)
+  - Enable Win9x support on a Pentium3 PC (crazii)
+  - Add PC98 image extensions in file open dialogs (maron2000)
+  - Fix input in configuration tool (SDL2) (maron2000)
+  - Reduce warnings by replacing sOffset (use offsetof) (jg1uaa)
+  - Fix LFN functions (nanshiki, SmileTheory)
+     Fixed a bug in which 2 extra bytes were copied to the buffer (ax=714eh,714fh).
+     Fixed wrong value of date/time etc. in file information (ax=714eh,714fh,71a6h).
+     Fixed date/time conversion to be correct (ax=71a7h)
+     Report correct file size on win32 when file is open (ax=71a6h).
+  - Fix C++11 uncompliant codes (midi_alsa.h, gamelink.cpp) (maron2000)
 
 2023.10.06
   - Add "VRD" debugger command to force redraw of the VGA screen.

--- a/src/gamelink/gamelink.cpp
+++ b/src/gamelink/gamelink.cpp
@@ -686,7 +686,7 @@ void GameLink::Out( const uint16_t frame_width,
 				int base = g_p_shared_memory->peek.addr[ 0 ];
 				for (int i = 0; i < g_p_shared_memory->peek.addr_count; i++) {
 					uint8_t seek = g_p_shared_memory->peek.data[ i ];
-					if (g_p_shared_memory->peek.addr[ i ] > 0x1000'0000) continue;
+                    if (g_p_shared_memory->peek.addr[ i ] > 0x10000000) continue;
 					int oaddr = g_p_shared_memory->peek.addr[ i ] - base + addr;
 					if (oaddr >= g_membase_size || p_sysmem[ oaddr ] != seek) {
 						match = false;

--- a/src/gui/midi_alsa.h
+++ b/src/gui/midi_alsa.h
@@ -241,11 +241,17 @@ public:
 	}
 
     void ListAll(Program* base) {
-        auto print_port = [base, this](auto *client_info, auto *port_info) {
-            const auto *addr = snd_seq_port_info_get_addr(port_info);
+#if __cplusplus <= 201103L // C++11 compliant code not tested
+        auto print_port = [base, this](snd_seq_client_info_t *client_info, snd_seq_port_info_t *port_info) {
+            const auto* addr = snd_seq_port_info_get_addr(port_info);
             const unsigned int type = snd_seq_port_info_get_type(port_info);
             const unsigned int caps = snd_seq_port_info_get_capability(port_info);
-
+#else
+        auto print_port = [base, this](auto* client_info, auto* port_info) {
+            const auto* addr = snd_seq_port_info_get_addr(port_info);
+            const unsigned int type = snd_seq_port_info_get_type(port_info);
+            const unsigned int caps = snd_seq_port_info_get_capability(port_info);
+#endif
             if ((type & SND_SEQ_PORT_TYPE_SYNTHESIZER) || port_is_writable(caps)) {
                 const bool selected = (addr->client == this->seq.client && addr->port == this->seq.port);
                 const char esc_color[] = "\033[32;1m";


### PR DESCRIPTION
The DOSBox-X code tree is intended to be C++11 compliant, so added a testing job in CI workflow.
Also, patched a few codes that caused an error while building with `--enable-force-cxx11` option.

Fixes #4658