### PR TITLE
Switch macOS x86 CI runner image to macos-13

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ jobs:
       actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
       contents: write # for actions/checkout to fetch code and softprops/action-gh-release
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.12.1


### PR DESCRIPTION
macOS x86 CI runner is currently `macos-12` which is planned to retire on Dec.3rd 2024.
This PR switches to `macos-13`, the latest image for x86 macOS.

https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/