### PR TITLE
Add FFmpeg support for CI builds for testing builds in Linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Update build info
         shell: bash
         run: |
+          echo "timestamp=`git show -s --format=%at | xargs -I# date -d @# +%Y%m%d%H%M%S`" >> $GITHUB_ENV
           export shortsha=`echo ${GITHUB_SHA} | cut -c1-7`
           export copyrightyear=`git show -s --format=%at | xargs -I# date -d @# +'%Y'`
           export updatestr=`git show -s --format=%at | xargs -I# date -d @# +'%b %d, %Y %I:%M:%S%P'`

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install libraries
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y nasm fluidsynth libfluidsynth-dev libpcap-dev libslirp-dev libsdl-net1.2-dev libsdl2-net-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev libpng-dev
+          sudo apt-get install -y nasm fluidsynth libfluidsynth-dev libpcap-dev libslirp-dev libsdl-net1.2-dev libsdl2-net-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev libpng-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libavdevice-dev libavcodec-extra
           mkdir src/bin
       - name: Update build info
         shell: bash
@@ -46,13 +46,13 @@ jobs:
       - name: Build Linux SDL1
         run: |
           top=`pwd`
-          ./build-debug
+          ./build-debug --enable-avcodec
           strip -s $top/src/dosbox-x
           cp $top/src/dosbox-x $top/src/bin/dosbox-x-sdl1
       - name: Build Linux SDL2
         run: |
           top=`pwd`
-          ./build-debug-sdl2
+          ./build-debug-sdl2 --enable-avcodec
           strip -s $top/src/dosbox-x
           cp $top/src/dosbox-x $top/src/bin/dosbox-x-sdl2
       - name: Unit testing


### PR DESCRIPTION
Since FFmpeg deprecates some functions once in a while, add build option to test building with FFmpeg enabled to ensure it is still buildable.

With this PR, github CI runner runs Ubuntu 24.04 with FFmpeg 6.1.1, and the current code is known to be buildable with FFmpeg 8 (on FreeBSD).

So the current code as of Sept.2025 at least supports FFmpeg 6 to 8.