### PR TITLE
Fix creation of overlay special files

### DIFF
--- a/src/dos/drive_overlay.cpp
+++ b/src/dos/drive_overlay.cpp
@@ -1499,7 +1499,7 @@ void Overlay_Drive::add_deleted_file(const char* name,bool create_on_disk) {
 		strcat(tname,temp_name);
 	if (!is_deleted_file(tname)) {
 		deleted_files_in_base.emplace_back(tname);
-		if (create_on_disk) add_special_file_to_disk(tname, "DEL");
+		if (create_on_disk) add_special_file_to_disk(name, "DEL");
 	}
 }
 


### PR DESCRIPTION
Closes #4354

Might be a naive fix, but changing the variable from `tname` to `name` seems to fix the crashing issue. Tested it for a few hours, including with Windows 3.1, and everything seems fine.