### PR TITLE
INT10_GetCursorPos: Remove range check causing text glitches

### DIFF
--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -1291,6 +1291,8 @@ void INT10_GetCursorPos(uint8_t *row, uint8_t*col, const uint8_t page)
 void INT10_SetCursorPos(uint8_t row,uint8_t col,uint8_t page) {
     // Get the dimensions
     BIOS_NCOLS;
+
+#if 0 // Disabled to fix Bad Dude (issue #6114). Elder Scrolls Arena installer still works fine, but may need additional fixes.  
     BIOS_NROWS;
 
     // EGA/VGA: Emulate a VGA BIOS that range-checks at least the row.
@@ -1302,6 +1304,7 @@ void INT10_SetCursorPos(uint8_t row,uint8_t col,uint8_t page) {
         if (nrows && row >= nrows)
 		row = nrows - 1;
     }
+#endif
 
     if (IS_DOSV && DOSV_CheckCJKVideoMode()) DOSV_OffCursor();
     else if(J3_IsJapanese()) J3_OffCursor();


### PR DESCRIPTION
Fix text glitches in Bad Dudes.

## What issue(s) does this PR address?
Fixes #6114 

<img width="642" height="452" alt="image" src="https://github.com/user-attachments/assets/b15a2a2f-912f-468e-a433-8de35f337a2a" />


Elder Scrolls: Arena installer still working fine without glitches.
<img width="722" height="452" alt="image" src="https://github.com/user-attachments/assets/d94f23df-b453-498d-a848-78153bfea11f" />
