### PR TITLE
Fix upload failure of Release builds of Windows installers

### DIFF
--- a/.github/workflows/vsbuild_xp.yml
+++ b/.github/workflows/vsbuild_xp.yml
@@ -275,12 +275,6 @@ jobs:
           #ls -lg contrib/windows/installer/WinXP
           cd contrib/windows/installer/
           ./ISCC.exe ./DOSBox-X-setupXP.iss
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            VERSION=$(echo "${GITHUB_REF##*/}" | sed -E 's/^dosbox-x-v([0-9]+\.[0-9]+\.[0-9]+)$/\1/' || echo "unknown")
-            echo "VERSION=$VERSION" >> $GITHUB_ENV
-            OUTFILE=$(ls dosbox-x-winXP-*.exe | head -n1)
-            mv "$OUTFILE" "dosbox-x-winXP-${VERSION}-setup.exe"
-          fi
       - name: Upload preview installer
         uses: actions/upload-artifact@v7.0.0
         with:

--- a/.github/workflows/windows-installers.yml
+++ b/.github/workflows/windows-installers.yml
@@ -398,12 +398,6 @@ jobs:
           ls -lg contrib/windows/installer/windows
           cd contrib/windows/installer/
           ISCC.exe ./DOSBox-X-installer.iss
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            VERSION=$(echo "${GITHUB_REF##*/}" | sed -E 's/^dosbox-x-v([0-9]+\.[0-9]+\.[0-9]+)$/\1/' || echo "unknown")
-            echo "VERSION=$VERSION" >> $GITHUB_ENV
-            OUTFILE=$(ls dosbox-x-windows-*.exe | head -n1)
-            mv "$OUTFILE" "dosbox-x-windows-${VERSION}-setup.exe"
-          fi
       - name: Upload preview installer
         uses: actions/upload-artifact@v7.0.0
         with:


### PR DESCRIPTION
This PR fixes a regression of uploading Release builds of Windows installers.
The previous commit worked for my test release, but it wasn't the case for production.
Apologies for the confusion.

I recommend deleting the current 2026.03.29 release, and retag the commit to create a fixed release.