### PR TITLE
Fix file open dialog encoding

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -778,7 +778,7 @@ void MenuBrowseImageFile(char drive, bool arc, bool boot, bool multiple) {
 		} else if (lTheOpenFileName) {
             std::string readonly = mountiro[drive - 'A'] ? "\n(" + std::string(MSG_Get("READONLY_MODE")) + ")" : "";
             std::string image = arc ? std::string(MSG_Get("ARCHIVE")) : std::string(MSG_Get("DISK_IMAGE"));
-            drive_warn = formatString(MSG_Get("PROGRAM_MOUNT_IMAGE"), image.c_str(),std::string(1, drive).c_str(), lTheOpenFileName, readonly.c_str());
+            drive_warn = formatString(MSG_Get("PROGRAM_MOUNT_IMAGE"), image.c_str(),std::string(1, drive).c_str(), GetNewStr(lTheOpenFileName).c_str(), readonly.c_str());
             systemmessagebox(MSG_Get("INFORMATION"),drive_warn.c_str(),"ok","info", 1);
 		}
 	}


### PR DESCRIPTION
## What issue(s) does this PR address?

This PR fixes the corrupted file name in the dialog when opening an image file.
Tested on Visual Studio x64 SDL2, Windows 11 24H2.

Before fix
<img width="242" height="149" alt="image" src="https://github.com/user-attachments/assets/c671fead-dcca-434f-8dce-e53883543d5a" />

After Fix
<img width="342" height="155" alt="image" src="https://github.com/user-attachments/assets/b5e69886-1212-448a-b91d-5a52b2d5b8c3" />

<img width="242" height="148" alt="image" src="https://github.com/user-attachments/assets/c2d13aa4-c4b2-4750-aeef-fb0abe97a70a" />

<img width="243" height="148" alt="image" src="https://github.com/user-attachments/assets/c562059f-911a-402c-88c2-b3fd0226c099" />

