### PR TITLE
Fix loading language file on launch

### DIFF
--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -49,9 +49,12 @@ void DOSBox_SetSysMenu(void);
 bool OpenGL_using(void), isDBCSCP(void);
 void change_output(int output), UpdateSDLDrawTexture();
 void SwitchLanguage(int oldcp, int newcp, bool confirm);
+Bitu DOS_ChangeCodepage(int32_t codepage, const char* codepagefile);
 void MSG_Init(), JFONT_Init(), runRescan(const char *str);
 extern int tryconvertcp, toSetCodePage(DOS_Shell *shell, int newCP, int opt);
 extern bool jfont_init;
+extern int msgcodepage;
+
 static FILE* OpenDosboxFile(const char* name) {
 	uint8_t drive;
 	char fullname[DOS_PATHLENGTH];
@@ -1735,9 +1738,12 @@ public:
                     UpdateSDLDrawTexture();
 #endif
             }
-            SwitchLanguage(cpbak, dos.loaded_codepage, false);
         }
-	}
+        if(msgcodepage) {
+            SwitchLanguage(dos.loaded_codepage, msgcodepage, false);
+            DOS_ChangeCodepage(msgcodepage, "auto");
+        }
+    }
 
 	~DOS_KeyboardLayout(){
 		if ((dos.loaded_codepage!=GetDefaultCP()) && (CurMode->type==M_TEXT)) {

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -891,7 +891,8 @@ void DOS_Shell::Prepare(void) {
                     } else if (control->opt_langcp && !name && (layout.empty() || layout=="auto"))
                         SetKEYBCP();
                 }
-                if (lastmsgcp && lastmsgcp != dos.loaded_codepage) SwitchLanguage(lastmsgcp, dos.loaded_codepage, true);
+                //if (lastmsgcp && lastmsgcp != dos.loaded_codepage) SwitchLanguage(lastmsgcp, dos.loaded_codepage, true);
+                if (msgcodepage && msgcodepage != dos.loaded_codepage) SwitchLanguage(dos.loaded_codepage, msgcodepage, true);
             }
 			if (country>0&&!control->opt_noconfig) {
 				countryNo = country;


### PR DESCRIPTION
Fixed language file loaded on launch was forced to change when keyboard layout was loaded.  

Fixes #4968

![image](https://github.com/joncampbell123/dosbox-x/assets/68574602/f4a24d68-a8e7-4672-890e-d5453ee28091)
