### PR TITLE
Fix PC-98 welcome screen alignment

### DIFF
--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -763,7 +763,7 @@ void showWelcome(Program *shell) {
             "\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44"
             "\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44"
             "\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x44\x86\x56\n"));
-        shell->WriteOut(ParseMsg((std::string("\x86\x46 \033[32m")+(MSG_Get("SHELL_STARTUP_TITLE")+std::string("             ")).substr(0,30)+std::string("  \033[33m%*s\033[37m \x86\x46\n")).c_str()),34,verstr.c_str());
+        shell->WriteOut(ParseMsg((std::string("\x86\x46 \033[32m")+(MSG_Get("SHELL_STARTUP_TITLE")+std::string("      ")).substr(0,22)+std::string("  \033[33m%*s\033[37m \x86\x46\n")).c_str()),42,verstr.c_str());
         shell->WriteOut(ParseMsg("\x86\x46                                                                    \x86\x46\n"));
         shell->WriteOut(ParseMsg((std::string("\x86\x46 ")+MSG_Get("SHELL_STARTUP_HEAD1_PC98")+std::string(" \x86\x46\n")).c_str()));
         shell->WriteOut(ParseMsg("\x86\x46                                                                    \x86\x46\n"));


### PR DESCRIPTION
Since long version strings was introduced by PR #4718, the alignment of the welcome screen in PC-98 mode was screwed up.
This PR fixes the alignment.

Before

![command_001](https://github.com/joncampbell123/dosbox-x/assets/68574602/b3f37f66-b6df-4ef4-b3f4-f3a017d2373c)

After

![command_002](https://github.com/joncampbell123/dosbox-x/assets/68574602/d740cbdd-df47-4275-bf75-a6ab85beb66e)
