### PR TITLE
Linters - fixup freedesktop metainfo and flatpak

### DIFF
--- a/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
+++ b/contrib/linux/com.dosbox_x.DOSBox-X.metainfo.xml.in
@@ -6,8 +6,13 @@
   <metadata_license>CC0-1.0</metadata_license>
   <name>DOSBox-X</name>
   <summary>x86/DOS emulator with sound and graphics</summary>
+  <launchable type="desktop-id">com.dosbox_x.DOSBox-X.desktop</launchable>
+  <developer id="com.dosbox-x">
+	  <name>DOSBox-X team</name>
+  </developer>
   <categories>
-    <category>Emulation</category>
+    <category>Game</category>
+    <category>Emulator</category>
   </categories>
   <releases>
           <release version="@PACKAGE_VERSION@" date="2025-10-7"/>
@@ -43,8 +48,6 @@
 	  </screenshot>
   </screenshots>
   <content_rating type="oars-1.1" />
-  <translation/>
-  <developer_name>DOSBox-X team</developer_name>
   <update_contact>noreply@dosbox-x.com</update_contact>
   <description>
 <p> DOSBox-X is an open-source DOS emulator for running DOS games and applications.
@@ -53,33 +56,8 @@ Compared to DOSBox, DOSBox-X is much more flexible and provides more features.
 </p>
 <p>DOSBox-X emulates a PC necessary for running many DOS games and applications that simply cannot be run on modern PCs and operating systems, similar to DOSBox. However, while the main focus of DOSBox is for running DOS games, DOSBox-X goes much further than this. Started as a fork of the DOSBox project, it retains compatibility with the wide base of DOS games and DOS gaming DOSBox was designed for. But it is also a platform for running DOS applications, including emulating the environments to run Windows 3.x, 9x and ME and software written for those versions of Windows. By adding official support for Windows 95, 98, and ME emulation and acceleration, we hope that those old Windows games and applications could be enjoyed or used once more. Moreover, DOSBox-X adds support for emulating the NEC PC-98 such that you can also play PC-98 games with it.
 </p>
-<p>
-DOSBox-X emulates a legacy IBM PC and DOS environment, and has many emulation options and features such as:
+<p>DOSBox-X emulates a legacy IBM PC and DOS environment, and has many emulation options which you can find documented on the DOSBox-X website.
 </p>
-	<ul>
-		<li>Emulate several PC variants: IBM PC, IBM PCjr, Tandy 1000, Amstrad and NEC PC-98</li>
-		<li>CPUs: 8086, 286, 386, 486, Pentium, Pentium Pro, Pentium MMX, Pentium II and III</li>
-		<li>Graphics chipsets: MDA, Hercules, CGA, EGA, MCGA, VGA and SVGA (S3 Trio64, ET3000, ET4000, Paradise)</li>
-		<li>Sound options: Sound Blaster series, Gravis Ultrasound, Disney Sound source and more audio options</li>
-		<li>MIDI: FluidSynth, Roland MT-32 and General MIDI options</li>
-		<li>Extended Serial, Parallel and Game port support</li>
-		<li>Printer support (real or virtual) and emulation options</li>
-		<li>3dfx Voodoo emulation with Glide wrapper support</li>
-		<li>Network emulation: IPX over UDP, and serial modem</li>
-		<li>Network adapter emulation: NE2000 (pcap or slirp backend)</li>
-		<li>Mounting a host directory as a harddisk, floppy or CD-ROM drive</li>
-		<li>Mounting harddisk images, floppy disk and CD-ROM images, including IDE emulation</li>
-		<li>ISO9660, FAT12, FAT16 and FAT32 filesystem support, including long filenames (LFN)</li>
-		<li>Support for running real DOS systems (MS-DOS, IBM PC DOS, FreeDOS)</li>
-		<li>Support for running Windows 1.0 to Windows 3.11, Windows 9x and Windows ME</li>
-		<li>GUI drop-down menu for easier usage</li>
-		<li>Built-in graphical configuration tool</li>
-		<li>Save and load state with support for save files and up to 100 save slots</li>
-		<li>More DOS commands, and ability to add your own programs to the virtual Z: drive</li>
-		<li>Support for clipboard copy &amp; paste and scalable TrueType fonts (TTF)</li>
-		<li>Various output options, including output scaling (such as pixel-perfect scaling) and OpenGL shaders</li>
-	</ul>
-	With the help of DOSBox-X, you can run plenty of the old classics that don't run on your new computer!
   </description>
   <url type="homepage">https://dosbox-x.com</url>
   <url type="bugtracker">https://github.com/joncampbell123/dosbox-x/issues</url>
@@ -89,9 +67,4 @@ DOSBox-X emulates a legacy IBM PC and DOS environment, and has many emulation op
 	  <control>pointing</control>
 	  <control>gamepad</control>
   </recommends>
-  <mimetypes>
-	  <mimetype>application/x-cd-image</mimetype>
-	  <mimetype>application/x-cue</mimetype>
-	  <mimetype>application/x-raw-disk-image</mimetype>
-  </mimetypes>
 </component>

--- a/contrib/linux/com.dosbox_x.DOSBox-X.yaml
+++ b/contrib/linux/com.dosbox_x.DOSBox-X.yaml
@@ -1,15 +1,15 @@
 ---
 app-id: com.dosbox_x.DOSBox-X
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 
 command: dosbox-x
 
 finish-args:         # flatpak permissions
-  - --device=all     # needed for gamepads and serial/parallel
+  - --device=all     # needed for OpenGL, gamepads and serial/parallel
   - --share=ipc      # needed for X11
-  - --share=network  # needed for networking (NE2000, IPX)
+  - --share=network  # Needed for NE2000, IPX and serial over TCP/IP
   - --socket=x11     # default to X11 due to fullscreen issues
   - --socket=pulseaudio
   - --filesystem=home
@@ -31,8 +31,8 @@ modules:
       - --disable-static
     sources:
       - type: archive
-        url: https://ftp.osuosl.org/pub/blfs/conglomeration/glu/glu-9.0.2.tar.xz
-        sha256: 6e7280ff585c6a1d9dfcdf2fca489251634b3377bfc33c29e4002466a38d02d4
+        url: https://ftp.osuosl.org/pub/blfs/conglomeration/glu/glu-9.0.3.tar.xz
+        sha256: bd43fe12f374b1192eb15fe20e45ff456b9bc26ab57f0eee919f96ca0f8a330f
     cleanup:
       - /include
       - /lib/*.a
@@ -52,10 +52,10 @@ modules:
       - "*.so"
     sources:
       - type: archive
-        url: https://github.com/FluidSynth/fluidsynth/archive/v2.2.9.tar.gz
-        sha256: bc62494ec2554fdcfc01512a2580f12fc1e1b01ce37a18b370dd7902af7a8159
+        url: https://github.com/FluidSynth/fluidsynth/archive/refs/tags/v2.5.0.tar.gz
+        sha256: e4ae831ce02f38b5594ab4dacb11c1a4067ca65ea183523655ebdc9c1b2b92a1
 
-  # Build libslirp for networking
+  # Build libslirp for TCP/IP networking
   - name: libslirp
     buildsystem: meson
     cleanup:
@@ -64,7 +64,7 @@ modules:
     sources:
       - type: git
         url: https://gitlab.freedesktop.org/slirp/libslirp
-        tag: "v4.7.0"
+        tag: "v4.9.1"
     x-checker-data:
       type: anitya
       project-id: 96796
@@ -75,6 +75,7 @@ modules:
   - name: dosbox-x
     buildsystem: autotools
     config-opts:
+      - --enable-core-inline
       - --enable-debug=heavy
       - --enable-sdl2
     sources:
@@ -83,3 +84,5 @@ modules:
     post-install:
       - install -Dm644 /app/share/icons/hicolor/scalable/apps/dosbox-x.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
       - desktop-file-edit --set-key=Icon --set-value=${FLATPAK_ID} /app/share/applications/${FLATPAK_ID}.desktop
+      - install -Dm644 com.dosbox_x.DOSBox-X.metainfo.xml /app/share/metainfo/${FLATPAK_ID}.metainfo.xml
+...


### PR DESCRIPTION
Recent spec and linter updates require updates to the freedesktop metainfo and flatpak files to get things building.

## What issue(s) does this PR address?

Makes it pass the linters for freedesktop metainfo and for flatpak builds again.

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No

## Additional information

Also links the flatpak manifest to current GLU, FluidSynth and libslirp versions
