### PR TITLE
Fixes corrupted display when loading language files at launch.

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -90,7 +90,7 @@ bool isDBCSCP();
 uint32_t BIOS_get_PC98_INT_STUB(void);
 uint16_t GetDefaultCP(void);
 void ResolvePath(std::string& in);
-void SwitchLanguage(int oldcp, int newcp, bool confirm);
+bool SwitchLanguage(int oldcp, int newcp, bool confirm);
 void makestdcp950table(), makeseacp951table();
 std::string GetDOSBoxXPath(bool withexe=false);
 extern std::string prefix_local, prefix_overlay;

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -1728,7 +1728,6 @@ public:
 
             if (!TTF_using() || (TTF_using() && isSupportedCP(tocp))){
                 toSetCodePage(NULL, msgcodepage ? msgcodepage : tocp, msgcodepage ? -1: -2);
-                runRescan("-A -Q");
 #if C_OPENGL && DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW
                 if (OpenGL_using() && control->opt_lang.size() && lastcp && lastcp != dos.loaded_codepage)
                     UpdateSDLDrawTexture();

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -48,7 +48,6 @@ int lastcp = 0;
 void DOSBox_SetSysMenu(void);
 bool OpenGL_using(void), isDBCSCP(void);
 void change_output(int output), UpdateSDLDrawTexture();
-void SwitchLanguage(int oldcp, int newcp, bool confirm);
 Bitu DOS_ChangeCodepage(int32_t codepage, const char* codepagefile);
 void MSG_Init(), JFONT_Init(), runRescan(const char *str);
 extern int tryconvertcp, toSetCodePage(DOS_Shell *shell, int newCP, int opt);
@@ -1425,8 +1424,10 @@ Bitu DOS_ChangeKeyboardLayout(const char* layoutname, int32_t codepage) {
 
 Bitu DOS_ChangeCodepage(int32_t codepage, const char* codepagefile) {
     // try to read the layout for the specified codepage
+    int32_t oldcp = dos.loaded_codepage;
     Bitu kerrcode = loaded_layout->read_codepage_file(codepagefile, codepage);
     if(kerrcode) {
+        loaded_layout->read_codepage_file("auto", oldcp);
         return kerrcode;
     }
     // Everything went fine
@@ -1487,7 +1488,7 @@ public:
 					layoutname = "bg241";
 					break; */
 				case 1028: // Taiwan, CP 950, Alt CP 951
-                    layoutname = "us";
+                    layoutname = "tw";
                     tocp = 950;
                     break;
 				case 1029: // Czech Republic, CP 852, Alt CP 850
@@ -1535,7 +1536,7 @@ public:
                     tocp = 932;
                     break;
 				case 1042: // Korea, CP 949
-                    layoutname = "us";
+                    layoutname = "ko";
                     tocp = 949;
                     break;
 				case 1043: // Netherlands, CP 850, Alt CP 437
@@ -1604,7 +1605,7 @@ public:
 					layoutname = "hy";
 					break; */
 				case 2052: // China, CP 936
-                    layoutname = "us";
+                    layoutname = "cn";
                     tocp = 936;
                     break;
 				case 2055: // Swiss-German, CP 850, Alt CP 437
@@ -1631,7 +1632,7 @@ public:
 					layoutname = "po";
 					break;
 				case 3076: // Hong Kong, CP 950, Alt CP 951
-                    layoutname = "us";
+                    layoutname = "hk";
                     tocp = 950;
                     break;
 				case 3081: // Australia, CP 850, Alt CP 437

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -1448,11 +1448,11 @@ public:
         const Section_prop* section = static_cast<Section_prop*>(configuration);
 		const char * layoutname=section->Get_string("keyboardlayout");
 		dos.loaded_codepage = GetDefaultCP();	// default codepage already initialized
-        int tocp=!stricmp(layoutname, "jp")||IS_JDOSV?932:(!stricmp(layoutname, "ko")||IS_KDOSV?949:(!stricmp(layoutname, "tw")||!stricmp(layoutname, "hk")||!stricmp(layoutname, "zht")||IS_TDOSV?950:(!stricmp(layoutname, "cn")||!stricmp(layoutname, "zh")||!stricmp(layoutname, "zhs")||IS_PDOSV?936:(!stricmp(layoutname, "us")?437:0))));
+        int tocp=!strcmp(layoutname, "jp")||IS_JDOSV?932:(!strcmp(layoutname, "ko")||IS_KDOSV?949:(!strcmp(layoutname, "tw")||!strcmp(layoutname, "hk")||!strcmp(layoutname, "zht")||IS_TDOSV?950:(!strcmp(layoutname, "cn")||!strcmp(layoutname, "zh")||!strcmp(layoutname, "zhs")||IS_PDOSV?936:(!strcmp(layoutname, "us")?437:0))));
 #if defined(WIN32)
 		if (dos.loaded_codepage == 932 && !IS_PC98_ARCH && GetKeyboardType(0) == 7 && !strcmp(layoutname, "auto")) layoutname = "jp106";
 #endif
-        if (tocp && stricmp(layoutname, "jp106") && stricmp(layoutname, "jp") && stricmp(layoutname, "ko") && stricmp(layoutname, "cn") && stricmp(layoutname, "hk") && stricmp(layoutname, "tw")) layoutname="us";
+        if (tocp && strcmp(layoutname, "jp106") && strcmp(layoutname, "jp") && strcmp(layoutname, "ko") && strcmp(layoutname, "cn") && strcmp(layoutname, "hk") && strcmp(layoutname, "tw")) layoutname="us";
 
 #if defined(USE_TTF)
         if (TTF_using()) setTTFCodePage(); else
@@ -1702,11 +1702,11 @@ public:
 /*		if (strncmp(layoutname,"auto",4) && strncmp(layoutname,"none",4)) {
 			LOG_MSG("Loading DOS keyboard layout %s ...",layoutname);
 		} */
-        if(!stricmp(layoutname, "cn") || !stricmp(layoutname, "hk") || !stricmp(layoutname, "tw") || !stricmp(layoutname, "ko")) {
+        if(!strcmp(layoutname, "cn") || !strcmp(layoutname, "hk") || !strcmp(layoutname, "tw") || !strcmp(layoutname, "ko")) {
             loaded_layout->read_keyboard_file("us", 437);
-            if(!stricmp(layoutname, "cn")) dos.loaded_codepage = 936;
-            if(!stricmp(layoutname, "hk") || !stricmp(layoutname, "tw")) dos.loaded_codepage = 950;
-            if(!stricmp(layoutname, "ko")) dos.loaded_codepage = 949;
+            if(!strcmp(layoutname, "cn")) dos.loaded_codepage = 936;
+            if(!strcmp(layoutname, "hk") || !strcmp(layoutname, "tw")) dos.loaded_codepage = 950;
+            if(!strcmp(layoutname, "ko")) dos.loaded_codepage = 949;
         }
         if (!tocp && loaded_layout->read_keyboard_file(layoutname, dos.loaded_codepage)) {
             if (strncmp(layoutname,"auto",4)) {
@@ -1720,14 +1720,14 @@ public:
 		}
         if (tocp && !IS_PC98_ARCH) {
             uint16_t cpbak = dos.loaded_codepage;
-            if((dos.loaded_codepage == 932 || tocp == 932) && (!stricmp(layoutname, "jp106") || !stricmp(layoutname, "jp"))) loaded_layout->read_keyboard_file(layoutname, 932);
-            if(!stricmp(layoutname, "ko") || !stricmp(layoutname, "cn") || !stricmp(layoutname, "tw") || !stricmp(layoutname, "hk")) {
+            if((dos.loaded_codepage == 932 || tocp == 932) && (!strcmp(layoutname, "jp106") || !strcmp(layoutname, "jp"))) loaded_layout->read_keyboard_file(layoutname, 932);
+            if(!strcmp(layoutname, "ko") || !strcmp(layoutname, "cn") || !strcmp(layoutname, "tw") || !strcmp(layoutname, "hk")) {
                 loaded_layout->read_keyboard_file("us", 437);
                 dos.loaded_codepage = tocp;
             }
 
             if (!TTF_using() || (TTF_using() && isSupportedCP(tocp))){
-                toSetCodePage(NULL, msgcodepage ? msgcodepage : tocp, -2);
+                toSetCodePage(NULL, msgcodepage ? msgcodepage : tocp, msgcodepage ? -1: -2);
                 runRescan("-A -Q");
 #if C_OPENGL && DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW
                 if (OpenGL_using() && control->opt_lang.size() && lastcp && lastcp != dos.loaded_codepage)

--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -1142,7 +1142,7 @@ Bitu keyboard_layout::read_codepage_file(const char* codepage_file_name, int32_t
 
 		uint16_t seg=0;
 		uint16_t size=0x1500;
-		if (!DOS_AllocateMemory(&seg,&size)) E_Exit("Not enough free low memory to unpack data");
+        if (!DOS_AllocateMemory(&seg, &size)) E_Exit("Not enough free low memory to unpack data");
 		MEM_BlockWrite(((unsigned int)seg<<4u)+0x100u,cpi_buf,size_of_cpxdata);
 
 		// setup segments
@@ -1704,9 +1704,9 @@ public:
 		} */
         if(!strcmp(layoutname, "cn") || !strcmp(layoutname, "hk") || !strcmp(layoutname, "tw") || !strcmp(layoutname, "ko")) {
             loaded_layout->read_keyboard_file("us", 437);
-            if(!strcmp(layoutname, "cn")) dos.loaded_codepage = 936;
-            if(!strcmp(layoutname, "hk") || !strcmp(layoutname, "tw")) dos.loaded_codepage = 950;
-            if(!strcmp(layoutname, "ko")) dos.loaded_codepage = 949;
+            if(!strcmp(layoutname, "cn")) tocp = 936;
+            if(!strcmp(layoutname, "hk") || !strcmp(layoutname, "tw")) tocp = 950;
+            if(!strcmp(layoutname, "ko")) tocp = 949;
         }
         if (!tocp && loaded_layout->read_keyboard_file(layoutname, dos.loaded_codepage)) {
             if (strncmp(layoutname,"auto",4)) {
@@ -1718,7 +1718,7 @@ public:
 				LOG_MSG("DOS keyboard layout loaded with main language code %s for layout %s",lcode,layoutname);
 			}
 		}
-        if (tocp && !IS_PC98_ARCH) {
+        if ((tocp || msgcodepage) && !IS_PC98_ARCH) {
             uint16_t cpbak = dos.loaded_codepage;
             if((dos.loaded_codepage == 932 || tocp == 932) && (!strcmp(layoutname, "jp106") || !strcmp(layoutname, "jp"))) loaded_layout->read_keyboard_file(layoutname, 932);
             if(!strcmp(layoutname, "ko") || !strcmp(layoutname, "cn") || !strcmp(layoutname, "tw") || !strcmp(layoutname, "hk")) {

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -111,7 +111,7 @@ std::string ldir[256];
 static host_cnv_char_t cpcnv_temp[4096];
 static host_cnv_char_t cpcnv_ltemp[4096];
 host_cnv_char_t *CodePageGuestToHost(const char *s);
-extern bool isDBCSCP(), isKanji1(uint8_t chr), shiftjis_lead_byte(int c);
+bool isDBCSCP(), isKanji1(uint8_t chr), shiftjis_lead_byte(int c), CheckDBCSCP(int32_t codepage);
 extern bool rsize, morelen, force_sfn, enable_share_exe, chinasea, uao, halfwidthkana, dbcs_sbcs, inmsg, forceswk;
 extern int lfn_filefind_handle, freesizecap, file_access_tries;
 extern unsigned long totalc, freec;
@@ -1010,7 +1010,7 @@ bool CodePageGuestToHostUTF8(char *d/*CROSS_LEN*/,const char *s/*CROSS_LEN*/) {
 host_cnv_char_t *CodePageGuestToHost(const char *s) {
 #if defined(host_cnv_use_wchar)
     uint16_t cp = GetACP(), cpbak = dos.loaded_codepage;
-    if (tryconvertcp && !notrycp && cpbak == 437 && (cp == 932 || cp == 936 || cp == 949 || cp == 950 || cp == 951)) {
+    if (tryconvertcp && !notrycp && cpbak == 437 && CheckDBCSCP(cp)) {
         dos.loaded_codepage = cp;
         if (CodePageGuestToHostUTF16((uint16_t *)cpcnv_temp,s)) {
             dos.loaded_codepage = cpbak;
@@ -1030,7 +1030,7 @@ host_cnv_char_t *CodePageGuestToHost(const char *s) {
 char *CodePageHostToGuest(const host_cnv_char_t *s) {
 #if defined(host_cnv_use_wchar)
     uint16_t cp = GetACP(), cpbak = dos.loaded_codepage;
-    if (tryconvertcp && !notrycp && cpbak == 437 && (cp == 932 || cp == 936 || cp == 949 || cp == 950 || cp == 951)) {
+    if (tryconvertcp && !notrycp && cpbak == 437 && CheckDBCSCP(cp)) {
         dos.loaded_codepage = cp;
         if (CodePageHostToGuestUTF16((char *)cpcnv_temp,(const uint16_t *)s)) {
             dos.loaded_codepage = cpbak;
@@ -1050,7 +1050,7 @@ char *CodePageHostToGuest(const host_cnv_char_t *s) {
 char *CodePageHostToGuestL(const host_cnv_char_t *s) {
 #if defined(host_cnv_use_wchar)
     uint16_t cp = GetACP(), cpbak = dos.loaded_codepage;
-    if (tryconvertcp && !notrycp && cpbak == 437 && (cp == 932 || cp == 936 || cp == 949 || cp == 950 || cp == 951)) {
+    if (tryconvertcp && !notrycp && cpbak == 437 && CheckDBCSCP(cp)) {
         dos.loaded_codepage = cp;
         if (CodePageHostToGuestUTF16((char *)cpcnv_ltemp,(const uint16_t *)s)) {
             dos.loaded_codepage = cpbak;

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -41,7 +41,7 @@ extern const uint8_t freedos_mbr[];
 extern int bootdrive, tryconvertcp;
 extern bool int13_disk_change_detect_enable, skipintprog, rsize;
 extern bool int13_extensions_enable, bootguest, bootvm, use_quick_reboot;
-extern bool isDBCSCP(), isKanji1_gbk(uint8_t chr), shiftjis_lead_byte(int c);
+bool isDBCSCP(), isKanji1_gbk(uint8_t chr), shiftjis_lead_byte(int c), CheckDBCSCP(int32_t codepage);
 extern bool CodePageGuestToHostUTF16(uint16_t *d/*CROSS_LEN*/,const char *s/*CROSS_LEN*/);
 
 #define STATIC_ASSERTM(A,B) static_assertion_##A##_##B
@@ -514,7 +514,7 @@ struct fatFromDOSDrive
                         uint16_t uname[4];
 #if defined(WIN32)
                         uint16_t cp = GetACP(), cpbak = dos.loaded_codepage;
-                        if (tryconvertcp && cpbak == 437 && (cp == 932 || cp == 936 || cp == 949 || cp == 950 || cp == 951))
+                        if (tryconvertcp && cpbak == 437 && CheckDBCSCP(cp))
                             dos.loaded_codepage = cp;
 #endif
                         for (size_t i=0; i < lfnlen; i++) {

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -397,26 +397,9 @@ void LoadMessageFile(const char * fname) {
     menu_update_autocycle();
     update_bindbutton_text();
     dos.loaded_codepage=cp;
-    if (loadlangcp && msgcodepage>0 && isSupportedCP(msgcodepage) && msgcodepage != dos.loaded_codepage) {
-        ShutFontHandle();
-        if(CheckDBCSCP(msgcodepage)) {
-            dos.loaded_codepage = msgcodepage;
-            InitFontHandle();
-            JFONT_Init();
-        }
-        if (!IS_DOSV && !IS_JEGA_ARCH) {
-#if defined(USE_TTF)
-            if (ttf.inUse) toSetCodePage(NULL, msgcodepage, -2); else
-#endif
-            {
-                dos.loaded_codepage = msgcodepage;
-                DOSBox_SetSysMenu();
-#if C_OPENGL && DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW
-                if (OpenGL_using() && control->opt_lang.size() && lastcp && lastcp != dos.loaded_codepage)
-                    UpdateSDLDrawTexture();
-#endif
-            }
-            SetKEYBCP();
+    if (loadlangcp && msgcodepage>0) {
+        if(!IS_DOSV && !IS_JEGA_ARCH) {
+            toSetCodePage(NULL, msgcodepage, -1);
         }
     }
     refreshExtChar();

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -94,7 +94,7 @@ void MSG_Replace(const char * _name, const char* _val) {
 
 bool InitCodePage() {
     if (!dos.loaded_codepage || dos_kernel_disabled || force_conversion) {
-        if (((control->opt_langcp && msgcodepage != dos.loaded_codepage) || uselangcp) && msgcodepage>0 && isSupportedCP(msgcodepage)) {
+        if (((control->opt_langcp && msgcodepage != dos.loaded_codepage) || uselangcp) && msgcodepage>0) {
             dos.loaded_codepage = msgcodepage;
             return true;
         }
@@ -103,10 +103,11 @@ bool InitCodePage() {
             char *countrystr = (char *)section->Get_string("country"), *r=strchr(countrystr, ',');
             if (r!=NULL && *(r+1)) {
                 int cp = atoi(trim(r+1));
-                if (cp>0 && isSupportedCP(cp)) {
+                if(cp > 0 && isSupportedCP(cp) && !msgcodepage) {
                     dos.loaded_codepage = cp;
                     return true;
                 }
+                else dos.loaded_codepage = msgcodepage;
             }
         }
         if (msgcodepage>0) {

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -52,6 +52,7 @@ extern const char * RunningProgram;
 Bitu DOS_ChangeKeyboardLayout(const char* layoutname, int32_t codepage);
 Bitu DOS_ChangeCodepage(int32_t codepage, const char* codepagefile);
 Bitu DOS_LoadKeyboardLayout(const char* layoutname, int32_t codepage, const char* codepagefile);
+bool CheckDBCSCP(int32_t codepage);
 
 #define LINE_IN_MAXLEN 2048
 
@@ -204,12 +205,21 @@ void AddMessages() {
     MSG_Add("AUTO_CYCLE_OFF","Auto cycles [off]");
 }
 
+// True if specified codepage is a DBCS codepage
+bool CheckDBCSCP(int32_t codepage) {
+    if(codepage == 932 || codepage == 936 || codepage == 949 || codepage == 950 || codepage == 951) {
+        //LOG_MSG("CheckDBCSCP: Codepage %d true", codepage);
+        return true;
+    }
+    else return false;
+}
+
 void MSG_Init(void);
 void SetKEYBCP() {
     if (IS_PC98_ARCH || IS_JEGA_ARCH || IS_DOSV || dos_kernel_disabled || !strcmp(RunningProgram, "LOADLIN")) return;
     Bitu return_code;
 
-    if(msgcodepage == 932 || msgcodepage == 936 || msgcodepage == 949 || msgcodepage == 950 || msgcodepage == 951) {
+    if(CheckDBCSCP(msgcodepage)) {
         MSG_Init();
         InitFontHandle();
         JFONT_Init();
@@ -389,7 +399,7 @@ void LoadMessageFile(const char * fname) {
     dos.loaded_codepage=cp;
     if (loadlangcp && msgcodepage>0 && isSupportedCP(msgcodepage) && msgcodepage != dos.loaded_codepage) {
         ShutFontHandle();
-        if(msgcodepage == 932 || msgcodepage == 936 || msgcodepage == 949 || msgcodepage == 950 || msgcodepage == 951) {
+        if(CheckDBCSCP(msgcodepage)) {
             dos.loaded_codepage = msgcodepage;
             InitFontHandle();
             JFONT_Init();
@@ -486,7 +496,7 @@ void MSG_Init() {
                 sprintf(cstr, "%s,%d", countrystr, msgcodepage);
                 SetVal("config", "country", cstr);
                 const char *imestr = section->Get_string("ime");
-                if (tonoime && !strcasecmp(imestr, "auto") && (msgcodepage == 932 || msgcodepage == 936 || msgcodepage == 949 || msgcodepage == 950 || msgcodepage == 951)) {
+                if (tonoime && !strcasecmp(imestr, "auto") && CheckDBCSCP(msgcodepage)) {
                     tonoime = false;
                     enableime = true;
                     SetIME();

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -52,7 +52,9 @@ extern const char * RunningProgram;
 Bitu DOS_ChangeKeyboardLayout(const char* layoutname, int32_t codepage);
 Bitu DOS_ChangeCodepage(int32_t codepage, const char* codepagefile);
 Bitu DOS_LoadKeyboardLayout(const char* layoutname, int32_t codepage, const char* codepagefile);
+const char* DOS_GetLoadedLayout(void);
 bool CheckDBCSCP(int32_t codepage);
+void MSG_Init(void);
 
 #define LINE_IN_MAXLEN 2048
 
@@ -214,7 +216,6 @@ bool CheckDBCSCP(int32_t codepage) {
     else return false;
 }
 
-void MSG_Init(void);
 void SetKEYBCP() {
     if (IS_PC98_ARCH || IS_JEGA_ARCH || IS_DOSV || dos_kernel_disabled || !strcmp(RunningProgram, "LOADLIN")) return;
     Bitu return_code;
@@ -398,7 +399,8 @@ void LoadMessageFile(const char * fname) {
     update_bindbutton_text();
     dos.loaded_codepage=cp;
     if (loadlangcp && msgcodepage>0) {
-        if(!IS_DOSV && !IS_JEGA_ARCH) {
+        const char* layoutname = DOS_GetLoadedLayout();
+        if(!IS_DOSV && !IS_JEGA_ARCH && layoutname != NULL) {
             toSetCodePage(NULL, msgcodepage, -1);
         }
     }

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -46,7 +46,7 @@ bool isSupportedCP(int newCP), CodePageHostToGuestUTF8(char *d/*CROSS_LEN*/,cons
 void InitFontHandle(void), ShutFontHandle(void), refreshExtChar(void), SetIME(void), runRescan(const char *str), menu_update_dynamic(void), menu_update_autocycle(void), update_bindbutton_text(void), set_eventbutton_text(const char *eventname, const char *buttonname), JFONT_Init(), DOSBox_SetSysMenu(), UpdateSDLDrawTexture(), makestdcp950table(), makeseacp951table();
 std::string langname = "", langnote = "", GetDOSBoxXPath(bool withexe=false);
 extern int lastcp, FileDirExistUTF8(std::string &localname, const char *name), toSetCodePage(DOS_Shell *shell, int newCP, int opt);
-extern bool dos_kernel_disabled, force_conversion, showdbcs, dbcs_sbcs, enableime, tonoime, chinasea;
+extern bool dos_kernel_disabled, force_conversion, showdbcs, dbcs_sbcs, enableime, tonoime, chinasea, CHCP_changed;
 extern uint16_t GetDefaultCP();
 extern const char * RunningProgram;
 Bitu DOS_ChangeKeyboardLayout(const char* layoutname, int32_t codepage);
@@ -335,7 +335,7 @@ void LoadMessageFile(const char * fname) {
                         }
                         else {
                             std::string msg = "The specified language file uses code page " + std::to_string(c) + ". Do you want to change to this code page accordingly?";
-                            if(c != dos.loaded_codepage && (control->opt_langcp || uselangcp || !loadlang || (loadlang && systemmessagebox("DOSBox-X language file", msg.c_str(), "yesno", "question", 1)))){
+                            if(c != dos.loaded_codepage && (control->opt_langcp || uselangcp || !CHCP_changed || !loadlang || (loadlang && systemmessagebox("DOSBox-X language file", msg.c_str(), "yesno", "question", 1)))){
                                 loadlangcp = true;
                                 msgcodepage = c;
                                 dos.loaded_codepage = c;

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -335,7 +335,7 @@ void LoadMessageFile(const char * fname) {
                         }
                         else {
                             std::string msg = "The specified language file uses code page " + std::to_string(c) + ". Do you want to change to this code page accordingly?";
-                            if(c != dos.loaded_codepage && (control->opt_langcp || uselangcp || !CHCP_changed || !loadlang || (loadlang && systemmessagebox("DOSBox-X language file", msg.c_str(), "yesno", "question", 1)))){
+                            if(c != dos.loaded_codepage && (control->opt_langcp || uselangcp || !CHCP_changed || CheckDBCSCP(c) || !loadlang || (loadlang && systemmessagebox("DOSBox-X language file", msg.c_str(), "yesno", "question", 1)))) {
                                 loadlangcp = true;
                                 msgcodepage = c;
                                 dos.loaded_codepage = c;

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -726,7 +726,7 @@ void dos_ver_menu(bool start), ReloadMapper(Section_prop *sec, bool init), SetGa
 bool set_ver(char *s), GFX_IsFullscreen(void);
 
 void Load_Language(std::string name) {
-    if (control->opt_lang != "") control->opt_lang = name;
+    control->opt_lang = name;
     MSG_Init();
 #if DOSBOXMENU_TYPE == DOSBOXMENU_HMENU || DOSBOXMENU_TYPE == DOSBOXMENU_NSMENU
     mainMenu.unbuild();
@@ -738,12 +738,14 @@ void Load_Language(std::string name) {
 #if defined(USE_TTF)
     if (TTF_using()) resetFontSize();
 #endif
+#if 0
     if (!uselangcp && !incall) {
         int oldmsgcp = msgcodepage;
         msgcodepage = dos.loaded_codepage;
         SetKEYBCP();
         msgcodepage = oldmsgcp;
     }
+#endif
 }
 
 void ApplySetting(std::string pvar, std::string inputline, bool quiet) {

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -726,7 +726,7 @@ void dos_ver_menu(bool start), ReloadMapper(Section_prop *sec, bool init), SetGa
 bool set_ver(char *s), GFX_IsFullscreen(void);
 
 void Load_Language(std::string name) {
-    control->opt_lang = name;
+    if(control->opt_lang != "") control->opt_lang = name;
     MSG_Init();
 #if DOSBOXMENU_TYPE == DOSBOXMENU_HMENU || DOSBOXMENU_TYPE == DOSBOXMENU_NSMENU
     mainMenu.unbuild();

--- a/src/output/output_ttf.cpp
+++ b/src/output/output_ttf.cpp
@@ -125,6 +125,7 @@ bool init_once = false, init_twice = false;
 int menuwidth_atleast(int width), FileDirExistCP(const char *name), FileDirExistUTF8(std::string &localname, const char *name);
 void AdjustIMEFontSize(void),refreshExtChar(void), initcodepagefont(void), change_output(int output), drawmenu(Bitu val), KEYBOARD_Clear(void), RENDER_Reset(void), DOSBox_SetSysMenu(void), GetMaxWidthHeight(unsigned int *pmaxWidth, unsigned int *pmaxHeight), SetWindowTransparency(int trans), resetFontSize(void), RENDER_CallBack( GFX_CallBackFunctions_t function );
 bool isDBCSCP(void), InitCodePage(void), CodePageGuestToHostUTF16(uint16_t *d/*CROSS_LEN*/,const char *s/*CROSS_LEN*/), systemmessagebox(char const * aTitle, char const * aMessage, char const * aDialogType, char const * aIconType, int aDefaultButton);
+bool CheckDBCSCP(int32_t codepage);
 std::string GetDOSBoxXPath(bool withexe=false);
 
 #if defined(C_SDL2)
@@ -502,14 +503,14 @@ int setTTFMap(bool changecp) {
         uname[0]=0;
         uname[1]=0;
         if (cp == 932 && (halfwidthkana || IS_JEGA_ARCH)) forceswk=true;
-        if (cp == 932 || cp == 936 || cp == 949 || cp == 950 || cp == 951) dos.loaded_codepage = 437;
+        if (CheckDBCSCP(cp)) dos.loaded_codepage = 437;
         if (CodePageGuestToHostUTF16(uname,text)) {
             wcTest[i] = uname[1]==0?uname[0]:i;
             if (cp == 932 && lowboxdrawmap.find(i)!=lowboxdrawmap.end() && TTF_GlyphIsProvided(ttf.SDL_font, wcTest[i]))
                 cpMap[i] = wcTest[i];
         }
         forceswk=false;
-        if (cp == 932 || cp == 936 || cp == 949 || cp == 950 || cp == 951) dos.loaded_codepage = cp;
+        if (CheckDBCSCP(cp)) dos.loaded_codepage = cp;
     }
     uint16_t unimap;
     int notMapped = 0;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -77,7 +77,7 @@ void initcodepagefont(void);
 void runMount(const char *str);
 void ResolvePath(std::string& in);
 void DOS_SetCountry(uint16_t countryNo);
-void SwitchLanguage(int oldcp, int newcp, bool confirm);
+bool SwitchLanguage(int oldcp, int newcp, bool confirm);
 void CALLBACK_DeAllocate(Bitu in), DOSBox_ConsolePauseWait();
 void GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused);
 bool isDBCSCP(), InitCodePage(), isKanji1(uint8_t chr), shiftjis_lead_byte(int c), sdl_wait_on_error();

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -4526,7 +4526,7 @@ void DOS_Shell::CMD_COUNTRY(char * args) {
 	return;
 }
 
-extern bool jfont_init, isDBCSCP();
+extern bool jfont_init, finish_prepare, isDBCSCP();
 extern Bitu DOS_LoadKeyboardLayout(const char * layoutname, int32_t codepage, const char * codepagefile);
 void runRescan(const char *str), MSG_Init(), JFONT_Init(), InitFontHandle(), ShutFontHandle(), initcodepagefont(), DOSBox_SetSysMenu();
 int toSetCodePage(DOS_Shell *shell, int newCP, int opt) {
@@ -4567,7 +4567,7 @@ int toSetCodePage(DOS_Shell *shell, int newCP, int opt) {
             JFONT_Init();
             SetupDBCSTable();
         }
-        runRescan("-A -Q");
+        if (finish_prepare) runRescan("-A -Q");
 #if defined(USE_TTF)
         if ((opt==-1||opt==-2)&&TTF_using()) {
             Section_prop * ttf_section = static_cast<Section_prop *>(control->GetSection("ttf"));

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -140,6 +140,7 @@ extern void MAPPER_AutoType(std::vector<std::string> &sequence, const uint32_t w
 extern void DOS_SetCountry(uint16_t countryNo), DOSV_FillScreen(void);
 std::string GetDOSBoxXPath(bool withexe=false);
 FILE *testLoadLangFile(const char *fname);
+bool CheckDBCSCP(int32_t codepage);
 
 /* support functions */
 static char empty_char = 0;
@@ -4599,7 +4600,7 @@ void DOS_Shell::CMD_CHCP(char * args) {
     int32_t cp = dos.loaded_codepage;
     Bitu keyb_error;
     if(n == 1) {
-        if(newCP == 932 || newCP == 936 || newCP == 949 || newCP == 950 || newCP == 951
+        if(CheckDBCSCP(newCP)
 #if defined(USE_TTF)
             || (ttf.inUse && (newCP >= 1250 && newCP <= 1258))
 #endif
@@ -4636,7 +4637,7 @@ void DOS_Shell::CMD_CHCP(char * args) {
         if(*buff == ':' && strchr(StripArg(args), ':')) {
             std::string name = buff + 1;
             if(name.empty() && iter != langcp_map.end()) name = iter->second;
-            if(newCP == 932 || newCP == 936 || newCP == 949 || newCP == 950 || newCP == 951) {
+            if(CheckDBCSCP(newCP)) {
                 missing = toSetCodePage(this, newCP, -1);
                 if(missing > -1) SwitchLanguage(cp, newCP, true);
                 if(missing > 0) WriteOut(MSG_Get("SHELL_CMD_CHCP_MISSING"), missing);


### PR DESCRIPTION
This PR fixes display may be corrupted when loading language files at launch.

`dosbox-x -lang zh_tw -set output=ttf -set keyboardlayout=auto`

Edit: Fixed some regressions, and this PR is ready to be merged.

Before fix
![image](https://github.com/user-attachments/assets/439e0f8a-b559-4c2c-a181-e5a17c517be7)

After fix
![image](https://github.com/user-attachments/assets/6ec2fd10-b6ae-4128-ba9a-f4ae02bacd85)
