### PR TITLE
Calculates true parent's relative path in Differencing VHD locator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,8 +139,3 @@ contrib/macos/dosbox-x.plist
 # ignore default dosbox config files (used for manual testing)
 /dosbox-x.conf
 /src/dosbox-x.conf
-
-src/dos/dos_programs.7z
-src/lnkvhd.cpp
-src/mkvhd.cpp
-src/mkvhd.exe

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,7 @@ contrib/macos/dosbox-x.plist
 /dosbox-x.conf
 /src/dosbox-x.conf
 
+src/dos/dos_programs.7z
+src/lnkvhd.cpp
+src/mkvhd.cpp
+src/mkvhd.exe

--- a/src/ints/bios_vhd.cpp
+++ b/src/ints/bios_vhd.cpp
@@ -49,7 +49,7 @@
 *
 */
 
-// returns the path of "base" in a form relative to "child", where both exist
+// returns the path of "base" in a form relative to "child"
 char* calc_relative_path(const char* base, const char* child) {
 #ifndef WIN32
     char abs_base[PATH_MAX];
@@ -76,6 +76,8 @@ char* calc_relative_path(const char* base, const char* child) {
     // strips common subpath, if any
     while(*p++ == *q++);
     p--, q--;
+    // returns base if they don't share anything
+    if(!strcmp(p, abs_base)) return strdup(base);
     x = q;
     // count slashes
     while(*x) {
@@ -83,8 +85,12 @@ char* calc_relative_path(const char* base, const char* child) {
         x++;
     }
     // allocates space for the resulting string
-    y = (char*)malloc(strlen(q) + n * 3); // n * strlen("..\\")
+    y = (char*)malloc(strlen(q) + n * 3 + 2); // n * strlen("..\\")
     z = y;
+    if(!n) {
+        strcpy(z, ".\\");
+        z += 2;
+    }
     while(n--) {
         strcpy(z, "..\\");
         z += 3;


### PR DESCRIPTION
This patch is tested both in Windows 11 and Linux (Ubuntu, WSL). It refines the Differencing VHD handler in following ways:

- always tries to handle an absolute W2ku locator;
- more log messages to debug;
- 2nd locator offset is relative to 1st, a fixed position is no more assumed;
- calculates and stores the true parent's relative path in W2ru locator (parent's path has to be relative to child's path, not current working directory).

As a consequence, VHD sets created in Windows can be shared with Linux users and vice-versa (due to correct relative locator).

NOTE FOR THE WILLING PROGRAMMER: a `-relink` switch could be added to `VHDMAKE` allowing to move a parent VHD and manually relink its childs.

Closes #5145 