### PR TITLE
Show OSFREE in the title and help message to distinguish OSFREE builds

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1132,9 +1132,15 @@ void GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused) {
 //  if (timing != -1) internal_timing = timing;
 //  if (frameskip != -1) internal_frameskip = frameskip;
 
+#ifdef C_OSFREE
+    constexpr const char* dosbox_name = "DOSBox-X OSFREE";
+#else
+    constexpr const char* dosbox_name = "DOSBox-X";
+#endif
+
     bool showbasic = section->Get_bool("showbasic");
     if (showbasic) {
-        sprintf(title,"%s%sDOSBox-X %s", dosbox_title.c_str(),dosbox_title.empty()?"":" - ", VERSION);
+        sprintf(title, "%s%s%s %s", dosbox_title.c_str(), dosbox_title.empty() ? "" : " - ", dosbox_name, VERSION);
 
         const char *what = RunningProgram;
         if (what != NULL && *what != 0) {
@@ -1149,7 +1155,7 @@ void GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused) {
         else
             sprintf(p,"%d cycles/ms", (int)internal_cycles);
     } else
-        sprintf(title,"%s%sDOSBox-X", dosbox_title.c_str(),dosbox_title.empty()?"":" - ");
+        sprintf(title, "%s%s%s", dosbox_title.c_str(), dosbox_title.empty() ? "" : " - ", dosbox_name);
 
     if (!menu.hidecycles) {
         char *p = title + strlen(title); // append to end of string

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1191,7 +1191,7 @@ bool DOS_Shell::OSFreeOperatingSystemNotFound(void) {
 	} while(1);
 
 	WriteOut("\n");
-	WriteOut("This version was built without MS-DOS emulation.\n");
+	WriteOut("This is the OSFREE version, which was built without MS-DOS emulation.\n");
 	WriteOut("\n");
 	WriteOut("The full version may be unavailable for your use for legal reasons including\n");
 	WriteOut("but not limited to OS level age verification requirements in your local\n");


### PR DESCRIPTION
Add "OSFREE" to the title and help message to make OSFREE builds easier to distinguish from regular DOSBox-X builds.

<img width="722" height="452" alt="image" src="https://github.com/user-attachments/assets/b40e915e-60ca-4345-bb40-4da390e082a4" />

## What issue(s) does this PR address?
Fixes #6337
