### PR TITLE
Supports J-3100 video mode 75h

### DIFF
--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -1100,8 +1100,8 @@ CX	640x480	800x600	  1024x768/1280x1024
 			break;
 		}
 		break;
-	case 0x82:// Set/Read the scroll mode when the video mode is JEGA graphic mode
-		if (J3_IsJapanese()) {
+		case 0x82:// Set/Read the scroll mode when the video mode is JEGA graphic mode
+		if (J3_IsJapanese() || (IS_J3100 && GetTrueVideoMode() == 0x75)) {
 			if(reg_al == 0x00) {
 				// scroll mode
 				reg_al = real_readb(BIOSMEM_J3_SEG, BIOSMEM_J3_SCROLL);

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -105,6 +105,7 @@ VideoModeBlock ModeList_VGA[]={
 
 /* Toshiba T3100, J-3100 */
 { 0x074  ,M_DCGA   ,640 ,400 ,80 ,25 ,8 ,16 ,1 ,0xB8000 ,0x8000 ,100 ,449 ,80 ,400 ,0	},
+{ 0x075  ,M_EGA    ,640 ,400 ,80 ,25 ,8 ,16 ,1 ,0xA0000 ,0xA000 ,100 ,525 ,80 ,400 ,0	},
 
 /* Follow vesa 1.2 for first 0x20 */
 { 0x100  ,M_LIN8   ,640 ,400 ,80 ,25 ,8 ,16 ,1 ,0xA0000 ,0x10000,100 ,449 ,80 ,400 ,0   },
@@ -399,6 +400,7 @@ VideoModeBlock ModeList_VGA_Tseng[]={
 
 /* Toshiba T3100, J-3100 */
 { 0x074  ,M_DCGA   ,640 ,400 ,80 ,25 ,8 ,16 ,1 ,0xB8000 ,0x8000 ,100 ,449 ,80 ,400 ,0	},
+{ 0x075  ,M_EGA    ,640 ,400 ,80 ,25 ,8 ,16 ,1 ,0xA0000 ,0xA000 ,100 ,525 ,80 ,400 ,0	},
 
 // Sierra SC1148x Hi-Color DAC modes
 { 0x213  ,M_LIN15  ,320 ,200 ,40 ,25 ,8 ,8  ,1 ,0xA0000 ,0x10000,100 ,449 ,80 ,400 , _VGA_PIXEL_DOUBLE | _REPEAT1 },
@@ -1850,6 +1852,8 @@ bool INT10_SetVideoMode(uint16_t mode) {
 				case 0x10:
 				case 0x12: 
 					goto att_text16;
+				case 0x75: 
+					if(IS_J3100) goto att_text16;
 				default:
 					if ( CurMode->type == M_LIN4 )
 						goto att_text16;

--- a/src/ints/int_dosv.cpp
+++ b/src/ints/int_dosv.cpp
@@ -1712,6 +1712,9 @@ bool DOSV_CheckCJKVideoMode()
 	if(IS_DOS_CJK && (TrueVideoMode == 0x03 || TrueVideoMode == 0x12 || (TrueVideoMode >= 0x70 && TrueVideoMode <= 0x73) || TrueVideoMode == 0x78)) {
 		return true;
 	}
+	if(IS_J3100 && TrueVideoMode == 0x75) {
+		return true;
+	}
 	return false;
 }
 


### PR DESCRIPTION
Video mode 75h of J-3100 is 640x400 16 colors.
[dosv] j3100colorscroll=true enables Toshiba EGA to be used with Toshiba Windows 3.1 display driver.