### PR TITLE
Debugger: fix F11 (trace into next instruction) collision being swallowed by Windows Terminal

### DIFF
--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -4339,11 +4339,96 @@ int32_t DEBUG_Run(int32_t amount,bool quickexit) {
 	return ret;
 }
 
+#ifdef WIN32
+/* Translate VT escape sequences into ncurses KEY_* constants. Needed because
+   we set ENABLE_VIRTUAL_TERMINAL_INPUT on the debugger console input handle
+   (so the terminal host stops swallowing F11 etc. for fullscreen). With that
+   flag, function keys arrive as VT sequences (e.g. F11 = ESC [ 23 ~) instead of
+   virtual key codes, so ncurses' getch() returns them char by char and the
+   KEY_F(N) cases below never fire. */
+static int dbg_getch_vt(void) {
+	int c = getch();
+	if (c != 27) return c;
+
+	int c2 = getch();
+	if (c2 < 0) return 27; /* plain ESC */
+
+	if (c2 == 'O') {
+		/* SS3: ESC O X */
+		int c3 = getch();
+		switch (c3) {
+			case 'P': return KEY_F(1);
+			case 'Q': return KEY_F(2);
+			case 'R': return KEY_F(3);
+			case 'S': return KEY_F(4);
+			case 'A': return KEY_UP;
+			case 'B': return KEY_DOWN;
+			case 'C': return KEY_RIGHT;
+			case 'D': return KEY_LEFT;
+			case 'H': return KEY_HOME;
+			case 'F': return KEY_END;
+		}
+		return 27;
+	}
+
+	if (c2 == '[') {
+		/* CSI: ESC [ [params] final */
+		int param = 0;
+		int c3 = getch();
+		while (c3 >= '0' && c3 <= '9') {
+			param = param * 10 + (c3 - '0');
+			c3 = getch();
+		}
+		if (c3 == '~') {
+			switch (param) {
+				case 1: return KEY_HOME;
+				case 2: return KEY_IC;
+				case 3: return KEY_DC;
+				case 4: return KEY_END;
+				case 5: return KEY_PPAGE;
+				case 6: return KEY_NPAGE;
+				case 11: return KEY_F(1);
+				case 12: return KEY_F(2);
+				case 13: return KEY_F(3);
+				case 14: return KEY_F(4);
+				case 15: return KEY_F(5);
+				case 17: return KEY_F(6);
+				case 18: return KEY_F(7);
+				case 19: return KEY_F(8);
+				case 20: return KEY_F(9);
+				case 21: return KEY_F(10);
+				case 23: return KEY_F(11);
+				case 24: return KEY_F(12);
+			}
+		} else if (param == 0) {
+			switch (c3) {
+				case 'A': return KEY_UP;
+				case 'B': return KEY_DOWN;
+				case 'C': return KEY_RIGHT;
+				case 'D': return KEY_LEFT;
+				case 'H': return KEY_HOME;
+				case 'F': return KEY_END;
+			}
+		}
+		return 27;
+	}
+
+	/* Alt+letter or other ESC-prefixed sequence — push back so the existing
+	   case 27 handler below can read it as before. */
+	ungetch(c2);
+	return 27;
+}
+#endif
+
 uint32_t DEBUG_CheckKeys(void) {
 	Bits ret=0;
 	bool numberrun = false;
 	bool skipDraw = false;
+#ifdef WIN32
+	int key=dbg_getch_vt();
+#else
 	int key=getch();
+#endif
 
     if (key == KEY_RESIZE) {
 #ifdef WIN32 /* BUG: pdcurses notifies us immediately upon getting a resize event but does not update it's

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -624,7 +624,21 @@ void DBGUI_StartUp(void) {
 	scrollok(stdscr,false);
 	nodelay(dbg.win_main,true);
 	keypad(dbg.win_main,true);
-	#ifndef WIN32
+	#ifdef WIN32
+	/* After ncurses' initscr/cbreak/keypad have configured the console input mode,
+	   re-apply ENABLE_VIRTUAL_TERMINAL_INPUT so the terminal host (Windows Terminal,
+	   ConPTY, modern conhost) stops intercepting keys like F11 (fullscreen toggle)
+	   and forwards them to the application instead. */
+	#ifndef ENABLE_VIRTUAL_TERMINAL_INPUT
+	#define ENABLE_VIRTUAL_TERMINAL_INPUT 0x0200
+	#endif
+	{
+		HANDLE hIn = GetStdHandle(STD_INPUT_HANDLE);
+		DWORD dwInMode = 0;
+		if (GetConsoleMode(hIn, &dwInMode))
+			SetConsoleMode(hIn, dwInMode | ENABLE_VIRTUAL_TERMINAL_INPUT);
+	}
+	#else
 	touchwin(dbg.win_main);
 	#endif
 	old_cursor_state = curs_set(0);

--- a/src/debug/debug_win32.cpp
+++ b/src/debug/debug_win32.cpp
@@ -72,6 +72,9 @@ static void ResizeConsole( HANDLE hConsole, SHORT xSize, SHORT ySize ) {
 #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
 #define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
 #endif
+#ifndef ENABLE_VIRTUAL_TERMINAL_INPUT
+#define ENABLE_VIRTUAL_TERMINAL_INPUT 0x0200
+#endif
 void DEBUG_ShowMsg(char const* format,...);
 void WIN32_Console() {
 	AllocConsole();
@@ -79,6 +82,11 @@ void WIN32_Console() {
 	HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
 	DWORD dwMode = 0;
 	if (GetConsoleMode(hOut, &dwMode)) SetConsoleMode(hOut, dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+	/* Forward keys (F11 etc.) to the application instead of letting the terminal
+	   host (Windows Terminal) swallow them as its own shortcuts (F11 = fullscreen). */
+	HANDLE hIn = GetStdHandle(STD_INPUT_HANDLE);
+	DWORD dwInMode = 0;
+	if (GetConsoleMode(hIn, &dwInMode)) SetConsoleMode(hIn, dwInMode | ENABLE_VIRTUAL_TERMINAL_INPUT);
 	ResizeConsole(hOut,80,50);
 }
 #endif


### PR DESCRIPTION
This is an issue that has existed in DOSBox-X (Windows only) for years for people who want to debug programs and use the debugger. Here is the solution at last.

In the DOSBox-X debugger console on Windows, pressing F11 toggled Windows Terminal fullscreen instead of "trace into the next instruction". Windows Terminal grabs F11 as its own fullscreen accelerator; in a stock build the debugger's other special keys (arrows, PgUp/PgDn, F5/F9/F10, etc.) are unaffected. Original DOSBox does not have this problem.

Why DOSBox is not affected but DOSBox-X is
------------------------------------------
The difference is the curses input model, not any console-mode flag:

* DOSBox (Win32) links PDCurses, which reads the debugger console through the Win32 Console API (ReadConsoleInput -> KEY_EVENT_RECORD carrying VK_F11). Windows Terminal passes function keys straight through to the application as virtual-key events, so "trace into" works.

* DOSBox-X links GNU ncurses (ncursesw), which uses the terminfo/VT model: it treats the console as a VT terminal and reads keystrokes as an escape-sequence byte stream. Under Windows Terminal, WT handles its own accelerators (F11 = toggle fullscreen) before encoding/forwarding the keystroke, so F11 never reaches the application.

This was confirmed: a build whose WIN32_Console() was made byte-for-byte equivalent to DOSBox's (no SetConsoleMode at all) still sent F11 to Windows Terminal fullscreen, ruling out the output-handle flag ENABLE_VIRTUAL_TERMINAL_PROCESSING as the cause.

Fix (three coordinated changes, all Windows-only)
-------------------------------------------------
1. debug_win32.cpp (WIN32_Console): set ENABLE_VIRTUAL_TERMINAL_INPUT on STD_INPUT_HANDLE. This puts the console into win32-input-mode, in which Windows Terminal forwards every key (including F11) to the application as VT sequences instead of acting on them itself.

2. debug_gui.cpp (DBGUI_StartUp): re-apply ENABLE_VIRTUAL_TERMINAL_INPUT after curses' initscr/cbreak/keypad, which reset the input mode during init so the flag from step 1 alone does not survive.

3. debug.cpp: with VT input enabled, function keys arrive as VT escape sequences (F11 = ESC [ 23 ~, F1 = ESC O P, arrows = ESC [ A, etc.) rather than key codes, so getch() returns them byte by byte and the KEY_F(N) cases never fire. Add a dbg_getch_vt() wrapper that translates CSI/SS3 sequences back into KEY_F(N)/KEY_UP/... constants and use it instead of getch() in DEBUG_CheckKeys() on Windows. Non-CSI/SS3 ESC sequences (Alt+letter) are pushed back so the existing case-27 handler keeps working.

Maintenance note
----------------
dbg_getch_vt() only translates the VT sequences it currently knows about. If the debugger is later taught to react to additional special keys (more function keys, shifted/ctrl variants, Insert/Delete/Home/End/PgUp/PgDn, etc.), the matching CSI/SS3 sequence MUST also be added to the wrapper's tables. Reason: with ENABLE_VIRTUAL_TERMINAL_INPUT active, Windows Terminal delivers every special key as a VT escape sequence rather than as an ncurses KEY_* virtual code, so any key the translator does not decode arrives as raw escape bytes, matches no KEY_* case, and is silently dropped on Windows (it still works on non-Windows builds, which never go through the translator). In short, on Windows the set of keys the debugger can act on is bounded by what dbg_getch_vt() decodes.

Non-Windows builds are unchanged.