### PR TITLE
Fix codepage didn't change when loading language files in some cases

### DIFF
--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -1391,7 +1391,8 @@ Bitu DOS_LoadKeyboardLayout(const char * layoutname, int32_t codepage, const cha
 		return kerrcode;
 	}
 	// Everything went fine, switch to new layout
-	loaded_layout=temp_layout;
+    delete loaded_layout;
+    loaded_layout=temp_layout;
 	return KEYB_NOERROR;
 }
 
@@ -1405,7 +1406,7 @@ Bitu DOS_SwitchKeyboardLayout(const char* new_layout, int32_t& tried_cp) {
 			loaded_layout=changed_layout;
 		}
 		return ret_code;
-	} else return 0xff;
+	} else return 0xFF;
 }
 
 
@@ -1418,6 +1419,7 @@ Bitu DOS_ChangeKeyboardLayout(const char* layoutname, int32_t codepage) {
         return kerrcode;
     }
     // Everything went fine, switch to new layout
+    delete loaded_layout;
     loaded_layout = temp_layout;
     return KEYB_NOERROR;
 }

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -108,6 +108,7 @@ bool InitCodePage() {
                     return true;
                 }
                 else dos.loaded_codepage = msgcodepage;
+                return true;
             }
         }
         if (msgcodepage>0) {
@@ -217,6 +218,7 @@ bool CheckDBCSCP(int32_t codepage) {
     else return false;
 }
 
+#if 0
 void SetKEYBCP() {
     if (IS_PC98_ARCH || IS_JEGA_ARCH || IS_DOSV || dos_kernel_disabled || !strcmp(RunningProgram, "LOADLIN")) return;
     Bitu return_code;
@@ -236,6 +238,7 @@ void SetKEYBCP() {
     }
     runRescan("-A -Q");
 }
+#endif
 
 FILE *testLoadLangFile(const char *fname) {
     std::string config_path, res_path, exepath=GetDOSBoxXPath();
@@ -279,8 +282,7 @@ void LoadMessageFile(const char * fname) {
         //LOG_MSG("Message file %s already loaded.",fname);
         return;
     }
-    strcpy(loaded_fname, fname);
-	LOG(LOG_MISC,LOG_DEBUG)("Loading message file %s",loaded_fname);
+	LOG(LOG_MISC,LOG_DEBUG)("Loading message file %s",fname);
 
 	FILE * mfile=testLoadLangFile(fname);
 	/* This should never happen and since other modules depend on this use a normal printf */
@@ -292,6 +294,7 @@ void LoadMessageFile(const char * fname) {
 		control->opt_lang = "";
 		return;
 	}
+    strcpy(loaded_fname, fname);
     langname = langnote = "";
 	char linein[LINE_IN_MAXLEN+1024];
 	char name[LINE_IN_MAXLEN+1024], menu_name[LINE_IN_MAXLEN], mapper_name[LINE_IN_MAXLEN];
@@ -337,7 +340,10 @@ void LoadMessageFile(const char * fname) {
                         }
                         else {
                             std::string msg = "The specified language file uses code page " + std::to_string(c) + ". Do you want to change to this code page accordingly?";
-                            if(c == dos.loaded_codepage) msgcodepage = c;
+                            if(c == dos.loaded_codepage) {
+                                msgcodepage = c;
+                                lastmsgcp = msgcodepage;
+                            }
                             if(c != dos.loaded_codepage && (control->opt_langcp || uselangcp || !CHCP_changed || CheckDBCSCP(c) || !loadlang || (loadlang && systemmessagebox("DOSBox-X language file", msg.c_str(), "yesno", "question", 1)))) {
                                 loadlangcp = true;
                                 if(c == 950 && dos.loaded_codepage == 951) msgcodepage = 951; // zh_tw defaults to CP950, but CP951 is acceptable as well so keep it
@@ -404,7 +410,7 @@ void LoadMessageFile(const char * fname) {
     dos.loaded_codepage=cp;
     if (loadlangcp && msgcodepage>0) {
         const char* layoutname = DOS_GetLoadedLayout();
-        if(!IS_DOSV && !IS_JEGA_ARCH && layoutname != NULL) {
+        if(!IS_DOSV && !IS_JEGA_ARCH && !IS_PC98_ARCH && layoutname != NULL) {
             toSetCodePage(NULL, msgcodepage, -1);
         }
     }

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -144,6 +144,11 @@ FILE *testLoadLangFile(const char *fname);
 Bitu DOS_ChangeCodepage(int32_t codepage, const char* codepagefile);
 bool CheckDBCSCP(int32_t codepage), SwitchLanguage(int oldcp, int newcp, bool confirm);
 void makestdcp950table(), makeseacp951table();
+#if C_OPENGL
+bool OpenGL_using(void);
+#endif
+void UpdateSDLDrawTexture();
+
 static int32_t lastsetcp = 0;
 bool CHCP_changed = false;
 
@@ -4578,7 +4583,7 @@ int toSetCodePage(DOS_Shell *shell, int newCP, int opt) {
         }
         if (finish_prepare) runRescan("-A -Q");
 #if C_OPENGL && DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW
-        if(OpenGL_using() && control->opt_lang.size() && lastcp && lastcp != dos.loaded_codepage)
+        if(OpenGL_using() && control->opt_lang.size())
             UpdateSDLDrawTexture();
 #endif
 #if defined(USE_TTF)


### PR DESCRIPTION
In cases such as `keyboardlayout=us`, codepage didn't change accordingly to the language file, resulting in garbled menubar and text.

This PR fixes such issue.

Before
![image](https://github.com/user-attachments/assets/a71e29d1-63ae-4295-a5b7-e56c5897ccd3)

After
![image](https://github.com/user-attachments/assets/1bf7594e-417c-4482-b6ff-800df4614d74)

