### PR TITLE
Fix screenshot color (macOS SDL1)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,8 @@ NEXT VERSION
   - Fixed clip_paste_bios option change was not reflected. Also, default is
     changed to "true" for Windows due to some characters fails to paste when
     set otherwise. (maron2000)
+  - Replaced some deprecated functions in dosbox.h. (maron2000)
+  - Fixed colors in the screenshot of macOS SDL1 build were wrong.(maron2000)
 
 2026.03.29
   - Add dosbox.conf option to control the duration of the beep when

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -944,7 +944,22 @@ void CAPTURE_AddImage(Bitu width, Bitu height, Bitu bpp, Bitu pitch, Bitu flags,
 				rowPointer = doubleRow;
 				break;
 			case 32:
-				if (flags & CAPTURE_FLAG_DBLW) {
+#if defined(MACOSX) && !C_SDL2
+                if (flags & CAPTURE_FLAG_DBLW) {
+					for (Bitu x=0;x<countWidth;x++) {
+						doubleRow[x*6+2] = doubleRow[x*6+5] = ((uint8_t *)srcLine)[x*4+1];
+						doubleRow[x*6+1] = doubleRow[x*6+4] = ((uint8_t *)srcLine)[x*4+2];
+						doubleRow[x*6+0] = doubleRow[x*6+3] = ((uint8_t *)srcLine)[x*4+3];
+					}
+				} else {
+					for (Bitu x=0;x<countWidth;x++) {
+						doubleRow[x*3+2] = ((uint8_t *)srcLine)[x*4+1];
+						doubleRow[x*3+1] = ((uint8_t *)srcLine)[x*4+2];
+						doubleRow[x*3+0] = ((uint8_t *)srcLine)[x*4+3];
+					}
+				}
+#else
+                if (flags & CAPTURE_FLAG_DBLW) {
 					for (Bitu x=0;x<countWidth;x++) {
 						doubleRow[x*6+0] = doubleRow[x*6+3] = ((uint8_t *)srcLine)[x*4+0];
 						doubleRow[x*6+1] = doubleRow[x*6+4] = ((uint8_t *)srcLine)[x*4+1];
@@ -957,7 +972,8 @@ void CAPTURE_AddImage(Bitu width, Bitu height, Bitu bpp, Bitu pitch, Bitu flags,
 						doubleRow[x*3+2] = ((uint8_t *)srcLine)[x*4+2];
 					}
 				}
-				rowPointer = doubleRow;
+#endif
+                rowPointer = doubleRow;
 				break;
 			}
 			png_write_row(png_ptr, (png_bytep)rowPointer);


### PR DESCRIPTION
Fix screenshot colors of macOS SDL1 builds were wrong.

<img width="720" height="400" alt="command_008" src="https://github.com/user-attachments/assets/40bc1b96-70f9-4969-8477-25f7084b2121" />
<img width="640" height="400" alt="command_009" src="https://github.com/user-attachments/assets/b6be33e2-9f4c-48fc-bf81-8a0325033533" />
<img width="640" height="400" alt="command_010" src="https://github.com/user-attachments/assets/df5fa4f1-c04e-4bf4-b877-1435ca4f1a85" />

Fixes #727
Fixes #3317
Fixes #4515
