### PR TITLE
Fix for issue #3073

### DIFF
--- a/src/output/output_opengl.cpp
+++ b/src/output/output_opengl.cpp
@@ -779,7 +779,7 @@ Bitu OUTPUT_OPENGL_SetSize()
     }
 #endif
 
-    if (sdl.desktop.fullscreen&&sdl_opengl.use_shader)
+    if (sdl_opengl.use_shader)
         glViewport((sdl.surface->w-sdl.clip.w)/2,(sdl.surface->h-sdl.clip.h)/2,sdl.clip.w,sdl.clip.h);
     else
         glViewport(0, 0, sdl.surface->w, sdl.surface->h);


### PR DESCRIPTION
Fix for OpenGL surface mode.

Previously when using OpenGL shaders, aspect/scaling/clipping was only applied for fullscreen mode.
It is now applied in non fullscreen too.

## What issue(s) does this PR address?

Fixes #3073