### PR TITLE
Fix savestate load producing scrambled graphics

### DIFF
--- a/src/hardware/vga.cpp
+++ b/src/hardware/vga.cpp
@@ -2279,6 +2279,12 @@ private:
 
 		if( tandy_membase_idx == 0xffffffff ) vga.tandy.mem_base = vga.mem.linear;
 		else vga.tandy.mem_base = MemBase + tandy_membase_idx;
+
+		// fix: re-derive VGA_DrawLine, line_length, address_add, width, height, etc. from the
+		// freshly-loaded VGA registers. The serialised drawline_idx enum covers only 14 of ~46
+		// variants and the load-side switch has no default, so without this the renderer can be
+		// left pointing at a stale function (mode 13h → vertical colour bands).
+		VGA_SetupDrawing(0);
 	}
 } dummy;
 }

--- a/src/hardware/vga_dac.cpp
+++ b/src/hardware/vga_dac.cpp
@@ -495,4 +495,8 @@ void POD_Load_VGA_Dac( std::istream& stream )
 
 
 	// no static globals found
+
+	// fix: regenerate xlat32/xlat16 caches from rgb[] using the current host pixel format;
+	// loading them raw from the save desyncs colours when host format differs from save-time
+	VGA_DAC_UpdateColorPalette();
 }

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -8368,7 +8368,7 @@ void POD_Save_VGA_Draw( std::ostream& stream )
 {
 	uint8_t linear_base_idx;
 	uint8_t font_tables_idx[2];
-	uint8_t drawline_idx;
+	uint8_t drawline_idx = 0u; // fix: was uninitialised; if/else below covers only 14 of ~46 VGA_DrawLine variants, so unmatched modes wrote stack garbage
 
 
 	if(0) {}


### PR DESCRIPTION
Loading certain savestates renders the screen with scrambled graphics instead of the ingame image.
I reproduced this in Street Fighter 2 (VGA mode 13h). I checked that this solves loading my savestate that previously showed bad colors.

This probably solves #2674 and similar issues reporting the same problem ([savestate issues](https://github.com/joncampbell123/dosbox-x/issues?q=is%3Aissue%20state%3Aopen%20savestate))

Three root causes:

1. POD_Save_VGA_Draw serialises VGA_DrawLine via a tiny enum (drawline_idx) but the if/else chain covers only 14 of ~46 possible draw routines. drawline_idx was declared without an initialiser, so unmatched modes wrote a stack-garbage byte to disk. The load-side switch has no default, so on unknown values VGA_DrawLine was left pointing at whatever the renderer last set before the load began.

2. vga.dac.xlat32/xlat16 are precomputed colour caches that depend on the host renderer pixel format (GFX_Rshift/Gshift/Bshift/Amask). They were memcpy-loaded raw from the save; if the host pixel format at load differs from save, colours come out scrambled.

3. Even with (1) and (2) fixed, the load path never re-derived the renderer state (VGA_DrawLine, line_length, address_add, width, height) from the freshly-loaded VGA registers.

Why it superficially worked sometimes: if VGA_DrawLine already pointed at the correct mode function before the user clicked Load (same game session), the stale pointer happened to be right. Game switching video modes or loading from a different game exposed the bug.