### PR TITLE
Fix build error of SDL1 version on ArchLinux

### DIFF
--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -47,10 +47,8 @@
 #include "support.h"
 #include "setup.h"
 
-#ifdef __MINGW32__
-#ifndef __MINGW64__
+#if (defined( __MINGW32__) && !defined(__MINGW64__ )) || defined(LINUX)
 #pragma push_macro("__inline__")
-#endif
 #endif
 #include "src/libs/decoders/audio_convert.c"
 #include "src/libs/decoders/SDL_sound.c"
@@ -61,10 +59,8 @@
 #include "src/libs/decoders/mp3_seek_table.cpp"
 #include "src/libs/decoders/mp3.cpp"
 #include "src/libs/decoders/dr_flac.h"
-#ifdef __MINGW32__
-#ifndef __MINGW64__
+#if (defined( __MINGW32__) && !defined(__MINGW64__ )) || defined(LINUX)
 #pragma pop_macro("__inline__")
-#endif
 #endif
 #include "src/libs/libchdr/chd.h"
 #include "src/libs/libchdr/libchdr_chd.c"

--- a/vs/sdl/src/video/Xext/XME/xme.c
+++ b/vs/sdl/src/video/Xext/XME/xme.c
@@ -206,7 +206,7 @@ static char *xigmisc_extension_name = XIGMISC_PROTOCOL_NAME;
 /*
  * find_display - locate the display info block
  */
-static int XiGMiscCloseDisplay();
+static int XiGMiscCloseDisplay(Display *, XExtCodes *);
 
 static XExtensionHooks xigmisc_extension_hooks = {
     NULL,                               /* create_gc */

--- a/vs/sdl/src/video/Xext/Xinerama/Xinerama.c
+++ b/vs/sdl/src/video/Xext/Xinerama/Xinerama.c
@@ -50,7 +50,7 @@ static /* const */ char *panoramiX_extension_name = PANORAMIX_PROTOCOL_NAME;
 #define PanoramiXSimpleCheckExtension(dpy,i) \
   XextSimpleCheckExtension (dpy, i, panoramiX_extension_name)
 
-static int close_display();
+static int close_display(Display *, XExtCodes *);
 static /* const */ XExtensionHooks panoramiX_extension_hooks = {
     NULL,				/* create_gc */
     NULL,				/* copy_gc */


### PR DESCRIPTION
This PR fixes a build error in SDL1 build on ArchLinux due to a more strict check than it previously was.

## What issue(s) does this PR address?
Fixes #5692

![image](https://github.com/user-attachments/assets/7c9dd4cd-d9e3-40ee-9c72-12e0dbe49bf4)
