### PR TITLE
Refine Version strings display

### DIFF
--- a/include/version_string.h
+++ b/include/version_string.h
@@ -1,0 +1,25 @@
+#if WIN32 && !defined(HX_DOS)
+#ifdef _MSC_VER
+#define OS_PLATFORM "Windows"
+#elif defined(__MINGW32__)
+#define OS_PLATFORM "MinGW"
+#else
+#define OS_PLATFORM "Windows"
+#endif
+#elif defined(HX_DOS)
+#define OS_PLATFORM "DOS"
+#elif defined(LINUX)
+#define OS_PLATFORM "Linux"
+#elif defined(MACOSX)
+#define OS_PLATFORM "macOS"
+#else
+#define OS_PLATFORM ""
+#endif
+
+#if defined(_M_X64) || defined (_M_AMD64) || defined (_M_ARM64) || defined (_M_IA64) || defined(__ia64__) || defined(__LP64__) || defined(_WIN64) || defined(__x86_64__) || defined(__aarch64__) || defined(__powerpc64__)
+#define OS_BIT "64"
+#define OS_BIT_INT 64
+#else
+#define OS_BIT "32"
+#define OS_BIT_INT 32
+#endif

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -63,6 +63,7 @@
 
 #include "SDL_syswm.h"
 #include "sdlmain.h"
+#include "version_string.h"
 
 #if !defined(HX_DOS)
 #include "../libs/tinyfiledialogs/tinyfiledialogs.h"
@@ -145,13 +146,9 @@ void getlogtext(std::string &str), getcodetext(std::string &text), ApplySetting(
 void ttf_switch_on(bool ss=true), ttf_switch_off(bool ss=true), setAspectRatio(Section_prop * section), GFX_ForceRedrawScreen(void), SetWindowTransparency(int trans);
 bool CheckQuit(void), OpenGL_using(void);
 char tmp1[CROSS_LEN*2], tmp2[CROSS_LEN];
-const char *aboutmsg = "DOSBox-X version " VERSION " ("
-#if defined(_M_X64) || defined (_M_AMD64) || defined (_M_ARM64) || defined (_M_IA64) || defined(__ia64__) || defined(__LP64__) || defined(_WIN64) || defined(__x86_64__) || defined(__aarch64__) || defined(__powerpc64__)
-	"64"
-#else
-	"32"
-#endif
-	"-bit " SDL_STRING ")\nBuild date/time: " UPDATED_STR "\nCopyright 2011-" COPYRIGHT_END_YEAR " The DOSBox-X Team\nProject maintainer: joncampbell123\nDOSBox-X homepage: https://dosbox-x.com";
+const char *aboutmsg = "DOSBox-X ver." VERSION " (" OS_PLATFORM " " SDL_STRING " " OS_BIT "-bit)\n" \
+                       "Build date/time: " UPDATED_STR "\nCopyright 2011-" COPYRIGHT_END_YEAR \
+                       " The DOSBox-X Team\nProject maintainer: joncampbell123\nDOSBox-X homepage: https://dosbox-x.com";
 
 void RebootConfig(std::string filename, bool confirm=false) {
     std::string exepath=GetDOSBoxXPath(true), para="-conf \""+filename+"\"";

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -246,6 +246,7 @@ extern "C" void sdl1_hax_macosx_highdpi_set_enable(const bool enable);
 
 #include "sdlmain.h"
 #include "build_timestamp.h"
+#include "version_string.h"
 
 #if C_OPENGL
 namespace gl2 {
@@ -8556,19 +8557,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 #endif
 
         /* -- Welcome to DOSBox-X! */
-        LOG_MSG("DOSBox-X version %s ("
-#if defined(WIN32)
-                "Windows"
-#elif defined(HX_DOS)
-                "DOS"
-#elif defined(LINUX)
-                "Linux"
-#elif defined(MACOSX)
-                "macOS"
-#else
-                ""
-#endif
-        " %s)",VERSION,SDL_STRING);
+        LOG_MSG("DOSBox-X version %s (%s %s %d-bit)",VERSION, OS_PLATFORM, SDL_STRING, OS_BIT_INT);
         LOG(LOG_MISC,LOG_NORMAL)("Copyright 2011-%s The DOSBox-X Team. Project maintainer: joncampbell123 (The Great Codeholio). DOSBox-X published under GNU GPL.",std::string(COPYRIGHT_END_YEAR).c_str());
 
 #if defined(MACOSX)

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -52,6 +52,7 @@ extern bool PS1AudioCard;
 #include "sdlmain.h"
 #include <time.h>
 #include <sys/stat.h>
+#include "version_string.h"
 
 #if defined(DB_HAVE_CLOCK_GETTIME) && ! defined(WIN32)
 //time.h is already included
@@ -509,7 +510,7 @@ void dosbox_integration_trigger_read() {
             dosbox_int_register = 0;
 #endif
             if (control->opt_securemode || control->SecureMode()) dosbox_int_register = 0;
-#if defined(_M_X64) || defined (_M_AMD64) || defined (_M_ARM64) || defined (_M_IA64) || defined(__ia64__) || defined(__LP64__) || defined(_WIN64) || defined(__x86_64__) || defined(__aarch64__) || defined(__powerpc64__)
+#if OS_BIT_INT == 64
             dosbox_int_register += 0x20; // 64-bit
 #else
             dosbox_int_register += 0x10; // 32-bit
@@ -9253,12 +9254,7 @@ private:
         strcpy(logostr[3], "|  D O S B o x - X !  |");
         strcpy(logostr[4], "|                     |");
         sprintf(logostr[5],"|     %d-bit %s     |",
-#if defined(_M_X64) || defined (_M_AMD64) || defined (_M_ARM64) || defined (_M_IA64) || defined(__ia64__) || defined(__LP64__) || defined(_WIN64) || defined(__x86_64__) || defined(__aarch64__) || defined(__powerpc64__)^M
-        64
-#else
-        32
-#endif
-        , SDL_STRING);
+        OS_BIT_INT, SDL_STRING);
         sprintf(logostr[6], "| Version %10s  |", VERSION);
         strcpy(logostr[7], "+---------------------+");
 startfunction:
@@ -9970,7 +9966,8 @@ public:
                 else if (s == "false" || s == "0")
                     isa_memory_hole_15mb = false;
                 else if (IS_PC98_ARCH)
-                    isa_memory_hole_15mb = true; // For the sake of some DOS games, enable by default
+                    isa_memory_hole_15mb = true;
+ // For the sake of some DOS games, enable by default
                 else
                     isa_memory_hole_15mb = false;
             }

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -51,6 +51,7 @@
 #include "sdlmain.h"
 #include "menudef.h"
 #include "build_timestamp.h"
+#include "version_string.h"
 
 #include <output/output_ttf.h>
 
@@ -235,7 +236,7 @@ bool DOS_Shell::CheckConfig(char* cmd_in,char*line) {
 bool enable_config_as_shell_commands = false;
 
 bool DOS_Shell::execute_shell_cmd(char *name, char *arguments) {
-	SHELL_Cmd shell_cmd = {};
+	// SHELL_Cmd shell_cmd = {}; /* unused */
 	uint32_t cmd_index=0;
 	while (cmd_list[cmd_index].name) {
 		if (strcasecmp(cmd_list[cmd_index].name,name)==0) {
@@ -3401,9 +3402,10 @@ bool get_param(char *&args, char *&rem, char *&temp, char &wait_char, int &wait_
 void DOS_Shell::CMD_CHOICE(char * args){
 	HELP("CHOICE");
 	static char defchoice[3] = {MSG_Get("INT21_6523_YESNO_CHARS")[0],MSG_Get("INT21_6523_YESNO_CHARS")[1],0};
-	char *rem1 = NULL, *rem2 = NULL, *rem = NULL, *temp = NULL, waitchar = 0, *ptr;
+	//char *rem1 = NULL, *rem2 = NULL; /* unused */
+	char *rem = NULL, *temp = NULL, waitchar = 0, *ptr;
 	int waitsec = 0;
-	bool optC = false, optT = false;
+	//bool optC = false, optT = false; /* unused */
 	bool optN = ScanCMDBool(args,"N");
 	bool optS = ScanCMDBool(args,"S"); //Case-sensitive matching
 	// ignore /b and /m switches for compatibility
@@ -3705,7 +3707,7 @@ void DOS_Shell::CMD_VER(char *args) {
 		dos_ver_menu(false);
 	} else {
 		WriteOut(MSG_Get("SHELL_CMD_VER_VER"),VERSION,SDL_STRING,dos.version.major,dos.version.minor);
-		if (optR) WriteOut("DOSBox-X Git commit %s, built on %s\n", GIT_COMMIT_HASH, UPDATED_STR);
+		if (optR) WriteOut("DOSBox-X Git commit %s, built on %s\nPlatform: %s %d-bit", GIT_COMMIT_HASH, UPDATED_STR, OS_PLATFORM, OS_BIT_INT);
 	}
 }
 

--- a/vs/dosbox-x.vcxproj
+++ b/vs/dosbox-x.vcxproj
@@ -1699,6 +1699,7 @@ for /d %%i in ($(SolutionDir)\..\contrib\translations\*) do copy %%i\*.lng "$(Ou
     <ClInclude Include="..\include\util_math.h" />
     <ClInclude Include="..\include\util_pointer.h" />
     <ClInclude Include="..\include\util_units.h" />
+    <ClInclude Include="..\include\version_string.h" />
     <ClInclude Include="..\include\vga.h" />
     <ClInclude Include="..\include\video.h" />
     <ClInclude Include="..\include\voodoo.h" />


### PR DESCRIPTION
Show version, SDL version, and 32/64-bit where version is displayed so that users can identify which version is currently used.

![ver_string1](https://github.com/joncampbell123/dosbox-x/assets/68574602/2f3d8744-34c4-44b3-abfe-7e1b44c911bd)
![ver_string2](https://github.com/joncampbell123/dosbox-x/assets/68574602/78279817-b8fb-46b4-bb17-d247eeedddff)
![ver_string3](https://github.com/joncampbell123/dosbox-x/assets/68574602/26a3639b-066a-4ae4-96c6-e477a6491c75)
