### PR TITLE
Isolated Modeswitching for use with SDL2 only

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2190,9 +2190,10 @@ void DOSBOX_SetupConfigSections(void) {
             "For pixel-perfect scaling (output=openglpp), it is recommended to turn this option off.");
     Pbool->SetBasic(true);
 
-    Pbool = secprop->Add_bool("modeswitch",Property::Changeable::Always,true);
-    Pbool->Set_help("Let DOSBox-X determine the resolution of the monitor. ");
-    Pbool->SetBasic(true);
+    Pbool = secprop->Add_bool("modeswitch",Property::Changeable::Always,false);
+    Pbool->Set_help("Let DOSBox-X determine the resolution of the monitor. "
+			"This feature is only available when DOSBox-X is compiled with SDL2 support.");
+    Pbool->SetBasic(false);
 
     Pmulti = secprop->Add_multi("scaler",Property::Changeable::Always," ");
     Pmulti->SetValue("normal2x",/*init*/true);

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -399,9 +399,10 @@ static const char *def_menu_video_output[] =
 #endif
     "--",
     "doublescan",
-    "modeswitch",
 #if !defined(C_SDL2)
     "doublebuf",
+#else
+    "modeswitch",
 #endif
     NULL
 };

--- a/src/gui/menu_callback.cpp
+++ b/src/gui/menu_callback.cpp
@@ -3253,8 +3253,10 @@ void AllocCallback1() {
 #endif
                 mainMenu.alloc_item(DOSBoxMenu::item_type_id,"doublescan").set_text("Doublescan").
                     set_callback_function(doublescan_menu_callback);
+#if C_SDL2
                 mainMenu.alloc_item(DOSBoxMenu::item_type_id,"modeswitch").set_text("Modeswitch").
                     set_callback_function(modeswitch_menu_callback);
+#endif
             }
             {
                 DOSBoxMenu::item &item = mainMenu.alloc_item(DOSBoxMenu::submenu_type_id,"VideoVsyncMenu");

--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -1161,6 +1161,7 @@ void RENDER_OnSectionPropChange(Section *x) {
 
     bool p_doublescan = vga.draw.doublescan_set;
     bool p_char9 = vga.draw.char9_set;
+    bool p_modeswitch = vga.draw.modeswitch_set;
     int p_aspect = render.aspect;
 
     std::string s_aspect = section->Get_string("aspect");
@@ -1174,18 +1175,26 @@ void RENDER_OnSectionPropChange(Section *x) {
     render.frameskip.max = (Bitu)section->Get_int("frameskip");
 
     vga.draw.doublescan_set=section->Get_bool("doublescan");
-    vga.draw.modeswitch_set=section->Get_bool("modeswitch");
     vga.draw.char9_set=section->Get_bool("char9");
+    
+#if C_SDL2
+	vga.draw.modeswitch_set=section->Get_bool("modeswitch");
+#endif
 
-    if (render.aspect != p_aspect || vga.draw.doublescan_set != p_doublescan || vga.draw.char9_set != p_char9)
+    if (render.aspect != p_aspect || vga.draw.doublescan_set != p_doublescan || \
+		vga.draw.char9_set != p_char9 || vga.draw.modeswitch_set != p_modeswitch)
         RENDER_CallBack(GFX_CallBackReset);
-    if (vga.draw.doublescan_set != p_doublescan || vga.draw.char9_set != p_char9)
+    if (vga.draw.doublescan_set != p_doublescan || vga.draw.char9_set != p_char9 || \
+		vga.draw.modeswitch_set != p_modeswitch)
         VGA_StartResize();
 
     mainMenu.get_item("vga_9widetext").check(vga.draw.char9_set).refresh_item(mainMenu);
     mainMenu.get_item("doublescan").check(vga.draw.doublescan_set).refresh_item(mainMenu);
-    mainMenu.get_item("modeswitch").check(vga.draw.modeswitch_set).refresh_item(mainMenu);
     mainMenu.get_item("mapper_aspratio").check(render.aspect).refresh_item(mainMenu);
+
+#if C_SDL2
+    mainMenu.get_item("modeswitch").check(vga.draw.modeswitch_set).refresh_item(mainMenu);
+#endif
 
 #if C_XBRZ
     xBRZ_Change_Options(section);
@@ -1360,8 +1369,12 @@ void RENDER_Init() {
     control->GetSection("render")->onpropchange.push_back(&RENDER_OnSectionPropChange);
 
     vga.draw.doublescan_set=section->Get_bool("doublescan");
-    vga.draw.modeswitch_set=section->Get_bool("modeswitch");
     vga.draw.char9_set=section->Get_bool("char9");
+
+#if C_SDL2
+	vga.draw.modeswitch_set=section->Get_bool("modeswitch");
+#endif
+
 	eurAscii = section->Get_int("euro");
 	if (eurAscii != -1 && (eurAscii < 33 || eurAscii > 255)) {
 		LOG_MSG("Euro ASCII value has to be between 33 and 255\n");
@@ -1445,8 +1458,11 @@ void RENDER_Init() {
 
     mainMenu.get_item("vga_9widetext").check(vga.draw.char9_set).refresh_item(mainMenu);
     mainMenu.get_item("doublescan").check(vga.draw.doublescan_set).refresh_item(mainMenu);
-    mainMenu.get_item("modeswitch").check(vga.draw.modeswitch_set).refresh_item(mainMenu);
     mainMenu.get_item("mapper_aspratio").check(render.aspect).refresh_item(mainMenu);
+
+#if C_SDL2
+    mainMenu.get_item("modeswitch").check(vga.draw.modeswitch_set).refresh_item(mainMenu);
+#endif
 
     RENDER_UpdateFrameskipMenu();
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1642,21 +1642,19 @@ SDL_Window* GFX_SetSDLWindowMode(uint16_t width, uint16_t height, SCREEN_TYPES s
      * On Android, desktop res is the only way.
      */
     SDL_SetWindowResizable(sdl.window, SDL2_resize_enable ? SDL_TRUE : SDL_FALSE);
+    SDL_WindowFlags flags = SDL_WINDOW_FULLSCREEN_DESKTOP;
 
-    SDL_WindowFlags flags;
-    bool p_modeswitch = vga.draw.modeswitch_set;
-
+#if C_SDL2
 	/*
 	 * When modeswitching _is_ enabled let's go with sane values.
 	 */
-
-	if( p_modeswitch ) {
+	bool p_modeswitch = vga.draw.modeswitch_set;
+	if(p_modeswitch) {
 		flags = SDL_WINDOW_FULLSCREEN;
 		width = sdl.draw.width;
 		height = sdl.draw.height;
-	} else {
-		flags = SDL_WINDOW_FULLSCREEN_DESKTOP;
 	}
+#endif
 
     if (GFX_IsFullscreen()) {
         SDL_DisplayMode displayMode;


### PR DESCRIPTION
Modeswitching is exclusive to when DOSBox-X is compiled with SDL2 and now **modeswitch=false** is the default config. While most of the code pertinent to handling the gui modeswitching is now in preprocessor conditional blocks.  This may potentially resolve bug: #5559. However, I have been unable to recreate the issue. Additionally, the position of the **Modeswitch** label in the GUI menu has been shifted to last, below the **Double Buffering (fullscreen)** label.