### PR TITLE
Ehanced DetectGeometry

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -358,6 +358,7 @@ public:
     static uint32_t CreateDifferencing(const char* filename, const char* basename);
     uint32_t CreateSnapshot();
     void DetectGeometry(Bitu sizes[]);
+    static void DetectGeometry(uint8_t* buf, Bitu sizes[], uint64_t currentSize);
     static uint64_t scanMBR(uint8_t* mbr, Bitu sizes[], uint64_t disksize=0);
     bool MergeSnapshot(uint32_t* totalSectorsMerged, uint32_t* totalBlocksUpdated);
     static void SizeToCHS(uint64_t size, uint16_t* c, uint8_t* h, uint8_t* s);


### PR DESCRIPTION
- avoids duplicating imageDisk for Fixed VHDs by splitting DetectGeometry
- removed unused code

This fixes my previous patch according to @maron2000 suggestions.