### PR TITLE
Fix codepage conflicting with loaded language file on restart

### DIFF
--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -337,6 +337,7 @@ void LoadMessageFile(const char * fname) {
                         }
                         else {
                             std::string msg = "The specified language file uses code page " + std::to_string(c) + ". Do you want to change to this code page accordingly?";
+                            if(c == dos.loaded_codepage) msgcodepage = c;
                             if(c != dos.loaded_codepage && (control->opt_langcp || uselangcp || !CHCP_changed || CheckDBCSCP(c) || !loadlang || (loadlang && systemmessagebox("DOSBox-X language file", msg.c_str(), "yesno", "question", 1)))) {
                                 loadlangcp = true;
                                 if(c == 950 && dos.loaded_codepage == 951) msgcodepage = 951; // zh_tw defaults to CP950, but CP951 is acceptable as well so keep it
@@ -511,7 +512,7 @@ void MSG_Init() {
                 if (lang.size()) LoadMessageFile(lang.c_str());
             }
         }
-	}
+    }
     std::string showdbcsstr = static_cast<Section_prop *>(control->GetSection("dosv"))->Get_string("showdbcsnodosv");
 #if defined(USE_TTF)
     showdbcs = showdbcsstr=="true"||showdbcsstr=="1"||(showdbcsstr=="auto" && (loadlang || dbcs_sbcs));


### PR DESCRIPTION
In certain condition, text and menubar gets garbled on restart from menu or pressing `Host + R`.
This PR fixes such flaw.

Steps to reproduce:
1. Launch DOSBox-X specifying a codepage in "country" option.  e.g. `country=81,951` 
2. Load a language file using a codepage different from the one above. e.g. `ru_RU.lng`
3. Restart DOSBox-X by pressing `Host + R`

## Additional information
![image](https://github.com/user-attachments/assets/0e8cd2ca-48cd-4d70-bba7-1783fae611e9)
