### PR TITLE
Fix Z Drive path expansion to be case insensitive

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+Next
+  - Fixed Z Drive path expansion to be case insensitive (maron2000)
+
 2024.10.01
   - Allow the ".inst" extension for CUE sheets. (Allofich)
   - Add SET /FIRST, a DOSBox-X extension, that takes the specified
@@ -96,6 +99,7 @@
     - retain 'show advanced options' state throughout session
   - SVN r4483: Fix compilation in Visual Studio 2008 (Allofich)
   - DOSBox Staging: Decouple CMS and OPL emulations (Allofich)
+  - Fixed reading NEC specific character font data.(nanshiki)
 
 2024.07.01
   - Correct Hercules InColor memory emulation. Read and write planar

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -2810,7 +2810,7 @@ void DOS_Shell::CMD_SET(char * args) {
 				WriteOut(MSG_Get("SHELL_CMD_SET_NOT_SET"),env_name.c_str());
 			break;
 		case set_env:
-			if (zdirpath && env_name == "path") GetExpandedPath(env_value);
+            if(zdirpath && !strcasecmp(env_name.c_str(), "path")) GetExpandedPath(env_value);
 
 			/* No parsing is needed. The command interpreter does the variable substitution for us */
 			/* NTS: If Win95 is any example, the command interpreter expands the variables for us */


### PR DESCRIPTION
If you add `Z:\` to `PATH`, it should be expanded to `Z:\;Z:\SYSTEM;Z:\BIN;Z:\DOS;Z:\4DOS;Z:\DEBUG;Z:\TEXTUTIL`.
The current release (2024.10.01) expands it only if you set `path` in lower case.
This PR makes it case-insensitive so that it accepts `PATH` (or mixture like `Path`) as well.

## What issue(s) does this PR address?
Fixes #5232

![image](https://github.com/user-attachments/assets/98d56ef1-b4aa-4d11-bb2f-e9c6f60a9ee1)
