### PR TITLE
IMGMOUNT: Ensure not to attach a new drive to the IDE Controller when running a booted guest OS.

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -7368,8 +7368,8 @@ class IMGMOUNT : public Program {
 			if (!dos_kernel_disabled)
 				mem_writeb(Real2Phys(dos.tables.mediaid) + ((unsigned int)drive - 'A') * dos.tables.dpb_size, mediaid);
 
-			// Attach to IDE controller as ATAPI CD-ROM device, unless replacement mode
-            if(!opt_replace) {
+			// Attach the new drive to IDE controller as ATAPI CD-ROM device, unless replacement mode. (New drives may not be mounted on a booted guest OS.)
+            if(!opt_replace && !dos_kernel_disabled) {
                 // If no IDE index specified (negative value), try to find an open slot for a CD-ROM drive
                 if(ide_index < 0) {
                     if(!IDE_controller_occupied(1, false)) { // CD-ROMS default to Secondary master if not occupied

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -1817,16 +1817,33 @@ void imageDisk::Set_Geometry(uint32_t setHeads, uint32_t setCyl, uint32_t setSec
     sectors = 63; // Default to 63 sectors per track.
     heads = 16;   // Default to 16 heads.
 
-    if(setHeads == 0 || setCyl == 0 || setSect == 0 || total_sectors > 0x0FFFFFFF) {
+    if(((setSectSize & (setSectSize - 1)) != 0)) {
+        LOG_MSG("bios_disk: Invalid sector size %u, must be a power of 2.", setSectSize);
+        active = false;
+        return;
+    }
+
+    if(total_sectors == 0) {
         LOG_MSG("bios_disk: Invalid disk geometry C, H, S = %u, %u, %u", setCyl, setHeads, setSect);
         active = false;
         return;
     }
     else if (total_sectors > 1024ULL * 255ULL * 63ULL) {
-        LOG_MSG("bios_disk: Disk geometry C, H, S = %u, %u, %u is too large, setting to max limits", setCyl, setHeads, setSect);
+        LOG_MSG("bios_disk: Disk geometry C, H, S = %u, %u, %u exceeds 8.4GB disk size, setting to max limits", setCyl, setHeads, setSect);
         cylinders = 1024;
         heads = 255;
         sectors = 63;
+        sector_size = setSectSize;
+        active = true;
+        return;
+    }
+
+    // Use the provided geometry, if it is valid
+    if(setCyl > 0 && setCyl <= 1024 && setHeads > 0 && setHeads <= 255 && setSect >0 && setSect <= 63) {
+        cylinders = setCyl;
+        heads = setHeads;
+        sectors = setSect;
+        sector_size = setSectSize;
         active = true;
         return;
     }


### PR DESCRIPTION
As discussed in PR #6298, add a condition not to attach a new drive to the IDE controller when running a booted guest OS.
