### PR TITLE
Recalibrated Pentium cycles rating / Added Pentium 200MHz MMX

### DIFF
--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -263,7 +263,7 @@ static const char *def_menu_cpu_speed[] =
     "cpu586-120",
     "cpu586-133",
     "cpu586-166",
-    "cpuak6-166",
+    "cpu586-200",
     "cpuak6-200",
     "cpuak6-300",
     "cpuath-600",
@@ -906,7 +906,7 @@ DOSBoxMenu::displaylist::displaylist() {
 
 DOSBoxMenu::displaylist::~displaylist() {
 }
-        
+
 bool DOSBoxMenu::item_exists(const std::string &name) {
     const auto i = name_map.find(name);
 
@@ -1538,7 +1538,7 @@ void ConstructSubMenu(DOSBoxMenu::item_handle_t item_id, const char * const * li
         const char *ref = list[i];
 
         /* NTS: This code calls mainMenu.get_item(item_id) every iteration.
-         *      
+         *
          *      This seemingly inefficient method of populating the display
          *      list is REQUIRED because DOSBoxMenu::item& is a reference
          *      to a std::vector, and the reference becomes invalid when
@@ -2242,7 +2242,7 @@ void BrowseFolder( char drive , std::string drive_type ) {
 void mem_conf(std::string memtype, int option) {
     std::string tmp;
     Section* sec = control->GetSection("dos");
-    Section_prop * section=static_cast<Section_prop *>(sec); 
+    Section_prop * section=static_cast<Section_prop *>(sec);
     if (!option) {
         tmp = section->Get_bool(memtype) ? "false" : "true";
     } else {
@@ -2278,7 +2278,7 @@ umount:
         switch (DriveManager::UnmountDrive(i_drive-'A')) {
         case 0:
             Drives[i_drive-'A'] = 0;
-            if(i_drive-'A' == DOS_GetDefaultDrive()) 
+            if(i_drive-'A' == DOS_GetDefaultDrive())
                 DOS_SetDrive(toupper('Z') - 'A');
             LOG_MSG("GUI:Drive %c has successfully been removed.",i_drive); break;
         case 1:

--- a/src/gui/menu_callback.cpp
+++ b/src/gui/menu_callback.cpp
@@ -957,23 +957,23 @@ bool cpu_speed_emulate_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * 
     else if (!strcmp(mname, "cpu486-133"))
         cyclemu = 47810;
     else if (!strcmp(mname, "cpu586-60"))
-        cyclemu = 31545;
+        cyclemu = 32090;
     else if (!strcmp(mname, "cpu586-66"))
         cyclemu = 35620;
     else if (!strcmp(mname, "cpu586-75"))
-        cyclemu = 43500;
+        cyclemu = 40072;
     else if (!strcmp(mname, "cpu586-90"))
-        cyclemu = 52000;
+        cyclemu = 48087;
     else if (!strcmp(mname, "cpu586-100"))
-        cyclemu = 60000;
+        cyclemu = 53430;
     else if (!strcmp(mname, "cpu586-120"))
-        cyclemu = 74000;
+        cyclemu = 64180;
     else if (!strcmp(mname, "cpu586-133"))
-        cyclemu = 80000;
+        cyclemu = 71240;
     else if (!strcmp(mname, "cpu586-166"))
-        cyclemu = 97240;
-    else if (!strcmp(mname, "cpuak6-166"))
-        cyclemu = 110000;
+        cyclemu = 95548;
+    else if (!strcmp(mname, "cpu586-200"))
+        cyclemu = 114657;
     else if (!strcmp(mname, "cpuak6-200"))
         cyclemu = 130000;
     else if (!strcmp(mname, "cpuak6-300"))
@@ -1248,7 +1248,7 @@ bool vid_pc98_enable_188user_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::i
 
         mainMenu.get_item("pc98_enable_188user").check(enable_pc98_188usermod).refresh_item(mainMenu);
     }
-    
+
     return true;
 }
 
@@ -1271,7 +1271,7 @@ bool vid_pc98_enable_egc_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item 
 
             if(!enable_pc98_grcg) { //Also enable GRCG if GRCG is disabled when enabling EGC
                 enable_pc98_grcg = !enable_pc98_grcg;
-                mem_writeb(0x54C,(enable_pc98_grcg ? 0x02 : 0x00) | (enable_pc98_16color ? 0x04 : 0x00));   
+                mem_writeb(0x54C,(enable_pc98_grcg ? 0x02 : 0x00) | (enable_pc98_16color ? 0x04 : 0x00));
                 pc98_section->HandleInputline("pc-98 enable grcg=1");
             }
         }
@@ -1281,7 +1281,7 @@ bool vid_pc98_enable_egc_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item 
         mainMenu.get_item("pc98_enable_egc").check(enable_pc98_egc).refresh_item(mainMenu);
         mainMenu.get_item("pc98_enable_grcg").check(enable_pc98_grcg).refresh_item(mainMenu);
     }
-    
+
     return true;
 }
 
@@ -1305,7 +1305,7 @@ bool vid_pc98_enable_grcg_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item
         if ((!enable_pc98_grcg) && enable_pc98_egc) { // Also disable EGC if switching off GRCG
             void gdc_egc_enable_update_vars(void);
             enable_pc98_egc = !enable_pc98_egc;
-            gdc_egc_enable_update_vars();   
+            gdc_egc_enable_update_vars();
             pc98_section->HandleInputline("pc-98 enable egc=0");
         }
 
@@ -1319,7 +1319,7 @@ bool vid_pc98_enable_grcg_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item
 bool vid_pc98_enable_analog_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
     (void)menuitem;//UNUSED
-    //NOTE: I thought that even later PC-9801s and some PC-9821s could use EGC features in digital 8-colors mode? 
+    //NOTE: I thought that even later PC-9801s and some PC-9821s could use EGC features in digital 8-colors mode?
     extern bool enable_pc98_16color;
     void gdc_16color_enable_update_vars(void);
 
@@ -1342,7 +1342,7 @@ bool vid_pc98_enable_analog_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::it
 bool vid_pc98_enable_analog256_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
     (void)menuitem;//UNUSED
-    //NOTE: I thought that even later PC-9801s and some PC-9821s could use EGC features in digital 8-colors mode? 
+    //NOTE: I thought that even later PC-9801s and some PC-9821s could use EGC features in digital 8-colors mode?
     extern bool enable_pc98_256color;
     void gdc_16color_enable_update_vars(void);
 
@@ -3129,15 +3129,15 @@ void AllocCallback1() {
             mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpu486-66").set_text("486DX2 66MHz (~23880 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
             mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpu486-100").set_text("486DX4 100MHz (~33445 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
             mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpu486-133").set_text("486DX5 133MHz (~47810 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
-            mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpu586-60").set_text("Pentium 60MHz (~31545 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
+            mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpu586-60").set_text("Pentium 60MHz (~32090 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
             mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpu586-66").set_text("Pentium 66MHz (~35620 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
-            mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpu586-75").set_text("Pentium 75MHz (~43500 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
-            mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpu586-90").set_text("Pentium 90MHz (~52000 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
-            mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpu586-100").set_text("Pentium 100MHz (~60000 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
-            mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpu586-120").set_text("Pentium 120MHz (~74000 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
-            mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpu586-133").set_text("Pentium 133MHz (~80000 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
-            mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpu586-166").set_text("Pentium 166MHz MMX (~97240 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
-            mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpuak6-166").set_text("AMD K6 166MHz (~110000 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
+            mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpu586-75").set_text("Pentium 75MHz (~40072 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
+            mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpu586-90").set_text("Pentium 90MHz (~48087 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
+            mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpu586-100").set_text("Pentium 100MHz (~53430 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
+            mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpu586-120").set_text("Pentium 120MHz (~64180 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
+            mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpu586-133").set_text("Pentium 133MHz (~71240 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
+            mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpu586-166").set_text("Pentium 166MHz MMX (~95548 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
+            mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpu586-200").set_text("Pentium 200MHz MMX (~114657 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
             mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpuak6-200").set_text("AMD K6 200MHz (~130000 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
             mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpuak6-300").set_text("AMD K6-2 300MHz (~193000 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
             mainMenu.alloc_item(DOSBoxMenu::item_type_id,"cpuath-600").set_text("AMD Athlon 600MHz (~306000 cycles)").set_callback_function(cpu_speed_emulate_menu_callback);
@@ -3149,7 +3149,7 @@ void AllocCallback1() {
             {
                 DOSBoxMenu::item &item = mainMenu.alloc_item(DOSBoxMenu::submenu_type_id,"VideoFrameskipMenu");
                 item.set_text("Frameskip");
-        
+
                 mainMenu.alloc_item(DOSBoxMenu::item_type_id,"frameskip_0").set_text("Off").
                     set_callback_function(video_frameskip_common_menu_callback);
 


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?


## Does this PR introduce new feature(s)?

Added Pentium 200MHz MMX; Removed AMD K6-166MHz (they are too close anyway).
But Pentiums are calibrated.

## Does this PR introduce any breaking change(s)?

If yes, describe the breaking change(s) in detail.

## Additional information

It was calibrated in DOS, against my real PC museum, and against Norton Utilities / SI8.
Here are my Lab results:
 --- Pentium Era ---
 Pentium-66                   211.4 (reference result; NU8/SI8)
 Pentium-100                  317.6 (my museum, 2024)
 AMD K5-100 (PR100)           397.0 (my museum, 2024)
 Pentium-133                  421.3 (correct both in my pc in 1997 and in 2023 in my museum PC 2024)
 Pentium-166              ??  528.5 (theoretical)
 Pentium-200              ??  634.2 (theoretical)
 Pentium-MMX-166              567.1 (my museum, 2024)  *1.0729725 (+7% faster)
 Pentium-MMX-200              680.6 (my museum, 2024)
 Pentium-MMX-233              794.0 (my museum, 2024)
 Pentium II-233               585.0 (my museum, 2024)  <-- Pentium II is slower than Pentium 1 executing 16-bit code.
 Pentium II-266               668.6 (my museum, 2024)
 Pentium II-300               752.2 (my museum, 2024)
 Pentium II-333               835.6 (father`s 1998)
 Pentium II-350               877.6 (my museum, 2024)
 Pentium II-400              1002.9 (my museum, 2024)
 Pentium III-450             1128.3 (my museum, 2024) "Katmai" + (Uzi's 1999)
 Pentium III-500             1253.7 (my museum, 2024) "Katmai"
 Pentium III-550             1379.0 (my museum, 2024) "Katmai"
 Pentium III-600             1504.4 (my museum, 2024) "Katmai"
