### PR TITLE
Force SDL window regeneration when exiting fullscreen

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1760,7 +1760,7 @@ SDL_Window* GFX_SetSDLWindowMode(uint16_t width, uint16_t height, SCREEN_TYPES s
      */
     if (!sdl.window
             || (lastType != screenType)
-            || !GFX_IsFullscreen() && ( SDL_GetWindowFlags(sdl.window) & SDL_WINDOW_FULLSCREEN )
+            || ( !GFX_IsFullscreen() && ( SDL_GetWindowFlags(sdl.window) & SDL_WINDOW_FULLSCREEN ))
 //          || (currWidth != width) || (currHeight != height)
 //          || (glwindow != (0 != (SDL_GetWindowFlags(sdl.window) & SDL_WINDOW_OPENGL)))
 //          || (fullscreen && (0 == (SDL_GetWindowFlags(sdl.window) & SDL_WINDOW_FULLSCREEN)))


### PR DESCRIPTION
Forces SDL2 window to regenerate when coming from fullscreen.

## What issue(s) does this PR address?

#5990

# Additional Info

The alternative fix for #5990 would be to disable SDL2 Framebuffer Acceleration by default. Unclear if that has any performance implications though, probably not.