### PR TITLE
Fix savestate load "Memory size mismatch" error on MSVC builds

### DIFF
--- a/src/misc/savestates.cpp
+++ b/src/misc/savestates.cpp
@@ -523,7 +523,7 @@ void SaveState::save(size_t slot) { //throw (Error)
 		if ((errclose=zipOutOpenFile(zf,"Memory_Size",zi,compresssaveparts)) != ZIP_OK) { save_err = true; goto done; }
 		zip_ostreambuf zos(zf); std::ostream memorysize(&zos);
 
-		memorysize << MEM_TotalPages();
+		memorysize << std::to_string( MEM_TotalPages());
 
 		if ((errclose=zos.close()) != ZIP_OK) { save_err = true; goto done; }
 	}


### PR DESCRIPTION
Fixes issue writing MEM_TotalPages() to the savestate because of some problem with the MSVC ostream implementation ?

## What issue(s) does this PR address?

Fixes #6068