### PR TITLE
Fix regression of CD detection due to Volume Label fix

### DIFF
--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -300,7 +300,7 @@ void Set_Label(char const * const input, char * const output, bool cdrom) {
 
     while (togo > 0) {
         if(upcasebuf[vnamePos] == 0) str_end = true;
-        output[labelPos] = !str_end ? upcasebuf[vnamePos] : 0x20; // Pad empty characters with white space (0x20)
+        output[labelPos] = !str_end ? upcasebuf[vnamePos] : 0x0; // Pad empty characters with 0x00
         labelPos++;
         vnamePos++;
         togo--;

--- a/tests/drives_tests.cpp
+++ b/tests/drives_tests.cpp
@@ -108,12 +108,12 @@ TEST(LWildFileCmp, LFNCompare)
 TEST(Set_Label, Daggerfall)
 {
     std::string output = run_Set_Label("Daggerfall", false);
-    EXPECT_EQ("Daggerfall ", output);
+    EXPECT_EQ("Daggerfall", output);
 }
 TEST(Set_Label, DaggerfallCD)
 {
     std::string output = run_Set_Label("Daggerfall", true);
-    EXPECT_EQ("Daggerfall ", output);
+    EXPECT_EQ("Daggerfall", output);
 }
 
 TEST(Set_Label, LongerThan11)
@@ -130,12 +130,12 @@ TEST(Set_Label, LongerThan11CD)
 TEST(Set_Label, ShorterThan8)
 {
     std::string output = run_Set_Label("a123456", false);
-    EXPECT_EQ("a123456    ", output);
+    EXPECT_EQ("a123456", output);
 }
 TEST(Set_Label, ShorterThan8CD)
 {
     std::string output = run_Set_Label("a123456", true);
-    EXPECT_EQ("a123456    ", output);
+    EXPECT_EQ("a123456", output);
 }
 
 // Tests that the CD-ROM version adds a trailing dot when
@@ -143,36 +143,36 @@ TEST(Set_Label, ShorterThan8CD)
 TEST(Set_Label, EqualTo8)
 {
     std::string output = run_Set_Label("a1234567", false);
-    EXPECT_EQ("a1234567   ", output);
+    EXPECT_EQ("a1234567", output);
 }
 TEST(Set_Label, EqualTo8CD)
 {
     std::string output = run_Set_Label("a1234567", true);
-    EXPECT_EQ("a1234567   ", output);
+    EXPECT_EQ("a1234567", output);
 }
 
 // A test to ensure non-CD-ROM function strips trailing dot
 TEST(Set_Label, StripEndingDot)
 {
     std::string output = run_Set_Label("a1234567.", false);
-    EXPECT_EQ("a1234567.  ", output);
+    EXPECT_EQ("a1234567.", output);
 }
 TEST(Set_Label, NoStripEndingDotCD)
 {
     std::string output = run_Set_Label("a1234567.", true);
-    EXPECT_EQ("a1234567.  ", output);
+    EXPECT_EQ("a1234567.", output);
 }
 
 // Just to make sure this function doesn't clean invalid DOS labels
 TEST(Set_Label, InvalidCharsEndingDot)
 {
     std::string output = run_Set_Label("?*':&@(..", false);
-    EXPECT_EQ("?*':&@(..  ", output);
+    EXPECT_EQ("?*':&@(..", output);
 }
 TEST(Set_Label, InvalidCharsEndingDotCD)
 {
     std::string output = run_Set_Label("?*':&@(..", true);
-    EXPECT_EQ("?*':&@(..  ", output);
+    EXPECT_EQ("?*':&@(..", output);
 }
 
 } // namespace


### PR DESCRIPTION
#PR 5396 induced a failure in CD detection by volume label.
This PR fixes such regression.
An example is Lands of Lore: Guardians of Destiny.

Before fix: Game asks to insert the CD despite it already is inserted.
![image](https://github.com/user-attachments/assets/99c02510-dcbf-40ee-ac82-2741cb8c046d)

After fix: Game launches fine.
![image](https://github.com/user-attachments/assets/58cadbf8-e78b-493c-a861-3b57465b0f99)
