### PR TITLE
Add an option not to pause after host program execution is completed

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
 Next
+  - Added an option not to pause after host program execution is 
+    completed (maron2000)
+  - Fixed corrupted display when loading language files at launch
+    (maron2000)
   - Fixed Z Drive path expansion to be case insensitive (maron2000)
 
 2024.10.01

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -843,6 +843,7 @@ void HostAppRun() {
     char comline[256], *p=comline;
     char winDirCur[512], winDirNew[512], winName[256], dir[CROSS_LEN+15];
     char *fullname=appname;
+    std::string winPath;
     uint8_t drive;
     if (!DOS_MakeName(fullname, winDirNew, &drive)) return;
     bool net = false;
@@ -891,6 +892,16 @@ void HostAppRun() {
         } else {
             strcpy(winDirNew, useoverlay?odp->getOverlaydir():Drives[drive]->GetBaseDir());
             strcat(winDirNew, Drives[drive]->curdir);
+        }
+        if(!(std::isalpha(winDirNew[0]) && winDirNew[1] == ':') && winDirNew[0] != '\\') {
+            //LOG_MSG("not a absolute path");
+            winPath = winDirCur + std::string("\\") + std::string(winDirNew);
+            strcpy(winDirNew, winPath.c_str());
+        }
+        if(!(std::isalpha(winName[0]) && winName[1] == ':') && winName[0] != '\\') {
+            //LOG_MSG("not a absolute path");
+            winPath = winDirCur + std::string("\\") + std::string(winName);
+            strcpy(winName, winPath.c_str());
         }
         if (SetCurrentDirectory(winDirNew)||net) {
             SHELLEXECUTEINFO lpExecInfo;

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -912,9 +912,9 @@ void HostAppRun() {
                 lpExecInfo.lpDirectory = NULL;
                 lpExecInfo.nShow = SW_SHOW;
                 lpExecInfo.hInstApp = (HINSTANCE) SE_ERR_DDEFAIL;
-                strcpy(dir, "/C \"");
+                strcpy(dir, "/C \"\"");
                 strcat(dir, winName);
-                strcat(dir, " ");
+                strcat(dir, "\" ");
                 strcat(dir, comline);
                 strcat(dir, " & echo( & echo The command execution is completed.");
                 startnopause = section->Get_bool("startnopause");
@@ -953,7 +953,6 @@ void HostAppRun() {
                         char msg[]="(Press Ctrl+C to exit immediately)\r\n";
                         uint16_t s = (uint16_t)strlen(msg);
                         DOS_WriteFile(STDOUT,(uint8_t*)msg,&s);
-                        runRescan(" -A -Q");
                     }
                 }
                 dos.return_code = exitCode&255;
@@ -965,6 +964,7 @@ void HostAppRun() {
                 hret = errno;
             DOS_SetError((uint16_t)hret);
             hret=0;
+            runRescan(" -A -Q");
             return;
         } else if (startquiet) {
             char msg[]="This program cannot be run in DOS mode.\r\n";

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -893,12 +893,12 @@ void HostAppRun() {
             strcpy(winDirNew, useoverlay?odp->getOverlaydir():Drives[drive]->GetBaseDir());
             strcat(winDirNew, Drives[drive]->curdir);
         }
-        if(!(std::isalpha(winDirNew[0]) && winDirNew[1] == ':') && winDirNew[0] != '\\') {
+        if(!(isalpha(winDirNew[0]) && winDirNew[1] == ':') && winDirNew[0] != '\\') {
             //LOG_MSG("not a absolute path");
             winPath = winDirCur + std::string("\\") + std::string(winDirNew);
             strcpy(winDirNew, winPath.c_str());
         }
-        if(!(std::isalpha(winName[0]) && winName[1] == ':') && winName[0] != '\\') {
+        if(!(isalpha(winName[0]) && winName[1] == ':') && winName[0] != '\\') {
             //LOG_MSG("not a absolute path");
             winPath = winDirCur + std::string("\\") + std::string(winName);
             strcpy(winName, winPath.c_str());

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -4731,6 +4731,10 @@ void DOSBOX_SetupConfigSections(void) {
     Pstring = secprop->Add_string("startincon",Property::Changeable::OnlyAtStart,"assoc attrib chcp copy dir echo for ftype help if set type ver vol xcopy");
     Pstring->Set_help("START command will start these commands (separated by space) in a console and wait for a key press before exiting.");
 
+    Pbool = secprop->Add_bool("startnopause", Property::Changeable::WhenIdle, false);
+    Pbool->Set_help("If set, DOSBox-X will not pause after host command execution is completed.");
+    Pbool->SetBasic(true);
+
     Pbool = secprop->Add_bool("vmware",Property::Changeable::WhenIdle,true);
     Pbool->Set_help("Enable VMware interface emulation including guest mouse integration (when used along with e.g. VMware mouse driver for Windows 3.x).");
     Pbool->SetBasic(true);


### PR DESCRIPTION
Add option `startnopause`, if set to true, command execution will complete without waiting for a key press.

## What issue(s) does this PR address?
Closes #5238
