### PR TITLE
Fix BOOT command fails to boot a floppy image

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -143,6 +143,7 @@ Next version
     to emulate a now-empty CD-ROM drive. (joncampbell123)
   - Enable "Swap disk" menu command for floppy drives even while running a
     guest OS, as long as a floppy drive was already mounted there. (joncampbell123)
+  - BOOT: Fixed a regression of floppy image detection (maron2000)
 
 2026.05.02
   - DOSBox-X will now check both the current directory and the .config

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2619,7 +2619,7 @@ public:
             else if(!memcmp(hdr, "T98FDDIMAGE.R1\0\0", 16))
                 newDiskSwap[index] = new imageDiskNFD(usefile, fname, floppysize, false, 1);
             else
-                newDiskSwap[index] = new imageDisk(usefile, fname, floppysize, floppysize > 2880);
+                newDiskSwap[index] = new imageDisk(usefile, fname, rombytesize, rombytesize > 2880 * 1024);
 
             if(newDiskSwap[index]) {
                 newDiskSwap[index]->Addref();


### PR DESCRIPTION
Fix BOOT command fails to boot a floppy image due to detection of floppy image fails.

## What issue(s) does this PR address?
Fixes #6291

Before fix
<img width="726" height="586" alt="image" src="https://github.com/user-attachments/assets/c6fbf66b-a7e8-4908-a959-d02893b2e66d" />

After fix
<img width="717" height="615" alt="image" src="https://github.com/user-attachments/assets/313e5c9f-9b15-44e0-91f8-6c209078a49d" />
