### PR TITLE
Fix graphical printouts corrupted

### DIFF
--- a/src/hardware/parport/printer.cpp
+++ b/src/hardware/parport/printer.cpp
@@ -60,7 +60,7 @@ extern bool halfwidthkana, mouselocked;
 
 static CPrinter* defaultPrinter = NULL;
 
-#define PARAM16(I) (params[I+1]*256+params[I])
+#define PARAM16(I) ((uint16_t)(params[I+1] << 8) | params[I])
 #define PIXX ((Bitu)floor(curX*dpi+0.5))
 #define PIXY ((Bitu)floor(curY*dpi+0.5))
 

--- a/src/hardware/parport/printer.cpp
+++ b/src/hardware/parport/printer.cpp
@@ -77,7 +77,6 @@ static std::string actstd, acterr;
 
 void UpdateDefaultPrinterFont() {
     if (defaultPrinter!=NULL) {
-        defaultPrinter->curFont = NULL;
         defaultPrinter->updateFont();
     }
 }
@@ -1588,55 +1587,84 @@ void CPrinter::printChar(uint8_t ch, int box)
     }
 	FT_UInt index = FT_Get_Char_Index(curFont, printch);
 	
-	// Load the glyph 
-	FT_Load_Glyph(curFont, index, FT_LOAD_DEFAULT);
+    // Load and render the glyph.
+    FT_Error error;
 
-	// Render a high-quality bitmap
-	FT_Render_Glyph(curFont->glyph, FT_RENDER_MODE_NORMAL);
+    error = FT_Load_Glyph(curFont, index, FT_LOAD_DEFAULT);
+    if(error)
+        return;
 
-	uint16_t penX = (uint16_t)(PIXX + curFont->glyph->bitmap_left);
-	uint16_t penY = (uint16_t)(PIXY - curFont->glyph->bitmap_top + curFont->size->metrics.ascender / 64);
+    error = FT_Render_Glyph(curFont->glyph, FT_RENDER_MODE_NORMAL);
+    if(error)
+        return;
 
-	if (style & STYLE_SUBSCRIPT) penY += curFont->glyph->bitmap.rows / 2;
+    const FT_GlyphSlot slot = curFont->glyph;
 
-	// Copy bitmap into page
-	SDL_LockSurface(page);
+    // Calculate drawing position using the font metrics.
+    const uint16_t penX = static_cast<uint16_t>(
+        PIXX + slot->bitmap_left);
 
-	blitGlyph(curFont->glyph->bitmap, penX, penY, false);
-	blitGlyph(curFont->glyph->bitmap, penX+1, penY, true);
+    uint16_t penY = static_cast<uint16_t>(
+        PIXY -
+        slot->bitmap_top +
+        (curFont->size->metrics.ascender >> 6));
 
-	// Doublestrike => Print the glyph a second time one pixel below
-	if (style & STYLE_DOUBLESTRIKE)
+    if(style & STYLE_SUBSCRIPT)
+        penY += slot->bitmap.rows / 2;
+
+    // Copy bitmap into page.
+    SDL_LockSurface(page);
+
+    blitGlyph(slot->bitmap, penX, penY, false);
+    blitGlyph(slot->bitmap, penX + 1, penY, true);
+
+    // Double-strike.
+    if(style & STYLE_DOUBLESTRIKE)
     {
-		blitGlyph(curFont->glyph->bitmap, penX, penY+1, true);
-		blitGlyph(curFont->glyph->bitmap, penX+1, penY+1, true);
-	}
+        blitGlyph(slot->bitmap, penX, penY + 1, true);
+        blitGlyph(slot->bitmap, penX + 1, penY + 1, true);
+    }
 
-	// Bold => Print the glyph a second time one pixel to the right
-	// or be a bit more bold...
-	if (style & STYLE_BOLD)
+    // Bold.
+    if(style & STYLE_BOLD)
     {
-		blitGlyph(curFont->glyph->bitmap, penX+1, penY, true);
-		blitGlyph(curFont->glyph->bitmap, penX+2, penY, true);
-		blitGlyph(curFont->glyph->bitmap, penX+3, penY, true);
-	}
-	SDL_UnlockSurface(page);
+        blitGlyph(slot->bitmap, penX + 1, penY, true);
+        blitGlyph(slot->bitmap, penX + 2, penY, true);
+        blitGlyph(slot->bitmap, penX + 3, penY, true);
+    }
 
-	// For line printing
-	uint16_t lineStart = (uint16_t)PIXX;
+    SDL_UnlockSurface(page);
 
-	// advance the cursor to the right
-	double x_advance;
-	if ((style & STYLE_PROP) || dbcs)
-		x_advance = (double)((double)(curFont->glyph->advance.x) / (double)(dpi * 64));
-	else
+    // For line printing.
+    const uint16_t lineStart = static_cast<uint16_t>(PIXX);
+
+    // Advance the cursor.
+    double x_advance;
+
+    if(style & STYLE_PROP)
     {
-		if (hmi < 0)
-            x_advance = 1 / (double)actcpi;
-		else
-            x_advance = hmi;
-	}
-	x_advance += extraIntraSpace;
+        // Proportional printing uses the font advance.
+        x_advance = static_cast<double>(slot->advance.x) /
+            static_cast<double>(dpi * 64);
+    }
+    else
+    {
+        // Fixed-pitch printing uses the printer cell width.
+        if(hmi < 0)
+        {
+            x_advance = dbcs ?
+                (2.0 / static_cast<double>(actcpi)) :
+                (1.0 / static_cast<double>(actcpi));
+        }
+        else
+        {
+            x_advance = dbcs ?
+                (hmi * 2.0) :
+                hmi;
+        }
+    }
+
+    x_advance += extraIntraSpace;
     curX += x_advance;
 
 	// Draw lines if desired

--- a/src/hardware/parport/printer.cpp
+++ b/src/hardware/parport/printer.cpp
@@ -1000,7 +1000,7 @@ bool CPrinter::processCommandChar(uint8_t ch)
 		    case 0x53: // Select superscript/subscript printing (ESC S)
 			    if (params[0] == 0 || params[0] == 48)
 				    style |= STYLE_SUBSCRIPT;
-			    if (params[0] == 1 || params[1] == 49)
+			    if (params[0] == 1 || params[0] == 49)
 				    style |= STYLE_SUPERSCRIPT;
 			    updateFont();
 			    break;

--- a/src/hardware/parport/printer.cpp
+++ b/src/hardware/parport/printer.cpp
@@ -544,12 +544,29 @@ void CPrinter::updateFont()
 
 bool CPrinter::processCommandChar(uint8_t ch)
 {
-	if (ESCSeen || FSSeen)
+    if(ESCCmd == ESC_SKIP_VARIABLE && variableLength != 0)
+    {
+        ++variableCount;
+
+        if(variableCount < variableLength)
+            return true;
+
+        // End of variable-length command reached
+        ESCCmd = 0;
+        neededParam = 0;
+        numParam = 0;
+        variableLength = 0;
+        variableCount = 0;
+        return true;
+    }
+
+    if (ESCSeen || FSSeen)
 	{
 		ESCCmd = ch;
-		if(FSSeen) ESCCmd |= 0x800;
+		if(FSSeen) ESCCmd |= FS_COMMAND;
 		ESCSeen = FSSeen = false;
 		numParam = 0;
+        neededParam = 0;
 
 		switch (ESCCmd) {
 		    case 0x02: // Undocumented
@@ -666,7 +683,7 @@ bool CPrinter::processCommandChar(uint8_t ch)
 			    return true;
 		    default:
 			    LOG_MSG("PRINTER: Unknown command %s (%02Xh) %c , unable to skip parameters.",
-				    (ESCCmd & 0x800)?"FS":"ESC",ESCCmd, ESCCmd);
+				    (ESCCmd & FS_COMMAND)?"FS":"ESC",ESCCmd, ESCCmd);
 			
 			    neededParam = 0;
 			    ESCCmd = 0;
@@ -680,7 +697,7 @@ bool CPrinter::processCommandChar(uint8_t ch)
 	// Two bytes sequence
 	if (ESCCmd == '(')
 	{
-		ESCCmd = 0x200 + ch;
+		ESCCmd = ESC_PAREN_COMMAND | ch;
 
 		switch (ESCCmd)
 		{
@@ -709,7 +726,7 @@ bool CPrinter::processCommandChar(uint8_t ch)
 			    //LOG(LOG_MISC,LOG_ERROR)
 				    LOG_MSG("PRINTER: Skipping unsupported command ESC ( %c (%02X).", ESCCmd, ESCCmd);
 			    neededParam = 2;
-			    ESCCmd = 0x101;
+			    ESCCmd = ESC_SKIP_VARIABLE;
 			    return true;
 		}
 
@@ -1131,10 +1148,12 @@ bool CPrinter::processCommandChar(uint8_t ch)
 			    bottomMargin = pageHeight;
 			    topMargin = 0.0;
 			    break;
-		    case 0x101: // Skip unsupported ESC ( command
+            /**
+            case 0x101: // Skip unsupported ESC ( command
 			    neededParam = PARAM16(0);
 			    numParam = 0;
 			    break;
+            */
 		    case 0x274: // Assign character table (ESC (t)
 			    if (params[2] < 4 && params[3] < 15)
 			    {
@@ -1161,9 +1180,12 @@ bool CPrinter::processCommandChar(uint8_t ch)
 		    case 0x242: // Bar code setup and print (ESC (B)
 			    LOG(LOG_MISC,LOG_ERROR)("PRINTER: Bardcode printing not supported");
 			    // Find out how many bytes to skip
-			    neededParam = PARAM16(0);
-			    numParam = 0;
-			    break;
+                variableLength = PARAM16(0);
+                variableCount = 0;
+                neededParam = 0;
+                numParam = 0;
+                ESCCmd = ESC_SKIP_VARIABLE;
+                return true; // Force exit immediately to engage the variable parser state machine loop cleanly
 		    case 0x243: // Set page length in defined unit (ESC (C)
 			    if (params[0] != 0 && definedUnit > 0)
 			    {

--- a/src/hardware/parport/printer.cpp
+++ b/src/hardware/parport/printer.cpp
@@ -1414,6 +1414,13 @@ void CPrinter::printChar(uint8_t ch, int box)
     bool dbcs=false;
     uint8_t ll = 0;
     uint16_t dbchar = 0;
+
+    // Are we currently printing a bit graphic?
+    if(bitGraph.remBytes > 0) {
+        printBitGraph(ch);
+        return;
+    }
+
     if ((printdbcs==1 || (printdbcs==-1 && (isJEGAEnabled() || IS_DOSV || ((TTF_using() || showdbcs)
 #if defined(USE_TTF)
     && dbcs_sbcs
@@ -1555,12 +1562,6 @@ void CPrinter::printChar(uint8_t ch, int box)
 	if (msb != 255) {
 		if (msb == 0) ch &= 0x7F;
 		if (msb == 1) ch |= 0x80;
-	}
-
-	// Are we currently printing a bit graphic?
-	if (bitGraph.remBytes > 0) {
-		printBitGraph(ch);
-		return;
 	}
 
 	// Print everything?

--- a/src/hardware/parport/printer.h
+++ b/src/hardware/parport/printer.h
@@ -84,6 +84,11 @@ enum Typeface
 	svjittra = 31
 };
 
+constexpr uint16_t FS_COMMAND = 0x800;
+constexpr uint16_t ESC_PAREN_COMMAND = 0x200;
+constexpr uint16_t ESC_SKIP_VARIABLE = 0x101;
+constexpr uint16_t ESC_BARCODE_DATA = 0x102;
+
 class CPrinter {
 public:
 
@@ -182,7 +187,9 @@ private:
 	uint8_t numParam = 0, neededParam = 0;		// Numbers of parameters already read/needed to process command
 
     uint8_t params[20] = {};					// Buffer for the read params
-	uint16_t style = 0;						// Style of font (see STYLE_* constants)
+    uint16_t variableLength = 0;                // Length of variable command
+    uint16_t variableCount = 0;                 // Bytes of variable command read
+    uint16_t style = 0;						// Style of font (see STYLE_* constants)
 	double cpi = 0, actcpi = 0;					// CPI value set by program and the actual one (taking in account font types)
 	uint8_t score = 0;						// Score for lines (see SCORE_* constants)
 


### PR DESCRIPTION
Fixed graphical data not to be handled as printing command or text characters. 

Figure below is a printout test using JWCAD. 

<img width="3060" height="3960" alt="page6" src="https://github.com/user-attachments/assets/42a6791a-bf2e-4ca6-99b3-36d38b8f44ed" />