### PR TITLE
Add a dot to CD labels when longer than 8 characters

### DIFF
--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -298,10 +298,12 @@ void Set_Label(char const * const input, char * const output, bool cdrom) {
     strncpy(upcasebuf, input, 11);
     //DBCS_upcase(upcasebuf);  /* Another mscdex quirk. Label is not always uppercase. (Daggerfall) */ 
 
-    (void)cdrom;
-
     while (togo > 0) {
         if(upcasebuf[vnamePos] == 0) str_end = true;
+        else if(cdrom && vnamePos == 8 && !str_end && upcasebuf[vnamePos] != '.') {
+            output[labelPos] = '.'; // add a dot between 8th and 9th character (Descent 2 installer needs this)
+            labelPos++;
+        }
         output[labelPos] = !str_end ? upcasebuf[vnamePos] : 0x0; // Pad empty characters with 0x00
         labelPos++;
         vnamePos++;

--- a/tests/drives_tests.cpp
+++ b/tests/drives_tests.cpp
@@ -113,7 +113,7 @@ TEST(Set_Label, Daggerfall)
 TEST(Set_Label, DaggerfallCD)
 {
     std::string output = run_Set_Label("Daggerfall", true);
-    EXPECT_EQ("Daggerfall", output);
+    EXPECT_EQ("Daggerfa.ll", output);
 }
 
 TEST(Set_Label, LongerThan11)
@@ -124,7 +124,7 @@ TEST(Set_Label, LongerThan11)
 TEST(Set_Label, LongerThan11CD)
 {
     std::string output = run_Set_Label("a123456789AAA", true);
-    EXPECT_EQ("a123456789A", output);
+    EXPECT_EQ("a1234567.89A", output);
 }
 
 TEST(Set_Label, ShorterThan8)


### PR DESCRIPTION
PR #5396 had a regression that the installer of Descent 2 cannot detect the installation CD.
Tested Visual Studio x64 SDL1 build on Windows 10 23H2.

## What issue(s) does this PR address?
Fixes #5564

![image](https://github.com/user-attachments/assets/d78b059d-9ec7-43da-ade6-8f7ce00c0b3b)