### PR TITLE
Reflect "Autolock mouse" gui menu

### DIFF
--- a/src/gui/menu_callback.cpp
+++ b/src/gui/menu_callback.cpp
@@ -2533,6 +2533,7 @@ bool autolock_mouse_menu_callback(DOSBoxMenu * const menu, DOSBoxMenu::item * co
     (void)menuitem;//UNUSED
     sdl.mouse.autoenable = !sdl.mouse.autoenable;
     mainMenu.get_item("auto_lock_mouse").check(sdl.mouse.autoenable).refresh_item(mainMenu);
+    Mouse_AutoLock(sdl.mouse.autoenable);
     return true;
 }
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3944,9 +3944,6 @@ void Mouse_AutoLock(bool enable) {
     }
 #endif // C_GAMELINK
 
-    if (sdl.mouse.autolock == enable)
-        return;
-
     sdl.mouse.autolock=enable;
     if (sdl.mouse.autoenable) sdl.mouse.requestlock=enable;
     else {

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -4471,6 +4471,8 @@ static void HandleMouseButton(SDL_MouseButtonEvent * button, SDL_MouseMotionEven
 #endif
     bool inputToScreen = false;
     bool inMenu = false;
+    Section_prop * section=static_cast<Section_prop *>(control->GetSection("sdl"));
+    std::string munlock;
 
 #if DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW /* SDL drawn menus */
     if (GFX_GetPreventFullscreen()) {
@@ -4996,7 +4998,8 @@ static void HandleMouseButton(SDL_MouseButtonEvent * button, SDL_MouseMotionEven
             // Don't pass click to mouse handler
             break;
         }
-        if (((middleunlock == 1 && !sdl.mouse.autoenable) || (middleunlock == 2 && sdl.mouse.autoenable) || middleunlock == 3) && sdl.mouse.autolock && mouse_notify_mode == 0 && button->button == SDL_BUTTON_MIDDLE) {
+        munlock = section->Get_string("middle_unlock");
+        if (((munlock == "manual" && !sdl.mouse.autoenable) || (munlock == "auto" && sdl.mouse.autoenable) || munlock == "both") && mouse_notify_mode == 0 && button->button == SDL_BUTTON_MIDDLE) {
             GFX_CaptureMouse();
             break;
         }


### PR DESCRIPTION
This PR fixes Issue #1532 Toggling the menu option "Autolock mouse" does nothing
Tested on VS x64 SDL2 build on Windows 10 22H2, booting Windows 98 as guest.

## What issue(s) does this PR address?
Fixes #1532
