### PR TITLE
Show loaded conf file in log in full path

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8217,7 +8217,8 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         if (control->opt_promptfolder < 0)
             control->opt_promptfolder = 1;
 #else
-        if (control->opt_promptfolder < 0)
+        std::unique_ptr<char[]> cwd(new char[PATH_MAX]);
+        if (control->opt_promptfolder < 0 && getcwd(cwd.get(), PATH_MAX) != nullptr)
             control->opt_promptfolder = (!isatty(0) || !strcmp(cwd.get(), "/")) ? 1 : 0;
 #endif
         if (control->opt_promptfolder == 1 && workdiropt == "default" && workdirdef.size()) {

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -47,6 +47,14 @@
 #define PATH_SEPARATOR '/'
 #endif
 
+#ifndef PATH_MAX
+    #if defined(WIN32)
+        #define PATH_MAX MAX_PATH
+    #else
+        #define PATH_MAX 4096 /* LINUX sets to 4096, while this varies from 260 to 4096 depending on platforms */
+    #endif
+#endif
+
 static int get_dirname(const char* path, char* dirbuf, size_t size);
 static int dir_exists(const char* path);
 static int mkdir_recursive(const char* path);


### PR DESCRIPTION
Although DOSBox-X logs the conf file loaded, only the name of the file was shown if it is located in current directory.
This PR will make the location shown in full path to make it easier for users to recognize.

Also, the max length of path was hardcoded to 512 bytes, which may not be enough for platforms like Linux or macOS so extended it to PATH_MAX to match the actual limit.

![image](https://github.com/user-attachments/assets/2a1b53b3-2445-47d8-b43f-40c4a88da307)
![image](https://github.com/user-attachments/assets/fcccef04-9f30-443e-a4ed-6b64fe9e5641)
