### PR TITLE
Use windows-2022 image for ARM64 build

### DIFF
--- a/.github/workflows/vsbuild64.yml
+++ b/.github/workflows/vsbuild64.yml
@@ -132,7 +132,7 @@ jobs:
       actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
       contents: write # for actions/checkout to fetch code and softprops/action-gh-release
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: windows-latest
+    runs-on: windows-2022
     defaults:
       run:
         shell: pwsh


### PR DESCRIPTION
The latest CI runner image is now under deployment and availability of VS build tool v143 is unstable, making building ARM64 builds fail.
This PR switches to windows-2022 image at the moment, where we can stably assume v143 to be available.

The problem is already reported to github CI runner devs, so that once it is solved, we will resume using latest runner.
https://github.com/actions/runner-images/issues/14215

