### PR TITLE
Fix a Y2038 bug by replacing Int32x32To64 with regular multiplication

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -5076,7 +5076,7 @@ void DOS_Int21_7143(char *name1, const char *name2) {
 						t->tm_mon  = ((int)(reg_di >> 5) & 0x0f) - 1;
 						t->tm_year = ((int)(reg_di >> 9) & 0x7f) + 80;
 						ttime=mktime(t);
-						LONGLONG ll = Int32x32To64(ttime, 10000000) + 116444736000000000 + (reg_bl==0x07?reg_si*100000:0);
+						LONGLONG ll = (ttime * 10000000LL) + 116444736000000000LL + (reg_bl==0x07?reg_si*100000:0);
 						time.dwLowDateTime = (DWORD) ll;
 						time.dwHighDateTime = (DWORD) (ll >> 32);
 						if (!SetFileTime(hFile, reg_bl==0x07?&time:NULL,reg_bl==0x05?&time:NULL,reg_bl==0x03?&time:NULL)) {

--- a/src/dos/dos_network2.h
+++ b/src/dos/dos_network2.h
@@ -304,7 +304,7 @@ bool Network_SetFileAttr(char const * const filename, uint16_t attr) {
     t->tm_mon  = ((int)(odate >> 5) & 0x0f) - 1;
     t->tm_year = ((int)(odate >> 9) & 0x7f) + 80;
     ttime=mktime(t);
-    LONGLONG ll = Int32x32To64(ttime, 10000000) + 116444736000000000;
+    LONGLONG ll = (ttime * 10000000LL) + 116444736000000000LL;
     time.dwLowDateTime = (DWORD) ll;
     time.dwHighDateTime = (DWORD) (ll >> 32);
 	if (!SetFileTime(hand, NULL, NULL, &time)) {


### PR DESCRIPTION
## What issue(s) does this PR address?

`Int32x32To64` macro internally truncates the arguments to int32, while `time_t` is 64-bit on most/all modern platforms. Therefore, usage of this macro creates a Year 2038 bug.

I detailed this issue a while ago in a writeup, and spotted the same issue in this repository when updating the list of affected repositories:
<https://cookieplmonster.github.io/2022/02/17/year-2038-problem/>

## Does this PR introduce new feature(s)?

N/A

## Does this PR introduce any breaking change(s)?

It should not.

## Additional information

Untested, but it's a small and easy enough to reason change that I am hoping the CI passing is enough.
