### PR TITLE
Fix TTF mode didn’t switch to graphic mode when machine=hercules

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+Next
+  - Fixed update-version-number script to patch all *.iss files, not 
+    just the specific one it did before, to ensure future releases have
+    correct version numbers. (joncampbell123).
+  - Updated Nuked-OPL3 code to nukeykt/Nuked-OPL3@cfedb09 (StevenSYS) 
+  - Updated SDL2 library to 2.30.4 (maron2000)
+  - Fixed TTF mode didn't change to graphic mode when machine = Hercules
+    (maron2000)
+
 2024.07.01
   - Correct Hercules InColor memory emulation. Read and write planar
     behavior was incorrect due to a misunderstanding of available

--- a/src/hardware/vga_other.cpp
+++ b/src/hardware/vga_other.cpp
@@ -29,6 +29,13 @@
 #include "mapper.h"
 #include "control.h"
 
+#include <output/output_ttf.h>
+
+#if defined(USE_TTF)
+void ttf_switch_on(bool ss = true);
+void ttf_switch_off(bool ss = true);
+#endif
+
 /* do not issue CPU-side I/O here -- this code emulates functions that the GDC itself carries out, not on the CPU */
 #include "cpu_io_is_forbidden.h"
 
@@ -1108,13 +1115,19 @@ static void write_hercules(Bitu port,Bitu val,Bitu /*iolen*/) {
 			// already set
 			if (!(val&0x2)) {
 				vga.herc.mode_control &= ~0x2;
-				VGA_SetMode(M_HERC_TEXT);
+#if defined(USE_TTF)
+                ttf_switch_on(false); // Enable TTF output if output=ttf
+#endif
+                VGA_SetMode(M_HERC_TEXT);
 			}
 		} else {
 			// not set, can only set if protection bit is set
 			if ((val & 0x2) && (vga.herc.enable_bits & 0x1)) {
 				vga.herc.mode_control |= 0x2;
-				VGA_SetMode(M_HERC_GFX);
+#if defined(USE_TTF)
+                ttf_switch_off(false); // Disable TTF output when switching to graphics mode
+#endif
+                VGA_SetMode(M_HERC_GFX);
 			}
 		}
 		if (vga.herc.mode_control&0x80) {


### PR DESCRIPTION
TTF mode when machine=hercules didn’t switch to graphics mode.
This PR fixes such issue.

Tested on VS x64 SDL2.

Steps to reproduce the issue
1. Start DOSBox-X with `machine=hercules` and `output=ttf`
2. Run a software or a game using graphical screen