### PR TITLE
Allow controlling K-CG via BIOS interrupt

### DIFF
--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -141,6 +141,9 @@ extern bool enable_fpu;
 extern bool finish_prepare;
 extern bool is_ttfswitched_on;
 
+/* vga_pc98_cg.cpp */
+extern bool pc98_cg_kanji_dot_access_mode;
+
 bool pc98_timestamp5c = true; // port 5ch and 5eh "time stamp/hardware wait"
 
 uint32_t Keyb_ig_status();
@@ -3997,7 +4000,7 @@ static Bitu INT18_PC98_Handler(void) {
                 0       25lines     20lines
                 1       80cols      40cols
                 2       v.lines     simp.graphics
-                3       K-CG access mode(not used in PC-98) */
+                3       K-CG access mode(not available on original PC-9801) */
             
             //TODO: set 25/20 lines mode and 80/40 columns mode.
             //Attribute bit (bit 2)
@@ -4009,8 +4012,7 @@ static Bitu INT18_PC98_Handler(void) {
 
             mem_writeb(0x53C,(mem_readb(0x53C) & 0xF0u) | (reg_al & 0x0Fu));
 
-            if (reg_al & 8)
-                LOG_MSG("INT 18H AH=0Ah warning: K-CG dot access mode not supported");
+            pc98_cg_kanji_dot_access_mode = !!(reg_al & 8);
 
             pc98_update_text_lineheight_from_bda();
             pc98_update_text_layer_lineheight_from_bda();
@@ -4023,7 +4025,7 @@ static Bitu INT18_PC98_Handler(void) {
                 0       25lines     20lines
                 1       80cols      40cols
                 2       v.lines     simp.graphics
-                3       K-CG access mode(not used in PC-98) 
+                3       K-CG access mode(not available on original PC-9801)
                 7       std CRT     hi-res CRT */
             /* NTS: I assume that real hardware doesn't offer a way to read back the state of these bits,
              *      so the BIOS's only option is to read the mode byte back from the data area.


### PR DESCRIPTION
There is more than one way of controlling the K-CG mode. Implement the interrupt-based one.

## What issue(s) does this PR address?

Fixes issue seen in #5894.

## Does this PR introduce new feature(s)?

n/a

## Does this PR introduce any breaking change(s)?

Fixes something that was missed in #5814.

## Additional information

With this change, Doukyuusei's text renders correctly again.
