### PR TITLE
Fix blank screen when output=ttf on PC-98 mode

### DIFF
--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -3819,15 +3819,13 @@ static Bitu INT18_PC98_Handler(void) {
     }
 #endif
 #if defined(USE_TTF)
-    if(ttf.inUse)
-        ttf_reset();
-    else {
+    if(!finish_prepare){
         conf_output= static_cast<Section_prop*>(control->GetSection("sdl"))->Get_string("output");
-        if(!finish_prepare && conf_output == "ttf") { // Workaround for blank BIOS screen in TTF mode
-            toOutput("surface");
+        if(conf_output == "ttf") { // BIOS screen does not like TTF mode, switch it on later
             toOutput("ttf");
             ttf_switch_off(true);
             is_ttfswitched_on = true;
+            //LOG_MSG("TTF output is temporary switched off");
         }
     }
 #endif

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -10908,6 +10908,25 @@ startfunction:
             CALLBACK_RunRealInt(0x18);
 
             bios_pc98_posx = x;
+
+            reg_eax = 0x4200;   // setup 640x400 graphics
+            reg_ecx = 0xC000;
+            CALLBACK_RunRealInt(0x18);
+
+            IO_Write(0x6A, 0x01);    // enable 16-color analog mode (this makes the 4th bitplane appear)
+            IO_Write(0x6A, 0x04);    // but we don't need the EGC graphics
+            IO_Write(0xA4, 0x00);    // display page 0
+            IO_Write(0xA6, 0x00);    // write to page 0
+
+            // setup palette for TTF mode
+            for(unsigned int i = 0; i < 16; i++) {
+                unsigned int bias = (i & 8) ? 0x5 : 0x0;
+
+                IO_Write(0xA8, i);   // DAC index
+                IO_Write(0xAA, ((i & 2) ? 0xA : 0x0) + bias);    // green
+                IO_Write(0xAC, ((i & 4) ? 0xA : 0x0) + bias);    // red
+                IO_Write(0xAE, ((i & 1) ? 0xA : 0x0) + bias);    // blue
+            }
         }
         else {
             reg_eax = 3;        // 80x25 text

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -60,6 +60,7 @@ extern const char* RunningProgram;
 extern int enablelfn, msgcodepage, lastmsgcp;
 extern uint16_t countryNo;
 extern unsigned int dosbox_shell_env_size;
+extern bool is_ttfswitched_on;
 bool outcon = true, usecon = true, pipetmpdev = true;
 bool shellrun = false, prepared = false, testerr = false;
 
@@ -830,7 +831,7 @@ bool finish_prepare = false;
 void DOS_Shell::Prepare(void) {
     if (this == first_shell) {
 #if defined(USE_TTF)
-        if(CurMode->type == M_TEXT) ttf_switch_on(true); // Initialization completed, M_TEXT modes can switch to TTF mode from now on.
+        if(CurMode->type == M_TEXT || (IS_PC98_ARCH && is_ttfswitched_on)) ttf_switch_on(true); // Initialization completed, M_TEXT modes can switch to TTF mode from now on.
         if(ttf.inUse) {
             int cols = static_cast<Section_prop*>(control->GetSection("ttf"))->Get_int("cols");
             int lins = static_cast<Section_prop*>(control->GetSection("ttf"))->Get_int("lins");


### PR DESCRIPTION
Since 2025.01.01 release, TTF output in PC-98 mode was blanked and not usable.
This PR fixes such issue by reverting some codes with some additional changes.
Tested on VS x64 SDL1 on Windows 10.

## What issue(s) does this PR address?
Fixes #5480 

![image](https://github.com/user-attachments/assets/5c2bc684-4131-4305-b1ff-33dc09b5f543)
