### PR TITLE
Fix regression of specifying DBCS fontx file was ignored

### DIFF
--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -4577,7 +4577,6 @@ int toSetCodePage(DOS_Shell *shell, int newCP, int opt) {
             InitFontHandle();
             JFONT_Init();
             SetupDBCSTable();
-            clearFontCache();
             if(newCP == 950 && !chinasea) makestdcp950table();
             if(newCP == 951 && chinasea) makeseacp951table();
         }


### PR DESCRIPTION
As reported in issue #5434, the specified DBCS fontx file was ignored in the latest release.
This PR fixes the regression. 

## What issue(s) does this PR address?
Fixes #5434

![image](https://github.com/user-attachments/assets/ad993451-a883-402e-995c-ed6b07d15f76)

Japanese font file loads fine as well.
![image](https://github.com/user-attachments/assets/df630e74-4d8d-41b3-85d0-93972e74ea3d)
