### PR TITLE
Fix Metal support detection: add framework linker flags to configure check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -674,6 +674,8 @@ have_metal=no
 case "$host_os" in
   darwin*)
     AC_LANG_PUSH([Objective C++])
+    save_LIBS="$LIBS"
+    LIBS="$LIBS -framework Metal -framework QuartzCore"
 
     AC_LINK_IFELSE(
       [AC_LANG_PROGRAM([[
@@ -686,6 +688,7 @@ case "$host_os" in
       [have_metal=no]
     )
 
+    LIBS="$save_LIBS"
     AC_LANG_POP
     ;;
 esac


### PR DESCRIPTION
Add frameworks required for Metal support detection to the link flags to ensure required headers as well as frameworks exist in the build environment.
