### PR TITLE
Add package information for macOS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -105,11 +105,11 @@ Where ``<filename>`` is the main file name of the RPM package you wish to instal
 
 ### SnapCraft
 You can find DOSBox-X on SnapCraft (https://snapcraft.io/dosbox-x), which maintains universal Linux packages for software including DOSBox-X.
-But please note the DOSBox-X Linux packages on this website are built and updated by SnapCraft instead of the DOSBox-X Team.
+But please note that these packages are NOT built or updated by the DOSBox-X team.
 
 ### AUR Package
-DOSBox-X is packaged for archlinux, and available in the user contributed AUR Package Repository.
-But please note that this package is not built or updated by the DOSBox-X Team.
+DOSBox-X is packaged for Arch Linux, and available in the user contributed AUR Package Repository.
+But please note that these packages are NOT built or updated by the DOSBox-X Team.
 
 - SDL1 build: https://aur.archlinux.org/packages/dosbox-x/
 - SDL2 build: https://aur.archlinux.org/packages/dosbox-x-sdl2/
@@ -119,9 +119,8 @@ DOSBox-X is packaged for Debian, and available in the
 [trixie](https://packages.debian.org/trixie/dosbox-x) and
 [unstable](https://packages.debian.org/unstable/dosbox-x)
 repositories.
-But please note that this package is not built or updated by the
-DOSBox-X Team, and that it only contains a small subset of the DOS
-programs provided in the Z: drive.
+But please note that these packages are NOT built or updated by the DOSBox-X Team,
+and that it only contains a small subset of the DOS programs provided in the Z: drive.
 
 ## macOS Packages (Portable)
 
@@ -162,8 +161,26 @@ You should be able to solve the problem by running the following command once in
 1. Using the Terminal app, go to the unzipped folder of the macOS zip package. (You should find two folders ```dosbox-x``` and ```dosbox-x-sdl2```)
 2. Run ``xattr -cr .``
 
+### macOS Packages (Homebrew)
+Homebrew provides packages for macOS Ventura and after.
+You can install the package by the following steps.
+1. Install [Homebrew](https://brew.sh)
+2. In macOS Terminal (Applications -> Utilities -> Terminal) run `brew install dosbox-x`
+3. Launch DOSBox-X by running `dosbox-x` in macOS Terminal.
+
+Please note that these packages are NOT built or updated by the DOSBox-X team.
+
+### macOS Packages (MacPorts)
+[MacPorts](https://www.macports.org/) provides packages for High Sierra (10.13) and after. 
+You can install the package by the following steps.
+1. [Install MacPorts](https://www.macports.org/install.php)
+2. In macOS terminal (Applications -> Utilities -> Terminal) run `sudo port install dosbox-x`
+3. Launch DOSBox-X by running `dosbox-x` in macOS Terminal.
+
+Please note that these packages are NOT built or updated by the DOSBox-X team.
+
 ### DOSBox-X for older macOS versions
-Packages for macOS versions 10.14 (Mojave) and earlier are no longer provided. Low-end builds named `DOSBox-X-macos-(version)-high-sierra.zip` were available up to [2022.09.0 (0.84.3)](https://github.com/joncampbell123/dosbox-x/releases/tag/dosbox-x-v0.84.3) for 10.12 (Sierra) and after.
+Official portable packages for macOS versions 10.14 (Mojave) and earlier are no longer provided. Low-end builds named `DOSBox-X-macos-(version)-high-sierra.zip` were available up to [2022.09.0 (0.84.3)](https://github.com/joncampbell123/dosbox-x/releases/tag/dosbox-x-v0.84.3) for 10.12 (Sierra) and after.
 Binaries for macOS versions earlier than 10.12 (Sierra) have not been provided. You may try to build yourself with the help of [MacPorts](https://www.macports.org/). 
 
 ## DOS Packages (Portable)


### PR DESCRIPTION
Add package information for macOS (Homebrew, MacPorts).
It should be highlighted that MacPorts provides working builds for High Sierra and after.

Fixes #4866