### PR TITLE
Fix COLOR command to match behavior on Windows

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 Next
+  - Fixed COLOR command to match behavior on Windows (maron2000)
   - Fixed INT21h AH=0a cursor position moved by bell due to keyboard buffer full
     (maron2000)
   - Fixed INT21h AH=01 echo behavior (maron2000)


### PR DESCRIPTION
Fix COLOR command to match behavior on Windows.

- Set errorlevel 1 and do nothing when foreground and background color is the same
- Change color of the whole screen, not only whatever displayed after the COLOR command
- If the parameter specified is only one digit, handle that as foreground color and set background color to black
- Show usage if illegal parameters are specified

![image](https://github.com/user-attachments/assets/a3f87762-2b30-4546-a41d-3b06bf7a0d54)
![image](https://github.com/user-attachments/assets/afea319f-f031-444e-820e-cd3992b024f1)
 
## What issue(s) does this PR address?
Fixes #5603
