### PR TITLE
Reapply patches for Win9x-lowend builds

### DIFF
--- a/src/libs/tinyfiledialogs/tinyfiledialogs.c
+++ b/src/libs/tinyfiledialogs/tinyfiledialogs.c
@@ -108,6 +108,10 @@ misrepresented as being the original software.
 #endif
 #define LOW_MULTIPLE_FILES 32
 
+#if defined(_WIN32_WINDOWS)
+#define GetConsoleWindow() FALSE
+#endif
+
 char tinyfd_version[8] = "3.17.4";
 
 /******************************************************************************************************/
@@ -703,7 +707,7 @@ static void wipefileW(wchar_t const * aFilename)
 {
 		int i;
 		FILE * lIn;
-#if defined(__MINGW32_MAJOR_VERSION) && !defined(__MINGW64__) && (__MINGW32_MAJOR_VERSION <= 3)
+#if defined(__MINGW32_MAJOR_VERSION) && !defined(__MINGW64__) && (__MINGW32_MAJOR_VERSION <= 3) || (defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS==32)) 
 		struct _stat st;
 		if (_wstat(aFilename, &st) == 0)
 #else
@@ -840,7 +844,7 @@ static void RGB2HexW( unsigned char const aRGB[3], wchar_t aoResultHexRGB[8])
 
 static int dirExists(char const * aDirPath)
 {
-#if defined(__MINGW32_MAJOR_VERSION) && !defined(__MINGW64__) && (__MINGW32_MAJOR_VERSION <= 3)
+#if defined(__MINGW32_MAJOR_VERSION) && !defined(__MINGW64__) && (__MINGW32_MAJOR_VERSION <= 3) || (defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS==32))
 	struct _stat lInfo;
 #else
 	struct __stat64 lInfo;
@@ -860,7 +864,7 @@ static int dirExists(char const * aDirPath)
 		if (tinyfd_winUtf8)
 		{
 						lTmpWChar = tinyfd_utf8to16(aDirPath);
-#if defined(__MINGW32_MAJOR_VERSION) && !defined(__MINGW64__) && (__MINGW32_MAJOR_VERSION <= 3)
+#if defined(__MINGW32_MAJOR_VERSION) && !defined(__MINGW64__) && (__MINGW32_MAJOR_VERSION <= 3) || (defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS==32))
 			lStatRet = _wstat(lTmpWChar, &lInfo);
 #else
 			lStatRet = _wstat64(lTmpWChar, &lInfo);
@@ -872,7 +876,7 @@ static int dirExists(char const * aDirPath)
 			else
 						return 0;
 		}
-#if defined(__MINGW32_MAJOR_VERSION) && !defined(__MINGW64__) && (__MINGW32_MAJOR_VERSION <= 3)
+#if defined(__MINGW32_MAJOR_VERSION) && !defined(__MINGW64__) && (__MINGW32_MAJOR_VERSION <= 3) || (defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS==32))
 		else if (_stat(aDirPath, &lInfo) != 0)
 #else
 		else if (_stat64(aDirPath, &lInfo) != 0)
@@ -887,7 +891,7 @@ static int dirExists(char const * aDirPath)
 
 static int fileExists(char const * aFilePathAndName)
 {
-#if defined(__MINGW32_MAJOR_VERSION) && !defined(__MINGW64__) && (__MINGW32_MAJOR_VERSION <= 3)
+#if defined(__MINGW32_MAJOR_VERSION) && !defined(__MINGW64__) && (__MINGW32_MAJOR_VERSION <= 3) || (defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS==32))
 	struct _stat lInfo;
 #else
 	struct __stat64 lInfo;
@@ -904,7 +908,7 @@ static int fileExists(char const * aFilePathAndName)
 		if (tinyfd_winUtf8)
 		{
 						lTmpWChar = tinyfd_utf8to16(aFilePathAndName);
-#if defined(__MINGW32_MAJOR_VERSION) && !defined(__MINGW64__) && (__MINGW32_MAJOR_VERSION <= 3)
+#if defined(__MINGW32_MAJOR_VERSION) && !defined(__MINGW64__) && (__MINGW32_MAJOR_VERSION <= 3) || (defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS==32))
 			lStatRet = _wstat(lTmpWChar, &lInfo);
 #else
 			lStatRet = _wstat64(lTmpWChar, &lInfo);


### PR DESCRIPTION
Some patches were required to tinyfiledialogs in order to run Win9x/NT4 build.

## What issue(s) does this PR address?
Fixes #5314
