### PR TITLE
Fix savestate format incompatibility between MSVC and MinGW builds

### DIFF
--- a/src/hardware/pic.cpp
+++ b/src/hardware/pic.cpp
@@ -1309,7 +1309,13 @@ private:
 					uint16_t event_idx;
 
 					// - data
-					stream.write(reinterpret_cast<const char*>(&pic_queue.entries[lcv].index), sizeof(pic_queue.entries[lcv].index) );
+					/* Serialize .index as a fixed 8-byte double, not the raw
+					 * pic_tickindex_t (long double) bytes — MSVC has
+					 * sizeof(long double)==8 while MinGW has 16, so writing the
+					 * raw bytes makes the savestate file incompatible across
+					 * toolchains. Runtime keeps long double. */
+					double index_d = (double)pic_queue.entries[lcv].index;
+					stream.write(reinterpret_cast<const char*>(&index_d), sizeof(index_d) );
 					stream.write(reinterpret_cast<const char*>(&pic_queue.entries[lcv].value), sizeof(pic_queue.entries[lcv].value) );
 
 					// - function ptr
@@ -1331,7 +1337,10 @@ private:
 
 				// - data
         stream.write(reinterpret_cast<const char*>(&InEventService), sizeof(InEventService) );
-        stream.write(reinterpret_cast<const char*>(&srv_lag), sizeof(srv_lag) );
+        {
+            double srv_lag_d = (double)srv_lag; /* fixed-width on disk; see PICEntry.index above */
+            stream.write(reinterpret_cast<const char*>(&srv_lag_d), sizeof(srv_lag_d) );
+        }
 
 
 				// - reloc ptr
@@ -1380,7 +1389,10 @@ private:
 					uint16_t event_idx, next_idx;
 
 					// - data
-					stream.read(reinterpret_cast<char*>(&pic_queue.entries[lcv].index), sizeof(pic_queue.entries[lcv].index) );
+					/* Read .index as fixed 8-byte double (see save side). */
+					double index_d = 0.0;
+					stream.read(reinterpret_cast<char*>(&index_d), sizeof(index_d) );
+					pic_queue.entries[lcv].index = (pic_tickindex_t)index_d;
 					stream.read(reinterpret_cast<char*>(&pic_queue.entries[lcv].value), sizeof(pic_queue.entries[lcv].value) );
 
 
@@ -1412,7 +1424,11 @@ private:
 
 				// - data
         stream.read(reinterpret_cast<char*>(&InEventService), sizeof(InEventService) );
-        stream.read(reinterpret_cast<char*>(&srv_lag), sizeof(srv_lag) );
+        {
+            double srv_lag_d = 0.0; /* fixed-width on disk; see PICEntry.index above */
+            stream.read(reinterpret_cast<char*>(&srv_lag_d), sizeof(srv_lag_d) );
+            srv_lag = (pic_tickindex_t)srv_lag_d;
+        }
 
 
 				// 1- wipe old data


### PR DESCRIPTION
When loading a save state between identical DOSBox-X versions that were built with different compilers, DOSBox-X displays a message such as:
LOG: 551240505 ERROR PIC: Event queue full

and then crashes.

This was introduced in this commit:
https://github.com/joncampbell123/dosbox-x/commit/6eb895b7f

PICEntry.index and srv_lag are pic_tickindex_t (long double) but were written to the savestate as their raw in-memory bytes. sizeof(long double) is 8 with MSVC but 16 with MinGW g++, so save/load across toolchains desynchronizes the stream and crashes with PIC: Event queue full.

Write/read these two fields as a fixed 8-byte double instead. Runtime type is unchanged.

That precision loss is completely negligible in practice:

- The discarded bits represent sub-femtomillisecond resolution (below 10⁻¹⁵ ms). No emulated hardware — PIT, PIC, DMA, sound timing, etc. — operates anywhere near that granularity. The emulator's event scheduling is driven by millisecond-scale ticks, so the dropped precision is far beyond anything that could ever affect emulated behavior or timing accuracy.

- The runtime type is unchanged — internally DOSBox-X keeps using pic_tickindex_t (long double) for all live computation. Only the serialized representation in the savestate file is narrowed to double. There is zero impact on emulation precision while running; the value is only rounded at the moment it's written to disk and read back.

- MSVC builds already serialize these fields as 8-byte double today (since long double == double under MSVC), and savestates from those builds have worked fine for years. This change simply makes every toolchain agree on that same format.

In exchange, we gain savestate portability across toolchains. Today, a savestate written by an MSVC build cannot be loaded by a MinGW/GCC build (and vice versa): the differing long double width desynchronizes the stream and corrupts the PIC event queue, producing PIC: Event queue full followed by a crash. After this fix, savestates are interchangeable between MSVC, MinGW, and GCC builds.

A few sub-femtomillisecond bits in a save file are a trivial price for cross-toolchain compatibility that users reasonably expect to "just work."