### PR TITLE
gui/sdl_mapper: fix startup crash with joysticks reporting >1 hat switch

### DIFF
--- a/src/gui/sdl_mapper.cpp
+++ b/src/gui/sdl_mapper.cpp
@@ -1832,7 +1832,7 @@ public:
         pos_axis_lists=new CBindList[MAXAXIS];
         neg_axis_lists=new CBindList[MAXAXIS];
         button_lists=new CBindList[MAXBUTTON];
-        hat_lists=new CBindList[4];
+        hat_lists=new CBindList[MAXHAT*4]; /* 4 binding lists (one per direction) per hat, for up to MAXHAT hats */
         Bitu i;
         for (i=0; i<MAXBUTTON; i++) {
             button_autofire[i]=0;


### PR DESCRIPTION
## Summary

Fixes #5942 — DOSBox-X crashes on startup when a connected joystick reports more than one POV hat switch (Fanatec wheels, many HOTAS sticks, vJoy configured with >1 hat, etc.).

## Root cause

`src/gui/sdl_mapper.cpp`, `CStickBindGroup`: the per-stick hat binding lists are allocated for a single hat —

```cpp
hat_lists = new CBindList[4];   // 4 = one hat * 4 directions
```

but `MAXHAT` is `2`, and the hat poll loop in `ActivateJoystickBoundEvents()` indexes them per hat as `(i<<2)+dir` for `i` up to `hats` (clamped to `MAXHAT`):

```cpp
for (i=0; i<hats; i++) {
    ...
    ActivateBindList(&hat_lists[(i<<2)+0], ...);  // i=1 -> hat_lists[4]
    ActivateBindList(&hat_lists[(i<<2)+1], ...);  //        hat_lists[5]
    ActivateBindList(&hat_lists[(i<<2)+2], ...);  //        hat_lists[6]
    ActivateBindList(&hat_lists[(i<<2)+3], ...);  //        hat_lists[7]
}
```

For a second hat (`i=1`) this touches `hat_lists[4..7]`, past the 4-element array, so `Activate`/`DeactivateBindList` iterate a corrupted `CBindList`. Symbolizing the access violation against a debug-build PDB confirms the faulting instruction is `std::list<CBind*>::begin()` (`CBindList::begin()`), reached from this hat path.

## Fix

```cpp
hat_lists = new CBindList[MAXHAT*4];
```

Allocate four binding lists (one per direction) for each of the `MAXHAT` hats. The base `CStickBindGroup` ctor performs the allocation, so the `CCH`/`CFCS`/`C4Axis` subclasses are covered too.

## Testing / reproduction

- Reproduced on Windows 11 25H2 with a VKBSim Gunfighter MCG Ultimate (reports 2 hats); DOSBox-X's own log prints `Using joystick ... with 7 axes, 128 buttons and 2 hat(s)` immediately before the crash.
- #5942 additionally reproduces with a Fanatec CSL DD and with vJoy configured for >1 hat switch.
- Workaround without the fix: `[joystick] joysticktype=none`.

Note: buttons are not involved — with the default `buttonwrap=true`, `button_cap` is clamped to 16, so high button counts stay in bounds; the overflow is specifically `hats >= 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)