### PR TITLE
Do not use Enet on OS/2

### DIFF
--- a/src/hardware/serialport/misc_util.cpp
+++ b/src/hardware/serialport/misc_util.cpp
@@ -27,6 +27,13 @@
 // C++ SDLnet wrapper
 
 #if !defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR)
+#define WITH_ENET_IMPLEMENTATION
+#endif
+#if defined(OS2)
+#undef WITH_ENET_IMPLEMENTATION
+#endif
+
+#if defined(WITH_ENET_IMPLEMENTATION)
  #define ENET_IMPLEMENTATION
  #include "enet.h"
 #endif
@@ -86,7 +93,7 @@ NETClientSocket *NETClientSocket::NETClientFactory(SocketTypesE socketType,
 	switch (socketType) {
 	case SOCKET_TYPE_TCP: return new TCPClientSocket(destination, port);
 
-#if !defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR)
+#if defined(WITH_ENET_IMPLEMENTATION)
 	case SOCKET_TYPE_ENET: return new ENETClientSocket(destination, port);
 #endif
 
@@ -145,7 +152,7 @@ NETServerSocket *NETServerSocket::NETServerFactory(SocketTypesE socketType,
 	switch (socketType) {
 	case SOCKET_TYPE_TCP: return new TCPServerSocket(port);
 
-#if !defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR)
+#if defined(WITH_ENET_IMPLEMENTATION)
 	case SOCKET_TYPE_ENET: return new ENETServerSocket(port);
 #endif
 
@@ -156,7 +163,7 @@ NETServerSocket *NETServerSocket::NETServerFactory(SocketTypesE socketType,
 
 // --- ENet UDP NET INTERFACE ------------------------------------------------
 
-#if !defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR)
+#if defined(WITH_ENET_IMPLEMENTATION)
 class enet_manager_t {
 public:
 	enet_manager_t()

--- a/src/hardware/serialport/misc_util.h
+++ b/src/hardware/serialport/misc_util.h
@@ -65,6 +65,13 @@
 #include <SDL_net.h>
 
 #if !defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR)
+#define WITH_ENET_HEADER
+#endif
+#if defined(OS2)
+#undef WITH_ENET_HEADER
+#endif
+
+#if defined(WITH_ENET_HEADER)
 #include "enet.h"
 #endif
 
@@ -131,7 +138,7 @@ public:
 
 // --- ENET UDP NET INTERFACE ------------------------------------------------
 
-#if !defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR)
+#if defined(WITH_ENET_HEADER)
 class ENETServerSocket : public NETServerSocket {
 public:
 	ENETServerSocket(uint16_t port);


### PR DESCRIPTION
Do not use Enet on OS/2 (has no IPV6).
Win XP build does not break this time ;-)
