### PR TITLE
Optional switch to disable post exit delay in DX-CAPTURE

### DIFF
--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1809,7 +1809,7 @@ void SHELL_Init() {
 	MSG_Add("SHELL_CMD_TRUENAME_HELP","Finds the fully-expanded name for a file.\n");
 	MSG_Add("SHELL_CMD_TRUENAME_HELP_LONG","TRUENAME [/H] file\n");
 	MSG_Add("SHELL_CMD_DXCAPTURE_HELP","Runs program with video or audio capture.\n");
-	MSG_Add("SHELL_CMD_DXCAPTURE_HELP_LONG","DX-CAPTURE [/V|/-V] [/A|/-A] [/M|/-M] [/O|/-O] [command] [options]\n\nIt will start video or audio capture, run program, and then automatically stop capture when the program exits.\n /V for video, /A for audio, /M multi-track audio and /O for OPL FM (DROv2 format)");
+	MSG_Add("SHELL_CMD_DXCAPTURE_HELP_LONG","DX-CAPTURE [/V|/-V] [/A|/-A] [/M|/-M] [/O|/-O] [/D|/-D] [command] [options]\n\nIt will start video or audio capture, run program, and then automatically stop capture when the program exits.\n /V for video, /A for audio, /M multi-track audio, /O for OPL FM (DROv2 format) and /-D for disabling the post-exit delay.");
 #if C_DEBUG
 	MSG_Add("SHELL_CMD_DEBUGBOX_HELP","Runs program and breaks into debugger at entry point.\n");
 	MSG_Add("SHELL_CMD_DEBUGBOX_HELP_LONG","DEBUGBOX [command] [options]\n\nType DEBUGBOX without a parameter to start the debugger.\n");

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -4390,7 +4390,8 @@ void DOS_Shell::CMD_DXCAPTURE(char * args) {
     bool cap_audio = false;
     bool cap_mtaudio = false;
     bool cap_opl = false;
-    unsigned long post_exit_delay_ms = 3000; /* 3 sec */
+    const unsigned long default_post_exit_delay_ms = 3000; /* 3 sec */
+    unsigned long post_exit_delay_ms = default_post_exit_delay_ms;
 
     if (!strcmp(args,"-?")) {
 		args[0]='/';
@@ -4419,6 +4420,10 @@ void DOS_Shell::CMD_DXCAPTURE(char * args) {
 			cap_mtaudio = true;
 		else if (!(strcmp(arg1,"/-M")))
 			cap_mtaudio = false;
+		else if (!(strcmp(arg1,"/D")))
+			post_exit_delay_ms = default_post_exit_delay_ms;
+		else if (!(strcmp(arg1,"/-D")))
+			post_exit_delay_ms = 0;
 		else {
 			WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"),arg1);
 			return;


### PR DESCRIPTION
By default, a three second delay is applied after capture is done. However, this is not always desired in headless capture settings. Adding a switch to enable/disable the delay per the existing switch convention.

## What issue(s) does this PR address?

There is a three-second post-exit delay on video capture when using `DX-CAPTURE`.

This can already be disabled by keyboard input, but this option is not feasible in unsupervised and/or headless settings.

Hence, implementing a new `-D` switch to disable the post-exit delay on the command line.

## Does this PR introduce new feature(s)?

A switch for `DX-CAPTURE` to enable/disable the delay per the existing switch convention.

## Does this PR introduce any breaking change(s)?

No, this is an optional switch for `DX-CAPTURE`. Original functionality is preserved.

## Additional information

Also code cleanup per `.editorconfig` (separate commit for easier reviewing).