### PR TITLE
Windows 3.1 style for configuration tool

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@ NEXT
   - Updated SDL2 library to 2.30.4 (maron2000)
   - Fixed TTF mode didn't change to graphic mode when machine = Hercules
     (maron2000)
+  - CFGTOOL: more Windows 3.1 styling, general UX/UI improvements (aybe).
 
 2024.07.01
   - Correct Hercules InColor memory emulation. Read and write planar

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -715,7 +715,7 @@ public:
         sx += 4;
         ex -= 4;
 
-        d.setColor(GUI::Color::Shadow3D);
+        d.setColor(GUI::CurrentTheme.Shadow3D);
         d.drawDotLine(sx,y,ex,y);
     }
 };

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -3137,7 +3137,6 @@ public:
         bar->addItem(2,mainMenu.get_item("help_about").get_text().c_str());
         bar->addActionHandler(this);
 
-        new GUI::Label(this, 10, 30, MSG_Get("CONFIGURE_GROUP"));
         advopt = new GUI::Checkbox(this, 340, 30, MSG_Get("SHOW_ADVOPT"));
         Section_prop * section=static_cast<Section_prop *>(control->GetSection("dosbox"));
         advopt->setChecked(section->Get_bool("show advanced options"));

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1453,8 +1453,22 @@ public:
         b = new GUI::Button(this, button_row_cx + (button_w + button_pad_w), button_row_y, MSG_Get("OK"), button_w);
 
         int i = 0, j = 0;
-        Property *prop;
-        while ((prop = section->Get_prop(i))) {
+        Property *property;
+        std::vector<Property*> properties;
+        auto propertyIndex = 0;
+        
+        while ((property = section->Get_prop(propertyIndex++)))
+        {
+            properties.push_back(property);
+        }
+
+        std::sort(properties.begin(), properties.end(),[](const Property* a, const Property* b)
+        {
+            return a->propname < b->propname;
+        });
+        
+        for(const auto & prop : properties)
+        {
             if (!advopt->isChecked() && !prop->basic()) {i++;continue;}
             Prop_bool   *pbool   = dynamic_cast<Prop_bool*>(prop);
             Prop_int    *pint    = dynamic_cast<Prop_int*>(prop);

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -3141,7 +3141,7 @@ public:
         int gridbtnwidth = 130;
         int gridbtnheight = 26;
         int gridbtnx = 12;
-        int gridbtny = 50;
+        int gridbtny = 25;
         int btnperrow = 4;
         int i = 0;
 

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1330,9 +1330,22 @@ public:
         Section_prop* sec = dynamic_cast<Section_prop*>(title.substr(0, 4)=="Ide,"?control->GetSection("ide, primary"):section);
         if (sec) {
             std::string msg;
-            Property *p;
-            int i = 0;
-            while ((p = sec->Get_prop(i++))) {
+
+            Property *property;
+            std::vector<Property*> properties;
+            auto propertyIndex = 0;
+            while ((property = sec->Get_prop(propertyIndex++)))
+            {
+                properties.push_back(property);
+            }
+
+            std::sort(properties.begin(), properties.end(),[](const Property* a, const Property* b)
+            {
+                return a->propname < b->propname;
+            });
+
+            for(const auto& p : properties)
+            {
                 std::string help=title=="4dos"&&p->propname=="rem"?"This is the 4DOS.INI file (if you use 4DOS as the command shell).":p->Get_help();
                 if (title!="4dos" && title!="Config" && title!="Autoexec" && !advopt->isChecked() && !p->basic()) continue;
                 std::string propvalues = "";

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -3150,8 +3150,11 @@ public:
         int btnperrow = 4;
         int i = 0;
 
+        const auto xSpace = gridbtnwidth + 2;
+        const auto ySpace = gridbtnheight + 2;
+        
         std::function< std::pair<int,int>(const int) > gridfunc = [&/*access to locals here*/](const int i){
-            return std::pair<int,int>(gridbtnx+(i%btnperrow)*gridbtnwidth, gridbtny+(i/btnperrow)*gridbtnheight);
+            return std::pair<int,int>(gridbtnx+(i%btnperrow)*xSpace, gridbtny+(i/btnperrow)*ySpace);
         };
 
         while ((sec = control->GetSection(i))) {
@@ -3167,13 +3170,13 @@ public:
         }
 
         const auto finalgridpos = gridfunc(i - 1);
-        int closerow_y = finalgridpos.second + 5 + gridbtnheight;
+        int closerow_y = finalgridpos.second + 5 + ySpace;
 
         strcpy(tmp1, (MSG_Get("SAVE")+std::string("...")).c_str());
         (saveButton = new GUI::Button(this, 158, closerow_y, tmp1, 110))->addActionHandler(this);
         (closeButton = new GUI::Button(this, 276, closerow_y, MSG_Get("CLOSE"), 110))->addActionHandler(this);
 
-        resize(gridbtnx + (gridbtnwidth * btnperrow) + 12 + border_left + border_right,
+        resize(gridbtnx + (xSpace * btnperrow) + 12 + border_left + border_right,
                closerow_y + closeButton->getHeight() + 8 + border_top + border_bottom);
 
         bar->resize(getWidth(),bar->getHeight());

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1423,10 +1423,7 @@ public:
         if ((this->y + this->getHeight()) > parent->getHeight())
             move(this->x,parent->getHeight() - this->getHeight());
 
-        std::string title(section->GetName());
-        sprintf(tmp1, MSG_Get("CONFIGURATION_FOR"), CapName(title).c_str());
-        setTitle(tmp1);
-        title[0] = std::toupper(title[0]);
+        setTitle(CapName(std::string(section->GetName())).c_str());
 
         new GUI::Label(this, 5, button_row_y - 20, MSG_Get("HELP_INFO"));
 
@@ -1597,10 +1594,7 @@ public:
         if (scroll_h > allowed_dialog_y)
             scroll_h = allowed_dialog_y;
 
-        std::string title(section->GetName());
-        sprintf(tmp1, MSG_Get("CONFIGURATION_FOR"), CapName(title).c_str());
-        setTitle(tmp1);
-        title[0] = std::toupper(title[0]);
+        setTitle(CapName(std::string(section->GetName())).c_str());
 
 		char extra_data[4096] = { 0 };
 		const char * extra = const_cast<char*>(section->data.c_str());

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -3137,10 +3137,6 @@ public:
         bar->addItem(2,mainMenu.get_item("help_about").get_text().c_str());
         bar->addActionHandler(this);
 
-        advopt = new GUI::Checkbox(this, 340, 30, MSG_Get("SHOW_ADVOPT"));
-        Section_prop * section=static_cast<Section_prop *>(control->GetSection("dosbox"));
-        advopt->setChecked(section->Get_bool("show advanced options"));
-
         Section *sec;
         int gridbtnwidth = 130;
         int gridbtnheight = 26;
@@ -3171,9 +3167,13 @@ public:
         const auto finalgridpos = gridfunc(i - 1);
         int closerow_y = finalgridpos.second + 5 + ySpace;
 
+        advopt = new GUI::Checkbox(this, gridbtnx, closerow_y, MSG_Get("SHOW_ADVOPT"));
+        Section_prop * section=static_cast<Section_prop *>(control->GetSection("dosbox"));
+        advopt->setChecked(section->Get_bool("show advanced options"));
+
         strcpy(tmp1, (MSG_Get("SAVE")+std::string("...")).c_str());
-        (saveButton = new GUI::Button(this, 158, closerow_y, tmp1, 110))->addActionHandler(this);
-        (closeButton = new GUI::Button(this, 276, closerow_y, MSG_Get("CLOSE"), 110))->addActionHandler(this);
+        (saveButton = new GUI::Button(this, 310, closerow_y, tmp1, 110, gridbtnheight))->addActionHandler(this);
+        (closeButton = new GUI::Button(this, 428, closerow_y, MSG_Get("CLOSE"), 110, gridbtnheight))->addActionHandler(this);
 
         resize(gridbtnx + (xSpace * btnperrow) + 12 + border_left + border_right,
                closerow_y + closeButton->getHeight() + 8 + border_top + border_bottom);

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -849,9 +849,9 @@ public:
         if (title=="4dos"&&!strcmp(prop->propname.c_str(), "rem"))
             input = new GUI::Input(this, 30, 0, 470);
         else {
-            input = new GUI::Input(this, 270, 0, opts?200:230);
+            input = new GUI::Input(this, 260, 0, opts?195:235);
             if (opts) {
-                infoButton=new GUI::Button(this, 470, 0, "...", 30, 24);
+                infoButton=new GUI::Button(this, 460, 0, "...", 35, 24);
                 infoButton->addActionHandler(this);
             }
         }
@@ -907,9 +907,9 @@ protected:
 public:
     PropertyEditorFloat(Window *parent, int x, int y, Section_prop *section, Property *prop, bool opts) :
         PropertyEditor(parent, x, y, section, prop, opts) {
-        input = new GUI::Input(this, 380, 0, opts?90:120);
+        input = new GUI::Input(this, 365, 0, opts?90:130);
         if (opts) {
-            infoButton=new GUI::Button(this, 470, 0, "...", 30, 24);
+            infoButton=new GUI::Button(this, 460, 0, "...", 35, 24);
             infoButton->addActionHandler(this);
         }
         input->setText(stringify((double)prop->GetValue()));
@@ -964,9 +964,9 @@ protected:
 public:
     PropertyEditorHex(Window *parent, int x, int y, Section_prop *section, Property *prop, bool opts) :
         PropertyEditor(parent, x, y, section, prop, opts) {
-        input = new GUI::Input(this, 380, 0, opts?90:120);
+        input = new GUI::Input(this, 365, 0, opts?90:130);
         if (opts) {
-            infoButton=new GUI::Button(this, 470, 0, "...", 30, 24);
+            infoButton=new GUI::Button(this, 460, 0, "...", 35, 24);
             infoButton->addActionHandler(this);
         }
         std::string temps = prop->GetValue().ToString();
@@ -1022,9 +1022,9 @@ protected:
 public:
     PropertyEditorInt(Window *parent, int x, int y, Section_prop *section, Property *prop, bool opts) :
         PropertyEditor(parent, x, y, section, prop, opts) {
-        input = new GUI::Input(this, 380, 0, opts?90:120);
+        input = new GUI::Input(this, 365, 0, opts?90:130);
         if (opts) {
-            infoButton=new GUI::Button(this, 470, 0, "...", 30, 24);
+            infoButton=new GUI::Button(this, 460, 0, "...", 35, 24);
             infoButton->addActionHandler(this);
         }
         //Maybe use ToString() of Value

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -3144,7 +3144,7 @@ public:
 
         Section *sec;
         int gridbtnwidth = 130;
-        int gridbtnheight = 28;
+        int gridbtnheight = 26;
         int gridbtnx = 12;
         int gridbtny = 50;
         int btnperrow = 4;

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1388,7 +1388,7 @@ public:
     std::vector<GUI::Char> cfg_sname;
 public:
     SectionEditor(GUI::Screen *parent, int x, int y, Section_prop *section) :
-        ToplevelWindow(parent, x, y, 510, 442, ""), section(section) {
+        ToplevelWindow(parent, x, y, 510, 422, ""), section(section) {
         if (section == NULL) {
             LOG_MSG("BUG: SectionEditor constructor called with section == NULL\n");
             return;
@@ -1420,7 +1420,7 @@ public:
 
         wiw = new GUI::WindowInWindow(this, 5, 5, width-border_left-border_right-10, scroll_h);
 
-        int button_row_y = first_row_y + scroll_h + 25;
+        int button_row_y = first_row_y + scroll_h + 5;
         int button_w = 90;
         int button_pad_w = 10;
         int button_row_w = ((button_pad_w + button_w) * 3) - button_pad_w;
@@ -1433,8 +1433,6 @@ public:
             move(this->x,parent->getHeight() - this->getHeight());
 
         setTitle(CapName(std::string(section->GetName())).c_str());
-
-        new GUI::Label(this, 5, button_row_y - 20, MSG_Get("HELP_INFO"));
 
         GUI::Button *b = new GUI::Button(this, button_row_cx, button_row_y, mainMenu.get_item("HelpMenu").get_text().c_str(), button_w);
         b->addActionHandler(this);

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1084,9 +1084,9 @@ std::string CapName(std::string name) {
     else if (name=="dosv")
         dispname="DOS/V";
     else if (name=="ttf")
-        dispname="TTF Output";
+        dispname="TrueType";
     else if (name=="vsync")
-        dispname="V-Sync";
+        dispname="VSync";
     else if (name=="4dos")
         dispname="4DOS.INI";
     else if (name=="config")
@@ -1094,9 +1094,9 @@ std::string CapName(std::string name) {
     else if (name=="autoexec")
         dispname="AUTOEXEC.BAT";
     else if (name=="sblaster")
-        dispname="Sound Blaster";
+        dispname="SB";
     else if (name=="speaker")
-        dispname="PC Speaker";
+        dispname="PC speaker";
     else if (name=="serial")
         dispname="Serial";
     else if (name=="parallel")
@@ -1120,9 +1120,9 @@ std::string CapName(std::string name) {
     else if (name=="ide, octernary")
         dispname="IDE #8";
     else if (name=="ethernet, pcap")
-        dispname="Ethernet PCap";
+        dispname="pcap";
     else if (name=="ethernet, slirp")
-        dispname="Ethernet Slirp";
+        dispname="SLiRP";
     else
         dispname[0] = std::toupper(name[0]);
     return dispname;
@@ -1136,9 +1136,9 @@ std::string RestoreName(std::string name) {
         dispname="pc98";
     else if (name=="DOS/V")
         dispname="dosv";
-    else if (name=="TTF Output")
+    else if (name=="TrueType")
         dispname="ttf";
-    else if (name=="V-Sync")
+    else if (name=="VSync")
         dispname="vsync";
     else if (name=="4DOS.INI")
         dispname="4dos";
@@ -1146,9 +1146,9 @@ std::string RestoreName(std::string name) {
         dispname="config";
     else if (name=="AUTOEXEC.BAT")
         dispname="autoexec";
-    else if (name=="Sound Blaster")
+    else if (name=="SB")
         dispname="sblaster";
-    else if (name=="PC Speaker")
+    else if (name=="PC speaker")
         dispname="speaker";
     else if (name=="Serial")
         dispname="serial";
@@ -1172,9 +1172,9 @@ std::string RestoreName(std::string name) {
         dispname="ide, septernary";
     else if (name=="IDE #8")
         dispname="ide, octernary";
-    else if (name=="Ethernet PCap")
+    else if (name=="pcap")
         dispname="ethernet, pcap";
-    else if (name=="Ethernet Slirp")
+    else if (name=="SLiRP")
         dispname="ethernet, slirp";
     return dispname;
 }

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1097,6 +1097,10 @@ std::string CapName(std::string name) {
         dispname="SB";
     else if (name=="speaker")
         dispname="PC speaker";
+    else if (name=="imfc")
+        dispname="IMFC";
+    else if (name=="innova")
+        dispname="SSI-2001";
     else if (name=="serial")
         dispname="Serial";
     else if (name=="parallel")
@@ -1150,6 +1154,10 @@ std::string RestoreName(std::string name) {
         dispname="sblaster";
     else if (name=="PC speaker")
         dispname="speaker";
+    else if (name=="IMFC")
+        dispname="imfc";
+    else if (name=="SSI-2001")
+        dispname="innova";
     else if (name=="Serial")
         dispname="serial";
     else if (name=="Parallel")

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1097,7 +1097,7 @@ std::string CapName(std::string name) {
     else if (name=="sblaster")
         dispname="SB";
     else if (name=="speaker")
-        dispname="PC speaker";
+        dispname="PC Speaker";
     else if (name=="imfc")
         dispname="IMFC";
     else if (name=="innova")
@@ -1153,7 +1153,7 @@ std::string RestoreName(std::string name) {
         dispname="autoexec";
     else if (name=="SB")
         dispname="sblaster";
-    else if (name=="PC speaker")
+    else if (name=="PC Speaker")
         dispname="speaker";
     else if (name=="IMFC")
         dispname="imfc";

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1098,27 +1098,27 @@ std::string CapName(std::string name) {
     else if (name=="speaker")
         dispname="PC Speaker";
     else if (name=="serial")
-        dispname="Serial Ports";
+        dispname="Serial";
     else if (name=="parallel")
-        dispname="Parallel Ports";
+        dispname="Parallel";
     else if (name=="fdc, primary")
-        dispname="Floppy Port #1";
+        dispname="Floppy";
     else if (name=="ide, primary")
-        dispname="IDE Port #1";
+        dispname="IDE #1";
     else if (name=="ide, secondary")
-        dispname="IDE Port #2";
+        dispname="IDE #2";
     else if (name=="ide, tertiary")
-        dispname="IDE Port #3";
+        dispname="IDE #3";
     else if (name=="ide, quaternary")
-        dispname="IDE Port #4";
+        dispname="IDE #4";
     else if (name=="ide, quinternary")
-        dispname="IDE Port #5";
+        dispname="IDE #5";
     else if (name=="ide, sexternary")
-        dispname="IDE Port #6";
+        dispname="IDE #6";
     else if (name=="ide, septernary")
-        dispname="IDE Port #7";
+        dispname="IDE #7";
     else if (name=="ide, octernary")
-        dispname="IDE Port #8";
+        dispname="IDE #8";
     else if (name=="ethernet, pcap")
         dispname="Ethernet PCap";
     else if (name=="ethernet, slirp")
@@ -1150,27 +1150,27 @@ std::string RestoreName(std::string name) {
         dispname="sblaster";
     else if (name=="PC Speaker")
         dispname="speaker";
-    else if (name=="Serial Ports")
+    else if (name=="Serial")
         dispname="serial";
-    else if (name=="Parallel Ports")
+    else if (name=="Parallel")
         dispname="parallel";
-    else if (name=="Floppy Port #1")
+    else if (name=="Floppy")
         dispname="fdc, primary";
-    else if (name=="IDE Port #1")
+    else if (name=="IDE #1")
         dispname="ide, primary";
-    else if (name=="IDE Port #2")
+    else if (name=="IDE #2")
         dispname="ide, secondary";
-    else if (name=="IDE Port #3")
+    else if (name=="IDE #3")
         dispname="ide, tertiary";
-    else if (name=="IDE Port #4")
+    else if (name=="IDE #4")
         dispname="ide, quaternary";
-    else if (name=="IDE Port #5")
+    else if (name=="IDE #5")
         dispname="ide, quinternary";
-    else if (name=="IDE Port #6")
+    else if (name=="IDE #6")
         dispname="ide, sexternary";
-    else if (name=="IDE Port #7")
+    else if (name=="IDE #7")
         dispname="ide, septernary";
-    else if (name=="IDE Port #8")
+    else if (name=="IDE #8")
         dispname="ide, octernary";
     else if (name=="Ethernet PCap")
         dispname="ethernet, pcap";

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -3172,8 +3172,8 @@ public:
         advopt->setChecked(section->Get_bool("show advanced options"));
 
         strcpy(tmp1, (MSG_Get("SAVE")+std::string("...")).c_str());
-        (saveButton = new GUI::Button(this, 310, closerow_y, tmp1, 110, gridbtnheight))->addActionHandler(this);
-        (closeButton = new GUI::Button(this, 428, closerow_y, MSG_Get("CLOSE"), 110, gridbtnheight))->addActionHandler(this);
+        (saveButton = new GUI::Button(this, 276, closerow_y, tmp1, 130, gridbtnheight))->addActionHandler(this);
+        (closeButton = new GUI::Button(this, 408, closerow_y, MSG_Get("CLOSE"), 130, gridbtnheight))->addActionHandler(this);
 
         resize(gridbtnx + (xSpace * btnperrow) + 12 + border_left + border_right,
                closerow_y + closeButton->getHeight() + 8 + border_top + border_bottom);

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -58,7 +58,6 @@ int titlebox_y_height = 20;
 int titlebox_sysmenu_width = 20; // includes black divider line
 
 namespace Color {
-	RGB Light3D =			0xfffcfcfc;
 	RGB Shadow3D =			0xff808080;
 	RGB Border =			0xff000000;
 	RGB SelectionBackground =	0xff000080;
@@ -1087,7 +1086,7 @@ void ToplevelWindow::paint(Drawable &d) const
 	d.drawLine(5,titlebox_y_start,width-7,titlebox_y_start);
 	d.drawLine(5,titlebox_y_start,5,titlebox_y_start+titlebox_y_height-2);
 
-	d.setColor(Color::Light3D);
+	d.setColor(CurrentTheme.Light3D);
 	d.drawLine(1,1,width-3,1);
 	d.drawLine(1,1,1,height-3);
 
@@ -1456,7 +1455,7 @@ void Button::paint(Drawable& d) const
 		d.drawLine(1+offset,1+offset,width-3-offset,1+offset);
 		d.drawLine(1+offset,1+offset,1+offset,height-3-offset);
 
-		d.setColor(Color::Light3D);
+		d.setColor(CurrentTheme.Light3D);
 
 		d.drawLine(2+offset,2+offset,width-4-offset,2+offset);
 		d.drawLine(2+offset,2+offset,2+offset,height-4-offset);
@@ -1504,7 +1503,7 @@ void Checkbox::paint(Drawable &d) const
 	d.drawLine(2,(height/2)-7,13,(height/2)-7);
 	d.drawLine(2,(height/2)-7,2,(height/2)+5);
 
-	d.setColor(Color::Light3D);
+	d.setColor(CurrentTheme.Light3D);
 	d.drawLine(2,(height/2)+5,14,(height/2)+5);
 	d.drawLine(14,(height/2)-7,14,(height/2)+5);
 
@@ -1560,7 +1559,7 @@ bool Radiobox::keyUp(const Key &key)
 
 void Radiobox::paint(Drawable &d) const
 {
-	d.setColor(Color::Light3D);
+	d.setColor(CurrentTheme.Light3D);
 	d.drawLine(6,(height/2)+6,9,(height/2)+6);
 	d.drawLine(4,(height/2)+5,11,(height/2)+5);
 	d.drawLine(13,(height/2)-1,13,(height/2)+2);
@@ -1615,7 +1614,7 @@ void Menu::paint(Drawable &d) const
 	d.drawLine(0,height-2,width-2,height-2);
 	d.drawLine(width-2,0,width-2,height-2);
 
-	d.setColor(Color::Light3D);
+	d.setColor(CurrentTheme.Light3D);
 	d.drawLine(1,1,width-3,1);
 	d.drawLine(1,1,1,height-3);
 
@@ -1639,7 +1638,7 @@ void Menu::paint(Drawable &d) const
 		if ((*i).empty()) {
 			d.setColor(Color::Shadow3D);
 			d.drawLine(x+1,y-asc+6,cwidth,y-asc+6);
-			d.setColor(Color::Light3D);
+			d.setColor(CurrentTheme.Light3D);
 			d.drawLine(x+1,y-asc+7,cwidth,y-asc+7);
 			y += 12;
         } else if (*i == "|") {
@@ -1653,7 +1652,7 @@ void Menu::paint(Drawable &d) const
 
                 d.setColor(Color::Shadow3D);
                 d.drawLine(x-2,2,x-2,this->height-4);
-                d.setColor(Color::Light3D);
+                d.setColor(CurrentTheme.Light3D);
                 d.drawLine(x-1,2,x-1,this->height-4);
             }
         } else {
@@ -1675,7 +1674,7 @@ void Menubar::paint(Drawable &d) const
 {
 	const Font *f = Font::getFont("menu");
 
-	d.setColor(Color::Light3D);
+	d.setColor(CurrentTheme.Light3D);
 	d.drawLine(0,height-1,width-1,height-1);
 	d.setColor(Color::Shadow3D);
 	d.drawLine(0,height-2,width-1,height-2);
@@ -1730,7 +1729,7 @@ void Frame::paint(Drawable &d) const {
 	d.drawLine(2,height-3,width-3,height-3);
 	d.drawLine(width-3,top+1);
 	
-	d.setColor(Color::Light3D);
+	d.setColor(CurrentTheme.Light3D);
 	d.drawLine(2,height-3,2,top+1);
 	d.drawLine(8,top+1);
 	d.drawLine((label.empty()?8:f->getWidth(label)+14),top+1,width-3,top+1);
@@ -2353,7 +2352,7 @@ void WindowInWindow::paintScrollBar3DInset(Drawable &dscroll, int x, int y, int 
 }
 
 void WindowInWindow::paintScrollBar3DOutset(Drawable &dscroll, int x, int y, int w, int h) const {
-    dscroll.setColor(Color::Light3D);
+    dscroll.setColor(CurrentTheme.Light3D);
     dscroll.drawLine(x,y,x+w-2,y);
     dscroll.drawLine(x,y,x,    y+h-2);
 
@@ -2391,7 +2390,7 @@ void WindowInWindow::paintScrollBarThumbDragOutline(Drawable &dscroll,const vscr
     int y = (drag_y - vsl.scrollthumbRegion.y) - ((vsl.thumbheight + 2) / 2);
     if (y < 0) y = 0;
     if (y > vsl.thumbtravel) y = vsl.thumbtravel;
-    dscroll.setColor(Color::Light3D);
+    dscroll.setColor(CurrentTheme.Light3D);
     dscroll.drawDotRect(x+vsl.scrollthumbRegion.x,y+vsl.scrollthumbRegion.y,vsl.thumbwidth-1,vsl.thumbheight-1);
 }
 
@@ -2477,7 +2476,7 @@ void WindowInWindow::paintAll(Drawable &d) const {
         dchild.drawLine(0,0,w,0);
         dchild.drawLine(0,0,0,h);
 
-        dchild.setColor(Color::Light3D);
+        dchild.setColor(CurrentTheme.Light3D);
         dchild.drawLine(0,h,w,h);
         dchild.drawLine(w,0,w,h);
     }

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -58,7 +58,6 @@ int titlebox_y_height = 20;
 int titlebox_sysmenu_width = 20; // includes black divider line
 
 namespace Color {
-	RGB Border =			0xff000000;
 	RGB SelectionBackground =	0xff000080;
 	RGB SelectionForeground =	0xffffffff;
 	RGB EditableBackground =	0xffffffff;
@@ -1072,7 +1071,7 @@ void ToplevelWindow::paint(Drawable &d) const
 	unsigned int mask = (systemMenu->isVisible()?Color::RedMask|Color::GreenMask|Color::BlueMask:0);
 	d.clear(CurrentTheme.Background);
 
-	d.setColor(Color::Border);
+	d.setColor(CurrentTheme.Border);
 	d.drawLine(0,height-1,width-1,height-1);
 	d.drawLine(width-1,0,width-1,height-1);
 
@@ -1108,7 +1107,7 @@ void ToplevelWindow::paint(Drawable &d) const
         d.fillRect(x+1,y+1,w-2,h-2);
     }
 
-	d.setColor(Color::Border);
+	d.setColor(CurrentTheme.Border);
 	d.drawLine(6+titlebox_sysmenu_width-1,titlebox_y_start+1,6+titlebox_sysmenu_width-1,titlebox_y_start+titlebox_y_height-2);
 
     bool active = hasFocus();
@@ -1432,7 +1431,7 @@ void Button::paint(Drawable& d) const
 
 	if (hasFocus()) {
 		offset = 0;
-		d.setColor(Color::Border);
+		d.setColor(CurrentTheme.Border);
 		d.drawLine(0,0,width,0);
 		d.drawLine(0,0,0,height);
 
@@ -1464,7 +1463,7 @@ void Button::paint(Drawable& d) const
 		d.drawLine(2+offset,height-3-offset,width-2-offset,height-3-offset);
 		d.drawLine(width-3-offset,2+offset,width-3-offset,height-2-offset);
 
-		d.setColor(Color::Border);
+		d.setColor(CurrentTheme.Border);
 
 		d.drawLine(width-2-offset,1+offset,width-2-offset,height-2-offset);
 		d.drawLine(1+offset,height-2-offset,width-2-offset,height-2-offset);
@@ -1511,7 +1510,7 @@ void Checkbox::paint(Drawable &d) const
 		d.fillRect(4,(height/2)-5,9,9);
 	}
 
-	d.setColor(Color::Border);
+	d.setColor(CurrentTheme.Border);
 	d.drawLine(3,(height/2)-6,12,(height/2)-6);
 	d.drawLine(3,(height/2)-6,3,(height/2)+4);
 
@@ -1576,7 +1575,7 @@ void Radiobox::paint(Drawable &d) const
 	d.drawLine(2,(height/2)-1,2,(height/2)+2);
 	d.drawLine(3,(height/2)-3,3,(height/2)+4);
 
-	d.setColor(Color::Border);
+	d.setColor(CurrentTheme.Border);
 	d.drawLine(6,(height/2)-4,9,(height/2)-4);
 	d.drawLine(4,(height/2)-3,11,(height/2)-3);
 	d.drawLine(3,(height/2)-1,3,(height/2)+2);
@@ -1603,7 +1602,7 @@ void Menu::paint(Drawable &d) const
 {
 	d.clear(CurrentTheme.Background3D);
 
-	d.setColor(Color::Border);
+	d.setColor(CurrentTheme.Border);
 	d.drawLine(0,height-1,width-1,height-1);
 	d.drawLine(width-1,0,width-1,height-1);
 

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -1374,7 +1374,6 @@ void Button::paint(Drawable& d) const
     d.setColor(0xFFFF00FF);
     d.fillRect(0, 0, width, height);
 #endif
-    // this time we draw exact requested size // TODO adjust other parts
     const auto w = width;
     const auto h = height;
 

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -2879,7 +2879,7 @@ bool WindowInWindow::mouseDoubleClicked(int x, int y, MouseButton button) {
 bool WindowInWindow::mouseWheel(int wheel)
 {
     // BUG requires to click at least once in window for it to work
-    scroll_pos_y = min(max(scroll_pos_y - wheel * 15, 0), scroll_pos_h);
+    scroll_pos_y = imin(imax(scroll_pos_y - wheel * 15, 0), scroll_pos_h);
     return Window::mouseWheel(wheel);
 }
 

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -61,7 +61,6 @@ namespace Color {
 	RGB Light3D =			0xfffcfcfc;
 	RGB Shadow3D =			0xff808080;
 	RGB Border =			0xff000000;
-	RGB Background =		0xffc0c0c0;
 	RGB SelectionBackground =	0xff000080;
 	RGB SelectionForeground =	0xffffffff;
 	RGB EditableBackground =	0xffffffff;
@@ -1073,7 +1072,7 @@ bool BorderedWindow::mouseDragged(int x, int y, MouseButton button)
 void ToplevelWindow::paint(Drawable &d) const
 {
 	unsigned int mask = (systemMenu->isVisible()?Color::RedMask|Color::GreenMask|Color::BlueMask:0);
-	d.clear(Color::Background);
+	d.clear(CurrentTheme.Background);
 
 	d.setColor(Color::Border);
 	d.drawLine(0,height-1,width-1,height-1);

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -58,7 +58,6 @@ int titlebox_y_height = 20;
 int titlebox_sysmenu_width = 20; // includes black divider line
 
 namespace Color {
-	RGB SelectionForeground =	0xffffffff;
 	RGB EditableBackground =	0xffffffff;
 	RGB Titlebar =			0xffa4c8f0;
 	RGB TitlebarText =		0xff000000;
@@ -1185,7 +1184,7 @@ void Input::paint(Drawable &d) const
 			dr.fillRect(0,  sy-f->getAscent()+f->getHeight(), width+offset,    ey-sy-f->getHeight());
 			dr.fillRect(0,  ey-f->getAscent(),		ex,	      f->getHeight()	);
 		}
-		dr.setColor(Color::SelectionForeground);
+		dr.setColor(CurrentTheme.SelectionForeground);
 		dr.drawText(sx, sy, text, multi, start, end-start);
 	}
 
@@ -1656,7 +1655,7 @@ void Menu::paint(Drawable &d) const
 			if (index == selected && hasFocus()) {
 				d.setColor(CurrentTheme.SelectionBackground);
 				d.fillRect(x,y-asc,cwidth,height);
-				d.setColor(Color::SelectionForeground);
+				d.setColor(CurrentTheme.SelectionForeground);
 			} else {
 				d.setColor(CurrentTheme.TextColor);
 			}
@@ -1684,7 +1683,7 @@ void Menubar::paint(Drawable &d) const
 			int w = f->getWidth((*i)->getName());
 			d.setColor(CurrentTheme.SelectionBackground);
 			d.fillRect(d.getX()-7,0,w+14,height-2);
-			d.setColor(Color::SelectionForeground);
+			d.setColor(CurrentTheme.SelectionForeground);
 			d.gotoXY(d.getX()+7,f->getAscent()+2);
 		} else {
 			d.setColor(CurrentTheme.TextColor);

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -1361,8 +1361,79 @@ void BorderedWindow::paintAll(Drawable &d) const
 	}
 }
 
-void Button::paint(Drawable &d) const
+void Button::paint(Drawable& d) const
 {
+    // Windows 3.1 pixel perfect button style
+#define WIN31_STYLE 1
+#define WIN31_STYLE_DEBUG 0
+#if WIN31_STYLE
+#if WIN31_STYLE_DEBUG
+    d.setColor(0xFFFF00FF);
+    d.fillRect(0, 0, width, height);
+#endif
+    // this time we draw exact requested size // TODO adjust other parts
+    const auto w = width;
+    const auto h = height;
+
+    // TODO extract colors as a theme // TODO gather others first
+    constexpr RGB buttonBorder        = 0xFF000000;
+    constexpr RGB buttonFill          = 0xFFC0C7C8;
+    constexpr RGB button3DTopLeft     = 0xFFFFFFFF;
+    constexpr RGB button3DBottomRight = 0xFF87888F;
+    if(hasFocus())
+    {
+        d.setColor(buttonBorder);
+        d.fillRect(0, 1, 2, h - 2);     // L
+        d.fillRect(1, 0, w - 2, 2);     // T
+        d.fillRect(w - 2, 1, 2, h - 2); // R
+        d.fillRect(1, h - 2, w - 2, 2); // B
+
+        if(pressed)
+        {
+            d.setColor(button3DBottomRight);
+            d.drawLine(2, 2, 2, h - 3); // L
+            d.drawLine(3, 2, w - 3, 2); // T
+            d.setColor(buttonFill);
+            d.fillRect(3, 3, w - 5, h - 5);
+        }
+        else
+        {
+            d.setColor(button3DTopLeft);
+            d.drawLine(2, 2, 2, h - 4); // L
+            d.drawLine(3, 2, 3, h - 5); // L
+            d.drawLine(4, 2, w - 4, 2); // T
+            d.drawLine(4, 3, w - 5, 3); // T
+            d.setColor(button3DBottomRight);
+            d.drawLine(w - 4, 3, w - 4, h - 3); // R
+            d.drawLine(w - 3, 2, w - 3, h - 3); // R
+            d.drawLine(3, h - 4, w - 5, h - 4); // B
+            d.drawLine(2, h - 3, w - 5, h - 3); // B
+            d.setColor(buttonFill);
+            d.fillRect(4, 4, w - 8, h - 8);
+        }
+    }
+    else
+    {
+        d.setColor(buttonBorder);
+        d.drawLine(0, 1, 0, h - 2);         // L
+        d.drawLine(1, 0, w - 2, 0);         // T
+        d.drawLine(w - 1, 1, w - 1, h - 2); // R
+        d.drawLine(1, h - 1, w - 2, h - 1); // B
+        d.setColor(button3DTopLeft);
+        d.drawLine(1, 1, 1, h - 3); // L
+        d.drawLine(2, 1, 2, h - 4); // L
+        d.drawLine(3, 1, w - 3, 1); // T
+        d.drawLine(3, 2, w - 4, 2); // T
+        d.setColor(button3DBottomRight);
+        d.drawLine(w - 2, 1, w - 2, h - 2); // R
+        d.drawLine(w - 3, 2, w - 3, h - 2); // R
+        d.drawLine(2, h - 3, w - 4, h - 3); // B
+        d.drawLine(1, h - 2, w - 4, h - 2); // B
+        d.setColor(buttonFill);
+        d.fillRect(3, 3, w - 6, h - 6);
+    }
+ // TODO delete old style once satisfied
+ #else
 	int offset = -1;
 
 	if (hasFocus()) {
@@ -1403,7 +1474,8 @@ void Button::paint(Drawable &d) const
 
 		d.drawLine(width-2-offset,1+offset,width-2-offset,height-2-offset);
 		d.drawLine(1+offset,height-2-offset,width-2-offset,height-2-offset);
-	}
+    }
+#endif
 }
 
 bool Checkbox::keyDown(const Key &key)

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -2333,8 +2333,10 @@ bool ScreenSDL::event(SDL_Event &event) {
 		}
 		lastdown = 0;
 		return rc;
+#if C_SDL2	    
     case SDL_MOUSEWHEEL:
         return mouseWheel(event.wheel.y);
+#endif
     }
 
 	return false;

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -58,7 +58,6 @@ int titlebox_y_height = 20;
 int titlebox_sysmenu_width = 20; // includes black divider line
 
 namespace Color {
-	RGB Background3D =		0xffc0c0c0;
 	RGB Light3D =			0xfffcfcfc;
 	RGB Shadow3D =			0xff808080;
 	RGB Border =			0xff000000;
@@ -1096,7 +1095,7 @@ void ToplevelWindow::paint(Drawable &d) const
 	d.drawLine(5,titlebox_y_start+titlebox_y_height-1,width-6,titlebox_y_start+titlebox_y_height-1);
 	d.drawLine(width-6,5,width-6,titlebox_y_start+titlebox_y_height-1);
 
-	d.setColor(Color::Background3D^mask);
+	d.setColor(CurrentTheme.Background3D^mask);
 	d.fillRect(6,titlebox_y_start+1,titlebox_sysmenu_width-1,titlebox_y_height-2);
     {
         int y = titlebox_y_start+((titlebox_y_height-4)/2);
@@ -1162,7 +1161,7 @@ void Input::paint(Drawable &d) const
 	d.drawLine(0,0,width-2,0);
 	d.drawLine(0,0,0,height-2);
 
-	d.setColor(Color::Background3D);
+	d.setColor(CurrentTheme.Background3D);
 	d.drawLine(1,height-2,width-2,height-2);
 	d.drawLine(width-2,1,width-2,height-2);
 
@@ -1444,7 +1443,7 @@ void Button::paint(Drawable& d) const
 		d.drawLine(width-1,0,width-1,height);
 	}
 
-	d.setColor(Color::Background3D);
+	d.setColor(CurrentTheme.Background3D);
 	d.fillRect(2,2,width-4,height-4);
 
 	if (pressed) {
@@ -1453,7 +1452,7 @@ void Button::paint(Drawable& d) const
 		d.drawLine(1+offset,1+offset,width-2-offset,1+offset);
 		d.drawLine(1+offset,1+offset,1+offset,height-2-offset);
 	} else {
-		d.setColor(Color::Background3D);
+		d.setColor(CurrentTheme.Background3D);
 
 		d.drawLine(1+offset,1+offset,width-3-offset,1+offset);
 		d.drawLine(1+offset,1+offset,1+offset,height-3-offset);
@@ -1499,7 +1498,7 @@ bool Checkbox::keyUp(const Key &key)
 
 void Checkbox::paint(Drawable &d) const
 {
-	d.setColor(Color::Background3D);
+	d.setColor(CurrentTheme.Background3D);
 	d.fillRect(2,(height/2)-7,14,14);
 
 	d.setColor(Color::Shadow3D);
@@ -1568,7 +1567,7 @@ void Radiobox::paint(Drawable &d) const
 	d.drawLine(13,(height/2)-1,13,(height/2)+2);
 	d.drawLine(12,(height/2)-2,12,(height/2)+4);
 
-	d.setColor(Color::Background3D);
+	d.setColor(CurrentTheme.Background3D);
 	d.drawLine(6,(height/2)+5,9,(height/2)+5);
 	d.drawLine(4,(height/2)+4,11,(height/2)+4);
 	d.drawLine(12,(height/2)-1,12,(height/2)+2);
@@ -1586,7 +1585,7 @@ void Radiobox::paint(Drawable &d) const
 	d.drawLine(3,(height/2)-1,3,(height/2)+2);
 	d.drawLine(4,(height/2)-3,4,(height/2)+3);
 
-	d.setColor(pressed ? Color::Background3D : Color::EditableBackground); // do not omit this draw, doing so makes the radio button look a little crappy
+	d.setColor(pressed ? CurrentTheme.Background3D : Color::EditableBackground); // do not omit this draw, doing so makes the radio button look a little crappy
 	d.fillRect(5,(height/2)-2,6,6);
 	d.fillRect(4,(height/2)-1,8,4);
 	d.fillRect(6,(height/2)-3,4,8);
@@ -1605,7 +1604,7 @@ void Radiobox::paint(Drawable &d) const
 
 void Menu::paint(Drawable &d) const
 {
-	d.clear(Color::Background3D);
+	d.clear(CurrentTheme.Background3D);
 
 	d.setColor(Color::Border);
 	d.drawLine(0,height-1,width-1,height-1);
@@ -2382,7 +2381,7 @@ void WindowInWindow::paintScrollBarBackground(Drawable &dscroll,const vscrollbar
     dscroll.setColor(vsl.disabled ? Color::Shadow3D : Color::Black);
     dscroll.drawRect(vsl.scrollthumbRegion.x,  vsl.scrollthumbRegion.y,  vsl.scrollthumbRegion.w-1,vsl.scrollthumbRegion.h-1);
 
-    dscroll.setColor(Color::Background3D);
+    dscroll.setColor(CurrentTheme.Background3D);
     dscroll.fillRect(vsl.scrollthumbRegion.x+1,vsl.scrollthumbRegion.y+1,vsl.scrollthumbRegion.w-2,vsl.scrollthumbRegion.h-2);
 }
 

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -1024,6 +1024,12 @@ bool Window::mouseDoubleClicked(int x, int y, MouseButton button)
 	return mouseChild->mouseDoubleClicked(x-mouseChild->x, y-mouseChild->y, button);
 }
 
+bool Window::mouseWheel(int wheel)
+{
+	if (mouseChild == NULL) return false;
+	return mouseChild->mouseWheel(wheel);
+}
+
 bool BorderedWindow::mouseDown(int x, int y, MouseButton button)
 {
 	mouseChild = NULL;
@@ -2327,7 +2333,9 @@ bool ScreenSDL::event(SDL_Event &event) {
 		}
 		lastdown = 0;
 		return rc;
-	}
+    case SDL_MOUSEWHEEL:
+        return mouseWheel(event.wheel.y);
+    }
 
 	return false;
 }
@@ -2864,6 +2872,13 @@ bool WindowInWindow::mouseDoubleClicked(int x, int y, MouseButton button) {
     }
 
     return Window::mouseDoubleClicked(x-xadj,y-xadj,button);
+}
+
+bool WindowInWindow::mouseWheel(int wheel)
+{
+    // BUG requires to click at least once in window for it to work
+    scroll_pos_y = min(max(scroll_pos_y - wheel * 15, 0), scroll_pos_h);
+    return Window::mouseWheel(wheel);
 }
 
 void WindowInWindow::resize(int w, int h) {

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -801,7 +801,10 @@ bool Window::keyDown(const Key &key)
 			++i;
 		}
 		if (tab_quit) return false;
-		return (i != e) || toplevel/*prevent TAB escape to another window*/;
+	    // BUG/TODO swapped operands below to fix 'list iterators incompatible'
+	    // occurs in VS debug build when pressing TAB after opening configuration tool
+	    // currently this works but that just sweeps the problem under the rug
+		return toplevel /*prevent TAB escape to another window*/ || (i != e);
 	}
 }
 

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -62,7 +62,6 @@ namespace Color {
 	RGB Light3D =			0xfffcfcfc;
 	RGB Shadow3D =			0xff808080;
 	RGB Border =			0xff000000;
-	RGB Text =			0xff000000;
 	RGB Background =		0xffc0c0c0;
 	RGB SelectionBackground =	0xff000080;
 	RGB SelectionForeground =	0xffffffff;
@@ -1167,7 +1166,7 @@ void Input::paint(Drawable &d) const
 	d.drawLine(1,height-2,width-2,height-2);
 	d.drawLine(width-2,1,width-2,height-2);
 
-	d.setColor(Color::Text);
+	d.setColor(CurrentTheme.TextColor);
 	d.drawLine(1,1,width-3,1);
 	d.drawLine(1,1,1,height-3);
 
@@ -1196,7 +1195,7 @@ void Input::paint(Drawable &d) const
 		dr.drawText(sx, sy, text, multi, start, end-start);
 	}
 
-	dr.setColor(Color::Text);
+	dr.setColor(CurrentTheme.TextColor);
 
 	dr.drawText(text, multi, end);
 
@@ -1526,7 +1525,7 @@ void Checkbox::paint(Drawable &d) const
 	}
 
 	if (checked) {
-		d.setColor(Color::Text);
+		d.setColor(CurrentTheme.TextColor);
 		d.drawLine(5,(height/2)-2,7,(height/2)  );
 		d.drawLine(11,(height/2)-4);
 		d.drawLine(5,(height/2)-1,7,(height/2)+1);
@@ -1598,7 +1597,7 @@ void Radiobox::paint(Drawable &d) const
 	}
 
 	if (checked) {
-		d.setColor(Color::Text);
+		d.setColor(CurrentTheme.TextColor);
 		d.fillRect(6,(height/2),4,2);
 		d.fillRect(7,(height/2)-1,2,4);
 	}
@@ -1665,7 +1664,7 @@ void Menu::paint(Drawable &d) const
 				d.fillRect(x,y-asc,cwidth,height);
 				d.setColor(Color::SelectionForeground);
 			} else {
-				d.setColor(Color::Text);
+				d.setColor(CurrentTheme.TextColor);
 			}
 			d.drawText(x+17,y,(*i),false,0);
 			y += height;
@@ -1694,7 +1693,7 @@ void Menubar::paint(Drawable &d) const
 			d.setColor(Color::SelectionForeground);
 			d.gotoXY(d.getX()+7,f->getAscent()+2);
 		} else {
-			d.setColor(Color::Text);
+			d.setColor(CurrentTheme.TextColor);
 		}
 		d.drawText((*i)->getName(),false);
 		d.gotoXY(d.getX()+14,f->getAscent()+2);
@@ -1740,7 +1739,7 @@ void Frame::paint(Drawable &d) const {
 	d.drawLine(2,height-2,width-2,height-2);
 	d.drawLine(width-2,top+1);
 
-	d.setColor(Color::Text);
+	d.setColor(CurrentTheme.TextColor);
 	d.drawText(11,f->getAscent()+1,label,false,0);
 }
 

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -58,7 +58,6 @@ int titlebox_y_height = 20;
 int titlebox_sysmenu_width = 20; // includes black divider line
 
 namespace Color {
-	RGB Shadow3D =			0xff808080;
 	RGB Border =			0xff000000;
 	RGB SelectionBackground =	0xff000080;
 	RGB SelectionForeground =	0xffffffff;
@@ -1077,7 +1076,7 @@ void ToplevelWindow::paint(Drawable &d) const
 	d.drawLine(0,height-1,width-1,height-1);
 	d.drawLine(width-1,0,width-1,height-1);
 
-	d.setColor(Color::Shadow3D);
+	d.setColor(CurrentTheme.Shadow3D);
 	d.drawLine(0,0,width-2,0);
 	d.drawLine(0,0,0,height-2);
 	d.drawLine(0,height-2,width-2,height-2);
@@ -1155,7 +1154,7 @@ void Input::paint(Drawable &d) const
 {
 	d.clear(Color::EditableBackground);
 
-	d.setColor(Color::Shadow3D);
+	d.setColor(CurrentTheme.Shadow3D);
 	d.drawLine(0,0,width-2,0);
 	d.drawLine(0,0,0,height-2);
 
@@ -1445,7 +1444,7 @@ void Button::paint(Drawable& d) const
 	d.fillRect(2,2,width-4,height-4);
 
 	if (pressed) {
-		d.setColor(Color::Shadow3D);
+		d.setColor(CurrentTheme.Shadow3D);
 
 		d.drawLine(1+offset,1+offset,width-2-offset,1+offset);
 		d.drawLine(1+offset,1+offset,1+offset,height-2-offset);
@@ -1460,7 +1459,7 @@ void Button::paint(Drawable& d) const
 		d.drawLine(2+offset,2+offset,width-4-offset,2+offset);
 		d.drawLine(2+offset,2+offset,2+offset,height-4-offset);
 
-		d.setColor(Color::Shadow3D);
+		d.setColor(CurrentTheme.Shadow3D);
 
 		d.drawLine(2+offset,height-3-offset,width-2-offset,height-3-offset);
 		d.drawLine(width-3-offset,2+offset,width-3-offset,height-2-offset);
@@ -1499,7 +1498,7 @@ void Checkbox::paint(Drawable &d) const
 	d.setColor(CurrentTheme.Background3D);
 	d.fillRect(2,(height/2)-7,14,14);
 
-	d.setColor(Color::Shadow3D);
+	d.setColor(CurrentTheme.Shadow3D);
 	d.drawLine(2,(height/2)-7,13,(height/2)-7);
 	d.drawLine(2,(height/2)-7,2,(height/2)+5);
 
@@ -1571,7 +1570,7 @@ void Radiobox::paint(Drawable &d) const
 	d.drawLine(12,(height/2)-1,12,(height/2)+2);
 	d.drawLine(11,(height/2)-2,11,(height/2)+4);
 
-	d.setColor(Color::Shadow3D);
+	d.setColor(CurrentTheme.Shadow3D);
 	d.drawLine(6,(height/2)-5,9,(height/2)-5);
 	d.drawLine(4,(height/2)-4,11,(height/2)-4);
 	d.drawLine(2,(height/2)-1,2,(height/2)+2);
@@ -1608,7 +1607,7 @@ void Menu::paint(Drawable &d) const
 	d.drawLine(0,height-1,width-1,height-1);
 	d.drawLine(width-1,0,width-1,height-1);
 
-	d.setColor(Color::Shadow3D);
+	d.setColor(CurrentTheme.Shadow3D);
 	d.drawLine(0,0,width-2,0);
 	d.drawLine(0,0,0,height-2);
 	d.drawLine(0,height-2,width-2,height-2);
@@ -1636,7 +1635,7 @@ void Menu::paint(Drawable &d) const
 
 	for (std::vector<String>::const_iterator i = items.begin(); i != items.end(); ++i) {
 		if ((*i).empty()) {
-			d.setColor(Color::Shadow3D);
+			d.setColor(CurrentTheme.Shadow3D);
 			d.drawLine(x+1,y-asc+6,cwidth,y-asc+6);
 			d.setColor(CurrentTheme.Light3D);
 			d.drawLine(x+1,y-asc+7,cwidth,y-asc+7);
@@ -1650,7 +1649,7 @@ void Menu::paint(Drawable &d) const
                     cwidth = colx[coli] - x;
                 }
 
-                d.setColor(Color::Shadow3D);
+                d.setColor(CurrentTheme.Shadow3D);
                 d.drawLine(x-2,2,x-2,this->height-4);
                 d.setColor(CurrentTheme.Light3D);
                 d.drawLine(x-1,2,x-1,this->height-4);
@@ -1676,7 +1675,7 @@ void Menubar::paint(Drawable &d) const
 
 	d.setColor(CurrentTheme.Light3D);
 	d.drawLine(0,height-1,width-1,height-1);
-	d.setColor(Color::Shadow3D);
+	d.setColor(CurrentTheme.Shadow3D);
 	d.drawLine(0,height-2,width-1,height-2);
 
 	d.gotoXY(7,f->getAscent()+2);
@@ -1722,7 +1721,7 @@ void Frame::paint(Drawable &d) const {
 	const Font *f = Font::getFont("default");
 	const int top = (label.empty()?1:f->getAscent()/2+1);
 
-	d.setColor(Color::Shadow3D);
+	d.setColor(CurrentTheme.Shadow3D);
 	d.drawLine(1,height-2,1,top);
 	d.drawLine(8,top);
 	d.drawLine((label.empty()?8:f->getWidth(label)+14),top,width-2,top);
@@ -2346,7 +2345,7 @@ bool ScreenSDL::event(SDL_Event &event) {
 
 void WindowInWindow::paintScrollBar3DInset(Drawable &dscroll, int x, int y, int w, int h) const {
     // Windows 3.1 renders the shadow one pixel wide, no highlight
-    dscroll.setColor(Color::Shadow3D);
+    dscroll.setColor(CurrentTheme.Shadow3D);
     dscroll.drawLine(x,y,x+w-1,y);
     dscroll.drawLine(x,y,x,    y+h-1);
 }
@@ -2357,7 +2356,7 @@ void WindowInWindow::paintScrollBar3DOutset(Drawable &dscroll, int x, int y, int
     dscroll.drawLine(x,y,x,    y+h-2);
 
     // Windows 3.1 renders the shadow two pixels wide
-    dscroll.setColor(Color::Shadow3D);
+    dscroll.setColor(CurrentTheme.Shadow3D);
     dscroll.drawLine(x,    y+h-1,x+w-1,y+h-1);
     dscroll.drawLine(x+w-1,y,    x+w-1,y+h-1);
 
@@ -2367,7 +2366,7 @@ void WindowInWindow::paintScrollBar3DOutset(Drawable &dscroll, int x, int y, int
 
 void WindowInWindow::paintScrollBarThumb(Drawable &dscroll, vscrollbarlayout &vsl) const {
     // black border
-    dscroll.setColor(vsl.disabled ? Color::Shadow3D : Color::Black);
+    dscroll.setColor(vsl.disabled ? CurrentTheme.Shadow3D : Color::Black);
     dscroll.drawRect(vsl.xleft,vsl.ytop,vsl.thumbwidth-1,vsl.thumbheight-1);
 
     // 3D outset style, 1 pixel inward each side, inside the black rectangle we just drew
@@ -2376,7 +2375,7 @@ void WindowInWindow::paintScrollBarThumb(Drawable &dscroll, vscrollbarlayout &vs
 
 void WindowInWindow::paintScrollBarBackground(Drawable &dscroll,const vscrollbarlayout &vsl) const {
     /* scroll bar border, background */
-    dscroll.setColor(vsl.disabled ? Color::Shadow3D : Color::Black);
+    dscroll.setColor(vsl.disabled ? CurrentTheme.Shadow3D : Color::Black);
     dscroll.drawRect(vsl.scrollthumbRegion.x,  vsl.scrollthumbRegion.y,  vsl.scrollthumbRegion.w-1,vsl.scrollthumbRegion.h-1);
 
     dscroll.setColor(CurrentTheme.Background3D);
@@ -2435,7 +2434,7 @@ void WindowInWindow::paintScrollBarArrowInBox(Drawable &dscroll,const int x,cons
     const int ax = ((w - aw) / 2) + x;
     const int ay = ((h - ah) / 2) + y;
 
-    dscroll.setColor(disabled ? Color::Shadow3D : Color::Black);
+    dscroll.setColor(disabled ? CurrentTheme.Shadow3D : Color::Black);
 
     if (downArrow) {
         dscroll.fillRect(ax+2,ay,3,3);
@@ -2472,7 +2471,7 @@ void WindowInWindow::paintAll(Drawable &d) const {
         if (vscroll)
             w -= (vscroll?vscroll_display_width:0);
 
-        dchild.setColor(Color::Shadow3D);
+        dchild.setColor(CurrentTheme.Shadow3D);
         dchild.drawLine(0,0,w,0);
         dchild.drawLine(0,0,0,h);
 
@@ -2498,7 +2497,7 @@ void WindowInWindow::paintAll(Drawable &d) const {
                 const int h = vsl.scrollthumbRegion.y + 1; /* want black border of thumb to overlap our black border 1 pixel */
 
                 // black border
-                dscroll.setColor(vsl.disabled ? Color::Shadow3D : Color::Black);
+                dscroll.setColor(vsl.disabled ? CurrentTheme.Shadow3D : Color::Black);
                 dscroll.drawRect(x,y,w-1,h-1);
 
                 // 3D outset style, 1 pixel inward each side, inside the black rectangle we just drew
@@ -2520,7 +2519,7 @@ void WindowInWindow::paintAll(Drawable &d) const {
                 const int h = height - y;
 
                 // black border
-                dscroll.setColor(vsl.disabled ? Color::Shadow3D : Color::Black);
+                dscroll.setColor(vsl.disabled ? CurrentTheme.Shadow3D : Color::Black);
                 dscroll.drawRect(x,y,w-1,h-1);
 
                 // 3D outset style, 1 pixel inward each side, inside the black rectangle we just drew

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -57,13 +57,6 @@ int titlebox_y_height = 20;
 /* width of the system menu */
 int titlebox_sysmenu_width = 20; // includes black divider line
 
-namespace Color {
-	RGB Titlebar =			0xffa4c8f0;
-	RGB TitlebarText =		0xff000000;
-	RGB TitlebarInactive =			0xffffffff;
-	RGB TitlebarInactiveText =		0xff000000;
-}
-
 Theme CurrentTheme = ThemeLight();
 
 std::map<const char *,Font *,Font::ltstr> Font::registry;
@@ -1132,11 +1125,11 @@ void ToplevelWindow::paint(Drawable &d) const
         }
     }
 
-	d.setColor(active ? Color::Titlebar : Color::TitlebarInactive);
+	d.setColor(active ? CurrentTheme.TitleBar : CurrentTheme.TitleBarInactive);
 	d.fillRect(6+titlebox_sysmenu_width,titlebox_y_start+1,width-(6+titlebox_sysmenu_width+6),titlebox_y_height-2);
 
 	const Font *font = Font::getFont("title");
-	d.setColor(active ? Color::TitlebarText : Color::TitlebarInactiveText);
+	d.setColor(active ? CurrentTheme.TitleBarText : CurrentTheme.TitleBarInactiveText);
 	d.setFont(font);
 	d.drawText(31+(width-39-font->getWidth(title))/2,titlebox_y_start+(titlebox_y_height-font->getHeight())/2+font->getAscent(),title,false,0);
 }

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -58,7 +58,6 @@ int titlebox_y_height = 20;
 int titlebox_sysmenu_width = 20; // includes black divider line
 
 namespace Color {
-	RGB EditableBackground =	0xffffffff;
 	RGB Titlebar =			0xffa4c8f0;
 	RGB TitlebarText =		0xff000000;
 	RGB TitlebarInactive =			0xffffffff;
@@ -1149,7 +1148,7 @@ void Input::posToEnd(void) {
 
 void Input::paint(Drawable &d) const
 {
-	d.clear(Color::EditableBackground);
+	d.clear(CurrentTheme.EditableBackground);
 
 	d.setColor(CurrentTheme.Shadow3D);
 	d.drawLine(0,0,width-2,0);
@@ -1504,7 +1503,7 @@ void Checkbox::paint(Drawable &d) const
 	d.drawLine(14,(height/2)-7,14,(height/2)+5);
 
 	if (!pressed) {
-		d.setColor(Color::EditableBackground);
+		d.setColor(CurrentTheme.EditableBackground);
 		d.fillRect(4,(height/2)-5,9,9);
 	}
 
@@ -1579,7 +1578,7 @@ void Radiobox::paint(Drawable &d) const
 	d.drawLine(3,(height/2)-1,3,(height/2)+2);
 	d.drawLine(4,(height/2)-3,4,(height/2)+3);
 
-	d.setColor(pressed ? CurrentTheme.Background3D : Color::EditableBackground); // do not omit this draw, doing so makes the radio button look a little crappy
+	d.setColor(pressed ? CurrentTheme.Background3D : CurrentTheme.EditableBackground); // do not omit this draw, doing so makes the radio button look a little crappy
 	d.fillRect(5,(height/2)-2,6,6);
 	d.fillRect(4,(height/2)-1,8,4);
 	d.fillRect(6,(height/2)-3,4,8);

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -58,7 +58,6 @@ int titlebox_y_height = 20;
 int titlebox_sysmenu_width = 20; // includes black divider line
 
 namespace Color {
-	RGB SelectionBackground =	0xff000080;
 	RGB SelectionForeground =	0xffffffff;
 	RGB EditableBackground =	0xffffffff;
 	RGB Titlebar =			0xffa4c8f0;
@@ -1179,7 +1178,7 @@ void Input::paint(Drawable &d) const
 	int ex = dr.getX(), ey = dr.getY();
 
 	if (sx != ex || sy != ey) {
-		dr.setColor(Color::SelectionBackground);
+		dr.setColor(CurrentTheme.SelectionBackground);
 		if (sy == ey) dr.fillRect(sx,sy-f->getAscent(),ex-sx,f->getHeight()+1);
 		else {
 			dr.fillRect(sx, sy-f->getAscent(),		width-sx+offset, f->getHeight()	);
@@ -1655,7 +1654,7 @@ void Menu::paint(Drawable &d) const
             }
         } else {
 			if (index == selected && hasFocus()) {
-				d.setColor(Color::SelectionBackground);
+				d.setColor(CurrentTheme.SelectionBackground);
 				d.fillRect(x,y-asc,cwidth,height);
 				d.setColor(Color::SelectionForeground);
 			} else {
@@ -1683,7 +1682,7 @@ void Menubar::paint(Drawable &d) const
 	for (std::vector<Menu*>::const_iterator i = menus.begin(); i != menus.end(); ++i, ++index) {
 		if (index == selected && (*i)->isVisible()) {
 			int w = f->getWidth((*i)->getName());
-			d.setColor(Color::SelectionBackground);
+			d.setColor(CurrentTheme.SelectionBackground);
 			d.fillRect(d.getX()-7,0,w+14,height-2);
 			d.setColor(Color::SelectionForeground);
 			d.gotoXY(d.getX()+7,f->getAscent()+2);

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -73,6 +73,8 @@ namespace Color {
 	RGB TitlebarInactiveText =		0xff000000;
 }
 
+Theme CurrentTheme = ThemeLight();
+
 std::map<const char *,Font *,Font::ltstr> Font::registry;
 
 bool ToplevelWindow::mouseDoubleClicked(int x, int y, MouseButton button) {
@@ -1377,14 +1379,9 @@ void Button::paint(Drawable& d) const
     const auto w = width;
     const auto h = height;
 
-    // TODO extract colors as a theme // TODO gather others first
-    constexpr RGB buttonBorder        = 0xFF000000;
-    constexpr RGB buttonFill          = 0xFFC0C7C8;
-    constexpr RGB button3DTopLeft     = 0xFFFFFFFF;
-    constexpr RGB button3DBottomRight = 0xFF87888F;
     if(hasFocus())
     {
-        d.setColor(buttonBorder);
+        d.setColor(CurrentTheme.ButtonBorder);
         d.fillRect(0, 1, 2, h - 2);     // L
         d.fillRect(1, 0, w - 2, 2);     // T
         d.fillRect(w - 2, 1, 2, h - 2); // R
@@ -1392,46 +1389,46 @@ void Button::paint(Drawable& d) const
 
         if(pressed)
         {
-            d.setColor(button3DBottomRight);
+            d.setColor(CurrentTheme.ButtonBevel2);
             d.drawLine(2, 2, 2, h - 3); // L
             d.drawLine(3, 2, w - 3, 2); // T
-            d.setColor(buttonFill);
+            d.setColor(CurrentTheme.ButtonFiller);
             d.fillRect(3, 3, w - 5, h - 5);
         }
         else
         {
-            d.setColor(button3DTopLeft);
+            d.setColor(CurrentTheme.ButtonBevel1);
             d.drawLine(2, 2, 2, h - 4); // L
             d.drawLine(3, 2, 3, h - 5); // L
             d.drawLine(4, 2, w - 4, 2); // T
             d.drawLine(4, 3, w - 5, 3); // T
-            d.setColor(button3DBottomRight);
+            d.setColor(CurrentTheme.ButtonBevel2);
             d.drawLine(w - 4, 3, w - 4, h - 3); // R
             d.drawLine(w - 3, 2, w - 3, h - 3); // R
             d.drawLine(3, h - 4, w - 5, h - 4); // B
             d.drawLine(2, h - 3, w - 5, h - 3); // B
-            d.setColor(buttonFill);
+            d.setColor(CurrentTheme.ButtonFiller);
             d.fillRect(4, 4, w - 8, h - 8);
         }
     }
     else
     {
-        d.setColor(buttonBorder);
+        d.setColor(CurrentTheme.ButtonBorder);
         d.drawLine(0, 1, 0, h - 2);         // L
         d.drawLine(1, 0, w - 2, 0);         // T
         d.drawLine(w - 1, 1, w - 1, h - 2); // R
         d.drawLine(1, h - 1, w - 2, h - 1); // B
-        d.setColor(button3DTopLeft);
+        d.setColor(CurrentTheme.ButtonBevel1);
         d.drawLine(1, 1, 1, h - 3); // L
         d.drawLine(2, 1, 2, h - 4); // L
         d.drawLine(3, 1, w - 3, 1); // T
         d.drawLine(3, 2, w - 4, 2); // T
-        d.setColor(button3DBottomRight);
+        d.setColor(CurrentTheme.ButtonBevel2);
         d.drawLine(w - 2, 1, w - 2, h - 2); // R
         d.drawLine(w - 3, 2, w - 3, h - 2); // R
         d.drawLine(2, h - 3, w - 4, h - 3); // B
         d.drawLine(1, h - 2, w - 4, h - 2); // B
-        d.setColor(buttonFill);
+        d.setColor(CurrentTheme.ButtonFiller);
         d.fillRect(3, 3, w - 6, h - 6);
     }
  // TODO delete old style once satisfied

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -1081,7 +1081,7 @@ void ToplevelWindow::paint(Drawable &d) const
 	d.drawLine(5,titlebox_y_start+titlebox_y_height-1,width-6,titlebox_y_start+titlebox_y_height-1);
 	d.drawLine(width-6,5,width-6,titlebox_y_start+titlebox_y_height-1);
 
-	d.setColor(CurrentTheme.Background3D^mask);
+	d.setColor(CurrentTheme.Background^mask);
 	d.fillRect(6,titlebox_y_start+1,titlebox_sysmenu_width-1,titlebox_y_height-2);
     {
         int y = titlebox_y_start+((titlebox_y_height-4)/2);
@@ -1147,7 +1147,7 @@ void Input::paint(Drawable &d) const
 	d.drawLine(0,0,width-2,0);
 	d.drawLine(0,0,0,height-2);
 
-	d.setColor(CurrentTheme.Background3D);
+	d.setColor(CurrentTheme.Background);
 	d.drawLine(1,height-2,width-2,height-2);
 	d.drawLine(width-2,1,width-2,height-2);
 
@@ -1429,7 +1429,7 @@ void Button::paint(Drawable& d) const
 		d.drawLine(width-1,0,width-1,height);
 	}
 
-	d.setColor(CurrentTheme.Background3D);
+	d.setColor(CurrentTheme.Background);
 	d.fillRect(2,2,width-4,height-4);
 
 	if (pressed) {
@@ -1438,7 +1438,7 @@ void Button::paint(Drawable& d) const
 		d.drawLine(1+offset,1+offset,width-2-offset,1+offset);
 		d.drawLine(1+offset,1+offset,1+offset,height-2-offset);
 	} else {
-		d.setColor(CurrentTheme.Background3D);
+		d.setColor(CurrentTheme.Background);
 
 		d.drawLine(1+offset,1+offset,width-3-offset,1+offset);
 		d.drawLine(1+offset,1+offset,1+offset,height-3-offset);
@@ -1484,7 +1484,7 @@ bool Checkbox::keyUp(const Key &key)
 
 void Checkbox::paint(Drawable &d) const
 {
-	d.setColor(CurrentTheme.Background3D);
+	d.setColor(CurrentTheme.Background);
 	d.fillRect(2,(height/2)-7,14,14);
 
 	d.setColor(CurrentTheme.Shadow3D);
@@ -1553,7 +1553,7 @@ void Radiobox::paint(Drawable &d) const
 	d.drawLine(13,(height/2)-1,13,(height/2)+2);
 	d.drawLine(12,(height/2)-2,12,(height/2)+4);
 
-	d.setColor(CurrentTheme.Background3D);
+	d.setColor(CurrentTheme.Background);
 	d.drawLine(6,(height/2)+5,9,(height/2)+5);
 	d.drawLine(4,(height/2)+4,11,(height/2)+4);
 	d.drawLine(12,(height/2)-1,12,(height/2)+2);
@@ -1571,7 +1571,7 @@ void Radiobox::paint(Drawable &d) const
 	d.drawLine(3,(height/2)-1,3,(height/2)+2);
 	d.drawLine(4,(height/2)-3,4,(height/2)+3);
 
-	d.setColor(pressed ? CurrentTheme.Background3D : CurrentTheme.EditableBackground); // do not omit this draw, doing so makes the radio button look a little crappy
+	d.setColor(pressed ? CurrentTheme.Background : CurrentTheme.EditableBackground); // do not omit this draw, doing so makes the radio button look a little crappy
 	d.fillRect(5,(height/2)-2,6,6);
 	d.fillRect(4,(height/2)-1,8,4);
 	d.fillRect(6,(height/2)-3,4,8);
@@ -1590,7 +1590,7 @@ void Radiobox::paint(Drawable &d) const
 
 void Menu::paint(Drawable &d) const
 {
-	d.clear(CurrentTheme.Background3D);
+	d.clear(CurrentTheme.Background);
 
 	d.setColor(CurrentTheme.Border);
 	d.drawLine(0,height-1,width-1,height-1);
@@ -2367,7 +2367,7 @@ void WindowInWindow::paintScrollBarBackground(Drawable &dscroll,const vscrollbar
     dscroll.setColor(vsl.disabled ? CurrentTheme.Shadow3D : Color::Black);
     dscroll.drawRect(vsl.scrollthumbRegion.x,  vsl.scrollthumbRegion.y,  vsl.scrollthumbRegion.w-1,vsl.scrollthumbRegion.h-1);
 
-    dscroll.setColor(CurrentTheme.Background3D);
+    dscroll.setColor(CurrentTheme.Background);
     dscroll.fillRect(vsl.scrollthumbRegion.x+1,vsl.scrollthumbRegion.y+1,vsl.scrollthumbRegion.w-2,vsl.scrollthumbRegion.h-2);
 }
 

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -263,7 +263,8 @@ static inline unsigned int A(RGB val) { return ((val&Color::AlphaMask)>>Color::A
 struct Theme
     // TODO gather others colors
 {
-    uint32_t Background3D           = 0xFFC0C0C0;
+    uint32_t Background             = 0xFFC0C0C0; // TODO this is confusing
+    uint32_t Background3D           = 0xFFC0C0C0; // TODO this is confusing
     uint32_t ButtonBorder           = 0xFF000000;
     uint32_t ButtonFiller           = 0xFF808080;
     uint32_t ButtonBevel1           = 0xFFFFFFFF;

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -1648,6 +1648,9 @@ public:
 	/// Retrieve current color
 	RGB getColor() { return color; }
 
+    static constexpr auto FocusInner = 2;          // TODO extract style
+    static constexpr auto FocusColor = 0xFF87888F; // TODO extract style
+
 	/// Calculate label size. Parameters are ignored.
 	void resize(int w = -1, int h = -1) override {
         (void)h;//UNUSED
@@ -1658,13 +1661,24 @@ public:
 		d.drawText(0, font->getAscent(), text, interpret, 0);
 		if (interpret) Window::resize(w, d.getY()-font->getAscent()+font->getHeight());
 		else Window::resize(d.getX(), font->getHeight());
-	}
+
+	    // override non-interpreted so as focus adapts itself better to text
+	    // one depends on the other, that's fundamentally wrong but well ...
+	    // that said, it's pretty darn close to how it looks in Windows 3.11
+        if (interpret == false)
+        {
+            const auto tw = font->getWidth(this->text);
+            const auto th = font->getHeight();
+            constexpr auto px = 1; // font-specific fix
+            Window::resize(tw + FocusInner + px, th + FocusInner);
+        }
+    }
 
 	/// Returns \c true if this window has currently the keyboard focus.
 	bool hasFocus() const override { return allow_focus && Window::hasFocus(); }
 
 	/// Paint label
-	void paint(Drawable &d) const override { d.setColor(color); d.drawText(0, font->getAscent(), text, interpret, 0); if (hasFocus()) d.drawDotRect(0,0,width-1,height-1); }
+	void paint(Drawable &d) const override { d.setColor(color); d.drawText(FocusInner, FocusInner + font->getAscent(), text, interpret, 0); if (hasFocus()) { d.setColor(FocusColor); d.drawDotRect(0,0,width-1,height-1);} }
 
 	bool raise() override { return false; }
 };

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -273,6 +273,7 @@ struct Theme
     int32_t  FocusPadding           = 2;
     int32_t  FocusPaddingHorizontal = 1;
     uint32_t TextColor              = 0xFF000000;
+    uint32_t Light3D                = 0xFFFCFCFC;
 };
 
 // Windows 3.1 theme

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -260,6 +260,32 @@ static inline unsigned int A(RGB val) { return ((val&Color::AlphaMask)>>Color::A
 
 }
 
+struct Theme
+    // TODO gather others colors
+{
+    uint32_t ButtonBorder           = 0xFF000000;
+    uint32_t ButtonFiller           = 0xFF808080;
+    uint32_t ButtonBevel1           = 0xFFFFFFFF;
+    uint32_t ButtonBevel2           = 0xFFC0C0C0;
+    uint32_t FocusColor             = 0xFF000000;
+    int32_t  FocusPadding           = 2;
+    int32_t  FocusPaddingHorizontal = 1;
+};
+
+// Windows 3.1 theme
+struct ThemeLight : Theme
+{
+    ThemeLight()
+    {
+        ButtonFiller = 0xFFC0C7C8;
+        ButtonBevel1 = 0xFFFFFFFF;
+        ButtonBevel2 = 0xFF87888F;
+        FocusColor   = 0xFF87888F;
+    }
+};
+
+extern Theme CurrentTheme;
+
 /// Identifies a mouse button.
 enum MouseButton { NoButton, Left, Right, Middle, WheelUp, WheelDown, WheelLeft, WheelRight };
 
@@ -1648,9 +1674,6 @@ public:
 	/// Retrieve current color
 	RGB getColor() { return color; }
 
-    static constexpr auto FocusInner = 2;          // TODO extract style
-    static constexpr auto FocusColor = 0xFF87888F; // TODO extract style
-
 	/// Calculate label size. Parameters are ignored.
 	void resize(int w = -1, int h = -1) override {
         (void)h;//UNUSED
@@ -1669,16 +1692,26 @@ public:
         {
             const auto tw = font->getWidth(this->text);
             const auto th = font->getHeight();
-            constexpr auto px = 1; // font-specific fix
-            Window::resize(tw + FocusInner + px, th + FocusInner);
+            Window::resize(tw + CurrentTheme.FocusPadding + CurrentTheme.FocusPaddingHorizontal, th + CurrentTheme.FocusPadding);
         }
     }
 
 	/// Returns \c true if this window has currently the keyboard focus.
 	bool hasFocus() const override { return allow_focus && Window::hasFocus(); }
 
-	/// Paint label
-	void paint(Drawable &d) const override { d.setColor(color); d.drawText(FocusInner, FocusInner + font->getAscent(), text, interpret, 0); if (hasFocus()) { d.setColor(FocusColor); d.drawDotRect(0,0,width-1,height-1);} }
+    /// Paint label
+    void paint(Drawable& d) const override
+    {
+        d.setColor(color);
+
+        d.drawText(CurrentTheme.FocusPadding, CurrentTheme.FocusPadding + font->getAscent(), text, interpret, 0);
+
+        if(hasFocus())
+        {
+            d.setColor(CurrentTheme.FocusColor);
+            d.drawDotRect(0, 0, width - 1, height - 1);
+        }
+    }
 
 	bool raise() override { return false; }
 };

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -275,6 +275,7 @@ struct Theme
     uint32_t TextColor              = 0xFF000000;
     uint32_t Light3D                = 0xFFFCFCFC;
     uint32_t Shadow3D               = 0xFF808080;
+    uint32_t Border                 = 0xFF000000;
 };
 
 // Windows 3.1 theme

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -278,6 +278,7 @@ struct Theme
     uint32_t Border                 = 0xFF000000;
     uint32_t SelectionBackground    = 0xFF000080;
     uint32_t SelectionForeground    = 0xFFFFFFFF;
+    uint32_t EditableBackground     = 0xFFFFFFFF;
 };
 
 // Windows 3.1 theme

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -224,8 +224,7 @@ static inline unsigned int A(RGB val) { return ((val&Color::AlphaMask)>>Color::A
 struct Theme
     // TODO gather others colors
 {
-    uint32_t Background             = 0xFFC0C0C0; // TODO this is confusing
-    uint32_t Background3D           = 0xFFC0C0C0; // TODO this is confusing
+    uint32_t Background             = 0xFFC0C0C0;
     uint32_t ButtonBorder           = 0xFF000000;
     uint32_t ButtonFiller           = 0xFF808080;
     uint32_t ButtonBevel1           = 0xFFFFFFFF;

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -274,6 +274,7 @@ struct Theme
     int32_t  FocusPaddingHorizontal = 1;
     uint32_t TextColor              = 0xFF000000;
     uint32_t Light3D                = 0xFFFCFCFC;
+    uint32_t Shadow3D               = 0xFF808080;
 };
 
 // Windows 3.1 theme

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -276,6 +276,7 @@ struct Theme
     uint32_t Light3D                = 0xFFFCFCFC;
     uint32_t Shadow3D               = 0xFF808080;
     uint32_t Border                 = 0xFF000000;
+    uint32_t SelectionBackground    = 0xFF000080;
 };
 
 // Windows 3.1 theme

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -2336,7 +2336,7 @@ public:
 		(void)y;//UNUSED
 
 		if (button == Left) {
-			border_left = 7; border_right = 5; border_top = 7; border_bottom = 3;
+			border_left = 7; border_right = 7; border_top = 6; border_bottom = 6;
 			pressed = true;
 		}
 		return true;

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -270,6 +270,7 @@ struct Theme
     uint32_t FocusColor             = 0xFF000000;
     int32_t  FocusPadding           = 2;
     int32_t  FocusPaddingHorizontal = 1;
+    uint32_t TextColor              = 0xFF000000;
 };
 
 // Windows 3.1 theme
@@ -1655,7 +1656,7 @@ public:
 
 	/// Create a text label with given position, \p text, \p font and \p color.
 	/** If \p width is given, the resulting label is a word-wrapped multiline label */
-	template <typename STR> Label(Window *parent, int x, int y, const STR text, int width = 0, const Font *font = Font::getFont("default"), RGB color = Color::Text) :
+	template <typename STR> Label(Window *parent, int x, int y, const STR text, int width = 0, const Font *font = Font::getFont("default"), RGB color = CurrentTheme.TextColor) :
 		Window(parent, x, y, (width?width:1), 1), font(font), color(color), text(text), interpret(width != 0)
 	{ Label::resize(); tabbable = false; }
 

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -263,6 +263,7 @@ static inline unsigned int A(RGB val) { return ((val&Color::AlphaMask)>>Color::A
 struct Theme
     // TODO gather others colors
 {
+    uint32_t Background3D           = 0xFFC0C0C0;
     uint32_t ButtonBorder           = 0xFF000000;
     uint32_t ButtonFiller           = 0xFF808080;
     uint32_t ButtonBevel1           = 0xFFFFFFFF;

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -743,6 +743,7 @@ public:
 	/// Transient windows by default should disappear.
 	virtual bool mouseDownOutside(MouseButton button);
 
+    virtual bool mouseWheel(int wheel);
 	/// Key was pressed. Returns true if event was handled.
 	virtual bool keyDown(const Key &key);
 	/// Key was released. Returns true if event was handled.
@@ -882,6 +883,7 @@ public:
 	/// Mouse was double-clicked. Returns true if event was handled.
 	bool mouseDoubleClicked(int x, int y, MouseButton button) override;
 
+    bool mouseWheel(int wheel) override;
 	/// Key was pressed. Returns true if event was handled.
 	bool keyDown(const Key &key) override;
 

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -2336,7 +2336,7 @@ public:
 		(void)y;//UNUSED
 
 		if (button == Left) {
-			border_left = 7; border_right = 7; border_top = 6; border_bottom = 6;
+			border_left = 7; border_right = 5; border_top = 6; border_bottom = 4;
 			pressed = true;
 		}
 		return true;

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -250,10 +250,13 @@ struct ThemeLight : Theme
 {
     ThemeLight()
     {
+        Background   = 0xFFC0C7C8;
         ButtonFiller = 0xFFC0C7C8;
         ButtonBevel1 = 0xFFFFFFFF;
         ButtonBevel2 = 0xFF87888F;
         FocusColor   = 0xFF87888F;
+        TitleBar     = 0xFF0000A8;
+        TitleBarText = 0xFFFFFFFF;
     }
 };
 

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -277,6 +277,7 @@ struct Theme
     uint32_t Shadow3D               = 0xFF808080;
     uint32_t Border                 = 0xFF000000;
     uint32_t SelectionBackground    = 0xFF000080;
+    uint32_t SelectionForeground    = 0xFFFFFFFF;
 };
 
 // Windows 3.1 theme

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -279,6 +279,10 @@ struct Theme
     uint32_t SelectionBackground    = 0xFF000080;
     uint32_t SelectionForeground    = 0xFFFFFFFF;
     uint32_t EditableBackground     = 0xFFFFFFFF;
+    uint32_t TitleBar               = 0xFFA4C8F0;
+    uint32_t TitleBarText           = 0xFF000000;
+    uint32_t TitleBarInactive       = 0xFFFFFFFF;
+    uint32_t TitleBarInactiveText   = 0xFF000000;
 };
 
 // Windows 3.1 theme

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -205,45 +205,6 @@ const RGB YellowMask = RedMask|GreenMask;
 /// 50% grey
 const RGB Grey50 = 0xff808080;
 
-/// Background color for 3D effects. May be customized.
-extern RGB Background3D;
-
-/// Light highlight color for 3D effects. May be customized.
-extern RGB Light3D;
-
-/// Dark highlight color (shadow) for 3D effects. May be customized.
-extern RGB Shadow3D;
-
-/// Generic border color for highlights or similar. May be customized.
-extern RGB Border;
-
-/// Foreground color for regular content (mainly text). May be customized.
-extern RGB Text;
-
-/// Background color for inactive areas. May be customized.
-extern RGB Background;
-
-/// Background color for selected areas. May be customized.
-extern RGB SelectionBackground;
-
-/// Foreground color for selected areas. May be customized.
-extern RGB SelectionForeground;
-
-/// Background color for inputs / application area. May be customized.
-extern RGB EditableBackground;
-
-/// Title bar color for windows. May be customized.
-extern RGB Titlebar;
-
-/// Title bar text color for windows. May be customized.
-extern RGB TitlebarText;
-
-/// Title bar color for windows. May be customized.
-extern RGB TitlebarInactive;
-
-/// Title bar text color for windows. May be customized.
-extern RGB TitlebarInactiveText;
-
 /// Convert separate r, g, b and a values (each 0-255) to an RGB value.
 static inline RGB rgba(unsigned int r, unsigned int g, unsigned int b, unsigned int a=0) {
 	return (((r&255)<<RedShift)|((g&255)<<GreenShift)|((b&255)<<BlueShift)|((a&255)<<AlphaShift));

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -177,7 +177,6 @@ void AddMessages() {
     MSG_Add("NETWORK_LIST","Network interface list");
     MSG_Add("PRINTER_LIST","Printer device list");
     MSG_Add("INTRODUCTION","Introduction");
-    MSG_Add("CONFIGURE_GROUP", "Choose a settings group to configure:");
     MSG_Add("SHOW_ADVOPT", "Show advanced options");
     MSG_Add("USE_PRIMARYCONFIG", "Use primary config file");
     MSG_Add("USE_PORTABLECONFIG", "Use portable config file");

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -156,7 +156,6 @@ void AddMessages() {
     MSG_Add("CONTENT","Content:");
     MSG_Add("EDIT_FOR","Edit %s");
     MSG_Add("HELP_FOR","Help for %s");
-    MSG_Add("HELP_INFO", "Click the \"Help\" button below to see detailed help information.");
     MSG_Add("SELECT_VALUE", "Select property value");
     MSG_Add("CONFIGURATION","Configuration");
     MSG_Add("SETTINGS","Settings");

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -158,7 +158,6 @@ void AddMessages() {
     MSG_Add("HELP_FOR","Help for %s");
     MSG_Add("HELP_INFO", "Click the \"Help\" button below to see detailed help information.");
     MSG_Add("SELECT_VALUE", "Select property value");
-    MSG_Add("CONFIGURATION_FOR","Configuration for %s");
     MSG_Add("CONFIGURATION","Configuration");
     MSG_Add("SETTINGS","Settings");
     MSG_Add("LOGGING_OUTPUT","DOSBox-X logging output");


### PR DESCRIPTION
## Does this PR introduce new feature(s)?

Trying to apply pixel-perfect Windows 3.11 look'n'feel to CFGTOOL...

Buttons are up as well as their focus style.

Ideally, 
 - extract/group/fix theme constants
 - sort messy help pages alphabetically
 - implement mouse wheel
 - simplify some aspects

Before:

![image](https://github.com/joncampbell123/dosbox-x/assets/1537591/32468c83-eb36-4ebb-968b-822b0c3b0306)

After:

![image](https://github.com/joncampbell123/dosbox-x/assets/1537591/0f273de2-2918-42f5-9d3d-4597ced54a88)
