### PR TITLE
Update Wiki - MEM not crashing anymore with 736K Conventional

### DIFF
--- a/wiki/Guide:Video-card-support-in-DOSBox‐X.html
+++ b/wiki/Guide:Video-card-support-in-DOSBox‐X.html
@@ -466,7 +466,7 @@ The vertical refresh of CGA is 60Hz, which matches up well with the majority of 
 <div class="title">Warning</div>
 </td>
 <td class="content">
-The <code>allow more than 640kb base memory</code> configuration option allows more conventional memory, for instance, in combination with CGA graphics you can have up to 736KB of base memory. But not all software is compatible with this option. Even the included <code>mem</code> command will crash if it is set.
+The <code>allow more than 640kb base memory</code> configuration option allows more conventional memory, for instance, in combination with CGA graphics you can have up to 736KB of base memory. But not all software is compatible with this option.
 </td>
 </tr>
 </table>


### PR DESCRIPTION
Remove text about MEM crashing.

Tested with `machine=cga` and `allow more than 640kb base memory = true`:
![image](https://github.com/user-attachments/assets/e10154b6-fa6a-48ce-8b98-937dc4c84c86)

I'm not sure if edit should be here or at https://github.com/rderooy/dosbox-x-wiki/blob/master/Guide%3AVideo-card-support-in-DOSBox%E2%80%90X.asciidoc