### PR TITLE
Fixed to set the drawing bit of the GDC status.

### DIFF
--- a/include/pc98_gdc.h
+++ b/include/pc98_gdc.h
@@ -174,6 +174,14 @@ struct PC98_GDC_state {
     bool                    doublescan;                 /* 200-line as 400-line */
 
     bool                    dbg_ev_partition;
+    uint8_t                 drawing_status;
+#if defined(C_SDL2)
+    int                     dot_count;
+    uint64_t                drawing_start;
+    uint64_t                drawing_time;
+#else
+    int                     drawing_count;
+#endif
 };
 
 typedef union pc98_tile             egc_quad[4];

--- a/include/pc98_gdc.h
+++ b/include/pc98_gdc.h
@@ -174,14 +174,10 @@ struct PC98_GDC_state {
     bool                    doublescan;                 /* 200-line as 400-line */
 
     bool                    dbg_ev_partition;
-    uint8_t                 drawing_status;
-#if defined(C_SDL2)
+
+    double                  drawing_end;
     int                     dot_count;
-    uint64_t                drawing_start;
-    uint64_t                drawing_time;
-#else
-    int                     drawing_count;
-#endif
+    uint8_t                 drawing_status;
 };
 
 typedef union pc98_tile             egc_quad[4];

--- a/src/hardware/vga_pc98_gdc.cpp
+++ b/src/hardware/vga_pc98_gdc.cpp
@@ -658,16 +658,9 @@ uint8_t PC98_GDC_state::read_status(void) {
         ret |= 0x01; // data ready
     else if (fifo_read == fifo_write) {
         if(drawing_status) {
-#if defined(C_SDL2)
-            if(SDL_GetPerformanceCounter() - drawing_start > drawing_time) {
+            if(PIC_FullIndex() > drawing_end) {
                 drawing_status = 0;
             }
-#else
-            drawing_count--;
-            if(drawing_count <= 0) {
-                drawing_status = 0;
-            }
-#endif
             ret |= drawing_status;
         }
     }

--- a/src/hardware/vga_pc98_gdc.cpp
+++ b/src/hardware/vga_pc98_gdc.cpp
@@ -150,6 +150,7 @@ PC98_GDC_state::PC98_GDC_state() {
     horizontal_back_porch_width = 0;
     vertical_front_porch_width = 0;
     vertical_back_porch_width = 0;
+    drawing_status = 0;
     reset_fifo();
     reset_rfifo();
     draw_reset();
@@ -656,16 +657,19 @@ uint8_t PC98_GDC_state::read_status(void) {
     if (rfifo_has_content())
         ret |= 0x01; // data ready
     else if (fifo_read == fifo_write) {
-#if 0 // THIS IS CAUSING SEVERE PERFORMANCE ISSUES, DISABLED!
-	// According to
-	// [http://hackipedia.org/browse.cgi/Computer/Platform/PC%2c%20NEC%20PC%2d98/Collections/Undocumented%209801%2c%209821%20Volume%202%20%28webtech.co.jp%29/io%5fdisp%2etxt]
-	// bit 3 (0x08) is supposed to indicate when the GDC is drawing. Perhaps the contributer who's
-	// pull request added this found a PC-98 game that failed to run without it. Re-enable when a
-	// higher performance implementation is possible. Also, recent commits in 2022 added actual
-	// GDC drawing functionality, so perhaps this should mirror that too?
-        initRand();
-        if (rand()%20<1) ret |= 0x08;
+        if(drawing_status) {
+#if defined(C_SDL2)
+            if(SDL_GetPerformanceCounter() - drawing_start > drawing_time) {
+                drawing_status = 0;
+            }
+#else
+            drawing_count--;
+            if(drawing_count <= 0) {
+                drawing_status = 0;
+            }
 #endif
+            ret |= drawing_status;
+        }
     }
 
     return ret;

--- a/src/hardware/vga_pc98_gdc_draw.cpp
+++ b/src/hardware/vga_pc98_gdc_draw.cpp
@@ -451,7 +451,7 @@ void PC98_GDC_state::box(void) {
         y -= vectdir[draw.dir].y2;
     }
 }
-#include <windows.h>
+
 void PC98_GDC_state::exec(uint8_t command) {
     dot_count = 0;
     switch(draw.ope & 0xf8) {

--- a/src/hardware/vga_pc98_gdc_draw.cpp
+++ b/src/hardware/vga_pc98_gdc_draw.cpp
@@ -7,7 +7,7 @@
 #include "logging.h"
 #include "pc98_gdc.h"
 #include "pc98_gdc_const.h"
-#include "timer.h"
+#include "pic.h"
 #include <math.h>
 
 /* do not issue CPU-side I/O here -- this code emulates functions that the GDC itself carries out, not on the CPU */
@@ -221,9 +221,7 @@ void PC98_GDC_state::draw_dot(uint16_t x, uint16_t y) {
             }
         }
     }
-#if defined(C_SDL2)
     dot_count++;
-#endif
 }
 
 void PC98_GDC_state::pset(void) {
@@ -453,11 +451,9 @@ void PC98_GDC_state::box(void) {
         y -= vectdir[draw.dir].y2;
     }
 }
-
+#include <windows.h>
 void PC98_GDC_state::exec(uint8_t command) {
-#if defined(C_SDL2)
     dot_count = 0;
-#endif
     switch(draw.ope & 0xf8) {
         case 0x00:
             pset();
@@ -483,12 +479,6 @@ void PC98_GDC_state::exec(uint8_t command) {
     draw_reset();
     // GDC status drawing bit
     drawing_status = 0x08;
-#if defined(C_SDL2)
     // uPD7220's 1-dot drawing time is 800ns
-    drawing_time = (uint64_t)(SDL_GetPerformanceFrequency() * (0.0000008 * dot_count));
-    drawing_start = SDL_GetPerformanceCounter();
-#else
-    // Number of read_status() calls
-    drawing_count = 3;
-#endif
+    drawing_end = PIC_FullIndex() + (0.0008 * dot_count);
 }

--- a/src/hardware/vga_pc98_gdc_draw.cpp
+++ b/src/hardware/vga_pc98_gdc_draw.cpp
@@ -7,6 +7,7 @@
 #include "logging.h"
 #include "pc98_gdc.h"
 #include "pc98_gdc_const.h"
+#include "timer.h"
 #include <math.h>
 
 /* do not issue CPU-side I/O here -- this code emulates functions that the GDC itself carries out, not on the CPU */
@@ -191,7 +192,8 @@ void PC98_GDC_state::draw_dot(uint16_t x, uint16_t y) {
     //       The GDC is documented to issue 16-bit read/modify/write when drawing, so
     //       that's what this code should do. Additionally, drawing with 8-bit memio
     //       and EGC causes minor artifacts.
-    if ((pc98_gdc_vramop & 0xE) == 0xA || (pc98_gdc_vramop & 0xE) == 0xE) {
+    // NOTE: It seems that the same behavior as EGC is required for GRCG+RMW.
+    if ((pc98_gdc_vramop & 0xE) == 0xA || (pc98_gdc_vramop & 0xC) == 0xC) {
         if(dot) {
             // REPLACE. COMPLEMENT or SET
             if(draw.mode == 0x00 || draw.mode == 0x01 || draw.mode == 0x03) {
@@ -219,6 +221,9 @@ void PC98_GDC_state::draw_dot(uint16_t x, uint16_t y) {
             }
         }
     }
+#if defined(C_SDL2)
+    dot_count++;
+#endif
 }
 
 void PC98_GDC_state::pset(void) {
@@ -450,6 +455,9 @@ void PC98_GDC_state::box(void) {
 }
 
 void PC98_GDC_state::exec(uint8_t command) {
+#if defined(C_SDL2)
+    dot_count = 0;
+#endif
     switch(draw.ope & 0xf8) {
         case 0x00:
             pset();
@@ -473,4 +481,14 @@ void PC98_GDC_state::exec(uint8_t command) {
             break;
     }
     draw_reset();
+    // GDC status drawing bit
+    drawing_status = 0x08;
+#if defined(C_SDL2)
+    // uPD7220's 1-dot drawing time is 800ns
+    drawing_time = (uint64_t)(SDL_GetPerformanceFrequency() * (0.0000008 * dot_count));
+    drawing_start = SDL_GetPerformanceCounter();
+#else
+    // Number of read_status() calls
+    drawing_count = 3;
+#endif
 }


### PR DESCRIPTION
Fix #4564
In case of SDL2, the bit is set for the time corresponding to the number of dots drawn, and in case of SDL1, the bit is set for the number of times specified in the status read.
Also, even if EGC is not enabled for port output, if GRCG and RMW are enabled, it is necessary to make GDC's dot drawing equivalent to EGC.
