### PR TITLE
Fix crash when changing floppies mounted by drive numbers on a booted guest OS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,10 @@
 Next
+  - Fixed crashes when changing floppies mounted by drive numbers on
+    a booted guest OS (maron2000)
+  - Fixed launching host programs with white spaces in path (Windows)
+    (maron2000)
+  - Convert paths from relative to absolute when launching host programs
+    in a mounted drive (Windows) (maron2000) 
   - Added an option not to pause after host program execution is 
     completed (maron2000)
   - Fixed corrupted display when loading language files at launch

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -58,6 +58,7 @@ extern bool CodePageGuestToHostUTF16(uint16_t *d/*CROSS_LEN*/,const char *s/*CRO
 extern bool CodePageHostToGuestUTF16(char *d/*CROSS_LEN*/,const uint16_t *s/*CROSS_LEN*/);
 extern bool wild_match(const char* haystack, char* needle);
 bool systemmessagebox(char const * aTitle, char const * aMessage, char const * aDialogType, char const * aIconType, int aDefaultButton);
+extern bool dos_kernel_disabled;
 
 int PC98AutoChoose_FAT(const std::vector<_PC98RawPartition> &parts,imageDisk *loadedDisk) {
         for (size_t i=0;i < parts.size();i++) {
@@ -1343,7 +1344,7 @@ fatDrive::fatDrive(const char* sysFilename, uint32_t bytesector, uint32_t cylsec
 	uint32_t filesize;
 	unsigned char bootcode[256];
 
-	if(imgDTASeg == 0) {
+	if(!dos_kernel_disabled && imgDTASeg == 0) {
 		imgDTASeg = DOS_GetMemory(4,"imgDTASeg");
 		imgDTAPtr = RealMake(imgDTASeg, 0);
 		imgDTA    = new DOS_DTA(imgDTAPtr);


### PR DESCRIPTION
This PR fixes a crash when changing floppies mounted by drive numbers on a booted guest OS.

## What issue(s) does this PR address?
Fixes #5179
Probably Fixes #4557
