### PR TITLE
PC-98: Enable mounting partitions with non-genuine IPL entry names

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -485,8 +485,8 @@ public:
  * Maximum 16 entries. */
 #pragma pack(push,1)
 struct _PC98RawPartition {
-	uint8_t		mid;		/* 0x80 - boot */
-	uint8_t		sid;		/* 0x80 - active */
+	uint8_t		mid;		/* 0x00: unused, 0x20: MS-DOS(not bootable), 0xa1-0xaf: MS-DOS(bootable) */
+	uint8_t		sid;		/* 0x00: unused, 0x81,0x91,0xa1,0xe1: MS-DOS(active), 0x01,0x11,0x21,0x61: MS-DOS(sleep) */
 	uint8_t		dum1;		/* dummy for padding */
 	uint8_t		dum2;		/* dummy for padding */
 	uint8_t		ipl_sect;	/* IPL sector */


### PR DESCRIPTION
The current code rejects mounting partitions except those with IPL entry name starting with "MS-DOS" or "Windows".
However, some PC-98 games have unique entry names.
This PR enables mounting such images, and add some alternative sanity checks.

An example of an image below, uploaded in issue #4820.
https://github.com/joncampbell123/dosbox-x/files/14356558/Rusty.zip
 
![rusty2](https://github.com/joncampbell123/dosbox-x/assets/68574602/f3d10f8a-a591-4b50-8606-98fddc02d943)
