### PR TITLE
Add "[dos] automount drive directories" option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+NEXT
+  - add "[dos] automount drive directories" option, this will mount
+    existing drive directories, from C drive to Y drive (aybe).
 2024.07.01
   - Correct Hercules InColor memory emulation. Read and write planar
     behavior was incorrect due to a misunderstanding of available

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 NEXT
-  - add "[dos] automount drive directories" option, this will mount
-    existing drive directories, from C drive to Y drive (aybe).
+  - add option "[dos] automount drive directories" for Windows builds,
+    this will mount existing drive directories from C to Y drive (aybe).
 2024.07.01
   - Correct Hercules InColor memory emulation. Read and write planar
     behavior was incorrect due to a misunderstanding of available

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -9335,6 +9335,7 @@ void Add_VFiles(bool usecp) {
 	VFILE_RegisterBuiltinFileBlob(bfb_EGA_CPX, "/CPI/");
 }
 
+#if WIN32
 void Add_Existing_Drive_Directories()
 {
     for(auto drive = 'C'; drive < 'Y'; drive++)
@@ -9356,6 +9357,7 @@ void Add_Existing_Drive_Directories()
         MountHelper(drive, path.c_str(), "LOCAL");
     }
 }
+#endif
 
 void DOS_SetupPrograms(void) {
     /*Add Messages */
@@ -9888,7 +9890,9 @@ void DOS_SetupPrograms(void) {
     /*regular setup*/
     Add_VFiles(false);
 
+#if WIN32
     if (dos_section->Get_bool("automount drive directories")) {
         Add_Existing_Drive_Directories();
     }
+#endif
 }

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -9335,6 +9335,28 @@ void Add_VFiles(bool usecp) {
 	VFILE_RegisterBuiltinFileBlob(bfb_EGA_CPX, "/CPI/");
 }
 
+void Add_Existing_Drive_Directories()
+{
+    for(auto drive = 'C'; drive < 'Y'; drive++)
+    {
+        auto name = std::string("drive");
+        auto path = std::string(".");
+
+        name += drive;
+        path += CROSS_FILESPLIT;
+        path += name;
+
+        getdrivezpath(path, name);
+
+        if (path.empty())
+            continue;
+
+        LOG_MSG("Mounting directory 'drive%c' found in DOSBox-X directory as drive %c.\n", static_cast<char>(drive + 32), drive);
+
+        MountHelper(drive, path.c_str(), "LOCAL");
+    }
+}
+
 void DOS_SetupPrograms(void) {
     /*Add Messages */
 
@@ -9865,4 +9887,8 @@ void DOS_SetupPrograms(void) {
 
     /*regular setup*/
     Add_VFiles(false);
+
+    if (dos_section->Get_bool("automount drive directories")) {
+        Add_Existing_Drive_Directories();
+    }
 }

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -4427,7 +4427,8 @@ void DOSBOX_SetupConfigSections(void) {
                       "Files with leading forward slashes (e.g. \"/DEBUG\\BIOSTEST.COM\") will become hidden files (DIR /A will list them).");
 
     Pbool = secprop->Add_bool("automount drive directories",Property::Changeable::OnlyAtStart, false);
-    Pbool->Set_help("If set, DOSBox-X will automatically mount existing drive directories from C drive to Y drive, e.g. \"DriveC\".");
+    Pbool->Set_help("If set, DOSBox-X will automatically mount existing drive directories from C drive to Y drive, e.g. \"DriveC\".\n"
+                    "NOTE: This option is only available under Windows.");
 
     Pbool = secprop->Add_bool("hidenonrepresentable",Property::Changeable::WhenIdle,true);
     Pbool->Set_help("If set, DOSBox-X will hide files on local drives that are non-representative in the current DOS code page.\n"

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -4426,6 +4426,9 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring->Set_help("The files or directories listed here (separated by space) will be either hidden or removed from the Z drive.\n"
                       "Files with leading forward slashes (e.g. \"/DEBUG\\BIOSTEST.COM\") will become hidden files (DIR /A will list them).");
 
+    Pbool = secprop->Add_bool("automount drive directories",Property::Changeable::OnlyAtStart, false);
+    Pbool->Set_help("If set, DOSBox-X will automatically mount existing drive directories from C drive to Y drive, e.g. \"DriveC\".");
+
     Pbool = secprop->Add_bool("hidenonrepresentable",Property::Changeable::WhenIdle,true);
     Pbool->Set_help("If set, DOSBox-X will hide files on local drives that are non-representative in the current DOS code page.\n"
                     "This may be required for some programs such as Windows 3.x Setup if the drives contain international filenames.");


### PR DESCRIPTION
## Does this PR introduce new feature(s)?

```
[dos]
automount drive directories=true
```

This will auto-mount existing directories, from `DriveC` to `DriveY`.

Somewhat handy but on the other hand it might be troublesome, default value has been set to `false`.

Not sure if it's worth it in the end... feel free to merge... or not.