### PR TITLE
Use existing user config file rather than renewing it when DOSBox-X is upgraded

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -172,7 +172,6 @@ static bool init_output = false;
 std::string extractDateFromFilename(const std::string& filename);
 std::string findLatestConfigFile(const std::string& directory, std::string& latestDate);
 bool copyFile(const std::string& src, const std::string& dest);
-bool versionFileExists(const std::string& directory, const std::string& filename);
 
 BOOL CALLBACK EnumDispProc(HMONITOR hMon, HDC dcMon, RECT* pRcMon, LPARAM lParam) {
     (void)hMon;
@@ -7744,17 +7743,25 @@ void grGlideShutdown(void);
 
 // Function to extract the date (YYYY.MM.DD) from the filename
 std::string extractDateFromFilename(const std::string& filename) {
-    std::regex datePattern(R"((\d{4}\.\d{2}\.\d{2}))");
+    // Regular expression to match YYYY.MM.DD and YYYY.M.D formats
+    std::regex datePattern(R"((\d{4})\.(\d{1,2})\.(\d{1,2}))");
     std::smatch match;
+
     if(std::regex_search(filename, match, datePattern)) {
-        return match.str(1);
+        // Ensure two-digit month and day for consistent comparison
+        std::string year = match[1].str();
+        std::string month = (match[2].str().size() == 1) ? "0" + match[2].str() : match[2].str();
+        std::string day = (match[3].str().size() == 1) ? "0" + match[3].str() : match[3].str();
+
+        return year + "." + month + "." + day; // Return as YYYY.MM.DD format
     }
-    return "";
+
+    return ""; // Return empty string if no valid date is found
 }
 
 // Function to find the .conf file of the latest version in the specified directory
 std::string findLatestConfigFile(const std::string& directory, std::string& latestDate) {
-    std::string latestFile;
+    std::string latestFile="";
     latestDate = "";
 
 #ifdef _WIN32

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -180,14 +180,11 @@ void Cross::GetPlatformConfigDir(std::string& in) {
 }
 
 void Cross::GetPlatformConfigName(std::string& in) {
-#ifdef WIN32
-#define DEFAULT_CONFIG_FILE "dosbox-x-" VERSION ".conf"
-#elif defined(MACOSX)
-#define DEFAULT_CONFIG_FILE "DOSBox-X " VERSION " Preferences"
-#else /*linux freebsd*/
-#define DEFAULT_CONFIG_FILE "dosbox-x-" VERSION ".conf"
+#if defined(MACOSX)
+    in = "DOSBox-X " + std::string(VERSION) + " Preferences";
+#else
+    in = "dosbox-x-" + std::string(VERSION) + ".conf";
 #endif
-	in = DEFAULT_CONFIG_FILE;
 }
 
 void Cross::CreatePlatformConfigDir(std::string& in) {


### PR DESCRIPTION
When DOSBox-X is upgraded, a new user config file is created and all settings are set back to defaults.
Rather than asking users to recover the previous settings, just copy the old file and continue using it.
If no existing user config files are found, DOSBox-X will then create one for you. 

Tested on VS x64 SDL1 build on Windows 10.

## What issue(s) does this PR address?
Fixes #5506
Fixes #4609 
Fixes #4643

![image](https://github.com/user-attachments/assets/d099e562-23af-44a3-8974-169364c5b738)
