### PR TITLE
Temporarily use windows-2019 to build XP builds

### DIFF
--- a/.github/workflows/vsbuild_xp.yml
+++ b/.github/workflows/vsbuild_xp.yml
@@ -12,7 +12,7 @@ jobs:
       actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
       contents: write # for actions/checkout to fetch code and softprops/action-gh-release
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: windows-latest
+    runs-on: windows-2019
     defaults:
       run:
         shell: pwsh


### PR DESCRIPTION
According to https://github.com/actions/runner-images/issues/9701, the build tool v141 required to build XP builds was dropped in windows-latest runner.
This PR uses windows-2019 runner instead which includes v141 build tool to enable building XP builds again.