### PR TITLE
Fix direct input of half-width kana 

### DIFF
--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -53,6 +53,7 @@ void MSG_Init(), JFONT_Init(), runRescan(const char *str);
 extern int tryconvertcp, toSetCodePage(DOS_Shell *shell, int newCP, int opt);
 extern bool jfont_init;
 extern int msgcodepage;
+extern bool kana_input;
 
 static FILE* OpenDosboxFile(const char* name) {
 	uint8_t drive;
@@ -651,8 +652,14 @@ bool keyboard_layout::map_key(Bitu key, uint16_t layouted_key, bool is_command, 
 		}
 
 		// add remapped key to keybuf
-		if (is_keypair) BIOS_AddKeyToBuffer(layouted_key);
-		else BIOS_AddKeyToBuffer((uint16_t)(key<<8) | (layouted_key&0xff));
+        if(is_keypair) {
+            if(kana_input) kana_input = false;
+            else BIOS_AddKeyToBuffer(layouted_key);
+        }
+        else {
+            if(kana_input) kana_input = false;
+            else BIOS_AddKeyToBuffer((uint16_t)(key << 8) | (layouted_key & 0xff));
+        }
 
 		return true;
 	}

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -78,6 +78,7 @@ bool OpenGL_using(void), Direct3D_using(void);
 void DOSBox_SetSysMenu(void), GFX_OpenGLRedrawScreen(void), InitFontHandle(void), DOSV_FillScreen(void), refreshExtChar(void), Add_VFiles(bool usecp), SetAlpha(double alpha), SetWindowTransparency(int trans);
 void MenuBrowseProgramFile(void), OutputSettingMenuUpdate(void), aspect_ratio_menu(void), update_pc98_clock_pit_menu(void), AllocCallback1(void), AllocCallback2(void), ToggleMenu(bool pressed);
 extern int tryconvertcp, Reflect_Menu(void);
+bool kana_input = false; // true if a half-width kana was typed
 
 #ifndef _GNU_SOURCE
 # define _GNU_SOURCE
@@ -5805,6 +5806,7 @@ void GFX_Events() {
                                         BIOS_AddKeyToBuffer(0xf000 | buff[no]);
                                         }
                                     } else {
+                                        kana_input = true;
                                         BIOS_AddKeyToBuffer(buff[no]);
                                     }
                                 } else {

--- a/src/ints/bios_keyboard.cpp
+++ b/src/ints/bios_keyboard.cpp
@@ -32,6 +32,8 @@
 #include "jfont.h"
 #include "render.h"
 
+extern bool kana_input;
+
 #if defined(_MSC_VER)
 # pragma warning(disable:4244) /* const fmath::local::uint64_t to double possible loss of data */
 #endif
@@ -814,6 +816,7 @@ static Bitu IRQ1_Handler(void) {
         uint16_t asciiscan;
         /* Now Handle the releasing of keys and see if they match up for a code */
         /* Handle the actual scancode */
+        if(kana_input) { kana_input = false; goto irq1_end; }
         if (scancode & 0x80) goto irq1_end;
         if (scancode > MAX_SCAN_CODE) goto irq1_end;
         if (flags1 & 0x08) {                    /* Alt is being pressed */
@@ -1027,6 +1030,7 @@ static Bitu IRQ1_Handler_PC98(void) {
         //                  KEY         UNSHIFT SHIFT   CTRL    KANA
         //                  ----------------------------------------
         if (pressed && sc_8251 <= 0x6f) { // skip shift-keys (0x70-0x74)
+            if(kana_input) { kana_input = false; goto pc98irq1_end;}
             if (sc_8251 == 0x60) { // STOP
                 // does not pass it on.
                 // According to Neko Project II source code, STOP invokes INT 6h
@@ -1158,6 +1162,7 @@ static Bitu IRQ1_Handler_PC98(void) {
                 }
             }
         }
+pc98irq1_end:
         if (--patience == 0) break; /* in case of stuck 8251 */
         status = IO_ReadB(0x43); /* 8251 status */
     } while (status & 2/*RxRDY*/);


### PR DESCRIPTION
Typing half-width kana directly with Japanese IME resulted in a pair of the kana and non-kana.
For instance, if you type the key `a` then you get `ﾁa` instead of a single `ﾁ`.

This PR fixes such bug.
Tested on VS x64 SDL2 build on Windows 10.

Before fix
![image](https://github.com/user-attachments/assets/203cb9d1-fbb4-43de-814e-ebad9ed17e5f)

After fix
![image](https://github.com/user-attachments/assets/6214b238-2642-4352-8428-fcf578936fa8)

Fixes #5469