### PR TITLE
Fix insertion of characters in command history

### DIFF
--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -1053,6 +1053,7 @@ void DOS_BreakAction();
 bool read_kanji1 = false;
 uint8_t temp_char = 0;
 void WriteChar(uint16_t col, uint16_t row, uint8_t page, uint16_t chr, uint8_t attr, bool useattr);
+extern bool dbcs_sbcs;
 
 bool device_CON::Write(const uint8_t * data,uint16_t * size) {
 	uint16_t count=0;
@@ -1117,7 +1118,11 @@ bool device_CON::Write(const uint8_t * data,uint16_t * size) {
         col = CURSOR_POS_COL(page);
         BIOS_NCOLS;
 
-        if(isDBCSCP() && !dos.direct_output) { // Consideration of first byte of DBCS characters at the end of line 
+        if(isDBCSCP() && !dos.direct_output
+#if defined(USE_TTF)
+            && dbcs_sbcs
+#endif
+            ) { // Consideration of first byte of DBCS characters at the end of line 
             if(!read_kanji1 && isKanji1(data[count])) {
                 read_kanji1 = true;
                 temp_char = data[count];


### PR DESCRIPTION
As reported in the conversation of PR #5574, insertion and overwriting of characters in a DBCS string was not working as intended.
This PR fixes the insertion/overwriting of characters.

Before fix
![image](https://github.com/user-attachments/assets/14e4c1b8-1eea-46d2-9151-83f952e8d544)

After fix
![image](https://github.com/user-attachments/assets/3981279e-033b-4474-871f-aae2884f2c0c)
