### PR TITLE
CD Audio: Fix track not advancing at end of playback

### DIFF
--- a/src/dos/cdrom.h
+++ b/src/dos/cdrom.h
@@ -355,6 +355,7 @@ public:
 	bool	PlayAudioSector         (unsigned long start, unsigned long len) override;
 	bool	PauseAudio              (bool resume) override;
 	bool	StopAudio               (void) override;
+    bool    PlayNextAudioTrack      (void);
 	void	ChannelControl          (TCtrl ctrl) override;
 	bool	ReadSectors             (PhysPt buffer, bool raw, unsigned long sector, unsigned long num) override;
 	/* This is needed for IDE hack, who's buffer does not exist in DOS physical memory */
@@ -400,6 +401,7 @@ private:
 		int      playbackRemaining;
 		uint16_t   bufferPos;
 		uint16_t   bufferConsumed;
+        int currentTrackIdx = -1;
 	} player;
 
 	// Private utility functions

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -695,6 +695,7 @@ bool CDROM_Interface_Image::PlayAudioSector(unsigned long start, unsigned long l
 
 			player.cd = this;
 			player.trackFile = trackFile;
+            player.currentTrackIdx = track;
 			player.startFrame = start;
 			player.currFrame = start;
 			player.numFrames = len;
@@ -855,6 +856,20 @@ bool CDROM_Interface_Image::ReadSector(uint8_t *buffer, bool raw, unsigned long 
 	return tracks[track].file->read(buffer, seek, length);
 }
 
+bool CDROM_Interface_Image::PlayNextAudioTrack(void)
+{
+    const int totalTracks = (int)tracks.size() - 1; 
+    for(int i = player.currentTrackIdx + 1; i < totalTracks; i++) {
+        if(tracks[i].attr != 0x40 && tracks[i].file != nullptr) {
+            return player.cd->PlayAudioSector(tracks[i].start, tracks[i].length);
+        }
+    }
+
+    // No more playable tracks, so stop playback
+    player.cd->StopAudio();
+    return false;
+}
+
 void CDROM_Interface_Image::CDAudioCallBack(Bitu len)
 {
 	// Our member object "playbackRemaining" holds the
@@ -970,6 +985,24 @@ void CDROM_Interface_Image::CDAudioCallBack(Bitu len)
 
 					memset(player.buffer + player.bufferPos, 0, underDecode);
 					player.bufferPos += underDecode;
+
+                    const uint32_t rate = player.trackFile->getRate();
+                    const uint8_t channels = player.trackFile->getChannels();
+                    const int32_t bytesPerSec = rate * channels * 2;
+
+#if 0 // Dosbox-staging requires this for Alone in the Dark 2, but since it did work without it on DOSBox-X, we will disable this for now 
+                    const int32_t twoSecBytes = bytesPerSec * 2;
+
+                    if(player.playbackRemaining < twoSecBytes) {
+#else
+                    if(player.playbackRemaining < bytesPerSec * 0.001) { // less than 1 ms remaining
+#endif
+                        player.cd->StopAudio();
+                    }
+                    else 
+                        player.cd->PlayNextAudioTrack();
+                    
+                    return;
 				}
 				// printProgress( (player.bufferPos - player.bufferConsumed)/(float)AUDIO_DECODE_BUFFER_SIZE, "fill");
 			} // end of fill-while

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -716,7 +716,7 @@ bool CDROM_Interface_Image::PlayAudioSector(unsigned long start, unsigned long l
 			player.playbackTotal = lround(len * tracks[track].sectorSize * bytesPerMs / 176.4);
 			player.playbackRemaining = player.playbackTotal;
 
-            LOG_MSG("CDROM: Playing track # %d %.1f min.-mark", tracks[track].number, tracks[track].skip * (1 / 10584000.0));
+            LOG_MSG("CDROM: Playing track # %d %.1f min.-mark", tracks[track].number, offset * (1 / 10584000.0));
 
 			#ifdef DEBUG
             LOG_MSG(
@@ -995,7 +995,7 @@ void CDROM_Interface_Image::CDAudioCallBack(Bitu len)
 
                     if(player.playbackRemaining < twoSecBytes) {
 #else
-                    if(player.playbackRemaining < bytesPerSec * 0.001) { // less than 1 ms remaining
+                    if(player.playbackRemaining < bytesPerSec * 0.001) { // Stop playback if less than 1 ms remaining
 #endif
                         player.cd->StopAudio();
                     }


### PR DESCRIPTION
This PR fixes a flaw in CD Audio that when a track reaches to an end, it didn't advance to the next track.
(Possibly when the each audio tracks are independent files.) 
