### PR TITLE
Fix crash on startup due to SDLnet library linked externally (macOS)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,10 +21,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install libraries
         run: |
-          brew install autoconf automake nasm glfw glew sdl_net sdl2 coreutils sevenzip
+          brew install autoconf automake nasm glfw glew coreutils sevenzip
           mkdir -p package/dosbox-x
           mkdir -p package/dosbox-x-sdl2
-          cd vs/sdlnet && ./build-dosbox.sh
+          # cd vs/sdlnet && ./build-dosbox.sh
       - name: Update build info
         run: |
           echo "timestamp=`git show -s --format=%at | xargs -I# gdate -d @# +%Y%m%d%H%M%S`" >> $GITHUB_ENV

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -41,7 +41,13 @@ Next:
   - Added escape sequences (ESC[0J ESC[1J ESC[0K ESC[1K ESC[2K ESC[nL) (nanshiki)
   - Fixed behavior of Kanji character output at the right edge of screen (nanshiki)
   - Fixed Media ID was being written to an incorrect location in DPB (nanshiki)
+  - Refined version info (maron2000)
+  - Added NEC mouse functions in INT33h (nanshiki)
   - Bump Nuked-OPL3 code to commit 730f8c2 (13 Nov. 2023) (maron2000)
+  - Implemented INT21 function 0x5D subfunction 0x00 (Remote Server Call) (Yogi-baer)
+  - Fixed missing keystroke SDLK_LESS on DE keyboard (Yogi-baer)
+  - Enabled OPL pass-through code (oplmode=hardware)(dbjh)
+  - Fixed crash on startup due to SDLnet library linked externally (macOS) (maron2000)
 
 2023.10.06
   - Add "VRD" debugger command to force redraw of the VGA screen. (joncampbell123)

--- a/build-macos-sdl2
+++ b/build-macos-sdl2
@@ -90,6 +90,10 @@ for arch in ${architectures}; do
     CXXFLAGS="${CXXFLAGS}${new}"
     export CFLAGS LDFLAGS CPPFLAGS CXXFLAGS
 
+    # prefer to compile against our own copy of SDLnet 1.x
+    echo "Compiling our internal SDLnet 1.x"
+    (cd vs/sdlnet && ./build-dosbox.sh) || exit 1
+
     # prefer to compile against our own zlib
     echo "Compiling our internal zlib"
     (cd vs/zlib && ./build-dosbox.sh) || exit 1


### PR DESCRIPTION
Current nightly builds for macOS uses SDLnet library installed via homebrew.
Some flaws regarding installation of SDL2 library made it crash on startup reported in issue #4438.
This PR compiles the in-tree SDLnet code to avoid such crash.

Fixes #4438 
Fixes #4600 
Fixes #4638