### PR TITLE
Use MACH_PORT_NULL instead of kIOMainPortDefault for old macOS

### DIFF
--- a/build-macos-sdl2
+++ b/build-macos-sdl2
@@ -65,14 +65,6 @@ if [ -n "${x86_64_brew_cmd}" ] && [ "${universal}" -eq 1 ]; then
     x86_64_brew_cmd="/usr/bin/arch -x86_64 ${x86_64_brew_cmd}"
 fi
 
-OSVER=$(sw_vers -productVersion | cut -d. -f1)
-
-if [ "$OSVER" -ge 12 ]; then
-    MINVER="12.0"
-else
-    MINVER="10.13"
-fi
-
 for arch in ${architectures}; do
     declare brew_cmd="${arch}_brew_cmd"
     if [ -n "${!brew_cmd}" ]; then
@@ -83,7 +75,7 @@ for arch in ${architectures}; do
 
     do_cleanup
 
-    arch_flags="-arch ${arch} -mmacosx-version-min=${MINVER} "
+    arch_flags="-arch ${arch} -mmacosx-version-min=10.13 "
     CFLAGS="${arch_flags}${orig_CFLAGS}"
     CXXFLAGS="${arch_flags}${orig_CXXFLAGS}"
     export CFLAGS CXXFLAGS

--- a/vs/sdl2/src/haptic/darwin/SDL_syshaptic.c
+++ b/vs/sdl2/src/haptic/darwin/SDL_syshaptic.c
@@ -162,7 +162,11 @@ int SDL_SYS_HapticInit(void)
     }
 
     /* Now search I/O Registry for matching devices. */
-    result = IOServiceGetMatchingServices(/*kIOMainPortDefault*/MACH_PORT_NULL, match, &iter); /* fixed for DOSBox-X */
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
+    result = IOServiceGetMatchingServices(MACH_PORT_NULL, match, &iter); /* fixed for DOSBox-X (old macOS support) */
+#else
+    result = IOServiceGetMatchingServices(kIOMainPortDefault, match, &iter);
+#endif
     if (result != kIOReturnSuccess) {
         return SDL_SetError("Haptic: Couldn't create a HID object iterator.");
     }

--- a/vs/sdl2/src/hidapi/SDL_hidapi.c
+++ b/vs/sdl2/src/hidapi/SDL_hidapi.c
@@ -257,7 +257,11 @@ static void HIDAPI_InitializeDiscovery(void)
 #endif /* defined(__WIN32__) || defined(__WINGDK__) */
 
 #if defined(__MACOSX__)
-    SDL_HIDAPI_discovery.m_notificationPort = IONotificationPortCreate(/*kIOMainPortDefault*/MACH_PORT_NULL); /* fixed for DOSBox-X */
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
+    SDL_HIDAPI_discovery.m_notificationPort = IONotificationPortCreate(MACH_PORT_NULL); /* fixed for DOSBox-X (old macOS support) */
+#else
+    SDL_HIDAPI_discovery.m_notificationPort = IONotificationPortCreate(kIOMainPortDefault);
+#endif
     if (SDL_HIDAPI_discovery.m_notificationPort) {
         {
             io_iterator_t portIterator = 0;


### PR DESCRIPTION
`kIOMainPortDefault` is not supported on old macOS (< 12.0), so replace it with its synonym `MACH_PORT_NULL` to support it.
