### PR TITLE
Fix `windowposition` option at launch

### DIFF
--- a/src/output/output_tools.cpp
+++ b/src/output/output_tools.cpp
@@ -290,7 +290,7 @@ void change_output(int output) {
 
 #ifdef C_SDL2
     // UX: always center window after changing output
-    SDL_SetWindowPosition(sdl.window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+    // SDL_SetWindowPosition(sdl.window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 #endif
 }
 


### PR DESCRIPTION
Fix window position is set to center position regardless of `windowposition` option.
Also on Windows SDL2 versions, window position is adjusted not to hide the title and menubar when y position is set to zero.

Tested on Windows VS x64 SDL1 & SDL2.

Fixes #6002 