### PR TITLE
Fix Host key (F11, F12) handling in Codepage 932 (Japanese Shift-JIS).

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 Next
+  - Fixed Host key (F11, F12) handling in Codepage 932 (Japanese Shift-JIS).
+    (maron2000)
+  - Fixed SSE PSADBW to match the Intel SDM. (fuel-pcbox) 
   - Bumped ESFMu to ver 1.2.6 (maron2000)
   - Fixed regression of adding a dot to CD labels when longer than 8 characters,
     required for games such as Descent 2 CD installer (maron2000)

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -1064,6 +1064,7 @@ void DOS_Shell::InputCommand(char * line) {
                     && dbcs_sbcs
 #endif
                     && IS_DOS_JAPANESE)) {
+                    if(dos.loaded_codepage == 932 && isKanji1(cr >> 8) && (cr & 0xFF) == 0) break;
                     bool kanji_flag = false;
                     uint16_t pos = str_index;
                     while(1) {


### PR DESCRIPTION
This PR fixes a bug that pressing the host key (F11/F12) when Codepage is 932 (Japanese  Shift-JIS) is misinterpreted as a Kanji character was typed, leading to a corrupted display.
Confirmed that BIOS still recognizes the F11/F12 key is typed after this fix, and Host-key procedures such as switching to Fullscreen (Host+F) works.

![image](https://github.com/user-attachments/assets/311e50b2-69f2-49b2-a81c-9aaa84418f4b)
