### PR TITLE
Add support for XDF disk format

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -141,7 +141,9 @@ Next:
   - Fixed BPB detection of PC-98 floppies (maron2000)
   - Changed sequence to boot with drive numbers when booting from image (maron2000) 
   - Added force JIS (JP106) keyboard layout option in PC-98 mode (maron2000)
-
+  - PC-98: Enable mounting partitions with non-genuine IPL entry names (maron2000)
+  - Added support for XDF disk format (maron2000)
+   
 2023.10.06
   - Add "VRD" debugger command to force redraw of the VGA screen. (joncampbell123)
   - Add VGA debug set commands to force a video start address and another

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -594,8 +594,8 @@ void MenuBrowseFDImage(char drive, int num, int type) {
     getcwd(Temp_CurrentDir, 512);
     char const * lTheOpenFileName;
     std::string files="", fname="";
-    const char *lFilterPatterns[] = {"*.ima","*.img","*.fdi","*.nfd","*.d88","*.IMA","*.IMG","*.FDI", "*.NFD", "*.D88"};
-    const char *lFilterDescription = "Floppy image files (*.ima, *.img, *.fdi, *.nfd, *.d88)";
+    const char *lFilterPatterns[] = {"*.ima","*.img","*.xdf","*.fdi","*.hdm","*.nfd","*.d88","*.IMA","*.IMG","*.XDF","*.FDI","*.HDM","*.NFD","*.D88"};
+    const char *lFilterDescription = "Floppy image files (*.ima, *.img, *.xdf, *.fdi, *.hdm, *.nfd, *.d88)";
     lTheOpenFileName = tinyfd_openFileDialog("Select a floppy image file","",4,lFilterPatterns,lFilterDescription,0);
 
     if (lTheOpenFileName) {
@@ -656,8 +656,8 @@ void MenuBrowseImageFile(char drive, bool arc, bool boot, bool multiple) {
         lTheOpenFileName = tinyfd_openFileDialog(("Select an archive file for Drive "+str+":").c_str(),"",4,lFilterPatterns,lFilterDescription,0);
         if (lTheOpenFileName) fname = GetNewStr(lTheOpenFileName);
     } else {
-        const char *lFilterPatterns[] = {"*.ima","*.img","*.vhd","*.fdi","*.hdi","*.nfd","*.nhd","*.d88","*.hdm","*.iso","*.cue","*.bin","*.chd","*.mdf","*.gog","*.ins","*.IMA","*.IMG","*.VHD","*.FDI","*.HDI","*.NFD","*.NHD","*.D88","*.HDM","*.ISO","*.CUE","*.BIN","*.CHD","*.MDF","*.GOG","*.INS"};
-        const char *lFilterDescription = "Disk/CD image files (*.ima, *.img, *.vhd, *.fdi, *.hdi, *.nfd, *.nhd, *.d88, *.hdm, *.iso, *.cue, *.bin, *.chd, *.mdf, *.gog, *.ins)";
+        const char *lFilterPatterns[] = {"*.ima","*.img","*.vhd","*.fdi","*.hdi","*.nfd","*.nhd","*.d88","*.hdm","*.xdf","*.iso","*.cue","*.bin","*.chd","*.mdf","*.gog","*.ins","*.IMA","*.IMG","*.VHD","*.FDI","*.HDI","*.NFD","*.NHD","*.D88","*.HDM","*.XDF","*.ISO","*.CUE","*.BIN","*.CHD","*.MDF","*.GOG","*.INS"};
+        const char *lFilterDescription = "Disk/CD image files (*.ima, *.img, *.vhd, *.fdi, *.hdi, *.nfd, *.nhd, *.d88, *.hdm, *.xdf, *.iso, *.cue, *.bin, *.chd, *.mdf, *.gog, *.ins)";
         lTheOpenFileName = tinyfd_openFileDialog(((multiple?"Select image file(s) for Drive ":"Select an image file for Drive ")+str+":").c_str(),"",22,lFilterPatterns,lFilterDescription,multiple?1:0);
         if (lTheOpenFileName) fname = GetNewStr(lTheOpenFileName);
         if (multiple&&fname.size()) {

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -657,7 +657,7 @@ void MenuBrowseImageFile(char drive, bool arc, bool boot, bool multiple) {
         if (lTheOpenFileName) fname = GetNewStr(lTheOpenFileName);
     } else {
         const char *lFilterPatterns[] = {"*.ima","*.img","*.vhd","*.fdi","*.hdi","*.nfd","*.nhd","*.d88","*.hdm","*.xdf","*.iso","*.cue","*.bin","*.chd","*.mdf","*.gog","*.ins","*.IMA","*.IMG","*.VHD","*.FDI","*.HDI","*.NFD","*.NHD","*.D88","*.HDM","*.XDF","*.ISO","*.CUE","*.BIN","*.CHD","*.MDF","*.GOG","*.INS"};
-        const char *lFilterDescription = "Disk/CD image files (*.ima, *.img, *.vhd, *.fdi, *.hdi, *.nfd, *.nhd, *.d88, *.hdm, *.xdf, *.iso, *.cue, *.bin, *.chd, *.mdf, *.gog, *.ins)";
+        const char *lFilterDescription = "Disk/CD image files";
         lTheOpenFileName = tinyfd_openFileDialog(((multiple?"Select image file(s) for Drive ":"Select an image file for Drive ")+str+":").c_str(),"",22,lFilterPatterns,lFilterDescription,multiple?1:0);
         if (lTheOpenFileName) fname = GetNewStr(lTheOpenFileName);
         if (multiple&&fname.size()) {

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -1111,7 +1111,7 @@ diskGeo DiskGeometryList[] = {
     {2880, 36, 2, 80, 6, 512, 240, 2, 0xF0},      // IBM PC high density 3.5" double-sided 2.88MB
 
     {1232,  8, 2, 77, 7, 1024,192, 1, 0xFE},      // NEC PC-98 high density 3.5" double-sided 1.2MB "3-mode"
-    {1520, 19, 2, 80, 4, 512, 224, 1, 0xF9},      // IBM PC high density 5.25" double-sided 1.52MB (XDF)
+    {1520, 19, 2, 80, 2, 512, 224, 1, 0xF9},      // IBM PC high density 5.25" double-sided 1.52MB (XDF)
     {1840, 23, 2, 80, 4, 512, 224, 1, 0xF0},      // IBM PC high density 3.5" double-sided 1.84MB (XDF)
 
     {   0,  0, 0,  0, 0,    0,  0, 0,    0}

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -1111,6 +1111,8 @@ diskGeo DiskGeometryList[] = {
     {2880, 36, 2, 80, 6, 512, 240, 2, 0xF0},      // IBM PC high density 3.5" double-sided 2.88MB
 
     {1232,  8, 2, 77, 7, 1024,192, 1, 0xFE},      // NEC PC-98 high density 3.5" double-sided 1.2MB "3-mode"
+    {1520, 19, 2, 80, 4, 512, 224, 1, 0xF9},      // IBM PC high density 5.25" double-sided 1.52MB (XDF)
+    {1840, 23, 2, 80, 4, 512, 224, 1, 0xF0},      // IBM PC high density 3.5" double-sided 1.84MB (XDF)
 
     {   0,  0, 0,  0, 0,    0,  0, 0,    0}
 };
@@ -3592,7 +3594,7 @@ void LogPrintPartitionTable(const std::vector<_PC98RawPartition> &parts) {
 		const _PC98RawPartition &part = parts[i];
 
 		LOG(LOG_DOSMISC,LOG_DEBUG)("IPL #%u: boot=%u active=%u startchs=%u/%u/%u endchs=%u/%u/%u '%s'",
-			(unsigned int)i,(part.mid&0x80)?1:0,(part.sid&0x80)?1:0,
+        (unsigned int)i,(part.mid&0x80)?1:0,(part.sid&0x80)?1:0,
 			part.cyl,part.head,part.sector,part.end_cyl,part.end_head,part.end_sector,
 			std::string((char*)part.name,sizeof(part.name)).c_str());
 	}


### PR DESCRIPTION
PC-DOS 7.0 & 2000 is distributed using XDF image.
This PR enables mounting XDF images directly on DOSBox-X.

![xdf](https://github.com/joncampbell123/dosbox-x/assets/68574602/0bcdbcde-edf8-4843-b7b1-5e6e9727b3d5)

Fixes #1465 
