### PR TITLE
Fix build failure with libc++19

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 Next
+  - Fixed build failure with libc++ 19 (@DimitryAndric)
   - Fixed crashes when changing floppies mounted by drive numbers on
     a booted guest OS (maron2000)
   - Fixed launching host programs with white spaces in path (Windows)

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -81,7 +81,7 @@ host_cnv_char_t *CodePageGuestToHost(const char *s);
 #endif
 #ifdef C_ICONV
 #include "iconvpp.hpp"
-typedef uint16_t test_char_t;
+typedef char16_t test_char_t;
 typedef std::basic_string<test_char_t> test_string;
 typedef std::basic_string<char> test_char;
 #endif
@@ -102,6 +102,9 @@ bool mountwarning = true;
 bool qmount = false;
 bool nowarn = false;
 bool CodePageHostToGuestUTF8(char *d/*CROSS_LEN*/,const char *s/*CROSS_LEN*/), CodePageHostToGuestUTF16(char *d/*CROSS_LEN*/,const uint16_t *s/*CROSS_LEN*/);
+inline bool CodePageHostToGuestUTF16(char *d/*CROSS_LEN*/,const char16_t *s/*CROSS_LEN*/) {
+    return CodePageHostToGuestUTF16(d, reinterpret_cast<const uint16_t *>(s));
+}
 extern bool systemmessagebox(char const * aTitle, char const * aMessage, char const * aDialogType, char const * aIconType, int aDefaultButton);
 extern bool addovl, addipx, addne2k, prepared, inshell, usecon, uao, loadlang, morelen, mountfro[26], mountiro[26], resetcolor, staycolors, printfont, notrycp, internal_program;
 extern bool clear_screen(), OpenGL_using(void), DOS_SetAnsiAttr(uint8_t attr), isDBCSCP();

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -39,7 +39,11 @@ static uint16_t sdid[256];
 extern int lfn_filefind_handle;
 extern bool gbk, isDBCSCP(), isKanji1_gbk(uint8_t chr), shiftjis_lead_byte(int c);
 extern bool filename_not_8x3(const char *n), filename_not_strict_8x3(const char *n);
-extern bool CodePageHostToGuestUTF16(char *d/*CROSS_LEN*/,const uint16_t *s/*CROSS_LEN*/);
+bool CodePageHostToGuestUTF16(char *d/*CROSS_LEN*/,const uint16_t *s/*CROSS_LEN*/);
+inline bool CodePageHostToGuestUTF16(uint8_t *d/*CROSS_LEN*/,const uint8_t *s/*CROSS_LEN*/) {
+    std::u16string u16s(reinterpret_cast<const char16_t *>(s));
+    return CodePageHostToGuestUTF16(reinterpret_cast<char *>(d), reinterpret_cast<const uint16_t *>(u16s.c_str()));
+}
 
 using namespace std;
 
@@ -1762,7 +1766,7 @@ int isoDrive::readDirEntry(isoDirEntry* de, const uint8_t* data,unsigned int dir
 				// The string is big Endian UCS-16, convert to host Endian UCS-16
 				for (size_t i=0;((const uint16_t*)de->ident)[i] != 0;i++) ((uint16_t*)de->ident)[i] = be16toh(((uint16_t*)de->ident)[i]);
 				// finally, convert from UCS-16 to local code page, using C++ string construction to make a copy first
-				CodePageHostToGuestUTF16((char*)de->ident,std::basic_string<uint16_t>((const uint16_t*)de->ident).c_str());
+				CodePageHostToGuestUTF16(de->ident,de->ident);
 			}
 		}
 	} else {
@@ -1784,7 +1788,7 @@ int isoDrive::readDirEntry(isoDirEntry* de, const uint8_t* data,unsigned int dir
 			// The string is big Endian UCS-16, convert to host Endian UCS-16
 			for (size_t i=0;((const uint16_t*)de->ident)[i] != 0;i++) ((uint16_t*)de->ident)[i] = be16toh(((uint16_t*)de->ident)[i]);
 			// finally, convert from UCS-16 to local code page, using C++ string construction to make a copy first
-			CodePageHostToGuestUTF16((char*)de->ident,std::basic_string<uint16_t>((const uint16_t*)de->ident).c_str());
+			CodePageHostToGuestUTF16(de->ident,de->ident);
 		}
 		else {
 			// remove any file version identifiers as there are some cdroms that don't have them


### PR DESCRIPTION
As noted in the libc++ 19 release notes [[1]](https://libcxx.llvm.org/ReleaseNotes/19.html#deprecations-and-removals), `std::char_traits<>` is now only provided for `char`, `char8_t`, `char16_t`, `char32_t` and `wchar_t`, and any instantiation for other types will fail.
This PR fixes such build errors.

Credit of this PR goes to @DimitryAndric.

## What issue(s) does this PR address?
Fixes #5259
