### PR TITLE
Fix: File handle leak prevents save state file removal

### DIFF
--- a/src/misc/savestates.cpp
+++ b/src/misc/savestates.cpp
@@ -924,6 +924,7 @@ std::string SaveState::getName(size_t slot, bool nl) const {
 			if (length != 0) ret += nl?"Remark: "+(!strlen(buffer1)?"-":std::string(buffer1))+"\n":" - "+std::string(buffer1);
 		}
 	}
-
+    unzClose(zf);
 	return ret;
 }
+


### PR DESCRIPTION
Hello,

This Pull Request addresses a critical bug where save state files (.sav) could not be removed or deleted while DOSBox-X was running. This issue led to "Failed to remove the state" errors.

The Problem

The function SaveState::getName reads metadata (such as Program Name and Timestamp) from the .sav file for menu display. Since the file is a ZIP archive, it is opened using the C-based minizip function unzOpen2_64. The code was missing the corresponding C cleanup function unzClose(zf). This omission caused a persistent Operating System File Handle Leak on the file, preventing external deletion.

The Fix

The fix involves adding a single line to ensure the file handle is properly released after the metadata is read.

## What issue(s) does this PR address?

#5974

## Does this PR introduce new feature(s)?



## Does this PR introduce any breaking change(s)?



## Additional information


