### PR TITLE
Revise explanation of pc-98 chargen vsync-limited access option.

### DIFF
--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -703,7 +703,9 @@ monochrome_pal          = green
 #       pc-98 chargen vsync-limited access: If set, reading pixels from the character generator while in Code Access mode (or always, for ANK
 #                                             characters) will be invalid. Some models (i.e. PC-9821As3) dont seem to have this limitation, but
 #                                             many others do.
-#                                             Try enabling this if you suffer some glitches in text display.
+#                                             This option is set to false by default, set this option to true if you suffer text glitches.
+#                                             It is reported that setting this option to true will result in glitches in some titles;
+#                                             therefore revert this option to false in such cases.
 pc-98 BIOS copyright string              = false
 pc-98 int 1b fdc timer wait              = false
 pc-98 pic init to read isr               = true

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -2444,7 +2444,9 @@ void DOSBOX_SetupConfigSections(void) {
     Pbool->Set_help("If set, reading pixels from the character generator while in Code Access mode (or always, for ANK\n"
                     "characters) will be invalid. Some models (i.e. PC-9821As3) dont seem to have this limitation, but\n"
                     "many others do.\n"
-                    "Try enabling this if you suffer some glitches in text display.");
+                    "This option is set to false by default, set this option to true if you suffer text glitches.\n"
+                    "It is reported that setting this option to true will result in glitches in some titles;"
+                    "therefore revert this option to false in such cases.");
 
     secprop=control->AddSection_prop("dosv",&Null_Init,true);
 


### PR DESCRIPTION
Revise the explanation of `pc-98 chargen vsync-limited access` for clarity considering the regression.