### PR TITLE
Remove output option stubs

### DIFF
--- a/dosbox-x.reference.conf
+++ b/dosbox-x.reference.conf
@@ -15,7 +15,7 @@
 #                      The window will be centered with "," (or empty), and will be in the original position with "-".
 #           display: Specify a screen/display number to use for a multi-screen setup (0 = default).
 #            output: What video system to use for output (surface = software (SDL_Surface); openglnb = OpenGL nearest; openglpp = OpenGL perfect; ttf = TrueType font output).
-#                      Possible values: default, surface, overlay, ttf, opengl, openglnb, openglhq, openglpp, ddraw.
+#                      Possible values: default, surface, ttf, opengl, openglnb, openglhq, openglpp.
 #       videodriver: Forces a video driver (e.g. windib/windows, directx, x11, fbcon, dummy, etc) for the SDL library to use.
 #      transparency: Set the transparency of the DOSBox-X screen (both windowed and full-screen modes, on SDL2 and Windows SDL1 builds).
 #                      The valid value is from 0 (no transparency, the default setting) to 90 (high transparency).

--- a/dosbox-x.reference.full.conf
+++ b/dosbox-x.reference.full.conf
@@ -15,7 +15,7 @@
 #                      The window will be centered with "," (or empty), and will be in the original position with "-".
 #           display: Specify a screen/display number to use for a multi-screen setup (0 = default).
 #            output: What video system to use for output (surface = software (SDL_Surface); openglnb = OpenGL nearest; openglpp = OpenGL perfect; ttf = TrueType font output).
-#                      Possible values: default, surface, overlay, ttf, opengl, openglnb, openglhq, openglpp, ddraw.
+#                      Possible values: default, surface, ttf, opengl, openglnb, openglhq, openglpp.
 #       videodriver: Forces a video driver (e.g. windib/windows, directx, x11, fbcon, dummy, etc) for the SDL library to use.
 #      transparency: Set the transparency of the DOSBox-X screen (both windowed and full-screen modes, on SDL2 and Windows SDL1 builds).
 #                      The valid value is from 0 (no transparency, the default setting) to 90 (high transparency).

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1576,7 +1576,10 @@ void DOSBOX_SetupConfigSections(void) {
         "opengl", "openglnb", "openglhq", "openglpp",
 #endif
 #if C_DIRECT3D
-        "direct3d", "direct3d11",
+        "direct3d",
+#if defined(C_SDL2)
+        "direct3d11",
+#endif
 #endif
 #if defined(MACOSX) && defined(C_SDL2) && C_METAL
         "metal",

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -6826,16 +6826,21 @@ void SDL_SetupConfigSection() {
     Pstring->SetBasic(true);
 
     const char* outputs[] = {
-        "default", "surface", "overlay", "ttf",
+        "default", "surface",
+#if defined(USE_TTF)
+        "ttf",
+#endif
 #if C_OPENGL
         "opengl", "openglnb", "openglhq", "openglpp",
 #endif
 #if C_GAMELINK
         "gamelink",
 #endif
-        "ddraw",
 #if C_DIRECT3D
-        "direct3d", "direct3d11",
+        "direct3d",
+#if defined(C_SDL2)
+        "direct3d11",
+#endif
 #endif
 #if defined(MACOSX) && defined(C_SDL2) && C_METAL
         "metal",


### PR DESCRIPTION
`output=ddraw` and `output=overlay` option have been ~deprecated~ removed long ago and is currently a stub, so remove those options to be selectable so as to not confuse users.

<img width="722" height="452" alt="image" src="https://github.com/user-attachments/assets/a3e789db-d5cf-4b42-a617-771e6cee6098" />