### PR TITLE
Change workaround for the dynamic core

### DIFF
--- a/src/cpu/cpu.cpp
+++ b/src/cpu/cpu.cpp
@@ -3195,36 +3195,6 @@ bool CPU_CPUID(void) {
 	return true;
 }
 
-/* this is used by dynamic core as a workaround for sending the reset signal into the emulator
- * because C++ exceptions don't work from within dynamically generated code. */
-int reset_decode_signal = 0;
-Bits Reset_Decode(void) {
-	LOG_MSG("CPU: It is now safe to send reset signal");
-	cpudecoder = cpu.hlt.old_decoder;
-	throw int(reset_decode_signal);
-	return 0;
-}
-
-void CPU_SetResetSignal(int x) {
-	LOG_MSG("CPU: Queuing reset signal, to send when dynamic core has completed execution.");
-	reset_decode_signal = x;
-	cpu.hlt.old_decoder = cpudecoder;
-	cpudecoder = &Reset_Decode;
-	CPU_Cycles = 0;
-}
-
-bool CPU_DynamicCoreCannotUseCPPExceptions(void) {
-#if C_DYNAMIC_X86
-	if (cpudecoder == &CPU_Core_Dyn_X86_Run)
-		return true;
-#endif
-#if C_DYNREC
-	if (cpudecoder == &CPU_Core_Dynrec_Run)
-		return true;
-#endif
-	return false;
-}
-
 Bits HLT_Decode(void) {
 	/* Once an interrupt occurs, it should change cpu core */
 	if (reg_eip!=cpu.hlt.eip || SegValue(cs) != cpu.hlt.cs) {

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -55,6 +55,8 @@
 #include "../gamelink/gamelink.h"
 #endif // C_GAMELINK
 
+void RebootLanguage(std::string filename, bool confirm=false);
+
 /* memory from file, memory mapping */
 #if C_HAVE_MMAP
 # define DO_MEMORY_FILE
@@ -1602,6 +1604,7 @@ void On_Software_CPU_Reset() {
     /* this technique is NOT reliable when running the dynamic core! */
     if (cpudecoder == &CPU_Core_Dyn_X86_Run || cpudecoder == &CPU_Core_Dynrec_Run) {
         LOG_MSG("Warning: C++ exception method is not compatible with dynamic core when emulating reset");
+        RebootLanguage("");
     }
 #endif
 

--- a/src/hardware/memory.cpp
+++ b/src/hardware/memory.cpp
@@ -1420,9 +1420,6 @@ uint16_t CPU_Pop16(void);
 
 static bool cmos_reset_type_9_sarcastic_win31_comments=true;
 
-void CPU_SetResetSignal(int x);
-bool CPU_DynamicCoreCannotUseCPPExceptions(void);
-
 void On_Software_286_int15_block_move_return(unsigned char code) {
     uint16_t vec_seg,vec_off;
 
@@ -1461,10 +1458,8 @@ void On_Software_286_int15_block_move_return(unsigned char code) {
     CPU_IRET(false,0);
 
     /* force execution change (FIXME: Is there a better way to do this?) */
-    if (CPU_DynamicCoreCannotUseCPPExceptions())
-        CPU_SetResetSignal(4);
-    else
-        throw int(4);
+    throw int(4);
+    /* does not return */
 }
 
 void On_Software_286_reset_vector(unsigned char code) {
@@ -1504,10 +1499,8 @@ void On_Software_286_reset_vector(unsigned char code) {
     reg_eip = vec_off;
 
     /* force execution change (FIXME: Is there a better way to do this?) */
-    if (CPU_DynamicCoreCannotUseCPPExceptions())
-        CPU_SetResetSignal(4);
-    else
-        throw int(4);
+    throw int(4);
+    /* does not return */
 }
 
 void CPU_Exception_Level_Reset();
@@ -1585,10 +1578,7 @@ void On_Software_CPU_Reset() {
             LOG_MSG("PC-98 reset and continue: RETF to %04x:%04x",SegValue(cs),reg_ip);
 
             /* force execution change (FIXME: Is there a better way to do this?) */
-            if (CPU_DynamicCoreCannotUseCPPExceptions())
-                CPU_SetResetSignal(4);
-            else
-                throw int(4);
+            throw int(4);
             /* does not return */
         }
     }
@@ -1608,10 +1598,15 @@ void On_Software_CPU_Reset() {
         }
     }
 
-    if (CPU_DynamicCoreCannotUseCPPExceptions())
-        CPU_SetResetSignal(3);
-    else
-        throw int(3);
+#if C_DYNAMIC_X86
+    /* this technique is NOT reliable when running the dynamic core! */
+    if (cpudecoder == &CPU_Core_Dyn_X86_Run || cpudecoder == &CPU_Core_Dynrec_Run) {
+        LOG_MSG("Warning: C++ exception method is not compatible with dynamic core when emulating reset");
+    }
+#endif
+
+    throw int(3);
+    /* does not return */
 }
 
 /* Some PC-98 code uses this register to know if the 16MB "memory hole" is open,
@@ -1805,19 +1800,15 @@ HostPt GetMemBase(void) { return MemBase; }
 /*! \brief          REDOS.COM utility command on drive Z: to trigger restart of the DOS kernel
  */
 class REDOS : public Program {
-	public:
-		/*! \brief      Program entry point, when the command is run */
-		void Run(void) override {
-			if (cmd->FindExist("/?", false) || cmd->FindExist("-?", false)) {
-				WriteOut("Reboots the kernel of DOSBox-X's emulated DOS.\n\nRE-DOS\n");
-				return;
-			}
-
-			if (CPU_DynamicCoreCannotUseCPPExceptions())
-				CPU_SetResetSignal(6);
-			else
-				throw int(6);
+public:
+    /*! \brief      Program entry point, when the command is run */
+    void Run(void) override {
+		if (cmd->FindExist("/?", false) || cmd->FindExist("-?", false)) {
+			WriteOut("Reboots the kernel of DOSBox-X's emulated DOS.\n\nRE-DOS\n");
+			return;
 		}
+        throw int(6);
+    }
 };
 
 void REDOS_ProgramStart(Program * * make) {


### PR DESCRIPTION
The existing workaround for the dynamic core hangs the process instead of crashing, it made the workaround worse than the original situation. This PR undoes the problematic commit and replaces it will a full restart command automatically relaunching the process.

## What issue(s) does this PR address?

#5584

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

The entire software is now restarted, this does not break for me but I can't rule this out on more exotic configurations.

## Additional information

I totally get it if you'd rather not merge this quick workaround, but as this Daum style restart solves the issue for me I wanted to offer the changes to motivate the issue being fixed.