### PR TITLE
Consider function key display in MORE command (PC-98)

### DIFF
--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -2962,8 +2962,9 @@ void DOS_Shell::CMD_MORE(char * args) {
 	uint16_t n=1;
 	StripSpaces(args);
 	if (IS_PC98_ARCH) {
-		LINES=real_readb(0x60,0x113) & 0x01 ? 25 : 20;
-		COLS=80;
+        LINES=real_readb(0x60,0x113) & 0x01 ? 25 : 20;
+        COLS=80;
+        if (real_readb(0x60,0x111)) LINES--; // Function keys displayed
 	} else {
 		LINES=(IS_EGAVGA_ARCH?real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS):24)+1;
 		COLS=real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS);


### PR DESCRIPTION
`MORE` command on PC-98 didn't consider whether the Function key is displayed on the bottom of the display, so the command assumed all rows are available which is not always the case.
This PR adjusts the number of lines to display at a time considering whether the Function keys are displayed.

Fixes #4664.

25 lines with function key display
![more_25lines_fn](https://github.com/joncampbell123/dosbox-x/assets/68574602/89684ff8-8962-4aec-9f9f-97863044fc46)

25 lines, no function key display
![more_25lines](https://github.com/joncampbell123/dosbox-x/assets/68574602/4597c058-ae90-4642-9932-28ed6fff9509)

20 lines mode
![more_20lines_fn](https://github.com/joncampbell123/dosbox-x/assets/68574602/89bfe068-2068-4d64-bb46-2b5dcbcb6b36)

