### PR TITLE
Bugfix at output_tools.cpp - crash when menu item "ttf_extcharset" is not existing

### DIFF
--- a/src/output/output_tools.cpp
+++ b/src/output/output_tools.cpp
@@ -50,10 +50,12 @@ extern int initgl, posx, posy;
 extern bool rtl, gbk, chinasea, window_was_maximized, dpi_aware_enable, isVirtualBox;
 
 void refreshExtChar() {
-    mainMenu.get_item("ttf_extcharset").enable(TTF_using()&&!IS_PC98_ARCH&&!IS_JEGA_ARCH&&enable_dbcs_tables);
-    if (dos.loaded_codepage == 936) mainMenu.get_item("ttf_extcharset").check(gbk).refresh_item(mainMenu);
-    else if (dos.loaded_codepage == 950 || dos.loaded_codepage == 951) mainMenu.get_item("ttf_extcharset").check(chinasea).refresh_item(mainMenu);
-    else mainMenu.get_item("ttf_extcharset").check(gbk&&chinasea).refresh_item(mainMenu);
+    if (mainMenu.item_exists("ttf_extcharset")) {
+        mainMenu.get_item("ttf_extcharset").enable(TTF_using()&&!IS_PC98_ARCH&&!IS_JEGA_ARCH&&enable_dbcs_tables);
+        if (dos.loaded_codepage == 936) mainMenu.get_item("ttf_extcharset").check(gbk).refresh_item(mainMenu);
+        else if (dos.loaded_codepage == 950 || dos.loaded_codepage == 951) mainMenu.get_item("ttf_extcharset").check(chinasea).refresh_item(mainMenu);
+        else mainMenu.get_item("ttf_extcharset").check(gbk&&chinasea).refresh_item(mainMenu);
+    }
 }
 
 std::string GetDefaultOutput() {


### PR DESCRIPTION
During loading a language file this function is called although the menu item is not existing. This crashes dosbox-x.
I added the if statement avoiding the get_item call if the item does not exist.
From my point of view it is a bug fix.