### PR TITLE
Fix long freeze during startup on linux

### DIFF
--- a/src/gui/sdlmain_linux.cpp
+++ b/src/gui/sdlmain_linux.cpp
@@ -478,7 +478,20 @@ static bool Linux_TryXRandrGetDPI(ScreenSizeInfo &info,Display *display,Window w
     attr.x = x - attr.x;
     attr.y = y - attr.y;
 
-    if ((xr_screen=XRRGetScreenResources(display, DefaultRootWindow(display))) != NULL) {
+    xr_screen = XRRGetScreenResourcesCurrent(display, DefaultRootWindow(display));
+
+    if (xr_screen != NULL && xr_screen->noutput == 0)
+    {
+        XRRFreeScreenResources(xr_screen);
+        xr_screen = NULL;
+    }
+
+    if (xr_screen == NULL)
+    {
+        xr_screen = XRRGetScreenResources(display, DefaultRootWindow(display));
+    }
+
+    if (xr_screen != NULL) {
         /* Look for a valid CRTC, don't assume the first is valid (as the StackOverflow example does) */
         for (int c=0;c < xr_screen->ncrtc;c++) {
             XRRCrtcInfo *chk = XRRGetCrtcInfo(display, xr_screen, xr_screen->crtcs[c]);


### PR DESCRIPTION
This small patch tries to use XRRGetScreenResourcesCurrent() instead of XRRGetScreenResources() to avoid a freeze during startup.

## What issue(s) does this PR address?

I'm not aware of any open issues, but I was having a problem on Manjaro where DOSBox-X would take 20+ seconds to start, and every other programs' windows would freeze as well.  This patch alleviates that, but does not completely eliminate the startup delay.

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

I do not believe so.

## Additional information

I believe the rest of the startup delay occurs on https://github.com/joncampbell123/dosbox-x/blob/51f7eab94933b8dd0a8e93746043b9a124ef0fa7/src/gui/sdlmain.cpp#L1788 but I'd have to debug SDL2 to check.
