### PR TITLE
Fix a problem causing crash on loongarch64 machines

### DIFF
--- a/src/fpu/fpu_instructions_longdouble.h
+++ b/src/fpu/fpu_instructions_longdouble.h
@@ -22,7 +22,7 @@
 #ifdef __GNUC__
 # if defined(__MINGW32__) || (defined(MACOSX) && !defined(__arm64__))
 #  include "fpu_control_x86.h"
-# elif defined(ANDROID) || defined(__ANDROID__) || (defined(MACOSX) && defined(__arm64__)) || defined(EMSCRIPTEN) || defined(__powerpc__)
+# elif defined(ANDROID) || defined(__ANDROID__) || (defined(MACOSX) && defined(__arm64__)) || defined(EMSCRIPTEN) || defined(__powerpc__) || defined(__loongarch__)
 /* ? */
 #  define _FPU_SETCW(x) /* dummy */
 # else


### PR DESCRIPTION
Update `fpu_instructions_longdouble.h` to make it able to run on loongarch64.

## What issue(s) does this PR address?

#4475 Crash on a loongarch64 CPU (Loongson 3A5000M).

## Additional information
There are crash reports about dosbox-x on old MIPS machines. Is it able to run on such machines with additional code like ` || defined(__mips64__)` added?