### PR TITLE
Fixed a bug in IME character display on macOS Sonoma

### DIFF
--- a/vs/sdl/src/video/quartz/SDL_QuartzVideo.m
+++ b/vs/sdl/src/video/quartz/SDL_QuartzVideo.m
@@ -112,7 +112,7 @@ static inline void QZ_SetFrame(_THIS, NSScreen *nsscreen, NSRect frame)
     [super drawRect:dirtyRect];
     CGSize size = [_text size];
     [[NSColor whiteColor] set];
-    NSRectFill(dirtyRect);
+    NSRectFill(self.bounds);
     [_text drawInRect:CGRectMake(0, 0, size.width, size.height)];
 }
 @end

--- a/vs/sdl2/src/video/cocoa/SDL_cocoakeyboard.m
+++ b/vs/sdl2/src/video/cocoa/SDL_cocoakeyboard.m
@@ -45,7 +45,7 @@
     [super drawRect:dirtyRect];
     size = [_text size];
     [[NSColor whiteColor] set];
-    NSRectFill(dirtyRect);
+    NSRectFill(self.bounds);
     [_text drawInRect:CGRectMake(0, 0, size.width, size.height)];
 }
 @end


### PR DESCRIPTION
When I turn on IME on macOS Sonoma and enter characters, the entire screen turns white.
https://indiestack.com/2023/06/view-clipping-sonoma/
This has been fixed because it was affected by changes in Apple's internal properties.