### PR TITLE
Fix compile error of speexdsp/fftwrap.c on gcc-14

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,10 +4,11 @@ Next:
     0xD000 by default, but apparently there are games that require the EMS
     page frame to exist at 0xC000. For these games, you can now set under the
     [dos] section "ems frame=C000". (joncampbell123)
-  - Restore libslirp support for 32-bit MinGW CI builds which was temporarily
+  - Restored libslirp support for 32-bit MinGW CI builds which was temporarily
     dropped in 2024.03.01 release. Also since MinGW plans to gradually phase
     out 32-bit support, added code to manually build on our own. (maron2000)
-  - Fix build errors of Windows installers (maron2000) 
+  - Fixed build errors of Windows installers (maron2000) 
+  - Fixed compile error of speexdsp/fftwrap.c on gcc-14 (maron2000)
 
 2024.03.01
   - If an empty CD-ROM drive is attached to IDE emulation, return "Medium Not

--- a/configure.ac
+++ b/configure.ac
@@ -379,6 +379,7 @@ AC_CHECK_CXXFLAGS([ -Wextra ])
 AC_CHECK_CXXFLAGS([ -Wunused ])
 AC_CHECK_CXXFLAGS([ -pedantic ])
 AC_CHECK_CXXFLAGS([ -Wno-error=format-security ])     # imfc.cpp and later versions of GCC, see https://github.com/joncampbell123/dosbox-x/issues/4436
+AC_CHECK_CXXFLAGS([ -Wno-error=incompatible-pointer-types ]) # required to compile speexdsp/fftwrap.c with GCC 14
 #AC_CHECK_CXXFLAGS([ -Wconversion ])      DO NOT ENABLE. THIS WARNING IS WAY TOO PEDANTIC TO BE USEFUL, EXCEPT FOR SPECIFIC CASES
 #AC_CHECK_CXXFLAGS([ -Wsign-conversion ])
 AC_CHECK_CXXFLAGS([ -Wlogical-op ])


### PR DESCRIPTION
GCC 14 changed the `incompatible-pointer-type` warning to error, which made compiling speexdsp/fftwrap.c to be an error.
This PR makes such error to be as warnings again.

Fixes #4865