### PR TITLE
INT 13h AH=48h: Fix LBA detection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,10 @@ NEXT VERSION
     set otherwise. (maron2000)
   - Replaced some deprecated functions in dosbox.h. (maron2000)
   - Fixed colors in the screenshot of macOS SDL1 build were wrong.(maron2000)
+  - Fix savestate restore crash in POD_Load_DOS_Files during live file slot 
+    teardown (catbalony)
+  - Fixed mouse cursor display in DOS/V Japanese mode (nanshiki)
+  - INT 13h AH=48h: Fixed LBA detection (maron2000)
 
 2026.03.29
   - Add dosbox.conf option to control the duration of the beep when

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -96,6 +96,7 @@ class imageDisk {
 		virtual void Get_Geometry(uint32_t * getHeads, uint32_t *getCyl, uint32_t *getSect, uint32_t *getSectSize);
 		virtual uint8_t GetBiosType(void);
 		virtual uint32_t getSectSize(void);
+        virtual uint64_t getLBA(void) { LBA = image_length / sector_size; return LBA; }
 		imageDisk(class DOS_Drive *useDrive, unsigned int letter, uint32_t freeMB, int timeout);
 		imageDisk(FILE *imgFile, const char *imgName, uint32_t imgSizeK, bool isHardDisk);
 		imageDisk(FILE* diskimg, const char* diskName, uint32_t cylinders, uint32_t heads, uint32_t sectors, uint32_t sector_size, bool hardDrive);
@@ -115,6 +116,7 @@ class imageDisk {
 		uint64_t diskSizeK = 0;
 		FILE* diskimg = NULL;
 		bool diskChangeFlag = false;
+        uint64_t LBA = 0;
 
 		/* this is intended only for when the disk can change out from under us while mounted */
 		virtual bool detectDiskChange(void) { const bool r = diskChangeFlag; diskChangeFlag = false; return r; }

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -239,12 +239,14 @@ public:
     virtual void io_completion();
     virtual bool increment_current_address(Bitu count=1);
 public:
-    Bitu multiple_sector_max,multiple_sector_count;
-    Bitu heads,sects,cyls,progress_count;
-    Bitu phys_heads,phys_sects,phys_cyls;
+    uint64_t multiple_sector_max,multiple_sector_count;
+    uint64_t heads,sects,cyls,progress_count;
+    uint64_t phys_heads,phys_sects,phys_cyls; /* CHS value of IDE  */
+    uint64_t LBA;
     unsigned char sector[512 * 128] = {};
-    Bitu sector_i,sector_total;
+    uint64_t sector_i,sector_total;
     bool geo_translate;
+
 };
 
 enum {
@@ -2540,6 +2542,7 @@ void IDEATADevice::generate_identify_device() {
     /* total disk capacity in sectors */
     total = sects * cyls * heads;
     ptotal = phys_sects * phys_cyls * phys_heads;
+    uint32_t lba28 = LBA > 0x0FFFFFFF ? 0x0FFFFFFF : (uint32_t)LBA;
 
     host_writew(sector+(0*2),0x0040);   /* bit 6: 1=fixed disk */
     host_writew(sector+(1*2),phys_cyls);
@@ -2590,7 +2593,7 @@ void IDEATADevice::generate_identify_device() {
         host_writew(sector+(59*2),0x0100|multiple_sector_count); /* :8  multiple sector setting is valid */
                         /* 7:0 current setting for number of log. sectors per DRQ of READ/WRITE MULTIPLE */
 
-    host_writed(sector+(60*2),ptotal);  /* total user addressable sectors (LBA) */
+    host_writed(sector+(60*2),lba28);  /* total user addressable sectors (LBA) */
     host_writew(sector+(62*2),0x0000);  /* FIXME: ??? */
     host_writew(sector+(63*2),0x0000);  /* :10 0=Multiword DMA mode 2 not selected */
                         /* TODO: Basically, we don't do DMA. Fill out this comment */
@@ -2608,7 +2611,9 @@ void IDEATADevice::generate_identify_device() {
     host_writew(sector+(86*2),0x4000);  /* commands in 83 enabled */
     host_writew(sector+(87*2),0x4000);  /* FIXME: ??? */
     host_writew(sector+(88*2),0x0000);  /* FIXME: ??? */
-    host_writew(sector+(93*3),0x0000);  /* FIXME: ??? */
+    host_writew(sector+(93*2),0x0000);  /* FIXME: ??? */
+    host_writed(sector+(100*2), (uint32_t)(LBA & 0xFFFFFFFF)); // 48bit LBA lower 32 bits
+    host_writed(sector+(102*2), (uint32_t)(LBA >> 32));        // 48bit LBA upper 32 bits 
 
     /* ATA-8 integrity checksum */
     sector[510] = 0xA5;
@@ -2669,6 +2674,7 @@ void IDEATADevice::update_from_biosdisk() {
 	cyls = dsk->cylinders;
 	heads = dsk->heads;
 	sects = dsk->sectors;
+    LBA = dsk->getLBA();
 
 	if (heads > 16) {
 		geo_translate = true;
@@ -2690,8 +2696,7 @@ void IDEATADevice::update_from_biosdisk() {
 		}
 
 		{
-			uint64_t tmp = ((uint64_t)dsk->diskSizeK << (uint64_t)10) / (uint64_t)dsk->sector_size;
-			cyls = (tmp + (uint64_t)(sects * heads) - (uint64_t)1) / ((uint64_t)(sects * heads));
+			cyls = (uint32_t)(LBA / (sects * heads));
 		}
 
 		LOG_MSG("Mapping BIOS DISK C/H/S %u/%u/%u as IDE %u/%u/%u\n",
@@ -2974,7 +2979,7 @@ static void IDE_SelfIO_Out(IDEController *ide,Bitu port,Bitu val,Bitu len) {
 }
 
 /* Get physical (not logical INT 13h) geometry */
-bool IDE_GetPhysGeometry(unsigned char disk,uint32_t &heads,uint32_t &cyl,uint32_t &sect,uint32_t &size) {
+bool IDE_GetPhysGeometry(unsigned char disk,uint32_t &heads,uint32_t &cyl,uint32_t &sect,uint32_t &size, uint64_t &LBA) {
     IDEController *ide;
     IDEDevice *dev;
     Bitu idx,ms;
@@ -2994,6 +2999,7 @@ bool IDE_GetPhysGeometry(unsigned char disk,uint32_t &heads,uint32_t &cyl,uint32
                     heads = ata->phys_heads;
                     sect = ata->phys_sects;
                     cyl = ata->phys_cyls;
+                    LBA = ata->LBA;
                     size = 512;
                     return true;
                 }

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -2605,10 +2605,10 @@ void IDEATADevice::generate_identify_device() {
     host_writew(sector+(80*2),0x007E);  /* major version number. Here we say we support ATA-1 through ATA-8 */
     host_writew(sector+(81*2),0x0022);  /* minor version */
     host_writew(sector+(82*2),0x4208);  /* command set: NOP, DEVICE RESET[XXXXX], POWER MANAGEMENT */
-    host_writew(sector+(83*2),0x4000);  /* command set: LBA48[XXXX] */
+    host_writew(sector+(83*2),0x8400);  /* command set: bit15: valid, bit 10: enable 48bit LBA */
     host_writew(sector+(84*2),0x4000);  /* FIXME: ??? */
     host_writew(sector+(85*2),0x4208);  /* commands in 82 enabled */
-    host_writew(sector+(86*2),0x4000);  /* commands in 83 enabled */
+    host_writew(sector+(86*2),0x0400);  /* commands in 83 enabled bit10: enable 48bit LBA*/
     host_writew(sector+(87*2),0x4000);  /* FIXME: ??? */
     host_writew(sector+(88*2),0x0000);  /* FIXME: ??? */
     host_writew(sector+(93*2),0x0000);  /* FIXME: ??? */

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -1429,10 +1429,11 @@ imageDisk::imageDisk(FILE* diskimg, const char* diskName, uint32_t cylinders, ui
     this->heads = heads;
     this->sectors = sectors;
     image_base = 0;
-    this->image_length = (uint64_t)cylinders * heads * sectors * sector_size;
+    if (image_length == 0) image_length = (uint64_t)cylinders * heads * sectors * sector_size;
     refcount = 0;
     this->sector_size = sector_size;
     this->diskSizeK = this->image_length / 1024;
+    LBA = image_length / sector_size;
     reserved_cylinders = 0;
     this->diskimg = diskimg;
     class_id = ID_BASE;
@@ -1821,7 +1822,7 @@ static void readDAP(uint16_t seg, uint16_t off) {
 
 void IDE_ResetDiskByBIOS(unsigned char disk);
 void IDE_EmuINT13DiskReadByBIOS(unsigned char disk,unsigned int cyl,unsigned int head,unsigned sect);
-bool IDE_GetPhysGeometry(unsigned char disk,uint32_t &heads,uint32_t &cyl,uint32_t &sect,uint32_t &size);
+bool IDE_GetPhysGeometry(unsigned char disk,uint32_t &heads,uint32_t &cyl,uint32_t &sect,uint32_t &size, uint64_t &LBA);
 void IDE_EmuINT13DiskReadByBIOS_LBA(unsigned char disk,uint64_t lba);
 
 void diskio_delay(Bits value/*bytes*/, int type = -1);
@@ -1839,6 +1840,7 @@ static Bitu INT13_DiskHandler(void) {
     uint8_t sectbuf[2048/*CD-ROM support*/];
     uint8_t  drivenum;
     Bitu  i,t;
+    uint64_t LBA = 0;
     last_drive = reg_dl;
     drivenum = GetDosDriveNumber(reg_dl);
     bool any_images = false;
@@ -2390,15 +2392,17 @@ static Bitu INT13_DiskHandler(void) {
         else bufsz = 0x1A;
 
         tmpheads = tmpcyl = tmpsect = tmpsize = 0;
-        if (!IDE_GetPhysGeometry(drivenum,tmpheads,tmpcyl,tmpsect,tmpsize))
-                imageDiskList[drivenum]->Get_Geometry(&tmpheads, &tmpcyl, &tmpsect, &tmpsize);
-
+        if(!IDE_GetPhysGeometry(drivenum, tmpheads, tmpcyl, tmpsect, tmpsize, LBA)) {
+            imageDiskList[drivenum]->Get_Geometry(&tmpheads, &tmpcyl, &tmpsect, &tmpsize);
+            LBA = imageDiskList[drivenum]->getLBA();
+        }
         real_writew(segat,bufptr+0x00,bufsz);
         real_writew(segat,bufptr+0x02,0x0003);  /* C/H/S valid, DMA boundary errors handled */
         real_writed(segat,bufptr+0x04,tmpcyl);
         real_writed(segat,bufptr+0x08,tmpheads);
         real_writed(segat,bufptr+0x0C,tmpsect);
-        real_writed(segat,bufptr+0x10,tmpcyl*tmpheads*tmpsect);
+        real_writed(segat,bufptr+0x10, (uint32_t)(LBA & 0xFFFFFFFF)); /* LBA lower 32bit */
+        real_writed(segat,bufptr+0x14, (uint32_t)(LBA >> 32));        /* LBA upper 32bit */
         real_writed(segat,bufptr+0x14,0);
         real_writew(segat,bufptr+0x18,512);
         if (bufsz >= 0x1E)


### PR DESCRIPTION
Fixed LBA was calculated based on CHS value rather than the disk size.
Tested both INT 13h AH=48h and IDE IDENTIFY.
Tested on VS x64 SDL2 build.

## What issue(s) does this PR address?

Fixes #6234
Possibly Fixes #6108

<img width="717" height="499" alt="image" src="https://github.com/user-attachments/assets/7240f5aa-d18a-438a-a25a-0eaf37d2f782" />
