### PR TITLE
TTF mode: Limit window dimensions only on windowed mode

### DIFF
--- a/src/output/output_ttf.cpp
+++ b/src/output/output_ttf.cpp
@@ -835,9 +835,10 @@ void OUTPUT_TTF_Select(int fsize) {
     GetMaxWidthHeight(&maxWidth, &maxHeight);
 
     // Limit dimenions
-    maxWidth = (maxWidth * 2) / 3;
-    maxHeight = (maxHeight * 2) / 3;
-
+    if(!ttf.fullScrn) {
+        maxWidth = (maxWidth * 2) / 3;
+        maxHeight = (maxHeight * 2) / 3;
+    }
 #if DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW /* SDL drawn menus */
     maxHeight -= mainMenu.menuBarHeightBase * 2;
 #endif


### PR DESCRIPTION
Commit b67984c limited the windows size of TTF output to a reasonable size, however, the fontsize of fullscreen mode was limited as well.
This PR disables the limitation when in fullscreen mode.

Tested on VS x64 SDL2 and macOS SDL1.