### PR TITLE
Fix mapper not rendering anything on SDL2/Windows

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -45,6 +45,7 @@ Next version
   - Fix errors when initializing fluidsynth (maron2000)
   - PC-98: Redraw the function keys after updating them (bobsayshilol)
   - Do not carriage return with a single LF('\n') (maron2000)
+  - Fix mapper not rendering anything on SDL2/Windows (aybe)
 
 2025.05.03
   - Show TURBO status in title bar. (maron2000)

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -1868,6 +1868,9 @@ void SDL1_hax_SetMenu(HMENU menu) {
 extern "C" void SDL1_hax_SetMenu(HMENU menu);
 #endif
 
+/**
+ * NOTE: this function can make a SDL_Surface become invalid (e.g. mapper, Windows)
+ */
 void DOSBox_SetMenu(DOSBoxMenu &altMenu) {
 #if DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW
     /* nothing to do */

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -5313,6 +5313,7 @@ void update_all_shortcuts() {
 
 void UpdateMapperSurface()
 {
+#if defined(C_SDL2)
     mapper.surface = SDL_GetWindowSurface(mapper.window);
 
     if (mapper.surface == nullptr)
@@ -5321,6 +5322,7 @@ void UpdateMapperSurface()
 
         E_Exit("Could not initialize video mode for mapper: %s", error);
     }
+#endif
 }
 
 void MAPPER_RunInternal() {


### PR DESCRIPTION
## What issue(s) does this PR address?

Since my last contribution, the mapper would stubbornly render as a black screen.
After debugging, `DOSBox_SetMenu` is what makes the SDL surface become invalid.
Not sure why, maybe it's Windows' fault... But initializing it after fixes the problem.
