### PR TITLE
Fix logging of 'Packed file is corrupt' message detection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -79,6 +79,7 @@ Next version
     FAT filesystem driver, and then a drive letter. At this time, this
     is enough for Microsoft RAMDRIVE.SYS to load and appear as a working
     drive letter in DOSBox-X (joncampbell123)
+  - Fixed logging of 'Packed file is corrupt' message detection (maron2000)
 
 2026.05.02
   - DOSBox-X will now check both the current directory and the .config

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -2150,7 +2150,8 @@ static Bitu DOS_21Handler(void) {
                 }
 
                 MEM_BlockRead(SegPhys(ds)+reg_dx,dos_copybuf,towrite);
-                packerr=reg_bx==2&&!strncmp((char *)dos_copybuf,"Packed file is corrupt",towrite);
+                static const char* msg = "Packed file is corrupt";
+                packerr = reg_bx == 2 && towrite >= strlen(msg) && !memcmp(dos_copybuf, msg, strlen(msg));
                 if(packerr) LOG_MSG("INT 21h WRITE warning: Detected 'Packed file is corrupt' message, try loadfix utility if your program fails to launch.");
                 fWritten = (packerr && !(i4dos && !shellrun) && (!autofixwarn || (autofixwarn == 2 && infix == 0) || (autofixwarn == 1 && infix == 1)));
                 if(!fWritten)


### PR DESCRIPTION
Fixed matching 'Packed file is corrupt' message was not working as intended.

## What issue(s) does this PR address?
Fixes #6280

<img width="722" height="452" alt="image" src="https://github.com/user-attachments/assets/38db3814-d4b5-446c-8308-896517f3591a" />

<img width="642" height="452" alt="image" src="https://github.com/user-attachments/assets/006b2ce8-b073-4859-a724-509b41f7d9a9" />

