### PR TITLE
Fix a regression of floppy boot failure

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -7400,7 +7400,7 @@ class IMGMOUNT : public Program {
 			LOG(LOG_DOSMISC, LOG_NORMAL)("Mounting image as C/H/S %u/%u/%u with %u bytes/sector",
 					(unsigned int)sizes[3], (unsigned int)sizes[2], (unsigned int)sizes[1], (unsigned int)sizes[0]);
 
-			if (imagesize > 2880) newImage->Set_Geometry((uint32_t)sizes[2], (uint32_t)sizes[3], (uint32_t)sizes[1], (uint32_t)sizes[0]);
+			if (imagesize > 2880 * 1024) newImage->Set_Geometry((uint32_t)sizes[2], (uint32_t)sizes[3], (uint32_t)sizes[1], (uint32_t)sizes[0]);
 			if (reserved_cylinders > 0) newImage->Set_Reserved_Cylinders((Bitu)reserved_cylinders);
 
 			return newImage;


### PR DESCRIPTION
Fixed a regression that booting from a floppy drive fails due to incorrectly replacing its geometry.

## What issue(s) does this PR address?
Fixes #6270 

<img width="722" height="452" alt="image" src="https://github.com/user-attachments/assets/853d35d8-290c-4c44-bb32-64749cd2a513" />
