### PR TITLE
Change order of menubar to cope with inaccessible items due to overlapped menus

### DIFF
--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -124,10 +124,10 @@ static const char *def_menu__toplevel[] =
     "VideoMenu",
     "SoundMenu",
     "DOSMenu",
+    "DriveMenu",
 #if !defined(C_EMSCRIPTEN)
     "CaptureMenu",
 #endif
-    "DriveMenu",
 #if C_DEBUG
     "DebugMenu",
 #endif
@@ -709,9 +709,9 @@ static const char *def_menu_capture[] =
     "mapper_capnetrf",
     "--",
 #endif
-    "saveoptionmenu",
     "mapper_savestate",
     "mapper_loadstate",
+    "saveoptionmenu",
     "saveslotmenu",
     "autosavecfg",
     "browsesavefile",
@@ -860,7 +860,7 @@ static const char* def_menu_help_debug[] =
 static const char *def_menu_help[] =
 {
     "help_intro",
-    "HelpCommandMenu",
+    "help_about",
 #if !defined(HX_DOS)
     "--",
     "help_homepage",
@@ -880,7 +880,7 @@ static const char *def_menu_help[] =
 #if C_PCAP || C_PRINTER && defined(WIN32) || !C_DEBUG && !defined(MACOSX) && !defined(LINUX) && !defined(HX_DOS) && !defined(C_EMSCRIPTEN)
     "--",
 #endif
-    "help_about",
+    "HelpCommandMenu",
     NULL
 };
 


### PR DESCRIPTION
Some items in the SDL drawn menu were not accessible due to the overlapping of items.
This PR swaps some orders of the item to make it accessible.

1. "Drive" menu and "Capture" menu are swapped
2.  Move "Save/Load options"
3.  Swap "DOS command"reference and "About DOSBox-X"

## What issue(s) does this PR address?
Fixes #5249

![image](https://github.com/user-attachments/assets/acd0e626-95fa-4a88-be77-84105fee0b35)
![image](https://github.com/user-attachments/assets/fb0deab1-a202-4b9f-b762-aff8380c81e1)
![image](https://github.com/user-attachments/assets/57b067f3-9e4e-4f9a-a62b-156e8a9085ce)

Useful for Japanese users as well.
![image](https://github.com/user-attachments/assets/a05c9cc6-1587-4743-af93-449eb80a5418)

