### PR TITLE
Fix webpage regarding SDL2 version works on macOS 12+ only

### DIFF
--- a/_includes/version.html
+++ b/_includes/version.html
@@ -50,6 +50,8 @@
   {% include version_file.html version=version name="macos_intel_file" display_name="Intel-based Mac" %}
   |
   {% include version_file.html version=version name="macos_arm_file" display_name="ARM-based Mac" %}
+<br>
+SDL2 version is known to work on macOS 12+ only.
 </p>
 <p>
   {%- if version.macos_special_file -%}

--- a/devel-build.html
+++ b/devel-build.html
@@ -24,7 +24,7 @@ vsbuild64 | 64-bit Visual Studio portable builds (for Vista+/ARM)
 mingw32 | 32-bit MinGW (for 7+) and MinGW-lowend (for XP+, W9x/NT4+) portable builds
 mingw64 | 64-bit MinGW/UCRT64(experimental) portable builds (for 7+)
 linux | Linux (x86_64) builds
-macos | macOS (x86_64/ARM) builds
+macos | macOS (x86_64/ARM) builds (SDL2 works for macOS 12+ only)
 hxdos | HX-DOS (x86) build
 {%- endcapture -%}
 


### PR DESCRIPTION
Related to PR #5985, mention SDL2 support for macOS on webpage.