### PR TITLE
Fix some Linux issues in VHD code

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -8311,15 +8311,8 @@ void VHDMAKE::Run()
         safe_strcpy(basename, temp_line.c_str());
         cmd->FindCommand(2, temp_line);
         safe_strcpy(filename, temp_line.c_str());
-#ifdef WIN32
-        if(basename[1] == ':')
-            WriteOut(MSG_Get("PROGRAM_VHDMAKE_ABSPATH_WIN"));
-#else
-        if(basename[0] == '/') {
-            WriteOut(MSG_Get("PROGRAM_VHDMAKE_ABSPATH_UX"));
-            return;
-        }
-#endif
+        if(basename[1] == ':' || basename[0] == '/')
+            WriteOut(MSG_Get("PROGRAM_VHDMAKE_ABSPATH"));
         if(! bOverwrite && _access(filename, 0) == 0) {
             WriteOut(MSG_Get("PROGRAM_VHDMAKE_FNEEDED"));
             return;
@@ -9879,8 +9872,7 @@ void DOS_SetupPrograms(void) {
     MSG_Add("PROGRAM_VHDMAKE_MERGEOKDELETE", "Snapshot VHD merged and deleted.\n");
     MSG_Add("PROGRAM_VHDMAKE_MERGEFAILED", "Failure while merging, aborted!\n");
     MSG_Add("PROGRAM_VHDMAKE_MERGEWARNCORRUPTION", " Parent \"%s\" contents could be corrupted!\n");
-    MSG_Add("PROGRAM_VHDMAKE_ABSPATH_WIN", "Warning: an absolute path to parent limits portability to Windows.\nPlease prefer a path relative to differencing image file!\n");
-    MSG_Add("PROGRAM_VHDMAKE_ABSPATH_UX", "ERROR: an absolute path to parent inhibits portability.\nUse a path relative to differencing image file!\n");
+    MSG_Add("PROGRAM_VHDMAKE_ABSPATH", "Warning: an absolute path to parent prevents portability.\nPlease prefer a path relative to the differencing image file!\n");
     MSG_Add("PROGRAM_VHDMAKE_HELP",
         "Creates Dynamic or Differencing VHD images, converts raw images into Fixed VHD,\n"
         "shows information about VHD images and merges them.\n"

--- a/src/ints/bios_vhd.cpp
+++ b/src/ints/bios_vhd.cpp
@@ -733,10 +733,11 @@ uint32_t imageDiskVHD::CreateDifferencing(const char* filename, const char* base
 
     //Locators - Windows 11 wants at least the relative W2ru locator, or won't mount!
     // we store the absolute pathname to prevent complex depth calculations
-    char absBasePathName[MAX_PATH];
 #if defined (WIN32)
+    char absBasePathName[MAX_PATH];
     _fullpath(absBasePathName, basename, MAX_PATH);
 #else
+    char absBasePathName[PATH_MAX];
     realpath(basename, absBasePathName);
 #endif
     uint32_t l_basename = strlen(absBasePathName);

--- a/src/ints/bios_vhd.cpp
+++ b/src/ints/bios_vhd.cpp
@@ -760,7 +760,7 @@ uint32_t imageDiskVHD::CreateDifferencing(const char* filename, const char* base
         table_size -= 512;
     }
     //write Parent Locator sectors
-    wchar_t* w_basename = (wchar_t*)malloc(platsize);
+    uint16_t* w_basename = (uint16_t*)malloc(platsize);
     memset(w_basename, 0, platsize);
     for(uint32_t i = 0; i < l_basename; i++)
         //dirty hack to quickly convert ASCII -> UTF-16 *LE* and fix slashes


### PR DESCRIPTION
- imageDiskVHD::CreateDifferencing in bios_vhd.cpp avoids Linux incompatibilities uising uint16_t instead of wchar_t
- VHDMAKE now allows absolute pathnames for differencing images, under Linux as like under Windows

Closes #5132 and #5143 and possibly #5145