### PR TITLE
LABEL command to update timestamp

### DIFF
--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -874,7 +874,13 @@ nextfile:
 				while (j < 11 && *s != 0) sectbuf[entryoffset].entryname[j++] = *s++;
 				while (j < 11)            sectbuf[entryoffset].entryname[j++] = ' ';
 			}
-			writeSector(tmpsector,sectbuf);
+            uint16_t ct, cd;
+            time_t_to_DOS_DateTime(/*&*/ct,/*&*/cd, ::time(NULL));
+            sectbuf[entryoffset].modTime = ct;
+            sectbuf[entryoffset].modDate = cd;
+            sectbuf[entryoffset].accessDate = cd;
+
+            writeSector(tmpsector,sectbuf);
 			labelCache.SetLabel(label, false, true);
 			UpdateBootVolumeLabel(label);
 			return;


### PR DESCRIPTION
Make LABEL command to update the timestamp when changing volume label so to avoid errors in CHKDSK command. 

![image](https://github.com/user-attachments/assets/55d95a8a-e659-4fab-b16a-ad4ea96d53f0)

Fixes #5152