### PR TITLE
Feature: Add detailed info when loading savestate mismatch

### DIFF
--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -2859,11 +2859,21 @@ class ShowLoadWarning : public GUI::ToplevelWindow {
 protected:
     GUI::Input *name;
 public:
-    ShowLoadWarning(GUI::Screen *parent, int x, int y, const char *title) :
-        ToplevelWindow(parent, x, y, 430, 120, MSG_Get("WARNING")) {
+    ShowLoadWarning(GUI::Screen *parent, int x, int y, const char *title, const char *detail_what = nullptr, const char *detail_saved = nullptr, const char *detail_current = nullptr) :
+        ToplevelWindow(parent, x, y, (detail_what && detail_saved && strlen(detail_saved)>30)?560:430, detail_what?180:120, MSG_Get("WARNING")) {
             new GUI::Label(this, strncmp(title, "DOSBox-X ", 9)?30:10, 20, title);
-            (new GUI::Button(this, 140, 50, MSG_Get("YES"), 70))->addActionHandler(this);
-            (new GUI::Button(this, 230, 50, MSG_Get("NO"), 70))->addActionHandler(this);
+            int buttons_y = 50;
+            if (detail_what) {
+                int dy = 50;
+                std::string what = detail_what;
+                new GUI::Label(this, 30, dy, (std::string("Saved ") + what + ": " + (detail_saved?detail_saved:"")).c_str());
+                dy += 22;
+                new GUI::Label(this, 30, dy, (std::string("Current ") + what + ": " + (detail_current?detail_current:"")).c_str());
+                dy += 22;
+                buttons_y = dy + 10;
+            }
+            (new GUI::Button(this, (this->getWidth()-160)/2, buttons_y, MSG_Get("YES"), 70))->addActionHandler(this);
+            (new GUI::Button(this, (this->getWidth()-160)/2+90, buttons_y, MSG_Get("NO"), 70))->addActionHandler(this);
             move(parent->getWidth()>this->getWidth()?(parent->getWidth()-this->getWidth())/2:0,parent->getHeight()>this->getHeight()?(parent->getHeight()-this->getHeight())/2:0);
     }
 
@@ -3857,19 +3867,27 @@ static void UI_Select(GUI::ScreenSDL *screen, int select) {
             np6->raise();
             } break;
         case 23: {
-            auto *np7 = new ShowLoadWarning(screen, 150, 120, "DOSBox-X version mismatch. Load the state anyway?");
+            extern std::string loadstate_detail_saved, loadstate_detail_current;
+            auto *np7 = new ShowLoadWarning(screen, 150, 120, "DOSBox-X version mismatch. Load the state anyway?",
+                                            "version", loadstate_detail_saved.c_str(), loadstate_detail_current.c_str());
             np7->raise();
             } break;
         case 24: {
-            auto *np7 = new ShowLoadWarning(screen, 150, 120, "Program name mismatch. Load the state anyway?");
+            extern std::string loadstate_detail_saved, loadstate_detail_current;
+            auto *np7 = new ShowLoadWarning(screen, 150, 120, "Program name mismatch. Load the state anyway?",
+                                            "program", loadstate_detail_saved.c_str(), loadstate_detail_current.c_str());
             np7->raise();
             } break;
         case 25: {
-            auto *np7 = new ShowLoadWarning(screen, 150, 120, "Memory size mismatch. Load the state anyway?");
+            extern std::string loadstate_detail_saved, loadstate_detail_current;
+            auto *np7 = new ShowLoadWarning(screen, 150, 120, "Memory size mismatch. Load the state anyway?",
+                                            "memory size", loadstate_detail_saved.c_str(), loadstate_detail_current.c_str());
             np7->raise();
             } break;
         case 26: {
-            auto *np7 = new ShowLoadWarning(screen, 150, 120, "Machine type mismatch. Load the state anyway?");
+            extern std::string loadstate_detail_saved, loadstate_detail_current;
+            auto *np7 = new ShowLoadWarning(screen, 150, 120, "Machine type mismatch. Load the state anyway?",
+                                            "machine type", loadstate_detail_saved.c_str(), loadstate_detail_current.c_str());
             np7->raise();
             } break;
         case 27: {

--- a/src/misc/savestates.cpp
+++ b/src/misc/savestates.cpp
@@ -586,6 +586,8 @@ void savestatecorrupt(const char* part) {
 }
 
 bool confres=false;
+std::string loadstate_detail_saved;
+std::string loadstate_detail_current;
 bool loadstateconfirm(int ind) {
 	if (ind<0||ind>4) return false;
 	confres=true;
@@ -673,6 +675,8 @@ void SaveState::load(size_t slot) const { //throw (Error)
 		if (p!=NULL) *p=0;
 		std::string emulatorversion = std::string("DOSBox-X ") + VERSION + std::string(" (") + SDL_STRING + std::string(")");
 		if (strcasecmp(buffer,emulatorversion.c_str())) {
+			loadstate_detail_saved = strlen(buffer) ? std::string(buffer) : std::string("(none)");
+			loadstate_detail_current = emulatorversion;
 			if(!force_load_state&&!loadstateconfirm(0)) {
 				LOG_MSG("Aborted. Check your DOSBox-X version: %s",buffer);
 				load_err=true;
@@ -693,8 +697,10 @@ void SaveState::load(size_t slot) const { //throw (Error)
 		size_t length = (size_t)zis.xsgetn((zip_istreambuf::char_type*)buffer,sizeof(buffer)-1); buffer[length] = 0;
 
 		if (!length||(size_t)length!=strlen(RunningProgram)||strncmp(buffer,RunningProgram,length)) {
+			buffer[length]='\0';
+			loadstate_detail_saved = length ? std::string(buffer) : std::string("(none)");
+			loadstate_detail_current = RunningProgram ? std::string(RunningProgram) : std::string("(none)");
 			if(!force_load_state&&!loadstateconfirm(1)) {
-				buffer[length]='\0';
 				LOG_MSG("Aborted. Check your program name: %s",buffer);
 				load_err=true;
 				goto done;
@@ -727,8 +733,17 @@ void SaveState::load(size_t slot) const { //throw (Error)
 		char str[10];
 		itoa((int)MEM_TotalPages(), str, 10);
 		if(!length||(size_t)length!=strlen(str)||strncmp(buffer,str,length)) {
+			buffer[length]='\0';
+			{
+				char tmp[32];
+				int saved_mb = length ? (atoi(buffer)*4096/1024/1024) : 0;
+				int current_mb = (int)MEM_TotalPages()*4096/1024/1024;
+				snprintf(tmp,sizeof(tmp),"%d MB",saved_mb);
+				loadstate_detail_saved = tmp;
+				snprintf(tmp,sizeof(tmp),"%d MB",current_mb);
+				loadstate_detail_current = tmp;
+			}
 			if(!force_load_state&&!loadstateconfirm(2)) {
-				buffer[length]='\0';
 				int size=atoi(buffer)*4096/1024/1024;
 				LOG_MSG("Aborted. Check your memory size: %d MB", size);
 				load_err=true;
@@ -751,6 +766,9 @@ void SaveState::load(size_t slot) const { //throw (Error)
 		char str[20];
 		strcpy(str, getType().c_str());
 		if(!length||(size_t)length!=strlen(str)||strncmp(buffer,str,length)) {
+			buffer[length]='\0';
+			loadstate_detail_saved = length ? std::string(buffer) : std::string("(none)");
+			loadstate_detail_current = std::string(str);
 			if(!force_load_state&&!loadstateconfirm(3)) {
 				LOG_MSG("Aborted. Check your machine type: %s",buffer);
 				load_err=true;


### PR DESCRIPTION
When loading a savestate whose stored DOSBox-X version, program name, memory size or machine type does not match the running emulator, the dialog only said e.g. "Program name mismatch. Load the state anyway?". The user had no way to tell which two values were being compared, so deciding whether the load is safe required guessing or aborting.

Each of the four "X mismatch" dialogs now shows two extra lines:

    Saved <X>: ...
    Current <X>: ...

Both values are read from data the savestate already carries (DOSBox-X_Version, Program_Name, Memory_Size, Machine_Type) -- the save format and write side are unchanged, so existing .sav files load exactly as before.

Before this PR:
<img width="642" height="447" alt="imagen" src="https://github.com/user-attachments/assets/696b17fd-00cc-4c96-96f8-cfe3dd4006c7" />

If merged (MicroMachines 2 and Street Fighter 2):
<img width="642" height="447" alt="Program - New" src="https://github.com/user-attachments/assets/e56795f3-2c7b-4b90-9fda-c366c2f31bc7" />

Another example, if merged:
<img width="642" height="447" alt="DOSBox-X version - New" src="https://github.com/user-attachments/assets/0e7ebe81-fc37-4a2f-9c91-c709dbedaa28" />

This PR is similar to what @Torinde was expecting in #3591 
