### PR TITLE
Update macOS intel runner to macos-15

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ jobs:
       actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
       contents: write # for actions/checkout to fetch code and softprops/action-gh-release
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.12.1


### PR DESCRIPTION
The current macOS CI runner to build nightly builds (`macos-13`) is deprecated, so update it to `macos-15-intel`.
(macos-14 are not available for intel macOS) 

https://github.com/actions/runner-images?tab=readme-ov-file#available-images