### PR TITLE
Fix --disable-screenshots option (configure.ac)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build minimal
         run: |
           echo "timestamp=`git show -s --format=%at | xargs -I# date -d @# +%Y%m%d%H%M%S`" >> $GITHUB_ENV
-          ./build --disable-freetype --disable-libfluidsynth --disable-mt32
+          ./build --disable-freetype --disable-libfluidsynth --disable-mt32 --disable-screenshots
       - name: Install libraries
         run: |
           sudo apt-get update -y

--- a/configure.ac
+++ b/configure.ac
@@ -1098,17 +1098,17 @@ AH_TEMPLATE(C_LIBPNG,[Define to 1 if you have libpng])
 AH_TEMPLATE(C_SSHOT,[Define to 1 to enable screenshots, requires libpng])
 AC_ARG_ENABLE(screenshots,AC_HELP_STRING([--disable-screenshots],[Disable screenshots and movie recording]),,enable_screenshots=yes)
 AC_MSG_CHECKING([whether screenshots will be enabled])
-if test x$enable_screenshots = xyes; then 
-    if test x$have_png_lib = xyes -a x$have_png_h = xyes ; then
+if test x$have_png_lib = xyes -a x$have_png_h = xyes ; then
     LIBS="$LIBS -lpng -lz"
     AC_DEFINE(C_LIBPNG,1)
-    AC_DEFINE(C_SSHOT,1)
-    AC_MSG_RESULT([yes])
-  else
-    AC_MSG_RESULT([no, can't find libpng.])
-  fi
+    if test x$enable_screenshots = xyes; then 
+        AC_DEFINE(C_SSHOT,1)
+        AC_MSG_RESULT([yes])
+    else
+        AC_MSG_RESULT([no])
+    fi
 else
-  AC_MSG_RESULT([no])
+    AC_MSG_ERROR([Can't find libpng, install or try building the in-tree code])
 fi
 
 dnl FEATURE: Whether to use libpcap, and enable ethernet pass-through


### PR DESCRIPTION
Fix `configure.ac` so that libpng support is not disabled by `--disable-screenshots` option to build successfully with and without the option.
