### PR TITLE
Fix misaligned welcome screen in DBCS codepages

### DIFF
--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -1113,14 +1113,16 @@ bool device_CON::Write(const uint8_t * data,uint16_t * size) {
         page = real_readb(BIOSMEM_SEG, BIOSMEM_CURRENT_PAGE);
         col = CURSOR_POS_COL(page);
         BIOS_NCOLS;
-        if(isDBCSCP() && !dos.direct_output && (col == ncols - 1) && isKanji1(data[count])) { // Consideration of first byte of DBCS characters at the end of line 
-            BIOS_NROWS;
-            row = CURSOR_POS_ROW(page);
-            if(nrows == row + 1) {
-                INT10_ScrollWindow(0, 0, (uint8_t)(nrows - 1), (uint8_t)(ncols - 1), -1, ansi.attr, page);
-                INT10_SetCursorPos(row, 0, page);
-            }
-            else INT10_SetCursorPos(row+1, 0, page);
+
+        if(isDBCSCP() && !dos.direct_output && (col == ncols - 1)
+            && *size >= count+1 && isKanji1(data[count]) && isKanji2(data[count+1])) { // Consideration of first byte of DBCS characters at the end of line 
+                BIOS_NROWS;
+                row = CURSOR_POS_ROW(page);
+                if(nrows == row + 1) {
+                    INT10_ScrollWindow(0, 0, (uint8_t)(nrows - 1), (uint8_t)(ncols - 1), -1, ansi.attr, page);
+                    INT10_SetCursorPos(row, 0, page);
+                }
+                else INT10_SetCursorPos(row + 1, 0, page);
         }
 
         if (!ansi.esc){

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -239,7 +239,15 @@ void Program::WriteOut(const char * format,...) {
 			out = 0xD;DOS_WriteFile(STDOUT,&out,&s);
 		}
 		last_written_character = (char)(out = (uint8_t)buf[i]);
-		DOS_WriteFile(STDOUT,&out,&s);
+        if(isDBCSCP() && isKanji1(buf[i]) && i + 1 < size && isKanji2(buf[i + 1])) {
+            uint8_t dbchar[3] = { (uint8_t)buf[i], (uint8_t)buf[i + 1],0 };
+            s = 2;
+            DOS_WriteFile(STDOUT, dbchar, &s); // send two bytes if next character is a DBCS character
+            i++;
+            s = 1;
+            continue;
+        }
+        DOS_WriteFile(STDOUT,&out,&s);
 	}
 	dos.internal_output=false;
 	if (resetcolor && attr) DOS_SetAnsiAttr(attr);
@@ -255,12 +263,20 @@ void Program::WriteOut(const char *format, const char *arguments) {
 	uint16_t size = (uint16_t)strlen(buf);
 	dos.internal_output=true;
 	for(uint16_t i = 0; i < size;i++) {
-		uint8_t out;uint16_t s=1;
+        uint8_t out; uint16_t s = 1;
 		if (buf[i] == 0xA && last_written_character != 0xD) {
 			out = 0xD;DOS_WriteFile(STDOUT,&out,&s);
 		}
 		last_written_character = (char)(out = (uint8_t)buf[i]);
-		DOS_WriteFile(STDOUT,&out,&s);
+        if(isDBCSCP() && isKanji1(buf[i]) && i + 1 < size && isKanji2(buf[i + 1])) {
+            uint8_t dbchar[3] = { (uint8_t)buf[i], (uint8_t)buf[i + 1], 0};
+            s = 2;
+            DOS_WriteFile(STDOUT, dbchar, &s); // send two bytes if next character is a DBCS character
+            i++;
+            s = 1;
+            continue;
+        }
+        DOS_WriteFile(STDOUT,&out,&s);
 	}
 	dos.internal_output=false;
 

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -845,10 +845,7 @@ void DOS_Shell::Prepare(void) {
             toSetCodePage(NULL, cp, -1);
         }
         Section_prop *section = static_cast<Section_prop *>(control->GetSection("dosbox"));
-        if(section->Get_bool("startbanner") && !control->opt_fastlaunch)
-            showWelcome(NULL);
-        else if((CurMode->type == M_TEXT || IS_PC98_ARCH) && ANSI_SYS_installed())
-            WriteOut("\033[2J");
+        bool startbanner = section->Get_bool("startbanner");
         if (!countryNo) {
 #if defined(WIN32)
 			char buffer[128];
@@ -901,6 +898,12 @@ void DOS_Shell::Prepare(void) {
 			}
             if(!chinasea)makestdcp950table();
             if(chinasea) makeseacp951table();
+            InitCodePage();
+            if(startbanner && !control->opt_fastlaunch)
+                //showWelcome(this);
+                DoCommand((char *)std::string("z:\\system\\intro welcome").c_str());
+            else if((CurMode->type == M_TEXT || IS_PC98_ARCH) && ANSI_SYS_installed())
+                WriteOut("\033[2J");
             const char * extra = section->data.c_str();
 			if (extra&&!control->opt_securemode&&!control->SecureMode()&&!control->opt_noconfig) {
 				std::string vstr;


### PR DESCRIPTION
It was reported that welcome screen in DBCS codepages get misaligned after PR #5543 was merged.
This seems due to flaws in distinguishing between box-drawing characters and DBCS characters.  

## What issue(s) does this PR address?
https://github.com/joncampbell123/dosbox-x/pull/5543#issuecomment-2708090552

After fix
Welcome screen shows correctly. (Traditional Chinese)
![image](https://github.com/user-attachments/assets/f367d3f7-12b1-48f3-90df-90f851677053)

Handling of first byte of DBCS character at the end of line is still as intended. (Traditional Chinese)
![image](https://github.com/user-attachments/assets/97766c8f-cd12-4b30-8257-301789203975)

Handling of Japanese text is as intended as well.
![image](https://github.com/user-attachments/assets/2fc34d5a-3008-4ae1-bf70-a49ff4f52820)

