### PR TITLE
D3D11: Workaround for blanked screen in CGA/EGA/Tandy/Hercules modes

### DIFF
--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -326,11 +326,21 @@ static void RENDER_ScalerLineHandler(const void * s) {
 	}
 }
 
+void D3D11_DrawLine_8bpp(const void* src);
+
 static void RENDER_StartLineHandler(const void * s) {
     //LOG_MSG("RENDER_StartLineHandler called s=%p", s);
     if (render.disablerender)
         return;
-
+#if defined(C_DIRECT3D) && defined(C_SDL2)
+    if(sdl.desktop.type == SCREEN_DIRECT3D11 && render.src.bpp == 8){
+        GFX_StartUpdate(render.scale.outWrite, render.scale.outPitch);
+        RENDER_DrawLine = D3D11_DrawLine_8bpp;
+        //RENDER_DrawLine = RENDER_ScalerLineHandler;
+        RENDER_DrawLine(s);
+    }
+    else
+#endif
     if (RENDER_DrawLine_scanline_cacheHit(s)) { // line has not changed
         render.scale.cacheRead += render.scale.cachePitch;
         Scaler_ChangedLines[0] += Scaler_Aspect[ render.scale.inLine ];

--- a/src/output/output_direct3d11.h
+++ b/src/output/output_direct3d11.h
@@ -55,6 +55,8 @@ public:
     uint32_t window_height = 0; // Window width (Used when returning from fullscreen)
     bool was_fullscreen = false;
     bool device_ready = false;
+    int cpu_pitch = 0;
+    std::vector<uint8_t> cpu_buffer;
 
 private:
     ID3D11Device* device = nullptr;
@@ -80,15 +82,12 @@ private:
     UINT offset = 0;
 
     int width = 0, height = 0;
-    int cpu_pitch = 0;
-    std::vector<uint8_t> cpu_buffer;
     bool textureMapped = false;
     bool resizing = false;
     uint32_t last_window_w = 0;
     uint32_t last_window_h = 0;
     uint32_t last_tex_w = 0;
     uint32_t last_tex_h = 0;
-
 };
 
 #endif // defined(C_SDL2)


### PR DESCRIPTION
The experimental D3D11 output option somehow fails to display text & graphics on CGA/EGA/Tandy/Hercules modes.
This PR bypasses the existing renderer using a simple renderer as a workaround while figuring out the reason.
Due to the above workaround, some scalers/shaders are not working but better than a blank screen.

<img width="640" height="579" alt="image" src="https://github.com/user-attachments/assets/950f3f8b-d3cc-4413-9b09-615977bd5e77" />


<img width="636" height="626" alt="image" src="https://github.com/user-attachments/assets/9ed06cd7-3d30-4055-aab9-f6b334108390" />

