### PR TITLE
Fix big-endian build

### DIFF
--- a/include/fpu.h
+++ b/include/fpu.h
@@ -172,6 +172,10 @@ union alignas(8) MMX_reg {
 	} uw;
 	static_assert(sizeof(uw) == 8, "MMX packing error");
 
+	uint8_t uba[8];
+	uint16_t uwa[4];
+	uint32_t uda[2];
+
 	struct {
 		uint16_t w3,w2,w1,w0;
 	} sw;


### PR DESCRIPTION
Some new members were added to the MMX_reg union, but only for little endian. Add them to the big endian one too.