### PR TITLE
Save Kanji CG access mode setting, restrict output accordingly

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2436,6 +2436,11 @@ void DOSBOX_SetupConfigSections(void) {
                     "at driver startup AND when INT 33h AX=0 is called. This is NEC MOUSE.COM behavior and default\n"
                     "enabled. To emulate other drivers like QMOUSE that do not follow this behavior, set to false.");
 
+    Pbool = secprop->Add_bool("pc-98 chargen vsync-limited access",Property::Changeable::WhenIdle,true);
+    Pbool->Set_help("If set, reading pixels from the character generator while in Code Access mode (or always, for ANK\n"
+                    "characters) will be invalid. Some models (i.e. PC-9821As3) dont seem to have this limitation, but\n"
+                    "many others do.");
+
     secprop=control->AddSection_prop("dosv",&Null_Init,true);
 
     Pstring = secprop->Add_string("dosv",Property::Changeable::OnlyAtStart,"off");

--- a/src/hardware/vga_pc98_cg.cpp
+++ b/src/hardware/vga_pc98_cg.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "dosbox.h"
+#include "control.h"
 #include "logging.h"
 #include "setup.h"
 #include "video.h"
@@ -45,6 +46,7 @@
 #include "cpu_io_is_forbidden.h"
 
 /* Character Generator (CG) font access state */
+bool                        pc98_cg_kanji_dot_access_mode = false;
 uint16_t                    a1_font_load_addr = 0;
 uint8_t                     a1_font_char_offset = 0;
 
@@ -53,6 +55,9 @@ uint8_t                     a1_font_char_offset = 0;
  * a 1986 book published about NEC BIOS and BASIC ROM. */
 Bitu pc98_a1_read(Bitu port,Bitu iolen) {
     (void)iolen;//UNUSED
+
+    Section_prop *section = static_cast<Section_prop *>(control->GetSection("pc98"));
+
     switch (port) {
         case 0xA9: // an 8-bit I/O port to access font RAM by...
             // NOTES: On a PC-9821 Lt2 laptop, the character ROM doesn't seem to latch valid data beyond
@@ -60,7 +65,23 @@ Bitu pc98_a1_read(Bitu port,Bitu iolen) {
             //        on the bus can read back nonzero. This doesn't apply to 0x0000-0x00FF of course (single wide
             //        characters), but only to the double-wide character set where (c & 0x007F) >= 0x5D.
             //        This behavior should be emulated. */
-            return pc98_font_char_read(a1_font_load_addr,a1_font_char_offset & 0xF,(a1_font_char_offset & 0x20) ? 0 : 1);
+            //
+            //        On some (most?) models, reading from the character generator outside of VSync
+            //        (always with ANK, in Code Access mode with Kanji) is invalid and returns 0xFF.
+            if (
+                // Configured to ignore
+                (!section->Get_bool("pc-98 chargen vsync-limited access"))
+
+                // Kanji, Dot Access
+                || (((a1_font_load_addr & 0xFF00) != 0) && pc98_cg_kanji_dot_access_mode)
+                // Kanji, Code Access & ANK
+                || (pc98_gdc[0].read_status() & 0x20)
+            ) {
+                return pc98_font_char_read(a1_font_load_addr,a1_font_char_offset & 0xF,(a1_font_char_offset & 0x20) ? 0 : 1);
+            } else {
+                LOG_MSG("A9 port attempt to read char 0x%04x/line %X in code access mode outside of vsync",a1_font_load_addr,a1_font_char_offset & 0xF);
+                return ~0ul;
+            }
         default:
             break;
     }

--- a/src/hardware/vga_pc98_crtc.cpp
+++ b/src/hardware/vga_pc98_crtc.cpp
@@ -52,6 +52,7 @@ extern bool                 pc98_attr4_graphic;
 extern bool                 pc98_display_enable;
 extern bool                 pc98_monochrome_mode;
 extern bool                 pc98_graphics_hide_odd_raster_200line;
+extern bool                 pc98_cg_kanji_dot_access_mode;
 extern bool                 pc98_crt_mode;      // see port 6Ah command 40h/41h.
 
 // TODO: Other parts that change gdc_5mhz_mode should update these too!
@@ -290,9 +291,9 @@ void pc98_port68_command_write(unsigned char b) {
             if (vga_render_on_demand) VGA_RenderOnDemandUpTo();
             pc98_graphics_hide_odd_raster_200line = !!(b&1);
             break;
-        case 0x0A: // TODO
-        case 0x0B: // TODO
-            // TODO
+        case 0x0A: // Kanji Code Generator access mode: Code (reads only valid during VSync, can display kanji)
+        case 0x0B: //                                   Dot (reads always valid, cannot display kanji)
+            pc98_cg_kanji_dot_access_mode = !!(b&1);
             break;
         case 0x0E: // Display enable
         case 0x0F:


### PR DESCRIPTION
With an option for disabling this behaviour, since some machines don't seem to run into this issue when playing certain translation patches.

## What issue(s) does this PR address?

Playing the current translation patches for the following games on real hardware reveals an issue with the way text is drawn: It mostly consists of white blocks.

- Aegean Kai no Shizuku (https://github.com/Svipur/Aegean-Kai-No-Shizuku-PC98-English/issues/1)
- Azusa 999
- Rance 4.\*

These are caused by failing character bit reads from the Kanji Character Generator. Retrieving the bitmap of an ANK character (ASCII & Kana), or a Kanji while in Code Access mode, via port reads returns invalid values if a VSync is not currently in progress (Undocumented 9801/9821 says it's "not possible").

These translations were tested against emulators, which don't seem to implement this detail. So I'm implementing this here, in hopes of avoiding late surprises in future projects.

## Does this PR introduce new feature(s)?

The newly introduced `pc98->pc-98 chargen vsync-limited access` option, which is default-enabled, will make reads within certain character ranges & access types from port `0xA9` return `0xFF` outside of VSync. This matches the behaviour found on various, but seemingly not all, models of 9801s and 9821s.

<img width="694" height="505" alt="image" src="https://github.com/user-attachments/assets/e2ad0b05-bf5f-4d6a-93d8-f1a0f7659f30" />

## Does this PR introduce any breaking change(s)?

This will "break" some existing translation patches, in the same way that they're currently broken on real hardware. Until those patches are fixed, the option can be disabled in the settings when necessary.

I'm not sure if any other software that exists out in the wild relies on this behaviour working this way, either in emulators or on models that don't seem to have this restriction (whichever those are, only know that the blocks don't seem to appear on a PC-9821As3).

## Additional information

[`pc-98_translation_discussion`](https://discord.com/channels/231947749862539264/231949854463623168/1411356509056532581) channel on the PC-98 discord server, where we slowly worked out all the details of this.