### PR TITLE
Fix an ambiguous Hex operator== invocation

### DIFF
--- a/include/setup.h
+++ b/include/setup.h
@@ -37,7 +37,7 @@ private:
 public:
 	Hex(int in):_hex(in) { };
 	Hex():_hex(0) { };
-	bool operator==(Hex const& other) {return _hex == other._hex;}
+	bool operator==(Hex const& other) const {return _hex == other._hex;}
 	operator int () const { return _hex; }
 };
 

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -1104,7 +1104,7 @@ public:
     bool prepare(std::string &buffer) override {
         int val;
         convert(input->getText(), val, false, std::hex);
-        if ((Hex)val ==  prop->GetValue()) return false;
+        if ((Hex)val == (Hex)prop->GetValue()) return false;
         buffer.append(stringify(val, std::hex));
         return true;
     }


### PR DESCRIPTION
This fixes the following error reported by GCC 16:

```
../../../src/gui/sdl_gui.cpp: In member function 'virtual bool PropertyEditorHex::prepare(std::string&)': ../../../src/gui/sdl_gui.cpp:1066:22: error: ambiguous overload for 'operator==' (operand types are 'Hex' and 'const Value')
 1066 |         if ((Hex)val ==  prop->GetValue()) return false;
      |             ~~~~~~~~ ^~  ~~~~~~~~~~~~~~~~
      |             |                          |
      |             Hex                        const Value
  • there are 4 candidates
    ../../../src/gui/sdl_gui.cpp:1066:22:
     1066 |         if ((Hex)val ==  prop->GetValue()) return false;
          |             ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
In file included from ../../../src/gui/sdl_gui.cpp:34:
    • candidate 1: 'bool Value::operator==(const Value&) const' (reversed)
      ../../../include/setup.h:83:14:
         83 |         bool operator== (Value const & other) const;
            |              ^~~~~~~~
    • candidate 2: 'operator==(int, double)' (built-in)
      ../../../src/gui/sdl_gui.cpp:1066:22:
       1066 |         if ((Hex)val ==  prop->GetValue()) return false;
            |             ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
    • candidate 3: 'operator==(int, int)' (built-in)
    • candidate 4: 'bool Hex::operator==(const Hex&)'
      ../../../include/setup.h:40:14:
         40 |         bool operator==(Hex const& other) {return _hex == other._hex;}
            |              ^~~~~~~~
```

Adding the const in setup.h fixes the following warning:

```
../../../src/gui/sdl_gui.cpp: In member function 'virtual bool PropertyEditorHex::prepare(std::string&)': ../../../src/gui/sdl_gui.cpp:1066:45: warning: C++20 says that these are ambiguous, even though the second is reversed:
 1066 |         if ((Hex)val == (Hex)prop->GetValue()) return false;
      |                                             ^
In file included from ../../../src/gui/sdl_gui.cpp:34:
../../../include/setup.h:40:14: note: candidate 1: 'bool Hex::operator==(const Hex&)'
   40 |         bool operator==(Hex const& other) {return _hex == other._hex;}
      |              ^~~~~~~~
../../../include/setup.h:40:14: note: candidate 2: 'bool Hex::operator==(const Hex&)' (reversed)
../../../include/setup.h:40:14: note: try making the operator a 'const' member function
```
