### PR TITLE
Fixed PC-98 mouse cursor movement

### DIFF
--- a/src/hardware/keyboard.cpp
+++ b/src/hardware/keyboard.cpp
@@ -2252,14 +2252,8 @@ uint8_t p7fd9_8255_mouse_latch = 0;
 uint8_t p7fd8_8255_mouse_int_enable = 0;
 
 void pc98_mouse_movement_apply(int x,int y) {
-    x += p7fd9_8255_mouse_x;
-    if (x < -128) x = -128;
-    if (x > 127) x = 127;
-    y += p7fd9_8255_mouse_y;
-    if (y < -128) y = -128;
-    if (y > 127) y = 127;
-    p7fd9_8255_mouse_x = (int8_t)x;
-    p7fd9_8255_mouse_y = (int8_t)y;
+    p7fd9_8255_mouse_x += x;
+    p7fd9_8255_mouse_y += y;
 }
 
 unsigned int pc98_mouse_rate_hz = 120;


### PR DESCRIPTION
Fix #4585
It seems that the Macross Skull Leader mouse driver does not reset the counter, so if you limit it to -128 to 127, you cannot move it to the whole thing.
Normal mouse drivers reset the counter after reading the value of the counter, so there should be no problem without value limitation.