### PR TITLE
gh-page: Mention ARM mac in nightly builds

### DIFF
--- a/devel-build.html
+++ b/devel-build.html
@@ -24,7 +24,7 @@ vsbuild64 | 64-bit Visual Studio portable builds (for Vista+/ARM)
 mingw32 | 32-bit MinGW (for 7+) and MinGW-lowend (for XP+, W9x/NT4+) portable builds
 mingw64 | 64-bit MinGW portable builds (for 7+)
 linux | Linux (x86_64) builds
-macos | macOS (x86_64) builds
+macos | macOS (x86_64/ARM) builds
 hxdos | HX-DOS (x86) build
 {%- endcapture -%}
 


### PR DESCRIPTION
Nightly builds for ARM mac are now available, so mention that in the web site.
