### PR TITLE
Pass output dimensions to Direct3D shaders

### DIFF
--- a/src/output/direct3d/ScalingEffect.cpp
+++ b/src/output/direct3d/ScalingEffect.cpp
@@ -29,7 +29,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 ScalingEffect::ScalingEffect(LPDIRECT3DDEVICE9 pd3dDevice) :
     m_scale(0.0f), m_forceupdate(false), m_pd3dDevice(pd3dDevice), m_pEffect(0)
 {
-    m_iDim[0] = m_iDim[1] = 256.0f;	// Some sane default
+    m_iDim[0] = m_iDim[1] = m_oDim[0] = m_oDim[1] = 256.0f;	// Some sane default
     m_strName = "Unnamed";
     KillThis();
 }
@@ -195,6 +195,12 @@ HRESULT ScalingEffect::ParseParameters(LPD3DXEFFECTCOMPILER lpEffectCompiler)
 			return hr;
 		    }
 		}
+        else if(strcmpi(ParamDesc.Semantic, "outputdims") == 0) {
+            if(m_oDim[0] && m_oDim[1] && ((hr = m_pEffect->SetFloatArray(hParam, m_oDim, 2)) != D3D_OK)) {
+            m_strErrors += "Could not set outputdims parameter!";
+            return hr;
+            }
+        }
 	    }
 
 	    else if(ParamDesc.Class == D3DXPC_SCALAR && ParamDesc.Type == D3DXPT_FLOAT) {

--- a/src/output/direct3d/ScalingEffect.h
+++ b/src/output/direct3d/ScalingEffect.h
@@ -28,6 +28,7 @@ class ScalingEffect
 {
     float				m_scale;
     float				m_iDim[2];
+    float               m_oDim[2];
     BOOL				m_forceupdate;
     LPCSTR				m_strName;
     std::string				m_strErrors;
@@ -73,6 +74,7 @@ public:
     float getScale() { return m_scale; }
     bool getForceUpdate() { return m_forceupdate != FALSE; }
     void setinputDim(float w, float h) { m_iDim[0] = w; m_iDim[1] = h; }
+    void setoutputDim(float w, float h) { m_oDim[0] = w; m_oDim[1] = h; }
 
     // Does it have a preprocess step
     BOOL hasPreprocess() { return m_PreprocessTechnique1EffectHandle!=0; }

--- a/src/output/direct3d/direct3d.cpp
+++ b/src/output/direct3d/direct3d.cpp
@@ -1083,6 +1083,7 @@ HRESULT CDirect3D::LoadPixelShader(void)
 #endif
 
     psEffect->setinputDim((float)dwWidth, (float)dwHeight);
+    psEffect->setoutputDim((float)dwScaledWidth, (float)dwScaledHeight);
     if(FAILED(psEffect->LoadEffect(shader_translate_directory(pshader).c_str())) || FAILED(psEffect->Validate())) {
 	LOG_MSG("D3D:Pixel shader error:");
 


### PR DESCRIPTION
This PR passes the final output dimensions of the image to shaders, allowing for shaders to adjust scaling parameters automatically when needed.

## What issue(s) does this PR address?

None.
<!-- (For more information on using keywords like in above, read this document: https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) -->

## Does this PR introduce new feature(s)?

Yes, it adds an OUTPUTDIMS parameter to the D3D scaling effect, which contains the final (after all scaling has been performed) dimensions of the image.

## Does this PR introduce any breaking change(s)?

No, existing shaders should function identically to before.

## Additional information

Added this primarily so that a sharp-bilinear shader is feasible on Direct3D.
