### PR TITLE
PCI bus improvements : Allow device to see full size access

### DIFF
--- a/include/pci_bus.h
+++ b/include/pci_bus.h
@@ -84,7 +84,7 @@ public:
 			/* NTS: If I recall, this virtual function call means that we'll call the
 			 *      C++ subclass's config_read() NOT our own--right? */
 			for (Bitu i=0;i < iolen;i++)
-				v += ((config_read((uint8_t)(regnum+i),1)&0xFF) << ((iolen-i-1)*8));
+				v += ((config_read((uint8_t)(regnum+i),1)&0xFF) << (i*8));
 		}
 
 		return v;

--- a/src/hardware/pci_bus.cpp
+++ b/src/hardware/pci_bus.cpp
@@ -346,8 +346,9 @@ static void InitializePCI(void) {
 	PCI_ReadHandler[0].Install(0xcf8,read_pci_addr,IO_MD);
 	// install PCI-register read/write handlers
 	for (Bitu ct=0;ct<4;ct++) {
-		PCI_WriteHandler[1+ct].Install(0xcfc+ct,write_pci,IO_MB);
-		PCI_ReadHandler[1+ct].Install(0xcfc+ct,read_pci,IO_MB);
+		Bitu msk = IO_MB | ((ct & 1) ? 0 : IO_MW) | ((ct & 3) ? 0 : IO_MD);;
+		PCI_WriteHandler[1+ct].Install(0xcfc+ct,write_pci,msk);
+		PCI_ReadHandler[1+ct].Install(0xcfc+ct,read_pci,msk);
 	}
 
 	callback_pci.Install(&PCI_PM_Handler,CB_IRETD,"PCI PM");


### PR DESCRIPTION
## Does this PR introduce new feature(s)?

No, this is more preparation work for an upcoming feature.

## Does this PR introduce any breaking change(s)?

It shouldn't AFAICT.

## Additional information

The goal is to have PCIDevice that can see the full double-word / word access to the configuration space.
I'm working on some direct-to-hardware pass-through and it's important that the size of the access is exactly what the software issued.
