### PR TITLE
[FIX] CMS was always disabled regardles config settings

### DIFF
--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -3982,6 +3982,7 @@ public:
                 sect_updater->Get_prop("cms")->SetValue("auto");
             }
             sb.cms = true; // Game Blaster is CMS
+            break;
         default:
             if(sb.cms) {
                 LOG(LOG_SB, LOG_WARN)("'cms' setting 'on' not supported on this card, forcing 'auto'.");


### PR DESCRIPTION
CMS was not working cause of lost break in switch. It's always set sb.cms to false regardless of config value and selected sb.type

switch break added to allow correct working of CMS based on config value
