### PR TITLE
Fix MinGW configuration failure on determining OSFREE builds

### DIFF
--- a/.github/workflows/mingw64.yml
+++ b/.github/workflows/mingw64.yml
@@ -227,3 +227,122 @@ jobs:
         if: 0
         with:
           files: dosbox-x-UCRT64-experimental-${{ env.timestamp }}.zip
+
+  MinGW64_osfree_CI_build:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: write # for actions/checkout to fetch code and softprops/action-gh-release
+    if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.13.1
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v6
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: git make mingw-w64-x86_64-toolchain mingw-w64-x86_64-libtool mingw-w64-x86_64-nasm autoconf automake mingw-w64-x86_64-libslirp
+      - name: Update build info
+        shell: bash
+        run: |
+          echo "timestamp=`git show -s --format=%at | xargs -I# date -d @# +%Y%m%d%H%M%S`" >> $GITHUB_ENV
+          export shortsha=`echo ${GITHUB_SHA} | cut -c1-7`
+          export copyrightyear=`git show -s --format=%at | xargs -I# date -d @# +'%Y'`
+          export updatestr=`git show -s --format=%at | xargs -I# date -d @# +'%b %d, %Y %I:%M:%S%P'`
+          echo '/* auto generated */' > include/build_timestamp.h
+          echo "#define UPDATED_STR \"${updatestr}\"" >> include/build_timestamp.h
+          echo "#define GIT_COMMIT_HASH \"${shortsha}\""  >> include/build_timestamp.h
+          echo "#define COPYRIGHT_END_YEAR \"${copyrightyear}\"" >> include/build_timestamp.h
+          cat include/build_timestamp.h
+          echo '#define C_OSFREE 1' >> vs/config_package.h
+          echo '#define OSFREE 1' >> vs/config_package.h
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            VERSION=$(echo "${GITHUB_REF##*/}" | sed -E 's/^dosbox-x-v([0-9]+\.[0-9]+\.[0-9]+)$/\1/' || echo "unknown")
+            echo "VERSION=$VERSION" >> $GITHUB_ENV
+          fi
+      - name: Build MinGW64 SDL1 osfree
+        run: |
+          top=`pwd`
+          ./build-mingw
+          strip -s $top/src/dosbox-x.exe
+      - name: Package MinGW64 SDL1
+        run: |
+          top=`pwd`
+          mkdir -p $top/package/mingw-build/mingw/drivez
+          mkdir -p $top/package/mingw-build/mingw/scripts
+          mkdir -p $top/package/mingw-build/mingw/shaders
+          mkdir -p $top/package/mingw-build/mingw/glshaders
+          mkdir -p $top/package/mingw-build/mingw/languages
+          sed -e 's/^\(output[ ]*=[ ]*\)default$/\1ttf/;s/^\(windowposition[ ]*=\)[ ]*-/\1 /;s/^\(file access tries[ ]*=[ ]*\)0$/\13/;s/^\(printoutput[ ]*=[ ]*\)png$/\1printer/;s/\(drive data rate limit[ ]*=[ ]*\)-1$/\10/' $top/dosbox-x.reference.conf>$top/package/mingw-build/mingw/dosbox-x.conf
+          cp $top/src/dosbox-x.exe $top/package/mingw-build/mingw/dosbox-x.exe
+          cp $top/CHANGELOG $top/package/mingw-build/mingw/CHANGELOG.txt
+          cp $top/dosbox-x.reference.conf $top/package/mingw-build/mingw/dosbox-x.reference.conf
+          cp $top/dosbox-x.reference.full.conf $top/package/mingw-build/mingw/dosbox-x.reference.full.conf
+          cp $top/contrib/windows/installer/readme.txt $top/package/mingw-build/mingw/README.txt
+          cp $top/contrib/windows/installer/inpoutx64.dll $top/package/mingw-build/mingw/inpoutx64.dll
+          cp $top/contrib/fonts/FREECG98.BMP $top/package/mingw-build/mingw/FREECG98.BMP
+          cp $top/contrib/fonts/wqy_1?pt.bdf $top/package/mingw-build/mingw/
+          cp $top/contrib/fonts/Nouveau_IBM.ttf $top/package/mingw-build/mingw/Nouveau_IBM.ttf
+          cp $top/contrib/fonts/SarasaGothicFixed.ttf $top/package/mingw-build/mingw/SarasaGothicFixed.ttf
+          cp $top/contrib/windows/installer/drivez_readme.txt $top/package/mingw-build/mingw/drivez/readme.txt
+          cp $top/contrib/windows/installer/windows_explorer_context_menu*.bat $top/package/mingw-build/mingw/scripts/
+          cp $top/contrib/windows/shaders/* $top/package/mingw-build/mingw/shaders/
+          cp $top/contrib/glshaders/* $top/package/mingw-build/mingw/glshaders/
+          cp $top/contrib/translations/*/*.lng $top/package/mingw-build/mingw/languages/
+      - name: Build MinGW64 SDL2 osfree
+        run: |
+          top=`pwd`
+          ./build-mingw-sdl2
+          strip -s $top/src/dosbox-x.exe
+      - name: Package MinGW64 SDL2
+        run: |
+          top=`pwd`
+          mkdir -p $top/package/mingw-build/mingw-sdl2/drivez
+          mkdir -p $top/package/mingw-build/mingw-sdl2/scripts
+          mkdir -p $top/package/mingw-build/mingw-sdl2/shaders
+          mkdir -p $top/package/mingw-build/mingw-sdl2/glshaders
+          mkdir -p $top/package/mingw-build/mingw-sdl2/languages
+          sed -e 's/^\(output[ ]*=[ ]*\)default$/\1ttf/;s/^\(windowposition[ ]*=\)[ ]*-/\1 /;s/^\(file access tries[ ]*=[ ]*\)0$/\13/;s/^\(printoutput[ ]*=[ ]*\)png$/\1printer/;s/\(drive data rate limit[ ]*=[ ]*\)-1$/\10/' $top/dosbox-x.reference.conf>$top/package/mingw-build/mingw-sdl2/dosbox-x.conf
+          cp $top/src/dosbox-x.exe $top/package/mingw-build/mingw-sdl2/dosbox-x.exe
+          cp $top/CHANGELOG $top/package/mingw-build/mingw-sdl2/CHANGELOG.txt
+          cp $top/dosbox-x.reference.conf $top/package/mingw-build/mingw-sdl2/dosbox-x.reference.conf
+          cp $top/dosbox-x.reference.full.conf $top/package/mingw-build/mingw-sdl2/dosbox-x.reference.full.conf
+          cp $top/contrib/windows/installer/readme.txt $top/package/mingw-build/mingw-sdl2/README.txt
+          cp $top/contrib/windows/installer/inpoutx64.dll $top/package/mingw-build/mingw-sdl2/inpoutx64.dll
+          cp $top/contrib/fonts/FREECG98.BMP $top/package/mingw-build/mingw-sdl2/FREECG98.BMP
+          cp $top/contrib/fonts/wqy_1?pt.bdf $top/package/mingw-build/mingw-sdl2/
+          cp $top/contrib/fonts/Nouveau_IBM.ttf $top/package/mingw-build/mingw-sdl2/Nouveau_IBM.ttf
+          cp $top/contrib/fonts/SarasaGothicFixed.ttf $top/package/mingw-build/mingw-sdl2/SarasaGothicFixed.ttf
+          cp $top/contrib/windows/installer/drivez_readme.txt $top/package/mingw-build/mingw-sdl2/drivez/readme.txt
+          cp $top/contrib/windows/installer/windows_explorer_context_menu*.bat $top/package/mingw-build/mingw-sdl2/scripts/
+          cp $top/contrib/windows/shaders/* $top/package/mingw-build/mingw-sdl2/shaders/
+          cp $top/contrib/glshaders/* $top/package/mingw-build/mingw-sdl2/glshaders/
+          cp $top/contrib/translations/*/*.lng $top/package/mingw-build/mingw-sdl2/languages/
+          cp $top/COPYING $top/package/COPYING
+          cd $top/package/
+          TIMESTAMP="${{ env.timestamp }}"
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            ZIPNAME="dosbox-x-mingw64-${VERSION}-osfree-portable.zip"
+            $top/vs/tool/zip.exe -r -9 "$top/$ZIPNAME" *
+          else
+            ZIPNAME="dosbox-x-mingw64-${TIMESTAMP}-osfree-nightly"
+          fi
+          echo "ZIPNAME=$ZIPNAME" >> $GITHUB_ENV
+          cd $top
+      - name: Upload preview package
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: ${{ env.ZIPNAME }}
+          path: ${{ github.workspace }}/package/
+      - name: Upload release package
+        uses: softprops/action-gh-release@v3
+        #if: startsWith(github.ref, 'refs/tags/')
+        if: 0
+        with:
+          files: ${{ env.ZIPNAME }}

--- a/configure.ac
+++ b/configure.ac
@@ -143,18 +143,16 @@ COMMIT_HASH=`git rev-parse --short=7 HEAD 2>/dev/null || echo "unknown"`
 AC_SUBST([COMMIT_HASH])
 AC_MSG_RESULT([$COMMIT_HASH])
 
-GITBRANCH=`git rev-parse --abbrev-ref HEAD`
+GITBRANCH="${GITHUB_REF_NAME:-`git rev-parse --abbrev-ref HEAD 2>/dev/null`}"
 OSFREE=0
 AH_TEMPLATE(C_OSFREE,[Define to 1 to make an OSFREE version])
 
 # automated builds on GitHub are failing to detect main-osfree branch for osfree?
 # try looking at vs/config_package.h
-TMP=`grep -R "#define OSFREE" vs/config_package.h`
-
-if [[ x"$GITBRANCH" == x"main-osfree" ]]; then
-    AC_DEFINE(C_OSFREE,1,[Make an OSFREE build])
-elif [[ -n "$TMP" ]]; then # vs/config_package.h is OSFREE
-    AC_DEFINE(C_OSFREE,1,[Make an OSFREE build])
+if test "x$GITBRANCH" = "xmain-osfree"; then
+    AC_DEFINE([C_OSFREE],[1],[Make an OSFREE build])
+elif grep -q "#define OSFREE" vs/config_package.h 2>/dev/null; then
+    AC_DEFINE([C_OSFREE],[1],[Make an OSFREE build])
 fi
 
 dnl Setup for automake


### PR DESCRIPTION
configure scripts generated by autoconf are executed using /bin/sh, which is not guaranteed to be bash-compatible.
This PR replaces bash-specific shell syntax with POSIX-compatible equivalents to avoid configure-time errors on environments where /bin/sh is not bash.
Not tested on main-osfree branch, so additional fix maybe required.

## What issue(s) does this PR address?
Fixes #6311 