### PR TITLE
Clear modifier keys before savestate gets saved

### DIFF
--- a/src/misc/savestates.cpp
+++ b/src/misc/savestates.cpp
@@ -170,6 +170,8 @@ namespace
 	void SaveGameState(bool pressed) {
 		if (!pressed) return;
 
+		GFX_LosingFocus();
+
 		try
 		{
 			LOG_MSG("Saving state to slot: %d", (int)currentSlot + 1);
@@ -194,7 +196,7 @@ namespace
 		//        LOG_MSG("[%s]: State %d is empty!", getTime().c_str(), currentSlot + 1);
 		//        return;
 		//    }
-		if (!GFX_IsFullscreen()&&render.aspect) GFX_LosingFocus();
+
 		try
 		{
 			LOG_MSG("Loading state from slot: %d", (int)currentSlot + 1);


### PR DESCRIPTION
Clears modifier key status before savestate gets saved.
This fixes an issue where F11 would be "stuck" after a savestate load.

## What issue(s) does this PR address?

Fixes #6080 