### PR TITLE
Guess BPB values if floppy image has an invalid bootsector

### DIFF
--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -37,6 +37,7 @@ struct diskGeo {
 	uint16_t rootentries;  /* Root directory entries */
 	uint8_t sectcluster;   /* Sectors per cluster */
 	uint8_t mediaid;       /* Media ID */
+    uint8_t fatsz;         /* FAT size in sectors */
 };
 extern diskGeo DiskGeometryList[];
 

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -72,6 +72,8 @@ extern bool int13_enable_48bitLBA;
 std::string formatString(const char* format, ...);
 #endif
 
+extern diskGeo DiskGeometryList[];
+
 char* removeTrailingSpaces(char* str) {
 	char* end = str + strlen(str) - 1;
 	while (end >= str && *end == ' ') end--;
@@ -2162,9 +2164,32 @@ void fatDrive::fatDriveInit(const char *sysFilename, uint32_t bytesector, uint32
 		/* a clue that we're not really looking at FAT is invalid or weird values in the boot sector */
 		if (BPB.v.BPB_SecPerTrk == 0 || (BPB.v.BPB_SecPerTrk > ((filesize <= 3000) ? 40 : 255)) ||
 				(BPB.v.BPB_NumHeads > ((filesize <= 3000) ? 64 : 255))) {
-			LOG_MSG("Rejecting image, boot sector has weird values not consistent with FAT filesystem");
-			created_successfully = false;
-			return;
+            int i = 0;
+            if(!is_hdd) {
+                while(DiskGeometryList[i].ksize != 0) {
+                    if(DiskGeometryList[i].ksize == loadedDisk->diskSizeK) break;
+                    i++;
+                }
+                if(DiskGeometryList[i].ksize != 0) {
+                    LOG_MSG("Values in boot sector in the floppy image are not consistent with FAT filesystem. Setting typical value instead.");
+                    BPB.v.BPB_BytsPerSec = bytesector;
+                    BPB.v.BPB_SecPerClus = DiskGeometryList[i].sectcluster;
+                    BPB.v.BPB_RsvdSecCnt = 1;
+                    BPB.v.BPB_NumFATs = 2;
+                    BPB.v.BPB_SecPerTrk = cylsector;
+                    BPB.v.BPB_NumHeads = headscyl;
+                    BPB.v.BPB_RootEntCnt = DiskGeometryList[i].rootentries;
+                    BPB.v.BPB_TotSec16 = static_cast<uint16_t>(
+                        DiskGeometryList[i].ksize * 1024 / bytesector);
+                    BPB.v.BPB_Media = DiskGeometryList[i].mediaid;
+                    BPB.v.BPB_FATSz16 = DiskGeometryList[i].fatsz;
+                }
+            }
+            if(is_hdd || (!is_hdd && DiskGeometryList[i].ksize == 0)) {
+                LOG_MSG("Rejecting image, boot sector has weird values not consistent with FAT filesystem");
+                created_successfully = false;
+                return;
+            }
 		}
 	}
 

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -1106,22 +1106,23 @@ bool saveDiskImage(imageDisk *image, const char *name) {
 }
 
 diskGeo DiskGeometryList[] = {
-    { 160,  8, 1, 40, 0, 512,  64, 1, 0xFE},      // IBM PC double density 5.25" single-sided 160KB
-    { 180,  9, 1, 40, 0, 512,  64, 1, 0xFC},      // IBM PC double density 5.25" single-sided 180KB
-    { 200, 10, 1, 40, 0, 512,  64, 2, 0xFC},      // DEC Rainbow double density 5.25" single-sided 200KB (I think...)
-    { 320,  8, 2, 40, 1, 512, 112, 2, 0xFF},      // IBM PC double density 5.25" double-sided 320KB
-    { 360,  9, 2, 40, 1, 512, 112, 2, 0xFD},      // IBM PC double density 5.25" double-sided 360KB
-    { 400, 10, 2, 40, 1, 512, 112, 2, 0xFD},      // DEC Rainbow double density 5.25" double-sided 400KB (I think...)
-    { 640,  8, 2, 80, 3, 512, 112, 2, 0xFB},      // IBM PC double density 3.5" double-sided 640KB
-    { 720,  9, 2, 80, 3, 512, 112, 2, 0xF9},      // IBM PC double density 3.5" double-sided 720KB
-    {1200, 15, 2, 80, 2, 512, 224, 1, 0xF9},      // IBM PC double density 5.25" double-sided 1.2MB
-    {1440, 18, 2, 80, 4, 512, 224, 1, 0xF0},      // IBM PC high density 3.5" double-sided 1.44MB
-    {1680, 21, 2, 80, 4, 512,  16, 4, 0xF0},      // IBM PC high density 3.5" double-sided 1.68MB (DMF)
-    {2880, 36, 2, 80, 6, 512, 240, 2, 0xF0},      // IBM PC high density 3.5" double-sided 2.88MB
+    /* KB   S  H  C type SS  root clus ID  fatsz */
+    { 160,  8, 1, 40, 0, 512,  64, 1, 0xFE, 1},      // IBM PC double density 5.25" single-sided 160KB
+    { 180,  9, 1, 40, 0, 512,  64, 1, 0xFC, 2},      // IBM PC double density 5.25" single-sided 180KB
+    { 200, 10, 1, 40, 0, 512,  64, 2, 0xFC, 2},      // DEC Rainbow double density 5.25" single-sided 200KB (I think...)
+    { 320,  8, 2, 40, 1, 512, 112, 2, 0xFF, 1},      // IBM PC double density 5.25" double-sided 320KB
+    { 360,  9, 2, 40, 1, 512, 112, 2, 0xFD, 2},      // IBM PC double density 5.25" double-sided 360KB
+    { 400, 10, 2, 40, 1, 512, 112, 2, 0xFD, 2},      // DEC Rainbow double density 5.25" double-sided 400KB (I think...)
+    { 640,  8, 2, 80, 3, 512, 112, 2, 0xFB, 2},      // IBM PC double density 3.5" double-sided 640KB
+    { 720,  9, 2, 80, 3, 512, 112, 2, 0xF9, 3},      // IBM PC double density 3.5" double-sided 720KB
+    {1200, 15, 2, 80, 2, 512, 224, 1, 0xF9, 7},      // IBM PC double density 5.25" double-sided 1.2MB
+    {1440, 18, 2, 80, 4, 512, 224, 1, 0xF0, 9},      // IBM PC high density 3.5" double-sided 1.44MB
+    {1680, 21, 2, 80, 4, 512,  16, 4, 0xF0, 3},      // IBM PC high density 3.5" double-sided 1.68MB (DMF)
+    {2880, 36, 2, 80, 6, 512, 240, 2, 0xF0, 9},      // IBM PC high density 3.5" double-sided 2.88MB
 
-    {1232,  8, 2, 77, 7, 1024,192, 1, 0xFE},      // NEC PC-98 high density 3.5" double-sided 1.2MB "3-mode"
-    {1520, 19, 2, 80, 2, 512, 224, 1, 0xF9},      // IBM PC high density 5.25" double-sided 1.52MB (XDF)
-    {1840, 23, 2, 80, 4, 512, 224, 1, 0xF0},      // IBM PC high density 3.5" double-sided 1.84MB (XDF)
+    {1232,  8, 2, 77, 7, 1024,192, 1, 0xFE, 2},      // NEC PC-98 high density 3.5" double-sided 1.2MB "3-mode"
+    {1520, 19, 2, 80, 2, 512, 224, 1, 0xF9, 10},      // IBM PC high density 5.25" double-sided 1.52MB (XDF)
+    {1840, 23, 2, 80, 4, 512, 224, 1, 0xF0, 12},      // IBM PC high density 3.5" double-sided 1.84MB (XDF)
 
     {   0,  0, 0,  0, 0,    0,  0, 0,    0}
 };


### PR DESCRIPTION
Some games requires to mount images incompatible with FAT structure.
This PR enables mounting such images instead of rejecting it, provided that the image size is a valid existing floppy size listed in DiskGeometryList[].

## What issue(s) does this PR address?
Fixes #6378
