### PR TITLE
Fix a message showed in English instead of the translated one.

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -6489,7 +6489,7 @@ class IMGMOUNT : public Program {
 						}
 					}
 					if (!skipDetectGeometry && !DetectGeometry(NULL, paths[i].c_str(), sizes)) {
-						errorMessage = "Unable to detect geometry\n";
+						errorMessage = MSG_Get("PROGRAM_IMGMOUNT_GEOMETRY_ERROR");
 					}
 				}
 


### PR DESCRIPTION
Fixed a message showed in English instead of the translated one, as reported in https://github.com/joncampbell123/dosbox-x/pull/5532#issuecomment-2814486142.

![image](https://github.com/user-attachments/assets/0f60e3d4-8fca-448e-b5cf-5342f0cb5cc3)

