### PR TITLE
Don't  carriage return with a single LF

### DIFF
--- a/src/dos/dev_con.h
+++ b/src/dos/dev_con.h
@@ -650,7 +650,6 @@ private:
 			cur_col=0;
 			break;
 		case '\n':
-			cur_col=0;
 			cur_row++;
 			break;
 		case '\t':


### PR DESCRIPTION
This PR fixes the column position not change with a single LF ('\n').

## What issue(s) does this PR address?
Fixes #5785

<img width="642" height="151" alt="image" src="https://github.com/user-attachments/assets/e700e511-1c60-4094-a9fe-872b15a71d12" />
