### PR TITLE
Fix build errors in MinGW

### DIFF
--- a/.github/workflows/mingw32.yml
+++ b/.github/workflows/mingw32.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           msystem: MINGW32
           update: true
-          install: git make base-devel mingw-w64-i686-toolchain mingw-w64-i686-libtool mingw-w64-i686-nasm autoconf automake mingw-w64-i686-ncurses mingw-w64-i686-binutils mingw-w64-i686-libslirp
+          install: git make base-devel mingw-w64-i686-toolchain mingw-w64-i686-libtool mingw-w64-i686-nasm autoconf automake mingw-w64-i686-ncurses mingw-w64-i686-binutils
       - name: Install libslirp
         if: false
         run: |

--- a/.github/workflows/mingw64.yml
+++ b/.github/workflows/mingw64.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           msystem: MINGW64
           update: true
-          install: git mingw-w64-x86_64-toolchain mingw-w64-x86_64-libslirp mingw-w64-x86_64-libtool mingw-w64-x86_64-nasm autoconf automake
+          install: git mingw-w64-x86_64-toolchain mingw-w64-x86_64-libtool mingw-w64-x86_64-nasm autoconf automake
       - name: Update build info
         shell: bash
         run: |

--- a/.github/workflows/windows-installers.yml
+++ b/.github/workflows/windows-installers.yml
@@ -179,7 +179,7 @@ jobs:
         with:
           msystem: MINGW32
           update: true
-          install: git mingw-w64-i686-toolchain mingw-w64-i686-libtool mingw-w64-i686-nasm autoconf automake mingw-w64-i686-libslirp
+          install: git mingw-w64-i686-toolchain mingw-w64-i686-libtool mingw-w64-i686-nasm autoconf automake
       - name: Update build info
         shell: bash
         run: |
@@ -239,7 +239,7 @@ jobs:
         with:
           msystem: MINGW64
           update: true
-          install: git mingw-w64-x86_64-toolchain mingw-w64-x86_64-libslirp mingw-w64-x86_64-libtool mingw-w64-x86_64-nasm autoconf automake
+          install: git mingw-w64-x86_64-toolchain mingw-w64-x86_64-libtool mingw-w64-x86_64-nasm autoconf automake
       - name: Update build info
         shell: bash
         run: |

--- a/build-mingw
+++ b/build-mingw
@@ -29,6 +29,7 @@ sed -i 's/^#define ENABLE_IM_EVENT 1$/\/\/#define ENABLE_IM_EVENT 1/g' vs/sdl/in
 
 # prefer to compile against our own copy of SDL 1.x
 echo "Compiling our internal SDL 1.x"
+cp vs/sdl/build-dosbox.sh vs/sdl/build-dosbox.bak
 sed -i 's/^make -j3/sed -i '"'"'s\/\^CFLAGS\.\*\/CFLAGS = -g -O2 -Wno-error=incompatible-pointer-types\/g'"'"' \.\/Makefile\nmake -j3/g' vs/sdl/build-dosbox.sh
 (cd vs/sdl && ./build-dosbox.sh) || exit 1
 
@@ -38,6 +39,9 @@ echo "Compiling our internal SDLnet 1.x"
 
 sed -i 's/^\/\/#define ENABLE_IM_EVENT 1$/#define ENABLE_IM_EVENT 1/g' vs/sdl/include/SDL_platform.h
 (cd vs/sdl && ./build-dosbox.sh) || exit 1
+rm vs/sdl/build-dosbox.sh
+mv vs/sdl/build-dosbox.bak vs/sdl/build-dosbox.sh
+chmod +x vs/sdl/build-dosbox.sh
 
 # NTS: MinGW provides zlib for us
 if false; then

--- a/build-mingw
+++ b/build-mingw
@@ -29,6 +29,7 @@ sed -i 's/^#define ENABLE_IM_EVENT 1$/\/\/#define ENABLE_IM_EVENT 1/g' vs/sdl/in
 
 # prefer to compile against our own copy of SDL 1.x
 echo "Compiling our internal SDL 1.x"
+sed -i 's/^make -j3/sed -i '"'"'s\/\^CFLAGS\.\*\/CFLAGS = -g -O2 -Wno-error=incompatible-pointer-types\/g'"'"' \.\/Makefile\nmake -j3/g' vs/sdl/build-dosbox.sh
 (cd vs/sdl && ./build-dosbox.sh) || exit 1
 
 # prefer to compile against our own copy of SDLnet 1.x

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8740,6 +8740,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 #endif //defined (C_SDL2)
 #if defined(__MINGW32__) && defined(C_DEBUG)
         LOG_MSG("EXPERIMENTAL: Debugger enabled for MinGW build, DOSBox-X crashes depending on the terminal software you use. Launching from command prompt (cmd.exe) is recommended.");
+        LOG_MSG("NOTICE: libslirp support disabled due to a bug in recent libslirp release");
 #endif
         /* -- -- decide whether to show menu in GUI */
         if (control->opt_nogui || menu.compatible)

--- a/src/libs/fluidsynth/fluid_seqbind.c
+++ b/src/libs/fluidsynth/fluid_seqbind.c
@@ -51,6 +51,7 @@ typedef struct _fluid_seqbind_t fluid_seqbind_t;
 
 int fluid_seqbind_timer_callback(void* data, unsigned int msec);
 void fluid_seq_fluidsynth_callback(unsigned int time, fluid_event_t* event, fluid_sequencer_t* seq, void* data);
+void fluid_event_key_pressure(fluid_event_t* evt, int channel, short key, short val);
 
 /* Proper cleanup of the seqbind struct. */
 void 


### PR DESCRIPTION
This PR fixes MinGW builds failed due to updates in gcc and libslirp.
libslirp is now temporarily disabled again until static linking becomes possible.
