### PR TITLE
Fix SDL1 build error (Linux & MinGW)

### DIFF
--- a/build-mingw
+++ b/build-mingw
@@ -29,8 +29,6 @@ sed -i 's/^#define ENABLE_IM_EVENT 1$/\/\/#define ENABLE_IM_EVENT 1/g' vs/sdl/in
 
 # prefer to compile against our own copy of SDL 1.x
 echo "Compiling our internal SDL 1.x"
-cp vs/sdl/build-dosbox.sh vs/sdl/build-dosbox.bak
-sed -i 's/^make -j3/sed -i '"'"'s\/\^CFLAGS\.\*\/CFLAGS = -g -O2 -Wno-error=incompatible-pointer-types\/g'"'"' \.\/Makefile\nmake -j3/g' vs/sdl/build-dosbox.sh
 (cd vs/sdl && ./build-dosbox.sh) || exit 1
 
 # prefer to compile against our own copy of SDLnet 1.x
@@ -39,9 +37,6 @@ echo "Compiling our internal SDLnet 1.x"
 
 sed -i 's/^\/\/#define ENABLE_IM_EVENT 1$/#define ENABLE_IM_EVENT 1/g' vs/sdl/include/SDL_platform.h
 (cd vs/sdl && ./build-dosbox.sh) || exit 1
-rm vs/sdl/build-dosbox.sh
-mv vs/sdl/build-dosbox.bak vs/sdl/build-dosbox.sh
-chmod +x vs/sdl/build-dosbox.sh
 
 # NTS: MinGW provides zlib for us
 if false; then

--- a/vs/sdl/build-dosbox.sh
+++ b/vs/sdl/build-dosbox.sh
@@ -47,6 +47,9 @@ mkdir -p linux-build || exit 1
 mkdir -p linux-build/build || exit 1
 mkdir -p linux-build/include || exit 1
 
+#Don't treat incompatible-pointer-types warnings as errors (gcc-14) 
+sed -i 's/^CFLAGS\(.*\)/CFLAGS\1 -Wno-error=incompatible-pointer-types/g' ./Makefile
+
 make -j3 || exit 1
 make install || exit 1  # will install into ./linux-host
 


### PR DESCRIPTION
MinGW migrated gcc to version 14 that resulted SDL1 builds to fail which was fixed by commit 6e3fae1.
gcc version of Linux also migrated as well, so fix the build script to enable SDL1 builds possible. 

Confirmed build on MinGW and ArchLinux with gcc version 14.
