### PR TITLE
Optimized Network_IsNetworkResource()

### DIFF
--- a/src/dos/dos_network2.h
+++ b/src/dos/dos_network2.h
@@ -42,11 +42,23 @@ extern bool CodePageGuestToHostUTF16(uint16_t *d/*CROSS_LEN*/,const char *s/*CRO
 
  bool Network_IsNetworkResource(const char * filename)
 {
-	if(strlen(filename)>1 && enable_network_redirector && !control->SecureMode() && ((filename[0]=='\\' && filename[1]=='\\') || (strlen(filename)>2 && filename[0]=='"' && filename[1]=='\\' && filename[2]=='\\'))) {
-        char *p = strrchr_dbcs((char *)filename, '\\');
-        return p && ((filename[0]=='\\' && p > filename+1) || (filename[0]=='"' && p > filename+2));
-    } else
-		return false;
+    if (!enable_network_redirector || control->SecureMode())
+        return false;
+
+    // Must begin with two backslashes optionally preceded by a double quote:
+    switch (*filename) {
+        case '"':
+            if (*++filename != '\\')
+                return false;
+            /* fallthrough */
+        case '\\':
+            if (*++filename != '\\')
+                return false;
+            // The rest of the string must contain at least one backslash:
+            return strchr_dbcs(const_cast<char *>(filename + 1), '\\');
+        default:
+            return false;
+    }
 }//bool	Network_IsNetworkFile(uint16_t entry)
 
 


### PR DESCRIPTION
This eliminates two `strlen()` calls, some useless branching, and uses [`strchr_dbcs()`](https://github.com/jaakristioja/dosbox-x/blob/0c88e5f8d81ffb457a7cff2ef342ff9249caec55/src/misc/support.cpp#L64-L76) instead of [`strrchr_dbcs()`](https://github.com/jaakristioja/dosbox-x/blob/0c88e5f8d81ffb457a7cff2ef342ff9249caec55/src/misc/support.cpp#L78-L90) to traverse less of the (remaining) string.

Also added some comments and changed a C-style cast to `const_cast` to express the purpose for this cast cast in code.

## What issue(s) does this PR address?

The `Network_IsNetworkResource()` code was a bit painful for me to look at. ;/

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

Some code line breaks, which hopefully make the code easier to read. :)

## Additional information

None.
