### PR TITLE
Fix color glitches in EGA, Tandy, Hercules mode on macOS SDL2 build 

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3101,7 +3101,7 @@ Bitu GFX_GetRGB(uint8_t red, uint8_t green, uint8_t blue) {
 
 #if C_OPENGL
         case SCREEN_OPENGL:
-# if SDL_BYTEORDER == SDL_LIL_ENDIAN && defined(MACOSX) /* macOS Intel builds use a weird RGBA order (alpha in the low 8 bits) */
+# if SDL_BYTEORDER == SDL_LIL_ENDIAN && defined(MACOSX) && !defined(C_SDL2) /* macOS Intel builds use a weird RGBA order (alpha in the low 8 bits) */
             //USE BGRA
             return (((unsigned long)blue << 24ul) | ((unsigned long)green << 16ul) | ((unsigned long)red <<  8ul)) | (255ul <<  0ul);
 # else


### PR DESCRIPTION
This PR fixes the color glitches in EGA, Tandy, Hercules mode on macOS SDL2 build with `output=opengl`

![image](https://github.com/user-attachments/assets/4fec7b59-993b-42b2-a578-d1b1422e19d3)
![image](https://github.com/user-attachments/assets/d474c566-5add-442a-b01d-6f5e1847dc22)

## What issue(s) does this PR address?
Fixes #4571
Fixes #4753
Fixes #5309