### PR TITLE
More Windows 3.1 styling for CFGTOOL

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,7 +21,14 @@ NEXT
   - Updated SDL2 library to 2.30.4 (maron2000)
   - Fixed TTF mode didn't change to graphic mode when machine = Hercules
     (maron2000)
-  - CFGTOOL: more Windows 3.1 styling, general UX/UI improvements (aybe).
+  - Configuration tool: (aybe)
+    - more Windows 3.1 styling: buttons, colors, focus, layout
+    - enhance main window layout, it is now visible in its entirety
+    - fix layout issues, off by one in rectangle drawing functions
+    - fix 'list iterators incompatible' when pressing the Tab key
+    - properties/help: sorted alphabetically, mouse wheel scrollable
+    - remove few rendundant labels, adjust names of some others
+    - retain 'show advanced options' state throughout session
 
 2024.07.01
   - Correct Hercules InColor memory emulation. Read and write planar

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -3264,8 +3264,12 @@ public:
         advopt->setChecked(section->Get_bool("show advanced options") || advOptUser);
 
         strcpy(tmp1, (MSG_Get("SAVE")+std::string("...")).c_str());
-        (saveButton = new GUI::Button(this, 276, closerow_y, tmp1, 130, gridbtnheight))->addActionHandler(this);
-        (closeButton = new GUI::Button(this, 408, closerow_y, MSG_Get("CLOSE"), 130, gridbtnheight))->addActionHandler(this);
+
+        const auto xSave = gridbtnx + (gridbtnwidth + margin) * 2;
+        const auto xExit = gridbtnx + (gridbtnwidth + margin) * 3;
+
+        (saveButton  = new GUI::Button(this, xSave, closerow_y, tmp1, 130, gridbtnheight))->addActionHandler(this);
+        (closeButton = new GUI::Button(this, xExit, closerow_y, MSG_Get("CLOSE"), 130, gridbtnheight))->addActionHandler(this);
 
         resize(gridbtnx + (xSpace * btnperrow) + 12 + border_left + border_right,
                closerow_y + closeButton->getHeight() + 8 + border_top + border_bottom);

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1662,7 +1662,7 @@ public:
 			}
 		}
 
-        int height=title=="Config"?100:210;
+        int height=title=="Config"?100:81;
         scroll_h += height + 2; /* border */
 
         wiw = new GUI::WindowInWindow(this, 5, 5, width-border_left-border_right-10, scroll_h);

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -3268,10 +3268,10 @@ public:
         const auto xSave = gridbtnx + (gridbtnwidth + margin) * 2;
         const auto xExit = gridbtnx + (gridbtnwidth + margin) * 3;
 
-        (saveButton  = new GUI::Button(this, xSave, closerow_y, tmp1, 130, gridbtnheight))->addActionHandler(this);
-        (closeButton = new GUI::Button(this, xExit, closerow_y, MSG_Get("CLOSE"), 130, gridbtnheight))->addActionHandler(this);
+        (saveButton  = new GUI::Button(this, xSave, closerow_y, tmp1, gridbtnwidth, gridbtnheight))->addActionHandler(this);
+        (closeButton = new GUI::Button(this, xExit, closerow_y, MSG_Get("CLOSE"), gridbtnwidth, gridbtnheight))->addActionHandler(this);
 
-        resize(gridbtnx + (xSpace * btnperrow) + 12 + border_left + border_right,
+        resize(gridbtnx + (xSpace * btnperrow) + gridbtnx + border_left + border_right,
                closerow_y + closeButton->getHeight() + 8 + border_top + border_bottom);
 
         bar->resize(getWidth(),bar->getHeight());

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -3245,7 +3245,6 @@ public:
         
         for(const auto & sec : sections)
         {
-            if (i != 0 && (i%15) == 0) bar->addItem(1, "|");
             if (i != 0 && (i%16) == 0) bar->addItem(1, "|");
             std::string sectionTitle = CapName(std::string(sec->GetName()));
             const auto sz = gridfunc(i);

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -3170,7 +3170,7 @@ public:
         bar->addActionHandler(this);
 
         int gridbtnwidth = 130;
-        int gridbtnheight = 26;
+        int gridbtnheight = GUI::CurrentTheme.ButtonHeight;
         int gridbtnx = 12;
         int gridbtny = 25;
         int btnperrow = 4;

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -3246,13 +3246,12 @@ public:
         for(const auto & sec : sections)
         {
             if (i != 0 && (i%15) == 0) bar->addItem(1, "|");
-            std::string name = sec->GetName();
-            std::string title = CapName(name);
-            name[0] = std::toupper(name[0]);
+            if (i != 0 && (i%16) == 0) bar->addItem(1, "|");
+            std::string sectionTitle = CapName(std::string(sec->GetName()));
             const auto sz = gridfunc(i);
-            GUI::Button *b = new GUI::Button(this, sz.first, sz.second, title, gridbtnwidth, gridbtnheight);
+            GUI::Button *b = new GUI::Button(this, sz.first, sz.second, sectionTitle, gridbtnwidth, gridbtnheight);
             b->addActionHandler(this);
-            bar->addItem(1, title);
+            bar->addItem(1, sectionTitle);
             i++;
         }
 

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -141,6 +141,10 @@ void                        macosx_reload_touchbar(void);
 
 std::list<std::string> proplist = {};
 GUI::Checkbox *advopt, *saveall, *imgfd360, *imgfd400, *imgfd720, *imgfd1200, *imgfd1440, *imgfd2880, *imghd250, *imghd520, *imghd1gig, *imghd2gig, *imghd4gig, *imghd8gig;
+
+// user pick of 'show advanced options' for the session
+bool advOptUser = false;
+
 std::string GetDOSBoxXPath(bool withexe);
 static std::map< std::vector<GUI::Char>, GUI::ToplevelWindow* > cfg_windows_active;
 void getlogtext(std::string &str), getcodetext(std::string &text), ApplySetting(std::string pvar, std::string inputline, bool quiet), GUI_Run(bool pressed);
@@ -3255,7 +3259,7 @@ public:
 
         advopt = new GUI::Checkbox(this, gridbtnx, closerow_y, MSG_Get("SHOW_ADVOPT"));
         Section_prop * section=static_cast<Section_prop *>(control->GetSection("dosbox"));
-        advopt->setChecked(section->Get_bool("show advanced options"));
+        advopt->setChecked(section->Get_bool("show advanced options") || advOptUser);
 
         strcpy(tmp1, (MSG_Get("SAVE")+std::string("...")).c_str());
         (saveButton = new GUI::Button(this, 276, closerow_y, tmp1, 130, gridbtnheight))->addActionHandler(this);
@@ -3287,6 +3291,7 @@ public:
     }
 
     void actionExecuted(GUI::ActionEventSource *b, const GUI::String &arg) override {
+        advOptUser = advopt->isChecked();
         GUI::String sname = RestoreName(arg);
         sname.at(0) = (unsigned int)std::tolower((int)sname.at(0));
         Section *sec;

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -3176,8 +3176,10 @@ public:
         int btnperrow = 4;
         int i = 0;
 
-        const auto xSpace = gridbtnwidth + 2;
-        const auto ySpace = gridbtnheight + 2;
+        constexpr auto margin = 3;
+        
+        const auto xSpace = gridbtnwidth + margin;
+        const auto ySpace = gridbtnheight + margin;
         
         std::function< std::pair<int,int>(const int) > gridfunc = [&/*access to locals here*/](const int i){
             return std::pair<int,int>(gridbtnx+(i%btnperrow)*xSpace, gridbtny+(i/btnperrow)*ySpace);

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -2393,7 +2393,7 @@ void WindowInWindow::paintScrollBar3DOutset(Drawable &dscroll, int x, int y, int
 void WindowInWindow::paintScrollBarThumb(Drawable &dscroll, vscrollbarlayout &vsl) const {
     // black border
     dscroll.setColor(vsl.disabled ? CurrentTheme.Shadow3D : Color::Black);
-    dscroll.drawRect(vsl.xleft,vsl.ytop,vsl.thumbwidth-1,vsl.thumbheight-1);
+    dscroll.drawRect(vsl.xleft,vsl.ytop,vsl.thumbwidth,vsl.thumbheight);
 
     // 3D outset style, 1 pixel inward each side, inside the black rectangle we just drew
     paintScrollBar3DOutset(dscroll, vsl.xleft+1, vsl.ytop+1, vsl.thumbwidth-2, vsl.thumbheight-2);
@@ -2402,7 +2402,7 @@ void WindowInWindow::paintScrollBarThumb(Drawable &dscroll, vscrollbarlayout &vs
 void WindowInWindow::paintScrollBarBackground(Drawable &dscroll,const vscrollbarlayout &vsl) const {
     /* scroll bar border, background */
     dscroll.setColor(vsl.disabled ? CurrentTheme.Shadow3D : Color::Black);
-    dscroll.drawRect(vsl.scrollthumbRegion.x,  vsl.scrollthumbRegion.y,  vsl.scrollthumbRegion.w-1,vsl.scrollthumbRegion.h-1);
+    dscroll.drawRect(vsl.scrollthumbRegion.x,  vsl.scrollthumbRegion.y,  vsl.scrollthumbRegion.w,vsl.scrollthumbRegion.h);
 
     dscroll.setColor(CurrentTheme.Background);
     dscroll.fillRect(vsl.scrollthumbRegion.x+1,vsl.scrollthumbRegion.y+1,vsl.scrollthumbRegion.w-2,vsl.scrollthumbRegion.h-2);
@@ -2524,7 +2524,7 @@ void WindowInWindow::paintAll(Drawable &d) const {
 
                 // black border
                 dscroll.setColor(vsl.disabled ? CurrentTheme.Shadow3D : Color::Black);
-                dscroll.drawRect(x,y,w-1,h-1);
+                dscroll.drawRect(x,y,w,h);
 
                 // 3D outset style, 1 pixel inward each side, inside the black rectangle we just drew
                 if (vscroll_uparrowhold && vscroll_uparrowdown)
@@ -2546,7 +2546,7 @@ void WindowInWindow::paintAll(Drawable &d) const {
 
                 // black border
                 dscroll.setColor(vsl.disabled ? CurrentTheme.Shadow3D : Color::Black);
-                dscroll.drawRect(x,y,w-1,h-1);
+                dscroll.drawRect(x,y,w,h);
 
                 // 3D outset style, 1 pixel inward each side, inside the black rectangle we just drew
                 if (vscroll_downarrowhold && vscroll_downarrowdown)

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -358,26 +358,26 @@ void Drawable::drawCircle(int d) {
 
 void Drawable::drawRect(int w, int h)
 {
-	gotoXY(x-lineWidth/2,y);
-	drawLine(x+w+lineWidth-1,y);
-	gotoXY(x-(lineWidth-1)/2,y);
-	drawLine(x,y+h);
-	gotoXY(x+(lineWidth-1)/2,y);
-	drawLine(x-w-lineWidth+1,y);
-	gotoXY(x+lineWidth/2,y);
-	drawLine(x,y-h);
+    gotoXY(x - lineWidth / 2, y);             // tl
+    drawLine(x + (w - 1) + lineWidth - 1, y); // tr
+    gotoXY(x - (lineWidth - 1) / 2, y);       // tl
+    drawLine(x, y + (h - 1));                 // bl
+    gotoXY(x + (lineWidth - 1) / 2, y);       // tl
+    drawLine(x - (w - 1) - lineWidth + 1, y); // tr
+    gotoXY(x + lineWidth / 2, y);             // tl
+    drawLine(x, y - (h - 1));                 // bl
 }
 
 void Drawable::drawDotRect(int w, int h)
 {
-	gotoXY(x-lineWidth/2,y);
-	drawDotLine(x+w+lineWidth-1,y);
-	gotoXY(x-(lineWidth-1)/2,y);
-	drawDotLine(x,y+h);
-	gotoXY(x+(lineWidth-1)/2,y);
-	drawDotLine(x-w-lineWidth+1,y);
-	gotoXY(x+lineWidth/2,y);
-	drawDotLine(x,y-h);
+    gotoXY(x - lineWidth / 2, y);                // tl
+    drawDotLine(x + (w - 1) + lineWidth - 1, y); // tr
+    gotoXY(x - (lineWidth - 1) / 2, y);          // tl
+    drawDotLine(x, y + (h - 1));                 // bl
+    gotoXY(x + (lineWidth - 1) / 2, y);          // tl
+    drawDotLine(x - (w - 1) - lineWidth + 1, y); // tr
+    gotoXY(x + lineWidth / 2, y);                // tl
+    drawDotLine(x, y - (h - 1));                 // bl
 }
 
 void Drawable::fill()

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -761,13 +761,15 @@ bool Window::keyDown(const Key &key)
 				if ((*i) != children.back()) children.back()->onTabbing(ONTABBING_REVTABFROMTHIS);
 				(*i)->onTabbing(ONTABBING_REVTABTOTHIS);
 				if ((*i)->raise())
-					break;
+				{
+				    toplevel = true;
+				    break;
+				}
 			}
 
 			++i;
 		}
-		if (tab_quit) return false;
-		return (i != e) || toplevel/*prevent TAB escape to another window*/;
+		return handleTab(tab_quit, i, e);
 	} else {
 		std::list<Window *>::iterator i = children.begin(), e = children.end();
 		--e;
@@ -781,16 +783,15 @@ bool Window::keyDown(const Key &key)
 				if ((*i) != children.back()) children.back()->onTabbing(ONTABBING_TABFROMTHIS);
 				(*i)->onTabbing(ONTABBING_TABTOTHIS);
 				if ((*i)->raise())
-					break;
+				{
+				    toplevel = true;
+				    break;
+				}
 			}
 
 			++i;
 		}
-		if (tab_quit) return false;
-	    // BUG/TODO swapped operands below to fix 'list iterators incompatible'
-	    // occurs in VS debug build when pressing TAB after opening configuration tool
-	    // currently this works but that just sweeps the problem under the rug
-		return toplevel /*prevent TAB escape to another window*/ || (i != e);
+		return handleTab(tab_quit, i, e);
 	}
 }
 
@@ -891,8 +892,7 @@ bool WindowInWindow::keyDown(const Key &key)
 
 			++i;
 		}
-		if (tab_quit) return false;
-		return (i != e) || toplevel/*prevent TAB escape to another window*/;
+		return handleTab(tab_quit, i, e);
 	} else {
 		std::list<Window *>::iterator i = children.begin(), e = children.end();
 		--e;
@@ -907,13 +907,15 @@ bool WindowInWindow::keyDown(const Key &key)
 				(*i)->onTabbing(ONTABBING_TABTOTHIS);
 				if (!tab_quit) scrollToWindow(*i);
 				if ((*i)->raise())
-					break;
+				{
+				    toplevel = true;
+				    break;
+				}
 			}
 
 			++i;
 		}
-		if (tab_quit) return false;
-		return (i != e) || toplevel/*prevent TAB escape to another window*/;
+		return handleTab(tab_quit, i, e);
 	}
 }
 

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -1041,7 +1041,7 @@ bool Window::mouseWheel(int x, int y, int wheel)
                     const auto xMax = xMin + win2->width - 1;
                     const auto yMax = yMin + win2->height - 1;
 
-                    if(x >= xMin && x <= xMax && y >= yMin && y < yMax)
+                    if(x >= xMin && x <= xMax && y >= yMin && y <= yMax)
                     {
                         return win2->mouseWheel(x, y, wheel);
                     }

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -2905,7 +2905,7 @@ bool WindowInWindow::mouseDoubleClicked(int x, int y, MouseButton button) {
 
 bool WindowInWindow::mouseWheel(int x, int y, int wheel)
 {
-    scroll_pos_y = imin(imax(scroll_pos_y - wheel * 15, 0), scroll_pos_h);
+    scroll_pos_y = imin(imax(scroll_pos_y - wheel * 30, 0), scroll_pos_h);
     return Window::mouseWheel(x, y, wheel);
 }
 

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -1030,7 +1030,7 @@ bool Window::mouseWheel(int x, int y, int wheel)
 {
     for(const auto& win1 : children)
     {
-        if(win1->toplevel && win1->hasFocus())
+        if(win1->hasFocus())
         {
             for(const auto& win2 : win1->children)
             {

--- a/src/libs/gui_tk/gui_tk.cpp
+++ b/src/libs/gui_tk/gui_tk.cpp
@@ -2358,11 +2358,13 @@ bool ScreenSDL::event(SDL_Event &event) {
 		lastdown = 0;
 		return rc;
 #if C_SDL2	    
+#if WIN32
     case SDL_MOUSEWHEEL:
     {
         const auto wheel = event.wheel;
         return mouseWheel(wheel.mouseX / scale, wheel.mouseY / scale, wheel.y);
     }
+#endif
 #endif
     }
 

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -229,6 +229,7 @@ struct Theme
     uint32_t ButtonFiller           = 0xFF808080;
     uint32_t ButtonBevel1           = 0xFFFFFFFF;
     uint32_t ButtonBevel2           = 0xFFC0C0C0;
+    uint32_t ButtonHeight           = 23;
     uint32_t FocusColor             = 0xFF000000;
     int32_t  FocusPadding           = 2;
     int32_t  FocusPaddingHorizontal = 1;

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -229,8 +229,8 @@ struct Theme
     uint32_t ButtonFiller           = 0xFF808080;
     uint32_t ButtonBevel1           = 0xFFFFFFFF;
     uint32_t ButtonBevel2           = 0xFFC0C0C0;
-    uint32_t ButtonHeight           = 23;
-    uint32_t ButtonContentHeight    = 15;
+    uint32_t ButtonHeight           = 23; // must be odd
+    uint32_t ButtonContentHeight    = 15; // must be odd
     uint32_t FocusColor             = 0xFF000000;
     int32_t  FocusPaddingHorizontal = 2;
     uint32_t TextColor              = 0xFF000000;
@@ -1672,7 +1672,7 @@ public:
 
 	    // override non-interpreted so as focus adapts itself better to text
 	    // one depends on the other, that's fundamentally wrong but well ...
-	    // that said, it's pretty darn close to how it looks in Windows 3.11
+	    // this is good but not perfect -> we need accurate width (per char)
         if (interpret == false)
         {
             auto tw = font->getWidth(this->text);

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -232,7 +232,6 @@ struct Theme
     uint32_t ButtonHeight           = 23;
     uint32_t ButtonContentHeight    = 15;
     uint32_t FocusColor             = 0xFF000000;
-    int32_t  FocusPadding           = 2;
     int32_t  FocusPaddingHorizontal = 1;
     uint32_t TextColor              = 0xFF000000;
     uint32_t Light3D                = 0xFFFCFCFC;
@@ -1677,7 +1676,7 @@ public:
         if (interpret == false)
         {
             const auto tw = font->getWidth(this->text);
-            Window::resize(tw + CurrentTheme.FocusPadding + CurrentTheme.FocusPaddingHorizontal, static_cast<int>(CurrentTheme.ButtonContentHeight) + CurrentTheme.FocusPadding);
+            Window::resize(tw + CurrentTheme.FocusPaddingHorizontal, static_cast<int>(CurrentTheme.ButtonContentHeight));
         }
     }
 
@@ -1689,7 +1688,7 @@ public:
     {
         d.setColor(color);
 
-        d.drawText(CurrentTheme.FocusPadding, CurrentTheme.FocusPadding + font->getAscent(), text, interpret, 0);
+        d.drawText(CurrentTheme.FocusPaddingHorizontal, font->getAscent(), text, interpret, 0);
 
         if(hasFocus())
         {

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -1692,7 +1692,7 @@ public:
     {
         d.setColor(color);
 
-        d.drawText(CurrentTheme.FocusPaddingHorizontal, font->getAscent(), text, interpret, 0);
+        d.drawText(CurrentTheme.FocusPaddingHorizontal + (width & 1), font->getAscent(), text, interpret, 0);
 
         if(hasFocus())
         {

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -232,7 +232,7 @@ struct Theme
     uint32_t ButtonHeight           = 23;
     uint32_t ButtonContentHeight    = 15;
     uint32_t FocusColor             = 0xFF000000;
-    int32_t  FocusPaddingHorizontal = 1;
+    int32_t  FocusPaddingHorizontal = 2;
     uint32_t TextColor              = 0xFF000000;
     uint32_t Light3D                = 0xFFFCFCFC;
     uint32_t Shadow3D               = 0xFF808080;
@@ -1676,7 +1676,7 @@ public:
         if (interpret == false)
         {
             const auto tw = font->getWidth(this->text);
-            Window::resize(tw + CurrentTheme.FocusPaddingHorizontal, static_cast<int>(CurrentTheme.ButtonContentHeight));
+            Window::resize(tw + CurrentTheme.FocusPaddingHorizontal * 2, static_cast<int>(CurrentTheme.ButtonContentHeight));
         }
     }
 

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -230,6 +230,7 @@ struct Theme
     uint32_t ButtonBevel1           = 0xFFFFFFFF;
     uint32_t ButtonBevel2           = 0xFFC0C0C0;
     uint32_t ButtonHeight           = 23;
+    uint32_t ButtonContentHeight    = 15;
     uint32_t FocusColor             = 0xFF000000;
     int32_t  FocusPadding           = 2;
     int32_t  FocusPaddingHorizontal = 1;
@@ -1676,8 +1677,7 @@ public:
         if (interpret == false)
         {
             const auto tw = font->getWidth(this->text);
-            const auto th = font->getHeight();
-            Window::resize(tw + CurrentTheme.FocusPadding + CurrentTheme.FocusPaddingHorizontal, th + CurrentTheme.FocusPadding);
+            Window::resize(tw + CurrentTheme.FocusPadding + CurrentTheme.FocusPaddingHorizontal, static_cast<int>(CurrentTheme.ButtonContentHeight) + CurrentTheme.FocusPadding);
         }
     }
 

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -1675,8 +1675,12 @@ public:
 	    // that said, it's pretty darn close to how it looks in Windows 3.11
         if (interpret == false)
         {
-            const auto tw = font->getWidth(this->text);
-            Window::resize(tw + CurrentTheme.FocusPaddingHorizontal * 2, static_cast<int>(CurrentTheme.ButtonContentHeight));
+            auto tw = font->getWidth(this->text);
+
+            tw = tw + CurrentTheme.FocusPaddingHorizontal * 2;
+            tw = tw & 1 ? tw : tw + 1;
+
+            Window::resize(tw, static_cast<int>(CurrentTheme.ButtonContentHeight));
         }
     }
 

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -2368,7 +2368,7 @@ public:
 		(void)y;//UNUSED
 
 		if (button == Left) {
-			border_left = 7; border_top = 6; border_right = 5; border_bottom = 4;
+			border_left = 7; border_top = 5; border_right = 5; border_bottom = 3;
 			pressed = true;
 		}
 		return true;
@@ -2381,7 +2381,7 @@ public:
 		(void)y;//UNUSED
 
 		if (button == Left) {
-			border_left = 6; border_top = 5; border_right = 6; border_bottom = 5;
+			border_left = 6; border_top = 4; border_right = 6; border_bottom = 4;
 			pressed = false;
 		}
 		return true;
@@ -2859,7 +2859,7 @@ template <typename STR> ToplevelWindow::ToplevelWindow(Screen *parent, int x, in
 }
 
 template <typename STR> Button::Button(Window *parent, int x, int y, const STR text, int w, int h) :
-	BorderedWindow(parent,x,y,w,h,6,5,6,5), ActionEventSource(text), pressed(0)
+	BorderedWindow(parent,x,y,w,h,6,4,6,4), ActionEventSource(text), pressed(0)
 {
 
 	Label *l = new Label(this,0,0,text);

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -749,6 +749,12 @@ public:
 	/// Key was released. Returns true if event was handled.
 	virtual bool keyUp(const Key &key);
 
+    template <typename Iterator>
+    bool handleTab(const bool tab_quit, const Iterator& i, const Iterator& e) const
+    {
+        return tab_quit == false && (toplevel /*prevent TAB escape to another window*/ || i != e);
+    }
+
 	/// Put this window on top of all it's siblings. Preserves relative order.
 	/** Returns true if the window accepts the raise request. */
 	virtual bool raise() {

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -2354,9 +2354,6 @@ protected:
 	bool pressed;
 
 public:
-	/// Create a button with given position and size
-	Button(Window *parent, int x, int y, int w, int h) : BorderedWindow(parent,x,y,w,h,6,5,6,5), ActionEventSource("GUI::Button"), pressed(0) {}
-
 	/// Create a text button.
 	/** If a size is specified, text is centered. Otherwise, button size is adjusted for the text. */
 	template <typename T> Button(Window *parent, int x, int y, const T text, int w = -1, int h = -1);

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -2368,7 +2368,7 @@ public:
 		(void)y;//UNUSED
 
 		if (button == Left) {
-			border_left = 7; border_right = 5; border_top = 6; border_bottom = 4;
+			border_left = 7; border_top = 6; border_right = 5; border_bottom = 4;
 			pressed = true;
 		}
 		return true;
@@ -2381,7 +2381,7 @@ public:
 		(void)y;//UNUSED
 
 		if (button == Left) {
-			border_left = 6; border_right = 6; border_top = 5; border_bottom = 5;
+			border_left = 6; border_top = 5; border_right = 6; border_bottom = 5;
 			pressed = false;
 		}
 		return true;

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -744,7 +744,7 @@ public:
 	/// Transient windows by default should disappear.
 	virtual bool mouseDownOutside(MouseButton button);
 
-    virtual bool mouseWheel(int wheel);
+    virtual bool mouseWheel(int x, int y, int wheel);
 	/// Key was pressed. Returns true if event was handled.
 	virtual bool keyDown(const Key &key);
 	/// Key was released. Returns true if event was handled.
@@ -890,7 +890,7 @@ public:
 	/// Mouse was double-clicked. Returns true if event was handled.
 	bool mouseDoubleClicked(int x, int y, MouseButton button) override;
 
-    bool mouseWheel(int wheel) override;
+    bool mouseWheel(int x, int y, int wheel) override;
 	/// Key was pressed. Returns true if event was handled.
 	bool keyDown(const Key &key) override;
 

--- a/src/libs/gui_tk/gui_tk.h
+++ b/src/libs/gui_tk/gui_tk.h
@@ -1693,7 +1693,7 @@ public:
         if(hasFocus())
         {
             d.setColor(CurrentTheme.FocusColor);
-            d.drawDotRect(0, 0, width - 1, height - 1);
+            d.drawDotRect(0, 0, width, height);
         }
     }
 

--- a/src/output/output_tools.cpp
+++ b/src/output/output_tools.cpp
@@ -275,6 +275,11 @@ void change_output(int output) {
     GFX_LogSDLState();
 
     UpdateWindowDimensions();
+
+#ifdef C_SDL2
+    // UX: always center window after changing output
+    SDL_SetWindowPosition(sdl.window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+#endif
 }
 
 void OutputSettingMenuUpdate(void) {

--- a/src/output/output_ttf.cpp
+++ b/src/output/output_ttf.cpp
@@ -1455,7 +1455,6 @@ void ttf_switch_on(bool ss=true) {
 #ifdef C_SDL2
         transparency = 0;
         SetWindowTransparency(static_cast<Section_prop *>(control->GetSection("sdl"))->Get_int("transparency"));
-        SDL_SetWindowPosition(sdl.window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 #endif
         if (!IS_PC98_ARCH && vga.draw.address_add != ttf.cols * 2) checkcol = ss?2:1;
     }


### PR DESCRIPTION
## What issue(s) does this PR address?

More pixel perfect, less off by one, fixed mouse wheel, no more 'list iterators incompatible', etc.

See the commits for the full story.

## Additional information

Before:

![image](https://github.com/joncampbell123/dosbox-x/assets/1537591/91c51bca-ffcf-4462-94ca-875dfb419276)

Now:

![image](https://github.com/user-attachments/assets/ee6ce0a7-b3a0-4004-af37-5059f3f3e7d1)
