### PR TITLE
Update 20241001.md

### DIFF
--- a/_release_notes/20241001.md
+++ b/_release_notes/20241001.md
@@ -44,3 +44,4 @@ date: October 1, 2024
     - retain 'show advanced options' state throughout session
 - SVN r4483: Fix compilation in Visual Studio 2008 (Allofich)
 - DOSBox Staging: Decouple CMS and OPL emulations (Allofich)
+- Fixed reading NEC specific character font data.(nanshiki)


### PR DESCRIPTION
Per latest CHANGELOG update

The same update applies to the [release page notes](https://github.com/joncampbell123/dosbox-x/releases/tag/dosbox-x-v2024.10.01), but I don't think my account can do that.