### PR TITLE
Fix definition of __inline__ macro for MinGW32

### DIFF
--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -46,6 +46,8 @@
 #include "logging.h"
 #include "support.h"
 #include "setup.h"
+
+#pragma push_macro("__inline__")
 #include "src/libs/decoders/audio_convert.c"
 #include "src/libs/decoders/SDL_sound.c"
 #include "src/libs/decoders/vorbis.c"
@@ -55,6 +57,7 @@
 #include "src/libs/decoders/mp3_seek_table.cpp"
 #include "src/libs/decoders/mp3.cpp"
 #include "src/libs/decoders/dr_flac.h"
+#pragma pop_macro("__inline__")
 #include "src/libs/libchdr/chd.h"
 #include "src/libs/libchdr/libchdr_chd.c"
 #include "src/libs/libchdr/libchdr_cdrom.c"

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -47,7 +47,11 @@
 #include "support.h"
 #include "setup.h"
 
+#ifdef __MINGW32__
+#ifndef __MINGW64__
 #pragma push_macro("__inline__")
+#endif
+#endif
 #include "src/libs/decoders/audio_convert.c"
 #include "src/libs/decoders/SDL_sound.c"
 #include "src/libs/decoders/vorbis.c"
@@ -57,7 +61,11 @@
 #include "src/libs/decoders/mp3_seek_table.cpp"
 #include "src/libs/decoders/mp3.cpp"
 #include "src/libs/decoders/dr_flac.h"
+#ifdef __MINGW32__
+#ifndef __MINGW64__
 #pragma pop_macro("__inline__")
+#endif
+#endif
 #include "src/libs/libchdr/chd.h"
 #include "src/libs/libchdr/libchdr_chd.c"
 #include "src/libs/libchdr/libchdr_cdrom.c"


### PR DESCRIPTION
This PR fixes MinGW32 builds failed using gcc15, due to a conflict in __inline__ macro.
Maybe a refctoring is required.

Special thanks to @lazka for proposing this patch.

## What issue(s) does this PR address?
Fixes #5666
