### PR TITLE
Fixed clip_paste_bios option change was not reflected

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,9 @@ NEXT VERSION
     (joncampbell123)
   - Fix segfault in TTF output code caused by codepage mapping when the
     TTF output is not active. (joncampbell123)
+  - Fixed clip_paste_bios option change was not reflected. Also, default is
+    changed to "true" for Windows due to some characters fails to paste when
+    set otherwise. (maron2000)
 
 2026.03.29
   - Add dosbox.conf option to control the duration of the beep when

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -977,11 +977,11 @@ bool                        startup_state_capslock = false; // Global for keyboa
 bool                        startup_state_scrlock = false; // Global for keyboard initialisation
 int mouse_start_x=-1, mouse_start_y=-1, mouse_end_x=-1, mouse_end_y=-1, fx=-1, fy=-1, paste_speed=20, wheel_key=0, mbutton=3;
 bool wheel_guest = false, clipboard_dosapi = true, clipboard_biospaste =
-#if defined (WIN32) && (!defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR))
-false;
-#else
+//#if defined (WIN32) && (!defined(__MINGW32__) || defined(__MINGW64_VERSION_MAJOR))
+//false;
+//#else
 true;
-#endif
+//#endif
 const char *modifier;
 
 #ifdef WIN32

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -61,7 +61,7 @@ extern unsigned int sendkeymap;
 extern std::string langname, configfile, dosbox_title;
 extern int autofixwarn, enablelfn, fat32setver, paste_speed, wheel_key, freesizecap, wpType, wpVersion, wpBG, wpFG, lastset, blinkCursor, msgcodepage;
 extern bool dos_kernel_disabled, force_nocachedir, wpcolon, convertimg, lockmount, enable_config_as_shell_commands, lesssize, load, winrun, winautorun, startcmd, startwait, startquiet, starttranspath, mountwarning, wheel_guest, clipboard_dosapi, noremark_save_state, force_load_state, sync_time, manualtime, ttfswitch, loadlang, showbold, showital, showline, showsout, char512, printfont, rtl, gbk, chinasea, uao, showdbcs, dbcs_sbcs, autoboxdraw, halfwidthkana, ticksLocked, outcon, enable_dbcs_tables, show_recorded_filename, internal_program, pipetmpdev, notrysgf, uselangcp, incall;
-
+extern bool clipboard_biospaste;
 /* This registers a file on the virtual drive and creates the correct structure for it*/
 
 static uint8_t exe_block[]={
@@ -817,6 +817,10 @@ void ApplySetting(std::string pvar, std::string inputline, bool quiet) {
             } else if (!strcasecmp(pvar.c_str(), "sdl")) {
                 modifier = section->Get_string("clip_key_modifier");
                 paste_speed = section->Get_int("clip_paste_speed");
+                const char* pastebios = section->Get_string("clip_paste_bios");
+                if(!strcasecmp(pastebios, "default") || !strcasecmp(pastebios, "true") || !strcmp(pastebios, "1")) clipboard_biospaste = true;
+                else if(!strcasecmp(pastebios, "false") || !strcmp(pastebios, "0")) clipboard_biospaste = false;
+                mainMenu.get_item("clipboard_biospaste").check(clipboard_biospaste).refresh_item(mainMenu);
                 if (!strcasecmp(inputline.substr(0, 16).c_str(), "mouse_wheel_key=")) {
                     wheel_key = section->Get_int("mouse_wheel_key");
                     wheel_guest=wheel_key>0;


### PR DESCRIPTION
Fixed `clip_paste_bios` option change was not reflected. 
Also, default is changed to "true" for Windows due to some characters fails to paste when set otherwise.

Fixes #6208

Tested on VS x64 SDL2 build.

<img width="722" height="452" alt="image" src="https://github.com/user-attachments/assets/14e76944-f0ca-41ca-ac13-90d256539558" />

