### PR TITLE
Explicitly specify files in Makefile.am instead of using wildcards

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,7 +15,8 @@ res_DATA = \
 	../dosbox-x.reference.conf \
 	../dosbox-x.reference.full.conf \
 	../contrib/fonts/FREECG98.BMP \
-	../contrib/fonts/wqy_1?pt.bdf \
+	../contrib/fonts/wqy_11pt.bdf \
+	../contrib/fonts/wqy_12pt.bdf \
 	../contrib/fonts/Nouveau_IBM.ttf \
 	../contrib/fonts/SarasaGothicFixed.ttf \
 	../CHANGELOG


### PR DESCRIPTION
Fix a build/install error due to using wildcards in Makefile.am, which is not supported in GNU Automake.

## What issue(s) does this PR address?
Fixes #5623
