### PR TITLE
Adjust the ChinaSea/Big5-2003 extended code point ranges for CP951 to 0x9140–0xA3FE and 0xC6A1–0xFEFE

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,7 +27,8 @@ NEXT VERSION
     DOSBox, but the hardware rate is 49716 and that should be the default
     (joncampbell123).
   - Fixed crash on starting debugger on MinGW builds (maron2000)
-  - Use more ChinaSea/Big5-2003 extended characters for CP951 (1abcd)
+  - Adjusted the ChinaSea/Big5-2003 extended code point ranges for CP951 to
+    0x9140–0xA3FE and 0xC6A1–0xFEFE (1abcd)
   - Replaced deprecated symbols to enable launching on old macOSs (maron2000)
   - Converted all bash-dependent shell files to POSIX-shell compliant
     (pandasoli)

--- a/include/cp951_uni.h
+++ b/include/cp951_uni.h
@@ -6851,15 +6851,16 @@ bool madecp951 = false;
 uint16_t cp951sea_to_unicode_raw[24320], cp951uaosea_to_unicode_raw[24320];
 void makeseacp951table() {
     if (madecp951) return;
-    for (int i=0; i<64*41; i++) {
+    for (int i=0; i<64*50; i++) {
         cp951sea_to_unicode_raw[i] = cp951_to_unicode_raw[i];
         cp951uaosea_to_unicode_raw[i] = cp951uao_to_unicode_raw[i];
     }
-    for (int i=64*41; i<64*98; i++) {
+    for (int i=64*50; i<64*107; i++) {
+        /* 0x9140-0xA3FE */
         cp951sea_to_unicode_raw[i] = cp950ext_to_unicode_raw[i];
         cp951uaosea_to_unicode_raw[i] = cp950ext_to_unicode_raw[i];
     }
-    for (int i=64*98; i<64*210; i++) {
+    for (int i=64*107; i<64*210; i++) {
         cp951sea_to_unicode_raw[i] = cp951_to_unicode_raw[i];
         cp951uaosea_to_unicode_raw[i] = cp951uao_to_unicode_raw[i];
     }


### PR DESCRIPTION
These ranges 0x9140–0xA3FE and 0xC6A1–0xFEFE cover the 1984 ETen extensions 0xA3C0–0xA3E0, 0xC6A1–0xC7F2, and 0xF9D6–0xF9FE. The range 0x8E40–0x90FE is excluded because it contains no displayable characters.

## Additional information
#6056

Big5-HKSCS & Big5-UAO mappings
Code Point | Unicode
-- | --
A156 | U+2013 (–) 
A1C2 | U+00AF (¯) 
A2A4 | U+2550 (═) 
A2A5 | U+255E (╞) 
A2A6 | U+256A (╪) 
A2A7 | U+2561 (╡) 
A2CC | U+5341 (十)
A2CD | U+5344 (卄)
A2CE | U+5345 (卅)

Big5-2003 mappings
Code Point | Unicode
-- | --
A156 | U+2015 (―)
A1C2 | U+203E (‾)
A2A4 | U+2501 (━)
A2A5 | U+251D (┝)
A2A6 | U+253F (┿)
A2A7 | U+2525 (┥)
A2CC | U+3038 (〸)
A2CD | U+3039 (〹)
A2CE | U+303A (〺)
A3C0 | U+2400 (␀) 
A3C1 | U+2401 (␁)
A3C2 | U+2402 (␂)
A3C3 | U+2403 (␃)
A3C4 | U+2404 (␄)
A3C5 | U+2405 (␅)
A3C6 | U+2406 (␆)
A3C7 | U+2407 (␇)
A3C8 | U+2408 (␈)
A3C9 | U+2409 (␉)
A3CA | U+240A (␊)
A3CB | U+240B (␋)
A3CC | U+240C (␌)
A3CD | U+240D (␍)
A3CE | U+240E (␎)
A3CF | U+240F (␏)
A3D0 | U+2410 (␐)
A3D1 | U+2411 (␑)
A3D2 | U+2412 (␒)
A3D3 | U+2413 (␓)
A3D4 | U+2414 (␔)
A3D5 | U+2415 (␕)
A3D6 | U+2416 (␖)
A3D7 | U+2417 (␗)
A3D8 | U+2418 (␘)
A3D9 | U+2419 (␙)
A3DA | U+241A (␚)
A3DB | U+241B (␛)
A3DC | U+241C (␜)
A3DD | U+241D (␝)
A3DE | U+241E (␞)
A3DF | U+241F (␟)
A3E0 | U+2421 (␡)

