### PR TITLE
Fix INT21h AH=01 echo behavior

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1097,14 +1097,15 @@ static Bitu DOS_21Handler(void) {
         case 0x01:      /* Read character from STDIN, with echo */
             {   
                 uint8_t c;uint16_t n=1;
-                dos.echo=true;
+                if(dos.version.major == 1) dos.echo=true;
                 DOS_ReadFile(STDIN,&c,&n);
                 if (c == 3) {
                     DOS_BreakAction();
                     if (!DOS_BreakTest()) return CBRET_NONE;
                 }
                 reg_al=c;
-                dos.echo=false;
+                if(dos.version.major > 1) DOS_WriteFile(STDOUT, &c, &n); /* RBIL: Character may be redirected under DOS 2 + */
+                if(dos.version.major == 1) dos.echo=false;
             }
             break;
         case 0x02:      /* Write character to STDOUT */


### PR DESCRIPTION
This PR fixes INT21h function AH=01 to properly redirect the output.

## What issue(s) does this PR address?
Fixes #5593

After fix
![image](https://github.com/user-attachments/assets/2c51616c-8b9d-4935-9cdc-88e453469527)

Behavior on PC-DOS 7
![image](https://github.com/user-attachments/assets/f98d0079-c556-4ce1-9cc2-3823af62a24a)
