### PR TITLE
Update msbuild to microsoft/setup-msbuild to v2

### DIFF
--- a/.github/workflows/vsbuild32.yml
+++ b/.github/workflows/vsbuild32.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v4
-      - uses: microsoft/setup-msbuild@v1.3
+      - uses: microsoft/setup-msbuild@v2
       - name: Prepare Visual Studio Win32
         shell: bash
         run: |
@@ -132,7 +132,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v4
-      - uses: microsoft/setup-msbuild@v1.3
+      - uses: microsoft/setup-msbuild@v2
       - name: Prepare Visual Studio ARM32
         shell: bash
         run: |

--- a/.github/workflows/vsbuild64.yml
+++ b/.github/workflows/vsbuild64.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v4
-      - uses: microsoft/setup-msbuild@v1.3
+      - uses: microsoft/setup-msbuild@v2
       - name: Prepare Visual Studio Win64
         shell: bash
         run: |
@@ -132,7 +132,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v4
-      - uses: microsoft/setup-msbuild@v1.3
+      - uses: microsoft/setup-msbuild@v2
       - name: Prepare Visual Studio ARM64
         shell: bash
         run: |

--- a/.github/workflows/vsbuild_xp.yml
+++ b/.github/workflows/vsbuild_xp.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v4
-      - uses: microsoft/setup-msbuild@v1.3
+      - uses: microsoft/setup-msbuild@v2
       - name: Prepare Visual Studio build for WinXP
         shell: bash
         run: |

--- a/.github/workflows/windows-installers.yml
+++ b/.github/workflows/windows-installers.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v4
-      - uses: microsoft/setup-msbuild@v1.3
+      - uses: microsoft/setup-msbuild@v2
       - name: Prepare Visual Studio builds
         shell: bash
         run: |

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -43,6 +43,10 @@ Next:
     out 32-bit support, added code to manually build on our own. (maron2000)
   - Fixed build errors of Windows installers (maron2000) 
   - Fixed compile error of speexdsp/fftwrap.c on gcc-14 (maron2000)
+  - PC-98: Fixed US keyboard support for tilde (Shift+grave) key (maron2000)
+  - Fixed DOSBox-X freezed when codepages regarding EGA18.CPX were set (maron2000)
+  - Fixed CUE sheets of GOG games were rejected. Still requires "-t iso" or 
+    "-t cdrom" option for uncommon file extensions except ".CUE". (maron2000)
 
 2024.03.01
   - If an empty CD-ROM drive is attached to IDE emulation, return "Medium Not


### PR DESCRIPTION
Update microsoft/setup-msbuild to v2 to eliminate warnings regarding use of Node.js 16 when building automated CI builds.
I think DOSBox-X doesn't make use of Node.js, so there shouldn't be any problems.

Also added recent changes to the CHANGELOG.