### PR TITLE
Fix regression of garbled menubar in Traditional Chinese menu

### DIFF
--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -339,9 +339,9 @@ void LoadMessageFile(const char * fname) {
                             std::string msg = "The specified language file uses code page " + std::to_string(c) + ". Do you want to change to this code page accordingly?";
                             if(c != dos.loaded_codepage && (control->opt_langcp || uselangcp || !CHCP_changed || CheckDBCSCP(c) || !loadlang || (loadlang && systemmessagebox("DOSBox-X language file", msg.c_str(), "yesno", "question", 1)))) {
                                 loadlangcp = true;
-                                if(c == 950 && dos.loaded_codepage == 951) c = 951; // zh_tw defaults to CP950, but CP951 is acceptable as well so keep it
-                                if(c == 951 && dos.loaded_codepage == 950) c = 950; // And vice versa for lang files requiring CP951
-                                msgcodepage = c;
+                                if(c == 950 && dos.loaded_codepage == 951) msgcodepage = 951; // zh_tw defaults to CP950, but CP951 is acceptable as well so keep it
+                                else if(c == 951 && dos.loaded_codepage == 950) msgcodepage = 950; // And vice versa for lang files requiring CP951
+                                else msgcodepage = c;
                                 dos.loaded_codepage = c;
                                 if (c == 950 && !chinasea) makestdcp950table();
                                 if (c == 951 && chinasea) makeseacp951table();

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -138,6 +138,7 @@ extern bool systemmessagebox(char const * aTitle, char const * aMessage, char co
 extern void Load_Language(std::string name), GetExpandedPath(std::string &path);
 extern void MAPPER_AutoType(std::vector<std::string> &sequence, const uint32_t wait_ms, const uint32_t pace_ms, bool choice);
 extern void DOS_SetCountry(uint16_t countryNo), DOSV_FillScreen(void);
+void clearFontCache(void);
 std::string GetDOSBoxXPath(bool withexe=false);
 FILE *testLoadLangFile(const char *fname);
 Bitu DOS_ChangeCodepage(int32_t codepage, const char* codepagefile);
@@ -4561,11 +4562,12 @@ int toSetCodePage(DOS_Shell *shell, int newCP, int opt) {
 #endif
             DOSBox_SetSysMenu();
         }
-        if (isDBCSCP()) {
+        if(isDBCSCP()) {
             ShutFontHandle();
             InitFontHandle();
             JFONT_Init();
             SetupDBCSTable();
+            clearFontCache();
         }
         if (finish_prepare) runRescan("-A -Q");
 #if defined(USE_TTF)


### PR DESCRIPTION
PR #5335 had an regression that some items in the menubar may become garbled in a certain condition when Traditional Chinese language file was chosen.
This PR fixes such bug.

Steps to reproduce:
Launch DOSBox-X by the following command.
```
dosbox-x -set country=81,951 -set uao=true -set keyboardlayout=us -set language=zh_tw
```

Before fix
![image](https://github.com/user-attachments/assets/8db1d53a-5d49-4f2a-a64d-3087846ecff6)

After fix
![image](https://github.com/user-attachments/assets/c4b268af-1425-4294-9d70-39139e66b152)
