### PR TITLE
Microphone input: Make Hands-Free profile optional

### DIFF
--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -713,8 +713,12 @@ fluid.soundfont =
 #                                 Set to 0 for the default setting of the sound card, or set to -1 to start DOSBox-X with the IRQ unassigned.
 #                                 Possible values: 7, 5, 3, 9, 10, 11, 12, 0, -1.
 #   listen to recording source: When the guest records audio from the Sound Blaster card, send the input source to the speakers as well so it can be heard.
-#             recording source: Audio source to use when guest is recording audio. At this time only generated audio sources are available.
-#                                 Possible values: silence, hiss, 1khz tone.
+#             recording source: Audio source to use when guest is recording audio. Options: silence, hiss, 1khz tone, or microphone (Windows WASAPI input).
+#                                 Possible values: silence, hiss, 1khz tone, microphone.
+#                   prefer hfp: Prefer Bluetooth HFP (Hands-Free Profile) microphone mode.
+#                               This allows using the microphone of a BT headset but reduces
+#                               audio quality (typically 8kHz E6kHz telephone quality).
+#                               When disabled, higher-quality microphones are preferred.
 #                          dma: The DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the DMA unassigned.
 #                                 Possible values: 1, 5, 0, 3, 6, 7, -1.
 #                         hdma: The High DMA number of the Sound Blaster. Set to -1 to start DOSBox-X with the High DMA unassigned.
@@ -749,6 +753,7 @@ sbbase                       = 220
 irq                          = 7
 listen to recording source   = false
 recording source             = silence
+prefer hfp                   = false
 dma                          = 1
 hdma                         = 5
 enable speaker               = false

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -1612,8 +1612,12 @@ fluid.chorus.type       = 0
 #                                                     the DMA transfer per block poorly in a way that causes popping and artifacts. Setting this option to 0 for
 #                                                     such DOS applications may reduce audible popping and artifacts.
 #                       listen to recording source: When the guest records audio from the Sound Blaster card, send the input source to the speakers as well so it can be heard.
-#                                 recording source: Audio source to use when guest is recording audio. At this time only generated audio sources are available.
-#                                                     Possible values: silence, hiss, 1khz tone.
+#                                 recording source: Audio source to use when guest is recording audio. Options: silence, hiss, 1khz tone, or microphone (Windows WASAPI input).
+#                                  Possible values: silence, hiss, 1khz tone, microphone.
+#                                       prefer hfp: Prefer Bluetooth HFP (Hands-Free Profile) microphone mode.
+#                                                   This allows using the microphone of a BT headset but reduces
+#                                                   audio quality (typically 8kHz E6kHz telephone quality).
+#                                                   When disabled, higher-quality microphones are preferred.
 #                                         irq hack: Specify a hack related to the Sound Blaster IRQ to avoid crashes in a handful of games and demos.
 #                                                         none                   Emulate IRQs normally
 #                                                         cs_equ_ds              Do not fire IRQ unless two CPU segment registers match: CS == DS. Read DOSBox-X Wiki or source code for details.
@@ -1724,6 +1728,7 @@ irq                                              = 7
 mindma                                           = -1
 listen to recording source                       = false
 recording source                                 = silence
+prefer hfp                                       = false
 irq hack                                         = none
 dma                                              = 1
 hdma                                             = 5

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3744,6 +3744,15 @@ void DOSBOX_SetupConfigSections(void) {
 			Pstring->Set_help("Audio source to use when guest is recording audio. Options: silence, hiss, 1khz tone, or microphone (Windows WASAPI input).");
 			Pstring->SetBasic(true);
 
+            Pbool = secprop->Add_bool("prefer hfp", Property::Changeable::WhenIdle, false);
+            Pbool->Set_help(
+                "Prefer Bluetooth HFP (Hands-Free Profile) microphone mode.\n"
+                "This allows using the microphone of a BT headset but reduces\n"
+                "audio quality (typically 8kHz–16kHz telephone quality).\n"
+                "When disabled, higher-quality microphones are preferred."
+            );
+            Pbool->SetBasic(true);
+
 			/* Sound Blaster IRQ hacks.
 			 *
 			 * These hacks reduce emulation accuracy but can be set to work around bugs or mistakes in some old

--- a/src/hardware/mic_input_win32.h
+++ b/src/hardware/mic_input_win32.h
@@ -80,6 +80,7 @@ public:
     // Initialization
     bool Initialize();
     void Shutdown();
+    bool GetPreferHFP();
 
     // Device enumeration
     std::vector<std::wstring> GetDeviceList();


### PR DESCRIPTION
Try to use high sample rate audio input and output devices when available instead of the Bluetooth Hands-Free Profile (HFP).
An option is also provided to prefer HFP instead.

## What issue(s) does this PR address?
Fixes #6119