### PR TITLE
Fix fullscreen mode not responding when launched in TTF mode (Windows)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 Next
+  - Fixed fullscreen mode not responding when launched in TTF mode 
+    in Windows (maron2000)
   - Fixed crashes when changing floppies mounted by drive numbers on
     a booted guest OS (maron2000)
   - Fixed launching host programs with white spaces in path (Windows)

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3809,8 +3809,12 @@ static void GUI_StartUp() {
     posy = -1;
     const char* windowposition = section->Get_string("windowposition");
     LOG_MSG("Configured windowposition: %s", windowposition);
-    if (windowposition && !strcmp(windowposition, "-"))
+    if(windowposition && !strcmp(windowposition, "-"))
+#if defined (WIN32) && !defined(C_SDL2)
+        posx = posy = -1;
+#else
         posx = posy = -2;
+#endif
     else if (windowposition && *windowposition && strcmp(windowposition, ",")) {
         char result[100];
         safe_strncpy(result, windowposition, sizeof(result));

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -880,7 +880,7 @@ void DOS_Shell::Prepare(void) {
                     }
                 }
             }
-			if (country>0&&!control->opt_noconfig) {
+            if (country>0&&!control->opt_noconfig) {
 				countryNo = country;
 				DOS_SetCountry(countryNo);
 			}
@@ -1139,7 +1139,6 @@ public:
                 }
                 if (control->opt_prerun) cmd += "\n";
             }
-
             autoexec_auto_bat.Install(cmd);
         }
         dos.loaded_codepage = cp;
@@ -1264,7 +1263,12 @@ public:
 #else
 		if (secure) autoexec[i++].Install("z:\\system\\config.com -securemode");
 #endif
-
+#if defined(WIN32)
+        if(TTF_using()) {
+            autoexec[i++].Install("@config -set output=surface");
+            autoexec[i++].Install("@config -set output=ttf");
+        }
+#endif
 		if (addexit) autoexec[i++].Install("exit");
 
 		assert(i <= 17); /* FIXME: autoexec[] should not be fixed size */


### PR DESCRIPTION
On Windows, DOSBox-X didn't respond when switched to fullscreen in TTF mode.

Tested on Visual Studio SDL1 & SDL2

Fixes #5142

Edit: This should be a problem for Windows (VS & MinGW) SDL2 builds.
        As far as I roughly tested, there seems no problem for mac & Linux (ArchLinux) builds.