### PR TITLE
Revert commit 706fd0e to fix Windows build errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
     location below 64KB. Option is off by default. This is intended
     for the startup routines of programs that assume 8086 wraparound
     to prevent them from crashing (joncampbell123).
+  - Bump tinyfiledialogs to v3.19.1 (maron2000)
   - Fix VGA render-on-demand bug that causes all screen updates to
     stop working if something changes video state without changing
     any other attribute (width, height, frame rate, etc.). In

--- a/src/libs/fluidsynth/fluid_adriver.c
+++ b/src/libs/fluidsynth/fluid_adriver.c
@@ -1,0 +1,404 @@
+/* FluidSynth - A Software Synthesizer
+ *
+ * Copyright (C) 2003  Peter Hanappe and others.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public License
+ * as published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA
+ */
+
+#define FLUIDINC
+#include "config.h"
+#if !C_FLUIDSYNTH && defined(WIN32) && !defined(C_HX_DOS)
+#include "fluid_adriver.h"
+#include "fluid_settings.h"
+
+/*
+ * fluid_adriver_definition_t
+ */
+
+typedef struct _fluid_audriver_definition_t
+{
+  char* name;
+  fluid_audio_driver_t* (*new)(fluid_settings_t* settings, fluid_synth_t* synth);
+  fluid_audio_driver_t* (*new2)(fluid_settings_t* settings,
+				fluid_audio_func_t func,
+				void* data);
+  int (*free)(fluid_audio_driver_t* driver);
+  void (*settings)(fluid_settings_t* settings);
+} fluid_audriver_definition_t;
+
+
+#if PULSE_SUPPORT
+fluid_audio_driver_t* new_fluid_pulse_audio_driver(fluid_settings_t* settings,
+						   fluid_synth_t* synth);
+fluid_audio_driver_t* new_fluid_pulse_audio_driver2(fluid_settings_t* settings,
+						    fluid_audio_func_t func, void* data);
+int delete_fluid_pulse_audio_driver(fluid_audio_driver_t* p);
+void fluid_pulse_audio_driver_settings(fluid_settings_t* settings);
+#endif
+
+#if ALSA_SUPPORT
+fluid_audio_driver_t* new_fluid_alsa_audio_driver(fluid_settings_t* settings,
+						  fluid_synth_t* synth);
+fluid_audio_driver_t* new_fluid_alsa_audio_driver2(fluid_settings_t* settings,
+						 fluid_audio_func_t func, void* data);
+int delete_fluid_alsa_audio_driver(fluid_audio_driver_t* p);
+void fluid_alsa_audio_driver_settings(fluid_settings_t* settings);
+#endif
+
+#if OSS_SUPPORT
+fluid_audio_driver_t* new_fluid_oss_audio_driver(fluid_settings_t* settings,
+						 fluid_synth_t* synth);
+fluid_audio_driver_t* new_fluid_oss_audio_driver2(fluid_settings_t* settings,
+						fluid_audio_func_t func, void* data);
+int delete_fluid_oss_audio_driver(fluid_audio_driver_t* p);
+void fluid_oss_audio_driver_settings(fluid_settings_t* settings);
+#endif
+
+#if COREAUDIO_SUPPORT
+fluid_audio_driver_t* new_fluid_core_audio_driver(fluid_settings_t* settings,
+						  fluid_synth_t* synth);
+fluid_audio_driver_t* new_fluid_core_audio_driver2(fluid_settings_t* settings,
+						      fluid_audio_func_t func,
+						      void* data);
+int delete_fluid_core_audio_driver(fluid_audio_driver_t* p);
+void fluid_core_audio_driver_settings(fluid_settings_t* settings);
+#endif
+
+#if DSOUND_SUPPORT
+fluid_audio_driver_t* new_fluid_dsound_audio_driver(fluid_settings_t* settings,
+						  fluid_synth_t* synth);
+int delete_fluid_dsound_audio_driver(fluid_audio_driver_t* p);
+void fluid_dsound_audio_driver_settings(fluid_settings_t* settings);
+#endif
+
+#if defined(C_SDL2)
+fluid_audio_driver_t* new_fluid_sdl2_audio_driver(fluid_settings_t* settings,
+	fluid_synth_t* synth);
+int delete_fluid_sdl2_audio_driver(fluid_audio_driver_t* p);
+void fluid_sdl2_audio_driver_settings(fluid_settings_t* settings);
+#endif
+
+#if PORTAUDIO_SUPPORT
+void fluid_portaudio_driver_settings (fluid_settings_t *settings);
+fluid_audio_driver_t* new_fluid_portaudio_driver(fluid_settings_t* settings,
+						 fluid_synth_t* synth);
+int delete_fluid_portaudio_driver(fluid_audio_driver_t* p);
+#endif
+
+#if JACK_SUPPORT
+fluid_audio_driver_t* new_fluid_jack_audio_driver(fluid_settings_t* settings, fluid_synth_t* synth);
+fluid_audio_driver_t* new_fluid_jack_audio_driver2(fluid_settings_t* settings,
+						 fluid_audio_func_t func, void* data);
+int delete_fluid_jack_audio_driver(fluid_audio_driver_t* p);
+void fluid_jack_audio_driver_settings(fluid_settings_t* settings);
+#endif
+
+#if SNDMAN_SUPPORT
+fluid_audio_driver_t* new_fluid_sndmgr_audio_driver(fluid_settings_t* settings,
+						  fluid_synth_t* synth);
+fluid_audio_driver_t* new_fluid_sndmgr_audio_driver2(fluid_settings_t* settings,
+						   fluid_audio_func_t func,
+						   void* data);
+int delete_fluid_sndmgr_audio_driver(fluid_audio_driver_t* p);
+#endif
+
+#if DART_SUPPORT
+fluid_audio_driver_t* new_fluid_dart_audio_driver(fluid_settings_t* settings,
+                          fluid_synth_t* synth);
+int delete_fluid_dart_audio_driver(fluid_audio_driver_t* p);
+void fluid_dart_audio_driver_settings(fluid_settings_t* settings);
+#endif
+
+#if AUFILE_SUPPORT
+fluid_audio_driver_t* new_fluid_file_audio_driver(fluid_settings_t* settings,
+						  fluid_synth_t* synth);
+int delete_fluid_file_audio_driver(fluid_audio_driver_t* p);
+#endif
+
+/* Available audio drivers, listed in order of preference */
+fluid_audriver_definition_t fluid_audio_drivers[] = {
+#if JACK_SUPPORT
+  { "jack",
+    new_fluid_jack_audio_driver,
+    new_fluid_jack_audio_driver2,
+    delete_fluid_jack_audio_driver,
+    fluid_jack_audio_driver_settings },
+#endif
+#if ALSA_SUPPORT
+  { "alsa",
+    new_fluid_alsa_audio_driver,
+    new_fluid_alsa_audio_driver2,
+    delete_fluid_alsa_audio_driver,
+    fluid_alsa_audio_driver_settings },
+#endif
+#if OSS_SUPPORT
+  { "oss",
+    new_fluid_oss_audio_driver,
+    new_fluid_oss_audio_driver2,
+    delete_fluid_oss_audio_driver,
+    fluid_oss_audio_driver_settings },
+#endif
+#if PULSE_SUPPORT
+  { "pulseaudio",
+    new_fluid_pulse_audio_driver,
+    new_fluid_pulse_audio_driver2,
+    delete_fluid_pulse_audio_driver,
+    fluid_pulse_audio_driver_settings },
+#endif
+#if COREAUDIO_SUPPORT
+  { "coreaudio",
+    new_fluid_core_audio_driver,
+    new_fluid_core_audio_driver2,
+    delete_fluid_core_audio_driver,
+    fluid_core_audio_driver_settings },
+#endif
+#if DSOUND_SUPPORT
+  { "dsound",
+    new_fluid_dsound_audio_driver,
+    NULL,
+    delete_fluid_dsound_audio_driver,
+    fluid_dsound_audio_driver_settings },
+#endif
+#if defined(C_SDL2)
+	{
+		"sdl2",
+		new_fluid_sdl2_audio_driver,
+		NULL,
+		delete_fluid_sdl2_audio_driver,
+		fluid_sdl2_audio_driver_settings
+	},
+#endif
+#if PORTAUDIO_SUPPORT
+  { "portaudio",
+    new_fluid_portaudio_driver,
+    NULL,
+    delete_fluid_portaudio_driver,
+    fluid_portaudio_driver_settings },
+#endif
+#if SNDMAN_SUPPORT
+  { "sndman",
+    new_fluid_sndmgr_audio_driver,
+    new_fluid_sndmgr_audio_driver2,
+    delete_fluid_sndmgr_audio_driver,
+    NULL },
+#endif
+#if DART_SUPPORT
+  { "dart",
+    new_fluid_dart_audio_driver,
+    NULL,
+    delete_fluid_dart_audio_driver,
+    fluid_dart_audio_driver_settings },
+#endif
+#if AUFILE_SUPPORT
+  { "file",
+    new_fluid_file_audio_driver,
+    NULL,
+    delete_fluid_file_audio_driver,
+    NULL },
+#endif
+  { NULL, NULL, NULL, NULL, NULL }
+};
+
+
+
+
+void fluid_audio_driver_settings(fluid_settings_t* settings)
+{
+  int i;
+
+  fluid_settings_register_str(settings, "audio.sample-format", "16bits", 0, NULL, NULL);
+  fluid_settings_add_option(settings, "audio.sample-format", "16bits");
+  fluid_settings_add_option(settings, "audio.sample-format", "float");
+
+  fluid_settings_register_int(settings, "audio.output-channels", 2, 2, 32, 0, NULL, NULL);
+  fluid_settings_register_int(settings, "audio.input-channels", 0, 0, 2, 0, NULL, NULL);
+
+
+#if defined(WIN32)
+  fluid_settings_register_int(settings, "audio.period-size", 512, 64, 8192, 0, NULL, NULL);
+  fluid_settings_register_int(settings, "audio.periods", 8, 2, 64, 0, NULL, NULL);
+#elif defined(MACOS9)
+  fluid_settings_register_int(settings, "audio.period-size", 64, 64, 8192, 0, NULL, NULL);
+  fluid_settings_register_int(settings, "audio.periods", 8, 2, 64, 0, NULL, NULL);
+#else
+  fluid_settings_register_int(settings, "audio.period-size", 64, 64, 8192, 0, NULL, NULL);
+  fluid_settings_register_int(settings, "audio.periods", 16, 2, 64, 0, NULL, NULL);
+#endif
+
+  fluid_settings_register_int (settings, "audio.realtime-prio",
+                               FLUID_DEFAULT_AUDIO_RT_PRIO, 0, 99, 0, NULL, NULL);
+
+  /* Set the default driver */
+#if JACK_SUPPORT
+  fluid_settings_register_str(settings, "audio.driver", "jack", 0, NULL, NULL);
+#elif ALSA_SUPPORT
+  fluid_settings_register_str(settings, "audio.driver", "alsa", 0, NULL, NULL);
+#elif PULSE_SUPPORT
+  fluid_settings_register_str(settings, "audio.driver", "pulseaudio", 0, NULL, NULL);
+#elif OSS_SUPPORT
+  fluid_settings_register_str(settings, "audio.driver", "oss", 0, NULL, NULL);
+#elif COREAUDIO_SUPPORT
+  fluid_settings_register_str(settings, "audio.driver", "coreaudio", 0, NULL, NULL);
+#elif DSOUND_SUPPORT && !(defined(C_SDL2) && defined(_MSC_VER) && defined(_M_IX86))
+  fluid_settings_register_str(settings, "audio.driver", "dsound", 0, NULL, NULL);
+#elif SNDMAN_SUPPORT
+  fluid_settings_register_str(settings, "audio.driver", "sndman", 0, NULL, NULL);
+#elif PORTAUDIO_SUPPORT
+  fluid_settings_register_str(settings, "audio.driver", "portaudio", 0, NULL, NULL);
+#elif DART_SUPPORT
+  fluid_settings_register_str(settings, "audio.driver", "dart", 0, NULL, NULL);
+#elif AUFILE_SUPPORT
+  fluid_settings_register_str(settings, "audio.driver", "file", 0, NULL, NULL);
+#else
+  fluid_settings_register_str(settings, "audio.driver", "", 0, NULL, NULL);
+#endif
+
+  /* Add all drivers to the list of options */
+#if PULSE_SUPPORT
+  fluid_settings_add_option(settings, "audio.driver", "pulseaudio");
+#endif
+#if ALSA_SUPPORT
+  fluid_settings_add_option(settings, "audio.driver", "alsa");
+#endif
+#if OSS_SUPPORT
+  fluid_settings_add_option(settings, "audio.driver", "oss");
+#endif
+#if COREAUDIO_SUPPORT
+  fluid_settings_add_option(settings, "audio.driver", "coreaudio");
+#endif
+#if DSOUND_SUPPORT
+  fluid_settings_add_option(settings, "audio.driver", "dsound");
+#endif
+#if SNDMAN_SUPPORT
+  fluid_settings_add_option(settings, "audio.driver", "sndman");
+#endif
+#if PORTAUDIO_SUPPORT
+  fluid_settings_add_option(settings, "audio.driver", "portaudio");
+#endif
+#if JACK_SUPPORT
+  fluid_settings_add_option(settings, "audio.driver", "jack");
+#endif
+#if DART_SUPPORT
+  fluid_settings_add_option(settings, "audio.driver", "dart");
+#endif
+#if AUFILE_SUPPORT
+  fluid_settings_add_option(settings, "audio.driver", "file");
+#endif
+
+  for (i = 0; fluid_audio_drivers[i].name != NULL; i++) {
+    if (fluid_audio_drivers[i].settings != NULL) {
+      fluid_audio_drivers[i].settings(settings);
+    }
+  }
+}
+
+/**
+ * Create a new audio driver.
+ * @param settings Configuration settings used to select and create the audio
+ *   driver.
+ * @param synth Synthesizer instance for which the audio driver is created for.
+ * @return The new audio driver instance.
+ *
+ * Creates a new audio driver for a given 'synth' instance with a defined set
+ * of configuration 'settings'.
+ */
+fluid_audio_driver_t*
+new_fluid_audio_driver(fluid_settings_t* settings, fluid_synth_t* synth)
+{
+  int i;
+  fluid_audio_driver_t* driver = NULL;
+  char* name;
+  char *allnames;
+
+  for (i = 0; fluid_audio_drivers[i].name != NULL; i++) {
+    if (fluid_settings_str_equal(settings, "audio.driver", fluid_audio_drivers[i].name)) {
+      FLUID_LOG(FLUID_DBG, "Using '%s' audio driver", fluid_audio_drivers[i].name);
+      driver = (*fluid_audio_drivers[i].new)(settings, synth);
+      if (driver) {
+	driver->name = fluid_audio_drivers[i].name;
+      }
+      return driver;
+    }
+  }
+
+  allnames = fluid_settings_option_concat (settings, "audio.driver", NULL);
+  fluid_settings_dupstr (settings, "audio.driver", &name);       /* ++ alloc name */
+  FLUID_LOG(FLUID_ERR, "Couldn't find the requested audio driver %s. Valid drivers are: %s.",
+            name ? name : "NULL", allnames ? allnames : "ERROR");
+  if (name) FLUID_FREE (name);
+  if (allnames) FLUID_FREE (allnames);
+  return NULL;
+}
+
+/**
+ * Create a new audio driver.
+ * @param settings Configuration settings used to select and create the audio
+ *   driver.
+ * @param func Function called to fill audio buffers for audio playback
+ * @param data User defined data pointer to pass to 'func'
+ * @return The new audio driver instance.
+ *
+ * Like new_fluid_audio_driver() but allows for custom audio processing before
+ * audio is sent to audio driver.  It is the responsibility of the callback
+ * 'func' to render the audio into the buffers.
+ *
+ * NOTE: Not as efficient as new_fluid_audio_driver().
+ */
+fluid_audio_driver_t*
+new_fluid_audio_driver2(fluid_settings_t* settings, fluid_audio_func_t func, void* data)
+{
+  int i;
+  fluid_audio_driver_t* driver = NULL;
+  char* name;
+
+  for (i = 0; fluid_audio_drivers[i].name != NULL; i++) {
+    if (fluid_settings_str_equal(settings, "audio.driver", fluid_audio_drivers[i].name) &&
+	(fluid_audio_drivers[i].new2 != NULL)) {
+      FLUID_LOG(FLUID_DBG, "Using '%s' audio driver", fluid_audio_drivers[i].name);
+      driver = (*fluid_audio_drivers[i].new2)(settings, func, data);
+      if (driver) {
+	driver->name = fluid_audio_drivers[i].name;
+      }
+      return driver;
+    }
+  }
+
+  fluid_settings_dupstr(settings, "audio.driver", &name);       /* ++ alloc name */
+  FLUID_LOG(FLUID_ERR, "Couldn't find the requested audio driver: %s",
+            name ? name : "NULL");
+  if (name) FLUID_FREE (name);
+  return NULL;
+}
+
+/**
+ * Deletes an audio driver instance.
+ * @param driver Audio driver instance to delete
+ *
+ * Shuts down an audio driver and deletes its instance.
+ */
+void
+delete_fluid_audio_driver(fluid_audio_driver_t* driver)
+{
+  int i;
+
+  for (i = 0; fluid_audio_drivers[i].name != NULL; i++) {
+    if (fluid_audio_drivers[i].name == driver->name) {
+      fluid_audio_drivers[i].free(driver);
+      return;
+    }
+  }
+}
+#endif

--- a/src/libs/fluidsynth/fluid_sdl2.c
+++ b/src/libs/fluidsynth/fluid_sdl2.c
@@ -1,0 +1,256 @@
+/* FluidSynth - A Software Synthesizer
+ *
+ * Copyright (C) 2003  Peter Hanappe and others.
+ * Copyright (C) 2018  Carlo Bramini
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA
+ */
+
+#define FLUIDINC
+#include "config.h"
+#if !C_FLUIDSYNTH && defined(WIN32) && !defined(C_HX_DOS)
+#include "fluid_synth.h"
+#include "fluid_adriver.h"
+#include "fluid_settings.h"
+
+#if defined(C_SDL2)
+
+#include "SDL.h"
+
+typedef struct
+{
+    fluid_audio_driver_t driver;
+
+    fluid_synth_t *synth;
+    fluid_audio_callback_t write_ptr;
+
+    SDL_AudioDeviceID devid;
+
+    int frame_size;
+
+} fluid_sdl2_audio_driver_t;
+int delete_fluid_sdl2_audio_driver(fluid_audio_driver_t* d);
+
+static void
+SDLAudioCallback(void *data, void *stream, int len)
+{
+    fluid_sdl2_audio_driver_t *dev = (fluid_sdl2_audio_driver_t *)data;
+
+    len /= dev->frame_size;
+
+    dev->write_ptr(dev->synth, len, stream, 0, 2, stream, 1, 2);
+}
+
+void fluid_sdl2_audio_driver_settings(fluid_settings_t *settings)
+{
+    int n, nDevs;
+
+    fluid_settings_register_str(settings, "audio.sdl2.device", "default", 0,NULL,NULL);
+    fluid_settings_add_option(settings, "audio.sdl2.device", "default");
+
+    if(!SDL_WasInit(SDL_INIT_AUDIO))
+    {
+        FLUID_LOG(FLUID_ERR, "SDL2 not initialized");
+        return;
+    }
+
+    nDevs = SDL_GetNumAudioDevices(0);
+
+    for(n = 0; n < nDevs; n++)
+    {
+        const char *dev_name = SDL_GetAudioDeviceName(n, 0);
+
+        if(dev_name != NULL)
+        {
+            FLUID_LOG(FLUID_DBG, "SDL2 driver testing audio device: %s", dev_name);
+            fluid_settings_add_option(settings, "audio.sdl2.device", dev_name);
+        }
+    }
+}
+
+
+/*
+ * new_fluid_sdl2_audio_driver
+ */
+fluid_audio_driver_t *
+new_fluid_sdl2_audio_driver(fluid_settings_t *settings, fluid_synth_t *synth)
+{
+    fluid_sdl2_audio_driver_t *dev = NULL;
+    fluid_audio_callback_t write_ptr;
+    double sample_rate;
+    int period_size, sample_size;
+    SDL_AudioSpec aspec, rspec;
+    char *device;
+    const char *dev_name;
+
+    /* Check if SDL library has been started */
+    if(!SDL_WasInit(SDL_INIT_AUDIO))
+    {
+        FLUID_LOG(FLUID_ERR, "Failed to create SDL2 audio driver, because the audio subsystem of SDL2 is not initialized.");
+        return NULL;
+    }
+
+    /* Retrieve the settings */
+    fluid_settings_getnum(settings, "synth.sample-rate", &sample_rate);
+    fluid_settings_getint(settings, "audio.period-size", &period_size);
+
+    /* Lower values do not seem to give good results */
+    if(period_size < 1024)
+    {
+        period_size = 1024;
+    }
+    else
+    {
+        /* According to documentation, it MUST be a power of two */
+        if((period_size & (period_size - 1)) != 0)
+        {
+            FLUID_LOG(FLUID_ERR, "\"audio.period-size\" must be a power of 2 for SDL2");
+            return NULL;
+        }
+    }
+    /* Clear the format buffer */
+    FLUID_MEMSET(&aspec, 0, sizeof(aspec));
+
+    /* Setup mixing frequency */
+    aspec.freq = (int)sample_rate;
+
+    /* Check the format */
+    if(fluid_settings_str_equal(settings, "audio.sample-format", "float"))
+    {
+        FLUID_LOG(FLUID_DBG, "Selected 32 bit sample format");
+
+        sample_size = sizeof(float);
+        write_ptr   = fluid_synth_write_float;
+
+        aspec.format = AUDIO_F32SYS;
+    }
+    else if(fluid_settings_str_equal(settings, "audio.sample-format", "16bits"))
+    {
+        FLUID_LOG(FLUID_DBG, "Selected 16 bit sample format");
+
+        sample_size = sizeof(short);
+        write_ptr   = fluid_synth_write_s16;
+
+        aspec.format = AUDIO_S16SYS;
+    }
+    else
+    {
+        FLUID_LOG(FLUID_ERR, "Unhandled sample format");
+        return NULL;
+    }
+
+    /* Compile the format buffer */
+    aspec.channels   = 2;
+    aspec.samples    = aspec.channels * ((period_size + 7) & ~7);
+    aspec.callback   = (SDL_AudioCallback)SDLAudioCallback;
+
+    /* Set default device to use */
+    device   = NULL;
+    dev_name = NULL;
+
+    /* get the selected device name. if none is specified, use default device. */
+    if(fluid_settings_dupstr(settings, "audio.sdl2.device", &device) == FLUID_OK
+            && device != NULL && device[0] != '\0')
+    {
+        int n, nDevs = SDL_GetNumAudioDevices(0);
+
+        for(n = 0; n < nDevs; n++)
+        {
+            dev_name = SDL_GetAudioDeviceName(n, 0);
+
+            if(FLUID_STRCASECMP(dev_name, device) == 0)
+            {
+                FLUID_LOG(FLUID_DBG, "Selected audio device GUID: %s", dev_name);
+                break;
+            }
+        }
+
+        if(n >= nDevs)
+        {
+            FLUID_LOG(FLUID_DBG, "Audio device %s, using \"default\"", device);
+            dev_name = NULL;
+        }
+    }
+
+    if(device != NULL)
+    {
+        FLUID_FREE(device);
+    }
+
+    do
+    {
+        /* create and clear the driver data */
+        dev = FLUID_NEW(fluid_sdl2_audio_driver_t);
+
+        if(dev == NULL)
+        {
+            FLUID_LOG(FLUID_ERR, "Out of memory");
+            break;
+        }
+
+        FLUID_MEMSET(dev, 0, sizeof(fluid_sdl2_audio_driver_t));
+
+        /* set device pointer to userdata */
+        aspec.userdata = dev;
+
+        /* Save copy of synth */
+        dev->synth = synth;
+
+        /* Save copy of other variables */
+        dev->write_ptr = write_ptr;
+        dev->frame_size = sample_size * aspec.channels;
+
+        /* Open audio device */
+        dev->devid = SDL_OpenAudioDevice(dev_name, 0, &aspec, &rspec, 0);
+
+        if(!dev->devid)
+        {
+            FLUID_LOG(FLUID_ERR, "Failed to open audio device");
+            break;
+        }
+
+        /* Start to play */
+        SDL_PauseAudioDevice(dev->devid, 0);
+
+        return (fluid_audio_driver_t *) dev;
+    }
+    while(0);
+
+    int rt=delete_fluid_sdl2_audio_driver(&dev->driver);
+    return NULL;
+}
+
+
+int delete_fluid_sdl2_audio_driver(fluid_audio_driver_t *d)
+{
+    fluid_sdl2_audio_driver_t *dev = (fluid_sdl2_audio_driver_t *) d;
+
+    if(dev != NULL)
+    {
+        if(dev->devid)
+        {
+            /* Stop audio and close */
+            SDL_PauseAudioDevice(dev->devid, 1);
+            SDL_CloseAudioDevice(dev->devid);
+        }
+
+        FLUID_FREE(dev);
+    }
+	return 0;
+}
+
+#endif /* SDL2_SUPPORT */
+#endif


### PR DESCRIPTION
Commit 706fd0e resulted in errors for all Windows related builds, so revert the deleted files.
