### PR TITLE
CMOS: fix INT 1Ah RTC "wait for the second to change" hang at the source (still fixes #4502 and now also #6299)

### DIFF
--- a/src/hardware/cmos.cpp
+++ b/src/hardware/cmos.cpp
@@ -305,12 +305,25 @@ static void cmos_writereg(Bitu port,Bitu val,Bitu iolen) {
             break;
         case 0x0b:      /* Status reg B */
             {
+                const uint8_t oldval = cmos.regs[cmos.reg];
                 cmos.ampm = !(val & 0x02);
                 cmos.bcd = !(val & 0x04);
                 cmos.lock = (val & 0x80) != 0;
                 if (cmos.lock) val &= ~0x10; /* Setting bit 7 clears bit 4 (UEI) */
                 cmos.regs[cmos.reg] = (uint8_t)val;
-                cmos_checktimer();
+                /* Only re-arm the periodic RTC event if a bit that affects its
+                 * scheduling actually changed: PIE (bit6, 0x40) or UIE (bit4,
+                 * 0x10). Otherwise a guest that writes reg B in a tight loop --
+                 * e.g. the BIOS INT 1A/02 handler's InitRtc() while a program
+                 * polls "wait until the RTC second changes" -- would call
+                 * cmos_checktimer() (PIC_RemoveEvents + re-AddEvent) faster than
+                 * the ~1ms periodic event can fire, perpetually pushing it into
+                 * the future and FREEZING the clock (UFO: Enemy Unknown intro).
+                 * The always-on 1-second tick is started at reset by the reg A
+                 * write and self-reschedules, so leaving the event alone here
+                 * keeps it running. */
+                if (((oldval ^ (uint8_t)val) & 0x50u) != 0u)
+                    cmos_checktimer();
             }
             break;
         case 0x0c:      /* Status reg C */

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -3099,10 +3099,6 @@ static Bitu INT1A_Handler(void) {
             reg_cl = ReadCmosByte(0x02);    // minutes
             reg_dh = ReadCmosByte(0x00);    // seconds
             reg_dl = ReadCmosByte(0x0b) & 0x01; // daylight saving time
-	    /* 2023/10/06 - Let interrupts and CPU cycles catch up and the RTC clock a chance to tick. This is needed for
-	     * "Pizza Tycoon" which appears to start by running in a loop reading time from the BIOS and writing
-	     * time to INT 21h in a loop until the second value changes. */
-            for (unsigned int c=0;c < 4;c++) CALLBACK_Idle();
         }
         CALLBACK_SCF(false);
         break;
@@ -3114,10 +3110,6 @@ static Bitu INT1A_Handler(void) {
             WriteCmosByte(0x02, reg_cl);        // minutes
             WriteCmosByte(0x00, reg_dh);        // seconds
             WriteCmosByte(0x0b, (ReadCmosByte(0x0b) & 0x7eu) | (reg_dh & 0x01u)); // dst + implicitly allow updates
-	    /* 2023/10/06 - Let interrupts and CPU cycles catch up and the RTC clock a chance to tick. This is needed for
-	     * "Pizza Tycoon" which appears to start by running in a loop reading time from the BIOS and writing
-	     * time to INT 21h in a loop until the second value changes. */
-            for (unsigned int c=0;c < 4;c++) CALLBACK_Idle();
         }
         break;
     case 0x04:  /* GET REAL-TIME ClOCK DATE  (AT,XT286,PS) */
@@ -3127,10 +3119,6 @@ static Bitu INT1A_Handler(void) {
             reg_cl = ReadCmosByte(0x09);    // year
             reg_dh = ReadCmosByte(0x08);    // month
             reg_dl = ReadCmosByte(0x07);    // day
-	    /* 2023/10/06 - Let interrupts and CPU cycles catch up and the RTC clock a chance to tick. This is needed for
-	     * "Pizza Tycoon" which appears to start by running in a loop reading time from the BIOS and writing
-	     * time to INT 21h in a loop until the second value changes. */
-            for (unsigned int c=0;c < 4;c++) CALLBACK_Idle();
         }
         CALLBACK_SCF(false);
         break;
@@ -3143,10 +3131,6 @@ static Bitu INT1A_Handler(void) {
             WriteCmosByte(0x08, reg_dh);    // month
             WriteCmosByte(0x07, reg_dl);    // day
             WriteCmosByte(0x0b, (ReadCmosByte(0x0b) & 0x7f));   // allow updates
-	    /* 2023/10/06 - Let interrupts and CPU cycles catch up and the RTC clock a chance to tick. This is needed for
-	     * "Pizza Tycoon" which appears to start by running in a loop reading time from the BIOS and writing
-	     * time to INT 21h in a loop until the second value changes. */
-            for (unsigned int c=0;c < 4;c++) CALLBACK_Idle();
         }
         break;
     case 0x80:  /* Pcjr Setup Sound Multiplexer */


### PR DESCRIPTION
A program that reads the RTC time via INT 1Ah AH=02h in a tight "wait until the seconds value changes" loop could hang forever: the RTC time-of-day stopped advancing for as long as the loop ran, so the seconds value never changed and the loop never exited.

Tested: still resolves issue #4502 (Pizza Tycoon) and now also issue #6299 (UFO: Enemy Unknown) -- both boot past the time-poll loop with this change and the CALLBACK_Idle() calls gone.

Root cause
----------
The INT 1Ah date/time handlers call InitRtc(), which writes CMOS status register B on every call. cmos_writereg()'s case 0x0B then unconditionally called cmos_checktimer(), which does PIC_RemoveEvents(cmos_timerevent) followed by PIC_AddEvent(...). When the guest polls faster than the periodic RTC event (regA=0x26 => 0.9766 ms), the event is removed and rescheduled on every poll before it can ever fire, so cmos_tick() never runs and cmos.clock.sec is frozen. INT 1Ah/02h keeps returning the same seconds value and the guest spins forever.

Fix
---
In cmos_writereg() case 0x0B, only re-arm the periodic event when a bit that actually affects its scheduling changes -- PIE (bit 6) or UIE (bit 4). InitRtc() only touches the SET/24h/DSE bits, so it no longer disturbs the running tick. The always-on 1-second tick is started at reset by the reg A write and self-reschedules, so leaving the event alone here keeps it ticking no matter how fast the guest polls.

Why this replaces the earlier CALLBACK_Idle() workaround
--------------------------------------------------------
A per-title workaround had been added to the INT 1Ah handlers for Pizza Tycoon (commit 54e564692, issue #4502): four CALLBACK_Idle() calls per INT 1Ah time call. That did not fix the bug -- it only masked the symptom by advancing emulated time inside the handler, hoping the starved RTC event would sneak a tick in before the next poll removed it again. Whether it won that race depended on per-call timing, so it happened to cover Pizza Tycoon (real mode) but NOT UFO: Enemy Unknown (issue #6299), whose intro polls INT 1Ah/02h from protected mode (DOS/4GW) and still hung on stock builds.

Removing the churn fixes the root cause for every fast poller regardless of CPU mode or polling rate, so the now-redundant CALLBACK_Idle() calls in the AH=02h/03h/04h/05h handlers are removed.