### PR TITLE
Add 'Send Alt+SysRq/PrtScr' menu item

### DIFF
--- a/contrib/translations/en/en_US.lng
+++ b/contrib/translations/en/en_US.lng
@@ -3501,6 +3501,9 @@ Send menu key
 :MENU:sendkey_alttab
 Send Alt+Tab
 .
+:MENU:sendkey_altsysrq
+Send Alt+SysRq/PrtScr
+.
 :MENU:sendkey_ctrlesc
 Send Ctrl+Esc
 .

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -185,6 +185,7 @@ static const char *def_menu_main_sendkey[] =
     "sendkey_winlogo",
     "sendkey_winmenu",
     "sendkey_alttab",
+    "sendkey_altsysrq",
     "sendkey_ctrlesc",
     "sendkey_ctrlbreak",
     "sendkey_cad",

--- a/src/gui/menu_callback.cpp
+++ b/src/gui/menu_callback.cpp
@@ -3837,6 +3837,7 @@ void AllocCallback2() {
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_winlogo").set_text("Send logo key").set_callback_function(sendkey_preset_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_winmenu").set_text("Send menu key").set_callback_function(sendkey_preset_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_alttab").set_text("Send Alt+Tab").set_callback_function(sendkey_preset_menu_callback);
+        mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_altsysrq").set_text("Send Alt+SysRq/PrtScr").set_callback_function(sendkey_preset_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_ctrlesc").set_text("Send Ctrl+Esc").set_callback_function(sendkey_preset_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_ctrlbreak").set_text("Send Ctrl+Break").set_callback_function(sendkey_preset_menu_callback);
         mainMenu.alloc_item(DOSBoxMenu::item_type_id,"sendkey_cad").set_text("Send Ctrl+Alt+Del").set_callback_function(sendkey_preset_menu_callback);

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -3665,6 +3665,11 @@ void SendKey(std::string key) {
         KEYBOARD_AddKey(KBD_tab, true);
         KEYBOARD_AddKey(KBD_leftalt, false);
         KEYBOARD_AddKey(KBD_tab, false);
+    } else if (key == "sendkey_altsysrq") {
+        KEYBOARD_AddKey(KBD_leftalt, true);
+        KEYBOARD_AddKey(KBD_printscreen, true);
+        KEYBOARD_AddKey(KBD_leftalt, false);
+        KEYBOARD_AddKey(KBD_printscreen, false);
     } else if (key == "sendkey_ctrlesc") {
         KEYBOARD_AddKey(KBD_leftctrl, true);
         KEYBOARD_AddKey(KBD_esc, true);


### PR DESCRIPTION
Adds a new entry to Main -> Send special key that injects the Alt+SysRq (a.k.a. Alt+PrintScreen) combo into the guest keyboard, following the same press/release pattern as the existing Send Alt+Tab item. This is the hotkey for SoftIce with some known configurations (hotkey stored in S-ICE.dat file as "ALTKEY SYSREQ").