### PR TITLE
Silence numerous warnings of deprecated functions

### DIFF
--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -258,31 +258,31 @@ extern int boothax;
 /* C++11 user-defined literal, to help with byte units */
 typedef unsigned long long bytecount_t;
 
-static inline constexpr bytecount_t operator "" _bytes(const bytecount_t x) {
+static inline constexpr bytecount_t operator""_bytes(const bytecount_t x) {
     return x;
 }
 
-static inline constexpr bytecount_t operator "" _parabytes(const bytecount_t x) { /* AKA bytes per segment increment in real mode */
+static inline constexpr bytecount_t operator""_parabytes(const bytecount_t x) { /* AKA bytes per segment increment in real mode */
     return x << bytecount_t(4u);
 }
 
-static inline constexpr bytecount_t operator "" _kibibytes(const bytecount_t x) {
+static inline constexpr bytecount_t operator""_kibibytes(const bytecount_t x) {
     return x << bytecount_t(10u);
 }
 
-static inline constexpr bytecount_t operator "" _pagebytes(const bytecount_t x) { /* bytes per 4KB page in protected mode */
+static inline constexpr bytecount_t operator""_pagebytes(const bytecount_t x) { /* bytes per 4KB page in protected mode */
     return x << bytecount_t(12u);
 }
 
-static inline constexpr bytecount_t operator "" _mibibytes(const bytecount_t x) {
+static inline constexpr bytecount_t operator""_mibibytes(const bytecount_t x) {
     return x << bytecount_t(20u);
 }
 
-static inline constexpr bytecount_t operator "" _gibibytes(const bytecount_t x) {
+static inline constexpr bytecount_t operator""_gibibytes(const bytecount_t x) {
     return x << bytecount_t(30u);
 }
 
-static inline constexpr bytecount_t operator "" _tebibytes(const bytecount_t x) {
+static inline constexpr bytecount_t operator""_tebibytes(const bytecount_t x) {
     return x << bytecount_t(40u);
 }
 

--- a/include/dosbox.h
+++ b/include/dosbox.h
@@ -416,13 +416,14 @@ public:
 protected:
     void getBytes(std::ostream& stream) override
     {
-        std::for_each(podRef.begin(), podRef.end(), std::bind1st(WriteGlobalPOD(), &stream));
+        for (auto& x : podRef) { WriteGlobalPOD(stream, x); }
     }
 
     void setBytes(std::istream& stream) override
     {
-        std::for_each(podRef.begin(), podRef.end(), std::bind1st(ReadGlobalPOD(), &stream));
+        for (auto& x : podRef) { ReadGlobalPOD(stream, x); }
     }
+
 
 private:
     struct POD
@@ -433,21 +434,15 @@ private:
         size_t size;
     };
 
-    struct WriteGlobalPOD : public std::binary_function<std::ostream*, POD, void>
+    static inline void WriteGlobalPOD(std::ostream& stream, const POD& data)
     {
-        void operator()(std::ostream* stream, const POD& data) const
-        {
-            stream->write(static_cast<const char*>(data.address), data.size);
-        }
-    };
+        stream.write(static_cast<const char*>(data.address), data.size);
+    }
 
-    struct ReadGlobalPOD : public std::binary_function<std::istream*, POD, void>
+    static inline void ReadGlobalPOD(std::istream& stream, POD& data)
     {
-        void operator()(std::istream* stream, const POD& data) const
-        {
-            stream->read(static_cast<char*>(data.address), data.size);
-        }
-    };
+        stream.read(static_cast<char*>(data.address), data.size);
+    }
 
     std::vector<POD> podRef;
 };


### PR DESCRIPTION
Silence numerous warnings due to a deprecated literal operator declaration.
The fixed syntax is valid since C++11 (so of course C++14), and should not affect any behavior.

```cpp
../../include/dosbox.h:281:49: warning: identifier
      '_gibibytes' preceded by whitespace in a literal operator declaration is
      deprecated [-Wdeprecated-literal-operator]
  281 | static inline constexpr bytecount_t operator "" _gibibytes(const bytecou...
      |                                     ~~~~~~~~~~~~^~~~~~~~~~
      |                                     operator""_gibibytes
../../include/dosbox.h:285:49: warning: identifier
      '_tebibytes' preceded by whitespace in a literal operator declaration is
      deprecated [-Wdeprecated-literal-operator]
  285 | static inline constexpr bytecount_t operator "" _tebibytes(const bytecou...
      |                                     ~~~~~~~~~~~~^~~~~~~~~~
      |                                     operator""_tebibytes
```