### PR TITLE
macos SDL2: Fix typo in build script

### DIFF
--- a/build-macos-sdl2
+++ b/build-macos-sdl2
@@ -118,7 +118,7 @@ for arch in ${architectures}; do
     echo "Compiling our internal freetype"
     (cd vs/freetype && ./build-dosbox.sh) || exit 1
     new="-I${top}/vs/freetype/linux-host/include/freetype2 "
-    nld="-I${top}/vs/freetype/linux-host/lib/ -lfreetype "
+    nld="-L${top}/vs/freetype/linux-host/lib/ -lfreetype "
     LDFLAGS="${LDFLAGS}${nld}"
     CPPFLAGS="${CPPFLAGS}${new}"
     INTERNAL_FREETYPE=1


### PR DESCRIPTION
Fix a typo in build script that made searching for internally built freetype library to fail.
