### PR TITLE
Restore libslirp for MinGW 32bit builds, and fix Windows installer Release builds

### DIFF
--- a/.github/workflows/mingw32.yml
+++ b/.github/workflows/mingw32.yml
@@ -26,22 +26,24 @@ jobs:
         with:
           msystem: MINGW32
           update: true
-          install: git make base-devel mingw-w64-i686-toolchain mingw-w64-i686-libtool mingw-w64-i686-nasm autoconf automake mingw-w64-i686-ncurses mingw-w64-i686-binutils mingw-w64-i686-glib2
+          install: git make base-devel mingw-w64-i686-toolchain mingw-w64-i686-libtool mingw-w64-i686-nasm autoconf automake mingw-w64-i686-ncurses mingw-w64-i686-binutils mingw-w64-i686-libslirp
       - name: Install libslirp
+        if: false
         run: |
+          # Run this job when MinGW drops 32-bit library support (Other libraries can be built as well)
           top=`pwd`
           mkdir pkg
           cd pkg
           git clone https://github.com/msys2/MINGW-packages.git
           pwd
           cd MINGW-packages
-          ls -lg
+          #ls -lg
           cd mingw-w64-libslirp
-          ls -lg
+          #ls -lg
           sed -i -e "s/^mingw_arch=\(.*\)/mingw_arch=(\'mingw32\')/" PKGBUILD
           MINGW_ARCH=MINGW32 makepkg-mingw -sCLf --noconfirm
-          ls -lg
-          # pacman --noconfirm -U mingw-w64-*-any.pkg.tar.zst
+          #ls -lg
+          pacman --noconfirm -U mingw-w64-*-any.pkg.tar.zst
       - name: Update build info
         shell: bash
         run: |

--- a/.github/workflows/vsbuild_xp.yml
+++ b/.github/workflows/vsbuild_xp.yml
@@ -110,11 +110,18 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: dosbox-x-vsbuild-XP-${{ env.timestamp }}.zip
-      - name: Cache Visual Studio builds
+      - name: Cache Visual Studio builds (nightly)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/vs-bin
-          key: vs-bin-${{ github.sha }}
+          key: vs-xp-bin-${{ github.sha }}
+      - name: Cache Visual Studio builds (release)
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/vs-bin
+          key: vs-xp-bin-r-${{ github.sha }}
   MinGW32_lowend_CI_build:
     permissions:
       actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
@@ -174,11 +181,18 @@ jobs:
           ./build-mingw
           strip -s src/dosbox-x.exe
           cp src/dosbox-x.exe mingw-bin/dosbox-x_mingw_lowend_SDL1.exe
-      - name: Cache MinGW32 lowend builds
+      - name: Cache MinGW32 lowend builds (nightly)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/mingw-bin
-          key: mingw-bin-${{ github.sha }}
+          key: mingw-xp-bin-${{ github.sha }}
+      - name: Cache MinGW32 lowend builds (release)
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/mingw-bin
+          key: mingw-xp-bin-r-${{ github.sha }}
   build-XP-installer:
     permissions:
       actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
@@ -192,16 +206,30 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
-      - name: Restore Visual Studio builds
+      - name: Restore Visual Studio builds (nightly)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/vs-bin
-          key: vs-bin-${{ github.sha }}
-      - name: Restore MinGW builds
+          key: vs-xp-bin-${{ github.sha }}
+      - name: Restore Visual Studio builds (release)
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/vs-bin
+          key: vs-xp-bin-r-${{ github.sha }}
+      - name: Restore MinGW builds (nightly)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/mingw-bin
-          key: mingw-bin-${{ github.sha }}
+          key: mingw-xp-bin-${{ github.sha }}
+      - name: Restore MinGW builds (release)
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/mingw-bin
+          key: mingw-xp-bin-r-${{ github.sha }}
       - name: Prepare files
         shell: bash
         run: |
@@ -226,13 +254,25 @@ jobs:
         with:
           files: |
             contrib/windows/installer/dosbox-x-winXP-*.exe
-      - name: Clean cache
+      - name: Clean cache (nightly)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         run: |
           gh extension install actions/gh-actions-cache
           ## need permission? disable the following lines if error occurs when deleting cache
           set +e
-          gh actions-cache delete mingw-bin-${{ github.sha }} --confirm
-          gh actions-cache delete vs-bin-${{ github.sha }} --confirm
+          gh actions-cache delete mingw-xp-bin-${{ github.sha }} --confirm
+          gh actions-cache delete vs-xp-bin-${{ github.sha }} --confirm
+          gh actions-cache list
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Clean cache (release)
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          gh extension install actions/gh-actions-cache
+          ## need permission? disable the following lines if error occurs when deleting cache
+          set +e
+          gh actions-cache delete mingw-xp-bin-r-${{ github.sha }} --confirm
+          gh actions-cache delete vs-xp-bin-r-${{ github.sha }} --confirm
           gh actions-cache list
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows-installers.yml
+++ b/.github/workflows/windows-installers.yml
@@ -149,11 +149,18 @@ jobs:
         with:
           name: dosbox-x-vsbuild-ARM32_64-${{ env.timestamp }}
           path: ${{ github.workspace }}/package/
-      - name: Cache Visual Studio builds
+      - name: Cache Visual Studio builds (nightly)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/vs-bin
           key: vs-${{ github.sha }}
+      - name: Cache Visual Studio builds (release)
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/vs-bin
+          key: vs-r-${{ github.sha }}
   MinGW32_CI_build:
     permissions:
       actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
@@ -172,7 +179,7 @@ jobs:
         with:
           msystem: MINGW32
           update: true
-          install: git mingw-w64-i686-toolchain mingw-w64-i686-libtool mingw-w64-i686-nasm autoconf automake
+          install: git mingw-w64-i686-toolchain mingw-w64-i686-libtool mingw-w64-i686-nasm autoconf automake mingw-w64-i686-libslirp
       - name: Update build info
         shell: bash
         run: |
@@ -202,11 +209,18 @@ jobs:
           strip -s $top/src/dosbox-x.exe
           cp $top/src/dosbox-x.exe $top/package/dosbox-x_MinGWx86_SDL2.exe
           cp $top/src/dosbox-x.exe $top/mingw-x86-bin/dosbox-x_MinGWx86_SDL2.exe
-      - name: Cache MinGW x86 builds
+      - name: Cache MinGW x86 builds (nightly)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/mingw-x86-bin
           key: mingw-x86-bin-${{ github.sha }}
+      - name: Cache MinGW x86 builds (release)
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/vs-bin
+          key: mingw-x86-bin-r-${{ github.sha }}
   MinGW64_CI_build:
     permissions:
       actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
@@ -255,11 +269,18 @@ jobs:
           strip -s $top/src/dosbox-x.exe
           cp $top/src/dosbox-x.exe $top/package/dosbox-x_MinGWx64_SDL2.exe
           cp $top/src/dosbox-x.exe $top/mingw-x64-bin/dosbox-x_MinGWx64_SDL2.exe
-      - name: Cache MinGW x64 builds
+      - name: Cache MinGW x64 builds (nightly)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/mingw-x64-bin
           key: mingw-x64-bin-${{ github.sha }}
+      - name: Cache MinGW x64 builds (release)
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/vs-bin
+          key: mingw-x64-bin-r-${{ github.sha }}
   Build_Windows_Installer:
     permissions:
       actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
@@ -273,21 +294,42 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
-      - name: Restore MinGW x86 builds
+      - name: Restore MinGW x86 builds (nightly)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/mingw-x86-bin
           key: mingw-x86-bin-${{ github.sha }}
-      - name: Restore MinGW x64 builds
+      - name: Restore MinGW x64 builds (nightly)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/mingw-x64-bin
           key: mingw-x64-bin-${{ github.sha }}
-      - name: Restore Visual Studio builds
+      - name: Restore Visual Studio builds (nightly)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/vs-bin
           key: vs-${{ github.sha }}
+      - name: Restore MinGW x86 builds (release)
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/mingw-x86-bin
+          key: mingw-x86-bin-r-${{ github.sha }}
+      - name: Restore MinGW x64 builds (release)
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/mingw-x64-bin
+          key: mingw-x64-bin-r-${{ github.sha }}
+      - name: Restore Visual Studio builds (release)
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/vs-bin
+          key: vs-r-${{ github.sha }}
       - name: Package MinGW builds
         run: |
           set +e
@@ -356,7 +398,8 @@ jobs:
         with:
           files: |
             contrib/windows/installer/dosbox-x-windows*.exe
-      - name: Clean cache
+      - name: Clean cache (nightly)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         run: |
           gh extension install actions/gh-actions-cache
           ## need permission? disable the following lines if error occurs when deleting cache
@@ -364,6 +407,18 @@ jobs:
           gh actions-cache delete mingw-x86-bin-${{ github.sha }} --confirm
           gh actions-cache delete mingw-x64-bin-${{ github.sha }} --confirm
           gh actions-cache delete vs-${{ github.sha }} --confirm
+          gh actions-cache list
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Clean cache (release)
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          gh extension install actions/gh-actions-cache
+          ## need permission? disable the following lines if error occurs when deleting cache
+          set +e
+          gh actions-cache delete mingw-x86-bin-r-${{ github.sha }} --confirm
+          gh actions-cache delete mingw-x64-bin-r-${{ github.sha }} --confirm
+          gh actions-cache delete vs-r-${{ github.sha }} --confirm
           gh actions-cache list
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 Next:
-  - 
+  - Restore libslirp support for 32-bit MinGW CI builds which was temporarily
+    dropped in 2024.03.01 release. Also since MinGW plans to gradually phase
+    out 32-bit support, added code to manually build on our own. (maron2000)
+  -
 
 2024.03.01
   - If an empty CD-ROM drive is attached to IDE emulation, return "Medium Not

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ Next:
   - Restore libslirp support for 32-bit MinGW CI builds which was temporarily
     dropped in 2024.03.01 release. Also since MinGW plans to gradually phase
     out 32-bit support, added code to manually build on our own. (maron2000)
-  -
+  - Fix build errors of Windows installers (maron2000) 
 
 2024.03.01
   - If an empty CD-ROM drive is attached to IDE emulation, return "Medium Not


### PR DESCRIPTION
Restore libslirp support for MinGW 32bit builds, since MinGW restored the dropped library.
Also, build error for Windows installer is hopefully fixed.

Fixes #4860 