### PR TITLE
Add int33 mickey threshold option to fix ultima underworld

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -4759,6 +4759,13 @@ void DOSBOX_SetupConfigSections(void) {
                       "spec:   <number>    position adjust, can be positive or negative\n"
                       "        max-excess  if game sets maximum larger than int33 max x/y, adjust the position forward by the difference");
 
+    Pint = secprop->Add_int("int33 mickey threshold",Property::Changeable::WhenIdle,1);
+    Pint->Set_help("The smallest amount of mouse motion that will be reported to the guest. Motion below this amount is buffered until the threshold is met.\n"
+                   "Some DOS programs do not properly respond to small mouse movements causing effects like a sluggish cursor or cursor drift.\n"
+                   "Increase this option to the smallest value that achieves natural feeling motion.\n"
+                   "- Ultima Underworld: Use 2");
+    Pint->SetMinMax(1,16);
+
     Pint = secprop->Add_int("mouse report rate",Property::Changeable::WhenIdle,0);
     Pint->Set_help("Mouse reporting rate, or 0 for auto. This affects how often mouse events are reported to the guest through the mouse interrupt.\n"
 		    "Some games including CyClone need a lower reporting rate to function correctly. Auto mode allows the guest to change the report rate through the PS/2 mouse emulation.\n"


### PR DESCRIPTION
Certain DOS games seem to not properly handle very small mouse deltas. Ultima Underworld is particularly notorious for this. Moving the mouse very slowly results in no cursor motion at all, since the game does not properly accumulate the small deltas. This creates a feeling of the cursor "sticking" or "lagging" making it very difficult to use. Period correct serial mice with low sample rates and low precision mitigate this effect somewhat, but modern high precision mice make it very noticeable.

This PR adds an option that will accumulate int33 mickeys until they exceed a threshold, at which point they are flushed to the mouse driver for the guest to consume. The default is 1, which will report all motion as normal. A setting of 2 completely fixes the cursor in UUW.