### PR TITLE
Fix language files were still locked after loading is completed

### DIFF
--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -597,8 +597,12 @@ void MSG_Init() {
         if (pathprop != NULL) {
             std::string path = pathprop->realpath;
             ResolvePath(path);
-            if (testLoadLangFile(path.c_str()))
+
+            FILE* f = testLoadLangFile(path.c_str());
+            if (f) {
+                fclose(f);
                 LoadMessageFile(path.c_str());
+            }
             else {
                 std::string lang = section->Get_string("language");
                 if (lang.size()) LoadMessageFile(lang.c_str());


### PR DESCRIPTION
Language file was locked even after all items were loaded, due to a missing fclose().
This PR adds the fclose() so that you can load/edit the same language file.
