### PR TITLE
Fix OpenGL resize / crash issue related to SDL and the internal GUI

### DIFF
--- a/src/output/output_opengl.cpp
+++ b/src/output/output_opengl.cpp
@@ -342,7 +342,8 @@ void OUTPUT_OPENGL_Select( GLKind kind )
     sdl_opengl.use_shader = false;
     initgl=0;
 #if defined(C_SDL2)
-    SDL_SetHint(SDL_HINT_FRAMEBUFFER_ACCELERATION, "opengl");
+    SDL_SetHint( SDL_HINT_FRAMEBUFFER_ACCELERATION, "1" ); // setting this to "opengl" caused crashes in certain situations (#3661). can still be overridden via environment variable
+
     void GFX_SetResizeable(bool enable);
     GFX_SetResizeable(true);
     sdl.window = GFX_SetSDLWindowMode(640,400, SCREEN_OPENGL);


### PR DESCRIPTION
Fixes a GUI issue and crash related to window resizing when running OpenGL mode.

Note i only tested this on Windows, some of the existing Issues mention Linux which i can't test here.

## What issue(s) does this PR address?

#3661 ( Fixed on Windows, Need confirmation for other platforms )
#5770 ( Likely fixed but need confirmation )