### PR TITLE
gh-pages: Switch order of Vista+ and XP installers in version sidebar

### DIFF
--- a/_includes/version.html
+++ b/_includes/version.html
@@ -19,10 +19,10 @@
 <p class="subtitle-mute">(Windows 9x/NT4 and later versions supported)</p>
 <p>
   32/64-bit Setup:
-  {% include version_file.html version=version name="winXP_setup_file" display_name="ReactOS/XP+ " %}
-  |
-  {% include version_file.html version=version name="windows_setup_file" display_name="Vista+" %}
+  {% include version_file.html version=version name="windows_setup_file" display_name="Vista+ " %}
   {% if version.windows_setup_file %}<sup>(Recommended)</sup>{% endif %}
+  |
+  {% include version_file.html version=version name="winXP_setup_file" display_name="ReactOS/XP+" %}
 </p>
 <p>
   32-bit Portable:

--- a/devel-build.html
+++ b/devel-build.html
@@ -1,5 +1,5 @@
 ---
-title: DOSBox-X Development Builds
+title: Development Builds
 ---
 
 <section class="align-center">


### PR DESCRIPTION
Saw https://github.com/joncampbell123/dosbox-x/issues/4257#issuecomment-2046626556 and realized I messed this up... oops

## What issue(s) does this PR address?

Potential confusion on which installer flavor is prefered
