### PR TITLE
Fixed PC-98 console output

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -3634,6 +3634,26 @@ static Bitu DOS_29Handler(void)
 					col--;
 				}
 			} else {
+				if(isDBCSCP() && isKanji1(reg_al) && col == ncols - 1) {
+					col = 0;
+					if(row < nrows) {
+						row++;
+					} else {
+						uint8_t tmp_al = reg_al;
+						reg_bh = 0x07;
+						reg_ax = 0x0601;
+						reg_cx = 0x0000;
+						reg_dl = (uint8_t)(ncols - 1);
+						reg_dh = (uint8_t)nrows;
+						CALLBACK_RunRealInt(0x10);
+						reg_al = tmp_al;
+					}
+					reg_ah = 0x02;
+					reg_bh = page;
+					reg_dl = col;
+					reg_dh = row;
+					CALLBACK_RunRealInt(0x10);
+				}
 				reg_ah = 0x09;
 				reg_bh = page;
 				reg_bl = int29h_data.ansi.attr;

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -955,6 +955,26 @@ void INTDC_CL10h_AH09h(uint16_t count) {
         DOS_CON->INTDC_CL10h_AH09h(count);
 }
 
+void INTDC_CL10h_AH0Ah(uint16_t pattern) {
+    if (DOS_CON != NULL)
+        DOS_CON->INTDC_CL10h_AH0Ah(pattern);
+}
+
+void INTDC_CL10h_AH0Bh(uint16_t pattern) {
+    if (DOS_CON != NULL)
+        DOS_CON->INTDC_CL10h_AH0Bh(pattern);
+}
+
+void INTDC_CL10h_AH0Ch(uint16_t count) {
+    if (DOS_CON != NULL)
+        DOS_CON->INTDC_CL10h_AH0Ch(count);
+}
+
+void INTDC_CL10h_AH0Dh(uint16_t count) {
+    if (DOS_CON != NULL)
+        DOS_CON->INTDC_CL10h_AH0Dh(count);
+}
+
 /* The CB_INT28 handler calls this callback then executes STI+HLT.
  * This works great when called from the CON device because on return,
  * when IRQ1 keyboard input breaks the HLT and returns to CON, this

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -5505,6 +5505,31 @@ static Bitu INTDC_PC98_Handler(void) {
                 INTDC_CL10h_AH09h(reg_dx);
                 goto done;
             }
+            else if (reg_ah == 0x0a) { /* CL=0x10 AH=0x0A DL=pattern Erase screen */
+                void INTDC_CL10h_AH0Ah(uint16_t pattern);
+                INTDC_CL10h_AH0Ah(reg_dx);
+                goto done;
+            }
+            else if (reg_ah == 0x0b) { /* CL=0x10 AH=0x0B DL=pattern Erase lines */
+                void INTDC_CL10h_AH0Bh(uint16_t pattern);
+                INTDC_CL10h_AH0Bh(reg_dx);
+                goto done;
+            }
+            else if (reg_ah == 0x0c) { /* CL=0x10 AH=0x0C DL=count Insert lines */
+                void INTDC_CL10h_AH0Ch(uint16_t count);
+                INTDC_CL10h_AH0Ch(reg_dx);
+                goto done;
+            }
+            else if (reg_ah == 0x0d) { /* CL=0x10 AH=0x0D DL=count Erase lines */
+                void INTDC_CL10h_AH0Dh(uint16_t count);
+                INTDC_CL10h_AH0Dh(reg_dx);
+                goto done;
+            }
+            else if (reg_ah == 0x0E) { /* CL=0x10 AH=0x0E DL=mode Change character mode */
+                void pc98_set_char_mode(bool mode);
+                pc98_set_char_mode(reg_dl == 0);
+                goto done;
+            }
             goto unknown;
         default: /* some compilers don't like not having a default case */
             goto unknown;


### PR DESCRIPTION
Added function for int DCh cl=10h ah=0Ah to 0Eh.
ah=0Ah is screen erase
ah=0Bh is line erase
ah=0Ch is insert line and scroll down
ah=0Dh is line erase and scroll up
ah=0Eh is kanji/graph character switch

Added the following to the escape sequence.
ESC[0J Erase from cursor position to end of screen
ESC[1J Erase from the beginning of the screen to the cursor position
ESC[0K Erase from cursor position to right end of line
ESC[1K Erase from left end of line to cursor position
ESC[2K Erase line
ESC[nL Insert n lines at cursor position and scroll down

In the case of PC-98, the cursor does not move to the left edge of the next line when outputting a character at column position 79, but moves collectively on the next character output.
Scrolling also doesn't occur until the next character is output.
If a Kanji character is output at column position 79, it will be displayed starting from the left end of the next line.
Also, regarding the kanji output at the right edge of the screen, the behavior is the same in DOS/V, so it has been corrected.
