### PR TITLE
Refine version strings for MinGW lowend CI automated builds

### DIFF
--- a/.github/workflows/mingw32.yml
+++ b/.github/workflows/mingw32.yml
@@ -133,7 +133,7 @@ jobs:
         with:
           msystem: MINGW32
           update: true
-          install: git make mingw-w64-i686-libtool autoconf automake
+          install: git make mingw-w64-i686-libtool autoconf automake p7zip
       - name: Update build info
         shell: bash
         run: |
@@ -146,19 +146,19 @@ jobs:
           echo "#define GIT_COMMIT_HASH \"${shortsha}\""  >> include/build_timestamp.h
           echo "#define COPYRIGHT_END_YEAR \"${copyrightyear}\"" >> include/build_timestamp.h
           cat include/build_timestamp.h
+          sed -i -e "s/#define OS_PLATFORM \"MinGW\"/#define OS_PLATFORM \"MinGWLE\"/" include/version_string.h
+          sed -i -e "s/#define OS_PLATFORM_LONG \"MinGW\"/#define OS_PLATFORM_LONG \"MinGW Low-end\"/" include/version_string.h
       - name: setup lowend build environment
-        shell: bash
         run: |
           top=`pwd`
           echo "${top}"
           export "MSYSTEM_PREFIX=/d/a/_temp/msys64/mingw32"
           echo "path=$PATH"
           cd ${MSYSTEM_PREFIX}/..
-          ls -lg
           rm -rf /d/a/_temp/msys64/mingw32
           mkdir mingw32
           7z x $top/build-scripts/mingw/lowend-bin/i686-7.3.0-release-posix-dwarf-rt_v5-rev0+nasm.7z -o${MSYSTEM_PREFIX}
-          cp $top/build-scripts/mingw/lowend-bin/make.exe ${MSYSTEM_PREFIX}/bin/make.exe
+          # cp $top/build-scripts/mingw/lowend-bin/make.exe ${MSYSTEM_PREFIX}/bin/make.exe
           echo "MSYSTEM_PREFIX=${MSYSTEM_PREFIX}"
           chmod +x ${MSYSTEM_PREFIX}/bin/*.*
           chmod +x ${MSYSTEM_PREFIX}/i686-w64-mingw32/bin/*.*
@@ -269,6 +269,8 @@ jobs:
           echo "#define GIT_COMMIT_HASH \"${shortsha}\""  >> include/build_timestamp.h
           echo "#define COPYRIGHT_END_YEAR \"${copyrightyear}\"" >> include/build_timestamp.h
           cat include/build_timestamp.h
+          sed -i -e "s/#define OS_PLATFORM \"MinGW\"/#define OS_PLATFORM \"MinGW9x\"/" include/version_string.h
+          sed -i -e "s/#define OS_PLATFORM_LONG \"MinGW\"/#define OS_PLATFORM_LONG \"MinGW Low-end 9x\"/" include/version_string.h
       - name: setup lowend9x build environment
         run: |
           top=`pwd`
@@ -276,7 +278,6 @@ jobs:
           export "MSYSTEM_PREFIX=/d/a/_temp/msys64/mingw32"
           echo "path=$PATH"
           cd ${MSYSTEM_PREFIX}/..
-          ls -lg
           rm -rf /d/a/_temp/msys64/mingw32         
           wget https://github.com/crazii/MINGW-toolchains-w9x/releases/download/v1.0.1-w95nt/mingw32.7z
           7z x mingw32.7z -o./

--- a/.github/workflows/vsbuild_xp.yml
+++ b/.github/workflows/vsbuild_xp.yml
@@ -130,7 +130,7 @@ jobs:
         with:
           msystem: MINGW32
           update: true
-          install: git make mingw-w64-i686-libtool autoconf automake
+          install: git make mingw-w64-i686-libtool autoconf automake p7zip
       - name: Update build info
         shell: bash
         run: |
@@ -143,19 +143,19 @@ jobs:
           echo "#define GIT_COMMIT_HASH \"${shortsha}\""  >> include/build_timestamp.h
           echo "#define COPYRIGHT_END_YEAR \"${copyrightyear}\"" >> include/build_timestamp.h
           cat include/build_timestamp.h
+          sed -i -e "s/#define OS_PLATFORM \"MinGW\"/#define OS_PLATFORM \"MinGWLE\"/" include/version_string.h
+          sed -i -e "s/#define OS_PLATFORM_LONG \"MinGW\"/#define OS_PLATFORM_LONG \"MinGW Low-end\"/" include/version_string.h
       - name: setup lowend build environment
-        shell: bash
         run: |
           top=`pwd`
           echo "${top}"
           export "MSYSTEM_PREFIX=/d/a/_temp/msys64/mingw32"
           echo "path=$PATH"
           cd ${MSYSTEM_PREFIX}/..
-          ls -lg
           rm -rf /d/a/_temp/msys64/mingw32
           mkdir mingw32
           7z x $top/build-scripts/mingw/lowend-bin/i686-7.3.0-release-posix-dwarf-rt_v5-rev0+nasm.7z -o${MSYSTEM_PREFIX}
-          cp $top/build-scripts/mingw/lowend-bin/make.exe ${MSYSTEM_PREFIX}/bin/make.exe
+          # cp $top/build-scripts/mingw/lowend-bin/make.exe ${MSYSTEM_PREFIX}/bin/make.exe
           echo "MSYSTEM_PREFIX=${MSYSTEM_PREFIX}"
           chmod +x ${MSYSTEM_PREFIX}/bin/*.*
           chmod +x ${MSYSTEM_PREFIX}/i686-w64-mingw32/bin/*.*


### PR DESCRIPTION
This PR enables MinGW lowend and Win9x CI automated builds display its version as such.
