### PR TITLE
Always set codepage to 932 for PC-98 emulation

### DIFF
--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -1461,7 +1461,11 @@ public:
 		loaded_layout=new keyboard_layout();
 
 		Bits wants_dos_codepage = -1;
-		if (!strncmp(layoutname,"auto",4)) {
+        if(IS_PC98_ARCH) {
+            layoutname = "jp";
+            tocp = 932;
+        }
+        else if(!strncmp(layoutname, "auto", 4)) {
 #if defined (WIN32)
 			WORD cur_kb_layout = LOWORD(GetKeyboardLayout(0));
 			WORD cur_kb_subID  = 0;
@@ -1677,25 +1681,13 @@ public:
 					break;
 			}
 #else // !WIN32
-			if (IS_PC98_ARCH) {
-				layoutname = "jp";
-				wants_dos_codepage = 932;
-			}
-			else {
-				layoutname = "us";
-				wants_dos_codepage = 437;
-			}
+    		layoutname = "us";
+			wants_dos_codepage = 437;
 #endif
 		}
 		else if(!strncmp(layoutname, "none", 4)) {
-			if (IS_PC98_ARCH) {
-				layoutname = "jp";
-				wants_dos_codepage = 932;
-			}
-			else {
-				layoutname = "us";
-				wants_dos_codepage = 437;
-			}
+			layoutname = "us";
+			wants_dos_codepage = 437;
 		}
 
 		bool extract_codepage = !tocp;


### PR DESCRIPTION
Commit b1fc67ac688b68ec636f6c6044a78a975c4973c6 fixed a regression of setting the codepage in PC-98 emulation mode.
This PR fixes the keyboard layout detection in Windows which also has such regression.
