### PR TITLE
Fix off-center window under TTF, add "Video/Center window" menu item

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 NEXT
   - fix off-center and off-screen window after entering the
     configuration tool while using TTF output mode (aybe).
+  - add menu item for centering window "Video/Center window" (aybe).
 2024.07.01
   - Correct Hercules InColor memory emulation. Read and write planar
     behavior was incorrect due to a misunderstanding of available

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+NEXT
+  - fix off-center and off-screen window after entering the
+    configuration tool while using TTF output mode (aybe).
 2024.07.01
   - Correct Hercules InColor memory emulation. Read and write planar
     behavior was incorrect due to a misunderstanding of available

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -525,7 +525,9 @@ static const char *def_menu_video[] =
 #endif
     "VideoRatioMenu",
     "mapper_aspratio",
+#if defined(C_SDL2)
     "center_window",
+#endif
 #if !defined(C_SDL2) && defined(MACOSX)
     "highdpienable",
 #endif

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -525,6 +525,7 @@ static const char *def_menu_video[] =
 #endif
     "VideoRatioMenu",
     "mapper_aspratio",
+    "center_window",
 #if !defined(C_SDL2) && defined(MACOSX)
     "highdpienable",
 #endif

--- a/src/gui/menu_callback.cpp
+++ b/src/gui/menu_callback.cpp
@@ -2074,7 +2074,9 @@ bool vsync_set_syncrate_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item *
 bool center_window_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
     (void)menuitem;//UNUSED
+#if defined(C_SDL2)
     SDL_SetWindowPosition(sdl.window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+#endif
     return true;
 }
 
@@ -3205,8 +3207,10 @@ void AllocCallback1() {
                         set_callback_function(scaler_set_menu_callback);
                 }
 
+#if defined(C_SDL2)
                 mainMenu.alloc_item(DOSBoxMenu::item_type_id,"center_window").set_text("Center window").
                     set_callback_function(center_window_menu_callback);
+#endif
 
                 mainMenu.alloc_item(DOSBoxMenu::item_type_id,"set_titletext").set_text("Set title bar text...").
                     set_callback_function(set_titletext_menu_callback);

--- a/src/gui/menu_callback.cpp
+++ b/src/gui/menu_callback.cpp
@@ -2071,6 +2071,13 @@ bool vsync_set_syncrate_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item *
     return true;
 }
 
+bool center_window_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+    SDL_SetWindowPosition(sdl.window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+    return true;
+}
+
 bool set_titletext_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
     (void)menuitem;//UNUSED
@@ -3197,6 +3204,9 @@ void AllocCallback1() {
                     mainMenu.alloc_item(DOSBoxMenu::item_type_id,name).set_text(scaler_menu_opts[i][1]).
                         set_callback_function(scaler_set_menu_callback);
                 }
+
+                mainMenu.alloc_item(DOSBoxMenu::item_type_id,"center_window").set_text("Center window").
+                    set_callback_function(center_window_menu_callback);
 
                 mainMenu.alloc_item(DOSBoxMenu::item_type_id,"set_titletext").set_text("Set title bar text...").
                     set_callback_function(set_titletext_menu_callback);

--- a/src/output/output_ttf.cpp
+++ b/src/output/output_ttf.cpp
@@ -1455,6 +1455,7 @@ void ttf_switch_on(bool ss=true) {
 #ifdef C_SDL2
         transparency = 0;
         SetWindowTransparency(static_cast<Section_prop *>(control->GetSection("sdl"))->Get_int("transparency"));
+        SDL_SetWindowPosition(sdl.window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 #endif
         if (!IS_PC98_ARCH && vga.draw.address_add != ttf.cols * 2) checkcol = ss?2:1;
     }


### PR DESCRIPTION
## What issue(s) does this PR address?

When launching the configuration tool while in TTF output, the window would be incorrectly centered like this:

![image](https://github.com/joncampbell123/dosbox-x/assets/1537591/715bb81d-ebac-47b1-acc1-f89e6cd68952)

This is because there's a switch to 'surface' and then 'TTF' adjusts itself to top/left of 'surface' which obviously is wrong.

So, not only it isn't centered anymore but it's also off-screen.

A very simple fix that improves user experience as that was pretty annoying.

## Does this PR introduce new feature(s)?

Added menu "Video/Center window", makes one's life easier when wanting to do so.
