### PR TITLE
Include seeking in file operations for log-fileio

### DIFF
--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -722,6 +722,11 @@ bool DOS_SeekFile(uint16_t entry,uint32_t * pos,uint32_t type,bool fcb) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	}
+
+	if (log_fileio) {
+		LOG(LOG_FILES, LOG_DEBUG)("Seeking to %d bytes from position type (%d) in %s ", *pos, type, Files[handle]->name);
+	}
+
 	return Files[handle]->Seek(pos,type);
 }
 


### PR DESCRIPTION
This PR adds a single debugging statement to log file seeking when -log-fileio is supplied.

## Does this PR introduce new feature(s)?

Only sort of.  It just adds a new operation to those that are logged; if file operations are logged at present, the amount of data read is logged, but the location in the file can't be backed out of that.  This allows the full IO operations to be tracked.

## Does this PR introduce any breaking change(s)?

Nope, none.
