### PR TITLE
Fix ARM/intel detection for version info on macOS builds

### DIFF
--- a/include/version_string.h
+++ b/include/version_string.h
@@ -44,7 +44,7 @@
 #define OS_PLATFORM "Linux"
 #define OS_PLATFORM_LONG "Linux"
 #elif defined(MACOSX)
-#ifdef __arm__
+#ifdef __arm64__
 #define OS_PLATFORM "ARM mac"
 #define OS_PLATFORM_LONG "macOS ARM"
 #else


### PR DESCRIPTION
The version info on macOS builds displayed in the Welcome screen, and other places as well, was wrong due to failure in detection of ARM/intel architectures.
This PR fixes the detection.

## What issue(s) does this PR address?
Fixes #4770
