### PR TITLE
D3D11: Reinitialize output after opening Configuration Tool or Mapper Tool

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -345,6 +345,11 @@ void change_output(int);
 #endif
 #endif
 
+#if C_DIRECT3D && C_SDL2
+void OUTPUT_DIRECT3D11_Shutdown();
+void change_output(int);
+#endif
+
 bool systemmessagebox(char const * aTitle, char const * aMessage, char const * aDialogType, char const * aIconType, int aDefaultButton);
 
 //! \brief Base CEvent class for mapper events
@@ -5578,7 +5583,12 @@ void MAPPER_RunInternal() {
         change_output(14);
     }  
 #endif
-
+#if C_DIRECT3D && C_SDL2
+    if(sdl.desktop.want_type == SCREEN_DIRECT3D11) {
+        OUTPUT_DIRECT3D11_Shutdown();
+        change_output(13);
+    }
+#endif
 //  KEYBOARD_ClrBuffer();
     GFX_LosingFocus();
 

--- a/src/output/output_direct3d11.cpp
+++ b/src/output/output_direct3d11.cpp
@@ -385,13 +385,13 @@ bool CDirect3D11::CreateSamplers(void) {
 }
 
 void CDirect3D11::SetSamplerMode() {
-    static int last_mode = -1;
-    if(last_mode == current_render_mode) return;
+    //static int last_mode = -1;
+    //if(last_mode == current_render_mode) return;
     ID3D11SamplerState* s = samplerLinear;
     if (current_render_mode == ASPECT_NEAREST) s = samplerNearest;
 
     context->PSSetSamplers(0, 1, &s);
-    last_mode = current_render_mode;
+    //last_mode = current_render_mode;
 }
 
 void CDirect3D11::GetRenderMode() {


### PR DESCRIPTION
This PR fixes Window aspect ratio unexpectedly changed when going in and out of Configuration Tool or Mapper Tool on experimental Direct3D11 output.

