### PR TITLE
Don't switch to CP950 if zh_tw.lng is loaded when CP is 951

### DIFF
--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -339,6 +339,8 @@ void LoadMessageFile(const char * fname) {
                             std::string msg = "The specified language file uses code page " + std::to_string(c) + ". Do you want to change to this code page accordingly?";
                             if(c != dos.loaded_codepage && (control->opt_langcp || uselangcp || !CHCP_changed || CheckDBCSCP(c) || !loadlang || (loadlang && systemmessagebox("DOSBox-X language file", msg.c_str(), "yesno", "question", 1)))) {
                                 loadlangcp = true;
+                                if(c == 950 && dos.loaded_codepage == 951) c = 951; // zh_tw defaults to CP950, but CP951 is acceptable as well so keep it
+                                if(c == 951 && dos.loaded_codepage == 950) c = 950; // And vice versa for lang files requiring CP951
                                 msgcodepage = c;
                                 dos.loaded_codepage = c;
                                 if (c == 950 && !chinasea) makestdcp950table();


### PR DESCRIPTION
Language files for CP 950/951 (Traditional Chinese) can be shared between each other, but CHCP command sometimes didn't accept it.
This PR fixes such issue.

Fixes #5327 (PR tested in ticket)
