### PR TITLE
Fix locking problem on Linux port

### DIFF
--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -2958,6 +2958,7 @@ bool LocalFile::LockFile(uint8_t mode, uint32_t pos, uint16_t size) {
 		case EINTR:
 		case ENOLCK:
 		case EAGAIN:
+		case EACCES:
 			DOS_SetError(0x21);
 			break;
 		case EBADF:


### PR DESCRIPTION
As per the fcntl(2) manpage, EACCES can also be returned to indicate lock contention.  This needs to be returned properly to DOS.

## What issue(s) does this PR address?

Without this change file locking is broken on Linux.

## Does this PR introduce any breaking change(s)?

Hopefully just a fixing change ;-)

## Additional information

This bug is minor, and mostly this project has been a dream to use.   Thanks for all your hard work!