### PR TITLE
Fix geometry detection of qcow2 images

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,6 +34,8 @@ Next version
     MS-DOS device driver, so that the bytes actually processed by the driver
     are returned in AX to the DOS program, instead of giving the DOS program
     the impression that all were processed when they may not have been. (joncampbell123)
+  - CD Audio: Fix track not advancing at end of playback (maron2000)
+  - Fix geometry detection of qcow2 images (maron2000)
 
 2026.05.02
   - DOSBox-X will now check both the current directory and the .config

--- a/include/qcow2_disk.h
+++ b/include/qcow2_disk.h
@@ -120,7 +120,7 @@ class QCow2Disk : public imageDisk{
 
 public:
 	
-	QCow2Disk(QCow2Image::QCow2Header& qcow2Header, FILE *qcow2File, const char *imgName, uint32_t imgSizeK, uint32_t sectorSizeBytes, bool isHardDisk);
+	QCow2Disk(QCow2Image::QCow2Header& qcow2Header, FILE *qcow2File, const char *imgName, uint64_t imgSize, uint32_t sectorSizeBytes, bool isHardDisk);
 
 	~QCow2Disk();
 	

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -141,6 +141,7 @@ void WriteChar(uint16_t col,uint16_t row,uint8_t page,uint16_t chr,uint8_t attr,
 std::string formatString(const char* format, ...);
 const char* MSG_GetUTF8(const char* msg);
 extern char char_yes, char_no;
+extern bool int13_enable_48bitLBA;
 
 #define MAXU32 0xffffffff
 #include "zip.h"
@@ -6670,27 +6671,28 @@ class IMGMOUNT : public Program {
 								}
 								QCow2Image::QCow2Header qcow2_header = QCow2Image::read_header(newDisk);
 								// uint64_t sectors; /* unused */
-								uint32_t imagesize;
 								sizes[0] = 512; // default sector size
-								if(qcow2_header.magic == QCow2Image::magic && (qcow2_header.version == 2 || qcow2_header.version == 3)) {
-									uint32_t cluster_size = 1u << qcow2_header.cluster_bits;
-									if((sizes[0] < 512) || ((cluster_size % sizes[0]) != 0)) {
-										WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_SECTORSIZE"), cluster_size);
-										return false;
-									}
-									// sectors = (uint64_t)qcow2_header.size / (uint64_t)sizes[0]; /* unused */
-									imagesize = (uint32_t)(qcow2_header.size / 1024L);
-									sizes[1] = 63; // sectors
-									sizes[2] = 16; // heads
-									sizes[3] = (uint64_t)qcow2_header.size / sizes[0] / sizes[1] / sizes[2]; // cylinders
-									setbuf(newDisk, NULL);
-									newImage = new QCow2Disk(qcow2_header, newDisk, fname, imagesize, (uint32_t)sizes[0], (imagesize > 2880));
-									skipDetectGeometry = true;
-									newImage->sector_size = sizes[0]; // sector size
-									newImage->sectors = sizes[1];     // sectors
-									newImage->heads = sizes[2];       // heads
-									newImage->cylinders = sizes[3];   // cylinders
-								}
+                                if(qcow2_header.magic == QCow2Image::magic && (qcow2_header.version == 2 || qcow2_header.version == 3)) {
+                                    uint32_t cluster_size = 1u << qcow2_header.cluster_bits;
+                                    if((sizes[0] < 512) || ((cluster_size % sizes[0]) != 0)) {
+                                        WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_SECTORSIZE"), cluster_size);
+                                        return false;
+                                    }
+                                    skipDetectGeometry = true;
+                                    DetectGeometry(sizes, qcow2_header.size); // Derive geometry from image size, since qcow2 doesn't have CHS values in the header
+                                    setbuf(newDisk, NULL);
+                                    newImage = new QCow2Disk(qcow2_header, newDisk, fname, qcow2_header.size, (uint32_t)sizes[0], (qcow2_header.size > 2880 * 1024));
+                                    if(newImage) {
+                                        LOG_MSG("IMGMOUNT: qcow2 image mounted (experimental)");
+                                        newImage->sector_size = sizes[0]; // sector size
+                                        newImage->sectors = sizes[1];     // sectors
+                                        newImage->heads = sizes[2];       // heads
+                                        newImage->cylinders = sizes[3];   // cylinders
+                                        uint64_t LBA = newImage->getLBA();
+                                        if(!int13_enable_48bitLBA && (LBA > 0x0FFFFFFF))
+                                            LOG_MSG("Warning: Disk size (%lf GB) exceeds 128GB limit for 28-bit LBA. You may need to enable 48-bit LBA support.", (double)newImage->LBA * 512.0 / (1024.0 * 1024 * 1024));
+                                    }
+                                }
 								else {
 									WriteOut(MSG_Get("PROGRAM_IMGMOUNT_QCOW2_INVALID"), fname);
 									fclose(newDisk);
@@ -7034,6 +7036,47 @@ class IMGMOUNT : public Program {
 			}
 		}
 
+        void DetectGeometry(Bitu sizes[], uint64_t currentSize) {
+            if(!sizes) return;
+
+            const uint16_t sector_size = 512;
+            uint64_t totalSectors = currentSize / sector_size;
+
+            uint32_t sectorsPerTrack;
+            uint32_t heads;
+            uint32_t cylinders;
+
+            if(totalSectors > 65535ULL * 16ULL * 63ULL) {
+                sectorsPerTrack = 255;
+                heads = 16;
+                cylinders = (uint32_t)(totalSectors / (sectorsPerTrack * heads));
+            }
+            else {
+                sectorsPerTrack = 17;
+
+                cylinders = (uint32_t)(totalSectors / sectorsPerTrack);
+                heads = (cylinders + 1023) / 1024;
+
+                if(heads < 4) heads = 4;
+                if(heads > 16) heads = 16;
+
+                if(heads > 0) {
+                    sectorsPerTrack = (uint32_t)(totalSectors / (heads * cylinders));
+                }
+
+                if(sectorsPerTrack < 17) sectorsPerTrack = 17;
+
+                cylinders = (uint32_t)(totalSectors / (heads * sectorsPerTrack));
+            }
+
+            if(cylinders > 65535) cylinders = 65535;
+
+            sizes[3] = cylinders;
+            sizes[2] = heads;
+            sizes[1] = sectorsPerTrack;
+            sizes[0] = sector_size; // sector_size
+        }
+
 		bool DetectMFMsectorPartition(uint8_t buf[], uint32_t fcsize, Bitu sizes[]) const {
 			// This is used for plain MFM sector format as created by IMGMAKE
 			// It tries to find the first partition. Addressing is in CHS format.
@@ -7250,10 +7293,17 @@ class IMGMOUNT : public Program {
 					WriteOut(MSG_Get("PROGRAM_IMGMOUNT_INVALID_SECTORSIZE"), cluster_size);
 					return nullptr;
 				}
-				sectors = (uint64_t)qcow2_header.size / (uint64_t)sizes[0];
 				imagesize = (uint32_t)(qcow2_header.size / 1024L);
 				setbuf(newDisk, NULL);
-				newImage = new QCow2Disk(qcow2_header, newDisk, fname, imagesize, (uint32_t)sizes[0], (imagesize > 2880));
+                DetectGeometry(sizes, qcow2_header.size);
+                newImage = new QCow2Disk(qcow2_header, newDisk, fname, qcow2_header.size, (uint32_t)sizes[0], (imagesize > 2880));
+                newImage->sector_size = sizes[0]; // sector size
+                newImage->sectors = sizes[1];     // sectors
+                newImage->heads = sizes[2];       // heads
+                newImage->cylinders = sizes[3];   // cylinders
+                uint64_t LBA = newImage->getLBA();
+                if(!int13_enable_48bitLBA && (LBA > 0x0FFFFFFF))
+                    LOG_MSG("Warning: Disk size (%lf GB) exceeds 128GB limit for 28-bit LBA. You may need to enable 48-bit LBA support.", (double)LBA * 512.0 / (1024.0 * 1024 * 1024));
 			}
 			else {
 				char tmp[256];

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -68,6 +68,7 @@ extern bool CodePageGuestToHostUTF16(uint16_t *d/*CROSS_LEN*/,const char *s/*CRO
 extern bool CodePageHostToGuestUTF16(char *d/*CROSS_LEN*/,const uint16_t *s/*CROSS_LEN*/);
 bool systemmessagebox(char const * aTitle, char const * aMessage, char const * aDialogType, char const * aIconType, int aDefaultButton);
 extern bool dos_kernel_disabled;
+extern bool int13_enable_48bitLBA;
 std::string formatString(const char* format, ...);
 #endif
 
@@ -1449,8 +1450,17 @@ fatDrive::fatDrive(const char* sysFilename, uint32_t bytesector, uint32_t cylsec
 			created_successfully = false;
 			return;
 		}
-		filesize = (uint32_t)(qcow2_header.size / 1024L);
-		loadedDisk = new QCow2Disk(qcow2_header, diskfile, fname, filesize, bytesector, (filesize > 2880));
+        filesize = (uint32_t)(qcow2_header.size / 1024L);
+		loadedDisk = new QCow2Disk(qcow2_header, diskfile, fname, qcow2_header.size, bytesector, (filesize > 2880));
+        loadedDisk->sector_size = bytesector; // sector size
+        loadedDisk->sectors = cylsector;     // sectors
+        loadedDisk->heads =   headscyl;      // heads
+        loadedDisk->cylinders = cylinders;   // cylinders
+        uint64_t LBA = loadedDisk->getLBA();
+        if(!int13_enable_48bitLBA && (LBA > 0x0FFFFFFF))
+            LOG_MSG("Warning: Disk size (%lf GB) exceeds 128GB limit for 28-bit LBA. You may need to enable 48-bit LBA support.", (double)LBA * 512.0 / (1024.0 * 1024 * 1024));
+
+
 	}
 	else{
 		fseeko64(diskfile, 0L, SEEK_SET);

--- a/src/ints/qcow2_disk.cpp
+++ b/src/ints/qcow2_disk.cpp
@@ -440,7 +440,7 @@ using namespace std;
 
 
 //Public Constructor.
-	QCow2Disk::QCow2Disk(QCow2Image::QCow2Header& qcow2Header, FILE *qcow2File, const char *imgName, uint32_t imgSizeK, uint32_t sectorSizeBytes, bool isHardDisk) : imageDisk(qcow2File, (const char*)imgName, imgSizeK, isHardDisk), qcowImage(qcow2Header, qcow2File, (const char*) imgName, sectorSizeBytes){
+	QCow2Disk::QCow2Disk(QCow2Image::QCow2Header& qcow2Header, FILE *qcow2File, const char *imgName, uint64_t imgSize, uint32_t sectorSizeBytes, bool isHardDisk) : imageDisk(qcow2File, (const char*)imgName, imgSize, isHardDisk), qcowImage(qcow2Header, qcow2File, (const char*) imgName, sectorSizeBytes){
 	}
 
 


### PR DESCRIPTION
Fix IDE geometry and LBA detection of qcow2 files was broken after #6235.
Confirmed FDISK and FORMAT command works on a 32GB qcow2 image.

## What issue(s) does this PR address?
Fixes #6264

<img width="722" height="452" alt="image" src="https://github.com/user-attachments/assets/a72c5170-ee90-4f63-a7d0-a30c9e42ac35" />

