### PR TITLE
Renamed variable ulimit to mlimit (bios.cpp) and class COLOR to COLORPGM (dos_programs.cpp)

### DIFF
--- a/build-os2.cmd
+++ b/build-os2.cmd
@@ -1,0 +1,4 @@
+echo off
+bash autogen.sh
+dash configure
+make -j4

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -8570,7 +8570,7 @@ static void VHDMAKE_ProgramStart(Program * * make) {
     *make=new VHDMAKE;
 }
 
-class COLOR : public Program {
+class COLORPGM : public Program {
 public:
     void Run(void) override;
 private:
@@ -8596,7 +8596,7 @@ private:
 	}
 };
 
-void COLOR::Run()
+void COLORPGM::Run()
 {
 	// Hack To allow long commandlines
 	ChangeToLongCmd();
@@ -8661,7 +8661,7 @@ void COLOR::Run()
 }
 
 static void COLOR_ProgramStart(Program * * make) {
-    *make=new COLOR;
+    *make=new COLORPGM;
 }
 
 alt_rgb altBGR[16], altBGR0[16], *rgbcolors = (alt_rgb*)render.pal.rgb;
@@ -10302,7 +10302,7 @@ void DOS_SetupPrograms(void) {
             "Return Color #7 to the default color value\n\n  SETCOLOR 3 +\n\n"
             "Return Color #3 to the preset color value\n\n  SETCOLOR MONO\n\n"
             "Display current MONO mode status\n\n"
-            "To change the current background and foreground colors, use COLOR command.\n");
+            "To change the current background and foreground colors, use COLORPGM command.\n");
     MSG_Add("PROGRAM_SETCOLOR_STATUS","MONO mode status: %s (video mode %d)\n");
     MSG_Add("PROGRAM_SETCOLOR_ACTIVE","active");
     MSG_Add("PROGRAM_SETCOLOR_INACTIVE","inactive");

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -8108,7 +8108,7 @@ void showBIOSSetup(const char* card, int x, int y) {
         BIOS_Int10RightJustifiedPrint(x,y,"              ESC: Exit  Arrows: Select Item  +/-: Change Values              ");
 }
 
-static Bitu ulimit = 0;
+static Bitu mlimit = 0;
 static Bitu t_conv = 0;
 static Bitu t_conv_real = 0;
 static bool bios_first_init=true;
@@ -11869,7 +11869,7 @@ public:
         /* INT 12 Memory Size default at 640 kb */
         callback[2].Install(&INT12_Handler,CB_IRET,"Int 12 Memory");
 
-        ulimit = 640;
+        mlimit = 640;
         t_conv = MEM_TotalPages() << 2; /* convert 4096/byte pages -> 1024/byte KB units */
         /* NTS: Tandy machines, because top of memory shares video memory, need more than 640KB of memory to present 640KB of memory
          *      to DOS. In that case, apparently, that gives 640KB to DOS and 128KB to video memory. 640KB of memory in a Tandy system
@@ -11885,18 +11885,18 @@ public:
          *      hardware in such a system. */
         if (allow_more_than_640kb) {
             if (machine == MCH_CGA)
-                ulimit = 736;       /* 640KB + 96KB = 0x00000-0xB7FFF */
+                mlimit = 736;       /* 640KB + 96KB = 0x00000-0xB7FFF */
             else if (machine == MCH_HERC || machine == MCH_MDA)
-                ulimit = 704;       /* 640KB + 64KB = 0x00000-0xAFFFF */
+                mlimit = 704;       /* 640KB + 64KB = 0x00000-0xAFFFF */
 	    else if (machine == MCH_TANDY)
-                ulimit = 768;       /* 640KB + 128KB = 0x00000-0xBFFFF */
+                mlimit = 768;       /* 640KB + 128KB = 0x00000-0xBFFFF */
 
             /* NTS: Yes, this means Tandy video memory at B8000 overlaps conventional memory, but the
              *      top of conventional memory is stolen as video memory anyway. Tandy documentation
              *      suggests that memory is only installed in multiples of 128KB so there doesn't seem
              *      to be a way to install only 704KB for example. */
 
-            if (t_conv > ulimit) t_conv = ulimit;
+            if (t_conv > mlimit) t_conv = mlimit;
             if (t_conv > 640 && machine != MCH_TANDY) {
                 /* because the memory emulation has already set things up
                  * HOWEVER Tandy emulation has already properly mapped A0000-BFFFF so don't mess with it */
@@ -11945,10 +11945,10 @@ public:
                 LOG(LOG_MISC,LOG_WARN)("Warning: Conventional memory size %uKB in PCjr mode is not a multiple of 32KB, games may not display graphics correctly",(unsigned int)t_conv);
         }
 
-        /* and then unmap RAM between t_conv and ulimit */
-        if (t_conv < ulimit) {
+        /* and then unmap RAM between t_conv and mlimit */
+        if (t_conv < mlimit) {
             Bitu start = (t_conv+3)/4;  /* start = 1KB to page round up */
-            Bitu end = ulimit/4;        /* end = 1KB to page round down */
+            Bitu end = mlimit/4;        /* end = 1KB to page round down */
             if (start < end) MEM_ResetPageHandler_Unmapped(start,end-start);
         }
 
@@ -11974,16 +11974,16 @@ public:
              * is installed! */
             if (t_conv > (640+32)) {
                 if (t_conv > 640) t_conv = 640;
-                if (ulimit > 640) ulimit = 640;
+                if (mlimit > 640) mlimit = 640;
 
                 /* Video memory takes the rest */
                 tandy_128kbase = 0xA0000;
             }
             else {
                 if (t_conv > 640) t_conv = 640;
-                if (ulimit > 640) ulimit = 640;
+                if (mlimit > 640) mlimit = 640;
                 t_conv -= 16;
-                ulimit -= 16;
+                mlimit -= 16;
 
                 /* if 32KB would cross a 128KB boundary, then adjust again or else
                  * things will horribly break between text and graphics modes */
@@ -12012,9 +12012,9 @@ public:
                 if (t_conv > 128) t_conv = 128;
                 t_conv -= 16;
             }
-            if (ulimit <= (128+16)) {
-                if (ulimit > 128) ulimit = 128;
-                ulimit -= 16;
+            if (mlimit <= (128+16)) {
+                if (mlimit > 128) mlimit = 128;
+                mlimit -= 16;
             }
         }
 


### PR DESCRIPTION
Renamed variable ulimit to mlimit (bios.cpp) and class COLOR to COLORPGM (dos_programs.cpp), because both symbols are always defined in OS/2 EMX.

## What issue(s) does this PR address?

To be able to port DOSBOX-X to OS/2, I need to solve the conflict with these pre-existing symbols.
Should be other names be more suitable, please say so.

## Does this PR introduce any breaking change(s)?

Should not break anything.

