### PR TITLE
Fix missing definition of 'htonl' and 'htons' on Windows

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -10262,8 +10262,10 @@ void Add_VFiles(bool usecp) {
 # endif
 	if (addne2k) {
 		VFILE_RegisterBuiltinFileBlob(bfb_NE2000_COM, "/SYSTEM/");
-		PROGRAMS_MakeFile("ETHNET.COM",ETHNET_ProgramStart,"/SYSTEM/");
-	}
+#if defined(C_SDL_NET) || defined(C_SDL2_NET)
+        PROGRAMS_MakeFile("ETHNET.COM",ETHNET_ProgramStart,"/SYSTEM/");
+#endif
+    }
 	if (addovl) VFILE_RegisterBuiltinFileBlob(bfb_GLIDE2X_OVL, "/SYSTEM/");
 #endif
 

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -8083,7 +8083,9 @@ void SERIAL_ProgramStart(Program * * make);
 void CONFIG_ProgramStart(Program * * make);
 #endif
 void IPXNET_ProgramStart(Program * * make);
+#if (defined(C_SDL_NET) || defined(C_SDL2_NET))
 void ETHNET_ProgramStart(Program * * make);
+#endif
 void A20GATE_ProgramStart(Program * * make);
 void CGASNOW_ProgramStart(Program * * make);
 void PARALLEL_ProgramStart(Program * * make);

--- a/src/misc/ethernet.cpp
+++ b/src/misc/ethernet.cpp
@@ -38,8 +38,10 @@ EthernetConnection* OpenEthernetConnection(std::string backendstr)
         backend = "slirp";
 #elif defined(C_PCAP)
         backend = "pcap";
-#else
+#elif defined(C_SDL_NET) || defined(C_SDL2_NET)
         backend = "ethnet";
+#else
+        backend = "none";
 #endif
     } else {
         backend = backendstr;

--- a/src/misc/ethernet.cpp
+++ b/src/misc/ethernet.cpp
@@ -62,6 +62,7 @@ EthernetConnection* OpenEthernetConnection(std::string backendstr)
         if (!conn->Initialize(settings)) { delete conn; conn = NULL; }
     }
 #endif
+#if defined(C_SDL_NET) || defined(C_SDL2_NET)
     if (backendstr == "auto" && !conn) backend = "ethnet";
     if (backend == "ethnet") {
         assert(conn == NULL);
@@ -69,7 +70,7 @@ EthernetConnection* OpenEthernetConnection(std::string backendstr)
         settings = control->GetSection("ethernet, pcap");//NTS: The ethnet uses no settings, but there is an assert below to ensure settings != NULL
         if (!conn->Initialize(settings)) { delete conn; conn = NULL; }
     }
-
+#endif
     if (backendstr == "auto" && !conn) backend = "nothing";
     if (backend == "nothing") {
         assert(conn == NULL);

--- a/src/misc/ethernet_ethnet.cpp
+++ b/src/misc/ethernet_ethnet.cpp
@@ -19,6 +19,12 @@
 #include "config.h"
 
 #if defined(C_SDL_NET) || defined(C_SDL2_NET)
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#endif
 #include "ethernet_ethnet.h"
 #include "dosbox.h"
 #include "logging.h"


### PR DESCRIPTION
This PR fixes the build failure on Windows due to missing definition of 'htonl' and 'htons'.

Fixes #6398
Fixes #6399