### PR TITLE
Add experimental UCRT64 build in nightly builds

### DIFF
--- a/.github/workflows/mingw64.yml
+++ b/.github/workflows/mingw64.yml
@@ -111,3 +111,107 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: dosbox-x-mingw-win64-${{ env.timestamp }}.zip
+  UCRT64_CI_build:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: write # for actions/checkout to fetch code and softprops/action-gh-release
+    if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v4
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: git make mingw-w64-ucrt-x86_64-toolchain mingw-w64-ucrt-x86_64-libtool mingw-w64-ucrt-x86_64-nasm autoconf automake mingw-w64-ucrt-x86_64-libslirp
+      - name: Update build info
+        shell: bash
+        run: |
+          echo "timestamp=`git show -s --format=%at | xargs -I# date -d @# +%Y%m%d%H%M%S`" >> $GITHUB_ENV
+          export shortsha=`echo ${GITHUB_SHA} | cut -c1-7`
+          export copyrightyear=`git show -s --format=%at | xargs -I# date -d @# +'%Y'`
+          export updatestr=`git show -s --format=%at | xargs -I# date -d @# +'%b %d, %Y %I:%M:%S%P'`
+          echo '/* auto generated */' > include/build_timestamp.h
+          echo "#define UPDATED_STR \"${updatestr}\"" >> include/build_timestamp.h
+          echo "#define GIT_COMMIT_HASH \"${shortsha}\""  >> include/build_timestamp.h
+          echo "#define COPYRIGHT_END_YEAR \"${copyrightyear}\"" >> include/build_timestamp.h
+          cat include/build_timestamp.h
+      - name: Build UCRT64 SDL1
+        run: |
+          top=`pwd`
+          ./build-mingw
+          strip -s $top/src/dosbox-x.exe
+      - name: Package UCRT64 SDL1
+        run: |
+          top=`pwd`
+          mkdir -p $top/package/mingw-build/mingw/drivez
+          mkdir -p $top/package/mingw-build/mingw/scripts
+          mkdir -p $top/package/mingw-build/mingw/shaders
+          mkdir -p $top/package/mingw-build/mingw/glshaders
+          mkdir -p $top/package/mingw-build/mingw/languages
+          sed -e 's/^\(output[ ]*=[ ]*\)default$/\1ttf/;s/^\(windowposition[ ]*=\)[ ]*-/\1 /;s/^\(file access tries[ ]*=[ ]*\)0$/\13/;s/^\(printoutput[ ]*=[ ]*\)png$/\1printer/;s/\(drive data rate limit[ ]*=[ ]*\)-1$/\10/' $top/dosbox-x.reference.conf>$top/package/mingw-build/mingw/dosbox-x.conf
+          cp $top/src/dosbox-x.exe $top/package/mingw-build/mingw/dosbox-x.exe
+          cp $top/CHANGELOG $top/package/mingw-build/mingw/CHANGELOG.txt
+          cp $top/dosbox-x.reference.conf $top/package/mingw-build/mingw/dosbox-x.reference.conf
+          cp $top/dosbox-x.reference.full.conf $top/package/mingw-build/mingw/dosbox-x.reference.full.conf
+          cp $top/contrib/windows/installer/readme.txt $top/package/mingw-build/mingw/README.txt
+          cp $top/contrib/windows/installer/inpoutx64.dll $top/package/mingw-build/mingw/inpoutx64.dll
+          cp $top/contrib/fonts/FREECG98.BMP $top/package/mingw-build/mingw/FREECG98.BMP
+          cp $top/contrib/fonts/wqy_1?pt.bdf $top/package/mingw-build/mingw/
+          cp $top/contrib/fonts/Nouveau_IBM.ttf $top/package/mingw-build/mingw/Nouveau_IBM.ttf
+          cp $top/contrib/fonts/SarasaGothicFixed.ttf $top/package/mingw-build/mingw/SarasaGothicFixed.ttf
+          cp $top/contrib/windows/installer/drivez_readme.txt $top/package/mingw-build/mingw/drivez/readme.txt
+          cp $top/contrib/windows/installer/windows_explorer_context_menu*.bat $top/package/mingw-build/mingw/scripts/
+          cp $top/contrib/windows/shaders/* $top/package/mingw-build/mingw/shaders/
+          cp $top/contrib/glshaders/* $top/package/mingw-build/mingw/glshaders/
+          cp $top/contrib/translations/*/*.lng $top/package/mingw-build/mingw/languages/
+      - name: Build UCRT64 SDL2
+        run: |
+          top=`pwd`
+          ./build-mingw-sdl2
+          strip -s $top/src/dosbox-x.exe
+      - name: Package UCRT64 SDL2
+        run: |
+          top=`pwd`
+          mkdir -p $top/package/mingw-build/mingw-sdl2/drivez
+          mkdir -p $top/package/mingw-build/mingw-sdl2/scripts
+          mkdir -p $top/package/mingw-build/mingw-sdl2/shaders
+          mkdir -p $top/package/mingw-build/mingw-sdl2/glshaders
+          mkdir -p $top/package/mingw-build/mingw-sdl2/languages
+          sed -e 's/^\(output[ ]*=[ ]*\)default$/\1ttf/;s/^\(windowposition[ ]*=\)[ ]*-/\1 /;s/^\(file access tries[ ]*=[ ]*\)0$/\13/;s/^\(printoutput[ ]*=[ ]*\)png$/\1printer/;s/\(drive data rate limit[ ]*=[ ]*\)-1$/\10/' $top/dosbox-x.reference.conf>$top/package/mingw-build/mingw-sdl2/dosbox-x.conf
+          cp $top/src/dosbox-x.exe $top/package/mingw-build/mingw-sdl2/dosbox-x.exe
+          cp $top/CHANGELOG $top/package/mingw-build/mingw-sdl2/CHANGELOG.txt
+          cp $top/dosbox-x.reference.conf $top/package/mingw-build/mingw-sdl2/dosbox-x.reference.conf
+          cp $top/dosbox-x.reference.full.conf $top/package/mingw-build/mingw-sdl2/dosbox-x.reference.full.conf
+          cp $top/contrib/windows/installer/readme.txt $top/package/mingw-build/mingw-sdl2/README.txt
+          cp $top/contrib/windows/installer/inpoutx64.dll $top/package/mingw-build/mingw-sdl2/inpoutx64.dll
+          cp $top/contrib/fonts/FREECG98.BMP $top/package/mingw-build/mingw-sdl2/FREECG98.BMP
+          cp $top/contrib/fonts/wqy_1?pt.bdf $top/package/mingw-build/mingw-sdl2/
+          cp $top/contrib/fonts/Nouveau_IBM.ttf $top/package/mingw-build/mingw-sdl2/Nouveau_IBM.ttf
+          cp $top/contrib/fonts/SarasaGothicFixed.ttf $top/package/mingw-build/mingw-sdl2/SarasaGothicFixed.ttf
+          cp $top/contrib/windows/installer/drivez_readme.txt $top/package/mingw-build/mingw-sdl2/drivez/readme.txt
+          cp $top/contrib/windows/installer/windows_explorer_context_menu*.bat $top/package/mingw-build/mingw-sdl2/scripts/
+          cp $top/contrib/windows/shaders/* $top/package/mingw-build/mingw-sdl2/shaders/
+          cp $top/contrib/glshaders/* $top/package/mingw-build/mingw-sdl2/glshaders/
+          cp $top/contrib/translations/*/*.lng $top/package/mingw-build/mingw-sdl2/languages/
+          cp $top/COPYING $top/package/COPYING
+          cd $top/package/
+          $top/vs/tool/zip.exe -r -9 $top/dosbox-x-UCRT64-experimental-${{ env.timestamp }}.zip *
+          cd $top
+      - name: Upload preview package
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: dosbox-x-mingw-win64-${{ env.timestamp }}
+          path: ${{ github.workspace }}/package/
+      - name: Upload release package
+        uses: softprops/action-gh-release@v2
+        if: 0
+        with:
+          files: dosbox-x--win64-${{ env.timestamp }}.zip

--- a/.github/workflows/mingw64.yml
+++ b/.github/workflows/mingw64.yml
@@ -208,10 +208,10 @@ jobs:
       - name: Upload preview package
         uses: actions/upload-artifact@v4.6.0
         with:
-          name: dosbox-x-mingw-win64-${{ env.timestamp }}
+          name: dosbox-x-UCRT64-experimental-${{ env.timestamp }}
           path: ${{ github.workspace }}/package/
       - name: Upload release package
         uses: softprops/action-gh-release@v2
         if: 0
         with:
-          files: dosbox-x--win64-${{ env.timestamp }}.zip
+          files: dosbox-x-UCRT64-experimental-${{ env.timestamp }}.zip


### PR DESCRIPTION
In response to MSYS2 [recommending UCRT64 instead of MinGW64](https://www.msys2.org/news/#2022-10-29-changing-the-default-environment-from-mingw64-to-ucrt64) as the default environment, add a workflow to build nighlty builds using UCRT64, so to prepare to migrate whenever required to.
