### PR TITLE
"Decouple CMS and OPL emulations" - dosbox-staging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -94,7 +94,8 @@ NEXT
     - properties/help: sorted alphabetically, mouse wheel scrollable
     - remove few rendundant labels, adjust names of some others
     - retain 'show advanced options' state throughout session
-  - SVN r4483: Fix compilation in Visual Studio 2008. (Allofich)
+  - SVN r4483: Fix compilation in Visual Studio 2008 (Allofich)
+  - DOSBox Staging: Decouple CMS and OPL emulations (Allofich)
 
 2024.07.01
   - Correct Hercules InColor memory emulation. Read and write planar

--- a/include/hardware.h
+++ b/include/hardware.h
@@ -22,7 +22,7 @@
 
 class Section;
 enum OPL_Mode {
-	OPL_none,OPL_cms,OPL_opl2,OPL_dualopl2,OPL_opl3,OPL_opl3gold,OPL_hardware,OPL_hardwareCMS,OPL_esfm
+	OPL_none,OPL_opl2,OPL_dualopl2,OPL_opl3,OPL_opl3gold,OPL_hardware,OPL_hardwareCMS,OPL_esfm
 };
 #define CAPTURE_WAVE	0x01
 #define CAPTURE_OPL		0x02
@@ -36,8 +36,9 @@ enum OPL_Mode {
 extern Bitu CaptureState;
 
 void OPL_Init(Section* sec,OPL_Mode oplmode);
-void CMS_Init(Section* sec);
 void OPL_ShutDown(Section* sec);
+
+void CMS_Init(Section* sec);
 void CMS_ShutDown(Section* sec);
 
 bool SB_Get_Address(Bitu& sbaddr, Bitu& sbirq, Bitu& sbdma);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1392,7 +1392,8 @@ void DOSBOX_SetupConfigSections(void) {
     const char *mt32reverbLevels[] = {"0", "1", "2", "3", "4", "5", "6", "7", nullptr};
     const char* gustypes[] = { "classic", "classic37", "max", "interwave", nullptr };
     const char* sbtypes[] = { "sb1", "sb2", "sbpro1", "sbpro2", "sb16", "sb16vibra", "gb", "ess688", "ess1688", "reveal_sc400", "none", nullptr };
-    const char* oplmodes[]={ "auto", "cms", "opl2", "dualopl2", "opl3", "opl3gold", "none", "hardware", "hardwaregb", "esfm", nullptr };
+    const char* cms_settings[] = { "on", "off", "auto", nullptr };
+    const char* oplmodes[] = { "auto", "opl2", "dualopl2", "opl3", "opl3gold", "none", "hardware", "hardwaregb", "esfm", nullptr };
     const char* serials[] = { "dummy", "disabled", "modem", "nullmodem", "serialmouse", "directserial", "log", "file", nullptr };
     const char* acpi_rsd_ptr_settings[] = { "auto", "bios", "ebda", nullptr };
     const char* cpm_compat_modes[] = { "auto", "off", "msdos2", "msdos5", "direct", nullptr };
@@ -3669,10 +3670,18 @@ void DOSBOX_SetupConfigSections(void) {
     Pbool->Set_help("Allow the Sound Blaster mixer to modify the DOSBox-X mixer.");
     Pbool->SetBasic(true);
 
+    Pstring = secprop->Add_string("cms", Property::Changeable::WhenIdle, "auto");
+    Pstring->Set_values(cms_settings);
+    Pstring->Set_help(
+        "Enable CMS emulation ('auto' by default).\n"
+        "  off:   Disable CMS emulation (except when the Game Blaster is selected).\n"
+        "  on:    Enable CMS emulation on Sound Blaster 1 and 2.\n"
+        "  auto:  Auto-enable CMS emulation for Sound Blaster 1 and Game Blaster.");
+
     Pstring = secprop->Add_string("oplmode",Property::Changeable::WhenIdle,"auto");
     Pstring->Set_values(oplmodes);
     Pstring->Set_help("Type of OPL emulation. On 'auto' the mode is determined by the 'sbtype' setting.\n"
-			"All OPL modes are AdLib-compatible, except for 'cms' (set 'sbtype=none' with 'cms' for a Game Blaster).");
+            "All OPL modes are AdLib-compatible.");
     Pstring->SetBasic(true);
 
     Pbool = secprop->Add_bool("adlib force timer overflow on detect",Property::Changeable::WhenIdle,false);

--- a/src/hardware/adlib.cpp
+++ b/src/hardware/adlib.cpp
@@ -1544,7 +1544,6 @@ OPL_Mode Module::oplmode=OPL_none;
 
 std::string getoplmode() {
     if (Adlib::Module::oplmode == OPL_none) return "None";
-    else if (Adlib::Module::oplmode == OPL_cms) return "CMS";
     else if (Adlib::Module::oplmode == OPL_opl2) return "OPL2";
     else if (Adlib::Module::oplmode == OPL_dualopl2) return "Dual OPL2";
     else if (Adlib::Module::oplmode == OPL_opl3) return "OPL3";


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

Re-implementation of https://github.com/joncampbell123/dosbox-x/pull/5220.

## Does this PR introduce new feature(s)?

As far as I understand this allows optionally enabling CMS for the Sound Blaster 1 or 2 while also having an OPL mode enabled.

## Does this PR introduce any breaking change(s)?

Existing save states using Adlib emulation might have a problem, as an enum value was removed.

## Additional information

See the DOSBox-Staging version at https://github.com/dosbox-staging/dosbox-staging/pull/3559/files.
