### PR TITLE
Temporarily fix MinGW 32bit builds due to MSYS2 dropped 32bit libslirp support

### DIFF
--- a/.github/workflows/mingw32.yml
+++ b/.github/workflows/mingw32.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           msystem: MINGW32
           update: true
-          install: git make mingw-w64-i686-toolchain mingw-w64-i686-libslirp mingw-w64-i686-libtool mingw-w64-i686-nasm autoconf automake mingw-w64-x86_64-ncurses
+          install: git make mingw-w64-i686-toolchain mingw-w64-i686-libtool mingw-w64-i686-nasm autoconf automake mingw-w64-x86_64-ncurses
       - name: Update build info
         shell: bash
         run: |

--- a/.github/workflows/windows-installers.yml
+++ b/.github/workflows/windows-installers.yml
@@ -172,7 +172,7 @@ jobs:
         with:
           msystem: MINGW32
           update: true
-          install: git mingw-w64-i686-toolchain mingw-w64-i686-libslirp mingw-w64-i686-libtool mingw-w64-i686-nasm autoconf automake
+          install: git mingw-w64-i686-toolchain mingw-w64-i686-libtool mingw-w64-i686-nasm autoconf automake
       - name: Update build info
         shell: bash
         run: |


### PR DESCRIPTION
As mentioned in #4849, MSYS2 dropped 32bit libslirp support.
Some argument can be seen here (https://github.com/msys2/MINGW-packages/issues/20191)

The current automated Release/Nightly builds tries to install libslirp in advance, resulting in a failure.
This PR quit installing libslirp in MinGW 32bit build so that at least we can build DOSBox-X.

