### PR TITLE
Set default value of  `int 13 enable 48-bit LBA` option to `true`

### DIFF
--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -2576,7 +2576,7 @@ timeout     = 0
 #                                                     This option is OFF by default.
 #                        int 13 disk change detect: Enable INT 13h disk change detect function (AH=16h)
 #                                int 13 extensions: Enable INT 13h extensions (functions 0x40-0x48). You will need this enabled if the virtual hard drive image is 8.4GB or larger.
-#                         int 13 enable 48-bit LBA: Enable 48-bit LBA support for INT 13h extensions. Needed for drives larger than 28-bit LBA limit. This is considered experimental.
+#                         int 13 enable 48-bit LBA: Enable 48-bit LBA support for INT 13h extensions. Needed for drives larger than 28-bit LBA limit (128GiB).
 #                                          biosps2: Emulate BIOS INT 15h PS/2 mouse services
 #                                                     Note that some OS's like Microsoft Windows neither use INT 33h nor
 #                                                     probe the AUX port directly and depend on this BIOS interface exclusively
@@ -2701,7 +2701,7 @@ int33 hide host cursor when polling              = false
 int33 disable cell granularity                   = false
 int 13 disk change detect                        = true
 int 13 extensions                                = true
-int 13 enable 48-bit LBA                         = false
+int 13 enable 48-bit LBA                         = true
 biosps2                                          = true
 int15 wait force unmask irq                      = true
 int15 mouse callback does not preserve registers = false

--- a/src/dos/drives.cpp
+++ b/src/dos/drives.cpp
@@ -533,7 +533,7 @@ char * DriveManager::GetDrivePosition(int drive) {
 bool drivemanager_init = false;
 bool int13_extensions_enable = true;
 bool int13_disk_change_detect_enable = true;
-bool int13_enable_48bitLBA = false;
+bool int13_enable_48bitLBA = true;
 
 void DriveManager::Init(Section* s) {
     const Section_prop* section = static_cast<Section_prop*>(s);

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -5041,8 +5041,8 @@ void DOSBOX_SetupConfigSections(void) {
     Pbool = secprop->Add_bool("int 13 extensions",Property::Changeable::WhenIdle,true);
     Pbool->Set_help("Enable INT 13h extensions (functions 0x40-0x48). You will need this enabled if the virtual hard drive image is 8.4GB or larger.");
 
-    Pbool = secprop->Add_bool("int 13 enable 48-bit LBA", Property::Changeable::WhenIdle, false);
-    Pbool->Set_help("Enable 48-bit LBA support for INT 13h extensions. Needed for drives larger than 28-bit LBA limit. This is considered experimental.");
+    Pbool = secprop->Add_bool("int 13 enable 48-bit LBA", Property::Changeable::WhenIdle, true);
+    Pbool->Set_help("Enable 48-bit LBA support for INT 13h extensions. Needed for drives larger than 28-bit LBA limit (128GiB).");
 
     Pbool = secprop->Add_bool("biosps2",Property::Changeable::OnlyAtStart,true);
     Pbool->Set_help("Emulate BIOS INT 15h PS/2 mouse services\n"

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -2543,8 +2543,8 @@ void IDEATADevice::generate_identify_device() {
     /* total disk capacity in sectors */
     total = sects * cyls * heads;
     ptotal = phys_sects * phys_cyls * phys_heads;
-    //uint32_t lba28 = LBA > 0x0FFFFFFF ? 0x0FFFFFFF : (uint32_t)LBA;
-    uint32_t lba28 = (uint32_t)LBA;
+    uint32_t lba28 = LBA > 0x0FFFFFFF ? 0x0FFFFFFF : (uint32_t)LBA;
+    //uint32_t lba28 = (uint32_t)LBA;
 
 
     host_writew(sector+(0*2),0x0040);   /* bit 6: 1=fixed disk */

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -1436,7 +1436,7 @@ imageDisk::imageDisk(FILE* diskimg, const char* diskName, uint32_t cylinders, ui
     this->diskSizeK = this->image_length / 1024;
     LBA = image_length / sector_size;
     if(!int13_enable_48bitLBA && (LBA > 0x0FFFFFFF))
-        LOG_MSG("Warning: Disk size (%lf GB) exceeds 128GB limit for 28-bit LBA. You may need to enable 48-bit LBA support.", (double)image_length / (1024.0 * 1024 * 1024));
+        LOG_MSG("Warning: Disk size (%lf GiB) exceeds 128GiB limit for 28-bit LBA. You may need to enable 48-bit LBA support.", (double)image_length / (1024.0 * 1024 * 1024));
     reserved_cylinders = 0;
     this->diskimg = diskimg;
     class_id = ID_BASE;
@@ -1659,7 +1659,7 @@ imageDisk::imageDisk(FILE* imgFile, const char* imgName, uint64_t imgSize, bool 
 
         LBA = imgSize / sector_size;
         if(!int13_enable_48bitLBA && (LBA > 0x0FFFFFFF))
-            LOG_MSG("Warning: Disk size (%lf GB) exceeds 128GB limit for 28-bit LBA. You may need to enable 48-bit LBA support.", (double)image_length / (1024.0 * 1024 * 1024));
+            LOG_MSG("Warning: Disk size (%lf GiB) exceeds 128GiB limit for 28-bit LBA. You may need to enable 48-bit LBA support.", (double)image_length / (1024.0 * 1024 * 1024));
         if (sectors == 0 || heads == 0 || cylinders == 0)
             active = false;
     }

--- a/src/ints/bios_vhd.cpp
+++ b/src/ints/bios_vhd.cpp
@@ -292,7 +292,7 @@ imageDiskVHD::ErrorCodes imageDiskVHD::Open(const char* fileName, const bool rea
     }
     vhd->LBA = vhd->getLBA(); /* Initialize LBA value */
     if(!int13_enable_48bitLBA && (vhd->LBA > 0x0FFFFFFF))
-        LOG_MSG("Warning: Disk size (%lf GB) exceeds 128GB limit for 28-bit LBA. You may need to enable 48-bit LBA support.", (double)vhd->image_length / (1024.0 * 1024 * 1024));
+        LOG_MSG("Warning: Disk size (%lf GiB) exceeds 128GiB limit for 28-bit LBA. You may need to enable 48-bit LBA support.", (double)vhd->image_length / (1024.0 * 1024 * 1024));
 
     *disk = vhd;
 	return !readOnly && roflag ? UNSUPPORTED_WRITE : OPEN_SUCCESS;


### PR DESCRIPTION
Set default value of  `int 13 enable 48-bit LBA` option to `true` since it was reported to improve behavior on Windows XP guest.
