### PR TITLE
Adding ESS ES1688; removing ESS ES1488 (see description for reason)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -173,9 +173,8 @@ Next:
   - Added support for XDF disk format (maron2000)
   - Added ESFM emulation (ESFMu v1.2 core) (Kagamiin)
   - Added support for ESS "ESFM" sound synthesis (oplemu=esfmu, oplmode=esfm) (Kagamiin)
-  - Added experimental/WIP support for the ESS ES1488 sblaster type (sbtype=ess1488) (Kagamiin)
-  - Delete obsolete information regarding "INTRO SPECIAL" option (maron2000)
   - Added experimental/WIP support for the ESS ES1688 sblaster type (sbtype=ess1688) (Kagamiin)
+  - Delete obsolete information regarding "INTRO SPECIAL" option (maron2000)
    
 2023.10.06
   - Add "VRD" debugger command to force redraw of the VGA screen. (joncampbell123)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -175,6 +175,7 @@ Next:
   - Added support for ESS "ESFM" sound synthesis (oplemu=esfmu, oplmode=esfm) (Kagamiin)
   - Added experimental/WIP support for the ESS ES1488 sblaster type (sbtype=ess1488) (Kagamiin)
   - Delete obsolete information regarding "INTRO SPECIAL" option (maron2000)
+  - Added experimental/WIP support for the ESS ES1688 sblaster type (sbtype=ess1688) (Kagamiin)
    
 2023.10.06
   - Add "VRD" debugger command to force redraw of the VGA screen. (joncampbell123)

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1288,7 +1288,7 @@ void DOSBOX_SetupConfigSections(void) {
     const char *mt32reverbTimes[] = {"0", "1", "2", "3", "4", "5", "6", "7",0};
     const char *mt32reverbLevels[] = {"0", "1", "2", "3", "4", "5", "6", "7",0};
     const char* gustypes[] = { "classic", "classic37", "max", "interwave", 0 };
-    const char* sbtypes[] = { "sb1", "sb2", "sbpro1", "sbpro2", "sb16", "sb16vibra", "gb", "ess688", "ess1488", "reveal_sc400", "none", 0 };
+    const char* sbtypes[] = { "sb1", "sb2", "sbpro1", "sbpro2", "sb16", "sb16vibra", "gb", "ess688", "ess1488", "ess1688", "reveal_sc400", "none", 0 };
     const char* oplmodes[]={ "auto", "cms", "opl2", "dualopl2", "opl3", "opl3gold", "none", "hardware", "hardwaregb", "esfm", 0};
     const char* serials[] = { "dummy", "disabled", "modem", "nullmodem", "serialmouse", "directserial", "log", "file", 0 };
     const char* acpi_rsd_ptr_settings[] = { "auto", "bios", "ebda", 0 };

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1288,7 +1288,7 @@ void DOSBOX_SetupConfigSections(void) {
     const char *mt32reverbTimes[] = {"0", "1", "2", "3", "4", "5", "6", "7",0};
     const char *mt32reverbLevels[] = {"0", "1", "2", "3", "4", "5", "6", "7",0};
     const char* gustypes[] = { "classic", "classic37", "max", "interwave", 0 };
-    const char* sbtypes[] = { "sb1", "sb2", "sbpro1", "sbpro2", "sb16", "sb16vibra", "gb", "ess688", "ess1488", "ess1688", "reveal_sc400", "none", 0 };
+    const char* sbtypes[] = { "sb1", "sb2", "sbpro1", "sbpro2", "sb16", "sb16vibra", "gb", "ess688", "ess1688", "reveal_sc400", "none", 0 };
     const char* oplmodes[]={ "auto", "cms", "opl2", "dualopl2", "opl3", "opl3gold", "none", "hardware", "hardwaregb", "esfm", 0};
     const char* serials[] = { "dummy", "disabled", "modem", "nullmodem", "serialmouse", "directserial", "log", "file", 0 };
     const char* acpi_rsd_ptr_settings[] = { "auto", "bios", "ebda", 0 };

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -101,7 +101,7 @@ enum {DSP_S_RESET,DSP_S_RESET_WAIT,DSP_S_NORMAL,DSP_S_HIGHSPEED};
 enum SB_TYPES {SBT_NONE=0,SBT_1=1,SBT_PRO1=2,SBT_2=3,SBT_PRO2=4,SBT_16=6,SBT_GB=7}; /* TODO: Need SB 2.0 vs SB 2.01 */
 enum REVEAL_SC_TYPES {RSC_NONE=0,RSC_SC400=1};
 enum SB_IRQS {SB_IRQ_8,SB_IRQ_16,SB_IRQ_MPU};
-enum ESS_TYPES {ESS_NONE=0,ESS_688=1,ESS_1488=2};
+enum ESS_TYPES {ESS_NONE=0,ESS_688=1,ESS_1488=2,ESS_1688=3};
 
 enum DSP_MODES {
     MODE_NONE,
@@ -2294,10 +2294,18 @@ static void DSP_DoCommand(void) {
             case ESS_NONE:
                 break;
             case ESS_688:
-            case ESS_1488:
-                // FIXME: This works for DOS games, but the ES1488 Windows driver seems to be rejecting it. Needs to be verified on a real ES1488 card.
                 DSP_AddData(0x68);
-                DSP_AddData(0x80 | 0x04/*ESS 688/1488 version*/);
+                DSP_AddData(0x80 | 0x04);
+                break;
+            case ESS_1488:
+                // Determined via Windows driver debugging.
+                DSP_AddData(0x48);
+                DSP_AddData(0x80 | 0x09);
+                break;
+            case ESS_1688:
+                // Determined via Windows driver debugging.
+                DSP_AddData(0x68);
+                DSP_AddData(0x80 | 0x09);
                 break;
             }
         }
@@ -3074,9 +3082,10 @@ static uint8_t CTMIXER_Read(void) {
         if (sb.ess_type != ESS_NONE) {
             switch (sb.ess_type) {
             case ESS_688:
+            case ESS_1488:
                 ret=0xa;
                 break;
-            case ESS_1488:
+            case ESS_1688:
                 ret=sb.mixer.ess_id_str[sb.mixer.ess_id_str_pos];
                 sb.mixer.ess_id_str_pos++;
                 if (sb.mixer.ess_id_str_pos >= 4) {
@@ -3684,10 +3693,17 @@ private:
         else if (!strcasecmp(sbtype,"ess1488")) {
             type=SBT_PRO2;
             sb.ess_type=ESS_1488;
-            sb.mixer.ess_id_str[0] = 0x14;
-            sb.mixer.ess_id_str[1] = 0x88;
             LOG(LOG_SB,LOG_DEBUG)("ESS ES1488 emulation enabled.");
             LOG(LOG_SB,LOG_WARN)("ESS ES1488 emulation is EXPERIMENTAL at this time and should not yet be used for normal gaming.");
+            LOG(LOG_SB,LOG_WARN)("Additional WARNING: the ES1488 is not recognized by DOS games using the Miles Sound System, and its MIDI driver under Windows does not use its ESFM capabilites. Therefore the ESFM part of this card is only useful for custom/modern applications that can recognize/work with it.");
+        }
+        else if (!strcasecmp(sbtype,"ess1688")) {
+            type=SBT_PRO2;
+            sb.ess_type=ESS_1688;
+            sb.mixer.ess_id_str[0] = 0x16;
+            sb.mixer.ess_id_str[1] = 0x88;
+            LOG(LOG_SB,LOG_DEBUG)("ESS ES1688 emulation enabled.");
+            LOG(LOG_SB,LOG_WARN)("ESS ES1688 emulation is EXPERIMENTAL at this time and should not yet be used for normal gaming.");
         }
         else type=SBT_16;
 
@@ -3972,6 +3988,8 @@ public:
             ReadHandler[i].Install(sb.hw.base+(IS_PC98_ARCH ? ((i+0x20u) << 8u) : i),read_sb,IO_MB);
             WriteHandler[i].Install(sb.hw.base+(IS_PC98_ARCH ? ((i+0x20u) << 8u) : i),write_sb,IO_MB);
         }
+
+        // TODO: read/write handler for ESS AudioDrive ES1688 (and later) MPU-401 ports (3x0h/3x1h; prevents Windows drivers from working with default settings if missing)
 
         // NTS: Unknown/undefined registers appear to return the register index you requested rather than the actual contents,
         //      according to real SB16 CSP/ASP hardware (chip version id 0x10).

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -101,7 +101,7 @@ enum {DSP_S_RESET,DSP_S_RESET_WAIT,DSP_S_NORMAL,DSP_S_HIGHSPEED};
 enum SB_TYPES {SBT_NONE=0,SBT_1=1,SBT_PRO1=2,SBT_2=3,SBT_PRO2=4,SBT_16=6,SBT_GB=7}; /* TODO: Need SB 2.0 vs SB 2.01 */
 enum REVEAL_SC_TYPES {RSC_NONE=0,RSC_SC400=1};
 enum SB_IRQS {SB_IRQ_8,SB_IRQ_16,SB_IRQ_MPU};
-enum ESS_TYPES {ESS_NONE=0,ESS_688=1,ESS_1488=2,ESS_1688=3};
+enum ESS_TYPES {ESS_NONE=0,ESS_688=1,ESS_1688=2};
 
 enum DSP_MODES {
     MODE_NONE,
@@ -2297,11 +2297,6 @@ static void DSP_DoCommand(void) {
                 DSP_AddData(0x68);
                 DSP_AddData(0x80 | 0x04);
                 break;
-            case ESS_1488:
-                // Determined via Windows driver debugging.
-                DSP_AddData(0x48);
-                DSP_AddData(0x80 | 0x09);
-                break;
             case ESS_1688:
                 // Determined via Windows driver debugging.
                 DSP_AddData(0x68);
@@ -3082,7 +3077,6 @@ static uint8_t CTMIXER_Read(void) {
         if (sb.ess_type != ESS_NONE) {
             switch (sb.ess_type) {
             case ESS_688:
-            case ESS_1488:
                 ret=0xa;
                 break;
             case ESS_1688:
@@ -3689,13 +3683,6 @@ private:
             LOG(LOG_SB,LOG_DEBUG)("Reveal SC400 emulation enabled.");
             LOG(LOG_SB,LOG_WARN)("Reveal SC400 emulation is EXPERIMENTAL at this time and should not yet be used for normal gaming.");
             LOG(LOG_SB,LOG_WARN)("Additional WARNING: This code only emulates the Sound Blaster portion of the card. Attempting to use the Windows Sound System part of the card (i.e. the Voyetra/SC400 Windows drivers) will not work!");
-        }
-        else if (!strcasecmp(sbtype,"ess1488")) {
-            type=SBT_PRO2;
-            sb.ess_type=ESS_1488;
-            LOG(LOG_SB,LOG_DEBUG)("ESS ES1488 emulation enabled.");
-            LOG(LOG_SB,LOG_WARN)("ESS ES1488 emulation is EXPERIMENTAL at this time and should not yet be used for normal gaming.");
-            LOG(LOG_SB,LOG_WARN)("Additional WARNING: the ES1488 is not recognized by DOS games using the Miles Sound System, and its MIDI driver under Windows does not use its ESFM capabilites. Therefore the ESFM part of this card is only useful for custom/modern applications that can recognize/work with it.");
         }
         else if (!strcasecmp(sbtype,"ess1688")) {
             type=SBT_PRO2;


### PR DESCRIPTION
This PR is adding the ESS AudioDrive ES1688 (`sbtype=ess1688`) sbtype.

This PR is also removing the ESS AudioDrive ES1488 (`sbtype=ess1488`), because as found out by further testing and implementation, it is unsupported by DOS games using the Miles Sound System and does not have ESFM MIDI support in its Windows driver, and therefore I see no use case for the ES1488 in DOSBox apart from custom software that's yet to be made in the future.

## What issue(s) does this PR address?

None.

## Does this PR introduce new feature(s)?

This PR adds support for the ESS AudioDrive ES1688 (`ess1688`) sbtype, which unlike the `ess1488` sbtype (as found out by further testing and implementation) is actually supported by DOS games using the Miles Sound System and does have ESFM MIDI support in its Windows driver.

## Does this PR introduce any breaking change(s)?

This PR is removing the ESS AudioDrive ES1488 (`ess1488`) sbtype. As I'm performing this removal 2 days after its addition, I'm hoping the impact will be minimal.

If there are any objections against this removal, however, I can simply revert commit d39ec9421, leaving both sbtypes to be used. However, I have updated the ES1488 implementation to better match the real hardware and give it compatibility with the Windows driver, which breaks compatibility with DOS games (the fact it was working before was, ironically, a bug).

## Additional information

The ES1688 contains a toggleable MPU-401 UART in the port range 3x0h-3x1h that I haven't implemented yet. By default, the ES1688 Windows driver tries to enable and test this UART, and if it doesn't work properly, it rejects the card. To get the card to work on Windows, you need to disable the MIDI UART.

In order to get the card to work under Windows: in the Device Manager, select the card, click on the Properties button, go onto the Resources tab, and in the `Setting based on:` spinbox, select `Basic configuration 2`. Check the list of resource settings above - the port range 3x0h-3x1h should have vanished. Adjust the port ranges to match your DOSBox settings and click OK, reboot the machine if needed, and the card should work.

Demonstration video of the ESS AudioDrive ES1688 working under Windows 95:

https://github.com/joncampbell123/dosbox-x/assets/102362203/14443fa0-748a-4640-97e7-9ae0116fd9cf
