### PR TITLE
printer.cpp: Fix occasional missing lines after page break following a line wrap

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,10 @@ NEXT VERSION
   - Fixed mouse cursor display in DOS/V Japanese mode (nanshiki)
   - INT 13h AH=48h: Fixed LBA detection (maron2000)
   - Fixed read/write errors on last sectors of disk image (maron2000)
+  - Int 13h: Added option to enable/disable 48-bit LBA support (maron2000)
+  - Fix VHD file geometry detection (maron2000)
+  - Fixed crash when printing out multipages to printer (Windows) (maron2000)
+  - printer.cpp: Fix occasional missing page break after line wrap (maron2000)
 
 2026.03.29
   - Add dosbox.conf option to control the duration of the beep when

--- a/src/hardware/parport/printer.cpp
+++ b/src/hardware/parport/printer.cpp
@@ -1641,7 +1641,7 @@ void CPrinter::printChar(uint8_t ch, int box)
     {
 		curX = leftMargin;
 		curY += lineSpacing;
-		if (curY > bottomMargin) newPage(true, false);
+		if (curY > bottomMargin - 0.0001) newPage(true, false);
 	}
 }
 


### PR DESCRIPTION
I found that the printed out [PDF](https://github.com/user-attachments/files/27199247/DOSBox-X.Printer.pdf) in PR #6246, there was a line missing between page 1 and page 2.
This PR fixes the decision to insert page break after line wrap.

Sample of print out after the fix.
[DOSBox-X Printer.pdf](https://github.com/user-attachments/files/27240131/DOSBox-X.Printer.pdf)
