### PR TITLE
Fix cue sheets of GOG games were rejected

### DIFF
--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -1285,12 +1285,13 @@ bool CDROM_Interface_Image::LoadCloneCDSheet(char *cuefile) {
 
 bool CDROM_Interface_Image::LoadCueSheet(char *cuefile)
 {
-	// If we're going to support CUE vs CCD vs anything else then this function must
-	// reject any file who's file extension is not .CUE
+	// reject any file which are not a CUE sheet, GOG is so smart that they set several different extensions so that we can't assume .cue only.
+    // Known extensions at the moment are: .cue, .ins, .dat, .inst (not sure it is an exhaustive list)
 	{
 		char *s = strrchr(cuefile,'.');
 		if (!s) return false;
-		if (strcasecmp(s,".cue")) return false;
+		if (!strcasecmp(s,".ccd") || !strcasecmp(s, ".chd") || !strcasecmp(s, ".iso") || !strcasecmp(s, ".img")
+            || !strcasecmp(s, ".mds") || !strcasecmp(s, ".mdf") || !strcasecmp(s, ".bin")) return false;
 	}
 
 	Track track = {0, 0, 0, 0, 0, 0, 0, false, NULL};

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -656,7 +656,7 @@ void MenuBrowseImageFile(char drive, bool arc, bool boot, bool multiple) {
         lTheOpenFileName = tinyfd_openFileDialog(("Select an archive file for Drive "+str+":").c_str(),"",4,lFilterPatterns,lFilterDescription,0);
         if (lTheOpenFileName) fname = GetNewStr(lTheOpenFileName);
     } else {
-        const char *lFilterPatterns[] = {"*.ima","*.img","*.vhd","*.fdi","*.hdi","*.nfd","*.nhd","*.d88","*.hdm","*.xdf","*.iso","*.cue","*.bin","*.chd","*.mdf","*.gog","*.ins","*.IMA","*.IMG","*.VHD","*.FDI","*.HDI","*.NFD","*.NHD","*.D88","*.HDM","*.XDF","*.ISO","*.CUE","*.BIN","*.CHD","*.MDF","*.GOG","*.INS"};
+        const char *lFilterPatterns[] = {"*.ima","*.img","*.vhd","*.fdi","*.hdi","*.nfd","*.nhd","*.d88","*.hdm","*.xdf","*.iso","*.cue","*.bin","*.chd","*.mdf","*.gog","*.ins","*.ccd","*.IMA","*.IMG","*.VHD","*.FDI","*.HDI","*.NFD","*.NHD","*.D88","*.HDM","*.XDF","*.ISO","*.CUE","*.BIN","*.CHD","*.MDF","*.GOG","*.INS", "*.CCD"};
         const char *lFilterDescription = "Disk/CD image files";
         lTheOpenFileName = tinyfd_openFileDialog(((multiple?"Select image file(s) for Drive ":"Select an image file for Drive ")+str+":").c_str(),"",22,lFilterPatterns,lFilterDescription,multiple?1:0);
         if (lTheOpenFileName) fname = GetNewStr(lTheOpenFileName);


### PR DESCRIPTION
The current code assumes the extension of CUE sheets is `.cue` but GOG sets several other extensions as well.
This PR fixes so that those cue sheets will not be rejected.

![cue](https://github.com/joncampbell123/dosbox-x/assets/68574602/12ca6ced-d36a-46e9-ab3e-df20e5c4147c)

In addition, added `.ccd` file to the filter of file open dialog.

Fixes #4881 