### PR TITLE
Remove duplicate code mappings of Chinese characters in cp950_uni.h

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 Next
   - Fixed glitch of DBCS character at the end of a line (maron2000)
-  - Removed duplicate code mappings of Chinese characters in cp951_uni.h (1abcd)
+  - Removed duplicate code mappings of Chinese characters in both cp950_uni.h and cp951_uni.h (1abcd)
   - Enabled changing drives mounted prior to switching to securemode (maron2000)
   - Enabled some messages to be translated in the translation files (maron2000)
   - Fixed fullscreen mode occasionally switched to windowed mode (maron2000)

--- a/include/cp950_uni.h
+++ b/include/cp950_uni.h
@@ -3445,9 +3445,9 @@ void makestdcp950table() {
     cp950_to_unicode_raw[64*6+37] = 0x255e;
     cp950_to_unicode_raw[64*6+38] = 0x256a;
     cp950_to_unicode_raw[64*6+39] = 0x2561;
-    cp950_to_unicode_raw[64*7+12] = 0x5341;
+    cp950_to_unicode_raw[64*7+12] = 0x0000; /* 0x5341 is duplicate mapping so replace it with 0x0000 */
     cp950_to_unicode_raw[64*7+13] = 0x5344;
-    cp950_to_unicode_raw[64*7+14] = 0x5345;
+    cp950_to_unicode_raw[64*7+14] = 0x0000; /* 0x5345 is duplicate mapping so replace it with 0x0000 */
     cp950_to_unicode_raw[64*101+21] = 0x5f5d;
     cp950_to_unicode_raw[64*260+58] = 0x256d;
     cp950_to_unicode_raw[64*260+59] = 0x256e;


### PR DESCRIPTION
This PR make these two Chinese characters "[十](https://zi-hi.com/sp/uni/5341)" and "[卅](https://zi-hi.com/sp/uni/5345)" get proper Big5-CP950 code points when user activate code page 950 and characters are typed with Chinese IME.

## What issue(s) does this PR address?
https://github.com/joncampbell123/dosbox-x/issues/5510

## Additional information

Character | Unicode | Big5-CP950 | Big5-2003
-- | -- | -- | --
十 | U+5341 | 0xA2CC, 0xA451 | 0xA451
卄 | U+5344 | 0xA2CD | none
卅 | U+5345 | 0xA2CE, 0xA4CA | 0xA4CA
〸 | U+3038 | none | 0xA2CC
〹 | U+3039 | none | 0xA2CD
〺 | U+303A|  none | 0xA2CE
