### PR TITLE
bugfix: FindNext DTA on drive_local

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
 Next version
+  - DOS file search bugfix: Prevent undefined stat_block usage on failed
+    ht_stat() calls. Use a separate variable for special file attribute
+    checks to avoid reusing stat_block when it contains garbage values.
+    This fixes issues on latest Darwin kernels. (cimarronm)
   - Added function to config to load MS-DOS device drivers. The command is
     config -device <device driver path> -devparm <parameters>. For example,
     to load OAKCDROM.SYS into memory, you could type:

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -1836,7 +1836,7 @@ char * DBCS_upcase(char * str);
 bool localDrive::FindNext(DOS_DTA & dta) {
 
 	char * dir_ent, *ldir_ent;
-	ht_stat_t stat_block;
+	ht_stat_t stat_block, special_stat_block;
 	char full_name[CROSS_LEN], lfull_name[LFN_NAMELENGTH+1];
 	char dir_entcopy[CROSS_LEN], ldir_entcopy[CROSS_LEN];
 
@@ -1892,8 +1892,8 @@ again:
 	if (!isdir) find_attr|=DOS_ATTR_ARCHIVE;
 	if(!(stat_block.st_mode & S_IWUSR)) find_attr|=DOS_ATTR_READ_ONLY;
 	std::string fname = create_filename_of_special_operation(temp_name, "ATR", false);
-	if (ht_stat(fname.c_str(),&stat_block)==0) {
-		unsigned int len = stat_block.st_size;
+	if (ht_stat(fname.c_str(), &special_stat_block)==0) {
+		unsigned int len = special_stat_block.st_size;
 		if (len & 1) {
 			if (isdir)
 				find_attr|=DOS_ATTR_ARCHIVE;


### PR DESCRIPTION
The stat_block variable was reused for checking special file attributes, but when ht_stat() fails, the struct remains in an undefined state. On latest Darwin kernels, this can contain garbage values that get used later. Use a separate special_stat_block variable for the special file check to prevent undefined behavior.