### PR TITLE
Fix glitch of DBCS character at the end of a line

### DIFF
--- a/include/programs.h
+++ b/include/programs.h
@@ -106,7 +106,7 @@ public:
 	bool EraseEnv(void);
 	virtual void WriteOut(const char *format, const char * arguments);
 	void WriteOut(const char * format,...);				//! Write to standard output 
-	virtual int WriteOut_NoParsing(const char * format, bool dbcs = false); //! Write to standard output, no parsing
+	virtual int WriteOut_NoParsing(const char * format, bool dbcs = true); //! Write to standard output, no parsing
 	void ChangeToLongCmd();                             //! Get command line from shell instead of PSP
 	void DebugDumpEnv();                                //! Dump environment block to log
 	void WriteExitStatus();                             //! Write exit status to CPU register AL for return to MS-DOS


### PR DESCRIPTION
When printing out messages in translation files, the current code is supposed to set the first byte of a DBCS character not to be located at the end of line, but by default the feature is disabled.
This PR fixes so that the feature is enabled by default.

![image](https://github.com/user-attachments/assets/cee97aad-8913-4611-84f5-3b5db8e5d3e7)