### PR TITLE
Changed Linux build to use 16-bit wide chars, to fix issue #5132

### DIFF
--- a/build
+++ b/build
@@ -9,6 +9,11 @@ if [ "$1" == "32" ]; then
     opt="--host=i686-pc-linux-gnu --target=i686-pc-linux-gnu"
 fi
 
+# Makes Linux use 16-bit wide chars instead of 32-bit
+CFLAGS="${CFLAGS} -fshort-wchar"
+CXXFLAGS="${CXXFLAGS} -fshort-wchar"
+export CCFLAGS CXXFLAGS
+
 # Jonathan C dev hack: refer to LNKDOS16 in /usr/src/doslib
 doslib=""
 if [ -d /usr/src/doslib ]; then doslib="/usr/src/doslib"; fi

--- a/build-debug
+++ b/build-debug
@@ -9,6 +9,11 @@ if [ "$1" == "32" ]; then
     opt="--host=i686-pc-linux-gnu --target=i686-pc-linux-gnu"
 fi
 
+# Makes Linux use 16-bit wide chars instead of 32-bit
+CFLAGS="${CFLAGS} -fshort-wchar"
+CXXFLAGS="${CXXFLAGS} -fshort-wchar"
+export CCFLAGS CXXFLAGS
+
 # Jonathan C dev hack: refer to LNKDOS16 in /usr/src/doslib
 doslib=
 if [ -d /usr/src/doslib ]; then doslib="/usr/src/doslib"; fi

--- a/build-debug-g3
+++ b/build-debug-g3
@@ -8,6 +8,11 @@ if [ "${1}" == "32" ]; then
     shift
 fi
 
+# Makes Linux use 16-bit wide chars instead of 32-bit
+CFLAGS="${CFLAGS} -fshort-wchar"
+CXXFLAGS="${CXXFLAGS} -fshort-wchar"
+export CCFLAGS CXXFLAGS
+
 # I'm sick and tired of all the churn the three versions of autoconf
 # are causing in this repo. Stop committing the configure scripts
 # and just autoregen.

--- a/build-debug-g3-sdl2
+++ b/build-debug-g3-sdl2
@@ -8,6 +8,11 @@ if [ "${1}" == "32" ]; then
     shift
 fi
 
+# Makes Linux use 16-bit wide chars instead of 32-bit
+CFLAGS="${CFLAGS} -fshort-wchar"
+CXXFLAGS="${CXXFLAGS} -fshort-wchar"
+export CCFLAGS CXXFLAGS
+
 # I'm sick and tired of all the churn the three versions of autoconf
 # are causing in this repo. Stop committing the configure scripts
 # and just autoregen.

--- a/build-debug-gcc-prof
+++ b/build-debug-gcc-prof
@@ -9,6 +9,11 @@ if [ "$1" == "32" ]; then
     opt="--host=i686-pc-linux-gnu --target=i686-pc-linux-gnu"
 fi
 
+# Makes Linux use 16-bit wide chars instead of 32-bit
+CFLAGS="${CFLAGS} -fshort-wchar"
+CXXFLAGS="${CXXFLAGS} -fshort-wchar"
+export CCFLAGS CXXFLAGS
+
 # I'm sick and tired of all the churn the three versions of autoconf
 # are causing in this repo. Stop committing the configure scripts
 # and just autoregen.

--- a/build-debug-sdl2
+++ b/build-debug-sdl2
@@ -10,6 +10,11 @@ if [ "$1" == "32" ]; then
     opt="--host=i686-pc-linux-gnu --target=i686-pc-linux-gnu"
 fi
 
+# Makes Linux use 16-bit wide chars instead of 32-bit
+CFLAGS="${CFLAGS} -fshort-wchar"
+CXXFLAGS="${CXXFLAGS} -fshort-wchar"
+export CCFLAGS CXXFLAGS
+
 # Jonathan C dev hack: refer to LNKDOS16 in /usr/src/doslib
 doslib=
 if [ -d /usr/src/doslib ]; then doslib="/usr/src/doslib"; fi


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?
#5132

## Does this PR introduce new feature(s)?
no

## Does this PR introduce any breaking change(s)?
no

## Additional information
VHD Differencing is broken on Linux systems, this fixes the issue, by using the same size chars as on Windows and Macs
