### PR TITLE
Fix segfault after unit testing

### DIFF
--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -917,7 +917,8 @@ bool DOS_CloseFile(uint16_t entry, bool fcb, uint8_t * refcnt) {
 		return Network_CloseFile(entry);
 # endif
 #endif
-	if (!Files[handle]) {
+
+    if ((Files && !Files[handle]) || !Files) {
 		DOS_SetError(DOSERR_INVALID_HANDLE);
 		return false;
 	}

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -330,9 +330,9 @@ DOS_Shell::~DOS_Shell() {
 	/* shell termination is not handled like a normal program.
 	 * memory allocated by the shell is not automatically freed on termination.
 	 * files are not automatically closed */
-	if (free_your_own_psp && psp->GetSegment()) {
+	if (free_your_own_psp && psp && psp->GetSegment()) {
 		DOS_FreeProcessMemory(psp->GetSegment());
-
+        free_your_own_psp = false;
 		/* NTS: DOS_PSP would ideally allow JFT handle operations regardless of whatever the
 		 *      current PSP segment is, but that's not how the code is written */
 		const uint16_t o_psp = dos.psp();


### PR DESCRIPTION
Fix possible segfaults after unit testing, which occurs in DOS_CloseFile(). (`dosbox-x -tests`)
However, I haven't understood the code enough, so please feel free to reject this and make a more appropriate fix.

<img width="587" height="648" alt="image" src="https://github.com/user-attachments/assets/3567f6aa-be81-4548-9b42-98d4d45fb95a" />

