### PR TITLE
Fix mounting a non-FAT VHD image

### DIFF
--- a/src/ints/bios_vhd.cpp
+++ b/src/ints/bios_vhd.cpp
@@ -970,20 +970,17 @@ uint64_t imageDiskVHD::scanMBR(uint8_t* mbr, Bitu sizes[], uint64_t disksize) {
         LOG_MSG("Invalid MBR, no signature");
         return 0;
     }
-#if 0 // exclude this check due to NTFS (or other valid type)
-    //search for the first DOS partition
+    //search for the first non-empty partition
     for(part = mbr + 0x1BE; part < mbr + 0x1FE; part += 16) {
         uint8_t partType = *((uint8_t*)(part + 4));
-        if(partType != 1 && partType != 4 && partType != 6 && partType != 7 &&
-            partType != 11 && partType != 12 && partType != 14) continue;
+        if(partType == 0) continue;
         partFound = true;
         break;
     }
     if(!partFound) {
-        LOG_MSG("No DOS partition in MBR");
+        LOG_MSG("No partition in use in MBR");
         return 0;
     }
-#endif
     //partition end
     h = (unsigned)*(part + 5);
     s = (unsigned)*(part + 6) & 0x3F;

--- a/src/ints/bios_vhd.cpp
+++ b/src/ints/bios_vhd.cpp
@@ -1,6 +1,6 @@
 /*
 *
-*  Copyright (c) 2018 Shane Krueger. Fixes and upgrades (c) 2023 maxpat78.
+*  Copyright (c) 2018 Shane Krueger. Fixes and upgrades (c) 2023-24 maxpat78.
 *
 *  This program is free software; you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by
@@ -970,11 +970,11 @@ uint64_t imageDiskVHD::scanMBR(uint8_t* mbr, Bitu sizes[], uint64_t disksize) {
         LOG_MSG("Invalid MBR, no signature");
         return 0;
     }
-
+#if 0 // exclude this check due to NTFS (or other valid type)
     //search for the first DOS partition
     for(part = mbr + 0x1BE; part < mbr + 0x1FE; part += 16) {
         uint8_t partType = *((uint8_t*)(part + 4));
-        if(partType != 1 && partType != 4 && partType != 6 &&
+        if(partType != 1 && partType != 4 && partType != 6 && partType != 7 &&
             partType != 11 && partType != 12 && partType != 14) continue;
         partFound = true;
         break;
@@ -983,7 +983,7 @@ uint64_t imageDiskVHD::scanMBR(uint8_t* mbr, Bitu sizes[], uint64_t disksize) {
         LOG_MSG("No DOS partition in MBR");
         return 0;
     }
-
+#endif
     //partition end
     h = (unsigned)*(part + 5);
     s = (unsigned)*(part + 6) & 0x3F;


### PR DESCRIPTION
scanMBR does not check anymore for a DOS partition type code, allowing correct recognition of non-FAT partitions (i.e. NTFS).

With this patch, a VHD containing a non-FAT filesystem (for example, like NTFS after Windows NT setup-performed conversion) can be mounted with consistent C-H-S geometry.

Closes #4792 