### PR TITLE
Scale mapper according display resolution

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,6 +46,7 @@ Next version
   - PC-98: Redraw the function keys after updating them (bobsayshilol)
   - Do not carriage return with a single LF('\n') (maron2000)
   - Fix mapper not rendering anything on SDL2/Windows (aybe)
+  - Scale mapper according display resolution (aybe)
 
 2025.05.03
   - Show TURBO status in title bar. (maron2000)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -45,6 +45,7 @@ Next version
   - Fix errors when initializing fluidsynth (maron2000)
   - PC-98: Redraw the function keys after updating them (bobsayshilol)
   - Do not carriage return with a single LF('\n') (maron2000)
+  - Fix mapper not rendering anything on SDL2/Windows (aybe)
 
 2025.05.03
   - Show TURBO status in title bar. (maron2000)

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -1868,6 +1868,9 @@ void SDL1_hax_SetMenu(HMENU menu) {
 extern "C" void SDL1_hax_SetMenu(HMENU menu);
 #endif
 
+/**
+ * NOTE: this function can make a SDL_Surface become invalid (e.g. mapper, Windows)
+ */
 void DOSBox_SetMenu(DOSBoxMenu &altMenu) {
 #if DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW
     /* nothing to do */

--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -2617,9 +2617,11 @@ public:
         Draw(true, true);
     }
     virtual bool OnTop(Bitu _x,Bitu _y) {
+#if defined(C_SDL2)
         const auto scale = mapper.window_scale;
         _x /= scale;
         _y /= scale;
+#endif
         return ( enabled && (_x>=x) && (_x<x+dx) && (_y>=y) && (_y<y+dy));
     }
     virtual void BindColor(void) {}
@@ -5331,19 +5333,24 @@ void UpdateMapperSurface()
 
 void GetDisplaySize(int* w, int* h)
 {
+#if defined(C_SDL2)
     SDL_DisplayMode mode = { };
     SDL_GetCurrentDisplayMode(0, &mode);
     *w = mode.w;
     *h = mode.h;
+#endif
 }
 
 void GetWindowSize(int* w, int* h)
 {
+#if defined(C_SDL2)
     SDL_GetWindowSize(mapper.window, w, h);
+#endif
 }
 
 void CenterWindow()
 {
+#if defined(C_SDL2)
     int dsp_w, dsp_h, win_w, win_h;
 
     GetDisplaySize(&dsp_w, &dsp_h);
@@ -5351,6 +5358,7 @@ void CenterWindow()
     GetWindowSize(&win_w, &win_h);
 
     SDL_SetWindowPosition(mapper.window, dsp_w / 2 - win_w / 2, dsp_h / 2 - win_h / 2);
+#endif
 }
 
 int GetMapperRenderWidth()
@@ -5365,6 +5373,7 @@ int GetMapperRenderHeight()
 
 int GetMapperScaleFactor()
 {
+#if defined(C_SDL2)
     SDL_DisplayMode mode = { };
 
     const auto rw = GetMapperRenderWidth();
@@ -5372,6 +5381,9 @@ int GetMapperScaleFactor()
     const auto sf = SDL_GetCurrentDisplayMode(0, &mode) != 0 ? 1 : std::max(1, std::min(mode.w / rw, mode.h / rh));
 
     return sf;
+#else
+    return 1;
+#endif
 }
 
 void MAPPER_RunInternal() {
@@ -5429,9 +5441,9 @@ void MAPPER_RunInternal() {
     const auto scale_by = GetMapperScaleFactor();
     const auto target_w = source_w * scale_by;
     const auto target_h = source_h * scale_by;
-    mapper.window_scale = scale_by;
 
 #if defined(C_SDL2)
+    mapper.window_scale = scale_by;
     void GFX_SetResizeable(bool enable);
     GFX_SetResizeable(false);
     mapper.window = OpenGL_using() ? GFX_SetSDLWindowMode(target_w,target_h,SCREEN_OPENGL) : GFX_SetSDLSurfaceWindow(target_w,target_h);


### PR DESCRIPTION
## What issue(s) does this PR address?

Eye comfort upgraded!

Before:

<img width="3840" height="2160" alt="Screenshot 2025-08-21 010526" src="https://github.com/user-attachments/assets/75a81799-b056-49fa-b8f3-cbd80160b2b6" />

After:

<img width="3840" height="2160" alt="Screenshot 2025-08-21 010542" src="https://github.com/user-attachments/assets/31237310-38bb-4cda-a4f9-4953749be028" />

