### PR TITLE
Rewrite DBCS character handling of Backspace key in command history

### DIFF
--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -1003,30 +1003,28 @@ void DOS_Shell::InputCommand(char * line) {
                     backone();
                     if(bytes == 2 && str_len >= 2) backone();
 
-                    if(str_index < str_len) {
-                        for(uint16_t i = str_index - bytes; i < str_len - bytes; i++) {
-                            line[i] = line[i + bytes];  // Shift buffer to left
-                        }
-                    }
+                    if(str_index < str_len)
+                        memmove(&line[str_index - bytes], &line[str_index], str_len - str_index);  // Shift buffer to left
+
                     line[str_len - 1] = '\0';
                     if(bytes == 2)line[str_len - 2] = '\0';
                     str_len -= bytes;
                     str_index -= bytes;
                     size -= bytes;
-                    if(str_index < str_len) {
-                        for(int i = str_len; i > 0; i--) backone();
 
+                    for(int i = str_len; i > 0; i--) backone();
+                    col = CURSOR_POS_COL(page);
+                    while(col > prompt_col) {
+                        backone();
                         col = CURSOR_POS_COL(page);
-                        while(col > prompt_col) {
-                            backone();
-                            col = CURSOR_POS_COL(page);
-                        }
+                    }
 
-                        uint16_t a = str_len;
-                        uint8_t* text = reinterpret_cast<uint8_t*>(&line[0]);
-                        DOS_WriteFile(STDOUT, text, &a); // Rewrite the command history
-                        outc(' '); outc(' ');  backone(); backone();
+                    uint16_t a = str_len;
+                    uint8_t* text = reinterpret_cast<uint8_t*>(&line[0]);
+                    DOS_WriteFile(STDOUT, text, &a); // Rewrite the command history
+                    outc(' '); outc(' ');  backone(); backone();
 
+                    if(str_index < str_len) {
                         for(int i = str_len; i > 0; i--) backone();
                         col = CURSOR_POS_COL(page);
                         while(col > prompt_col) {

--- a/src/shell/shell_misc.cpp
+++ b/src/shell/shell_misc.cpp
@@ -979,88 +979,64 @@ void DOS_Shell::InputCommand(char * line) {
                     if(str_index) {
                         size += DeleteBackspace(false, line, str_index, str_len);
                     }
-                } else {
-                    int k=1;
+                }
+                else {
                     if(str_index == 0)break;
-                    if (isDBCSCP()
-#if defined(USE_TTF)
-                        &&dbcs_sbcs
-#endif
-                        &&str_index>1&&(line[str_index-1]<0||((dos.loaded_codepage==932||(dos.loaded_codepage==936&&gbk)||dos.loaded_codepage==950||dos.loaded_codepage==951)&&line[str_index-1]>=0x40))&&line[str_index-2]<0)
-                        k=2;
                     page = real_readb(BIOSMEM_SEG, BIOSMEM_CURRENT_PAGE);
                     BIOS_NCOLS; BIOS_NROWS;
-                    col = CURSOR_POS_COL(page);
-                    row = CURSOR_POS_ROW(page);
-                    if(str_index >= k) {
-                        if(col == 0) {
-                            if(k == 1) {
-                                WriteChar(ncols - 1, row - 1, page, ' ', 0, false);
-                                backone();
-                            }
-                            else {
-                                uint16_t get_char;
-                                ReadCharAttr(ncols - 1, row - 1, page, &get_char);
-                                WriteChar(ncols - 1, row - 1, page, ' ', 0, false);
-                                WriteChar(ncols - 2, row - 1, page, ' ', 0, false);
-                                backone(); backone();
-                                if((uint8_t)(line[str_index - 1] & 0xFF) != (uint8_t)(get_char & 0xFF)) {
-                                    WriteChar(ncols - 3, row - 1, page, ' ', 0, false);
-                                    backone();
-                                }
-                            }
-                        }
-                        else {
-                            WriteChar(col - 1, row, page, ' ', 0, false);
-                            backone();
-                            if(k == 2) {
-                                assert(col >= k);
-                                WriteChar(col - 2, row, page, ' ', 0, false);
-                                backone();
-                            }
-                        }
-                        if(str_index == str_len) {
-                            if(k == 2)line[str_len - 2] = 0;
-                            line[str_len - 1] = 0;
-                            line[str_len] = 0;
-                            str_len -= k;
-                            str_index -= k;
-                            size += k;
-                            break;
-                        }
-                        col = CURSOR_POS_COL(page);
+                    uint8_t bytes = 1; // Previous character is DBCS or SBCS
+                    if(isDBCSCP()
+#if defined(USE_TTF)
+                        && dbcs_sbcs
+#endif
+                        ) bytes = GetLastCount(line, str_index);
+                    
+                    if(str_index < str_len) {
                         uint16_t a = str_len - str_index;
                         uint8_t* text = reinterpret_cast<uint8_t*>(&line[str_index]);
-                        DOS_WriteFile(STDOUT, text, &a);//write buffer to screen
-                        uint16_t col2 = CURSOR_POS_COL(page);
-                        row = CURSOR_POS_ROW(page);
-                        if(k == 2) {
-                            outc(' '); outc(' '); backone(); backone();
+                        DOS_WriteFile(STDOUT, text, &a);
+                    }
+                    backone();
+                    if(bytes == 2 && str_len >= 2) backone();
+                    outc(' ');
+                    if(bytes == 2 && str_len >= 2) outc(' ');
+                    backone();
+                    if(bytes == 2 && str_len >= 2) backone();
+
+                    if(str_index < str_len) {
+                        for(uint16_t i = str_index - bytes; i < str_len - bytes; i++) {
+                            line[i] = line[i + bytes];  // Shift buffer to left
                         }
-                        else {
-                            outc(' '); backone();
-                        }
-                        if(col2 >= ncols - (k == 2 ? 3 : 1) && row < nrows) {
-                            for(int i = 0; i <= k; i++) WriteChar(i, row + 1, page, ' ', 0, false);
-                        }
-                        col2 = CURSOR_POS_COL(page);
-                        if(col2 >= a) INT10_SetCursorPos(row, col2 - a, page);
-                        else {
-                            uint16_t lines_up = (a - col2 - 1) / ncols + 1;
-                            if(col2 < ncols) for(int i = col2; i < ncols; i++) WriteChar(i, row, page, ' ', 0, false);
-                            if(row >= lines_up) INT10_SetCursorPos(row - lines_up, col, page);
-                            else INT10_SetCursorPos(0, 0, page);
+                    }
+                    line[str_len - 1] = '\0';
+                    if(bytes == 2)line[str_len - 2] = '\0';
+                    str_len -= bytes;
+                    str_index -= bytes;
+                    size -= bytes;
+                    if(str_index < str_len) {
+                        for(int i = str_len; i > 0; i--) backone();
+
+                        col = CURSOR_POS_COL(page);
+                        while(col > prompt_col) {
+                            backone();
+                            col = CURSOR_POS_COL(page);
                         }
 
-                        for(Bitu i = str_index; i <= str_len; i++) {
-                            line[i-k] = line[i];
+                        uint16_t a = str_len;
+                        uint8_t* text = reinterpret_cast<uint8_t*>(&line[0]);
+                        DOS_WriteFile(STDOUT, text, &a); // Rewrite the command history
+                        outc(' '); outc(' ');  backone(); backone();
+
+                        for(int i = str_len; i > 0; i--) backone();
+                        col = CURSOR_POS_COL(page);
+                        while(col > prompt_col) {
+                            backone();
+                            col = CURSOR_POS_COL(page);
                         }
-                        line[str_len - k] = 0;
-                        line[str_len - k + 1] = 0;
-                        line[str_len] = 0;
-                        str_index -= k;
-                        str_len -= k;
-                        size += k;
+
+                        a = str_index;
+                        text = reinterpret_cast<uint8_t*>(&line[0]);
+                        DOS_WriteFile(STDOUT, text, &a); // Move to the cursor position
                     }
                 }
                 if (l_completion.size()) l_completion.clear();


### PR DESCRIPTION
The Backspace key fix in PR #5574 had some flaws, so rewritten to fix such cases.

Before fix: Character at the end of second line is garbled.
![image](https://github.com/user-attachments/assets/ce4d9882-b2a7-41df-a880-5c4557fb2302)

After fix
![image](https://github.com/user-attachments/assets/e716e723-3a02-4cc7-8048-b194f2507253)
