### PR TITLE
Fix some diacritics cannot be typed

### DIFF
--- a/include/bios.h
+++ b/include/bios.h
@@ -164,7 +164,7 @@ Bitu ROMBIOS_GetMemory(Bitu bytes,const char *who=NULL,Bitu alignment=1,Bitu mus
 extern RegionAllocTracking rombios_alloc;
 
 /* maximum of scancodes handled by keyboard bios routines */
-#define MAX_SCAN_CODE 0x93
+#define MAX_SCAN_CODE 0x7F
 
 /* The Section handling Bios Disk Access */
 //#define BIOS_MAX_DISK 10


### PR DESCRIPTION
This PR fixes an issue that particular dead keys were not working to input characters with diacritics.

Fixes #5127.

Tested on VS x64 SDL2 build.
![image](https://github.com/user-attachments/assets/e80bbe0d-d6bf-42a1-a818-d0d024f5450b)
