### PR TITLE
Log OpenGL context version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,4 +139,3 @@ contrib/macos/dosbox-x.plist
 # ignore default dosbox config files (used for manual testing)
 /dosbox-x.conf
 /src/dosbox-x.conf
-/vs/


### PR DESCRIPTION
Logs the OpenGL context version to the debug log. This is purely for information purposes.