### PR TITLE
macOS Install SDL2_net in CI workflow to enable internal modem support

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install libraries
         run: |
-          brew install autoconf automake nasm glfw glew coreutils sevenzip
+          brew install autoconf automake nasm glfw glew coreutils sevenzip libslirp fluid-synth pkg-config sdl2_net
           mkdir -p package/dosbox-x
           mkdir -p package/dosbox-x-sdl2
           # cd vs/sdlnet && ./build-dosbox.sh
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install libraries
         run: |
-          brew install autoconf automake nasm glfw glew coreutils sevenzip
+          brew install autoconf automake nasm glfw glew coreutils sevenzip libslirp fluid-synth pkg-config sdl2_net
           mkdir -p package/dosbox-x
           mkdir -p package/dosbox-x-sdl2
           # cd vs/sdlnet && ./build-dosbox.sh

--- a/BUILD.md
+++ b/BUILD.md
@@ -78,7 +78,7 @@ sudo make install
 * macOS
   * First install the required libraries needed.
     ```
-     brew install autoconf automake nasm glfw glew fluid-synth libslirp pkg-config
+     brew install autoconf automake nasm glfw glew fluid-synth libslirp pkg-config sdl2_net
     ```
   * Compile natively for the host architecture (SDL1 or SDL2)
     ```


### PR DESCRIPTION
This PR adds SDL2_net to enable internal modem support of Release and nightly builds.

Current CI builds fails to find SDL_net/SDL2_net.
```
configure: WARNING: Can't find SDL_net, internal modem and ipx disabled
```

## What issue(s) does this PR address?

Fixes #3534
