### PR TITLE
Workaround for MSVC ARM64 CI build failure

### DIFF
--- a/.github/workflows/vsbuild64.yml
+++ b/.github/workflows/vsbuild64.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build Visual Studio Win64 SDL1
         shell: pwsh
         run: |
-          msbuild -m vs/dosbox-x.sln -t:dosbox-x:Rebuild -p:Configuration=Release -p:Platform=x64
+          msbuild -m vs/dosbox-x.sln -t:dosbox-x:Rebuild -p:Configuration=Release -p:Platform=x64 
           if (-not(Test-Path -Path bin\x64\Release\dosbox-x.exe -PathType Leaf)) {exit 1}
           contrib\windows\installer\PatchPE.exe bin\x64\Release\dosbox-x.exe
       - name: Package Visual Studio Win64 SDL1
@@ -148,7 +148,7 @@ jobs:
       - name: Build Visual Studio ARM64 SDL1
         shell: pwsh
         run: |
-          msbuild -m vs/dosbox-x.sln -t:dosbox-x:Rebuild -p:Configuration=Release -p:Platform=ARM64 -p:PostBuildEventUseInBuild=false
+          msbuild -m vs/dosbox-x.sln -t:dosbox-x:Rebuild -p:Configuration=Release -p:Platform=ARM64 -p:PostBuildEventUseInBuild=false -p:WindowsTargetPlatformVersion=10.0.22621.0 
           if (-not(Test-Path -Path bin\ARM64\Release\dosbox-x.exe -PathType Leaf)) {exit 1}
       - name: Package Visual Studio ARM64 SDL1
         shell: bash
@@ -177,7 +177,7 @@ jobs:
       - name: Build Visual Studio ARM64 SDL2
         shell: pwsh
         run: |
-          msbuild -m vs/dosbox-x.sln -t:dosbox-x:Rebuild -p:Configuration="Release SDL2" -p:Platform=ARM64 -p:PostBuildEventUseInBuild=false
+          msbuild -m vs/dosbox-x.sln -t:dosbox-x:Rebuild -p:Configuration="Release SDL2" -p:Platform=ARM64 -p:PostBuildEventUseInBuild=false -p:WindowsTargetPlatformVersion=10.0.22621.0 
           if (-not(Test-Path -Path bin\ARM64\"Release SDL2"\dosbox-x.exe -PathType Leaf)) {exit 1}
       - name: Package Visual Studio ARM64 SDL2
         shell: bash


### PR DESCRIPTION
Currently, nightly builds for Visual Studio ARM64 build fails due to error in winnt.h.
This PR sets the Windows Platform Version to an older version (10.0.22621.0) as a workaround.

Still some investigation for the latest platform version (10.0.26100.0) is required to make this a permanent fix.

Related: #5525 and https://github.com/actions/runner-images/issues/11684