### PR TITLE
Clean up warnings and resolved issues

### DIFF
--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -438,26 +438,26 @@ class CDROM_Interface_Aspi : public CDROM_Interface
 public:
 	virtual ~CDROM_Interface_Aspi(void);
 
-	bool	SetDevice			(char* path, int forceCD);
+	bool	SetDevice			(char* path, int forceCD) override;
 
-	bool	GetUPC				(unsigned char& attr, char* upc);
+	bool	GetUPC				(unsigned char& attr, char* upc) override;
 
-	bool	GetAudioTracks		(int& stTrack, int& end, TMSF& leadOut);
-	bool	GetAudioTrackInfo	(int track, TMSF& start, unsigned char& attr);
-	bool	GetAudioSub			(unsigned char& attr, unsigned char& track, unsigned char& index, TMSF& relPos, TMSF& absPos);
-	bool	GetAudioStatus		(bool& playing, bool& pause);
-	bool	GetMediaTrayStatus	(bool& mediaPresent, bool& mediaChanged, bool& trayOpen);
+	bool	GetAudioTracks		(int& stTrack, int& end, TMSF& leadOut) override;
+	bool	GetAudioTrackInfo	(int track, TMSF& start, unsigned char& attr) override;
+	bool	GetAudioSub			(unsigned char& attr, unsigned char& track, unsigned char& index, TMSF& relPos, TMSF& absPos) override;
+	bool	GetAudioStatus		(bool& playing, bool& pause) override;
+	bool	GetMediaTrayStatus	(bool& mediaPresent, bool& mediaChanged, bool& trayOpen) override;
 
-	bool	PlayAudioSector		(unsigned long start,unsigned long len);
-	bool	PauseAudio			(bool resume);
-	bool	StopAudio			(void);
-	void	ChannelControl		(TCtrl ctrl) { (void)ctrl; return; };
+	bool	PlayAudioSector		(unsigned long start,unsigned long len) override;
+	bool	PauseAudio			(bool resume) override;
+	bool	StopAudio			(void) override;
+	void	ChannelControl		(TCtrl ctrl) override { (void)ctrl; return; };
 	
-	bool	ReadSectors			(PhysPt buffer, bool raw, unsigned long sector, unsigned long num);
+	bool	ReadSectors			(PhysPt buffer, bool raw, unsigned long sector, unsigned long num) override;
 	/* This is needed for IDE hack, who's buffer does not exist in DOS physical memory */
-	bool	ReadSectorsHost			(void* buffer, bool raw, unsigned long sector, unsigned long num);
+	bool	ReadSectorsHost			(void* buffer, bool raw, unsigned long sector, unsigned long num) override;
 	
-	bool	LoadUnloadMedia		(bool unload);
+	bool	LoadUnloadMedia		(bool unload) override;
 	
 private:
 	DWORD	GetTOC				(LPTOC toc);
@@ -491,29 +491,29 @@ public:
 	CDROM_Interface_Ioctl		(cdioctl_cdatype ioctl_cda);
 	virtual ~CDROM_Interface_Ioctl(void);
 
-	bool	SetDevice			(char* path, int forceCD);
+	bool	SetDevice			(char* path, int forceCD) override;
 
-	bool	GetUPC				(unsigned char& attr, char* upc);
+	bool	GetUPC				(unsigned char& attr, char* upc) override;
 
-	bool	GetAudioTracks		(int& stTrack, int& end, TMSF& leadOut);
-	bool	GetAudioTrackInfo	(int track, TMSF& start, unsigned char& attr);
-	bool	GetAudioSub			(unsigned char& attr, unsigned char& track, unsigned char& index, TMSF& relPos, TMSF& absPos);
-	bool	GetAudioStatus		(bool& playing, bool& pause);
-	bool	GetMediaTrayStatus	(bool& mediaPresent, bool& mediaChanged, bool& trayOpen);
+	bool	GetAudioTracks		(int& stTrack, int& end, TMSF& leadOut) override;
+	bool	GetAudioTrackInfo	(int track, TMSF& start, unsigned char& attr) override;
+	bool	GetAudioSub			(unsigned char& attr, unsigned char& track, unsigned char& index, TMSF& relPos, TMSF& absPos) override;
+	bool	GetAudioStatus		(bool& playing, bool& pause) override;
+	bool	GetMediaTrayStatus	(bool& mediaPresent, bool& mediaChanged, bool& trayOpen) override;
 
-	bool	PlayAudioSector		(unsigned long start,unsigned long len);
-	bool	PauseAudio			(bool resume);
-	bool	StopAudio			(void);
-	void	ChannelControl		(TCtrl ctrl);
+	bool	PlayAudioSector		(unsigned long start,unsigned long len) override;
+	bool	PauseAudio			(bool resume) override;
+	bool	StopAudio			(void) override;
+	void	ChannelControl		(TCtrl ctrl) override;
 	
 	bool	ReadSector			(uint8_t *buffer, bool raw, unsigned long sector);
-	bool	ReadSectors			(PhysPt buffer, bool raw, unsigned long sector, unsigned long num);
+	bool	ReadSectors			(PhysPt buffer, bool raw, unsigned long sector, unsigned long num) override;
 	/* This is needed for IDE hack, who's buffer does not exist in DOS physical memory */
-	bool	ReadSectorsHost			(void* buffer, bool raw, unsigned long sector, unsigned long num);
+	bool	ReadSectorsHost			(void* buffer, bool raw, unsigned long sector, unsigned long num) override;
 	
-	bool	LoadUnloadMedia		(bool unload);
+	bool	LoadUnloadMedia		(bool unload) override;
 
-	void	InitNewMedia		(void) { Close(); Open(); };
+	void	InitNewMedia		(void) override { Close(); Open(); };
 private:
 
 	bool	Open				(void);

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -3221,7 +3221,7 @@ static void LOADROM_ProgramStart(Program * * make) {
 #if C_DEBUG
 class BIOSTEST : public Program {
 public:
-    void Run(void) {
+    void Run(void) override {
         if (!(cmd->FindCommand(1, temp_line))) {
             WriteOut("Must specify BIOS file to load.\n");
             return;
@@ -7196,7 +7196,7 @@ void VFRCRATE_ProgramStart(Program * * make);
 #if defined C_DEBUG
 class NMITEST : public Program {
 public:
-    void Run(void) {
+    void Run(void) override {
         if (cmd->FindExist("-?", false) || cmd->FindExist("/?", false)) {
 			WriteOut("Generates a non-maskable interrupt (NMI).\n\nNMITEST\n\nNote: This is a debugging tool to test if the interrupt handler works properly.\n");
             return;

--- a/src/hardware/ipx.cpp
+++ b/src/hardware/ipx.cpp
@@ -1003,7 +1003,7 @@ public:
 		}
 	}
 
-	void Run(void)
+	void Run(void) override
 	{
 		WriteOut("IPX Tunneling utility for DOSBox-X\n\n");
 		if(!cmd->GetCount()) {


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

The project has a lot of compile warnings (especially -Wsuggest-override warnings in cdrom.h appear frequently) and there are many resolved-yet-open issues.
Through merging this PR, you can close these issues, which appear to have been resolved:
Closes #1746.
Closes #4977.
Closes #4398.
Closes #2826.
Closes #3345.
Closes #2829.
Closes #2733.
Closes #2869.
Closes #3451.
Closes #4209. (Consensus seems to have been that the problem was not in DOSBox-X)
Closes #2663.
Closes #2787.
Closes #2252. (I don't completely understand this issue from a quick read but there seems to be consensus that the problem was not in DOSBox-X)
Closes #3016.
Closes #1285.
Closes #1822.
Closes #5069.
Closes #3979.
Closes #835.
Closes #1780.
Closes #2589.
Closes #886.

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

No.

There is also the question of how to handle all the "Question"-tagged issues in the Issues page. For example in https://github.com/joncampbell123/dosbox-x/issues/3483, @maron2000 suggests closing the issue (a "Question" issue) because it had been answered. We could do that, or convert them to Discussions (see https://docs.github.com/en/discussions/managing-discussions-for-your-community/managing-discussions#converting-issues-based-on-labels). We could also leave them as they are, but I feel they are cluttering the Issues page.