### PR TITLE
Int21h AH=0x0a Keep cursor position if keyboard buffer full

### DIFF
--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -1293,7 +1293,13 @@ static Bitu DOS_21Handler(void) {
                     }
                     if (read == free && c != 13) {      // Keyboard buffer full
                         uint8_t bell = 7;
+                        uint8_t page = real_readb(BIOSMEM_SEG, BIOSMEM_CURRENT_PAGE);
+                        uint8_t col = CURSOR_POS_COL(page);
+                        uint8_t row = CURSOR_POS_ROW(page);
+                        BIOS_NCOLS;
                         DOS_WriteFile(STDOUT, &bell, &n);
+                        if(CURSOR_POS_COL(page) > col)
+                            INT10_SetCursorPos(row, col, page); // stay where we were
                         continue;
                     }
                     DOS_WriteFile(STDOUT,&c,&n);


### PR DESCRIPTION
Int21h AH=0x0a function (Buffered input) beeps when buffer is full.
This PR fixes so that cursor position is unchanged when it beeped.

According to PC-DOS 7.0, echoed beep can be redirected, but of course not included in the output buffer.