### PR TITLE
Toggle modeswitching

### DIFF
--- a/include/vga.h
+++ b/include/vga.h
@@ -212,6 +212,7 @@ typedef struct {
 	bool has_split;
 	bool vret_triggered;
 	bool vga_override;
+	bool modeswitch_set;
 	bool doublescan_set;
 	bool doublescan_effect;
 	bool char9_set;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2190,6 +2190,10 @@ void DOSBOX_SetupConfigSections(void) {
             "For pixel-perfect scaling (output=openglpp), it is recommended to turn this option off.");
     Pbool->SetBasic(true);
 
+    Pbool = secprop->Add_bool("modeswitch",Property::Changeable::Always,true);
+    Pbool->Set_help("Let DOSBox-X determine the resolution of the monitor. ");
+    Pbool->SetBasic(true);
+
     Pmulti = secprop->Add_multi("scaler",Property::Changeable::Always," ");
     Pmulti->SetValue("normal2x",/*init*/true);
     Pmulti->Set_help("Scaler used to enlarge/enhance low resolution modes. Add keyword 'forced', "

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -399,6 +399,7 @@ static const char *def_menu_video_output[] =
 #endif
     "--",
     "doublescan",
+    "modeswitch",
 #if !defined(C_SDL2)
     "doublebuf",
 #endif

--- a/src/gui/menu_callback.cpp
+++ b/src/gui/menu_callback.cpp
@@ -2299,6 +2299,13 @@ bool doublescan_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const m
     return true;
 }
 
+bool modeswitch_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
+    (void)menu;//UNUSED
+    (void)menuitem;//UNUSED
+    MENU_SetBool("render", "modeswitch");
+    return true;
+}
+
 bool scaler_set_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
     (void)menu;//UNUSED
 
@@ -3246,6 +3253,8 @@ void AllocCallback1() {
 #endif
                 mainMenu.alloc_item(DOSBoxMenu::item_type_id,"doublescan").set_text("Doublescan").
                     set_callback_function(doublescan_menu_callback);
+                mainMenu.alloc_item(DOSBoxMenu::item_type_id,"modeswitch").set_text("Modeswitch").
+                    set_callback_function(modeswitch_menu_callback);
             }
             {
                 DOSBoxMenu::item &item = mainMenu.alloc_item(DOSBoxMenu::submenu_type_id,"VideoVsyncMenu");

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -1160,6 +1160,7 @@ void RENDER_OnSectionPropChange(Section *x) {
     Section_prop * section = static_cast<Section_prop *>(control->GetSection("render"));
 
     bool p_doublescan = vga.draw.doublescan_set;
+//    bool p_modeswitch = vga.draw.modeswitch_set;
     bool p_char9 = vga.draw.char9_set;
     int p_aspect = render.aspect;
 
@@ -1174,15 +1175,17 @@ void RENDER_OnSectionPropChange(Section *x) {
     render.frameskip.max = (Bitu)section->Get_int("frameskip");
 
     vga.draw.doublescan_set=section->Get_bool("doublescan");
+    vga.draw.modeswitch_set=section->Get_bool("modeswitch");
     vga.draw.char9_set=section->Get_bool("char9");
 
     if (render.aspect != p_aspect || vga.draw.doublescan_set != p_doublescan || vga.draw.char9_set != p_char9)
         RENDER_CallBack(GFX_CallBackReset);
-    if (vga.draw.doublescan_set != p_doublescan || vga.draw.char9_set != p_char9)
+    if (vga.draw.doublescan_set != p_doublescan || vga.draw.char9_set != p_char9 )
         VGA_StartResize();
 
     mainMenu.get_item("vga_9widetext").check(vga.draw.char9_set).refresh_item(mainMenu);
     mainMenu.get_item("doublescan").check(vga.draw.doublescan_set).refresh_item(mainMenu);
+    mainMenu.get_item("modeswitch").check(vga.draw.modeswitch_set).refresh_item(mainMenu);
     mainMenu.get_item("mapper_aspratio").check(render.aspect).refresh_item(mainMenu);
 
 #if C_XBRZ
@@ -1358,6 +1361,7 @@ void RENDER_Init() {
     control->GetSection("render")->onpropchange.push_back(&RENDER_OnSectionPropChange);
 
     vga.draw.doublescan_set=section->Get_bool("doublescan");
+    vga.draw.modeswitch_set=section->Get_bool("modeswitch");
     vga.draw.char9_set=section->Get_bool("char9");
 	eurAscii = section->Get_int("euro");
 	if (eurAscii != -1 && (eurAscii < 33 || eurAscii > 255)) {
@@ -1442,6 +1446,7 @@ void RENDER_Init() {
 
     mainMenu.get_item("vga_9widetext").check(vga.draw.char9_set).refresh_item(mainMenu);
     mainMenu.get_item("doublescan").check(vga.draw.doublescan_set).refresh_item(mainMenu);
+    mainMenu.get_item("modeswitch").check(vga.draw.modeswitch_set).refresh_item(mainMenu);
     mainMenu.get_item("mapper_aspratio").check(render.aspect).refresh_item(mainMenu);
 
     RENDER_UpdateFrameskipMenu();

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -1160,7 +1160,6 @@ void RENDER_OnSectionPropChange(Section *x) {
     Section_prop * section = static_cast<Section_prop *>(control->GetSection("render"));
 
     bool p_doublescan = vga.draw.doublescan_set;
-//    bool p_modeswitch = vga.draw.modeswitch_set;
     bool p_char9 = vga.draw.char9_set;
     int p_aspect = render.aspect;
 
@@ -1178,7 +1177,7 @@ void RENDER_OnSectionPropChange(Section *x) {
     vga.draw.modeswitch_set=section->Get_bool("modeswitch");
     vga.draw.char9_set=section->Get_bool("char9");
 
-    if (render.aspect != p_aspect || vga.draw.doublescan_set != p_doublescan || vga.draw.char9_set != p_char9)
+    if (render.aspect != p_aspect || vga.draw.doublescan_set != p_doublescan || vga.draw.char9_set != p_char9 )
         RENDER_CallBack(GFX_CallBackReset);
     if (vga.draw.doublescan_set != p_doublescan || vga.draw.char9_set != p_char9 )
         VGA_StartResize();

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -1177,9 +1177,9 @@ void RENDER_OnSectionPropChange(Section *x) {
     vga.draw.modeswitch_set=section->Get_bool("modeswitch");
     vga.draw.char9_set=section->Get_bool("char9");
 
-    if (render.aspect != p_aspect || vga.draw.doublescan_set != p_doublescan || vga.draw.char9_set != p_char9 )
+    if (render.aspect != p_aspect || vga.draw.doublescan_set != p_doublescan || vga.draw.char9_set != p_char9)
         RENDER_CallBack(GFX_CallBackReset);
-    if (vga.draw.doublescan_set != p_doublescan || vga.draw.char9_set != p_char9 )
+    if (vga.draw.doublescan_set != p_doublescan || vga.draw.char9_set != p_char9)
         VGA_StartResize();
 
     mainMenu.get_item("vga_9widetext").check(vga.draw.char9_set).refresh_item(mainMenu);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1269,7 +1269,7 @@ bool pause_on_vsync = false;
 static bool IsFullscreen() {
     if (sdl.window == NULL) return false;
     uint32_t windowFlags = SDL_GetWindowFlags(sdl.window);
-    if (windowFlags & SDL_WINDOW_FULLSCREEN_DESKTOP) return true;
+    if (windowFlags & SDL_WINDOW_FULLSCREEN_DESKTOP || windowFlags & SDL_WINDOW_FULLSCREEN) return true;
     return false;
 }
 #endif
@@ -1642,14 +1642,31 @@ SDL_Window* GFX_SetSDLWindowMode(uint16_t width, uint16_t height, SCREEN_TYPES s
      * On Android, desktop res is the only way.
      */
     SDL_SetWindowResizable(sdl.window, SDL2_resize_enable ? SDL_TRUE : SDL_FALSE);
+
+    SDL_WindowFlags flags;
+    bool p_modeswitch = vga.draw.modeswitch_set;
+
+	/*
+	 * When modeswitching _is_ enabled let's go with sane values.
+	 */
+
+	if( p_modeswitch ) {
+		flags = SDL_WINDOW_FULLSCREEN;
+		width = sdl.draw.width;
+		height = sdl.draw.height;
+	} else {
+		flags = SDL_WINDOW_FULLSCREEN_DESKTOP;
+	}
+
     if (GFX_IsFullscreen()) {
         SDL_DisplayMode displayMode;
         SDL_GetWindowDisplayMode(sdl.window, &displayMode);
+
         displayMode.w = width;
         displayMode.h = height;
         SDL_SetWindowDisplayMode(sdl.window, &displayMode);
 
-        SDL_SetWindowFullscreen(sdl.window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+        SDL_SetWindowFullscreen(sdl.window, flags);
     } else {
         SDL_SetWindowFullscreen(sdl.window, 0);
 


### PR DESCRIPTION
This features lets the user chose whether to let DOSBox-X change the monitors resolution or use scaling when the application is fullscreen. A **Modeswitch** toggle has been added to the **[render]** section of the configuration file and in the **Video > Output** menu of the GUI. 