### PR TITLE
Restore libslirp support (MinGW 32-bit)

### DIFF
--- a/.github/workflows/mingw32.yml
+++ b/.github/workflows/mingw32.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           msystem: MINGW32
           update: true
-          install: git make base-devel mingw-w64-i686-toolchain mingw-w64-i686-libtool mingw-w64-i686-nasm autoconf automake mingw-w64-i686-ncurses mingw-w64-i686-binutils
+          install: git make base-devel mingw-w64-i686-toolchain mingw-w64-i686-libtool mingw-w64-i686-nasm autoconf automake mingw-w64-i686-ncurses mingw-w64-i686-binutils mingw-w64-i686-libslirp
       - name: Install libslirp
         if: false
         run: |

--- a/.github/workflows/windows-installers.yml
+++ b/.github/workflows/windows-installers.yml
@@ -179,7 +179,7 @@ jobs:
         with:
           msystem: MINGW32
           update: true
-          install: git mingw-w64-i686-toolchain mingw-w64-i686-libtool mingw-w64-i686-nasm autoconf automake
+          install: git mingw-w64-i686-toolchain mingw-w64-i686-libtool mingw-w64-i686-nasm autoconf automake mingw-w64-i686-libslirp
       - name: Update build info
         shell: bash
         run: |

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -178,6 +178,9 @@ Next:
   - Fixed issue that IMGSWAP command did not work for CD drives. (maron2000)
   - Fixed loaded language file unexpectedly changes on launch. (maron2000)
   - Added missing language file in Windows standard & XP installers. (maron2000)
+  - Fixed a bug in IME character display on macOS Sonoma (nanshiki)
+  - Fixed build errors of SDL1 code when built with gcc-14 (maron2000)
+  - Fixed static link errors of libslirp >= 4.8.0 (maron2000)
 
 2024.03.01
   - If an empty CD-ROM drive is attached to IDE emulation, return "Medium Not

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8745,7 +8745,6 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 #endif //defined (C_SDL2)
 #if defined(__MINGW32__) && defined(C_DEBUG)
         LOG_MSG("EXPERIMENTAL: Debugger enabled for MinGW build, DOSBox-X crashes depending on the terminal software you use. Launching from command prompt (cmd.exe) is recommended.");
-        LOG_MSG("NOTICE: libslirp support disabled due to a bug in recent libslirp release");
 #endif
         /* -- -- decide whether to show menu in GUI */
         if (control->opt_nogui || menu.compatible)

--- a/src/misc/ethernet_slirp.cpp
+++ b/src/misc/ethernet_slirp.cpp
@@ -56,7 +56,13 @@ int inet_pton_win(int af, const char* src, void* dst)
  * object. This is done by passing our SlirpEthernetConnection as user data.
  */
 
-ssize_t slirp_receive_packet(const void* buf, size_t len, void* opaque)
+// libslirp >= 4.8.0 defines slirp_ssize_t but will break compatibility with older versions
+#ifdef _WIN32
+SSIZE_T 
+#else
+ssize_t 
+#endif
+slirp_receive_packet(const void* buf, size_t len, void* opaque)
 {
 	SlirpEthernetConnection* conn = (SlirpEthernetConnection*)opaque;
 	conn->ReceivePacket((const uint8_t*)buf, len);


### PR DESCRIPTION
Fix build error of MinGW 32bit builds with libslirp enabled.
This PR and #5037 restores libslirp support for MinGW 32-bit and 64-bit builds.

