### PR TITLE
Fix regression of FIFA96 CD label detection

### DIFF
--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -299,7 +299,11 @@ void Set_Label(char const * const input, char * const output, bool cdrom) {
     //DBCS_upcase(upcasebuf);  /* Another mscdex quirk. Label is not always uppercase. (Daggerfall) */ 
 
     while (togo > 0) {
-        if(upcasebuf[vnamePos] == 0) str_end = true;
+        if(upcasebuf[vnamePos] == 0 && !str_end) {
+            str_end = true;
+            if(cdrom && vnamePos == 8) output[labelPos++] = '.';
+            //Add a trailing dot ('.') when on cdrom and label is exactly 8 characters, MSCDEX feature/bug (fifa96 cdrom detection)
+        }
         else if(cdrom && vnamePos == 8 && !str_end && upcasebuf[vnamePos] != '.') {
             output[labelPos] = '.'; // add a dot between 8th and 9th character (Descent 2 installer needs this)
             labelPos++;

--- a/tests/drives_tests.cpp
+++ b/tests/drives_tests.cpp
@@ -148,7 +148,7 @@ TEST(Set_Label, EqualTo8)
 TEST(Set_Label, EqualTo8CD)
 {
     std::string output = run_Set_Label("a1234567", true);
-    EXPECT_EQ("a1234567", output);
+    EXPECT_EQ("a1234567.", output);
 }
 
 // A test to ensure non-CD-ROM function strips trailing dot


### PR DESCRIPTION
This PR fixes a regression of label detection that made FIFA Soccer 96 fails to launch

## What issue(s) does this PR address?
Fixes #6001 

<img width="637" height="523" alt="image" src="https://github.com/user-attachments/assets/5f239407-c938-4e57-93b6-8a1cee780cb9" />
