### PR TITLE
Fix Linux needs dialog messages in UTF8, not guest codepage

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -786,6 +786,8 @@ void MenuBrowseImageFile(char drive, bool arc, bool boot, bool multiple) {
 #endif
 }
 
+bool CodePageGuestToHostUTF8(char *d/*CROSS_LEN*/,const char *s/*CROSS_LEN*/) ;
+
 void MenuBrowseFolder(char drive, std::string const& drive_type) {
     std::string str(1, drive);
 	if (Drives[drive-'A']) {
@@ -803,7 +805,15 @@ void MenuBrowseFolder(char drive, std::string const& drive_type) {
     std::string title = formatString(MSG_Get("PROGRAM_MOUNT_SELECT_DRIVE"), str.c_str(),MSG_Get(msg_key.c_str()));
     if(drive_type=="CDROM")
         title += "\n" + std::string(MSG_Get("PROGRAM_MOUNT_CDROM_SUPPORT"));
+#ifdef LINUX
+    size_t aMessageLength = strlen(title.c_str());
+    char *lMessage = (char *)malloc((aMessageLength * 2 + 1) * sizeof(char)); 
+    CodePageGuestToHostUTF8(lMessage, title.c_str()) ;
+    char const * lTheSelectFolderName = tinyfd_selectFolderDialog(lMessage, NULL);
+    free(lMessage);
+#else
     char const * lTheSelectFolderName = tinyfd_selectFolderDialog(title.c_str(), NULL);
+#endif
     if (lTheSelectFolderName) {
         MountHelper(drive,GetNewStr(lTheSelectFolderName).c_str(),drive_type);
         std::string drive_warn = formatString(MSG_Get("PROGRAM_MOUNT_SUCCESS"), std::string(1, drive).c_str(), lTheSelectFolderName);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1107,7 +1107,19 @@ std::string replaceNewlineWithEscaped(const std::string& input) {
         if (input[i] == '\\') {
             if(input[i+1] != 'n') output += '\\'; // "\n" needs to be escaped to "\\n" 
         }
-        else {
+        else if (input[i] == '\n'){
+            output += "\\\\n";   // '\n' needs to be replaced to "\\n" 
+            i++;
+        }
+        else if(input[i] == '`'){
+            output += "\\`";  // '`' needs to be replaced to "\\`" 
+            i++;
+        }
+        else if(input[i] == '"'){
+            output += "\\\"";  // '"' needs to be replaced to "\\\"" 
+            i++;
+        }
+        else  {
             output += input[i];
             i++;
         }

--- a/src/libs/tinyfiledialogs/tinyfiledialogs.c
+++ b/src/libs/tinyfiledialogs/tinyfiledialogs.c
@@ -2102,13 +2102,13 @@ static int messageBoxWinGui(
 
 		if (aTitle)
 		{
-				if (tinyfd_winUtf8) lTmpWChar = tinyfd_utf8to16(aTitle);
+				if (tinyfd_winUtf8 || !tfd_isDBCSCP()) lTmpWChar = tinyfd_utf8to16(aTitle);
 				else lTmpWChar = tinyfd_mbcsTo16(aTitle);
 				wcscpy(lTitle, lTmpWChar);
 		}
 		if (aMessage)
 		{
-				if (tinyfd_winUtf8) lTmpWChar = tinyfd_utf8to16(aMessage);
+				if (tinyfd_winUtf8 || !tfd_isDBCSCP()) lTmpWChar = tinyfd_utf8to16(aMessage);
 				else lTmpWChar = tinyfd_mbcsTo16(aMessage);
 				lMessage = (wchar_t *) malloc((wcslen(lTmpWChar) + 1)* sizeof(wchar_t));
 				if (lMessage) wcscpy(lMessage, lTmpWChar);
@@ -2900,8 +2900,8 @@ int tinyfd_messageBox(
 		UINT lOriginalCP = 0;
 		UINT lOriginalOutputCP = 0;
 
-		if (tfd_quoteDetected(aTitle)) return tinyfd_messageBox("INVALID TITLE WITH QUOTES", aMessage, aDialogType, aIconType, aDefaultButton);
-		if (tfd_quoteDetected(aMessage)) return tinyfd_messageBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDialogType, aIconType, aDefaultButton);
+		//if (tfd_quoteDetected(aTitle)) return tinyfd_messageBox("INVALID TITLE WITH QUOTES", aMessage, aDialogType, aIconType, aDefaultButton);
+		//if (tfd_quoteDetected(aMessage)) return tinyfd_messageBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDialogType, aIconType, aDefaultButton);
 
 		if ((!tinyfd_forceConsole || !(GetConsoleWindow() || dialogPresent()))
 				&& (!getenv("SSH_CLIENT") || getenvDISPLAY()))

--- a/src/libs/tinyfiledialogs/tinyfiledialogs.c
+++ b/src/libs/tinyfiledialogs/tinyfiledialogs.c
@@ -4781,7 +4781,7 @@ int tinyfd_messageBox(
 		lBuff[0]='\0';
 
 				if (tfd_quoteDetected(aTitle)) return tinyfd_messageBox("INVALID TITLE WITH QUOTES", aMessage, aDialogType, aIconType, aDefaultButton);
-				if (tfd_quoteDetected(aMessage)) return tinyfd_messageBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDialogType, aIconType, aDefaultButton);
+				//if (tfd_quoteDetected(aMessage)) return tinyfd_messageBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDialogType, aIconType, aDefaultButton);
 
 		lTitleLen =  aTitle ? strlen(aTitle) : 0 ;
 		lMessageLen =  aMessage ? strlen(aMessage) : 0 ;


### PR DESCRIPTION
Dialog boxes some times fails to show on Linux due to the encoding of messages were not UTF8.
This PR explicitly converts the messages to UTF-8 on Linux.

Edit: Added UTF-8 conversion for non-DBCS messages on Windows as well.