### PR TITLE
Mention only 95 OSR2 and later versions are supported

### DIFF
--- a/_includes/version.html
+++ b/_includes/version.html
@@ -16,17 +16,17 @@
 <h4>
   <img src="{{ '/images/windows_logo.png' | relative_url }}" alt="Windows logo" width="32" height="32" class="img-no-styling" /> Windows version
 </h4>
-<p class="subtitle-mute">(Windows 9x/NT4 and later versions supported)</p>
+<p class="subtitle-mute">(Windows 9x(95 OSR2)/NT4 and later versions supported)</p>
 <p>
   32/64-bit Setup:
   {% include version_file.html version=version name="windows_setup_file" display_name="Win7+ " %}
   {% if version.windows_setup_file %}<sup>(Recommended)</sup>{% endif %}
   |
-  {% include version_file.html version=version name="winXP_setup_file" display_name="ReactOS/XP+" %}
+  {% include version_file.html version=version name="winXP_setup_file" display_name="XP+" %}
 </p>
 <p>
   32-bit Portable:
-  {% include version_file.html version=version name="win9x_file" display_name=" 9x/NT4+" %}
+  {% include version_file.html version=version name="win9x_file" display_name=" 9x(95 OSR2+)/NT4+" %}
 </p>
 <p>
   <a href="https://github.com/joncampbell123/dosbox-x/blob/master/INSTALL.md#windows-packages-installer-or-portable">More options including other portable packages</a>


### PR DESCRIPTION
Fix webpage to mention that only 95 OSR2 and later is supported by 9x builds.
Fixes #5928