### PR TITLE
Utilize SDL2's keyboard capture logic to inhibit window manager shortcuts

### DIFF
--- a/contrib/translations/de/de_DE.lng
+++ b/contrib/translations/de/de_DE.lng
@@ -2619,6 +2619,9 @@ Schnellstartprogramm...
 :MENU:mapper_shutdown
 Beende DOSBox-X
 .
+:MENU:mapper_capkeyboard
+Capture keyboard
+.
 :MENU:mapper_capmouse
 Maus einfangen
 .

--- a/contrib/translations/de/de_pc98.lng
+++ b/contrib/translations/de/de_pc98.lng
@@ -2609,6 +2609,9 @@ Schnellstartprogramm...
 :MENU:mapper_shutdown
 Beende DOSBox-X
 .
+:MENU:mapper_capkeyboard
+Capture keyboard
+.
 :MENU:mapper_capmouse
 Maus einfangen
 .

--- a/contrib/translations/en/en_US.lng
+++ b/contrib/translations/en/en_US.lng
@@ -2406,6 +2406,9 @@ Quick launch program...
 :MENU:mapper_shutdown
 Quit from DOSBox-X
 .
+:MENU:mapper_capkeyboard
+Capture keyboard
+.
 :MENU:mapper_capmouse
 Capture mouse
 .

--- a/contrib/translations/es/es_ES.lng
+++ b/contrib/translations/es/es_ES.lng
@@ -2433,6 +2433,9 @@ Inicio rápido de programa...
 :MENU:mapper_shutdown
 Salir de DOSBox-X
 .
+:MENU:mapper_capkeyboard
+Capture keyboard
+.
 :MENU:mapper_capmouse
 Capturar ratón
 .

--- a/contrib/translations/fr/fr_FR.lng
+++ b/contrib/translations/fr/fr_FR.lng
@@ -2421,6 +2421,9 @@ Programme de lancement rapide...
 :MENU:mapper_shutdown
 Quitter
 .
+:MENU:mapper_capkeyboard
+Capturer le clavier
+.
 :MENU:mapper_capmouse
 Capturer la souris
 .

--- a/contrib/translations/hu/hu_HU.lng
+++ b/contrib/translations/hu/hu_HU.lng
@@ -2414,6 +2414,9 @@ Gyors program indítás...
 :MENU:mapper_shutdown
 Kilépés a DOSBox-X-ből
 .
+:MENU:mapper_capkeyboard
+Capture keyboard
+.
 :MENU:mapper_capmouse
 Az egér DOSBOX-X-hez rendelése (ALT+Tab a feloldáshoz)
 .

--- a/contrib/translations/it/it_IT.lng
+++ b/contrib/translations/it/it_IT.lng
@@ -2425,6 +2425,9 @@ Avvio rapido programma...
 :MENU:mapper_shutdown
 Esci da DOSBox-X
 .
+:MENU:mapper_capkeyboard
+Capture keyboard
+.
 :MENU:mapper_capmouse
 Cattura mouse
 .

--- a/contrib/translations/ja/ja_JP.lng
+++ b/contrib/translations/ja/ja_JP.lng
@@ -2414,6 +2414,9 @@ DOSBox-X コマンド・シェルの起動
 :MENU:mapper_shutdown
 DOSBox-Xを終了する
 .
+:MENU:mapper_capkeyboard
+Capture keyboard
+.
 :MENU:mapper_capmouse
 マウスをキャプチャ
 .

--- a/contrib/translations/ko/ko_KR.lng
+++ b/contrib/translations/ko/ko_KR.lng
@@ -2424,6 +2424,9 @@ DOSBox-X 명령 쉘을 시작합니다.
 :MENU:mapper_shutdown
 DOSBox-X를 종료
 .
+:MENU:mapper_capkeyboard
+Capture keyboard
+.
 :MENU:mapper_capmouse
 마우스를 갈무리
 .

--- a/contrib/translations/nl/nl_NL.lng
+++ b/contrib/translations/nl/nl_NL.lng
@@ -2411,6 +2411,9 @@ Snelstartprogramma...
 :MENU:mapper_shutdown
 Afsluiten van DOSBox-X
 .
+:MENU:mapper_capkeyboard
+Capture keyboard
+.
 :MENU:mapper_capmouse
 Muis vastleggen
 .

--- a/contrib/translations/pt/pt_BR.lng
+++ b/contrib/translations/pt/pt_BR.lng
@@ -2446,6 +2446,9 @@ Início rápido de programa...
 :MENU:mapper_shutdown
 Sair do DOSBox-X
 .
+:MENU:mapper_capkeyboard
+Capture keyboard
+.
 :MENU:mapper_capmouse
 Capturar mouse
 .

--- a/contrib/translations/ru/ru_RU.lng
+++ b/contrib/translations/ru/ru_RU.lng
@@ -2558,6 +2558,9 @@ DEBUGBOX [команда] [опции]
 :MENU:mapper_shutdown
 Выйти из DOSBox-X
 .
+:MENU:mapper_capkeyboard
+Capture keyboard
+.
 :MENU:mapper_capmouse
 Захват мыши
 .

--- a/contrib/translations/tr/tr_TR.lng
+++ b/contrib/translations/tr/tr_TR.lng
@@ -2433,6 +2433,9 @@ Hızlı program başlat...
 :MENU:mapper_shutdown
 DOSBox-X'ten çık
 .
+:MENU:mapper_capkeyboard
+Capture keyboard
+.
 :MENU:mapper_capmouse
 Fareyi yakala
 .

--- a/contrib/translations/zh/zh_CN.lng
+++ b/contrib/translations/zh/zh_CN.lng
@@ -2395,6 +2395,9 @@ To adjust the emulated CPU speed, use [31mhost+Plus[37m and [31mhost+Minus[3
 :MENU:mapper_shutdown
 退出 DOSBox-X
 .
+:MENU:mapper_capkeyboard
+Capture keyboard
+.
 :MENU:mapper_capmouse
 捕获鼠标
 .

--- a/contrib/translations/zh/zh_TW.lng
+++ b/contrib/translations/zh/zh_TW.lng
@@ -2385,6 +2385,9 @@ DEBUGBOX [命令] [選項]
 :MENU:mapper_shutdown
 結束 DOSBox-X
 .
+:MENU:mapper_capkeyboard
+Capture keyboard
+.
 :MENU:mapper_capmouse
 擷取滑鼠
 .

--- a/include/sdlmain.h
+++ b/include/sdlmain.h
@@ -174,6 +174,9 @@ struct SDL_Block {
         int ysensitivity = 0;
         MOUSE_EMULATION emulation = (MOUSE_EMULATION)0;
     } mouse;
+#if defined(C_SDL2)
+    bool capture_keyboard = false;
+#endif
     SDL_Rect updateRects[1024] = {};
     Bitu overscan_color = 0;
     Bitu overscan_width = 0;
@@ -238,6 +241,10 @@ SDL_Window* GFX_SetSDLWindowMode(uint16_t width, uint16_t height, SCREEN_TYPES s
 
 #if defined(C_SDL2) && defined(C_OPENGL)/*HACK*/
 void SDL_GL_SwapBuffers(void);
+#endif
+
+#if defined(C_SDL2)
+void GFX_KeyboardCapture(bool enabled);
 #endif
 
 #if defined(WIN32) && !defined(HX_DOS)

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -149,6 +149,9 @@ static const char *def_menu_main[] =
     "MainHostKey",
     "SharedClipboard",
     "--",
+#if defined(C_SDL2)
+    "mapper_capkeyboard",
+#endif
     "mapper_capmouse",
     "auto_lock_mouse",
     "WheelToArrow",


### PR DESCRIPTION
Attempts to inhibit window manager shortcuts by using [`SDL_SetWindowKeyboardGrab(SDL_Window*, SDL_bool)`](https://wiki.libsdl.org/SDL2/SDL_SetWindowKeyboardGrab) introduced in SDL 2.0.16 to capture the keyboard. There are a bunch of caveats -- like if another application attempts to grab the keyboard after us, they win and we lose our grab, or that not all shortcuts can be inhibited on all platforms (Windows always captures `Ctrl+Alt+Del` for example, irrespective of our application) -- but it works for the majority of cases.

Adds a simple keyboard mapping just like for other properties like mouse capture (defaults to `Ctrl+F11`, similar to mouse capture's `Ctrl+F10`), editable in the mapper tool just the same. Property is available in the config file as well, and restored on startup, with a big block of help text to make sure people are aware of the warnings and caveats associated with no-longer being able to use your WM to kill DOSBox-X if it gets stuck.

Also hints to SDL/WM to inhibit `Alt+Tab` too when fullscreen. As we have a dedicated fullscreen toggle to break out, and as applications inside DOSBox-X might utilize `Alt+Tab` for things like Windows' application switcher, it makes sense to capture this too. It's only set with [`SDL_SetHint(char*, char*)`](https://wiki.libsdl.org/SDL2/SDL_SetHint), so it's overridable via environment variable if the user doesn't like it.

As a sidenote, I believe I've added English and French translations to the menu entry correctly, but I'm not so hot with the rest of the languages for which there are translations files. They seem to include the English where yet untranslated so I've just copied that across verbatim to the rest of them.

This was all written and tested on Fedora Linux 43 x86_64, under both MATE X11 and FVWM X11 individually. It's largely based on existing work done in https://github.com/dosbox-staging/dosbox-staging/pull/4338 for DOSBox Staging's similar issue (https://github.com/dosbox-staging/dosbox-staging/issues/4306). Overall code layout attempts to mimic what's already in the DOSBox-X codebase and the files touched.

## What issue(s) does this PR address?

Closes #4911

## Does this PR introduce any breaking change(s)?

No, shouldn't do.

## Additional information

<img width="304" height="160" alt="image" src="https://github.com/user-attachments/assets/19e70609-c6dc-491e-9e90-dc61646bdaaa" />
<img width="580" height="375" alt="image" src="https://github.com/user-attachments/assets/07307929-1531-4e58-84bf-276824ea7476" />
