### PR TITLE
Fix handling of volume label searches

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -657,7 +657,7 @@ public:
 
     int GetFindData(int fmt,char * finddata,int *c);
 	
-	void SetupSearch(uint8_t _sdrive,uint8_t _sattr,char * pattern);
+	void SetupSearch(uint8_t _sdrive,uint8_t _sattr,const char * pattern);
 	void SetResult(const char * _name,const char * _lname,uint32_t _size,uint32_t _hsize,uint16_t _date,uint16_t _time,uint8_t _attr);
 	
 	uint8_t GetSearchDrive(void);

--- a/src/dos/dos_classes.cpp
+++ b/src/dos/dos_classes.cpp
@@ -434,7 +434,7 @@ bool DOS_PSP::SetNumFiles(uint16_t fileNum) {
 	return true;
 }
 
-void DOS_DTA::SetupSearch(uint8_t _sdrive,uint8_t _sattr,char * pattern) {
+void DOS_DTA::SetupSearch(uint8_t _sdrive,uint8_t _sattr,const char * pattern) {
 	unsigned int i;
 
 	if (lfn_filefind_handle<LFN_FILEFIND_NONE || forcelfn) {

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -683,6 +683,28 @@ bool DOS_FindFirst(const char * search,uint16_t attr,bool fcb_findfirst) {
 		DOS_SetError(DOSERR_NO_MORE_FILES);
 		return false;
 	}
+
+    if (attr == DOS_ATTR_VOLUME) {
+        const char* vol_pattern = search;
+
+        /* Optional drive specification */
+        if (search[1] == ':') {
+            drive = (search[0] | 0x20) - 'a';
+            vol_pattern = search + 2;
+        }
+        else {
+            drive = DOS_GetDefaultDrive();
+        }
+        if (drive >= DOS_DRIVES || !Drives[drive]) {
+            DOS_SetError(DOSERR_PATH_NOT_FOUND);
+            return false;
+        }
+        sdrive = drive;
+        dta.SetupSearch(drive, (uint8_t)attr, vol_pattern);
+
+        return Drives[drive]->FindFirst("", dta, fcb_findfirst);
+    }
+
 	if (!DOS_MakeName(search,fullsearch,&drive)) return false;
 	//Check for devices. FindDevice checks for leading subdir as well
 	bool device = (DOS_FindDevice(search) != DOS_DEVICES);


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

Fixes #6082.

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

I don't think so, although I only tested the problem cases (game installers and Quake .ini file).

## Additional information

Previously I sent in https://github.com/joncampbell123/dosbox-x/pull/4045 in order to fix some reported bugs with the installers of some games from Dynamix (Willy Beamish, Nova 9 and Stellar 7). Those were fixed, but then there was a problem that showed itself through Quake rewriting its .ini file on each run, so I sent in https://github.com/joncampbell123/dosbox-x/pull/4083 to fix that.

Now #6082 has been reported, saying that the Alone in the Dark 2 installer isn't working, but it did work before my fix for the Dynamix games. This seems to have been a regression from checking for the volume attribute bit with "==" instead of "&" in https://github.com/joncampbell123/dosbox-x/pull/4083.

The initial fix for the Dynamix games was hacky anyway in that it worked by modifying `DOS_MakeName` to undo its name modifications when handling volume labels. This PR reverts the previous fix attempts and instead of modifying `DOS_MakeName`, bypasses it entirely for volume name handling without changing volume attribute checks.