### PR TITLE
Fix intermittent buffer overflow upon savestate

### DIFF
--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -2287,7 +2287,7 @@ void POD_Save_DOS_Files( std::ostream& stream )
 			//**********************************************
 			//**********************************************
 
-			file_namelen = (uint8_t)strlen( Files[lcv]->name );
+			file_namelen = (uint8_t)( strlen( Files[lcv]->name ) + 1 );
 			file_name = (char *) alloca( file_namelen );
 			strcpy( file_name, Files[lcv]->name );
 


### PR DESCRIPTION
* allocate missing byte for string terminator for savestate filename to prevent buffer overflow

## What issue(s) does this PR address?

* Possibly a fix for #5287

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No

## Additional information

Some DOS programs (some but not all Commander Keen games) were always crashing upon savestate using 0ef6c2d020729b55f103a3b5cc0f82f96267696a and various release versions, each built from source on Ubuntu 24.04.

Using a debugger, I discovered an unsafe `strcpy` to a buffer insufficiently sized to hold the string being copied. Crashes disappeared after allocating an additional byte for the string terminator.
