### PR TITLE
Fix read/write errors on last sectors of disk image

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,6 +34,7 @@ NEXT VERSION
     teardown (catbalony)
   - Fixed mouse cursor display in DOS/V Japanese mode (nanshiki)
   - INT 13h AH=48h: Fixed LBA detection (maron2000)
+  - Fixed read/write errors on last sectors of disk image (maron2000)
 
 2026.03.29
   - Add dosbox.conf option to control the duration of the beep when

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -98,7 +98,7 @@ class imageDisk {
 		virtual uint32_t getSectSize(void);
         virtual uint64_t getLBA(void) { LBA = image_length / sector_size; return LBA; }
 		imageDisk(class DOS_Drive *useDrive, unsigned int letter, uint32_t freeMB, int timeout);
-		imageDisk(FILE *imgFile, const char *imgName, uint32_t imgSizeK, bool isHardDisk);
+		imageDisk(FILE *imgFile, const char *imgName, uint64_t imgSize, bool isHardDisk);
 		imageDisk(FILE* diskimg, const char* diskName, uint32_t cylinders, uint32_t heads, uint32_t sectors, uint32_t sector_size, bool hardDrive);
 		virtual ~imageDisk();
 		void Set_GeometryForHardDisk();

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -7224,7 +7224,7 @@ class IMGMOUNT : public Program {
 				}
 			}
 
-			uint32_t imagesize;
+			uint64_t imagesize;
 			/* auto-fill: sector size */
 			if (sizes[0] == 0) sizes[0] = 512;
 
@@ -7267,35 +7267,35 @@ class IMGMOUNT : public Program {
 					sectors = (uint64_t)ftello64(newDisk) / (uint64_t)sizes[0];
 					imagesize = (uint32_t)(sectors / 2); /* orig. code wants it in KBs */
 					setbuf(newDisk, NULL);
-					newImage = new imageDiskD88(newDisk, fname, imagesize, false/*this is a FLOPPY image format*/);
+					newImage = new imageDiskD88(newDisk, fname, (uint32_t)imagesize, false/*this is a FLOPPY image format*/);
 				}
 				else if (!memcmp(tmp, "VFD1.", 5)) { /* FDD files */
 					fseeko64(newDisk, 0L, SEEK_END);
 					sectors = (uint64_t)ftello64(newDisk) / (uint64_t)sizes[0];
 					imagesize = (uint32_t)(sectors / 2); /* orig. code wants it in KBs */
 					setbuf(newDisk, NULL);
-					newImage = new imageDiskVFD(newDisk, fname, imagesize, false/*this is a FLOPPY image format*/);
+					newImage = new imageDiskVFD(newDisk, fname, (uint32_t)imagesize, false/*this is a FLOPPY image format*/);
 				}
 				else if (!memcmp(tmp,"T98FDDIMAGE.R0\0\0",16)) {
 					fseeko64(newDisk, 0L, SEEK_END);
 					sectors = (uint64_t)ftello64(newDisk) / (uint64_t)sizes[0];
 					imagesize = (uint32_t)(sectors / 2); /* orig. code wants it in KBs */
 					setbuf(newDisk, NULL);
-					newImage = new imageDiskNFD(newDisk, fname, imagesize, false/*this is a FLOPPY image format*/, 0);
+					newImage = new imageDiskNFD(newDisk, fname, (uint32_t)imagesize, false/*this is a FLOPPY image format*/, 0);
 				}
 				else if (!memcmp(tmp,"T98FDDIMAGE.R1\0\0",16)) {
 					fseeko64(newDisk, 0L, SEEK_END);
 					sectors = (uint64_t)ftello64(newDisk) / (uint64_t)sizes[0];
 					imagesize = (uint32_t)(sectors / 2); /* orig. code wants it in KBs */
 					setbuf(newDisk, NULL);
-					newImage = new imageDiskNFD(newDisk, fname, imagesize, false/*this is a FLOPPY image format*/, 1);
+					newImage = new imageDiskNFD(newDisk, fname, (uint32_t)imagesize, false/*this is a FLOPPY image format*/, 1);
 				}
 				else {
 					fseeko64(newDisk, 0L, SEEK_END);
-					sectors = (uint64_t)ftello64(newDisk) / (uint64_t)sizes[0];
-					imagesize = (uint32_t)(sectors / 2); /* orig. code wants it in KBs */
+                    imagesize = ftello64(newDisk);
+                    sectors = imagesize / (uint64_t)sizes[0];
 					setbuf(newDisk, NULL);
-					newImage = new imageDisk(newDisk, fname, imagesize, (imagesize > 2880) || assumeHardDisk);
+					newImage = new imageDisk(newDisk, fname, imagesize, (imagesize > 2880 * 1024) || assumeHardDisk);
 				}
 			}
 

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1414,7 +1414,7 @@ fatDrive::~fatDrive() {
 FILE * fopen_lock(const char * fname, const char * mode, bool &readonly);
 fatDrive::fatDrive(const char* sysFilename, uint32_t bytesector, uint32_t cylsector, uint32_t headscyl, uint32_t cylinders, std::vector<std::string>& options) {
 	FILE *diskfile;
-	uint32_t filesize;
+	uint64_t filesize;
 	unsigned char bootcode[256];
 
 	if(!dos_kernel_disabled && imgDTASeg == 0) {
@@ -1468,27 +1468,27 @@ fatDrive::fatDrive(const char* sysFilename, uint32_t bytesector, uint32_t cylsec
 		if (ext != NULL && !strcasecmp(ext, ".d88")) {
 			fseeko64(diskfile, 0L, SEEK_END);
 			filesize = (uint32_t)(ftello64(diskfile) / 1024L);
-			loadedDisk = new imageDiskD88(diskfile, fname, filesize, false);
+			loadedDisk = new imageDiskD88(diskfile, fname, (uint32_t)filesize, false);
 		}
 		else if (!memcmp(bootcode,"VFD1.",5)) { /* FDD files */
 			fseeko64(diskfile, 0L, SEEK_END);
 			filesize = (uint32_t)(ftello64(diskfile) / 1024L);
-			loadedDisk = new imageDiskVFD(diskfile, fname, filesize, false);
+			loadedDisk = new imageDiskVFD(diskfile, fname, (uint32_t)filesize, false);
 		}
 		else if (!memcmp(bootcode,"T98FDDIMAGE.R0\0\0",16)) {
 			fseeko64(diskfile, 0L, SEEK_END);
 			filesize = (uint32_t)(ftello64(diskfile) / 1024L);
-			loadedDisk = new imageDiskNFD(diskfile, fname, filesize, false, 0);
+			loadedDisk = new imageDiskNFD(diskfile, fname, (uint32_t)filesize, false, 0);
 		}
 		else if (!memcmp(bootcode,"T98FDDIMAGE.R1\0\0",16)) {
 			fseeko64(diskfile, 0L, SEEK_END);
 			filesize = (uint32_t)(ftello64(diskfile) / 1024L);
-			loadedDisk = new imageDiskNFD(diskfile, fname, filesize, false, 1);
+			loadedDisk = new imageDiskNFD(diskfile, fname, (uint32_t)filesize, false, 1);
 		}
 		else {
 			fseeko64(diskfile, 0L, SEEK_END);
-			filesize = (uint32_t)(ftello64(diskfile) / 1024L);
-			loadedDisk = new imageDisk(diskfile, fname, filesize, (is_hdd | (filesize > 2880)));
+			filesize = ftello64(diskfile);
+			loadedDisk = new imageDisk(diskfile, fname, filesize, (is_hdd | (filesize > 2880 * 1024)));
 		}
 	}
 

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -1456,10 +1456,10 @@ void imageDisk::UpdateFloppyType(void) {
 	}
 }
 
-imageDisk::imageDisk(FILE* imgFile, const char* imgName, uint32_t imgSizeK, bool isHardDisk) : diskSizeK(imgSizeK), diskimg(imgFile), image_length((uint64_t)imgSizeK * 1024) {
+imageDisk::imageDisk(FILE* imgFile, const char* imgName, uint64_t imgSize, bool isHardDisk) : diskSizeK(imgSize/1024), diskimg(imgFile), image_length(imgSize) {
     if (imgName != NULL)
         diskname = imgName;
-
+    uint64_t imgSizeK = diskSizeK;
     active = false;
     hardDrive = isHardDisk;
     if(!isHardDisk) {


### PR DESCRIPTION
Previously, the disk size was converted to KB and then used again for size calculations, which could introduce small discrepancies. This PR avoids the loss of precision by using the original size directly, to ensure accurate sector calculations near the end of the disk.

Tested on VS x64 SDL2 build, using the following image file.
```
$ ls -lg disk.img
-rw-r--r-- 1 なし 138512691712  4月 22 17:07 disk.img
```

## What issue(s) does this PR address?
Fixes #6108

<img width="435" height="333" alt="image" src="https://github.com/user-attachments/assets/d6e79261-623b-482b-81c3-bee575658e53" />

<img width="311" height="117" alt="image" src="https://github.com/user-attachments/assets/247755b2-f1f3-4567-a4b8-44bad209021a" />

