### PR TITLE
Fix: Load GetDiskFreeSpaceExA at runtime to restore compatibility with Win95RTM

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ Apart from the Windows installers, you can also find portable zip files starting
 Regarding Joystick support, the *SDL1 builds requires XInput compatible devices*. If your joystick is not Xinput compatible, you may want to try the SDL2 builds or DirectInput to XInput wrappers such as [Xoutput](https://github.com/csutorasa/XOutput) or [Xbox 360 controller emulator](https://www.x360ce.com/).
 
 * Modern Windows users (7 and after) should use the standard (non-XP, non-lowend) builds but may try the non-standard builds if you prefer, although officially not supported.
-* Windows 9x(95 OSR2+)/NT4/2000 users should use the MinGW lowend 9x builds (32-bit SDL1 only).
+* Windows 9x/NT4/2000 users should use the MinGW lowend 9x builds (32-bit SDL1 only).
 * Windows XP users must use the XP compatible installer with "XP" in the file name, which includes Visual Studio XP builds and the 32-bit MinGW low-end builds. Note that not all features are available in the MinGW low-end builds, currently Slirp support is known to be missing. You also need to install the [DirectX runtime](https://www.microsoft.com/en-us/download/details.aspx?id=8109) or DOSBox-X will complain you're missing `XInput9_1_0.dll`. XP compatible builds works in ReactOS as well, but support is considered experimental.
 * Windows Vista users can use the XP installer or standard (non-XP) Visual Studio portable builds, because standard (non-XP) installer doesn't work in Vista. MinGW dropped support for XP/Vista, so install the 32-bit low-end builds from the XP compatible installer if you prefer MinGW builds.
 

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -2348,7 +2348,11 @@ bool localDrive::AllocationInfo64(uint32_t* _bytes_sector, uint32_t* _sectors_cl
         res = GetDiskFreeSpace(diskToQuery, &dwSectPerClust, &dwBytesPerSect, &dwFreeClusters, &dwTotalClusters);
         if(dwSectPerClust * dwBytesPerSect == 0) return false;
         ULARGE_INTEGER FreeBytesAvailableToCaller, TotalNumberOfBytes;
-        GetDiskFreeSpaceEx(diskToQuery, &FreeBytesAvailableToCaller, &TotalNumberOfBytes, NULL);
+        HMODULE __kernel32 = GetModuleHandleW(L"kernel32.dll");
+        auto __GetDiskFreeSpaceExA = (BOOL (WINAPI *)(LPCSTR, PULARGE_INTEGER, PULARGE_INTEGER, PULARGE_INTEGER))GetProcAddress(__kernel32,"GetDiskFreeSpaceExA");
+        if (!__GetDiskFreeSpaceExA)
+            return false;
+        __GetDiskFreeSpaceExA(diskToQuery, &FreeBytesAvailableToCaller, &TotalNumberOfBytes, NULL);
         qwTotalClusters = TotalNumberOfBytes.QuadPart / (dwSectPerClust * dwBytesPerSect);
         qwFreeClusters = FreeBytesAvailableToCaller.QuadPart / (dwSectPerClust * dwBytesPerSect);
 


### PR DESCRIPTION

Commit 9abdd15e423f7f85b6df613aea1d0ea3dee4c0b1 added a static import of `GetDiskFreeSpaceExA` which broke compatibility with Windows 95 RTM and OSR1. This PR loads it at runtime to restore compatibility. On Windows 95 RTM, the code falls back to the original `AllocationInfo` implementation, which doesn't use `GetDiskFreeSpaceExA`. Tested on Windows 95 RTM (with DCOM update) and Windows 11 24h2.

## What issue(s) does this PR address?

#5928 