### PR TITLE
 More refine Version strings display

### DIFF
--- a/include/version_string.h
+++ b/include/version_string.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2023  The DOSBox Team
+ *  Copyright (C) 2011-2023  The DOSBox-X Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/include/version_string.h
+++ b/include/version_string.h
@@ -54,6 +54,7 @@
 
 #else
 #define OS_PLATFORM ""
+#define OS_PLATFORM_LONG ""
 #endif
 
 #if defined(_M_X64) || defined (_M_AMD64) || defined (_M_ARM64) || defined (_M_IA64) || defined(__ia64__) || defined(__LP64__) || defined(_WIN64) || defined(__x86_64__) || defined(__aarch64__) || defined(__powerpc64__)

--- a/include/version_string.h
+++ b/include/version_string.h
@@ -1,17 +1,57 @@
+/*
+ *  Copyright (C) 2002-2023  The DOSBox Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
 #if WIN32 && !defined(HX_DOS)
 #ifdef _MSC_VER
-#define OS_PLATFORM "Windows"
+#if defined(_M_X64) || defined(_M_AMD64) || defined(_M_IX86)
+#if _MSC_VER <= 1916
+#define OS_PLATFORM "VS XP"
+#define OS_PLATFORM_LONG "Visual Studio XP"
+#else
+#define OS_PLATFORM "VS"
+#define OS_PLATFORM_LONG "Visual Studio"
+#endif
+#else
+#define OS_PLATFORM "VS ARM"
+#define OS_PLATFORM_LONG "Visual Studio ARM"
+#endif
 #elif defined(__MINGW32__)
 #define OS_PLATFORM "MinGW"
+#define OS_PLATFORM_LONG "MinGW"
 #else
 #define OS_PLATFORM "Windows"
+#define OS_PLATFORM_LONG "Windows"
 #endif
 #elif defined(HX_DOS)
 #define OS_PLATFORM "DOS"
+#define OS_PLATFORM_LONG "DOS"
 #elif defined(LINUX)
 #define OS_PLATFORM "Linux"
+#define OS_PLATFORM_LONG "Linux"
 #elif defined(MACOSX)
-#define OS_PLATFORM "macOS"
+#ifdef __arm__
+#define OS_PLATFORM "ARM mac"
+#define OS_PLATFORM_LONG "macOS ARM"
+#else
+#define OS_PLATFORM "x86 mac"
+#define OS_PLATFORM_LONG "macOS Intel"
+#endif
+
 #else
 #define OS_PLATFORM ""
 #endif

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8557,7 +8557,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 #endif
 
         /* -- Welcome to DOSBox-X! */
-        LOG_MSG("DOSBox-X version %s (%s %s %d-bit)",VERSION, OS_PLATFORM, SDL_STRING, OS_BIT_INT);
+        LOG_MSG("DOSBox-X version %s Commit %s (%s %s %d-bit)",VERSION, GIT_COMMIT_HASH, OS_PLATFORM_LONG, SDL_STRING, OS_BIT_INT);
         LOG(LOG_MISC,LOG_NORMAL)("Copyright 2011-%s The DOSBox-X Team. Project maintainer: joncampbell123 (The Great Codeholio). DOSBox-X published under GNU GPL.",std::string(COPYRIGHT_END_YEAR).c_str());
 
 #if defined(MACOSX)

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8719,7 +8719,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 #if defined(C_SDL2)
         SDL_version sdl_version;
         SDL_GetVersion(&sdl_version);
-        LOG_MSG("SDL: version %d.%d.%d, Video %s, Audio %s)",
+        LOG_MSG("SDL: version %d.%d.%d, Video %s, Audio %s",
             sdl_version.major, sdl_version.minor, sdl_version.patch,
             SDL_GetCurrentVideoDriver(), SDL_GetCurrentAudioDriver());
 #endif //defined (C_SDL2)

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -49,6 +49,7 @@
 #include <dirent.h>
 #endif
 #include "build_timestamp.h"
+#include "version_string.h"
 
 extern bool shell_keyboard_flush;
 extern bool dos_shell_running_program, mountwarning, winautorun;
@@ -754,7 +755,7 @@ void GetExpandedPath(std::string &path) {
 void showWelcome(Program *shell) {
     /* Start a normal shell and check for a first command init */
     ansiinstalled = is_ANSI_installed(shell);
-    std::string verstr = "v"+std::string(VERSION)+", "+GetPlatform(false);
+    std::string verstr = "v"+std::string(VERSION)+", "+OS_PLATFORM_LONG+" "+OS_BIT+"-bit";
     if (machine == MCH_PC98) {
         shell->WriteOut(ParseMsg("\x86\x52\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44"
             "\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44"

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -755,7 +755,7 @@ void GetExpandedPath(std::string &path) {
 void showWelcome(Program *shell) {
     /* Start a normal shell and check for a first command init */
     ansiinstalled = is_ANSI_installed(shell);
-    std::string verstr = "v"+std::string(VERSION)+", "+OS_PLATFORM_LONG+" "+OS_BIT+"-bit";
+    std::string verstr = "v"+std::string(VERSION)+", "+OS_PLATFORM_LONG+" "+SDL_STRING+" " + OS_BIT + "-bit";
     if (machine == MCH_PC98) {
         shell->WriteOut(ParseMsg("\x86\x52\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44"
             "\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44"

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -3707,7 +3707,7 @@ void DOS_Shell::CMD_VER(char *args) {
 		dos_ver_menu(false);
 	} else {
 		WriteOut(MSG_Get("SHELL_CMD_VER_VER"),VERSION,SDL_STRING,dos.version.major,dos.version.minor);
-		if (optR) WriteOut("DOSBox-X Git commit %s, built on %s\nPlatform: %s %d-bit", GIT_COMMIT_HASH, UPDATED_STR, OS_PLATFORM, OS_BIT_INT);
+		if (optR) WriteOut("DOSBox-X Git commit %s, built on %s\nPlatform: %s %d-bit", GIT_COMMIT_HASH, UPDATED_STR, OS_PLATFORM_LONG, OS_BIT_INT);
 	}
 }
 


### PR DESCRIPTION
 In addition to PR #4707,  the following changes are added
- Visual Studio builds including those for Windows XP are explicitly displayed
- Intel and Arm builds are explicitly displayed (Windows and macOS)
- The version string in the Welcome page wasn't changed so amended the version string as well

Edit: The following is a sample of VS XP build.
Edit2: Fixed SDL version string was missing
![welcome](https://github.com/joncampbell123/dosbox-x/assets/68574602/67797eb7-a8d6-4ff3-8f7c-3a5cef7d962c)
