### PR TITLE
MIDI: Show loaded Soundfont/ROM path only when required to.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -62,6 +62,9 @@ Next version
     (OPNA2608)
   - Added missing language options to Windows installers (maron2000)
   - Debugger: IV must not truncate addresses to 16-bit (cmsautter)
+  - Debugger: Warn single-stepping may not work as expected with Dynamic core
+    (maron2000)
+  - MIDI: Show loaded Soundfont/ROM path only when required to. (maron2000)
 
 2025.05.03
   - Show TURBO status in title bar. (maron2000)

--- a/src/gui/midi_mt32.h
+++ b/src/gui/midi_mt32.h
@@ -267,7 +267,8 @@ public:
 							LOG_MSG("MT32 emulation requires the PCM and CONTROL ROM files.");
 							LOG_MSG("To eliminate this error message, check the DOSBox-X wiki.");
 							LOG_MSG("The ROM files are: CM32L_CONTROL.ROM and CM32L_PCM.ROM or MT32_CONTROL.ROM and MT32_PCM.ROM");
-							return false;
+                            sffile = "Not available";
+                            return false;
 					}
 			}
 		}

--- a/src/gui/midi_synth.h
+++ b/src/gui/midi_synth.h
@@ -464,7 +464,7 @@ public:
 			soundfont_id = fluid_synth_sfload(synth, soundfont.c_str(), 1);
 			if (soundfont_id == FLUID_FAILED) {
 				/* Just consider this a warning (fluidsynth already prints) */
-				soundfont.clear();
+                soundfont.clear();
 				soundfont_id = -1;
 			}
 			else {
@@ -474,10 +474,11 @@ public:
 			}
 		}
 		else {
-			soundfont_id = -1;
+            soundfont_id = -1;
 			LOG_MSG("MIDI:fluidsynth: No SoundFont loaded");
 		}
-		return true;
+        if(soundfont_id == -1) sffile = "Not available";
+        return true;
 	}
 
 	void ListAll(Program* base) override {

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -2574,13 +2574,22 @@ public:
     ShowMidiDevice(GUI::Screen *parent, int x, int y, const char *title) :
         ToplevelWindow(parent, x, y, 320, 260, title) {
             std::string name=!midi.handler||!midi.handler->GetName()?"-":midi.handler->GetName();
+            std::string sf_rom{};
             if (name.size()) {
-                if (name=="mt32") name="MT32";
-                else if (name=="fluidsynth") name="FluidSynth";
+                if(name == "mt32") {
+                    name = "MT32";
+                    sf_rom = "\nMT32 ROM path:\n" + sffile;
+                }
+                else if(name == "fluidsynth") {
+                    name = "FluidSynth";
+                    sf_rom = "\nSoundFont file:\n" + sffile;
+                }
                 else name[0]=toupper(name[0]);
             }
             extern std::string getoplmode(), getoplemu();
-            std::string midiinfo = "MIDI available: "+std::string(midi.available?"Yes":"No")+"\nMIDI device: "+name+"\nMIDI soundfont file / ROM path:\n"+sffile+"\nOPL mode: "+getoplmode()+"\nOPL emulation: "+getoplemu();
+            std::string midiinfo = "MIDI available: "+std::string(midi.available?"Yes":"No")+"\nMIDI device: "+name+sf_rom
+                +"\nOPL mode: "+getoplmode()+"\nOPL emulation: "+getoplemu()
+                + (sf_rom.size()?"":"\n\n\n");
             std::istringstream in(midiinfo.c_str());
             int r=0;
             if (in)	for (std::string line; std::getline(in, line); ) {


### PR DESCRIPTION
DOSBox-X internal MT32 and FluidSynth shows the loaded Soundfont / MT32 ROM path in the `Show MIDI device configuration` dialog.
This PR fixes an issue that Soundfont / MT32 ROM path is shown as `Not available` even `mididevice` option is set to what DOSBox-X is supposed not to load anything.

## What issue(s) does this PR address?
Fixes #5859

<img width="317" height="258" alt="image" src="https://github.com/user-attachments/assets/7026eee7-2fc6-4e24-b5fb-0decf24ae214" />
<img width="315" height="254" alt="image" src="https://github.com/user-attachments/assets/b16ba045-074a-43ab-baa9-52fc45b78d9a" />

<img width="316" height="255" alt="image" src="https://github.com/user-attachments/assets/d6bdb110-4fe9-423c-805a-84962d4704c1" />
<img width="318" height="259" alt="image" src="https://github.com/user-attachments/assets/3e8b9353-5847-4ae1-8773-aa4cd56f4907" />
