### PR TITLE
Enable FONTX2 files in PC-98 mode.

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2223,6 +2223,15 @@ void DOSBOX_SetupConfigSections(void) {
                       "If you specify a font here then it will be tried first, perhaps before FONT.ROM (see previous option).");
     Pstring->SetBasic(true);
 
+    Pstring = secprop->Add_path("pc-98 fontx sbcs",Property::Changeable::OnlyAtStart,"");
+    Pstring->Set_help("Specifies a FONTX2 file (8x16) to be used in PC-98 mode.\n"
+                      "This file has priority over ANEX86.BMP and FREECG98.BMP.");
+    Pstring = secprop->Add_path("pc-98 fontx dbcs",Property::Changeable::OnlyAtStart,"");
+    Pstring->Set_help("Specifies a FONTX2 file (16x16) to be used in PC-98 mode.\n"
+                      "This file has priority over ANEX86.BMP and FREECG98.BMP.");
+    Pbool = secprop->Add_bool("pc-98 fontx internal symbol",Property::Changeable::WhenIdle,false);
+    Pbool->Set_help("If set, Use the internal data for hankaku symbols instead of the data in the FONTX2 file.");
+
     /* Explanation: NEC's mouse driver MOUSE.COM enables the graphics layer on startup and when INT 33h AX=0 is called.
      *              Some games by "Orange House" assume this behavior and do not make any effort on their
      *              own to show and enable graphics. Without this option, those games will not show any

--- a/src/ints/int_dosv.cpp
+++ b/src/ints/int_dosv.cpp
@@ -633,7 +633,7 @@ void readfontxtbl(fontxTbl *table, Bitu size, FILE *fp) {
     }
 }
 
-static bool LoadFontxFile(const char *fname, int height, bool dbcs) {
+bool LoadFontxFile(const char *fname, int height, bool dbcs) {
     fontx_h head;
     fontxTbl *table;
     Bitu code;


### PR DESCRIPTION
Added "pc-98 fontx sbcs" and "pc-98 fontx dbcs" to [pc98] to allow use of 8x16 and 16x16 dot FONTX2 files, respectively.
JPNHNX16.98 and JPNZNX16X.98 created with MKXFNT98.EXE can be used. FONTX2 files for DOS/V can also be used.
Incompatible parts of hankaku characters between PC-98 and DOS/V are adjusted when reading.
It has priority over reading ANEX86.BMP and FREECG98.BMP.
If there is a problem with the compatibility of hankaku characters in the FONTX2 file, use the internal data by setting [pc98] "pc-98 fontx internal symbol" to true.
