### PR TITLE
Fix savestate restore crash in POD_Load_DOS_Files during live file slot teardown

### DIFF
--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -2768,14 +2768,15 @@ void POD_Load_DOS_Files( std::istream& stream )
 
 			// - reloc ptr
 			READ_POD( &file_valid, file_valid );
-
 			// ignore system files
 			if( file_valid == 0xfe ) {
 				READ_POD( &Files[lcv]->refCtr, Files[lcv]->refCtr );
 				continue;
 			}
 
-			// shutdown old file
+			// Detach any live pre-restore file object from this slot before loading
+			// the saved entry. Closing/deleting the current object here can crash
+			// during same-session restore for active protected-mode titles.
 			if( Files[lcv] && Files[lcv]->GetName() != NULL ) {
 				// invalid file state - abort
 				if( strcmp( Files[lcv]->GetName(), "NUL" ) == 0 ) break;
@@ -2784,12 +2785,6 @@ void POD_Load_DOS_Files( std::istream& stream )
 				if( strcmp( Files[lcv]->GetName(), "PRN" ) == 0 ) break;
 				if( strcmp( Files[lcv]->GetName(), "AUX" ) == 0 ) break;
 				if( strcmp( Files[lcv]->GetName(), "EMMXXXX0" ) == 0 ) break;//raiden needs this
-
-
-				if( Files[lcv]->IsOpen() ) Files[lcv]->Close();
-				if (Files[lcv]->RemoveRef()<=0) {
-					delete Files[lcv];
-				}
 				Files[lcv]=nullptr;
 			}
 
@@ -2811,7 +2806,16 @@ void POD_Load_DOS_Files( std::istream& stream )
 
 
 			// NOTE: Must open regardless to get 'new' DOS_File class
-			Drives[file_drive]->FileOpen( &Files[lcv], file_name, file_flags );
+			if (file_drive >= DOS_DRIVES || Drives[file_drive] == nullptr) {
+				LOG_MSG("WARNING: Save-state restore skipped file handle %u for drive %u ('%s'): drive entry missing during DOS file restore",
+					(unsigned int)lcv,
+					(unsigned int)file_drive,
+					file_name);
+				Files[lcv] = nullptr;
+			}
+			else {
+				Drives[file_drive]->FileOpen( &Files[lcv], file_name, file_flags );
+			}
 
 			if( Files[lcv] ) {
 				Files[lcv]->LoadState(stream, false);


### PR DESCRIPTION
Fix savestate restore crash in POD_Load_DOS_Files during live file slot teardown

Summary

This fixes a savestate restore crash in POD_Load_DOS_Files() in src/dos/dos_files.cpp.

Root cause

During savestate restore, POD_Load_DOS_Files() iterates over saved SFT entries and tears down the live pre-restore file object in Files[lcv] before rebuilding the saved entry.

For same-session restores with a running protected-mode title, that teardown can crash if the live object is in an inconsistent state relative to the restore in progress. In the reproduced case, the crash occurred on an open .ERR handle in slot 4.

Fix

- Detach the live pre-restore slot by clearing Files[lcv] = nullptr instead of calling Close(), RemoveRef(), or delete during restore.
- Add a null/bounds guard before Drives[file_drive]->FileOpen() so restore does not dereference a missing drive entry if drive reconstruction failed earlier.

Restore is state replacement, not normal DOS file shutdown, so the usual teardown path is not safe here.

Testing / repro

Environment:
- Windows host
- DOSBox-X 2026.03.29 MinGW/UCRT64 local build
- 32-bit DOS protected-mode title (DOS4GW)
- Local DOS install mounted as C:
- CD image mounted as D:
- Direct launch, no DEBUGBOX, no LOADFIX
- File-backed savestate
- Same-session save, then immediate load

Before fix:
- Crash in POD_Load_DOS_Files() during slot 4 live-file teardown

After fix:
- Restore completes successfully
- Game resumes normally

Related issues

This appears to be a distinct crash path, but it is adjacent to:
- #6068: MSVC ostream Memory_Size empty
- #6118: savestate load instability
- #5974: savestate file locks
- #4539: -debug save failures

These were ruled out during investigation for this repro.

Scope

- Single-file change in src/dos/dos_files.cpp
- Restore path only
- No change to normal file close/teardown outside savestate restore

Additional note

First-time contributor. Earlier investigation also encountered memory-mismatch failure modes in other build/config paths, but the clean final repro for this PR was a restore crash in POD_Load_DOS_Files on a valid same-session save.

There's a chance some of the many issues with "memory size mistmatch error" may be related, that's how I originally found this bug, this is what finally solved it for my situation. 