### PR TITLE
Fix VHD file geometry detection

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -394,6 +394,7 @@ public:
     uint32_t CreateSnapshot();
     void DetectGeometry(Bitu sizes[]);
     static void DetectGeometry(uint8_t* buf, Bitu sizes[], uint64_t currentSize);
+    static void DetectGeometry(Bitu sizes[], uint64_t currentSize);
     static uint64_t scanMBR(uint8_t* mbr, Bitu sizes[], uint64_t disksize=0);
     bool MergeSnapshot(uint32_t* totalSectorsMerged, uint32_t* totalBlocksUpdated);
     static void SizeToCHS(uint64_t size, uint16_t* c, uint8_t* h, uint8_t* s);
@@ -452,7 +453,7 @@ private:
     bool currentBlockAllocated = false;
 	uint32_t currentBlockSectorOffset = 0;
 	uint8_t* currentBlockDirtyMap = nullptr;
-    uint64_t image_length = 0;
+    //uint64_t image_length = 0;
 };
 
 /* C++ class implementing El Torito floppy emulation */

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -7216,7 +7216,8 @@ class IMGMOUNT : public Program {
 							case imageDiskVHD::UNSUPPORTED_WRITE: roflag=true; break;
 							default: break;
 						}
-						return newImage;
+                        //LOG_MSG("LBA=%llu",newImage->LBA);
+                        return newImage;
 					}
 					else if (!strcasecmp(ext, ".hdi")) {
 						assumeHardDisk = true; /* bugfix for HDI images smaller than 2.88MB so that the .hdi file is not mistaken for a floppy disk image */

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1489,6 +1489,7 @@ fatDrive::fatDrive(const char* sysFilename, uint32_t bytesector, uint32_t cylsec
 			fseeko64(diskfile, 0L, SEEK_END);
 			filesize = ftello64(diskfile);
 			loadedDisk = new imageDisk(diskfile, fname, filesize, (is_hdd | (filesize > 2880 * 1024)));
+            filesize /= 1024L;
 		}
 	}
 

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -2543,7 +2543,9 @@ void IDEATADevice::generate_identify_device() {
     /* total disk capacity in sectors */
     total = sects * cyls * heads;
     ptotal = phys_sects * phys_cyls * phys_heads;
-    uint32_t lba28 = LBA > 0x0FFFFFFF ? 0x0FFFFFFF : (uint32_t)LBA;
+    //uint32_t lba28 = LBA > 0x0FFFFFFF ? 0x0FFFFFFF : (uint32_t)LBA;
+    uint32_t lba28 = (uint32_t)LBA;
+
 
     host_writew(sector+(0*2),0x0040);   /* bit 6: 1=fixed disk */
     host_writew(sector+(1*2),phys_cyls);
@@ -2708,6 +2710,10 @@ void IDEATADevice::update_from_biosdisk() {
 			(unsigned int)heads,
 			(unsigned int)sects);
 	}
+    else LOG_MSG("Mapping IDE DISK C/H/S %u/%u/%u\n",
+        (unsigned int)cyls,
+        (unsigned int)heads,
+        (unsigned int)sects);
 
 	phys_heads = heads;
 	phys_sects = sects;

--- a/src/ints/bios_vhd.cpp
+++ b/src/ints/bios_vhd.cpp
@@ -34,6 +34,8 @@
 #include "mapper.h"
 #include "SDL.h"
 
+extern bool int13_enable_48bitLBA;
+
 #if defined(__linux__) && !defined(__GLIBC__)
 // msul libc does not need 64 suffix to work with files > 2 GiB 
 #define fopen64 fopen
@@ -175,7 +177,7 @@ imageDiskVHD::ErrorCodes imageDiskVHD::Open(const char* fileName, const bool rea
     vhd->diskimg = file;
     vhd->diskname = fileName;
     vhd->hardDrive = true;
-    vhd->active = true;
+    vhd->active = true; 
     //use delete vhd from now on to release the disk image upon failure
 
     //if fixed image, store a plain imageDisk also
@@ -280,14 +282,19 @@ imageDiskVHD::ErrorCodes imageDiskVHD::Open(const char* fileName, const bool rea
 		return INVALID_DATA;
 	}
 
-    //detect real DOS geometry (MBR, BPB or default X-255-63)
-    Bitu sizes[4];
-    vhd->DetectGeometry(sizes);
-    vhd->cylinders = sizes[3];
-    vhd->heads = sizes[2];
-    vhd->sectors = sizes[1];
+    if(vhd->cylinders == 0 || vhd->heads == 0 || vhd->sectors == 0) {
+        Bitu sizes[4];
+        vhd->DetectGeometry(sizes, vhd->image_length); /* Derive geometry from image_length if geometry in VHD footer is not valid */
+        vhd->cylinders = sizes[3];
+        vhd->heads = sizes[2];
+        vhd->sectors = sizes[1];
+        vhd->sector_size = sizes[0];
+    }
+    vhd->LBA = vhd->getLBA(); /* Initialize LBA value */
+    if(!int13_enable_48bitLBA && (vhd->LBA > 0x0FFFFFFF))
+        LOG_MSG("Warning: Disk size (%lf GB) exceeds 128GB limit for 28-bit LBA. You may need to enable 48-bit LBA support.", (double)vhd->image_length / (1024.0 * 1024 * 1024));
 
-	*disk = vhd;
+    *disk = vhd;
 	return !readOnly && roflag ? UNSUPPORTED_WRITE : OPEN_SUCCESS;
 }
 
@@ -1058,6 +1065,11 @@ void imageDiskVHD::DetectGeometry(Bitu sizes[]) {
         Read_AbsoluteSector(lba / 512, buf);
         DetectGeometry(buf, sizes, footer.currentSize);
     }
+    else {
+        LBA = image_length / (sector_size ? sector_size : 512);
+        DetectGeometry(sizes, footer.currentSize);
+    }
+
 }
 
 void imageDiskVHD::DetectGeometry(uint8_t* buf, Bitu sizes[], uint64_t currentSize) {
@@ -1073,6 +1085,47 @@ void imageDiskVHD::DetectGeometry(uint8_t* buf, Bitu sizes[], uint64_t currentSi
             sizes[2] = h2;
             sizes[3] = currentSize / 512 / s2 / h2;
         }
+}
+
+void imageDiskVHD::DetectGeometry(Bitu sizes[], uint64_t currentSize) {
+    if(!sizes) return;
+
+    const uint16_t sector_size = 512;
+    uint64_t totalSectors = currentSize / sector_size;
+
+    uint32_t sectorsPerTrack;
+    uint32_t heads;
+    uint32_t cylinders;
+
+    if(totalSectors > 65535ULL * 16ULL * 63ULL) {
+        sectorsPerTrack = 255;
+        heads = 16;
+        cylinders = (uint32_t)(totalSectors / (sectorsPerTrack * heads));
+    }
+    else {
+        sectorsPerTrack = 17;
+
+        cylinders = (uint32_t)(totalSectors / sectorsPerTrack);
+        heads = (cylinders + 1023) / 1024;
+
+        if(heads < 4) heads = 4;
+        if(heads > 16) heads = 16;
+
+        if(heads > 0) {
+            sectorsPerTrack = (uint32_t)(totalSectors / (heads * cylinders));
+        }
+
+        if(sectorsPerTrack < 17) sectorsPerTrack = 17;
+
+        cylinders = (uint32_t)(totalSectors / (heads * sectorsPerTrack));
+    }
+
+    if(cylinders > 65535) cylinders = 65535;
+
+    sizes[3] = cylinders;
+    sizes[2] = heads;
+    sizes[1] = sectorsPerTrack;
+    sizes[0] = sector_size; // sector_size
 }
 
 //scans a MBR and returns


### PR DESCRIPTION
Fix IDE geometry and LBA detection of VHD files was broken after PR #6235.
Cylinders were calculated as zero.

```
CHS and LBA partition start differ, choosing LBA
Mapping BIOS DISK C/H/S 4079/255/63 as IDE 0/16/63
IMGMOUNT: HDD image mounted to drive no. 2 (IDE Primary Master)
```

```
LOG: Invalid MBR, no signature
LOG: Bad CHS partition start in MBR
LOG: Mapping BIOS DISK C/H/S 522/255/63 as IDE 8323/16/63
LOG: IMGMOUNT: HDD image mounted to drive no. 2 (IDE Primary Master)

```