### PR TITLE
Print syntax error if pipe has no command to pass output

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,9 @@ Next version
   - Fixed language files were still locked after loading is completed.
     (maron2000)
   - Fixed freeze when codepage switched to 3846, 3848. (maron2000)
+  - Fixed build error when internal debugger is disabled (maron2000)
+  - Show loaded conf file in log in full path (maron2000)
+  - Print syntax error if pipe has no command to pass output (maron2000)
 
 2025.05.03
   - Show TURBO status in title bar. (maron2000)

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -470,7 +470,9 @@ void DOS_Shell::ParseLine(char * line) {
 			DOS_OpenFile(in,OPEN_READ,&dummy);	//Open new stdin
 		} else {
 			WriteOut(!*in?"File open error\n":(dos.errorcode==DOSERR_ACCESS_DENIED?MSG_Get("SHELL_CMD_FILE_ACCESS_DENIED"):"File open error - %s\n"), in);
-			in = nullptr;
+            if(in) free(in);
+            if(out) free(out);
+            if(toc) free(toc);
 			return;
 		}
 	}

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -449,6 +449,15 @@ void DOS_Shell::ParseLine(char * line) {
 	bool normalstdout = false;	/* Bug: Assumed is they are "con"      */
 	
     GetRedirection(line, &in, &out, &toc, &append);
+
+    if(toc && *trim(toc) == '\0') { 
+        SyntaxError(); /* No command to pass output */
+        if(in) free(in);
+        if(out) free(out);
+        if(toc) free(toc);
+        return;
+    }
+
 	if (in || out || toc) {
 		normalstdin  = (psp->GetFileHandle(0) != 0xff); 
 		normalstdout = (psp->GetFileHandle(1) != 0xff); 


### PR DESCRIPTION
## What issue(s) does this PR address?
Currently DOSBox-X  shows nothing when a pipe does not have any command to pass output.
This PR fixes it to match the genuine MS-DOS, which prints Syntax error in such case.

![image](https://github.com/user-attachments/assets/ed23c930-aa2e-4a3f-be97-d4ac8e0fd1f8)
