### PR TITLE
Add permission to upload Release package by CI workflow (macos)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,7 +10,7 @@ jobs:
   macOS_CI_build:
     permissions:
       actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
-      contents: read  # for actions/checkout to fetch code
+      contents: write # for actions/checkout to fetch code and softprops/action-gh-release
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: macos-12
     steps:


### PR DESCRIPTION
The CI workflow of macos version failed to upload the release version that was built due to lack of permission.
This PR fixes the upload error by adding appropriate permission.