### PR TITLE
Implement seeking in MSCDEX

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -50,6 +50,11 @@ Next:
   - Added "*.ccd" in file open dialog (maron2000)
   - Added CI builds for ARM mac (maron2000)
   - Bump tinyfiledialogs to ver 3.17.4 (maron2000)
+  - Obtain geometry info of non-standard sized floppy from BPB (maron2000)
+  - PC-98: Implemented int 18h ah=47h,48h,49h (nanshiki)
+  - Added breakpoint type "Freeze memory" (Enmet)
+  - Implemented seeking in MSCDEX
+    (Imported from dosbox-staging/dosbox-staging#3516 authored by weirddan455)
 
 2024.03.01
   - If an empty CD-ROM drive is attached to IDE emulation, return "Medium Not

--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -52,12 +52,17 @@
 	*(M) = value;							\
 }
 #define MSF_TO_FRAMES(M, S, F)	((M)*60*CD_FPS+(S)*CD_FPS+(F))
+
 #include "../../vs/sdl/src/cdrom/compat_SDL_cdrom.h"
 #endif /* C_SDL2 */
 
 #define RAW_SECTOR_SIZE		2352
 #define COOKED_SECTOR_SIZE	2048
 #define AUDIO_DECODE_BUFFER_SIZE 16512
+
+#define REDBOOK_FRAME_PADDING 150u  // The relationship between High Sierra sectors and Redbook
+                                    // frames is described by the equation:
+                                    // Sector = Minute * 60 * 75 + Second * 75 + Frame - 150
 
 enum { CDROM_USE_SDL, CDROM_USE_ASPI, CDROM_USE_IOCTL_DIO, CDROM_USE_IOCTL_DX, CDROM_USE_IOCTL_MCI };
 


### PR DESCRIPTION
Some games (e.g Time Warriors, Alpha Storm) use 'Seek' function of MSCDEX, however DOSBox-X ignored it.
This PR introduces the function for such games.

Fixes #4916

This patch is imported from https://github.com/dosbox-staging/dosbox-staging/pull/3516 authored by @weirddan455
