### PR TITLE
debugger: IV must not truncate addresses to 16-bit

### DIFF
--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -1972,7 +1972,7 @@ bool ParseCommand(char* str) {
 
 	if (command == "IV") { // Insert variable
 		uint16_t seg = (uint16_t)GetHexValue(found,found); found++;
-		uint32_t ofs = (uint16_t)GetHexValue(found,found); found++;
+		uint32_t ofs = GetHexValue(found,found); found++;
 		char name[16];
 		for (int i=0; i<16; i++) {
 			if (found[i] && (found[i]!=' ')) name[i] = found[i];


### PR DESCRIPTION
### Summary

IV was casting to 16-bit, breaking 32-bit code (DPMI) by truncation. Remove the narrowing cast so IV matches SV/LV behavior.

Tested IV/SV/LV with 32-bit addresses: auto-replacement + save/load OK.

### What issue(s) does this PR address?
Closes #5851