### PR TITLE
Correct relative/absolute track offset in subchannel data for CD-ROM images

### DIFF
--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -577,7 +577,7 @@ bool CDROM_Interface_Image::GetAudioSub(unsigned char& attr, unsigned char& trac
 	track = (unsigned char)cur_track;
 	attr = tracks[track - 1].attr;
 	index = 1;
-	FRAMES_TO_MSF(player.currFrame + 150, &absPos.min, &absPos.sec, &absPos.fr);
+	FRAMES_TO_MSF(player.currFrame, &absPos.min, &absPos.sec, &absPos.fr);
 	FRAMES_TO_MSF(player.currFrame - tracks[track - 1].start, &relPos.min, &relPos.sec, &relPos.fr);
 	if(IS_PC98_ARCH && player.playbackRemaining == 0 && !strcmp(RunningProgram, "ITP")) {
 		// POLICENAUTS
@@ -593,7 +593,7 @@ bool CDROM_Interface_Image::GetAudioSub(unsigned char& attr, unsigned char& trac
 
 	LOG_MSG("%s CDROM: GetAudioSub absolute offset (%d), MSF=%d:%d:%d",
       get_time(),
-	  player.currFrame + 150,
+	  player.currFrame,
 	  absPos.min,
 	  absPos.sec,
 	  absPos.fr);

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -578,7 +578,7 @@ bool CDROM_Interface_Image::GetAudioSub(unsigned char& attr, unsigned char& trac
 	attr = tracks[track - 1].attr;
 	index = 1;
 	FRAMES_TO_MSF(player.currFrame + 150, &absPos.min, &absPos.sec, &absPos.fr);
-	FRAMES_TO_MSF(player.currFrame - tracks[track - 1].start + 150, &relPos.min, &relPos.sec, &relPos.fr);
+	FRAMES_TO_MSF(player.currFrame - tracks[track - 1].start, &relPos.min, &relPos.sec, &relPos.fr);
 	if(IS_PC98_ARCH && player.playbackRemaining == 0 && !strcmp(RunningProgram, "ITP")) {
 		// POLICENAUTS
 		// It freeze at the end of the Konami logo or opening.
@@ -599,7 +599,7 @@ bool CDROM_Interface_Image::GetAudioSub(unsigned char& attr, unsigned char& trac
 	  absPos.fr);
 	LOG_MSG("%s CDROM: GetAudioSub relative offset (%d), MSF=%d:%d:%d",
       get_time(),
-	  player.currFrame - tracks[track - 1].start + 150,
+	  player.currFrame - tracks[track - 1].start,
 	  relPos.min,
 	  relPos.sec,
 	  relPos.fr);


### PR DESCRIPTION
(see https://sourceforge.net/p/dosbox/code-0/4189)

The relative position returned by GetAudioSub is off by 150 sectors/2 seconds. 150 does not need to be added to this since the MMC specs for the READ SUB-CHANNEL command specify that the locations are relative to the *logical beginnings* of the media/track (i.e. without the pregap). The linked DOSBox-SVN commit only adjusts the relative track offset, though I am fairly sure they both need fixing.

## What issue(s) does this PR address?

Fixes #5136. Possibly fixes the Policenauts bug mentioned in the same part of the code, needs testing.

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

No.

## Additional information

None.
