### PR TITLE
Fix upper 32-bit of LBA was always cleared

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -79,6 +79,7 @@ Next version
     FAT filesystem driver, and then a drive letter. At this time, this
     is enough for Microsoft RAMDRIVE.SYS to load and appear as a working
     drive letter in DOSBox-X (joncampbell123)
+  - Fixed upper 32-bit of LBA was always cleared (maron2000)
 
 2026.05.02
   - DOSBox-X will now check both the current directory and the .config

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -2435,7 +2435,6 @@ static Bitu INT13_DiskHandler(void) {
         real_writed(segat,bufptr+0x0C,tmpsect);
         real_writed(segat,bufptr+0x10, int13_enable_48bitLBA?(uint32_t)(LBA & 0xFFFFFFFF): (uint32_t)(LBA > 0x0FFFFFFF?0x0FFFFFFF:LBA)); /* LBA lower 32bit */
         real_writed(segat,bufptr+0x14, int13_enable_48bitLBA?(uint32_t)(LBA >> 32):0); /* LBA upper 32bit */
-        real_writed(segat,bufptr+0x14,0);
         real_writew(segat,bufptr+0x18,512);
         if (bufsz >= 0x1E)
             real_writed(segat,bufptr+0x1A,0xFFFFFFFF); /* no EDD information available */


### PR DESCRIPTION
Fixed a bug where the upper 32-bit value of LBA was always cleared regardless of 48-bit LBA support.
