### PR TITLE
src/gui/render.cpp: Add missing ifdef conditional on C_METAL

### DIFF
--- a/src/gui/render.cpp
+++ b/src/gui/render.cpp
@@ -887,7 +887,7 @@ forcenormal:
 #if C_DIRECT3D && C_SDL2
             && (sdl.desktop.type != SCREEN_DIRECT3D11)
 #endif
-#if defined(MACOSX) && C_SDL2
+#if defined(MACOSX) && C_SDL2 && C_METAL
             && (sdl.desktop.type != SCREEN_METAL)
 #endif
             ) {
@@ -1375,7 +1375,7 @@ bool RENDER_IsScalerCompatibleWithDoublescan(void) {
 #if C_DIRECT3D && C_SDL2
             if(sdl.desktop.type == SCREEN_DIRECT3D11) return false;
 #endif
-#if defined(MACOSX) && C_SDL2
+#if defined(MACOSX) && C_SDL2 && C_METAL
             if(sdl.desktop.type == SCREEN_METAL) return false;
 #endif
             break;


### PR DESCRIPTION
Fixes this build error when building without Metal support on macOS/Darwin:

    render.cpp:891:37: error: use of undeclared identifier 'SCREEN_METAL'
      891 |             && (sdl.desktop.type != SCREEN_METAL)
          |                                     ^~~~~~~~~~~~
    render.cpp:1379:36: error: use of undeclared identifier 'SCREEN_METAL'
     1379 |             if(sdl.desktop.type == SCREEN_METAL) return false;
          |                                    ^~~~~~~~~~~~
    2 errors generated.
    make[3]: *** [render.o] Error 1

## What issue(s) does this PR address?

Fixes: 6a30e3c ("METAL: Consider existence of Metal support on build")

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

No.

## Additional information

-

Cc: @maron2000 