### PR TITLE
fix VHD and QCow 2 GiB issue

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -450,6 +450,7 @@ private:
     bool currentBlockAllocated = false;
 	uint32_t currentBlockSectorOffset = 0;
 	uint8_t* currentBlockDirtyMap = nullptr;
+    uint64_t image_length = 0;
 };
 
 /* C++ class implementing El Torito floppy emulation */

--- a/src/ints/bios_vhd.cpp
+++ b/src/ints/bios_vhd.cpp
@@ -1,6 +1,6 @@
 /*
 *
-*  Copyright (c) 2018 Shane Krueger. Fixes and upgrades (c) 2023-24 maxpat78.
+*  Copyright (c) 2018 Shane Krueger. Fixes and upgrades (c) 2023-26 maxpat78.
 *
 *  This program is free software; you can redistribute it and/or modify
 *  it under the terms of the GNU General Public License as published by
@@ -171,6 +171,7 @@ imageDiskVHD::ErrorCodes imageDiskVHD::Open(const char* fileName, const bool rea
     vhd->sectors = footer.geometry.sectors;
     vhd->sector_size = 512;
     vhd->diskSizeK = footer.currentSize / 1024;
+    vhd->image_length = footer.currentSize;
     vhd->diskimg = file;
     vhd->diskname = fileName;
     vhd->hardDrive = true;
@@ -209,7 +210,7 @@ imageDiskVHD::ErrorCodes imageDiskVHD::Open(const char* fileName, const bool rea
 	}
 	//read dynamic disk header (applicable for dynamic and differencing types)
 	DynamicHeader dynHeader;
-	if (fseeko64(file, (off_t)footer.dataOffset, SEEK_SET)) { delete vhd; return INVALID_DATA; }
+	if (fseeko64(file, footer.dataOffset, SEEK_SET)) { delete vhd; return INVALID_DATA; }
 	if (fread(&dynHeader, sizeof(uint8_t), 1024, file) != 1024) { delete vhd; return INVALID_DATA; }
 	//swap byte order and validate checksum
 	dynHeader.SwapByteOrder();
@@ -229,7 +230,7 @@ imageDiskVHD::ErrorCodes imageDiskVHD::Open(const char* fileName, const bool rea
 				uint32_t dataLength = dynHeader.parentLocatorEntry[i].platformDataLength;
 				uint8_t * buffer = nullptr;
 				if (dataOffset && dataLength && ((uint64_t)dataOffset + dataLength) <= footerPosition) {
-					if (fseeko64(file, (off_t)dataOffset, SEEK_SET)) { delete vhd; return INVALID_DATA; }
+					if (fseeko64(file, dataOffset, SEEK_SET)) { delete vhd; return INVALID_DATA; }
 					buffer = (uint8_t*)malloc(dataLength + 2);
 					if (!buffer) { delete vhd; return INVALID_DATA; }
 					if (fread(buffer, sizeof(uint8_t), dataLength, file) != dataLength) { free(buffer); delete vhd; return INVALID_DATA; }
@@ -398,7 +399,7 @@ uint8_t imageDiskVHD::Read_AbsoluteSector(uint32_t sectnum, void * data) {
 		uint32_t bitNum = sectorOffset % 8;
 		bool hasData = currentBlockDirtyMap[byteNum] & (1 << (7 - bitNum));
 		if (hasData) {
-			if (fseeko64(diskimg, (off_t)(((uint64_t)currentBlockSectorOffset + blockMapSectors + sectorOffset) * 512ull), SEEK_SET)) return 0x05; //can't seek
+			if (fseeko64(diskimg, (((uint64_t)currentBlockSectorOffset + blockMapSectors + sectorOffset) * 512ull), SEEK_SET)) return 0x05; //can't seek
 			if (fread(data, sizeof(uint8_t), 512, diskimg) != 512) return 0x05; //can't read
 			return 0;
 		}
@@ -414,11 +415,8 @@ uint8_t imageDiskVHD::Read_AbsoluteSector(uint32_t sectnum, void * data) {
 }
 
 bool imageDiskVHD::is_zeroed_sector(const void* data) {
-    uint32_t* p = (uint32_t*) data;
-    uint8_t* q = ((uint8_t*)data + 512);
-    while((void*)p < (void*)q && *p++ == 0);
-    if((void*)p < (void*)q) return false;
-    return true;
+    const auto* p = static_cast<const uint8_t*>(data);
+    return std::all_of(p, p + 512, [](uint8_t b) { return b == 0; });
 }
 
 bool imageDiskVHD::is_block_allocated(uint32_t blockNumber) {
@@ -431,7 +429,9 @@ uint8_t imageDiskVHD::Write_AbsoluteSector(uint32_t sectnum, const void * data) 
     if(vhdType == VHD_TYPE_FIXED) return fixedDisk->Write_AbsoluteSector(sectnum, data);
 	uint32_t blockNumber = sectnum / sectorsPerBlock;
 	uint32_t sectorOffset = sectnum % sectorsPerBlock;
-	if (!loadBlock(blockNumber)) return 0x05; //can't load block
+    if(!loadBlock(blockNumber)) {
+        return 0x05; //can't load block
+    }
 	if (!currentBlockAllocated) {
         //an unallocated block is kept virtual until zeroed
         if(is_zeroed_sector(data)) {
@@ -439,39 +439,63 @@ uint8_t imageDiskVHD::Write_AbsoluteSector(uint32_t sectnum, const void * data) 
             if(!is_block_allocated(blockNumber)) return 0;
         }
 
-		if (!copiedFooter) {
-			//write backup of footer at start of file (should already exist, but we never checked to be sure it is readable or matches the footer we used)
-			if (fseeko64(diskimg, (off_t)0, SEEK_SET)) return 0x05;
-			if (fwrite(&originalFooter, sizeof(uint8_t), 512, diskimg) != 512) return 0x05;
+        if(!copiedFooter) {
+            //write backup of footer at start of file (should already exist, but we never checked to be sure it is readable or matches the footer we used)
+            if(fseeko64(diskimg, 0, SEEK_SET)) {
+                return 0x05;
+            }
+            if(fwrite(&originalFooter, sizeof(uint8_t), 512, diskimg) != 512) {
+                return 0x05;
+            }
 			copiedFooter = true;
 			//flush the data to disk after writing the backup footer
-			if (fflush(diskimg)) return 0x05;
+            if(fflush(diskimg)) {
+                return 0x05;
+            }
 		}
 		//calculate new location of footer, and round up to nearest 512 byte increment "just in case"
         uint64_t newFooterPosition = (((footerPosition + blockMapSize + dynamicHeader.blockSize) + 511ull) / 512ull) * 512ull;
 		//attempt to extend the length appropriately first (on some operating systems this will extend the file)
-		if (fseeko64(diskimg, (off_t)newFooterPosition + 512, SEEK_SET)) return 0x05;
+        if(fseeko64(diskimg, newFooterPosition + 512, SEEK_SET)) {
+                return 0x05;
+        }
 		//now write the footer
-		if (fseeko64(diskimg, (off_t)newFooterPosition, SEEK_SET)) return 0x05;
-		if (fwrite(&originalFooter, sizeof(uint8_t), 512, diskimg) != 512) return 0x05;
+        if(fseeko64(diskimg, newFooterPosition, SEEK_SET)) {
+            return 0x05;
+        }
+        if(fwrite(&originalFooter, sizeof(uint8_t), 512, diskimg) != 512) {
+            return 0x05;
+        }
 		//save the new block location and new footer position
 		uint32_t newBlockSectorNumber = (uint32_t)((footerPosition + 511ul) / 512ul);
 		footerPosition = newFooterPosition;
 		//clear the dirty flags for the new footer position
 		for (uint32_t i = 0; i < blockMapSize; i++) currentBlockDirtyMap[i] = 0;
 		//write the dirty map
-		if (fseeko64(diskimg, (off_t)(newBlockSectorNumber * 512ull), SEEK_SET)) return 0x05;
-		if (fwrite(currentBlockDirtyMap, sizeof(uint8_t), blockMapSize, diskimg) != blockMapSize) return 0x05;
+        if(fseeko64(diskimg, (newBlockSectorNumber * 512ull), SEEK_SET)) {
+            return 0x05;
+        }
+        if(fwrite(currentBlockDirtyMap, sizeof(uint8_t), blockMapSize, diskimg) != blockMapSize) {
+            return 0x05;
+        }
 		//flush the data to disk after expanding the file, before allocating the block in the BAT
-		if (fflush(diskimg)) return 0x05;
+        if(fflush(diskimg)) {
+            return 0x05;
+        }
 		//update the BAT
-		if (fseeko64(diskimg, (off_t)(dynamicHeader.tableOffset + (blockNumber * 4ull)), SEEK_SET)) return 0x05;
+        if(fseeko64(diskimg, (dynamicHeader.tableOffset + (blockNumber * 4ull)), SEEK_SET)) {
+            return 0x05;
+        }
 		uint32_t newBlockSectorNumberBE = SDL_SwapBE32(newBlockSectorNumber);
-		if (fwrite(&newBlockSectorNumberBE, sizeof(uint8_t), 4, diskimg) != 4) return false;
+        if(fwrite(&newBlockSectorNumberBE, sizeof(uint8_t), 4, diskimg) != 4) {
+            return 0x05;
+        }
 		currentBlockAllocated = true;
 		currentBlockSectorOffset = newBlockSectorNumber;
 		//flush the data to disk after allocating a block
-		if (fflush(diskimg)) return 0x05;
+        if(fflush(diskimg)) {
+            return 0x05;
+        }
 	}
 	//current block has now been allocated
 	uint32_t byteNum = sectorOffset / 8;
@@ -480,13 +504,21 @@ uint8_t imageDiskVHD::Write_AbsoluteSector(uint32_t sectnum, const void * data) 
 	//if the sector hasn't been marked as dirty, mark it as dirty
 	if (!hasData) {
 		currentBlockDirtyMap[byteNum] |= 1 << (7 - bitNum);
-		if (fseeko64(diskimg, (off_t)(currentBlockSectorOffset * 512ull), SEEK_SET)) return 0x05; //can't seek
-		if (fwrite(currentBlockDirtyMap, sizeof(uint8_t), blockMapSize, diskimg) != blockMapSize) return 0x05;
+        if(fseeko64(diskimg, (currentBlockSectorOffset * 512ull), SEEK_SET)) {
+            return 0x05; //can't seek
+        }
+        if(fwrite(currentBlockDirtyMap, sizeof(uint8_t), blockMapSize, diskimg) != blockMapSize) {
+            return 0x05;
+        }
 	}
 	//current sector has now been marked as dirty
 	//write the sector
-	if (fseeko64(diskimg, (off_t)(((uint64_t)currentBlockSectorOffset + (uint64_t)blockMapSectors + (uint64_t)sectorOffset) * 512ull), SEEK_SET)) return 0x05; //can't seek
-	if (fwrite(data, sizeof(uint8_t), 512, diskimg) != 512) return 0x05; //can't write
+    if(fseeko64(diskimg, (((uint64_t)currentBlockSectorOffset + (uint64_t)blockMapSectors + (uint64_t)sectorOffset) * 512ull), SEEK_SET)) {
+        return 0x05; //can't seek
+    }
+    if(fwrite(data, sizeof(uint8_t), 512, diskimg) != 512) {
+        return 0x05; //can't write
+    }
 	return 0;
 }
 
@@ -507,7 +539,7 @@ imageDiskVHD::VHDTypes imageDiskVHD::GetVHDType(const char* fileName) {
 bool imageDiskVHD::loadBlock(const uint32_t blockNumber) {
 	if (currentBlock == blockNumber) return true;
 	if (blockNumber >= dynamicHeader.maxTableEntries) return false;
-	if (fseeko64(diskimg, (off_t)(dynamicHeader.tableOffset + (blockNumber * 4ull)), SEEK_SET)) return false;
+	if (fseeko64(diskimg, (dynamicHeader.tableOffset + (blockNumber * 4ull)), SEEK_SET)) return false;
 	uint32_t blockSectorOffset;
 	if (fread(&blockSectorOffset, sizeof(uint8_t), 4, diskimg) != 4) return false;
 	blockSectorOffset = SDL_SwapBE32(blockSectorOffset);
@@ -516,7 +548,7 @@ bool imageDiskVHD::loadBlock(const uint32_t blockNumber) {
 		currentBlockAllocated = false;
 	}
 	else {
-		if (fseeko64(diskimg, (off_t)(blockSectorOffset * (uint64_t)512), SEEK_SET)) return false;
+		if (fseeko64(diskimg, (blockSectorOffset * (uint64_t)512), SEEK_SET)) return false;
 		currentBlock = 0xFFFFFFFFul;
 		currentBlockAllocated = true;
 		currentBlockSectorOffset = blockSectorOffset;
@@ -616,7 +648,7 @@ void imageDiskVHD::DynamicHeader::SwapByteOrder() {
 	}
 	//parent guid might need the byte order swapped also
 	//however, for our purposes (comparing to the parent guid on differential disks),
-	//  it doesn't matter so long as we are consistent
+	//it doesn't matter so long as we are consistent
 }
 
 uint32_t imageDiskVHD::DynamicHeader::CalculateChecksum() {
@@ -769,7 +801,10 @@ uint32_t imageDiskVHD::CreateDifferencing(const char* filename, const char* base
     imageDiskVHD* base_vhd;
     if(Open(basename, true, (imageDisk**)&base_vhd) != OPEN_SUCCESS) return ERROR_OPENING_PARENT;
     FILE* vhd = fopen(filename, "wb");
-    if(!vhd) return ERROR_OPENING;
+    if(!vhd) {
+        delete base_vhd;
+        return ERROR_OPENING;
+    }
     uint32_t STATUS = OPEN_SUCCESS;
 
     //clone parent's VHD structures
@@ -952,6 +987,7 @@ bool imageDiskVHD::MergeSnapshot(uint32_t* totalSectorsMerged, uint32_t* totalBl
     }
     std::string name = parentDisk->diskname;
     parentDisk->Release();
+    parentDisk = nullptr;
     if(Open(name.c_str(), false, &parentDisk) != OPEN_SUCCESS) {
         LOG_MSG("Couldn't re-open parent in RW mode!");
         return false;
@@ -975,7 +1011,7 @@ bool imageDiskVHD::MergeSnapshot(uint32_t* totalSectorsMerged, uint32_t* totalBl
             bool hasData = currentBlockDirtyMap[byteNum] & (1 << (7 - bitNum));
             if(hasData) {
                 uint8_t data[512];
-                if(fseeko64(diskimg, (off_t)(((uint64_t)currentBlockSectorOffset + blockMapSectors + sector) * 512ull), SEEK_SET)) return false;
+                if(fseeko64(diskimg, (((uint64_t)currentBlockSectorOffset + blockMapSectors + sector) * 512ull), SEEK_SET)) return false;
                 if(fread(data, sizeof(uint8_t), 512, diskimg) != 512) return false;
                 uint32_t absoluteSector = block * sectorsPerBlock + sector;
                 //LOG_MSG("Merging sector %d", absoluteSector);
@@ -1075,7 +1111,7 @@ uint64_t imageDiskVHD::scanMBR(uint8_t* mbr, Bitu sizes[], uint64_t disksize) {
     //partition end
     h = (unsigned)*(part + 5);
     s = (unsigned)*(part + 6) & 0x3F;
-    c = (unsigned)*(part + 6) & 0xC0 | *(part + 7);
+    c = (((unsigned)*(part + 6) & 0xC0) << 2) | *(part + 7);
     //since a MBR partition *should* be aligned to a cylinder boundary,
     //the last sector CHS reveals total heads and sectors per cylinder
     spc = s;

--- a/src/ints/qcow2_disk.cpp
+++ b/src/ints/qcow2_disk.cpp
@@ -76,7 +76,7 @@ using namespace std;
 		if (header.backing_file_offset != 0 && header.backing_file_size != 0){
 			char* backing_file_name = new char[header.backing_file_size + 1];
 			backing_file_name[header.backing_file_size] = 0;
-			fseeko64(file, (off_t)header.backing_file_offset, SEEK_SET);
+			fseeko64(file, header.backing_file_offset, SEEK_SET);
             size_t readResult = fread(backing_file_name, header.backing_file_size, 1, file);
             if (readResult != 1) {
                 LOG(LOG_IO, LOG_ERROR) ("Reading error in QCow2Image constructor\n");
@@ -277,7 +277,7 @@ using namespace std;
 //Read data of arbitrary length that is present in the image file.
 	uint8_t QCow2Image::read_allocated_data(uint64_t file_offset, uint8_t* data, uint64_t data_size)
 	{
-		if (0 != fseeko64(file, (off_t)file_offset, SEEK_SET)){
+		if (0 != fseeko64(file, file_offset, SEEK_SET)){
 			return 0x05;
 		}
 		if (1 != fread(data, data_size, 1, file)){
@@ -393,7 +393,7 @@ using namespace std;
 
 //Write data of arbitrary length to the image file.
 	uint8_t QCow2Image::write_data(uint64_t file_offset, const uint8_t* data, uint64_t data_size){
-		if (0 != fseeko64(file, (off_t)file_offset, SEEK_SET)){
+		if (0 != fseeko64(file, file_offset, SEEK_SET)){
 			return 0x05;
 		}
 		if (1 != fwrite(data, data_size, 1, file)){


### PR DESCRIPTION
- allows VHD/qcow container expansion beyond 2 GiB removing (off_t) from fseeko64 calls
- optimized imageDiskVHD::is_zeroed_sector

Closes #5775 

The fix was simply removing the `(off_t)` cast from all `fseeko64 `calls in bios_vhd.cpp and qcow2_disk.cpp.
Those casts were truncating 64-bit values to 32 bits, preventing the disk container from being extended beyond 2 GiB.

My test (extracting a crafted 2 MiB ZIP to ~2060 MiB under Windows 98 — about an hour of torture even with TURBO enabled!) now completes without blue screens reporting write errors on the C: drive.

The issue became clear when my RDWRSEC tool was able to correctly read and write sector nos. 5,000,000 and 8,000,000 on a fresh 4 GiB dynamic VHD.
This confirmed that logical LBA access beyond 2 GiB was working correctly, while physical access was broken.

Also includes minor fixes and optimizations found with the help of Claude.
