### PR TITLE
[WIP] A more universal fix for glitch of DBCS character at the end of a line

### DIFF
--- a/include/programs.h
+++ b/include/programs.h
@@ -106,7 +106,7 @@ public:
 	bool EraseEnv(void);
 	virtual void WriteOut(const char *format, const char * arguments);
 	void WriteOut(const char * format,...);				//! Write to standard output 
-	virtual int WriteOut_NoParsing(const char * format, bool dbcs = true); //! Write to standard output, no parsing
+	virtual int WriteOut_NoParsing(const char * format, bool dbcs = false); //! Write to standard output, no parsing
 	void ChangeToLongCmd();                             //! Get command line from shell instead of PSP
 	void DebugDumpEnv();                                //! Dump environment block to log
 	void WriteExitStatus();                             //! Write exit status to CPU register AL for return to MS-DOS


### PR DESCRIPTION
PR #5528 fixed the glitch of DBCS character at the end of a line for only limited cases.
This PR patches the CON output for a more universal fix.

Test on Traditional Chinese
![image](https://github.com/user-attachments/assets/874cab47-9ec3-48f7-a911-781e9783d579)

Test on Japanese
![image](https://github.com/user-attachments/assets/ae984871-17b4-4717-b586-15b62eec019d)
