### PR TITLE
Revise CDROM track info logging

### DIFF
--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -509,7 +509,20 @@ bool CDROM_Interface_Image::SetDevice(char* path, int forceCD)
 		uint16_t size = (uint16_t)strlen(buf);
 		DOS_WriteFile(STDOUT, (uint8_t*)buf, &size);
 	}
-	return result;
+
+    int datatracks=0, audiotracks=0;
+    for(const auto& track : tracks) {
+        if(track.attr == 0x40) {
+            datatracks++;
+        }
+        else if(track.attr == 0) {
+            audiotracks++;
+        }
+    }
+    LOG_MSG("CDROM: Image loaded No. of data tracks=%d, audio tracks=%d",
+        datatracks, audiotracks-1
+        );
+    return result;
 }
 
 bool CDROM_Interface_Image::GetUPC(unsigned char& attr, char* upc)

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -525,14 +525,15 @@ bool CDROM_Interface_Image::GetAudioTracks(int& stTrack, int& end, TMSF& leadOut
 	end = (int)(tracks.size() - 1);
 	FRAMES_TO_MSF(tracks[tracks.size() - 1].start + 150, &leadOut.min, &leadOut.sec, &leadOut.fr);
 
-	//#ifdef DEBUG
-	LOG_MSG("CDROM: GetAudioTracks, stTrack=%d, end=%d, leadOut.min=%d, leadOut.sec=%d, leadOut.fr=%d",
-	  stTrack,
-	  end,
+	#ifdef DEBUG
+	LOG_MSG("%s CDROM: GetAudioTracks, stTrack=%d, end=%d, leadOut.min=%d, leadOut.sec=%d, leadOut.fr=%d",
+      get_time(),
+      stTrack,
+      end,
 	  leadOut.min,
 	  leadOut.sec,
 	  leadOut.fr);
-	//#endif
+	#endif
 
 	return true;
 }


### PR DESCRIPTION
DOSBox-X logged CDROM track info when games retrieved info.
Games such as Time Warriors retrieve  info repeatedly, resulting in tons of logs.
This PR changes the behavior so that track info is logged when the image is mounted to reduce the amount of logs.