### PR TITLE
Fix CD mount crash when drive is "empty"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 Next
-  - Fixed build failure with libc++ 19 (@DimitryAndric)
+  - Fixed crash when a CD image was loaded to an "empty" drive (maron2000)
+  - Log loaded .conf file (maron2000)
+  - Supress redundant screen reports in log (maron2000)
+  - Fixed mouse capture locking by middle button (maron2000) 
+  - Fixed toggling the menu option "Autolock mouse" did nothing (maron2000)
+  - Fixed build failure with libc++ 19 (DimitryAndric)
   - Fixed fullscreen mode not responding when launched in TTF mode 
     in Windows (maron2000)
   - Fixed crashes when changing floppies mounted by drive numbers on

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -430,7 +430,7 @@ void CMscdex::ReplaceDrive(CDROM_Interface* newCdrom, uint8_t subUnit) {
 }
 
 PhysPt CMscdex::GetDefaultBuffer(void) {
-	if (defaultBufSeg==0) {
+	if (defaultBufSeg==0 && !dos_kernel_disabled) {
 		uint16_t size = (2352*2+15)/16;
 		defaultBufSeg = DOS_GetMemory(size,"MSCDEX default buffer");
 	}
@@ -1504,7 +1504,8 @@ uint8_t MSCDEX_GetSubUnit(char driveLetter)
 
 bool MSCDEX_GetVolumeName(uint8_t subUnit, char* name)
 {
-	return mscdex->GetVolumeName(subUnit,name);
+    if(dos_kernel_disabled) return false;
+    return mscdex->GetVolumeName(subUnit,name);
 }
 
 bool MSCDEX_HasMediaChanged(uint8_t subUnit)

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -557,24 +557,38 @@ void MenuBrowseCDImage(char drive, int num) {
     const char *lFilterPatterns[] = {"*.iso","*.cue","*.bin","*.chd","*.mdf","*.gog","*.ins","*.inst","*.ISO","*.CUE","*.BIN","*.CHD","*.MDF","*.GOG","*.INS","*.INST" };
     const char *lFilterDescription = "CD image files (*.iso, *.cue, *.bin, *.chd, *.mdf, *.gog, *.ins, *.inst)";
     lTheOpenFileName = tinyfd_openFileDialog("Select a CD image file","", sizeof(lFilterPatterns) / sizeof(lFilterPatterns[0]),lFilterPatterns,lFilterDescription,0);
-
+    bool isempty = std::string(Drives[drive - 'A']->GetInfo() + 9) == "empty";
     if (lTheOpenFileName) {
         isoDrive *cdrom = dynamic_cast<isoDrive*>(Drives[drive-'A']);
         DOS_Drive *newDrive = NULL;
+        int error = -1;
+        uint8_t mediaid = 0xF8;
         if (cdrom && dos_kernel_disabled) {
             cdrom->setFileName(lTheOpenFileName);
+            if(isempty) {
+                newDrive = new isoDrive(drive, lTheOpenFileName, mediaid, error, options);
+                if(error) {
+                    delete newDrive;
+                    systemmessagebox("Error", "Could not mount the selected CD image.", "ok", "error", 1);
+                    chdir(Temp_CurrentDir);
+                    return;
+                }
+                delete cdrom;
+                cdrom = dynamic_cast<isoDrive*>(newDrive);
+                Drives[drive - 'A'] = cdrom;
+            }
         } else {
-            uint8_t mediaid = 0xF8;
-            int error = -1;
             newDrive = new isoDrive(drive, lTheOpenFileName, mediaid, error, options);
             if (error) {
+                delete newDrive;
                 systemmessagebox("Error","Could not mount the selected CD image.","ok","error", 1);
                 chdir( Temp_CurrentDir );
                 return;
             }
             cdrom = dynamic_cast<isoDrive*>(newDrive);
+            Drives[drive - 'A'] = cdrom;
         }
-        if (cdrom) DriveManager::ChangeDisk(drive-'A', cdrom);
+        if ((!isempty || !dos_kernel_disabled) && cdrom) DriveManager::ChangeDisk(drive-'A', cdrom);
 	}
 	chdir( Temp_CurrentDir );
 #endif

--- a/src/dos/drive_iso.cpp
+++ b/src/dos/drive_iso.cpp
@@ -1737,7 +1737,8 @@ bool isoDrive::ReadCachedSector(uint8_t** buffer, const uint32_t sector) {
 }
 
 inline bool isoDrive :: readSector(uint8_t *buffer, uint32_t sector) const {
-	return CDROM_Interface_Image::images[subUnit]->ReadSector(buffer, false, sector);
+    if(CDROM_Interface_Image::images[subUnit] == nullptr) return false;
+    return CDROM_Interface_Image::images[subUnit]->ReadSector(buffer, false, sector);
 }
 
 int isoDrive::readDirEntry(isoDirEntry* de, const uint8_t* data,unsigned int dirIteratorIndex) const {


### PR DESCRIPTION
This PR fixes issue #4988, DOSBox-X silently crashes when inserting a CD image to a empty drive on a booted guest.

## What issue(s) does this PR address?
Fixes #4988 