### PR TITLE
Fix BIOS screen and crash on reboot on TTF mode

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -67,6 +67,7 @@ extern bool force_load_state, force_conversion;
 extern bool pc98_force_ibm_layout, gbk, chinasea;
 extern bool inshell, enable_config_as_shell_commands;
 extern bool switchttf, ttfswitch, switch_output_from_ttf;
+extern bool finish_prepare;
 bool checkmenuwidth = false;
 bool dos_kernel_disabled = true;
 bool winrun=false, use_save_file=false;
@@ -9626,7 +9627,7 @@ fresh_boot:
 #if DOSBOXMENU_TYPE == DOSBOXMENU_HMENU
         Reflect_Menu();
 #endif
-
+        finish_prepare = false;
         if (run_bios) {
             LOG_MSG("Running a custom BIOS");
 
@@ -9853,7 +9854,6 @@ fresh_boot:
          * freed resources. */
         control = NULL; /* any deref past this point and you deserve to segfault */
     }
-
     return saved_opt_test&&testerr?1:0;
 }
 

--- a/src/ints/int10_modes.cpp
+++ b/src/ints/int10_modes.cpp
@@ -2429,8 +2429,9 @@ dac_text16:
         }
 #endif
     }
+#if defined(USE_TTF)
     else ttf_switch_off(true);
-
+#endif
 	// Enable screen memory access
 	IO_Write(0x3c4,1); IO_Write(0x3c5,seq_data[1] & ~0x20);
 	//LOG_MSG("setmode end");

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -85,6 +85,11 @@ void GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused);
 bool isDBCSCP(), InitCodePage(), isKanji1(uint8_t chr), shiftjis_lead_byte(int c), sdl_wait_on_error(), CheckDBCSCP(int32_t codepage), TTF_using(void);
 void makestdcp950table(), makeseacp951table();
 
+#if defined(USE_TTF)
+void ttf_switch_on(bool ss = true), ttf_switch_off(bool ss = true);
+#endif
+extern VideoModeBlock* CurMode;
+
 Bitu call_shellstop = 0;
 /* Larger scope so shell_del autoexec can use it to
  * remove things from the environment */
@@ -983,6 +988,7 @@ void DOS_Shell::Prepare(void) {
         //initcodepagefont();
         //dos.loaded_codepage=cp;
         finish_prepare = true;
+        if(CurMode->type == M_TEXT) ttf_switch_on(true); // Initialization completed, M_TEXT modes can switch to TTF mode from now on.
 
     }
 #if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11 || defined(MACOSX)) && (defined(C_SDL2) || defined(SDL_DOSBOX_X_SPECIAL))
@@ -1264,12 +1270,14 @@ public:
 #else
 		if (secure) autoexec[i++].Install("z:\\system\\config.com -securemode");
 #endif
-#if defined(WIN32)
-        if(TTF_using()) {
+#if 0
+//#if defined(WIN32) && defined(USE_TTF) /* Workaround for TTF screen initialization */
+        if(static_cast<Section_prop*>(control->GetSection("sdl"))->Get_string("output")=="ttf") {
             autoexec[i++].Install("@config -set output=surface");
             autoexec[i++].Install("@config -set output=ttf");
         }
-#endif
+//#endif /* (WIN32) && (USE_TTF) */
+#endif // 0
 		if (addexit) autoexec[i++].Install("exit");
 
 		assert(i <= 17); /* FIXME: autoexec[] should not be fixed size */

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -988,8 +988,9 @@ void DOS_Shell::Prepare(void) {
         //initcodepagefont();
         //dos.loaded_codepage=cp;
         finish_prepare = true;
+#if defined(USE_TTF)
         if(CurMode->type == M_TEXT) ttf_switch_on(true); // Initialization completed, M_TEXT modes can switch to TTF mode from now on.
-
+#endif
     }
 #if (defined(WIN32) && !defined(HX_DOS) || defined(LINUX) && C_X11 || defined(MACOSX)) && (defined(C_SDL2) || defined(SDL_DOSBOX_X_SPECIAL))
     if (enableime) SetIMPosition();


### PR DESCRIPTION
The new BIOS screen is not compatible with TTF mode, and only a blank screen was shown.
Also, the BIOS screen freezed when user reboots the machine.

This PR fixes such issues.

## What issue(s) does this PR address?
Fixes  #5464 

![image](https://github.com/user-attachments/assets/c636b14c-f719-4c85-95b4-185fd0425a01)
