### PR TITLE
Fix Windows installer build failure

### DIFF
--- a/contrib/windows/installer/DOSBox-X-installer.iss
+++ b/contrib/windows/installer/DOSBox-X-installer.iss
@@ -43,8 +43,8 @@ PrivilegesRequired=admin
 UninstallDisplayName={#MyAppName} {#MyAppVersion} {#MyAppBit}
 UninstallDisplayIcon={app}\{#MyAppExeName}
 WizardSmallImageFile=..\..\icons\dosbox-x.bmp
-;MinVersion below 6.1 is not recommended, however set to 6.0 to support Vista
-MinVersion=6.0
+;MinVersion 6.0 is required for Vista, however Inno Setup no longer supports it
+;MinVersion=6.0
 
 [Messages]
 InfoBeforeLabel=Please read the general information about DOSBox-X below.


### PR DESCRIPTION
Drop Windows Vista support due to build error of standard (non-XP) installer.
Vista users can still use the XP installer.