### PR TITLE
Refine log regarding attaching images to BIOS & IDE

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -981,14 +981,14 @@ void HostAppRun() {
 /* called by shell to flush keyboard buffer right before executing the program to avoid
  * having the Enter key in the buffer to confuse programs that act immediately on keyboard input. */
 void DOS_FlushSTDIN(void) {
-	LOG_MSG("Flush STDIN");
-	uint8_t handle=RealHandle(STDIN);
-	if (handle!=0xFF && Files[handle] && Files[handle]->IsName("CON")) {
-		uint8_t c;uint16_t n;
-		while (DOS_GetSTDINStatus()) {
-			n=1; DOS_ReadFile(STDIN,&c,&n);
-		}
-	}
+    LOG(LOG_DOSMISC, LOG_DEBUG)("Flush STDIN");
+    uint8_t handle=RealHandle(STDIN);
+    if (handle!=0xFF && Files[handle] && Files[handle]->IsName("CON")) {
+	    uint8_t c;uint16_t n;
+	    while (DOS_GetSTDINStatus()) {
+		    n=1; DOS_ReadFile(STDIN,&c,&n);
+	    }
+    }
 }
 
 static Bitu DOS_21Handler(void) {

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -4817,6 +4817,7 @@ bool AttachToBiosByLetter(imageDisk* image, const char drive) {
                 return AttachToBiosByIndex(image, index);
             }
         }
+        LOG_MSG("BIOS: Warning: Four hard drives (Disk no. 2-5) attached to BIOS already. Drive %c not attached", drive);
     }
     else if (IS_PC98_ARCH) {
         //for pc-98 machines, mount floppies at first available index
@@ -4841,6 +4842,7 @@ bool AttachToBiosAndIdeByLetter(imageDisk* image, const char drive, const unsign
                 return AttachToBiosAndIdeByIndex(image, index, ide_index, ide_slave);
             }
         }
+        LOG_MSG("BIOS: Warning: Four hard drives (Disk no. 2-5) attached to BIOS already. Drive %c not attached", drive);
     }
     else if (IS_PC98_ARCH) {
         //for pc-98 machines, mount floppies at first available index
@@ -4856,7 +4858,7 @@ bool AttachToBiosAndIdeByLetter(imageDisk* image, const char drive, const unsign
     return false;
 }
 
-char * GetIDEPosition(unsigned char bios_disk_index);
+std::string GetIDEPosition(unsigned char bios_disk_index);
 class IMGMOUNT : public Program {
 	public:
 		std::vector<std::string> options;
@@ -4912,7 +4914,7 @@ class IMGMOUNT : public Program {
 					}
 					if (!swaps) swaps=1;
 					sprintf(swapstr, "%d / %d", swaps==1?1:swapPosition+1, swaps);
-					WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_NUMBER_FORMAT"), std::to_string(index).c_str(), dynamic_cast<imageDiskElToritoFloppy *>(imageDiskList[index])!=NULL?"El Torito floppy drive":imageDiskList[index]->diskname.c_str(), GetIDEPosition(index), swapstr);
+					WriteOut(MSG_Get("PROGRAM_IMGMOUNT_STATUS_NUMBER_FORMAT"), std::to_string(index).c_str(), dynamic_cast<imageDiskElToritoFloppy *>(imageDiskList[index])!=NULL?"El Torito floppy drive":imageDiskList[index]->diskname.c_str(), GetIDEPosition(index).c_str(), swapstr);
 					none=false;
 				}
 			}
@@ -5052,7 +5054,6 @@ class IMGMOUNT : public Program {
 			if(isdigit(tdr) && tdr - '0' >= 2) { //Allocate to respective slots if drive number is specified
 				ide_index = (tdr - '2') / 2;     // Drive number 2 = 1m (index=0, slave=false), 3 = 1s (index=0, slave=true), ...
 				ide_slave = (tdr - '2') & 1 ? true : false;
-				LOG_MSG("IDE: index %d slave=%d", ide_index, ide_slave ? 1 : 0);
 			} else if(ideattach == "auto") {
 				//LOG_MSG("IDE: attach=auto type=%s", type);
 				if(type != "floppy") {
@@ -5063,13 +5064,11 @@ class IMGMOUNT : public Program {
 						}
 					}
 					if (ide_index < 0) IDE_Auto(ide_index, ide_slave);
-					LOG_MSG("IDE: index %d slave=%d", ide_index, ide_slave ? 1 : 0);
 				}
 			}
 			else if (ideattach != "none" && isdigit(ideattach[0]) && ideattach[0] > '0') { /* takes the form [controller]<m/s> such as: 1m for primary master */
 				ide_index = ideattach[0] - '1';
 				if (ideattach.length() >= 2) ide_slave = (ideattach[1] == 's');
-				LOG_MSG("IDE: index %d slave=%d",ide_index,ide_slave?1:0);
 			}
 
 			//if floppy, don't attach to ide controller
@@ -5177,7 +5176,6 @@ class IMGMOUNT : public Program {
                                     ide_slave = false;
                                 }
                                 else IDE_Auto(ide_index, ide_slave);
-                                LOG_MSG("IDE: index %d slave=%d", ide_index, ide_slave ? 1 : 0);
                             }
                         } else if (!strcasecmp(ext, ".ima")) {
                             type="floppy";
@@ -5255,7 +5253,7 @@ class IMGMOUNT : public Program {
 				else {
 					if (AttachToBiosAndIdeByIndex(newImage, (unsigned char)driveIndex, (unsigned char)ide_index, ide_slave)) {
 						WriteOut(MSG_Get("PROGRAM_IMGMOUNT_MOUNT_NUMBER"), drive - '0', (!paths.empty()) ? (wpcolon&&paths[0].length()>1&&paths[0].c_str()[0]==':'?paths[0].c_str()+1:paths[0].c_str()) : (el_torito != ""?"El Torito floppy drive":(type == "ram"?"RAM drive":"-")));
-						const char *ext = strrchr(paths[0].c_str(), '.');
+                        const char *ext = strrchr(paths[0].c_str(), '.');
 						if (ext != NULL) {
 							if ((!IS_PC98_ARCH && strcasecmp(ext,".img") && strcasecmp(ext,".ima") && strcasecmp(ext,".vhd") && strcasecmp(ext,".qcow2")) ||
 								(IS_PC98_ARCH && strcasecmp(ext,".hdi") && strcasecmp(ext,".nhd") && strcasecmp(ext,".img") && strcasecmp(ext,".ima"))){

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -2625,7 +2625,7 @@ public:
     }
 };
 
-char * GetIDEPosition(unsigned char bios_disk_index);
+std::string GetIDEPosition(unsigned char bios_disk_index);
 class ShowDriveNumber : public GUI::ToplevelWindow {
 protected:
     GUI::Input *name;


### PR DESCRIPTION
Add some information in logs when disk images are mounted, so that users can be aware of missing drives in BIOS or IDE especially when booting a guest OS.
Also, changed logging of keyboard flush to log only when user specifies to do so.
  
Examples of logs mounting one CD image and four hard drive images are shown below.
Since there are five images to attach to respective IDE slots, but by default there is only four (1m,1s,2m,2s) so log shows that you don't have enough slots.
Of course if you enable the tertiary controller, there will be no warnings.

```
LOG: IDE: WARNING Trying to attach image to IDE Tertiary controller but not available.  <- added
LOG: IMGMOUNT: CD-ROM image mounted to drive D (IDE Secondary Master) <- amended (previosly IDE: index 1 slave 0) 
LOG: FAT: Partition type is MBR (IBM PC)
LOG: Mounted FAT volume is FAT16 with 40742 clusters
LOG: Mapping BIOS DISK C/H/S 650/2/63 as IDE 650/2/63
LOG: IMGMOUNT: HDD image mounted to drive no. 2 (IDE Primary Master) <- amended
LOG: FAT: Partition type is MBR (IBM PC)
LOG: Mounted FAT volume is FAT16 with 40742 clusters
LOG: Mapping BIOS DISK C/H/S 650/2/63 as IDE 650/2/63
LOG: IMGMOUNT: HDD image mounted to drive no. 3 (IDE Primary Slave) <- amended
LOG: FAT: Partition type is MBR (IBM PC)
LOG: Mounted FAT volume is FAT16 with 40742 clusters
LOG: Mapping BIOS DISK C/H/S 650/2/63 as IDE 650/2/63
LOG: IMGMOUNT: HDD image mounted to drive no. 4 (IDE Secondary Slave) <- amended
LOG: FAT: Partition type is MBR (IBM PC)
LOG: Mounted FAT volume is FAT16 with 41631 clusters
LOG: IDE: WARNING: IDE controller Secondary Master already occupied, specify another slot. <- added
```


