### PR TITLE
Make applicable changes from SVN

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -47,6 +47,11 @@ Next version
   - Do not carriage return with a single LF('\n') (maron2000)
   - Fix mapper not rendering anything on SDL2/Windows (aybe)
   - Scale mapper according display resolution (aybe)
+  - Added applicable changes from SVN. (Allofich)
+    r4485: Enable writing to all planes when drawing pixels in EGA modes.
+    r4487: Correct panning of VESA text modes.
+    r4488: Correct comment about odd/even bit.
+    r4490: Set MCB ownership when *blocks==total at end of DOS_ResizeMemory.
 
 2025.05.03
   - Show TURBO status in title bar. (maron2000)

--- a/src/dos/dos_memory.cpp
+++ b/src/dos/dos_memory.cpp
@@ -419,7 +419,11 @@ bool DOS_ResizeMemory(uint16_t segment,uint16_t * blocks) {
 
 	mcb.SetSize(total);
 	mcb.SetPSPSeg(dos.psp());
-	if (*blocks==total) return true;	/* block fit exactly */
+	if (*blocks==total) {
+		/* block fit exactly */
+		mcb.SetPSPSeg(dos.psp());
+		return true;
+	}
 
 	*blocks=total;	/* return maximum */
 	DOS_SetError(DOSERR_INSUFFICIENT_MEMORY);

--- a/src/hardware/vga_seq.cpp
+++ b/src/hardware/vga_seq.cpp
@@ -207,7 +207,7 @@ void write_p3c5(Bitu /*port*/,Bitu val,Bitu iolen) {
 		/* 
 			0  Set if in an alphanumeric mode, clear in graphics modes.
 			1  Set if more than 64kbytes on the adapter.
-			2  Enables Odd/Even addressing mode if set. Odd/Even mode places all odd
+			2  Disables Odd/Even addressing mode if set. Odd/Even mode places all odd
 				bytes in plane 1&3, and all even bytes in plane 0&2.
 			3  If set address bit 0-1 selects video memory planes (256 color mode),
 				rather than the Map Mask and Read Map Select Registers.

--- a/src/ints/int10_put_pixel.cpp
+++ b/src/ints/int10_put_pixel.cpp
@@ -168,6 +168,8 @@ void INT10_PutPixel(uint16_t x,uint16_t y,uint8_t page,uint8_t color) {
 		}
 	case M_EGA:
 		{
+			/* Enable writing to all planes */
+			IO_Write(0x3c4,0x2);IO_Write(0x3c5,0xf);
 			/* Set the correct bitmask for the pixel position */
 			IO_Write(0x3ce,0x8);uint8_t mask=128u>>(x&7u);IO_Write(0x3cf,mask);
 			/* Set the color to set/reset register */

--- a/src/ints/int10_vesa.cpp
+++ b/src/ints/int10_vesa.cpp
@@ -832,6 +832,7 @@ uint8_t VESA_GetDisplayStart(uint16_t & x,uint16_t & y) {
 	IO_Read(0x3da);              // reset attribute flipflop
 	IO_Write(0x3c0,0x13 | 0x20); // panning register, screen on
 	uint8_t panning = IO_Read(0x3c1);
+	if ((CurMode->type == M_TEXT) && (panning > 7)) panning = 0;
 
 	/* FIXME: Why does this happen with VBETEST.EXE and more than 1MB of RAM? */
 	if (vga.config.scan_len == 0) {


### PR DESCRIPTION
From r4485, r4487, r4488 and r4490

Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

Closes #5800.

## Additional information

https://sourceforge.net/p/dosbox/code-0/4485/ - Added
https://sourceforge.net/p/dosbox/code-0/4486/ - Already in DOSBox-X
https://sourceforge.net/p/dosbox/code-0/4487/ - Panning fix added.
As for the "Don't include LFB address in VESA info of non-LFB modes" fix, DOSBox-X tests for
`!int10.vesa_nolfb && !int10.vesa_oldvbe && (modeAttributes&0x80)`
while SVN was just checking for `!int10.vesa_nolfb` and now just checks for `modeAttributes & 0x80`.
I left the DOSBox-X code there as is.
https://sourceforge.net/p/dosbox/code-0/4488/ - Added the comment fix. The actual code changes are already in DOSBox-X, just done differently.
https://sourceforge.net/p/dosbox/code-0/4489/ - Skipped since DOSBox-X handles it differently.
https://sourceforge.net/p/dosbox/code-0/4490/ - Added the `mcb.SetPSPSeg(dos.psp());` for the "block fit exactly" case. In the other case, DOSBox-X already does it but with a condition that `mcb.GetPSPSeg()==MCB_FREE && freed_mcb_allocate_on_resize`.
I left the DOSBox-X code there as is.

I also looked at https://sourceforge.net/p/dosbox/code-0/4484/, and that seems to already be in DOSBox-X.