### PR TITLE
Suppress redundant screen reports in log

### DIFF
--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -471,6 +471,8 @@ std::string RENDER_GetScaler(void) {
     return prop->GetSection()->Get_string("type");
 }
 
+static int aspect_x=0, aspect_y=0;
+
 void RENDER_Reset( void ) {
     Bitu width=render.src.width;
     Bitu height=render.src.height;
@@ -750,7 +752,11 @@ forcenormal:
     sdl.srcAspect.y = aspect_ratio_y>0?aspect_ratio_y:(int)floor((render.src.height * (render.src.dblh ? 2 : 1) * render.src.ratio) + 0.5);
     sdl.srcAspect.xToY = (double)sdl.srcAspect.x / sdl.srcAspect.y;
     sdl.srcAspect.yToX = (double)sdl.srcAspect.y / sdl.srcAspect.x;
-    LOG_MSG("Aspect ratio: %u x %u  xToY=%.3f yToX=%.3f",sdl.srcAspect.x,sdl.srcAspect.y,sdl.srcAspect.xToY,sdl.srcAspect.yToX);
+    if(aspect_x != sdl.srcAspect.x || aspect_y != sdl.srcAspect.y) {
+        LOG_MSG("Aspect ratio: %u x %u  xToY=%.3f yToX=%.3f", sdl.srcAspect.x, sdl.srcAspect.y, sdl.srcAspect.xToY, sdl.srcAspect.yToX);
+        aspect_x = sdl.srcAspect.x;
+        aspect_y = sdl.srcAspect.y;
+    }
 /* Setup the scaler variables */
 #if C_OPENGL
     GFX_SetShader(render.shader_src);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -698,6 +698,8 @@ void UpdateWindowDimensions(Bitu width, Bitu height)
     currentWindowHeight = height;
 }
 
+static Bitu dim_width=0, dim_height=0, dpi_width=0, dpi_height=0;
+
 void PrintScreenSizeInfo(void) {
 #if 1
     const char *method = "?";
@@ -708,10 +710,12 @@ void PrintScreenSizeInfo(void) {
         case METHOD_XRANDR:     method = "XRandR";      break;
         case METHOD_WIN98BASE:  method = "Win98base";   break;
         case METHOD_COREGRAPHICS:method = "CoreGraphics";break;
-        default:                                                        break;
+        default: break;
     }
 
-    LOG_MSG("Screen report: Method '%s' (%.3f x %.3f pixels) at (%.3f x %.3f) (%.3f x %.3f mm) (%.3f x %.3f in) (%.3f x %.3f DPI)",
+    if(dim_width != screen_size_info.screen_dimensions_pixels.width || dim_height != screen_size_info.screen_dimensions_pixels.height
+        || dpi_width != screen_size_info.screen_dpi.width || dpi_height != screen_size_info.screen_dpi.height) {
+        LOG_MSG("Screen report: Method '%s' (%.3f x %.3f pixels) at (%.3f x %.3f) (%.3f x %.3f mm) (%.3f x %.3f in) (%.3f x %.3f DPI)",
             method,
 
             screen_size_info.screen_dimensions_pixels.width,
@@ -728,6 +732,11 @@ void PrintScreenSizeInfo(void) {
 
             screen_size_info.screen_dpi.width,
             screen_size_info.screen_dpi.height);
+            dim_width = screen_size_info.screen_dimensions_pixels.width;
+            dim_height = screen_size_info.screen_dimensions_pixels.height;
+            dpi_width = screen_size_info.screen_dpi.width;
+            dpi_height = screen_size_info.screen_dpi.height;
+        }
 #endif
 }
 


### PR DESCRIPTION
DOSBox-X logs screen report such as when the window size is changed, however, the values of the log is identical in many cases, such as below.
```
LOG: Screen report: Method 'Win98base' (1280.000 x 800.000 pixels) at (0.000 x 0.000) (338.667 x 211.667 mm) (13.333 x 8.333 in) (96.000 x 96.000 DPI)
LOG: Aspect ratio: 720 x 540  xToY=1.333 yToX=0.750
LOG: Screen report: Method 'Win98base' (1280.000 x 800.000 pixels) at (0.000 x 0.000) (338.667 x 211.667 mm) (13.333 x 8.333 in) (96.000 x 96.000 DPI)
LOG: Aspect ratio: 720 x 540  xToY=1.333 yToX=0.750
LOG: Screen report: Method 'Win98base' (1280.000 x 800.000 pixels) at (0.000 x 0.000) (338.667 x 211.667 mm) (13.333 x 8.333 in) (96.000 x 96.000 DPI)
LOG: Screen report: Method 'Win98base' (1280.000 x 800.000 pixels) at (0.000 x 0.000) (338.667 x 211.667 mm) (13.333 x 8.333 in) (96.000 x 96.000 DPI)
LOG: Aspect ratio: 720 x 540  xToY=1.333 yToX=0.750
LOG: Screen report: Method 'Win98base' (1280.000 x 800.000 pixels) at (0.000 x 0.000) (338.667 x 211.667 mm) (13.333 x 8.333 in) (96.000 x 96.000 DPI)
LOG: Aspect ratio: 720 x 540  xToY=1.333 yToX=0.750
LOG: Screen report: Method 'Win98base' (1280.000 x 800.000 pixels) at (0.000 x 0.000) (338.667 x 211.667 mm) (13.333 x 8.333 in) (96.000 x 96.000 DPI)
LOG: Screen report: Method 'Win98base' (1280.000 x 800.000 pixels) at (0.000 x 0.000) (338.667 x 211.667 mm) (13.333 x 8.333 in) (96.000 x 96.000 DPI)
LOG: Aspect ratio: 720 x 540  xToY=1.333 yToX=0.750
LOG: Screen report: Method 'Win98base' (1280.000 x 800.000 pixels) at (0.000 x 0.000) (338.667 x 211.667 mm) (13.333 x 8.333 in) (96.000 x 96.000 DPI)
LOG: Aspect ratio: 720 x 540  xToY=1.333 yToX=0.750
LOG: Screen report: Method 'Win98base' (1280.000 x 800.000 pixels) at (0.000 x 0.000) (338.667 x 211.667 mm) (13.333 x 8.333 in) (96.000 x 96.000 DPI)
LOG: Screen report: Method 'Win98base' (1280.000 x 800.000 pixels) at (0.000 x 0.000) (338.667 x 211.667 mm) (13.333 x 8.333 in) (96.000 x 96.000 DPI)
LOG: Aspect ratio: 720 x 540  xToY=1.333 yToX=0.750
LOG: Screen report: Method 'Win98base' (1280.000 x 800.000 pixels) at (0.000 x 0.000) (338.667 x 211.667 mm) (13.333 x 8.333 in) (96.000 x 96.000 DPI)
LOG: Aspect ratio: 720 x 540  xToY=1.333 yToX=0.750
LOG: Screen report: Method 'Win98base' (1280.000 x 800.000 pixels) at (0.000 x 0.000) (338.667 x 211.667 mm) (13.333 x 8.333 in) (96.000 x 96.000 DPI)
LOG: Screen report: Method 'Win98base' (1280.000 x 800.000 pixels) at (0.000 x 0.000) (338.667 x 211.667 mm) (13.333 x 8.333 in) (96.000 x 96.000 DPI)
LOG: Aspect ratio: 720 x 540  xToY=1.333 yToX=0.750
LOG: Screen report: Method 'Win98base' (1280.000 x 800.000 pixels) at (0.000 x 0.000) (338.667 x 211.667 mm) (13.333 x 8.333 in) (96.000 x 96.000 DPI)
LOG: Aspect ratio: 720 x 540  xToY=1.333 yToX=0.750
LOG: Screen report: Method 'Win98base' (1280.000 x 800.000 pixels) at (0.000 x 0.000) (338.667 x 211.667 mm) (13.333 x 8.333 in) (96.000 x 96.000 DPI)
LOG: Screen report: Method 'Win98base' (1280.000 x 800.000 pixels) at (0.000 x 0.000) (338.667 x 211.667 mm) (13.333 x 8.333 in) (96.000 x 96.000 DPI)
LOG: Aspect ratio: 720 x 540  xToY=1.333 yToX=0.750
LOG: Screen report: Method 'Win98base' (1280.000 x 800.000 pixels) at (0.000 x 0.000) (338.667 x 211.667 mm) (13.333 x 8.333 in) (96.000 x 96.000 DPI)
LOG: Aspect ratio: 720 x 540  xToY=1.333 yToX=0.750
LOG: Screen report: Method 'Win98base' (1280.000 x 800.000 pixels) at (0.000 x 0.000) (338.667 x 211.667 mm) (13.333 x 8.333 in) (96.000 x 96.000 DPI)
```


This PR suppress such log and logs only when a value is changed.