### PR TITLE
Fix fullscreen mode occasionally switched to windowed mode

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -2707,6 +2707,10 @@ void GFX_SwitchFullScreen(void)
             resetFontSize();
         }
         modeSwitched(sdl.desktop.fullscreen);
+        SetVal("sdl", "fullscreen", sdl.desktop.fullscreen?"true":"false");
+        bool is_showmenu=static_cast<Section_prop *>(control->GetSection("SDL"))->Get_bool("showmenu");
+        if(sdl.desktop.fullscreen || !is_showmenu) DOSBox_NoMenu();
+        else DOSBox_SetMenu();
         return;
     }
 #endif


### PR DESCRIPTION
When DOSBox-X is in fullscreen with TTF output, launching a game will switch to graphics mode.
After quitting the game, DOSBox-X resumes to text mode (TTF output) but sometimes fails to resume to fullscreen.
This PR fixes this issue.

## What issue(s) does this PR address?
Fixes #5482
