### PR TITLE
Fix codepage when loading a language file at launch

### DIFF
--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -55,6 +55,7 @@ extern int tryconvertcp, toSetCodePage(DOS_Shell *shell, int newCP, int opt);
 extern bool jfont_init;
 extern int32_t msgcodepage;
 bool CheckDBCSCP(int32_t codepage);
+void Load_Language(std::string name);
 
 static FILE* OpenDosboxFile(const char* name) {
 	uint8_t drive;
@@ -1747,8 +1748,14 @@ public:
         }
         if(isSupportedCP(msgcodepage)) {
             SwitchLanguage(dos.loaded_codepage, msgcodepage, false);
+#if defined(USE_TTF)
+            if (ttf.inUse)
+                toSetCodePage(NULL, msgcodepage, -1);
+            else
+#endif
             if(!CheckDBCSCP(msgcodepage))DOS_ChangeCodepage(msgcodepage, "auto");
-            dos.loaded_codepage = msgcodepage;
+            Load_Language(layoutname);
+            dos.loaded_codepage=msgcodepage;
         }
     }
 

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -1387,15 +1387,18 @@ Bitu DOS_LoadKeyboardLayout(const char * layoutname, int32_t codepage, const cha
 		return kerrcode;
 	}
 	// ...else keyboard layout loaded successfully, change codepage accordingly
-	kerrcode=temp_layout->read_codepage_file(codepagefile, codepage);
-	if (kerrcode) {
-		delete temp_layout;
-		return kerrcode;
-	}
+    if(!CheckDBCSCP(codepage)){
+        kerrcode = temp_layout->read_codepage_file(codepagefile, codepage);
+        if(kerrcode) {
+            delete temp_layout;
+            return kerrcode;
+        }
+    }
 	// Everything went fine, switch to new layout
     delete loaded_layout;
     loaded_layout=temp_layout;
-	return KEYB_NOERROR;
+    dos.loaded_codepage = codepage;
+    return KEYB_NOERROR;
 }
 
 Bitu DOS_SwitchKeyboardLayout(const char* new_layout, int32_t& tried_cp) {
@@ -1421,7 +1424,9 @@ Bitu DOS_ChangeKeyboardLayout(const char* layoutname, int32_t codepage) {
         return kerrcode;
     }
     // Everything went fine, switch to new layout
+    delete loaded_layout;
     loaded_layout = temp_layout;
+    dos.loaded_codepage = codepage;
     return KEYB_NOERROR;
 }
 
@@ -1432,6 +1437,7 @@ Bitu DOS_ChangeCodepage(int32_t codepage, const char* codepagefile) {
         return kerrcode;
     }
     // Everything went fine
+    dos.loaded_codepage = codepage;
     return KEYB_NOERROR;
 }
 

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -114,6 +114,8 @@ void runBoot(const char *str), runMount(const char *str), runImgmount(const char
 void getdrivezpath(std::string &path, std::string const& dirname), drivezRegister(std::string const& path, std::string const& dir, bool usecp), UpdateDefaultPrinterFont(void);
 std::string GetDOSBoxXPath(bool withexe=false);
 FILE *testLoadLangFile(const char *fname);
+bool CheckDBCSCP(int32_t codepage);
+extern int32_t msgcodepage;
 
 #if defined(OS2)
 #define INCL DOSFILEMGR
@@ -215,10 +217,11 @@ void SwitchLanguage(int oldcp, int newcp, bool confirm) {
         if (file) {
             fclose(file);
             std::string msg = "You have changed the active code page to " + std::to_string(newcp) + ". Do you want to load language file " + langnew + " for this code page?";
-            if (!confirm || systemmessagebox("DOSBox-X language file", msg.c_str(), "yesno","question", 2)) {
+            if (!confirm || CheckDBCSCP(oldcp) || systemmessagebox("DOSBox-X language file", msg.c_str(), "yesno", "question", 2)) {
                 SetVal("dosbox", "language", langnew);
-                Load_Language(langnew);
+                msgcodepage = newcp;
                 lastmsgcp = newcp;
+                Load_Language(langnew);
             }
         }
     }

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -209,7 +209,6 @@ void DetachFromBios(imageDisk* image) {
 }
 
 void SwitchLanguage(int oldcp, int newcp, bool confirm) {
-    (void)oldcp; //unused
     auto iterold = langcp_map.find(lastmsgcp), iternew = langcp_map.find(newcp);
     std::string langold = iterold != langcp_map.end() ? iterold->second : "", langnew = iternew != langcp_map.end() ? iternew->second : "";
     if (loadlang && langnew.size() && strcasecmp(langold.c_str(), langnew.c_str())) {

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -53,7 +53,6 @@ Bitu DOS_ChangeKeyboardLayout(const char* layoutname, int32_t codepage);
 Bitu DOS_ChangeCodepage(int32_t codepage, const char* codepagefile);
 Bitu DOS_LoadKeyboardLayout(const char* layoutname, int32_t codepage, const char* codepagefile);
 bool CheckDBCSCP(int32_t codepage);
-void Load_Language(std::string name);
 
 #define LINE_IN_MAXLEN 2048
 
@@ -219,10 +218,10 @@ void SetKEYBCP() {
     if (IS_PC98_ARCH || IS_JEGA_ARCH || IS_DOSV || dos_kernel_disabled || !strcmp(RunningProgram, "LOADLIN")) return;
     Bitu return_code;
     if(CheckDBCSCP(msgcodepage)) {
-        dos.loaded_codepage = msgcodepage;
         ShutFontHandle();
         InitFontHandle();
         JFONT_Init();
+        dos.loaded_codepage = msgcodepage;
     }
     if (!CheckDBCSCP(msgcodepage) && DOS_ChangeCodepage(msgcodepage, "auto") == KEYB_NOERROR){
         dos.loaded_codepage = msgcodepage;

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -727,6 +727,7 @@ bool set_ver(char *s), GFX_IsFullscreen(void);
 
 void Load_Language(std::string name) {
     if (control->opt_lang != "") control->opt_lang = name;
+    dos.loaded_codepage = msgcodepage;
     MSG_Init();
 #if DOSBOXMENU_TYPE == DOSBOXMENU_HMENU || DOSBOXMENU_TYPE == DOSBOXMENU_NSMENU
     mainMenu.unbuild();
@@ -738,12 +739,12 @@ void Load_Language(std::string name) {
 #if defined(USE_TTF)
     if (TTF_using()) resetFontSize();
 #endif
-    if (!uselangcp && !incall) {
-        int oldmsgcp = msgcodepage;
-        msgcodepage = dos.loaded_codepage;
+    //if (!uselangcp && !incall) {
+        //int oldmsgcp = msgcodepage;
+        //dos.loaded_codepage = msgcodepage;
         SetKEYBCP();
-        msgcodepage = oldmsgcp;
-    }
+        //msgcodepage = oldmsgcp;
+    //}
 }
 
 void ApplySetting(std::string pvar, std::string inputline, bool quiet) {

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -57,7 +57,8 @@ extern bool startcmd, startwait, startquiet, internal_program;
 extern bool addovl, addipx, addne2k, enableime, showdbcs;
 extern bool halfwidthkana, force_conversion, gbk;
 extern const char* RunningProgram;
-extern int enablelfn, msgcodepage, lastmsgcp;
+extern int enablelfn;
+extern int32_t msgcodepage, lastmsgcp;
 extern uint16_t countryNo;
 extern unsigned int dosbox_shell_env_size;
 bool outcon = true, usecon = true, pipetmpdev = true;
@@ -81,6 +82,8 @@ void SwitchLanguage(int oldcp, int newcp, bool confirm);
 void CALLBACK_DeAllocate(Bitu in), DOSBox_ConsolePauseWait();
 void GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused);
 bool isDBCSCP(), InitCodePage(), isKanji1(uint8_t chr), shiftjis_lead_byte(int c), sdl_wait_on_error();
+void Load_Language(std::string name);
+bool CheckDBCSCP(int32_t codepage);
 
 Bitu call_shellstop = 0;
 /* Larger scope so shell_del autoexec can use it to
@@ -883,7 +886,7 @@ void DOS_Shell::Prepare(void) {
                         else if (IS_TDOSV) newCP=950;
                     }
                     const char* name = DOS_GetLoadedLayout();
-                    if (newCP==932||newCP==936||newCP==949||newCP==950||newCP==951) {
+                    if (CheckDBCSCP(newCP)) {
                         dos.loaded_codepage=newCP;
                         SetupDBCSTable();
                         runRescan("-A -Q");

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -4533,7 +4533,7 @@ int toSetCodePage(DOS_Shell *shell, int newCP, int opt) {
 		missing = TTF_using() ? setTTFCodePage() : 0;
 #endif
         if (!TTF_using()) initcodepagefont();
-        if (dos.loaded_codepage==437) DOS_LoadKeyboardLayout("us", 437, "auto");
+        if (dos.loaded_codepage==437 && DOS_GetLoadedLayout() == NULL) DOS_LoadKeyboardLayout("us", 437, "auto");
         if (opt==-1) {
             MSG_Init();
 #if DOSBOXMENU_TYPE == DOSBOXMENU_HMENU


### PR DESCRIPTION
This PR fixes a bug in PR #5209 that codepage was wrong when loading a language file at launch.
Used command `dosbox-x -set language=ko_kr -set output=default`

Before fix
![image](https://github.com/user-attachments/assets/5f60b7e3-0c7a-41ea-add6-dd505094235d)

After fix
![image](https://github.com/user-attachments/assets/f9dce621-f49b-49f3-b43f-a1c8d6e2a3a2)

![image](https://github.com/user-attachments/assets/66260611-39c0-4912-8ebc-408e1a58a31d)

![image](https://github.com/user-attachments/assets/c27d85d7-1e8d-4c2d-82df-dbd265ed8df7)

