### PR TITLE
Allocate enough memory to store the System File Table (SFT)

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -4715,6 +4715,7 @@ public:
 		DOS_ShutdownFiles();
 		void DOS_ShutdownDevices(void);
 		DOS_ShutdownDevices();
+        DOS_FreeTableMemory();
 		RealSetVec(0x30,int30);
 		RealSetVec(0x31,int31);
 	}

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -126,13 +126,42 @@ void DOS_InfoBlock::SetLocation(uint16_t segment) {
 	sSave(sDIB,nulString[6],(uint8_t)0x20);
 	sSave(sDIB,nulString[7],(uint8_t)0x20);
 
-	/* Create a fake SFT, so programs think there are 100 file handles */
+#if 0
+    /* Create a fake SFT, so programs think there are 100 file handles */
 	uint16_t sftOffset=offsetof(sDIB,firstFileTable)+0xa2;
 	sSave(sDIB,firstFileTable,RealMake(segment,sftOffset));
 	real_writed(segment,sftOffset+0x00,RealMake(segment+0x26,0));	//Next File Table
 	real_writew(segment,sftOffset+0x04,DOS_FILES/2);	//File Table supports DOS_FILES/2 files
 	real_writed(segment+0x26,0x00,0xffffffff);		//Last File Table
 	real_writew(segment+0x26,0x04,DOS_FILES-DOS_FILES/2);	//File Table supports DOS_FILES/2 files
+#endif
+    /* Imported from dosbox-staging/dosbox-staging#3680 */
+    constexpr int FakeHandles = 100;
+
+    constexpr uint32_t EndPointer = 0xffffffff;
+    constexpr uint16_t NextTableOffset = 0x0;
+    constexpr uint16_t NumberOfFilesOffset = 0x04;
+
+    // We only need to actually allocate enough space for 16 handles
+    // This is the maximum that will get written to by DOS_MultiplexFunctions() in dos_misc.cpp
+    constexpr int BytesPerPage = 16;
+    constexpr int TotalBytes = SftHeaderSize + (SftEntrySize * SftNumEntries);
+    constexpr int NumPages = (TotalBytes / BytesPerPage) + (TotalBytes % BytesPerPage > 0 ? 1 : 0);
+
+    const uint16_t first_sft_segment = DOS_GetMemory(NumPages);
+    const RealPt first_sft_addr = RealMake(first_sft_segment, 0);
+    SSET_DWORD(sDIB, firstFileTable, first_sft_addr);
+
+    // Windows for Workgroups requires a 2nd linked SFT table
+    // This one only needs to allocate the header
+    const uint16_t second_sft_segment = DOS_GetMemory(1);
+    const RealPt second_sft_addr = RealMake(second_sft_segment, 0);
+
+    real_writed(first_sft_segment, NextTableOffset, second_sft_addr);
+    real_writew(first_sft_segment, NumberOfFilesOffset, FakeHandles);
+
+    real_writed(second_sft_segment, NextTableOffset, EndPointer);
+    real_writew(second_sft_segment, NumberOfFilesOffset, FakeHandles);
 }
 
 void DOS_InfoBlock::SetFirstMCB(uint16_t _firstmcb) {

--- a/src/dos/dos_tables.cpp
+++ b/src/dos/dos_tables.cpp
@@ -74,6 +74,11 @@ void DOS_GetMemory_reset() {
 	dos_memseg = 0;
 }
 
+void DOS_FreeTableMemory()
+{
+    dos_memseg = DOS_PRIVATE_SEGMENT;
+}
+
 void DOS_GetMemory_reinit() {
     DOS_GetMemory_unmapped = false;
     DOS_GetMemory_reset();


### PR DESCRIPTION
Imported from dosbox-staging/dosbox-staging#3680

Fixes #5004


https://github.com/joncampbell123/dosbox-x/assets/68574602/6a4949cc-34e3-4d1d-a4f6-77364790d2f1

