### PR TITLE
Fix crash when a language file is loaded on a Windows host with US keyboard 

### DIFF
--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -1505,12 +1505,9 @@ public:
 					wants_dos_codepage = GetDefaultCP();
 					break;
 				case 1033: // US, CP 437
-#if defined(HX_DOS)
                     layoutname = "us";
                     wants_dos_codepage = GetDefaultCP();
                     break;
-#endif
-					return;
 				case 1032: // Greece, CP 869, Alt CP 813
 					layoutname = "gk";
 					break;
@@ -1688,8 +1685,12 @@ public:
 				default:
 					break;
 			}
-#endif
 		}
+        else if(!strncmp(layoutname, "none", 4)) {
+            layoutname = "us";
+            wants_dos_codepage = 437;
+#endif
+        }
 
 		bool extract_codepage = !tocp;
 		if (wants_dos_codepage>0) {

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -321,7 +321,8 @@ void LoadMessageFile(const char * fname) {
                                 return;
                             }
                             std::string msg = "The specified language file uses code page " + std::to_string(c) + ". Do you want to change to this code page accordingly?";
-                            if (!control->opt_langcp && !uselangcp && c != 437 && GetDefaultCP() == 437 && systemmessagebox("DOSBox-X language file", msg.c_str(), "yesno", "question", 1)) control->opt_langcp = true;
+                            if (loadlang && !control->opt_langcp && !uselangcp && c != 437 && GetDefaultCP() == 437 && systemmessagebox("DOSBox-X language file", msg.c_str(), "yesno", "question", 1)) control->opt_langcp = true;
+                            else control->opt_langcp = true;
                             msgcodepage = c;
                             dos.loaded_codepage = c;
                             if (c == 950 && !chinasea) makestdcp950table();


### PR DESCRIPTION
This PR fix crashes when a language file is loaded on a Windows host with a keyboard with US layout.

Tested on Windows 10 Pro 22H2.

## What issue(s) does this PR address?
Fixes #5174