### PR TITLE
Update BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,8 +1,8 @@
 Building DOSBox-X
 =================
 
-The page is about manually building the DOSBox-X source code. Automated
-development (preview) builds intended for testing purposes for various
+The page is about manually building the DOSBox-X source code.
+Automated development (preview) builds intended for testing purposes for various
 platforms are also available from the [DOSBox-X Development Builds](https://dosbox-x.com/devel-build.html) page.
 Released builds are available from the [Releases](https://github.com/joncampbell123/dosbox-x/releases) page.
 
@@ -14,91 +14,90 @@ General information on source code compilation
 
 The four major operating systems and platforms of DOSBox-X are:
 
-1. Windows 11, 10, 8, 7, Vista and XP for 32-bit and 64-bit x86/x64 and ARM
+1. Windows 11, 10, 8, 7, Vista and XP, 9x/NT4 for 32-bit and 64-bit x86/x64 and ARM
+- [Visual Studio (2017 and after)](#compiling-the-source-code-using-visual-studio-windows) for Vista and after
+- [MinGW standard and lowend builds](#compiling-the-source-code-using-mingw-windows)
 
 2. Linux (with X11) 64-bit x86/x64, and on a Raspberry Pi 3/4/5
+- [General procedures](#general-procedures-to-compile-the-source-code-cross-platform)
+- [Ubuntu](#to-compile-dosbox-x-in-ubuntu-tested-with-2004-and-2010)
+- [Fedora Workstation](#to-compile-dosbox-x-in-fedora-workstation)
+- [Raspberry Pi](#to-compile-dosbox-x-in-raspberry-pi)
 
-3. macOS (Mac OS X) recent version, 64-bit Intel, ARM-based, and Universal
+3. macOS (Mac OS X) High Sierra and after, Intel, ARM-based, and Universal
+- [macOS procedures](#compiling-the-source-code-in-macos)
 
 4. DOS (MS-DOS 5.0+ or compatible)
+- [HX-DOS](#to-compile-dosbox-x-for-dos-with-hx-dos-platform)
 
-Straight Windows builds are expected to compile using the free community edition
-of Visual Studio 2017 to Visual Studio 2022 and the DirectX 2010 SDK.
+The code requires a C++ compiler that can support the C++11 standard.
 
-Linux and MinGW Windows builds are expected to compile with the GNU autotools.
+DOSBox-X supports both SDL ([Simple Directmedia Library](https://www.libsdl.org/)) versions 1.x and 2.x.
 
-macOS builds are expected to compile on the terminal using GNU autotools and
-the LLVM/Clang compiler provided by XCode. Universal macOS builds are only
-possible when building on a host machine powered by an Apple Silicon CPU, due to
-requiring parallel Homebrew installations running natively *and* under
-Rosetta 2.
+Note that SDL1 version requires the in-tree SDL 1.x library since it has been heavily modified from 
+the original SDL 1.x source code and is thus somewhat incompatible with the stock library.
 
-In all cases, the code requires a C++ compiler that can support the C++11
-standard.
-
-Note that DOSBox-X supports both SDL 1.x and 2.x, and it is written to compile
-against the in-tree copy of the SDL 1.x (Simple Directmedia Library), or against
-the SDL 2.x library provided by your Linux distribution.
-
-For Visual Studio and MinGW compilation, the in-tree copy of SDL is always
-used. Note that the in-tree SDL 1.x library has been heavily modified from
-the original SDL 1.x source code and is thus somewhat incompatible with the
-stock library.
-
-The modifications provide additional functions needed to improve DOSBox-X
-and fix many issues with keyboard input, window management, and display
-management that previously required terrible kludges within the DOSBox
+Such modifications provide additional functions needed to improve DOSBox-X and fix many issues with keyboard input,
+window management, and display management that previously required terrible kludges within the DOSBox
 and DOSBox-X source code.
 
-In Windows, the modifications also permit the emulation to run independent
-of the main window so that moving, resizing, or using menus does not cause
-emulation to pause.
+In Windows, the modifications also permit the emulation to run independent of the main window so that moving,
+resizing, or using menus does not cause emulation to pause.
 
-In macOS, the modifications provide an interface to allow DOSBox-X to
-replace and manage the macOS menu bar.
+In macOS, the modifications provide an interface to allow DOSBox-X to replace and manage the macOS menu bar.
+
+On the other hand, only a slight modification regarding IME support on Windows and macOS are added to the 
+in-tree SDL2 code, so Linux and macOS users may choose to use the original SDL2 library,
+while on Windows in-tree SDL2 code is always used.
 
 Please look at the [README.source-code-description](README.source-code-description) file for more information
 and descriptions on the source code.
 
-How to compile the source code (cross-platform)
+Compiling the source code using Visual Studio (Windows)
+-------------------------------------------------------
+
+The source code can be built with Visual Studio 2017, 2019, and 2022.
+The executables will work on 32-bit and 64-bit Windows Vista or higher.
+
+Use the ```./vs/dosbox-x.sln``` "solution" file, select 32/64-bit, SDL1/2 and build the source code.
+You will need the DirectX 2010 SDK for Direct3D9 support.
+
+By default the targeted platform is v142 (Visual Studio 2019).
+Change it to v141 (VS2017) or v143 (VS2022) accordingly to your build environment.
+
+`WindowsTargetPlatformVersion` is set to `10.0` by default, which make VS pick the latest Windows SDK version installed,
+but VS2017 requires you to explicitly set the version installed in your PC, for example `10.0.22000.0`.
+_Note that ARM builds requires versions ``10.0.22621.0`` or before._ 
+
+To build executables that will work on Windows XP, you have to change the target platform to v141 (Visual Studio 2017).
+After the build is completed, you have to patch the PE header of the executable using a tool included in the source code.
+
+```./contrib/windows/installer/PatchPE.exe path-to-your-exe-file/dosbox-x.exe```
+
+Libraries such as SDL, freetype, libpdcurses, libpng and zlib are already included,
+and as of DOSBox-X 0.83.6 support for FluidSynth MIDI Synthesizer is also included
+for Windows builds (set ``mididevice=fluidsynth`` in the [midi] section of DOSBox-X's
+configuration file (dosbox-x.conf) along with required soundfont file [e.g.
+``FluidR3_GM.sf2`` or ``GeneralUser_GS.sf2``] to use it).
+
+The slirp backend for the NE2000 network emulation is only supported by MinGW builds
+but not Visual Studio builds.
+
+Build the source code for your platform (Win32, x64, ARM and ARM64 are supported).
+
+As of 2018/06/06, Visual Studio 2017 builds (32-bit and 64-bit) explicitly require
+a processor that supports the SSE instruction set. As of version 2022.09.01, Visual
+Studio ARM/ARM64 builds require a Windows SDK that includes the OpenGL library.
+
+Visual Studio Code is supported, too.
+
+Check the [README.development-in-Windows](README.development-in-Windows) file for more information about this platform.
+
+Compiling the source code using MinGW (Windows)
 -----------------------------------------------
+Depending on the target OS to run DOSBox-X, the build environment and procedures will vary.
 
-* General Linux or BSD compile (SDL1)
-```
-./build-debug
-sudo make install
-```
-
-* General Linux or BSD compile (SDL2)
-```
-./build-debug-sdl2
-sudo make install
-```
-
-* macOS
-  * First install the required libraries needed.
-    ```
-     brew install autoconf automake nasm glfw glew fluid-synth libslirp pkg-config sdl2_net
-    ```
-  * Compile natively for the host architecture (SDL1 or SDL2)
-    ```
-    ./build-macos
-    ```
-    ```
-    ./build-macos-sdl2
-    ```
-  * _(Optional)_ Add `universal` option to build an Universal Binary on an Apple Silicon CPU (will *not* work on Intel)
-    ```
-    ./build-macos universal
-    ```
-    ```
-    ./build-macos-sdl2 universal
-    ````
-  * You can build an App Bundle from the result of this build with
-    ```
-    make dosbox-x.app
-    ```
-* MinGW compile for Windows 7 or later
+* For Windows 7 or later
   * First install the required libraries needed.  
     Libraries for mingw32(32-bit)
     ```
@@ -108,6 +107,10 @@ sudo make install
     ```
     pacman -S git make mingw-w64-x86_64-toolchain mingw-w64-x86_64-libslirp mingw-w64-x86_64-libtool mingw-w64-x86_64-nasm autoconf automake  mingw-w64-x86_64-ncurses
     ```
+    Libraries for UCRT64(64-bit)
+    ```
+    pacman -S git make mingw-w64-ucrt-x86_64-toolchain mingw-w64-ucrt-x86_64-libtool mingw-w64-ucrt-x86_64-nasm autoconf automake mingw-w64-ucrt-x86_64-libslirp
+    ```
   * Compile (SDL1 or SDL2, Common for 32-bit/64-bit builds)
     ```
     ./build-mingw
@@ -115,21 +118,47 @@ sudo make install
     ```
     ./build-mingw-sdl2
     ```
-* MinGW compile (using MinGW32, not MinGW-w64: see NOTICE below) for lower-end systems including Windows XP or later (SDL1 or SDL2, 32-bit only)
-```
-./build-mingw-lowend
-```
-```
-./build-mingw-lowend-sdl2
-```
+* For Windows XP or later (SDL1 or SDL2, 32-bit only)
+  * Start a 32-bit toolchain from the original (MinGW not the MinGW-w64 project). 
+    Build environment for XP and later can be downloaded [here](https://github.com/joncampbell123/dosbox-x/blob/master/build-scripts/mingw/lowend-bin/i686-7.3.0-release-posix-dwarf-rt_v5-rev0%2Bnasm.7z).
 
-* MinGW compile (using MinGW32, not MinGW-w64: see NOTICE below) on Windows to target the DOS platform (MS-DOS or compatible with HX DOS Extender, SDL1 only)
-```
-./build-mingw-hx-dos
-```
+    As an example, the official Release and Nightly builds are built by overwriting MinGW32 environment of MSYS2 with the above environment.
+    Refer to `MinGW32_CI_lowend_build` section in [mingw32.yml](https://github.com/joncampbell123/dosbox-x/blob/master/.github/workflows/mingw32.yml) for details.
+  * Compile (SDL1 or SDL2, Common for 32-bit/64-bit builds)
+    ```
+    ./build-mingw-lowend
+    ```
+    ```
+    ./build-mingw-lowend-sdl2
+    ```
 
-NOTICE: Use the 32-bit toolchain from the original MinGW project for the lowend and HX-DOS builds, not the MinGW-w64 project.
-        Binaries compiled with MinGW-w64 have extra dependencies which are not supported by Windows XP or the HX DOS Extender.
+* For Windows 9x/NT4 (SDL1, 32-bit only)
+  * Start a 32-bit toolchain from the original MinGW (not the MinGW-w64 project). 
+    Build environment for 9x/NT4 build can be downloaded [here](https://github.com/crazii/MINGW-toolchains-w9x/releases/download/v1.0.1-w95nt/mingw32.7z).
+
+    As an example, the official Release and Nightly builds are built by overwriting MinGW32 environment of MSYS2 with the above environment.
+    Refer to `MinGW32_CI_lowend9x_build` section in [mingw32.yml](https://github.com/joncampbell123/dosbox-x/blob/master/.github/workflows/mingw32.yml) for details.
+  * Compile
+    ```
+    ./build-mingw-lowend9x
+    ```
+
+NOTICE: Lowend builds should NOT be compiled with MinGW-w64 since they have extra dependencies which are not supported by Windows XP, Vista and 9x/NT4.
+
+## General procedures to compile the source code (cross-platform)
+* First install the required tools and libraries, such as git, gcc, g++, make, Autotools, pkg-config, nasm, libxkbfile.
+  Depending on the [options](#libraries-used-by-dosbox-x) you want, some more may be required. 
+* Download the source code from the github repository
+```
+git clone https://github.com/joncampbell123/dosbox-x.git
+cd dosbox-x
+```
+* General Linux or BSD compile (SDL1)
+```
+./build-debug
+sudo make install
+```
+Alternatively you can also compile the SDL2 version by running the ``./build-debug-sdl2`` script.
 
 ## To compile DOSBox-X in Ubuntu (tested with 20.04 and 20.10):
 
@@ -191,49 +220,49 @@ cd dosbox-x
 ```
 If you have audio problems, you may want to try the SDL2 build using `./build-debug-sdl2` script.
 
-Compiling the source code using Visual Studio (Windows)
--------------------------------------------------------
+Compiling the source code in macOS (High Sierra and after)
+----------------------------------------------------------
+macOS builds are expected to compile on the terminal using GNU autotools and the LLVM/Clang compiler provided by XCode.
+Universal macOS builds are only possible when building on a host machine powered by an Apple Silicon CPU,
+due to requiring parallel Homebrew installations running natively *and* under Rosetta 2.
 
-You can build the source code with Visual Studio 2017, 2019, and 2022.
-(The code currently cannot be built with Visual Studio 2015)
-The executables will work on 32-bit and 64-bit Windows Vista or higher.
+* First install the required tools and libraries from [Homebrew](https://brew.sh/ja/) or [MacPorts](https://www.macports.org/).
+  To target older OS versions, MacPorts maybe recommended.
+  ```
+  brew install autoconf automake nasm glfw glew fluid-synth libslirp libpcap pkg-config sdl2_net
+  ```
+  ```
+  sudo port install autoconf automake nasm glfw glew fluidsynth libslirp libpcap pkgconfig libsdl2_net
+  ```
+* Compile natively for the host architecture (SDL1 or SDL2)
+  ```
+  ./build-macos
+  ```
+  ```
+  ./build-macos-sdl2
+  ```
+* _(Optional)_ Add `universal` option to build an Universal Binary on an Apple Silicon CPU (will *not* work on Intel)
+  ```
+  ./build-macos universal
+  ```
+  ```
+  ./build-macos-sdl2 universal
+  ````
+* You can build an App Bundle from the result of this build with
+  ```
+  make dosbox-x.app
+  ```
 
-Use the ```./vs/dosbox-x.sln``` "solution" file and build the source code.
-You will need the DirectX 2010 SDK for Direct3D9 support.
+## To compile DOSBox-X for DOS with HX-DOS platform
+  * Start a 32-bit toolchain from the original MinGW (not the MinGW-w64 project). 
 
-By default the targeted platform is v142 (Visual Studio 2019).
-To build the source code on Visual Studio 2017 or 2022,
-you may change the platform toolset to v141 or v143 respectively.
-For Visual Studio 2017, you have to set ``WindowsTargetPlatformVersion`` to whatever
-Windows SDK version installed in your PC, for example ``10.0.22000.0``.
-(Visual Studio 2019 and beyond will pick the latest Windows SDK version installed
-if you set the value to `10.0`)
-
-To build executables that will work on Windows XP,
-you have to change the target platform to v141 (Visual Studio 2017).
-After the build is completed, you have to patch the PE header of the executable using
-a tool included in the source code.
-
-```./contrib/windows/installer/PatchPE.exe path-to-your-exe-file/dosbox-x.exe```
-
-Libraries such as SDL, freetype, libpdcurses, libpng and zlib are already included,
-and as of DOSBox-X 0.83.6 support for FluidSynth MIDI Synthesizer is also included
-for Windows builds (set ``mididevice=fluidsynth`` in the [midi] section of DOSBox-X's
-configuration file (dosbox-x.conf) along with required soundfont file [e.g.
-``FluidR3_GM.sf2`` or ``GeneralUser_GS.sf2``] to use it).
-
-The slirp backend for the NE2000 network emulation is only supported by MinGW builds
-but not Visual Studio builds.
-
-Build the source code for your platform (Win32, x64, ARM and ARM64 are supported).
-
-As of 2018/06/06, Visual Studio 2017 builds (32-bit and 64-bit) explicitly require
-a processor that supports the SSE instruction set. As of version 2022.09.01, Visual
-Studio ARM/ARM64 builds require a Windows SDK that includes the OpenGL library.
-
-Visual Studio Code is supported, too.
-
-Check the [README.development-in-Windows](README.development-in-Windows) file for more information about this platform.
+    Build environment for HX-DOS build can be downloaded [here](https://github.com/joncampbell123/dosbox-x/blob/master/build-scripts/mingw/lowend-bin/mingw-get-0.6.2-mingw32-beta-20131004-1-bin.zip).
+    As an example, the procedures of official Release and Nightly builds can be found in [hxdos.yml](https://github.com/joncampbell123/dosbox-x/blob/master/.github/workflows/hxdos.yml) as a reference.
+  * Compile  (SDL1, 32-bit only)
+  ```
+  ./build-mingw-hx-dos
+  ```
+NOTICE: HX-DOS builds should NOT be compiled with MinGW-w64 since they have extra dependencies which are not supported by the HX DOS Extender.
 
 Libraries used by DOSBox-X
 --------------------------
@@ -249,6 +278,7 @@ The following libraries are used by DOSBox-X:
     
     Note that only version 1.2.x (SDL1 version) and version 2.x
     (SDL2 version) are currently supported.
+    You may use SDL3 if combined with sdl2-compat library. 
     
     License: LGPLv2+
 


### PR DESCRIPTION
Add links to jump to the explanation of each platform.
Add the following explanations
  - Mention build environments for MinGW lowend and HX-DOS builds
  - Add explanation for UCRT64 builds
  - Add explanation for installing packages from MacPorts  
