### PR TITLE
[WIP]Install mingw32 libslirp manually

### DIFF
--- a/.github/workflows/mingw32.yml
+++ b/.github/workflows/mingw32.yml
@@ -26,7 +26,22 @@ jobs:
         with:
           msystem: MINGW32
           update: true
-          install: git make mingw-w64-i686-toolchain mingw-w64-i686-libtool mingw-w64-i686-nasm autoconf automake mingw-w64-x86_64-ncurses
+          install: git make base-devel mingw-w64-i686-toolchain mingw-w64-i686-libtool mingw-w64-i686-nasm autoconf automake mingw-w64-i686-ncurses mingw-w64-i686-binutils mingw-w64-i686-glib2
+      - name: Install libslirp
+        run: |
+          top=`pwd`
+          mkdir pkg
+          cd pkg
+          git clone https://github.com/msys2/MINGW-packages.git
+          pwd
+          cd MINGW-packages
+          ls -lg
+          cd mingw-w64-libslirp
+          ls -lg
+          sed -i -e "s/^mingw_arch=\(.*\)/mingw_arch=(\'mingw32\')/" PKGBUILD
+          MINGW_ARCH=MINGW32 makepkg-mingw -sCLf --noconfirm
+          ls -lg
+          pacman --noconfirm -U mingw-w64-*-any.pkg.tar.zst
       - name: Update build info
         shell: bash
         run: |


### PR DESCRIPTION
I tried to build 32bit MinGW libslirp manually, and seems that the package is successfully built.
However, if I try to build DOSBox-X it fails to find some libraries, I assume it is glib-2.0.
I see the link flag `-lglib-2.0` exists so I don't know for sure what is wrong.

Some help or any other way to build the library is appreciated.

Should fix #4849 