### PR TITLE
Fix freeze when codepage switched to 3846, 3848

### DIFF
--- a/src/dos/dos_keyboard_layout.cpp
+++ b/src/dos/dos_keyboard_layout.cpp
@@ -805,7 +805,7 @@ void initcodepagefont() {
 	uint32_t start_pos;
 	uint16_t number_of_codepages;
 	static uint8_t cpi_buff[65536];
-	uint8_t *cpibuf = dos.loaded_codepage == 856 ? cpi_buff : cpi_buf;
+	uint8_t *cpibuf = cpi_buf;
 	uint32_t cpi_buf_size=0,size_of_cpxdata=0;
     switch (dos.loaded_codepage) {
 			case 437:	case 850:	case 852:	case 853:	case 857:	case 858:
@@ -861,7 +861,8 @@ void initcodepagefont() {
 				break;
 			case 856:	case 3846:	case 3848:
 				cpi_buf_size = get_builtin_codepage(bfb_EGA18_CPI);
-				break;
+				cpibuf = cpi_buff;
+                break;
             default:
                     return;
     }


### PR DESCRIPTION
This PR fixes that CHCP command freezed when codepage was set to 3846 or 3848.
Tested on VS x64 SDL2 and MinGW x64 SDL2 on Windows 10 22H2.

![image](https://github.com/user-attachments/assets/42962416-5203-46e9-9dc7-2764df01d484)

