### PR TITLE
Fix Windows installer release version build procedure

### DIFF
--- a/.github/workflows/vsbuild_xp.yml
+++ b/.github/workflows/vsbuild_xp.yml
@@ -244,6 +244,12 @@ jobs:
         with:
           path: ${{ github.workspace }}/mingw-bin
           key: mingw-xp-bin-r-${{ github.sha }}
+      - name: Update release version
+        if: startsWith(github.ref, 'refs/tags/') 
+        shell: bash
+        run: |
+          DOSBOX_X_RELEASE=`gh release list -L1 | grep -o "....-..-.." | head -n 1 | sed -e "s/-/./g"`
+          sed -i "s/^#define MyAppVersion.*/#define MyAppVersion \"$DOSBOX_X_RELEASE\"/" contrib/windows/installer/DOSBox-X-setupXP.iss
       - name: Prepare files
         shell: bash
         run: |

--- a/.github/workflows/windows-installers.yml
+++ b/.github/workflows/windows-installers.yml
@@ -219,7 +219,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: actions/cache/save@v4
         with:
-          path: ${{ github.workspace }}/vs-bin
+          path: ${{ github.workspace }}/mingw-x86-bin
           key: mingw-x86-bin-r-${{ github.sha }}
   MinGW64_CI_build:
     permissions:
@@ -278,7 +278,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: actions/cache/save@v4
         with:
-          path: ${{ github.workspace }}/vs-bin
+          path: ${{ github.workspace }}/mingw-x64-bin/
           key: mingw-x64-bin-r-${{ github.sha }}
   Build_Windows_Installer:
     permissions:

--- a/.github/workflows/windows-installers.yml
+++ b/.github/workflows/windows-installers.yml
@@ -278,7 +278,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: actions/cache/save@v4
         with:
-          path: ${{ github.workspace }}/mingw-x64-bin/
+          path: ${{ github.workspace }}/mingw-x64-bin
           key: mingw-x64-bin-r-${{ github.sha }}
   Build_Windows_Installer:
     permissions:


### PR DESCRIPTION
Windows installer release 2024.07.01 failed to build due to a mistake in preparing archived files.
This PR fixes such mistake, to successfully build in the next release.

Meanwhile, alternative file identical to the Release version can be downloaded from the following link.
https://github.com/joncampbell123/dosbox-x/actions/runs/9754660669/artifacts/1658029715

You must be logged in to github in order to download the file.
