### PR TITLE
Option to disable TTF winperc limit

### DIFF
--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -3346,6 +3346,11 @@ void DOSBOX_SetupConfigSections(void) {
     Pint->Set_help("Specifies the window percentage for the TTF output (100 = full screen). Ignored if the ptsize setting is specified.");
     Pint->SetBasic(true);
 
+    Pbool = secprop->Add_bool("enableWinPercLimit", Property::Changeable::Always, true);
+    Pbool->Set_help("If set, a TrueType window size will be limited to 60 percent of the screen.\n"
+        "Enabled by default; optionally disable the limit when using more than 25 lines in a TTF window.");
+    Pbool->SetBasic(true);
+
 	Pint = secprop->Add_int("ptsize", Property::Changeable::Always, 0);
     Pint->Set_help("Specifies the font point size for the TTF output. If specified (minimum: 9), it will override the winperc setting.");
     Pint->SetBasic(true);

--- a/src/output/output_ttf.cpp
+++ b/src/output/output_ttf.cpp
@@ -69,6 +69,7 @@ uint16_t cpMap_AX[32] = {
 #endif
 
 Render_ttf ttf;
+bool enablePercLimit = true;
 bool char512 = true;
 bool showbold = true;
 bool showital = true;
@@ -730,6 +731,7 @@ void OUTPUT_TTF_Select(int fsize) {
         winPerc = ttf_section->Get_int("winperc");
         if (winPerc>100||(fsize==2&&GFX_IsFullscreen())||(fsize!=1&&fsize!=2&&(control->opt_fullscreen||static_cast<Section_prop *>(control->GetSection("sdl"))->Get_bool("fullscreen")))) winPerc=100;
         else if (winPerc<25) winPerc=25;
+        enablePercLimit = ttf_section->Get_bool("enableWinPercLimit");
 #if defined(HX_DOS)
         winPerc=100;
 #else
@@ -834,10 +836,12 @@ void OUTPUT_TTF_Select(int fsize) {
     unsigned int maxWidth, maxHeight;
     GetMaxWidthHeight(&maxWidth, &maxHeight);
 
-    // Limit dimenions
+    // Limit dimensions
     if(!ttf.fullScrn) {
-        maxWidth = (maxWidth * 2) / 3;
-        maxHeight = (maxHeight * 2) / 3;
+        if(enablePercLimit) {
+           maxWidth = (maxWidth * 2) / 3;
+           maxHeight = (maxHeight * 2) / 3;
+        }
     }
 #if DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW /* SDL drawn menus */
     maxHeight -= mainMenu.menuBarHeightBase * 2;

--- a/src/output/output_ttf.cpp
+++ b/src/output/output_ttf.cpp
@@ -838,9 +838,11 @@ void OUTPUT_TTF_Select(int fsize) {
 
     // Limit dimensions
     if(!ttf.fullScrn) {
-        if(enablePercLimit) {
-           maxWidth = (maxWidth * 2) / 3;
-           maxHeight = (maxHeight * 2) / 3;
+        #if !defined(HX_DOS)
+            if(enablePercLimit) {
+            maxWidth = (maxWidth * 2) / 3;
+            maxHeight = (maxHeight * 2) / 3;
+        #endif
         }
     }
 #if DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW /* SDL drawn menus */


### PR DESCRIPTION
This PR adds a conf option that disables the winperc limit in TTF windows, so that windows larger than 60 percent are allowed. This is useful for applications that use more than 25 lines on screen.

Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

Makes it possible to use a large TTF window for text screens with 423, 50, 60, or more lines.

## Does this PR introduce new feature(s)?

It adds a conf option to disable the recently-added winperc limit.

## Does this PR introduce any breaking change(s)?

No. All existing defaults are unchanged.

*EDIT*: If this is approved, I'll post a PR that updates the reference.conf files, but I'll wait until it's clear that the names I used are OK.