### PR TITLE
Fix screenshot crash (and others) in protected-mode games with output…

### DIFF
--- a/src/output/output_ttf.cpp
+++ b/src/output/output_ttf.cpp
@@ -30,6 +30,7 @@
 #include "inout.h"
 #include "bios.h"
 #include "regs.h"
+#include "cpu.h"
 #include "control.h"
 #include "menudef.h"
 #include "callback.h"
@@ -1429,7 +1430,11 @@ void ttf_setlines(int cols, int lins) {
 void ttf_switch_on(bool ss=true) {
     if ((ss&&ttfswitch)||(!ss&&switch_output_from_ttf)) {
         checkcol = 0;
-        if (strcmp(RunningProgram, "LOADLIN")) {
+        /* Do NOT run a real-mode guest interrupt while the guest CPU is in
+         * protected mode (e.g. a game using a DOS extender). CALLBACK_RunRealInt()
+         * would push a real-mode-style frame and corrupt the extender,
+         * causing a #GP storm on the handler's IRETD. */
+        if (strcmp(RunningProgram, "LOADLIN") && !cpu.pmode) {
             uint16_t oldax=reg_ax;
             reg_ax=0x1600;
             CALLBACK_RunRealInt(0x2F);


### PR DESCRIPTION
I bring another fix for protected mode.

Debugging MicroMachines 2 (it uses DOS4GW DOS extender), i notice it crashes when trying to take a screenshot (Capture menu, Take screenshot) using output=ttf option in dosbox-x.conf. I checked it also crashes when stopping a video capture. This little change fixes it.

<img width="1290" height="680" alt="image" src="https://github.com/user-attachments/assets/74bf454a-ee1d-4cd9-95a1-6f9d7a3bdcb7" />

## Problem
Taking a screenshot (menu or hotkey) in a 32-bit protected-mode DOS-extender game with `output=ttf` caused DOSBox-X to crash or hang. Symptoms varied: guest #UD/#GP spam, infinite real↔protected mode ping-pong, or PIC event starvation.

## Root Cause
`ttf_switch_on()` in `src/output/output_ttf.cpp` unconditionally executed `CALLBACK_RunRealInt(0x2F)` — a real-mode guest interrupt — regardless of whether the guest CPU was in protected mode. This pushed a real-mode-style stack frame (with CS=0xF000) into protected-mode code, triggering #GP when the handler executed IRETD, and causing the DOS extender's fault-handling loop to spin infinitely.

## Solution
Guard the real-mode INT 2F call with a protected-mode check (`!cpu.pmode`). This ensures the interrupt is only executed when the guest is in real mode, mirroring the pre-existing LOADLIN exception in the same function.

## Changes
- Added `#include "cpu.h"` to `src/output/output_ttf.cpp`
- Changed condition from `if (strcmp(RunningProgram, "LOADLIN"))` to `if (strcmp(RunningProgram, "LOADLIN") && !cpu.pmode)`

## Scope & Testing
- Bug only affects `output=ttf`; other output modes never reach this code path
- Fix protects all callers of `ttf_switch_on()`: screenshot capture, runtime output toggle, video-capture stop, and mode switches
- Verified: MicroMachines 2 (32-bit DOS extender) screenshots now work without crash