### PR TITLE
Int 13h: Add option to enable/disable 48-bit LBA support

### DIFF
--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -2576,6 +2576,7 @@ timeout     = 0
 #                                                     This option is OFF by default.
 #                        int 13 disk change detect: Enable INT 13h disk change detect function (AH=16h)
 #                                int 13 extensions: Enable INT 13h extensions (functions 0x40-0x48). You will need this enabled if the virtual hard drive image is 8.4GB or larger.
+#                         int 13 enable 48-bit LBA: Enable 48-bit LBA support for INT 13h extensions. Needed for drives larger than 28-bit LBA limit. This is considered experimental.
 #                                          biosps2: Emulate BIOS INT 15h PS/2 mouse services
 #                                                     Note that some OS's like Microsoft Windows neither use INT 33h nor
 #                                                     probe the AUX port directly and depend on this BIOS interface exclusively
@@ -2700,6 +2701,7 @@ int33 hide host cursor when polling              = false
 int33 disable cell granularity                   = false
 int 13 disk change detect                        = true
 int 13 extensions                                = true
+int 13 enable 48-bit LBA                         = false
 biosps2                                          = true
 int15 wait force unmask irq                      = true
 int15 mouse callback does not preserve registers = false

--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -533,6 +533,7 @@ char * DriveManager::GetDrivePosition(int drive) {
 bool drivemanager_init = false;
 bool int13_extensions_enable = true;
 bool int13_disk_change_detect_enable = true;
+bool int13_enable_48bitLBA = false;
 
 void DriveManager::Init(Section* s) {
     const Section_prop* section = static_cast<Section_prop*>(s);
@@ -541,6 +542,7 @@ void DriveManager::Init(Section* s) {
 
 	int13_extensions_enable = section->Get_bool("int 13 extensions");
 	int13_disk_change_detect_enable = section->Get_bool("int 13 disk change detect");
+    int13_enable_48bitLBA = section->Get_bool("int 13 enable 48-bit LBA");
 
 	// setup driveInfos structure
 	currentDrive = 0;

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -5041,6 +5041,9 @@ void DOSBOX_SetupConfigSections(void) {
     Pbool = secprop->Add_bool("int 13 extensions",Property::Changeable::WhenIdle,true);
     Pbool->Set_help("Enable INT 13h extensions (functions 0x40-0x48). You will need this enabled if the virtual hard drive image is 8.4GB or larger.");
 
+    Pbool = secprop->Add_bool("int 13 enable 48-bit LBA", Property::Changeable::WhenIdle, false);
+    Pbool->Set_help("Enable 48-bit LBA support for INT 13h extensions. Needed for drives larger than 28-bit LBA limit. This is considered experimental.");
+
     Pbool = secprop->Add_bool("biosps2",Property::Changeable::OnlyAtStart,true);
     Pbool->Set_help("Emulate BIOS INT 15h PS/2 mouse services\n"
         "Note that some OS's like Microsoft Windows neither use INT 33h nor\n"

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -86,6 +86,7 @@ private:
 extern int bootdrive;
 extern bool bootguest, bootvm, use_quick_reboot;
 static unsigned char init_ide = 0;
+extern bool int13_enable_48bitLBA;
 
 static const unsigned char IDE_default_IRQs[4] = {
     14, /* primary */
@@ -2605,15 +2606,15 @@ void IDEATADevice::generate_identify_device() {
     host_writew(sector+(80*2),0x007E);  /* major version number. Here we say we support ATA-1 through ATA-8 */
     host_writew(sector+(81*2),0x0022);  /* minor version */
     host_writew(sector+(82*2),0x4208);  /* command set: NOP, DEVICE RESET[XXXXX], POWER MANAGEMENT */
-    host_writew(sector+(83*2),0x8400);  /* command set: bit15: valid, bit 10: enable 48bit LBA */
+    host_writew(sector+(83*2),int13_enable_48bitLBA?0xC400:0x4000);  /* command set: bit15: valid, bit14: NOP, bit 10: enable 48bit LBA */
     host_writew(sector+(84*2),0x4000);  /* FIXME: ??? */
     host_writew(sector+(85*2),0x4208);  /* commands in 82 enabled */
-    host_writew(sector+(86*2),0x0400);  /* commands in 83 enabled bit10: enable 48bit LBA*/
+    host_writew(sector+(86*2),int13_enable_48bitLBA?0xC400:0x4000);  /* commands in 83 enabled bit15: valid, bit14: NOP, bit10: enable 48bit LBA*/
     host_writew(sector+(87*2),0x4000);  /* FIXME: ??? */
     host_writew(sector+(88*2),0x0000);  /* FIXME: ??? */
     host_writew(sector+(93*2),0x0000);  /* FIXME: ??? */
-    host_writed(sector+(100*2), (uint32_t)(LBA & 0xFFFFFFFF)); // 48bit LBA lower 32 bits
-    host_writed(sector+(102*2), (uint32_t)(LBA >> 32));        // 48bit LBA upper 32 bits 
+    host_writed(sector+(100*2), int13_enable_48bitLBA ? (uint32_t)(LBA & 0xFFFFFFFF):0); // 48bit LBA lower 32 bits
+    host_writed(sector+(102*2), int13_enable_48bitLBA ? (uint32_t)(LBA >> 32):0);        // 48bit LBA upper 32 bits 
 
     /* ATA-8 integrity checksum */
     sector[510] = 0xA5;

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -48,6 +48,7 @@ extern const uint8_t freedos_mbr[];
 extern int bootdrive, tryconvertcp;
 extern bool int13_disk_change_detect_enable, skipintprog, rsize;
 extern bool int13_extensions_enable, bootguest, bootvm, use_quick_reboot;
+extern bool int13_enable_48bitLBA;
 bool isDBCSCP(), isKanji1_gbk(uint8_t chr), shiftjis_lead_byte(int c), CheckDBCSCP(int32_t codepage);
 extern bool CodePageGuestToHostUTF16(uint16_t *d/*CROSS_LEN*/,const char *s/*CROSS_LEN*/);
 
@@ -1434,6 +1435,8 @@ imageDisk::imageDisk(FILE* diskimg, const char* diskName, uint32_t cylinders, ui
     this->sector_size = sector_size;
     this->diskSizeK = this->image_length / 1024;
     LBA = image_length / sector_size;
+    if(!int13_enable_48bitLBA && (LBA > 0x0FFFFFFF))
+        LOG_MSG("Warning: Disk size (%lf GB) exceeds 128GB limit for 28-bit LBA. You may need to enable 48-bit LBA support.", (double)image_length / (1024.0 * 1024 * 1024));
     reserved_cylinders = 0;
     this->diskimg = diskimg;
     class_id = ID_BASE;
@@ -1654,6 +1657,9 @@ imageDisk::imageDisk(FILE* imgFile, const char* imgName, uint64_t imgSize, bool 
             }
         }
 
+        LBA = imgSize / sector_size;
+        if(!int13_enable_48bitLBA && (LBA > 0x0FFFFFFF))
+            LOG_MSG("Warning: Disk size (%lf GB) exceeds 128GB limit for 28-bit LBA. You may need to enable 48-bit LBA support.", (double)image_length / (1024.0 * 1024 * 1024));
         if (sectors == 0 || heads == 0 || cylinders == 0)
             active = false;
     }
@@ -2401,8 +2407,8 @@ static Bitu INT13_DiskHandler(void) {
         real_writed(segat,bufptr+0x04,tmpcyl);
         real_writed(segat,bufptr+0x08,tmpheads);
         real_writed(segat,bufptr+0x0C,tmpsect);
-        real_writed(segat,bufptr+0x10, (uint32_t)(LBA & 0xFFFFFFFF)); /* LBA lower 32bit */
-        real_writed(segat,bufptr+0x14, (uint32_t)(LBA >> 32));        /* LBA upper 32bit */
+        real_writed(segat,bufptr+0x10, int13_enable_48bitLBA?(uint32_t)(LBA & 0xFFFFFFFF): (uint32_t)(LBA > 0x0FFFFFFF?0x0FFFFFFF:LBA)); /* LBA lower 32bit */
+        real_writed(segat,bufptr+0x14, int13_enable_48bitLBA?(uint32_t)(LBA >> 32):0); /* LBA upper 32bit */
         real_writed(segat,bufptr+0x14,0);
         real_writew(segat,bufptr+0x18,512);
         if (bufsz >= 0x1E)


### PR DESCRIPTION
PR #6235 is reported to break launching NT/2000/XP/SRV2003 guests.
This PR adds an option to enable/disable 48-bit LBA support which was added in the said PR.
