### PR TITLE
Fix adding quotes to filenames for IMGMOUNT

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -718,9 +718,9 @@ void MenuBrowseImageFile(char drive, bool arc, bool boot, bool multiple) {
 		temp_str[0]=drive;
 		temp_str[1]=' ';
 		strcat(mountstring,temp_str);
-		if (!multiple) strcat(mountstring,"\"");
+		//if (!multiple) strcat(mountstring,"\"");
 		strcat(mountstring,files.size()?files.c_str():fname.c_str());
-        if(!multiple) strcat(mountstring, "\"");
+        //if(!multiple) strcat(mountstring, "\"");
         if(mountiro[drive - 'A']) strcat(mountstring, " -ro");
         if(boot) {
             strcat(mountstring, " -u");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1085,12 +1085,16 @@ bool warn_on_mem_write = false;
 
 bool systemmessagebox(char const * aTitle, char const * aMessage, char const * aDialogType, char const * aIconType, int aDefaultButton) {
 #if !defined(HX_DOS)
+    if(!aMessage) aMessage = "";
+    std::string lDialogString(aMessage);
+    std::replace(lDialogString.begin(), lDialogString.end(), '\"', ' ');
+
     bool fs=sdl.desktop.fullscreen;
     if (fs) GFX_SwitchFullScreen();
     MAPPER_ReleaseAllKeys();
     GFX_LosingFocus();
     GFX_ReleaseMouse();
-    bool ret=tinyfd_messageBox(aTitle, aMessage, aDialogType, aIconType, aDefaultButton);
+    bool ret=tinyfd_messageBox(aTitle, lDialogString.c_str(), aDialogType, aIconType, aDefaultButton);
     MAPPER_ReleaseAllKeys();
     GFX_LosingFocus();
     if (fs&&!sdl.desktop.fullscreen) GFX_SwitchFullScreen();


### PR DESCRIPTION
This PR fixes some syntax errors in displaying message dialogs, due to some mistake in adding double quotes to the filename.
Tested on Windows 10 VS build and Arch Linux.
