### PR TITLE
Don't add trailing backslash in path name if it is already there.

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -5276,16 +5276,18 @@ void DOS_Int21_7160(char *name1, char *name2) {
 		}
 		switch(reg_cl)          {
 			case 0:         // Canonoical path name
-				if(tail) strcat(name2, "\\");
-				MEM_BlockWrite(SegPhys(es)+reg_di,name2,(Bitu)(strlen(name2)+1));
+                //if(tail) strcat(name2, "\\");
+                if(tail && name2[strlen(name2) - 1] != '\\') strcat(name2, "\\");
+                MEM_BlockWrite(SegPhys(es)+reg_di,name2,(Bitu)(strlen(name2)+1));
 				reg_ax=0;
 				CALLBACK_SCF(false);
 				break;
 			case 1:         // SFN path name
 				checkwat=true;
 				if (DOS_GetSFNPath(name1,name2,false)) {
-					if(tail) strcat(name2, "\\");
-					MEM_BlockWrite(SegPhys(es)+reg_di,name2,(Bitu)(strlen(name2)+1));
+                    //if(tail) strcat(name2, "\\");
+                    if(tail && name2[strlen(name2) - 1] != '\\') strcat(name2, "\\");
+                    MEM_BlockWrite(SegPhys(es)+reg_di,name2,(Bitu)(strlen(name2)+1));
 					reg_ax=0;
 					CALLBACK_SCF(false);
 				} else {
@@ -5296,7 +5298,8 @@ void DOS_Int21_7160(char *name1, char *name2) {
 				break;
 			case 2:         // LFN path name
 				if (DOS_GetSFNPath(name1,name2,true)) {
-					if(tail) strcat(name2, "\\");
+					//if(tail) strcat(name2, "\\");
+                    if(tail && name2[strlen(name2) - 1] != '\\') strcat(name2, "\\");
 					MEM_BlockWrite(SegPhys(es)+reg_di,name2,(Bitu)(strlen(name2)+1));
 					reg_ax=0;
 					CALLBACK_SCF(false);


### PR DESCRIPTION
INT21 function 7160h adds a trailing backslash to the return path, but it should do so only when the backslash is missing. 

## What issue(s) does this PR address?
Closes #4134
Related to #4035 and #4087

![image](https://github.com/user-attachments/assets/6ce3f09a-bbf4-4f81-a8ed-6501bbd0f734)
