### PR TITLE
Fix misaligned SETCOLOR help message

### DIFF
--- a/contrib/translations/en/en_US.lng
+++ b/contrib/translations/en/en_US.lng
@@ -4154,6 +4154,7 @@ To change the current background and foreground colors, use COLOR command.
 .
 :PROGRAM_SETCOLOR_STATUS
 MONO mode status: %s (video mode %d)
+
 .
 :PROGRAM_SETCOLOR_ACTIVE
 active
@@ -4178,6 +4179,7 @@ Must be + or - for MONO: %s
 .
 :PROGRAM_SETCOLOR_COLOR
 Color %d: (%d,%d,%d) or #%02x%02x%02x
+
 .
 :PROGRAM_SETCOLOR_INVALID_NUMBER
 Invalid color number - %s

--- a/contrib/translations/ja/ja_JP.lng
+++ b/contrib/translations/ja/ja_JP.lng
@@ -4171,6 +4171,7 @@ SETCOLOR [color# [value]]
 .
 :PROGRAM_SETCOLOR_STATUS
 MONO モード 状態: %s (video mode %d)
+
 .
 :PROGRAM_SETCOLOR_ACTIVE
 有効
@@ -4195,6 +4196,7 @@ MONOは + または - を指定して下さい: %s
 .
 :PROGRAM_SETCOLOR_COLOR
 色番号 %d: (%d,%d,%d) または #%02x%02x%02x
+
 .
 :PROGRAM_SETCOLOR_INVALID_NUMBER
 色番号が無効です - %s


### PR DESCRIPTION
This PR fixes the help message of SETCOLOR command was misaligned in the translation file.

Before fix
![image](https://github.com/user-attachments/assets/fccfb81d-853f-477f-a378-6b8fb4cad084)

After fix
![image](https://github.com/user-attachments/assets/2bcedfe5-ab54-42bd-9bd6-19cfeab90150)
