### PR TITLE
Fix retrieving volume label

### DIFF
--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -290,54 +290,23 @@ int get_expanded_files(const std::string &path, std::vector<std::string> &paths,
 }
 
 void Set_Label(char const * const input, char * const output, bool cdrom) {
-    /* I don't know what MSCDEX.EXE does but don't put dots in the 11-char volume label for non-CD-ROM drives */
-    if (!cdrom) {
-        Bitu togo     = 11;
-        Bitu vnamePos = 0;
-        Bitu labelPos = 0;
-        char upcasebuf[12] = {0};
-        strncpy(upcasebuf, input, 11);
-        DBCS_upcase(upcasebuf);
+    uint8_t togo = 11;
+    uint8_t vnamePos = 0;
+    uint8_t labelPos = 0;
+    char upcasebuf[12];
+    bool str_end = false; // True if end of string is detected
+    strncpy(upcasebuf, input, 11);
+    //DBCS_upcase(upcasebuf);  /* Another mscdex quirk. Label is not always uppercase. (Daggerfall) */ 
 
-        while (togo > 0) {
-            if (upcasebuf[vnamePos]==0) break;
-            //Another mscdex quirk. Label is not always uppercase. (Daggerfall)
-            output[labelPos] = upcasebuf[vnamePos];
-            labelPos++;
-            vnamePos++;
-            togo--;
-        }
-        output[labelPos] = 0;
-        if((labelPos > 0) && (output[labelPos-1] == '.') && labelPos == 9) output[labelPos-1] = 0;
-        return;
+    while (togo > 0) {
+        if(upcasebuf[vnamePos] == 0) str_end = true;
+        output[labelPos] = !str_end ? upcasebuf[vnamePos] : 0x20; // Pad empty characters with white space (0x20)
+        labelPos++;
+        vnamePos++;
+        togo--;
     }
-
-	Bitu togo     = 8;
-	Bitu vnamePos = 0;
-	Bitu labelPos = 0;
-	bool point    = false;
-
-	//spacepadding the filenamepart to include spaces after the terminating zero is more closely to the specs. (not doing this now)
-	// HELLO\0' '' '
-
-	while (togo > 0) {
-		if (input[vnamePos]==0) break;
-		if (!point && (input[vnamePos]=='.')) {	togo=4; point=true; }
-
-		output[labelPos] = input[vnamePos];
-
-		labelPos++; vnamePos++;
-		togo--;
-		if ((togo==0) && !point) {
-			if (input[vnamePos]=='.') vnamePos++;
-			output[labelPos]='.'; labelPos++; point=true; togo=3;
-		}
-	}
-	output[labelPos]=0;
-
-	//Remove trailing dot. except when on cdrom and filename is exactly 8 (9 including the dot) letters. MSCDEX feature/bug (fifa96 cdrom detection)
-	if((labelPos > 0) && (output[labelPos-1] == '.') && !(cdrom && labelPos ==9))
-		output[labelPos-1] = 0;
+    output[labelPos] = 0;
+    return;
 }
 
 DOS_Drive::DOS_Drive() {

--- a/tests/drives_tests.cpp
+++ b/tests/drives_tests.cpp
@@ -108,34 +108,34 @@ TEST(LWildFileCmp, LFNCompare)
 TEST(Set_Label, Daggerfall)
 {
     std::string output = run_Set_Label("Daggerfall", false);
-    EXPECT_EQ("DAGGERFALL", output);
+    EXPECT_EQ("Daggerfall ", output);
 }
 TEST(Set_Label, DaggerfallCD)
 {
     std::string output = run_Set_Label("Daggerfall", true);
-    EXPECT_EQ("Daggerfa.ll", output);
+    EXPECT_EQ("Daggerfall ", output);
 }
 
 TEST(Set_Label, LongerThan11)
 {
     std::string output = run_Set_Label("a123456789AAA", false);
-    EXPECT_EQ("A123456789A", output);
+    EXPECT_EQ("a123456789A", output);
 }
 TEST(Set_Label, LongerThan11CD)
 {
     std::string output = run_Set_Label("a123456789AAA", true);
-    EXPECT_EQ("a1234567.89A", output);
+    EXPECT_EQ("a123456789A", output);
 }
 
 TEST(Set_Label, ShorterThan8)
 {
     std::string output = run_Set_Label("a123456", false);
-    EXPECT_EQ("A123456", output);
+    EXPECT_EQ("A123456    ", output);
 }
 TEST(Set_Label, ShorterThan8CD)
 {
     std::string output = run_Set_Label("a123456", true);
-    EXPECT_EQ("a123456", output);
+    EXPECT_EQ("a123456    ", output);
 }
 
 // Tests that the CD-ROM version adds a trailing dot when
@@ -143,24 +143,24 @@ TEST(Set_Label, ShorterThan8CD)
 TEST(Set_Label, EqualTo8)
 {
     std::string output = run_Set_Label("a1234567", false);
-    EXPECT_EQ("A1234567", output);
+    EXPECT_EQ("A1234567   ", output);
 }
 TEST(Set_Label, EqualTo8CD)
 {
     std::string output = run_Set_Label("a1234567", true);
-    EXPECT_EQ("a1234567.", output);
+    EXPECT_EQ("a1234567   ", output);
 }
 
 // A test to ensure non-CD-ROM function strips trailing dot
 TEST(Set_Label, StripEndingDot)
 {
     std::string output = run_Set_Label("a1234567.", false);
-    EXPECT_EQ("A1234567", output);
+    EXPECT_EQ("A1234567   ", output);
 }
 TEST(Set_Label, NoStripEndingDotCD)
 {
     std::string output = run_Set_Label("a1234567.", true);
-    EXPECT_EQ("a1234567.", output);
+    EXPECT_EQ("a1234567   ", output);
 }
 
 // Just to make sure this function doesn't clean invalid DOS labels

--- a/tests/drives_tests.cpp
+++ b/tests/drives_tests.cpp
@@ -130,7 +130,7 @@ TEST(Set_Label, LongerThan11CD)
 TEST(Set_Label, ShorterThan8)
 {
     std::string output = run_Set_Label("a123456", false);
-    EXPECT_EQ("A123456    ", output);
+    EXPECT_EQ("a123456    ", output);
 }
 TEST(Set_Label, ShorterThan8CD)
 {
@@ -143,7 +143,7 @@ TEST(Set_Label, ShorterThan8CD)
 TEST(Set_Label, EqualTo8)
 {
     std::string output = run_Set_Label("a1234567", false);
-    EXPECT_EQ("A1234567   ", output);
+    EXPECT_EQ("a1234567   ", output);
 }
 TEST(Set_Label, EqualTo8CD)
 {
@@ -155,7 +155,7 @@ TEST(Set_Label, EqualTo8CD)
 TEST(Set_Label, StripEndingDot)
 {
     std::string output = run_Set_Label("a1234567.", false);
-    EXPECT_EQ("A1234567.  ", output);
+    EXPECT_EQ("a1234567.  ", output);
 }
 TEST(Set_Label, NoStripEndingDotCD)
 {

--- a/tests/drives_tests.cpp
+++ b/tests/drives_tests.cpp
@@ -155,24 +155,24 @@ TEST(Set_Label, EqualTo8CD)
 TEST(Set_Label, StripEndingDot)
 {
     std::string output = run_Set_Label("a1234567.", false);
-    EXPECT_EQ("A1234567   ", output);
+    EXPECT_EQ("A1234567.  ", output);
 }
 TEST(Set_Label, NoStripEndingDotCD)
 {
     std::string output = run_Set_Label("a1234567.", true);
-    EXPECT_EQ("a1234567   ", output);
+    EXPECT_EQ("a1234567.  ", output);
 }
 
 // Just to make sure this function doesn't clean invalid DOS labels
 TEST(Set_Label, InvalidCharsEndingDot)
 {
     std::string output = run_Set_Label("?*':&@(..", false);
-    EXPECT_EQ("?*':&@(.", output);
+    EXPECT_EQ("?*':&@(..  ", output);
 }
 TEST(Set_Label, InvalidCharsEndingDotCD)
 {
     std::string output = run_Set_Label("?*':&@(..", true);
-    EXPECT_EQ("?*':&@(..", output);
+    EXPECT_EQ("?*':&@(..  ", output);
 }
 
 } // namespace


### PR DESCRIPTION
When retrieving volume labels of disks, the following two behaviors are different from genuine MS-DOS.
This PR fixes such differences.
1. A dot is added after the 8th character of the volume label (CD-ROMs only)
2. Lower case letters are converted to upper case. (This doesn't matter with LFN support)

Before fix
![image](https://github.com/user-attachments/assets/9bfcd70c-44f6-47f9-867f-28c9c42b335d)

After fix
No dots are added
![image](https://github.com/user-attachments/assets/93ef7d53-f422-4a1d-b145-160cf9940783)

Lower case letters are not converted
![image](https://github.com/user-attachments/assets/355ed526-ca99-4e7a-a73d-372e521dd133)

