### PR TITLE
Enable changing drives mounted prior to switching to securemode

### DIFF
--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -1264,7 +1264,7 @@ bool DOS_Shell::Execute(char* name, const char* args) {
 
 	const Section_prop* sec = static_cast<Section_prop*>(control->GetSection("dos"));
 	/* check for a drive change */
-	if (((strcmp(name + 1, ":") == 0) || (strcmp(name + 1, ":\\") == 0)) && isalpha(*name) && !control->SecureMode())
+	if (((strcmp(name + 1, ":") == 0) || (strcmp(name + 1, ":\\") == 0)) && isalpha(*name))
 	{
 #ifdef WIN32
 		uint8_t c;uint16_t n;


### PR DESCRIPTION
In secure mode, changing to drives mounted prior to setting to secure mode was not possible.

## What issue(s) does this PR address?
Fixes #4359

![image](https://github.com/user-attachments/assets/84920215-0025-4221-b797-8138f0249dc0)
