### PR TITLE
Fixed bug where bios memSize was not set when using TTF. This caused …

### DIFF
--- a/src/ints/int10.cpp
+++ b/src/ints/int10.cpp
@@ -325,6 +325,9 @@ Bitu INT10_Handler(void) {
 #if defined(USE_TTF)
 			if (ttf.inUse && reg_al == 0x12 && (real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE) == 0x03 || real_readb(BIOSMEM_SEG,BIOSMEM_CURRENT_MODE) == 0x55)) {
 				real_writeb(BIOSMEM_SEG,BIOSMEM_NB_ROWS,50-1);
+				Bitu pagesize=50*real_readb(BIOSMEM_SEG,BIOSMEM_NB_COLS)*2;
+				pagesize+=0x100; // bios adds extra on reload
+				real_writew(BIOSMEM_SEG,BIOSMEM_PAGE_SIZE,(uint16_t)pagesize);
 				ttf_reset();
 				break;
 			}


### PR DESCRIPTION
Fixed memory corruption when viewing output in 80x50 text mode on the Freepascal text-mode IDE.

## Additional information

Under DOS changing the font size via int `0x10`, with `ax=0x1112` updates `BIOSMEM_PAGE_SIZE` `[0x40:0x4C]`. This update is performed correctly when `INT10_LoadFont` is called, but not in the `USE_TTF` path. 

This resolves an issue where FreePascal's IDE would save and restore only the first half of video memory when in 80x50 text mode, as it was reading the incorrect value and restoring only that many bytes.