### PR TITLE
D3D11: Fix unintended window size change when switching from fullscreen to window mode

### DIFF
--- a/src/output/output_direct3d11.cpp
+++ b/src/output/output_direct3d11.cpp
@@ -579,6 +579,7 @@ bool CDirect3D11::Resize(
     uint32_t tex_w,    // texture width
     uint32_t tex_h)    // texture height
 {
+    static bool was_fullscreen = 0;  // Fix me: Hack for window size reset when exiting fullscreen mode
     const bool reset_window_size =
         (((userResizeWindowWidth == 0) && (userResizeWindowHeight == 0)) ||
         (tex_w != last_tex_w || tex_h != last_tex_h))
@@ -601,12 +602,12 @@ bool CDirect3D11::Resize(
             render.scale.hardware = true;
             hardware_scaler_selected = false;
         }
-        if(reset_window_size || render.scale.size != last_scalesize){
+        if(reset_window_size || render.scale.size != last_scalesize) {
             if(tex_h >= CurMode->sheight * 2) { // doublescan mode
                 uint32_t width = tex_w;
                 uint32_t height = tex_h;
                 if(render.aspect) {
-                    width = (uint32_t)((double)height * CurMode->swidth / CurMode->sheight +0.5); // First adjust width to match the original aspect ratio.
+                    width = (uint32_t)((double)height * CurMode->swidth / CurMode->sheight + 0.5); // First adjust width to match the original aspect ratio.
                     height = (uint32_t)((double)width / target_ratio + 0.5); // Then adjust height to match the target aspect ratio. This ensures the final window size maintains the target aspect ratio, even in doublescan mode.
                 }
                 window_w = (uint32_t)(height * target_ratio * (render.scale.hardware ? (double)render.scale.size / 2.0 : 1u) + 0.5);
@@ -632,6 +633,11 @@ bool CDirect3D11::Resize(
             //LOG_MSG("window_w=%d, window_h=%d, sdl.draw.width=%d, real_w=%d, real_h=%d, w/h=%lf, target=%lf", window_w, window_h, sdl.draw.width, real_w, real_h, (double)real_w/real_h, target_ratio);
         }
     }
+    else {
+        userResizeWindowWidth = 0;
+        userResizeWindowHeight = 0;
+        was_fullscreen = true;
+    }
 
     if(window_w == last_window_w &&
         window_h == last_window_h &&
@@ -645,7 +651,8 @@ bool CDirect3D11::Resize(
     frame_height = tex_h;
 
     if(sdl.window && !sdl.desktop.fullscreen) {
-        SDL_SetWindowSize(sdl.window, window_w, window_h);
+        SDL_SetWindowSize(sdl.window, (reset_window_size || was_fullscreen > 0) ? tex_w : window_w, (reset_window_size || was_fullscreen > 0) ? tex_h : window_h);
+        if(!reset_window_size) was_fullscreen = false; // Fix me: This flag is set to recover unintended size changes when returning from fullscreen mode.
     }
 
     int real_w = 0, real_h = 0;


### PR DESCRIPTION
In the experimental Direct3D11 output mode, the vertical size of the window was slightly reduced unintendedly.
This PR adds a flag to skip the window size change as a temporary fix.

Before fix: Window size somehow changes to 720x380 instead of 720x400
<img width="728" height="519" alt="image" src="https://github.com/user-attachments/assets/1228c8f0-0d41-4313-9aca-f42ce6578be1" />

After fix: Window size remains 720x400
<img width="718" height="540" alt="image" src="https://github.com/user-attachments/assets/a418cb9e-f064-4b34-9ce7-cff44ed86172" />
