### PR TITLE
Fix missing keystroke SDLK_LESS on DE keyboard

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1322,8 +1322,8 @@ Bitu GetKeyCode(SDL_keysym keysym) {
             default:
 #elif defined (__linux__)
             switch(keysym.scancode) { // Workaround for some of the keys return incorrect virtual keycodes 
-            //case 0x56:
-            //    return SDLK_LESS;
+            case 0x5E:
+                return SDLK_LESS;    //DE Keyboard on Debian GNU/Linux 12 (bookworm) Debian 1:6.1.63-1+rpt1 (2023-11-24) aarch64 Linux 6.1.0-rpi7-rpi-v8
             case 0x60:
                 return SDLK_F12;
             case 0x61:


### PR DESCRIPTION
Running dosbox-x on a Raspberry Pi 4 with an attached German keyboard, one key did not work at all. This change fixes the problem.

I verified this on Debian GNU/Linux 12 (bookworm) Debian 1:6.1.63-1+rpt1 (2023-11-24) aarch64 Linux 6.1.0-rpi7-rpi-v8.
On Ubuntu 20.04.6 LTS Linux 5.15.0-91-generic x86-64 there was no problem and this change keeps it the same way.
With this change my German keyboard is working properly on both systems.