### PR TITLE
Use more ChinaSea/Big5-2003 extended characters for CP951

### DIFF
--- a/include/cp951_uni.h
+++ b/include/cp951_uni.h
@@ -6859,11 +6859,12 @@ void makeseacp951table() {
         cp951sea_to_unicode_raw[i] = cp950ext_to_unicode_raw[i];
         cp951uaosea_to_unicode_raw[i] = cp950ext_to_unicode_raw[i];
     }
-    for (int i=64*98; i<64*365; i++) {
+    for (int i=64*98; i<64*210; i++) {
         cp951sea_to_unicode_raw[i] = cp951_to_unicode_raw[i];
         cp951uaosea_to_unicode_raw[i] = cp951uao_to_unicode_raw[i];
     }
-    for (int i=64*365; i<64*380; i++) {
+    for (int i=64*210; i<64*380; i++) {
+        /* 0xC6A1-0xFEFE */
         cp951sea_to_unicode_raw[i] = cp950ext_to_unicode_raw[i];
         cp951uaosea_to_unicode_raw[i] = cp950ext_to_unicode_raw[i];
     }


### PR DESCRIPTION
Use more ChinaSea/Big5-2003 extended characters for code page 951 when ChinaSea is set to true.

When ChinaSea is set to true, characters mapped to code points in the range 0xC6A1–0xFEFE are kept consistent across CP950 (Big5), CP951 (Big5-HKSCS), and CP951 (Big5-UAO).

<img width="654" height="461" alt="" src="https://github.com/user-attachments/assets/1fd59ce4-e39a-4261-9b66-821f8e753308" />

[cp950ext.txt](https://github.com/user-attachments/files/24547711/cp950ext.txt)



## Additional information
https://en.wikipedia.org/wiki/Big5#Vendor_extensions
https://zh.wikipedia.org/wiki/%E5%A4%A7%E4%BA%94%E7%A2%BC#%E9%9D%9E%E5%AE%98%E6%96%B9Big5%E5%BB%B6%E4%BC%B8


