### PR TITLE
output_ttf: Don't reset colors when already in TTF output mode

### DIFF
--- a/src/output/output_ttf.cpp
+++ b/src/output/output_ttf.cpp
@@ -693,7 +693,7 @@ void OUTPUT_TTF_Select(int fsize) {
         }
         const char * colors = ttf_section->Get_string("colors");
         staycolors = strlen(colors) && *colors == '+'; // Always switch to preset value when '+' is specified
-        if ((*colors && (!init_once || !init_twice))|| staycolors) {
+        if ((*colors && (!init_once || !init_twice))|| (staycolors && !ttf.inUse)) {
             if (!setColors(colors,-1)) {
                 LOG_MSG("Incorrect color scheme: %s", colors);
                 //setColors("#000000 #0000aa #00aa00 #00aaaa #aa0000 #aa00aa #aa5500 #aaaaaa #555555 #5555ff #55ff55 #55ffff #ff5555 #ff55ff #ffff55 #ffffff",-1);


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?
Fixes #6285

<img width="1122" height="702" alt="image" src="https://github.com/user-attachments/assets/6d02681d-62f9-4910-8c49-af7ecce5263b" />
