### PR TITLE
Fixed a problem when VZ Editor is resident in PC-98 mode

### DIFF
--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -626,6 +626,16 @@ bool DOS_Device::Read(uint8_t * data,uint16_t * size) {
 }
 
 bool DOS_Device::Write(const uint8_t * data,uint16_t * size) {
+	// Enables console capture with VZ editor resident and xscript
+	if(IS_PC98_ARCH && Devices[devnum]->IsName("CON")) {
+		uint16_t keep_ax = reg_ax;
+		for(uint16_t n = 0 ; n < *size ; n++) {
+			reg_al = *data++;
+			CALLBACK_RunRealInt(0x29);
+		}
+		reg_ax = keep_ax;
+		return true;
+	}
 	return Devices[devnum]->Write(data,size);
 }
 

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -452,9 +452,9 @@ void DOS_Shell::InputCommand(char * line) {
     uint16_t cr;
 
 #if defined(USE_TTF)
-	if(IS_DOSV || ttf_dosv) {
+	if(IS_DOSV || IS_PC98_ARCH || ttf_dosv) {
 #else
-	if(IS_DOSV) {
+	if(IS_DOSV || IS_PC98_ARCH) {
 #endif
 		uint16_t int21_seg = mem_readw(0x0086);
 		if(int21_seg != 0xf000) {


### PR DESCRIPTION
Fixed not being able to call when VZ Editor is resident and not being able to refer to console history.

PC-98 DOS standard output uses int 29h.
Programs that refer to the console history, such as VZ Editor's resident mode or xscript, get their character output by getting int 29h vectors.
