### PR TITLE
DOS MCB Refactor

### DIFF
--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -459,7 +459,7 @@ static INLINE uint16_t DOS_PackDate(uint16_t year,uint16_t mon,uint16_t day) {
 
 class MemStruct {
 public:
-    inline uint32_t GetIt(const uint32_t size, const PhysPt addr) {
+    inline uint32_t GetIt(const uint32_t size, const PhysPt addr) const {
 		switch (size) {
 		case 1:return mem_readb(pt+addr);
 		case 2:return mem_readw(pt+addr);
@@ -769,37 +769,7 @@ private:
 	#endif
 };
 
-class DOS_MCB : public MemStruct{
-public:
-	DOS_MCB(uint16_t seg) { SetPt(seg); }
-	void SetFileName(const char * const _name) { MEM_BlockWrite(pt+offsetof(sMCB,filename),_name,8); }
-	void GetFileName(char * const _name) { MEM_BlockRead(pt+offsetof(sMCB,filename),_name,8);_name[8]=0;}
-	void SetType(uint8_t _type) { sSave(sMCB,type,_type);}
-	void SetSize(uint16_t _size) { sSave(sMCB,size,_size);}
-	void SetPSPSeg(uint16_t _pspseg) { sSave(sMCB,psp_segment,_pspseg);}
-	uint8_t GetType(void) { return (uint8_t)sGet(sMCB,type);}
-	uint16_t GetSize(void) { return (uint16_t)sGet(sMCB,size);}
-	uint16_t GetPSPSeg(void) { return (uint16_t)sGet(sMCB,psp_segment);}
-	enum class MCBType : uint8_t
-	{
-		ValidBlock = 'M',
-		LastBlock = 'Z'
-	};
-private:
-	#ifdef _MSC_VER
-	#pragma pack (1)
-	#endif
-	struct sMCB {
-		uint8_t type;
-		uint16_t psp_segment;
-		uint16_t size;	
-		uint8_t unused[3];
-		uint8_t filename[8];
-	} GCC_ATTRIBUTE(packed);
-	#ifdef _MSC_VER
-	#pragma pack ()
-	#endif
-};
+#include "dos_mcb.h"
 
 class DOS_SDA : public MemStruct {
 public:

--- a/include/dos_inc.h
+++ b/include/dos_inc.h
@@ -26,6 +26,7 @@
 
 #include <list>
 #include <stddef.h> //for offsetof
+#include <string>
 
  /* Macros SSET_* and SGET_* are used to safely access fields in memory-mapped
   * DOS structures represented via classes inheriting from MemStruct class.
@@ -81,6 +82,7 @@ struct CommandTail{
 #endif
 
 extern bool dos_kernel_disabled;
+extern std::string RunningProgram;
 
 #if !defined(OSFREE)
 #define IS_DOS_JAPANESE (!dos_kernel_disabled && mem_readb(Real2Phys(dos.tables.dbcs) + 0x02) == 0x81 && mem_readb(Real2Phys(dos.tables.dbcs) + 0x03) == 0x9F)

--- a/include/dos_mcb.h
+++ b/include/dos_mcb.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <algorithm>
 #include <array>
+#include <cstring>
 #include <cstdint>
+#include <string>
 
 #include "dos_inc.h"
 
@@ -17,45 +20,49 @@ public:
 	DOS_MCB(uint16_t seg) { SetPt(seg); }
 
 	std::string GetFileName() const
-    {
-        std::array<char, 9> namebuf = {};
-        MEM_BlockRead(pt+offsetof(sMCB,filename), namebuf.data(), 8);
-        return {namebuf.data()};
-    }
+	{
+		std::array<char, 9> namebuf = {};
+		MEM_BlockRead(pt+offsetof(sMCB,filename), namebuf.data(), 8);
+		return {namebuf.data()};
+	}
 	uint16_t GetPSPSeg() const { return sGet(sMCB, psp_segment);}
-    uint16_t GetSeg() const { return pt>>4; }
+	uint16_t GetSeg() const { return pt>>4; }
 	uint16_t GetSize() const { return sGet(sMCB, size);}
 	MCBType GetType() const { return MCBType(sGet(sMCB, type));}
-    bool contains(uint16_t seg) const {
-        const uint32_t start = GetSeg();
-        const uint32_t end = start + GetSize();
-        return (seg > start) && (seg <= end);
-    }
-    bool contains(uint16_t seg, uint16_t off) const {
-        const PhysPt physaddr = PhysMake(seg, off);
-        const PhysPt start = pt + 16u;
-        const PhysPt end = pt + (PhysPt)((uint32_t(GetSize()) + 1u) << 4);
-        return (physaddr >= start) && (physaddr < end);
-    }
-    bool isLastMCB() const { return (GetType()==MCBType::LastBlock); }
-	bool isValid() const {
-        return (GetType()==MCBType::ValidBlock)||(GetType()==MCBType::LastBlock);
-    }
-	DOS_MCB nextMCB() const {
-	    const uint32_t nextseg = uint32_t(GetSeg()) + GetSize() + 1u;
-	    return DOS_MCB(nextseg <= 0xFFFFu ? static_cast<uint16_t>(nextseg) : 0);
+	bool contains(uint16_t seg) const {
+		const uint32_t start = GetSeg();
+		const uint32_t end = start + GetSize();
+		return (seg > start) && (seg <= end);
 	}
-    void SetFileName(const std::string& filename)
-    {
-        MEM_BlockWrite(
-            pt+offsetof(sMCB,filename), filename.c_str(), std::min((size_t)8, filename.size()+1)
-        );
-    }
+	bool contains(uint16_t seg, uint16_t off) const {
+		const PhysPt physaddr = PhysMake(seg, off);
+		const PhysPt start = pt + 16u;
+		const PhysPt end = pt + (PhysPt)((uint32_t(GetSize()) + 1u) << 4);
+		return (physaddr >= start) && (physaddr < end);
+	}
+	bool isLastMCB() const { return (GetType()==MCBType::LastBlock); }
+	bool isValid() const {
+		return (GetType()==MCBType::ValidBlock)||(GetType()==MCBType::LastBlock);
+	}
+	DOS_MCB nextMCB() const {
+		const uint32_t nextseg = uint32_t(GetSeg()) + GetSize() + 1u;
+		return DOS_MCB(nextseg <= 0xFFFFu ? static_cast<uint16_t>(nextseg) : 0);
+	}
+	void SetFileName(const char *filename)
+	{
+		std::array<char, 8> namebuf = {};
+		if (filename != nullptr) {
+			const auto len = (std::min)(std::strlen(filename), namebuf.size());
+			std::memcpy(namebuf.data(), filename, len);
+		}
+		MEM_BlockWrite(pt+offsetof(sMCB,filename), namebuf.data(), namebuf.size());
+	}
+	void SetFileName(const std::string& filename) { SetFileName(filename.c_str()); }
 	void SetPSPSeg(uint16_t pspseg) { sSave(sMCB, psp_segment, pspseg);}
 	void SetSize(uint16_t size) { sSave(sMCB, size, size);}
 	void SetType(MCBType type) { sSave(sMCB, type, (uint8_t)type);}
 
-    bool operator ==(const DOS_MCB& other) const { return pt == other.pt; }
+	bool operator ==(const DOS_MCB& other) const { return pt == other.pt; }
 
 private:
 	#ifdef _MSC_VER
@@ -73,29 +80,29 @@ private:
 	#endif
 
 public:
-    class Iterator {
-    public:
-        explicit Iterator(uint16_t seg) : seg(seg) {}
-        Iterator& operator++()
-        {
-            if (seg != 0) {
-                DOS_MCB cur(seg);
-                if (cur.isValid() && !cur.isLastMCB())
-                    seg = static_cast<uint16_t>(cur.GetSeg() + cur.GetSize() + 1);
-                else
-                    seg = 0;
-            }
-            return *this;
-        }
-        DOS_MCB operator*() const { return DOS_MCB(seg); }
-        bool operator==(const Iterator& o) const { return seg == o.seg; }
-        bool operator!=(const Iterator& o) const { return !(*this == o); }
-    private:
-        uint16_t seg; // 0 means end/invalid
-    };
+	class Iterator {
+	public:
+		explicit Iterator(uint16_t seg) : seg(seg) {}
+		Iterator& operator++()
+		{
+			if (seg != 0) {
+				DOS_MCB cur(seg);
+				if (cur.isValid() && !cur.isLastMCB())
+					seg = cur.nextMCB().GetSeg();
+				else
+					seg = 0;
+			}
+			return *this;
+		}
+		DOS_MCB operator*() const { return DOS_MCB(seg); }
+		bool operator==(const Iterator& o) const { return seg == o.seg; }
+		bool operator!=(const Iterator& o) const { return !(*this == o); }
+	private:
+		uint16_t seg; // 0 means end/invalid
+	};
 
-    Iterator begin() const { return Iterator(GetSeg()); }
-    Iterator end()   const { return Iterator(0); }
+	Iterator begin() const { return Iterator(GetSeg()); }
+	Iterator end()   const { return Iterator(0); }
 
     // class Iterator
     // {

--- a/include/dos_mcb.h
+++ b/include/dos_mcb.h
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#include "dos_inc.h"
+
+class DOS_MCB : public MemStruct
+{
+public:
+	enum class MCBType : uint8_t
+	{
+		ValidBlock = 'M',
+		LastBlock  = 'Z'
+	};
+
+	DOS_MCB(uint16_t seg) { SetPt(seg); }
+
+	std::string GetFileName() const
+    {
+        std::array<char, 9> namebuf = {};
+        MEM_BlockRead(pt+offsetof(sMCB,filename), namebuf.data(), 8);
+        return {namebuf.data()};
+    }
+	uint16_t GetPSPSeg() const { return sGet(sMCB, psp_segment);}
+    uint16_t GetSeg() const { return pt>>4; }
+	uint16_t GetSize() const { return sGet(sMCB, size);}
+	MCBType GetType() const { return MCBType(sGet(sMCB, type));}
+    bool contains(uint16_t seg) const {
+        const uint32_t start = GetSeg();
+        const uint32_t end = start + GetSize();
+        return (seg > start) && (seg <= end);
+    }
+    bool contains(uint16_t seg, uint16_t off) const {
+        const PhysPt physaddr = PhysMake(seg, off);
+        const PhysPt start = pt + 16u;
+        const PhysPt end = pt + (PhysPt)((uint32_t(GetSize()) + 1u) << 4);
+        return (physaddr >= start) && (physaddr < end);
+    }
+    bool isLastMCB() const { return (GetType()==MCBType::LastBlock); }
+	bool isValid() const {
+        return (GetType()==MCBType::ValidBlock)||(GetType()==MCBType::LastBlock);
+    }
+	DOS_MCB nextMCB() const {
+	    const uint32_t nextseg = uint32_t(GetSeg()) + GetSize() + 1u;
+	    return DOS_MCB(nextseg <= 0xFFFFu ? static_cast<uint16_t>(nextseg) : 0);
+	}
+    void SetFileName(const std::string& filename)
+    {
+        MEM_BlockWrite(
+            pt+offsetof(sMCB,filename), filename.c_str(), std::min((size_t)8, filename.size()+1)
+        );
+    }
+	void SetPSPSeg(uint16_t pspseg) { sSave(sMCB, psp_segment, pspseg);}
+	void SetSize(uint16_t size) { sSave(sMCB, size, size);}
+	void SetType(MCBType type) { sSave(sMCB, type, (uint8_t)type);}
+
+    bool operator ==(const DOS_MCB& other) const { return pt == other.pt; }
+
+private:
+	#ifdef _MSC_VER
+	#pragma pack (1)
+	#endif
+	struct sMCB {
+		uint8_t type;
+		uint16_t psp_segment;
+		uint16_t size;
+		uint8_t unused[3];
+		uint8_t filename[8];
+	} GCC_ATTRIBUTE(packed);
+	#ifdef _MSC_VER
+	#pragma pack ()
+	#endif
+
+public:
+    class Iterator {
+    public:
+        explicit Iterator(uint16_t seg) : seg(seg) {}
+        Iterator& operator++()
+        {
+            if (seg != 0) {
+                DOS_MCB cur(seg);
+                if (cur.isValid() && !cur.isLastMCB())
+                    seg = static_cast<uint16_t>(cur.GetSeg() + cur.GetSize() + 1);
+                else
+                    seg = 0;
+            }
+            return *this;
+        }
+        DOS_MCB operator*() const { return DOS_MCB(seg); }
+        bool operator==(const Iterator& o) const { return seg == o.seg; }
+        bool operator!=(const Iterator& o) const { return !(*this == o); }
+    private:
+        uint16_t seg; // 0 means end/invalid
+    };
+
+    Iterator begin() const { return Iterator(GetSeg()); }
+    Iterator end()   const { return Iterator(0); }
+
+    // class Iterator
+    // {
+    // public:
+    //     Iterator(const DOS_MCB& startMCB) : currentMCB(startMCB) {}
+    //     Iterator& operator++()
+    //     {
+    //         if (currentMCB.isValid() && !currentMCB.isLastMCB())
+    //             currentMCB = currentMCB.nextMCB();
+    //         else
+    //             currentMCB = DOS_MCB(0); // Invalidate iterator
+    //         return *this;
+    //     }
+    //     const DOS_MCB& operator*() const
+    //     {
+    //         return currentMCB;
+    //     }
+    //     bool operator==(const Iterator& other) const
+    //     {
+    //         return currentMCB == other.currentMCB;
+    //     }
+    // private:
+    //     DOS_MCB currentMCB;
+    // };
+
+    // Iterator begin() { return Iterator(*this); }
+    // const Iterator cbegin() { return Iterator(*this); }
+    // Iterator end() { return Iterator(DOS_MCB(0)); }
+    // const Iterator cend() { return Iterator(DOS_MCB(0)); }
+};

--- a/include/dos_mcb.h
+++ b/include/dos_mcb.h
@@ -103,33 +103,4 @@ public:
 
 	Iterator begin() const { return Iterator(GetSeg()); }
 	Iterator end()   const { return Iterator(0); }
-
-    // class Iterator
-    // {
-    // public:
-    //     Iterator(const DOS_MCB& startMCB) : currentMCB(startMCB) {}
-    //     Iterator& operator++()
-    //     {
-    //         if (currentMCB.isValid() && !currentMCB.isLastMCB())
-    //             currentMCB = currentMCB.nextMCB();
-    //         else
-    //             currentMCB = DOS_MCB(0); // Invalidate iterator
-    //         return *this;
-    //     }
-    //     const DOS_MCB& operator*() const
-    //     {
-    //         return currentMCB;
-    //     }
-    //     bool operator==(const Iterator& other) const
-    //     {
-    //         return currentMCB == other.currentMCB;
-    //     }
-    // private:
-    //     DOS_MCB currentMCB;
-    // };
-
-    // Iterator begin() { return Iterator(*this); }
-    // const Iterator cbegin() { return Iterator(*this); }
-    // Iterator end() { return Iterator(DOS_MCB(0)); }
-    // const Iterator cend() { return Iterator(DOS_MCB(0)); }
 };

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -5092,7 +5092,7 @@ static void LogDEVChain(uint32_t devhdr) {
 // Display the content of the MCB chain starting with the MCB at the specified segment.
 static void LogMCBChain(uint16_t mcb_segment) {
 	DOS_MCB mcb(mcb_segment);
-	char filename[9]; // 8 characters plus a terminating NUL
+	std::string filename;
 	const char *psp_seg_note;
 	uint16_t DOS_dataOfs = static_cast<uint16_t>(dataOfs); //Realmode addressing only
 	PhysPt dataAddr = PhysMake(dataSeg,DOS_dataOfs);// location being viewed in the "Data Overview"
@@ -5100,12 +5100,12 @@ static void LogMCBChain(uint16_t mcb_segment) {
 	// loop forever, breaking out of the loop once we've processed the last MCB
 	while (true) {
 		// verify that the type field is valid
-		if (mcb.GetType()!=0x4d && mcb.GetType()!=0x5a) {
+		if (!mcb.isValid()) {
 			DEBUG_ShowMsg("MCB chain broken at %04X:0000!",mcb_segment);
 			return;
 		}
 
-		mcb.GetFileName(filename);
+		filename = mcb.GetFileName();
 
 		// some PSP segment values have special meanings
 		switch (mcb.GetPSPSeg()) {
@@ -5119,7 +5119,7 @@ static void LogMCBChain(uint16_t mcb_segment) {
 				psp_seg_note = "";
 		}
 
-		DEBUG_ShowMsg("   %04X  %12u     %04X %-7s  %s",mcb_segment,mcb.GetSize() << 4,mcb.GetPSPSeg(), psp_seg_note, filename);
+		DEBUG_ShowMsg("   %04X  %12u     %04X %-7s  %s",mcb_segment,mcb.GetSize() << 4,mcb.GetPSPSeg(), psp_seg_note, filename.c_str());
 
 		// print a message if dataAddr is within this MCB's memory range
 		PhysPt mcbStartAddr = PhysMake(mcb_segment+1,0);
@@ -5130,7 +5130,7 @@ static void LogMCBChain(uint16_t mcb_segment) {
 
 		// if we've just processed the last MCB in the chain, break out of the loop
 		mcb_segment+=mcb.GetSize()+1;
-		if (mcb.GetType()==0x5a)
+		if (mcb.isLastMCB())
 			break;
 
 		// else, move to the next MCB in the chain
@@ -6229,5 +6229,3 @@ void DEBUG_StopLog(void) {
 
 
 #endif // DEBUG
-
-

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -5091,17 +5091,18 @@ static void LogDEVChain(uint32_t devhdr) {
 
 // Display the content of the MCB chain starting with the MCB at the specified segment.
 static void LogMCBChain(uint16_t mcb_segment) {
-	DOS_MCB mcb(mcb_segment);
 	std::string filename;
 	const char *psp_seg_note;
 	uint16_t DOS_dataOfs = static_cast<uint16_t>(dataOfs); //Realmode addressing only
 	PhysPt dataAddr = PhysMake(dataSeg,DOS_dataOfs);// location being viewed in the "Data Overview"
+	uint16_t end_of_chain_segment = mcb_segment;
 
-	// loop forever, breaking out of the loop once we've processed the last MCB
-	while (true) {
+	for (const auto mcb : DOS_MCB(mcb_segment)) {
+		const auto current_segment = mcb.GetSeg();
+
 		// verify that the type field is valid
 		if (!mcb.isValid()) {
-			DEBUG_ShowMsg("MCB chain broken at %04X:0000!",mcb_segment);
+			DEBUG_ShowMsg("MCB chain broken at %04X:0000!",current_segment);
 			return;
 		}
 
@@ -5119,25 +5120,18 @@ static void LogMCBChain(uint16_t mcb_segment) {
 				psp_seg_note = "";
 		}
 
-		DEBUG_ShowMsg("   %04X  %12u     %04X %-7s  %s",mcb_segment,mcb.GetSize() << 4,mcb.GetPSPSeg(), psp_seg_note, filename.c_str());
+		DEBUG_ShowMsg("   %04X  %12u     %04X %-7s  %s",current_segment,mcb.GetSize() << 4,mcb.GetPSPSeg(), psp_seg_note, filename.c_str());
 
 		// print a message if dataAddr is within this MCB's memory range
-		PhysPt mcbStartAddr = PhysMake(mcb_segment+1,0);
-		PhysPt mcbEndAddr = PhysMake(mcb_segment+1+mcb.GetSize(),0);
+		PhysPt mcbStartAddr = PhysMake(current_segment+1,0);
+		PhysPt mcbEndAddr = PhysMake(current_segment+1+mcb.GetSize(),0);
 		if (dataAddr >= mcbStartAddr && dataAddr < mcbEndAddr) {
 			DEBUG_ShowMsg("   (data addr %04hX:%04X is %u bytes past this MCB)",dataSeg,DOS_dataOfs,dataAddr - mcbStartAddr);
 		}
-
-		// if we've just processed the last MCB in the chain, break out of the loop
-		mcb_segment+=mcb.GetSize()+1;
-		if (mcb.isLastMCB())
-			break;
-
-		// else, move to the next MCB in the chain
-		mcb.SetPt(mcb_segment);
+		end_of_chain_segment = static_cast<uint16_t>(current_segment + mcb.GetSize() + 1);
 	}
 
-	DEBUG_ShowMsg("   %04X  END OF CHAIN",mcb_segment);
+	DEBUG_ShowMsg("   %04X  END OF CHAIN",end_of_chain_segment);
 }
 
 #include "regionalloctracking.h"

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -574,8 +574,6 @@ bool CDROM_Interface_Image::GetAudioTrackInfo(int track, TMSF& start, unsigned c
 	return true;
 }
 
-extern std::string RunningProgram;
-
 bool CDROM_Interface_Image::GetAudioSub(unsigned char& attr, unsigned char& track, unsigned char& index, TMSF& relPos, TMSF& absPos)
 {
 	int cur_track = GetTrack(player.currFrame);

--- a/src/dos/cdrom_image.cpp
+++ b/src/dos/cdrom_image.cpp
@@ -574,7 +574,7 @@ bool CDROM_Interface_Image::GetAudioTrackInfo(int track, TMSF& start, unsigned c
 	return true;
 }
 
-extern const char* RunningProgram;
+extern std::string RunningProgram;
 
 bool CDROM_Interface_Image::GetAudioSub(unsigned char& attr, unsigned char& track, unsigned char& index, TMSF& relPos, TMSF& absPos)
 {
@@ -585,7 +585,7 @@ bool CDROM_Interface_Image::GetAudioSub(unsigned char& attr, unsigned char& trac
 	index = 1;
 	FRAMES_TO_MSF(player.currFrame, &absPos.min, &absPos.sec, &absPos.fr);
 	FRAMES_TO_MSF(player.currFrame - tracks[track - 1].start, &relPos.min, &relPos.sec, &relPos.fr);
-	if(IS_PC98_ARCH && player.playbackRemaining == 0 && !strcmp(RunningProgram, "ITP")) {
+	if(IS_PC98_ARCH && player.playbackRemaining == 0 && RunningProgram == "ITP") {
 		// POLICENAUTS
 		// It freeze at the end of the Konami logo or opening.
 		// It seems that the end of CD-DA output is checked by the time and frame of the current track,

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -73,7 +73,6 @@ unsigned char exepack_handling = EXEPACK_UNPACK;
 static bool first_run=true;
 bool sync_time = false, manualtime = false;
 extern std::string log_dev_con_str;
-extern std::string RunningProgram;
 extern bool use_quick_reboot;
 #if !defined(OSFREE)
 extern bool j3100_start;

--- a/src/dos/dos.cpp
+++ b/src/dos/dos.cpp
@@ -73,7 +73,7 @@ unsigned char exepack_handling = EXEPACK_UNPACK;
 static bool first_run=true;
 bool sync_time = false, manualtime = false;
 extern std::string log_dev_con_str;
-extern const char* RunningProgram;
+extern std::string RunningProgram;
 extern bool use_quick_reboot;
 #if !defined(OSFREE)
 extern bool j3100_start;
@@ -1484,7 +1484,7 @@ static Bitu DOS_21Handler(void) {
         case 0x25:      /* Set Interrupt Vector */
             // Magical Girl Pretty Sammy
             // Patch sound driver bugs. Swap the order of "mov sp" and "mov ss".
-            if(IS_PC98_ARCH && reg_al == 0x60 && !strcmp(RunningProgram, "SNDCDDRV")
+            if(IS_PC98_ARCH && reg_al == 0x60 && RunningProgram == "SNDCDDRV"
               && real_readd(SegValue(ds), reg_dx + 47) == 0x0fa6268b && real_readd(SegValue(ds), reg_dx + 52) == 0x0fa4168e) {
                 real_writed(SegValue(ds), reg_dx + 47, 0x0fa4168e);
                 real_writed(SegValue(ds), reg_dx + 52, 0x0fa6268b);
@@ -2650,7 +2650,7 @@ static Bitu DOS_21Handler(void) {
 #endif
                 {
                     strcat(name1, "               ");									// Simply add 15 spaces
-                    if (!strcmp(RunningProgram, "4DOS") || (reg_ip == 0xeb31 && (reg_sp == 0xc25e || reg_sp == 0xc26e))) {	// 4DOS expects it to be 0 terminated (not documented)
+                    if (RunningProgram == "4DOS" || (reg_ip == 0xeb31 && (reg_sp == 0xc25e || reg_sp == 0xc26e))) {	// 4DOS expects it to be 0 terminated (not documented)
                         name1[16] = 0;
                         MEM_BlockWrite(SegPhys(ds)+reg_dx, name1, 17);
                     } else {
@@ -5068,7 +5068,7 @@ void DOS_EnableDriveMenu(char drv) {
 		}
 		name = std::string("drive_") + drv + "_saveimg";
 		mainMenu.get_item(name).enable(Drives[drv-'A'] != NULL && !dynamic_cast<fatDrive*>(Drives[drv-'A'])).refresh_item(mainMenu);
-		if (dos_kernel_disabled || !strcmp(RunningProgram, "LOADLIN")) {
+		if (dos_kernel_disabled || RunningProgram == "LOADLIN") {
 			bool found = false;
 			for (int i=0; i<MAX_DISK_IMAGES; i++)
 				if (imageDiskList[i] && imageDiskList[i]->ffdd && imageDiskList[i]->drvnum == drv-'A') {
@@ -5082,7 +5082,7 @@ void DOS_EnableDriveMenu(char drv) {
 
 void DOS_DoShutDown() {
 	if (test != NULL) {
-		if (strcmp(RunningProgram, "LOADLIN")) delete test;
+		if (RunningProgram != "LOADLIN") delete test;
 		test = NULL;
 	}
 

--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -51,7 +51,7 @@ Bitu XMS_GetEnabledA20(void);
 uint32_t RunningProgramHash[4] = {0,0,0,0};
 uint32_t RunningProgramLoadAddress = 0;
 
-const char * RunningProgram="DOSBOX-X";
+std::string RunningProgram="DOSBOX-X";
 
 #ifdef _MSC_VER
 #pragma pack(1)
@@ -96,12 +96,9 @@ extern uint8_t ZDRIVE_NUM;
 extern void GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused), menu_update_autocycle(void);
 void DOS_UpdatePSPName(void) {
 	DOS_MCB mcb(dos.psp()-1);
-	static char name[9];
-	mcb.GetFileName(name);
-	name[8] = 0;
-	if (!strlen(name)) strcpy(name,"DOSBOX-X");
-	for(Bitu i = 0;i < 8;i++) { //Don't put garbage in the title bar. Mac OS X doesn't like it
-		if (name[i] == 0) break;
+	std::string name = mcb.GetFileName();
+	if (name.empty()) name = "DOSBOX-X";
+	for(Bitu i = 0;i < 8 && i < name.size();i++) { //Don't put garbage in the title bar. Mac OS X doesn't like it
 		if ( !isprint(*reinterpret_cast<unsigned char*>(&name[i])) ) name[i] = '?';
 	}
 	RunningProgram = name;

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -752,10 +752,10 @@ bool DOS_FindFirst(const char * search,uint16_t attr,bool fcb_findfirst) {
 
 	// Silence CHKDSK "Invalid sub-directory entry"
 	if (fcb_findfirst && !strcmp(search+1, ":????????.???") && attr==30) {
-		char psp_name[9];
+		std::string psp_name;
 		DOS_MCB psp_mcb(dos.psp()-1);
-		psp_mcb.GetFileName(psp_name);
-		if (!strcmp(psp_name, "CHKDSK")) attr&=~DOS_ATTR_DIRECTORY;
+		psp_name = psp_mcb.GetFileName();
+		if (psp_name == "CHKDSK") attr&=~DOS_ATTR_DIRECTORY;
 	}
 
 	sdrive=drive;

--- a/src/dos/dos_memory.cpp
+++ b/src/dos/dos_memory.cpp
@@ -98,8 +98,8 @@ void DOS_CompressMemory(uint16_t first_segment=0/*default*/,uint32_t healfrom=0x
 
 	while (!mcb.isLastMCB()) {
 		if(counter++ > 10000000) DOS_Mem_E_Exit("DOS_CompressMemory: DOS MCB list corrupted.");
-		const uint16_t nseg = (uint16_t)(mcb_segment+mcb.GetSize()+1); 
-		mcb_next.SetPt(nseg);
+		mcb_next = mcb.nextMCB();
+		const uint16_t nseg = mcb_next.GetSeg();
 		if (GCC_UNLIKELY(!mcb_next.isValid())) {
 			/* there are some programs that chain load other programs, but when they shrink their MCB down
 			 * to their EXE resident size they put the stack or other data in the way of the next MCB free
@@ -122,8 +122,8 @@ void DOS_CompressMemory(uint16_t first_segment=0/*default*/,uint32_t healfrom=0x
 			mcb.SetSize(mcb.GetSize()+mcb_next.GetSize()+1);
 			mcb.SetType(mcb_next.GetType());
 		} else {
-			mcb_segment+=mcb.GetSize()+1;
-			mcb.SetPt(mcb_segment);
+			mcb = mcb_next;
+			mcb_segment = mcb.GetSeg();
 		}
 	}
 }
@@ -361,7 +361,10 @@ bool DOS_AllocateMemory(uint16_t * segment,uint16_t * blocks) {
 				DOS_SetError(DOSERR_INSUFFICIENT_MEMORY);
 				return false;
 			}
-		} else mcb_segment+=mcb.GetSize()+1;
+		} else {
+			mcb = mcb.nextMCB();
+			mcb_segment = mcb.GetSeg();
+		}
 	}
 
 #ifdef DEBUG_ALLOC

--- a/src/dos/dos_memory.cpp
+++ b/src/dos/dos_memory.cpp
@@ -48,32 +48,33 @@ void DOS_Mem_MCBdump(void) {
 	DOS_MCB mcb(mcb_segment);
 	DOS_MCB mcb_next(0);
 	Bitu counter=0;
-	char name[10];
+	std::string name;
 	char c;
 
 	if (mcb_segment == 0) return;
 
 	LOG_MSG("DOS MCB dump:\n");
-	while ((c=(char)mcb.GetType()) != 'Z') {
+	while (!mcb.isLastMCB()) {
+		c = (char)mcb.GetType(); if (c < 32) c = '.';
 		if (counter++ > 10000) break;
 		if (c != 'M') break;
 
-		mcb.GetFileName(name);
+		name = mcb.GetFileName();
 		LOG_MSG(" Type=0x%02x(%c) Seg=0x%04x size=0x%04x PSP=0x%04x name='%s'\n",
 			mcb.GetType(),c,
 			mcb_segment+1,
 			mcb.GetSize(),
 			mcb.GetPSPSeg(),
-			name);
+			name.c_str());
 		mcb_next.SetPt((uint16_t)(mcb_segment+mcb.GetSize()+1));
 		mcb_segment+=mcb.GetSize()+1;
 		mcb.SetPt(mcb_segment);
 	}
 
-	mcb.GetFileName(name);
+	name = mcb.GetFileName();
 	c = (char)mcb.GetType(); if (c < 32) c = '.';
 	LOG_MSG("FINAL: Type=0x%02x(%c) Seg=0x%04x size=0x%04x PSP=0x%04x name='%s'\n",
-		mcb.GetType(),c,mcb_segment+1,mcb.GetSize(),mcb.GetPSPSeg(),name);
+		mcb.GetType(),c,mcb_segment+1,mcb.GetSize(),mcb.GetPSPSeg(),name.c_str());
 	LOG_MSG("End dump\n");
 }
 
@@ -94,11 +95,11 @@ void DOS_CompressMemory(uint16_t first_segment=0/*default*/,uint32_t healfrom=0x
 	DOS_MCB mcb_next(0);
 	Bitu counter=0;
 
-	while (mcb.GetType()!='Z') {
+	while (!mcb.isLastMCB()) {
 		if(counter++ > 10000000) DOS_Mem_E_Exit("DOS_CompressMemory: DOS MCB list corrupted.");
 		const uint16_t nseg = (uint16_t)(mcb_segment+mcb.GetSize()+1); 
 		mcb_next.SetPt(nseg);
-		if (GCC_UNLIKELY((mcb_next.GetType()!=0x4d) && (mcb_next.GetType()!=0x5a))) {
+		if (GCC_UNLIKELY(!mcb_next.isValid())) {
 			/* there are some programs that chain load other programs, but when they shrink their MCB down
 			 * to their EXE resident size they put the stack or other data in the way of the next MCB free
 			 * block header. Real MS-DOS appears in this case to just scan up to the last valid block and
@@ -110,7 +111,7 @@ void DOS_CompressMemory(uint16_t first_segment=0/*default*/,uint32_t healfrom=0x
 				LOG(LOG_DOSMISC,LOG_ERROR)("Declaring all memory past it as a free block. This is apparently MS-DOS behavior.");
 				mcb_next.SetSize(CONV_MAX_SEG - (nseg + 1u));
 				mcb_next.SetPSPSeg(MCB_FREE);
-				mcb_next.SetType('Z');
+				mcb_next.SetType(DOS_MCB::MCBType::LastBlock);
 			}
 			else {
 				DOS_Mem_E_Exit("Corrupt MCB chain");
@@ -136,8 +137,8 @@ void DOS_FreeProcessMemory(uint16_t pspseg) {
 		if (mcb.GetPSPSeg()==pspseg) {
 			mcb.SetPSPSeg(MCB_FREE);
 		}
-		if (mcb.GetType()==0x5a) break;
-		if (GCC_UNLIKELY(mcb.GetType()!=0x4d)) DOS_Mem_E_Exit("Corrupt MCB chain");
+		if (mcb.isLastMCB()) break;
+		if (GCC_UNLIKELY(!mcb.isValid())) DOS_Mem_E_Exit("Corrupt MCB chain");
 		mcb_segment+=mcb.GetSize()+1;
 		mcb.SetPt(mcb_segment);
 	}
@@ -149,7 +150,7 @@ void DOS_FreeProcessMemory(uint16_t pspseg) {
 			if (umb_mcb.GetPSPSeg()==pspseg) {
 				umb_mcb.SetPSPSeg(MCB_FREE);
 			}
-			if (umb_mcb.GetType()!=0x4d) break;
+			if (!umb_mcb.isValid() || umb_mcb.isLastMCB()) break;
 			umb_start+=umb_mcb.GetSize()+1;
 			umb_mcb.SetPt(umb_start);
 		}
@@ -200,7 +201,7 @@ static uint16_t GetMaximumMCBFreeSize(uint16_t mcb_segment)
 	{
 		auto size = mcb.GetSize();
 		if (mcb.GetPSPSeg()==MCB_FREE) largestSize = (std::max)(largestSize, size);
-		endOfChain = DOS_MCB::MCBType(mcb.GetType())==DOS_MCB::MCBType::LastBlock;
+		endOfChain = mcb.isLastMCB();
 		last_mcb_segment = mcb_segment;
 		mcb_segment += size+1;
 		if (mcb_segment == last_mcb_segment) // Check for infinite loop
@@ -238,11 +239,10 @@ bool DOS_AllocateMemory(uint16_t * segment,uint16_t * blocks) {
 
 	DOS_MCB mcb(0);
 	DOS_MCB mcb_next(0);
-	char psp_name[9];
-	psp_mcb.GetFileName(psp_name);
+	std::string psp_name = psp_mcb.GetFileName();
 	if (umb_start==UMB_START_SEG && (dos.loaded_codepage == 936 || dos.loaded_codepage == 950 || dos.loaded_codepage == 951)) {
 		static constexpr std::array<const char*, 4> blacklisted {"KNL", "LIMD", "PY", "RDFNT"};
-		for (auto prog : blacklisted) if (!strcmp(psp_name, prog)) return false;
+		for (auto prog : blacklisted) if (psp_name == prog) return false;
 	}
 	uint16_t found_seg=0,found_seg_size=0;
 	for (;;) {
@@ -276,7 +276,7 @@ bool DOS_AllocateMemory(uint16_t * segment,uint16_t * blocks) {
 						mcb_next.SetType(mcb.GetType());
 						mcb_next.SetSize(block_size-*blocks-1);
 						mcb.SetSize(*blocks);
-						mcb.SetType(0x4d);		
+						mcb.SetType(DOS_MCB::MCBType::ValidBlock);		
 						mcb.SetPSPSeg(dos.psp());
 						mcb.SetFileName(psp_name);
 						//TODO Filename
@@ -305,7 +305,7 @@ bool DOS_AllocateMemory(uint16_t * segment,uint16_t * blocks) {
 			}
 		}
 		/* Onward to the next MCB if there is one */
-		if (mcb.GetType()==0x5a) {
+		if (mcb.isLastMCB()) {
 			if ((mem_strat&0x80) && (umb_start==UMB_START_SEG)) {
 				/* bit 7 set: try high memory first, then low */
 				mcb_segment=dos.firstMCB;
@@ -324,7 +324,7 @@ bool DOS_AllocateMemory(uint16_t * segment,uint16_t * blocks) {
 						mcb_next.SetSize(found_seg_size-*blocks-1);
 
 						mcb.SetSize(*blocks);
-						mcb.SetType(0x4d);		
+						mcb.SetType(DOS_MCB::MCBType::ValidBlock);		
 						mcb.SetPSPSeg(dos.psp());
 						mcb.SetFileName(psp_name);
 						//TODO Filename
@@ -356,7 +356,7 @@ bool DOS_AllocateMemory(uint16_t * segment,uint16_t * blocks) {
 						// Old Block
 						mcb.SetSize(found_seg_size-*blocks-1);
 						mcb.SetPSPSeg(MCB_FREE);
-						mcb.SetType(0x4D);
+						mcb.SetType(DOS_MCB::MCBType::ValidBlock);
 					}
 
 #if !defined(OSFREE)
@@ -393,7 +393,7 @@ bool DOS_ResizeMemory(uint16_t segment,uint16_t * blocks) {
 #endif
 
 	DOS_MCB mcb(segment-1);
-	if ((mcb.GetType()!=0x4d) && (mcb.GetType()!=0x5a)) {
+	if (!mcb.isValid()) {
 		DOS_SetError(DOSERR_MCB_DESTROYED);
 		return false;
 	}
@@ -429,9 +429,9 @@ bool DOS_ResizeMemory(uint16_t segment,uint16_t * blocks) {
 		DOS_MCB	mcb_new_next(segment+(*blocks));
 		mcb.SetSize(*blocks);
 		mcb_new_next.SetType(mcb.GetType());
-		if (mcb.GetType()==0x5a) {
+		if (mcb.isLastMCB()) {
 			/* Further blocks follow */
-			mcb.SetType(0x4d);
+			mcb.SetType(DOS_MCB::MCBType::ValidBlock);
 		}
 
 		mcb_new_next.SetSize(total-*blocks-1);
@@ -441,13 +441,13 @@ bool DOS_ResizeMemory(uint16_t segment,uint16_t * blocks) {
 		return true;
 	}
 	/* MCB will grow, try to join with following MCB */
-	if (mcb.GetType()!=0x5a) {
+	if (!mcb.isLastMCB()) {
 		if (mcb_next.GetPSPSeg()==MCB_FREE) {
 			total+=mcb_next.GetSize()+1;
 		}
 	}
 	if (*blocks<total) {
-		if (mcb.GetType()!=0x5a) {
+		if (!mcb.isLastMCB()) {
 			/* save type of following MCB */
 			mcb.SetType(mcb_next.GetType());
 		}
@@ -456,7 +456,7 @@ bool DOS_ResizeMemory(uint16_t segment,uint16_t * blocks) {
 		mcb_next.SetSize(total-*blocks-1);
 		mcb_next.SetType(mcb.GetType());
 		mcb_next.SetPSPSeg(MCB_FREE);
-		mcb.SetType(0x4d);
+		mcb.SetType(DOS_MCB::MCBType::ValidBlock);
 		mcb.SetPSPSeg(dos.psp());
 		return true;
 	}
@@ -464,7 +464,7 @@ bool DOS_ResizeMemory(uint16_t segment,uint16_t * blocks) {
 	/* at this point: *blocks==total (fits) or *blocks>total,
 	   in the second case resize block to maximum */
 
-	if ((mcb_next.GetPSPSeg()==MCB_FREE) && (mcb.GetType()!=0x5a)) {
+	if ((mcb_next.GetPSPSeg()==MCB_FREE) && !mcb.isLastMCB()) {
 		/* adjust type of joined MCB */
 		mcb.SetType(mcb_next.GetType());
 	}
@@ -495,7 +495,7 @@ bool DOS_FreeMemory(uint16_t segment) {
 	}
 
 	DOS_MCB mcb(segment-1);
-	if ((mcb.GetType()!=0x4d) && (mcb.GetType()!=0x5a)) {
+	if (!mcb.isValid()) {
 		DOS_SetError(DOSERR_MB_ADDRESS_INVALID);
 		return false;
 	}
@@ -537,12 +537,12 @@ void DOS_BuildUMBChain(bool umb_active,bool /*ems_active*/) {
 		DOS_MCB umb_mcb(first_umb_seg);
 		umb_mcb.SetPSPSeg(0);		// currently free
 		umb_mcb.SetSize(first_umb_size-1);
-		umb_mcb.SetType(0x5a);
+		umb_mcb.SetType(DOS_MCB::MCBType::LastBlock);
 
 		/* Scan MCB-chain for last block */
 		uint16_t mcb_segment=dos.firstMCB;
 		DOS_MCB mcb(mcb_segment);
-		while (mcb.GetType()!=0x5a) {
+		while (!mcb.isLastMCB()) {
 			mcb_segment+=mcb.GetSize()+1;
 			mcb.SetPt(mcb_segment);
 		}
@@ -551,7 +551,7 @@ void DOS_BuildUMBChain(bool umb_active,bool /*ems_active*/) {
 		   regular MCB-chain and the UMBs */
 		uint16_t cover_mcb=(uint16_t)(mcb_segment+mcb.GetSize()+1);
 		mcb.SetPt(cover_mcb);
-		mcb.SetType(0x4d);
+		mcb.SetType(DOS_MCB::MCBType::ValidBlock);
 		mcb.SetPSPSeg(0x0008);
 		mcb.SetSize(first_umb_seg-cover_mcb-1);
 		mcb.SetFileName("SC      ");
@@ -572,10 +572,10 @@ bool DOS_LinkUMBsToMemChain(uint16_t linkstate) {
 		return false;
 	} else if (dos.loaded_codepage == 936 || dos.loaded_codepage == 950 || dos.loaded_codepage == 951) {
 		static constexpr std::array<const char*, 6> blacklisted {"KNL", "LIMD", "PY", "RDFNT", "HAN16E", "HAN16V"};
-		char psp_name[9];
+		std::string psp_name;
 		DOS_MCB psp_mcb(dos.psp()-1);
-		psp_mcb.GetFileName(psp_name);
-		for (auto prog : blacklisted) if (!strcmp(psp_name, prog)) return false;
+		psp_name = psp_mcb.GetFileName();
+		for (auto prog : blacklisted) if (psp_name == prog) return false;
 	}
 
 	if ((linkstate&1)==(dos_infoblock.GetUMBChainState()&1)) return true;
@@ -584,7 +584,7 @@ bool DOS_LinkUMBsToMemChain(uint16_t linkstate) {
 	uint16_t mcb_segment=dos.firstMCB;
 	uint16_t prev_mcb_segment=dos.firstMCB;
 	DOS_MCB mcb(mcb_segment);
-	while ((mcb_segment!=umb_start) && (mcb.GetType()!=0x5a)) {
+	while ((mcb_segment!=umb_start) && !mcb.isLastMCB()) {
 		prev_mcb_segment=mcb_segment;
 		mcb_segment+=mcb.GetSize()+1;
 		mcb.SetPt(mcb_segment);
@@ -593,18 +593,18 @@ bool DOS_LinkUMBsToMemChain(uint16_t linkstate) {
 
 	switch (linkstate) {
 		case 0x0000:	// unlink
-			if ((prev_mcb.GetType()==0x4d) && (mcb_segment==umb_start)) {
-				prev_mcb.SetType(0x5a);
+			if (prev_mcb.isValid() && !prev_mcb.isLastMCB() && (mcb_segment==umb_start)) {
+				prev_mcb.SetType(DOS_MCB::MCBType::LastBlock);
 			}
 			dos_infoblock.SetUMBChainState(0);
 			break;
 		case 0x0001:	// link
-			if (mcb.GetType()==0x5a) {
+			if (mcb.isLastMCB()) {
 				if ((mcb_segment+mcb.GetSize()+1) != umb_start) {
 					LOG_MSG("MCB chain no longer goes to end of memory (corruption?), not linking in UMB!");
 					return false;
 				}
-				mcb.SetType(0x4d);
+				mcb.SetType(DOS_MCB::MCBType::ValidBlock);
 				dos_infoblock.SetUMBChainState(1);
 			}
 			break;
@@ -697,7 +697,7 @@ void DOS_MemStartChange(uint16_t adjto) {
 	while (sg < adjto) {
 		DOS_MCB mcb(sg);
 
-		if (!(mcb.GetType() == 0x5A || mcb.GetType() == 0x4D))
+		if (!mcb.isValid())
 			E_Exit("DOS_MemStartChange() MCB chain is corrupt");
 
 		uint32_t tdo = adjto - sg;
@@ -722,7 +722,7 @@ void DOS_MemStartChange(uint16_t adjto) {
 
 		/* block is now zero, need to keep moving? */
 		if (sg < adjto && tdo == 0) {
-			if (mcb.GetType() == 0x5A) break; /* do not remove the last block in the chain */
+			if (mcb.isLastMCB()) break; /* do not remove the last block in the chain */
 
 			LOG(LOG_MISC,LOG_DEBUG)("DOS_MemStartChange: mcb=%x type=%x size is zero and still need to adjust, deleting MCB block",
 				sg,mcb.GetType());
@@ -779,7 +779,7 @@ void DOS_SetupMemory(void) {
 
 	DOS_MCB mcb(DOS_MEM_START);
 	mcb.SetPSPSeg(MCB_FREE);						//Free
-	mcb.SetType(0x5a);								//Last Block
+	mcb.SetType(DOS_MCB::MCBType::LastBlock);						//Last Block
 	if (machine==MCH_TANDY) {
 		/* map memory as normal, the BIOS initialization is the code responsible
 		 * for subtracting 32KB from top of system memory for video memory. */
@@ -800,18 +800,18 @@ void DOS_SetupMemory(void) {
 			mcb_devicedummy.SetPt((uint16_t)0x2000);
 			mcb_devicedummy.SetPSPSeg(MCB_FREE);
 			mcb_devicedummy.SetSize(/*0x9FFF*/(seg_limit-1) - 0x2000);
-			mcb_devicedummy.SetType(0x5a);
+			mcb_devicedummy.SetType(DOS_MCB::MCBType::LastBlock);
 			CONV_MAX_SEG = seg_limit;
 
 			/* exclude PCJr graphics region */
 			mcb_devicedummy.SetPt((uint16_t)0x17ff);
 			mcb_devicedummy.SetPSPSeg(MCB_DOS);
 			mcb_devicedummy.SetSize(0x800);
-			mcb_devicedummy.SetType(0x4d);
+			mcb_devicedummy.SetType(DOS_MCB::MCBType::ValidBlock);
 
 			/* memory below 96k */
 			mcb.SetSize(0x1800 - DOS_MEM_START - 2);
-			mcb.SetType(0x4d);
+			mcb.SetType(DOS_MCB::MCBType::ValidBlock);
 		}
 		else {
 			/* Normal MCB chain, nothing special */

--- a/src/dos/dos_memory.cpp
+++ b/src/dos/dos_memory.cpp
@@ -45,16 +45,19 @@ static uint16_t memAllocStrategy = 0x00;
 
 void DOS_Mem_MCBdump(void) {
 	uint16_t mcb_segment=dos_kernel_disabled ? guest_msdos_mcb_chain : dos.firstMCB;
-	DOS_MCB mcb(mcb_segment);
-	DOS_MCB mcb_next(0);
 	Bitu counter=0;
 	std::string name;
 	char c;
+	DOS_MCB final_mcb(mcb_segment);
+	uint16_t final_mcb_segment = mcb_segment;
 
 	if (mcb_segment == 0) return;
 
 	LOG_MSG("DOS MCB dump:\n");
-	while (!mcb.isLastMCB()) {
+	for (auto mcb : DOS_MCB(mcb_segment)) {
+		final_mcb = mcb;
+		final_mcb_segment = mcb.GetSeg();
+
 		c = (char)mcb.GetType(); if (c < 32) c = '.';
 		if (counter++ > 10000) break;
 		if (c != 'M') break;
@@ -62,19 +65,17 @@ void DOS_Mem_MCBdump(void) {
 		name = mcb.GetFileName();
 		LOG_MSG(" Type=0x%02x(%c) Seg=0x%04x size=0x%04x PSP=0x%04x name='%s'\n",
 			mcb.GetType(),c,
-			mcb_segment+1,
+			final_mcb_segment+1,
 			mcb.GetSize(),
 			mcb.GetPSPSeg(),
 			name.c_str());
-		mcb_next.SetPt((uint16_t)(mcb_segment+mcb.GetSize()+1));
-		mcb_segment+=mcb.GetSize()+1;
-		mcb.SetPt(mcb_segment);
+
 	}
 
-	name = mcb.GetFileName();
-	c = (char)mcb.GetType(); if (c < 32) c = '.';
+	name = final_mcb.GetFileName();
+	c = (char)final_mcb.GetType(); if (c < 32) c = '.';
 	LOG_MSG("FINAL: Type=0x%02x(%c) Seg=0x%04x size=0x%04x PSP=0x%04x name='%s'\n",
-		mcb.GetType(),c,mcb_segment+1,mcb.GetSize(),mcb.GetPSPSeg(),name.c_str());
+		final_mcb.GetType(),c,final_mcb_segment+1,final_mcb.GetSize(),final_mcb.GetPSPSeg(),name.c_str());
 	LOG_MSG("End dump\n");
 }
 
@@ -129,30 +130,24 @@ void DOS_CompressMemory(uint16_t first_segment=0/*default*/,uint32_t healfrom=0x
 
 void DOS_FreeProcessMemory(uint16_t pspseg) {
 	uint16_t mcb_segment=dos.firstMCB;
-	DOS_MCB mcb(mcb_segment);
 	Bitu counter = 0;
 
-	for (;;) {
+	for (auto mcb : DOS_MCB(mcb_segment)) {
 		if(counter++ > 10000000) DOS_Mem_E_Exit("DOS_FreeProcessMemory: DOS MCB list corrupted.");
+		if (GCC_UNLIKELY(!mcb.isValid())) DOS_Mem_E_Exit("Corrupt MCB chain");
 		if (mcb.GetPSPSeg()==pspseg) {
 			mcb.SetPSPSeg(MCB_FREE);
 		}
-		if (mcb.isLastMCB()) break;
-		if (GCC_UNLIKELY(!mcb.isValid())) DOS_Mem_E_Exit("Corrupt MCB chain");
-		mcb_segment+=mcb.GetSize()+1;
-		mcb.SetPt(mcb_segment);
 	}
 
 	uint16_t umb_start=dos_infoblock.GetStartOfUMBChain();
 	if (umb_start==UMB_START_SEG) {
-		DOS_MCB umb_mcb(umb_start);
-		for (;;) {
+		for (auto umb_mcb : DOS_MCB(umb_start)) {
+			if (!umb_mcb.isValid())
+				break;
 			if (umb_mcb.GetPSPSeg()==pspseg) {
 				umb_mcb.SetPSPSeg(MCB_FREE);
 			}
-			if (!umb_mcb.isValid() || umb_mcb.isLastMCB()) break;
-			umb_start+=umb_mcb.GetSize()+1;
-			umb_mcb.SetPt(umb_start);
 		}
 	} else if (umb_start!=0xffff) LOG(LOG_DOSMISC,LOG_ERROR)("Corrupt UMB chain: %x",umb_start);
 
@@ -195,17 +190,11 @@ void DOS_zeromem(uint16_t seg,uint16_t para) {
 static uint16_t GetMaximumMCBFreeSize(uint16_t mcb_segment)
 {
 	uint16_t largestSize = 0;
-	DOS_MCB mcb(mcb_segment);
-	uint16_t last_mcb_segment;
-	for (bool endOfChain = false; !endOfChain; mcb.SetPt(mcb_segment))
-	{
-		auto size = mcb.GetSize();
-		if (mcb.GetPSPSeg()==MCB_FREE) largestSize = (std::max)(largestSize, size);
-		endOfChain = mcb.isLastMCB();
-		last_mcb_segment = mcb_segment;
-		mcb_segment += size+1;
-		if (mcb_segment == last_mcb_segment) // Check for infinite loop
+	for (const auto mcb : DOS_MCB(mcb_segment)) {
+		if (!mcb.isValid())
 			break;
+		const auto size = mcb.GetSize();
+		if (mcb.GetPSPSeg()==MCB_FREE) largestSize = (std::max)(largestSize, size);
 	}
 	return largestSize;
 }
@@ -540,11 +529,11 @@ void DOS_BuildUMBChain(bool umb_active,bool /*ems_active*/) {
 		umb_mcb.SetType(DOS_MCB::MCBType::LastBlock);
 
 		/* Scan MCB-chain for last block */
+		DOS_MCB mcb(dos.firstMCB);
 		uint16_t mcb_segment=dos.firstMCB;
-		DOS_MCB mcb(mcb_segment);
-		while (!mcb.isLastMCB()) {
-			mcb_segment+=mcb.GetSize()+1;
-			mcb.SetPt(mcb_segment);
+		for (const auto current_mcb : DOS_MCB(dos.firstMCB)) {
+			mcb = current_mcb;
+			mcb_segment = current_mcb.GetSeg();
 		}
 
 		/* A system MCB has to cover the space between the
@@ -584,10 +573,12 @@ bool DOS_LinkUMBsToMemChain(uint16_t linkstate) {
 	uint16_t mcb_segment=dos.firstMCB;
 	uint16_t prev_mcb_segment=dos.firstMCB;
 	DOS_MCB mcb(mcb_segment);
-	while ((mcb_segment!=umb_start) && !mcb.isLastMCB()) {
-		prev_mcb_segment=mcb_segment;
-		mcb_segment+=mcb.GetSize()+1;
-		mcb.SetPt(mcb_segment);
+	for (const auto current_mcb : DOS_MCB(dos.firstMCB)) {
+		mcb = current_mcb;
+		mcb_segment = current_mcb.GetSeg();
+		if ((mcb_segment == umb_start) || current_mcb.isLastMCB())
+			break;
+		prev_mcb_segment = mcb_segment;
 	}
 	DOS_MCB prev_mcb(prev_mcb_segment);
 

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -106,7 +106,6 @@ static Bitu INT2A_Handler(void) {
 	return CBRET_NONE;
 }
 
-extern std::string RunningProgram;
 extern std::string strPasteBuffer;
 extern bool i4dos, shellrun, clipboard_dosapi, swapad;
 extern RealPt DOS_DriveDataListHead;       // INT 2Fh AX=0803h DRIVER.SYS drive data table list

--- a/src/dos/dos_misc.cpp
+++ b/src/dos/dos_misc.cpp
@@ -106,7 +106,7 @@ static Bitu INT2A_Handler(void) {
 	return CBRET_NONE;
 }
 
-extern const char* RunningProgram;
+extern std::string RunningProgram;
 extern std::string strPasteBuffer;
 extern bool i4dos, shellrun, clipboard_dosapi, swapad;
 extern RealPt DOS_DriveDataListHead;       // INT 2Fh AX=0803h DRIVER.SYS drive data table list
@@ -271,10 +271,10 @@ static bool DOS_MultiplexFunctions(void) {
     case 0x1611:    /* Get shell parameters */
 		{
 			if (dos.version.major < 7) return false;
-			char psp_name[9];
+			std::string psp_name;
 			DOS_MCB psp_mcb(dos.psp()-1);
-			psp_mcb.GetFileName(psp_name);
-			if (!strcmp(psp_name, "DOSSETUP") || !strcmp(psp_name, "KRNL386")) {
+			psp_name = psp_mcb.GetFileName();
+			if (psp_name == "DOSSETUP" || psp_name == "KRNL386") {
 				/* Hack for Windows 98 SETUP.EXE (Wengier) */
 				return false;
 			}
@@ -309,7 +309,7 @@ static bool DOS_MultiplexFunctions(void) {
     case 0x1600:    /* Windows enhanced mode installation check */
         // Leave AX as 0x1600, indicating that neither Windows 3.x enhanced mode, Windows/386 2.x
         // nor Windows 95 are running, nor is XMS version 1 driver installed
-		if (!control->SecureMode() && ((reg_sp == 0xFFF6 && mem_readw(SegPhys(ss)+reg_sp) == 0x142A) || (reg_sp == 0xFF88 && mem_readw(SegPhys(ss)+reg_sp) == 0xFF9D) || !strcmp(RunningProgram, "DOSCLIP") || !strcmp(RunningProgram, "TOCLIP"))) // Hack for DOSCLIP/TOCLIP
+		if (!control->SecureMode() && ((reg_sp == 0xFFF6 && mem_readw(SegPhys(ss)+reg_sp) == 0x142A) || (reg_sp == 0xFF88 && mem_readw(SegPhys(ss)+reg_sp) == 0xFF9D) || RunningProgram == "DOSCLIP" || RunningProgram == "TOCLIP")) // Hack for DOSCLIP/TOCLIP
 			reg_ax = 0x301;
         return true;
 	case 0x1605:	/* Windows init broadcast */
@@ -436,11 +436,11 @@ static bool DOS_MultiplexFunctions(void) {
 		else return false;
 	case 0x160A:
 	{
-		char psp_name[9];
+		std::string psp_name;
 		DOS_MCB psp_mcb(dos.psp()-1);
-		psp_mcb.GetFileName(psp_name);
+		psp_name = psp_mcb.GetFileName();
 		// Report Windows version 4.0 (95) to PEDIT and NESTICLE x.xx so that they use LFN when available
-		if (uselfn && (!strcmp(psp_name, "PEDIT") || !strcmp(psp_name, "PEDITLGT") || ((!strcmp(psp_name, "EDIT") || reg_sp/0x100 == 0xF) && mem_readw(SegPhys(ss)+reg_sp) == 0x4A) || !strcmp(psp_name, "NESTICLE") || (reg_sp == 0x220A && mem_readw(SegPhys(ss)+reg_sp)/0x100 == 0x1F))) {
+		if (uselfn && (psp_name == "PEDIT" || psp_name == "PEDITLGT" || ((psp_name == "EDIT" || reg_sp/0x100 == 0xF) && mem_readw(SegPhys(ss)+reg_sp) == 0x4A) || psp_name == "NESTICLE" || (reg_sp == 0x220A && mem_readw(SegPhys(ss)+reg_sp)/0x100 == 0x1F))) {
 			reg_ax = 0;
 			reg_bx = 0x400;
 			reg_cx = 2;
@@ -468,13 +468,13 @@ static bool DOS_MultiplexFunctions(void) {
 			static constexpr std::array<const char*, 7> blacklisted {
 				"DEFRAG", "DISKEDIT", "NDD", "NDIAGS", "UNERASE", "UNFORMAT", "WINCHECK"
 			};
-            char psp_name[9];
+            std::string psp_name;
             DOS_MCB psp_mcb(dos.psp()-1);
-            psp_mcb.GetFileName(psp_name);
+            psp_name = psp_mcb.GetFileName();
 	    	// NTS: DEFRAG.EXE for MS-DOS 6.22 assumes Windows is running if this call responds affirmatively, because it would mean WINOLDAP is resident.
-            for (auto prog : blacklisted) if (!std::strcmp(psp_name, prog)) return false;
+            for (auto prog : blacklisted) if (psp_name == prog) return false;
             // Special case for INSTALL/INSTALLD
-            if (((!strcmp(psp_name, "INSTALL") || !strcmp(psp_name, "INSTALLD")) && reg_sp >= 0xD000 && mem_readw(SegPhys(ss)+reg_sp)/0x100 == 0x1E)) return false;
+            if (((psp_name == "INSTALL" || psp_name == "INSTALLD") && reg_sp >= 0xD000 && mem_readw(SegPhys(ss)+reg_sp)/0x100 == 0x1E)) return false;
         }
 		reg_al = 1;
 		reg_ah = 1;
@@ -754,7 +754,7 @@ void DOS_SetupMisc(void) {
 void CALLBACK_DeAllocate(Bitu in);
 
 void DOS_UninstallMisc(void) {
-    if (!strcmp(RunningProgram, "LOADLIN")) return;
+    if (RunningProgram == "LOADLIN") return;
 	/* these vectors shouldn't exist when booting a guest OS */
 	if (call_int2a) {
 		RealSetVec(0x2a,0);
@@ -767,4 +767,3 @@ void DOS_UninstallMisc(void) {
 		call_int2f=0;
 	}
 }
-

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -3174,8 +3174,6 @@ public:
                 }
             }
         } else {
-            extern std::string RunningProgram;
-
             if (max_seg < (IS_PC98_ARCH?0x2000:0x0800)) LOG(LOG_MISC,LOG_WARN)("Booting a guest OS with too small amount of RAM may not work correctly");
 
             /* Other versions of MS-DOS/PC-DOS have their own requirements about memory:

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -1003,10 +1003,10 @@ void MenuBrowseProgramFile() {
 		return;
 	std::string drive_warn;
 	DOS_MCB mcb(dos.psp()-1);
-	static char psp_name[9];
-	mcb.GetFileName(psp_name);
-	if(strlen(psp_name)&&strcmp(psp_name, "COMMAND")) {
-		drive_warn=strcmp(psp_name, "4DOS")? MSG_Get("PROGRAM_PROGRAM_ALREADY"): MSG_Get("PROGRAM_PROGRAM_ALREADY");
+	static std::string psp_name;
+	psp_name = mcb.GetFileName();
+	if(!psp_name.empty()&&psp_name!="COMMAND") {
+		drive_warn=psp_name!="4DOS"? MSG_Get("PROGRAM_PROGRAM_ALREADY"): MSG_Get("PROGRAM_PROGRAM_ALREADY");
 		systemmessagebox(MSG_Get("ERROR"),drive_warn.c_str(),"ok","error", 1);
 		return;
 	}
@@ -3174,7 +3174,7 @@ public:
                 }
             }
         } else {
-            extern const char* RunningProgram;
+            extern std::string RunningProgram;
 
             if (max_seg < (IS_PC98_ARCH?0x2000:0x0800)) LOG(LOG_MISC,LOG_WARN)("Booting a guest OS with too small amount of RAM may not work correctly");
 

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -2978,7 +2978,6 @@ bool LocalFile::LockFile(uint8_t mode, uint32_t pos, uint16_t size) {
 	return bRet;
 }
 
-extern std::string RunningProgram;
 bool LocalFile::Seek(uint32_t * pos,uint32_t type) {
 	int seektype;
 	switch (type) {

--- a/src/dos/drive_local.cpp
+++ b/src/dos/drive_local.cpp
@@ -2615,10 +2615,10 @@ uint8_t localDrive::GetMediaByte(void) {
 bool localDrive::isRemote(void) {
 	if (remote==1) return true;
 	if (remote==0) return false;
-	char psp_name[9];
+	std::string psp_name;
 	DOS_MCB psp_mcb(dos.psp()-1);
-	psp_mcb.GetFileName(psp_name);
-	if (!strcmp(psp_name, "SCANDISK") || !strcmp(psp_name, "CHKDSK")) {
+	psp_name = psp_mcb.GetFileName();
+	if (psp_name == "SCANDISK" || psp_name == "CHKDSK") {
 		/* Check for SCANDISK.EXE (or CHKDSK.EXE) and return true (Wengier) */
 		return true;
 	}
@@ -2978,7 +2978,7 @@ bool LocalFile::LockFile(uint8_t mode, uint32_t pos, uint16_t size) {
 	return bRet;
 }
 
-extern const char* RunningProgram;
+extern std::string RunningProgram;
 bool LocalFile::Seek(uint32_t * pos,uint32_t type) {
 	int seektype;
 	switch (type) {
@@ -2993,7 +2993,7 @@ bool LocalFile::Seek(uint32_t * pos,uint32_t type) {
     if (file_access_tries>0) {
         HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(fhandle));
         DWORD dwPtr = SetFilePointer(hFile, *pos, NULL, type);
-        if (dwPtr == INVALID_SET_FILE_POINTER && !strcmp(RunningProgram, "BTHORNE"))	// Fix for Black Thorne
+        if (dwPtr == INVALID_SET_FILE_POINTER && RunningProgram == "BTHORNE")	// Fix for Black Thorne
             dwPtr = SetFilePointer(hFile, 0, NULL, DOS_SEEK_END);
         if (dwPtr != INVALID_SET_FILE_POINTER) {										// If success
             *pos = (uint32_t)dwPtr;

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -679,10 +679,10 @@ bool Virtual_Drive::isRemote(void) {
     else if (!strcmp(opt,"0") || !strcmp(opt,"false")) {
         return false;
     }
-	char psp_name[9];
+	std::string psp_name;
 	DOS_MCB psp_mcb(dos.psp()-1);
-	psp_mcb.GetFileName(psp_name);
-	if (!strcmp(psp_name, "SCANDISK") || !strcmp(psp_name, "CHKDSK")) {
+	psp_name = psp_mcb.GetFileName();
+	if (psp_name == "SCANDISK" || psp_name == "CHKDSK") {
 		/* Check for SCANDISK.EXE (or CHKDSK.EXE) and return true (Wengier) */
 		return true;
 	}

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -2498,9 +2498,7 @@ void UnMount(int i_drive) {
     i_drive = toupper(i_drive);
     if(i_drive-'A' == DOS_GetDefaultDrive()) {
         DOS_MCB mcb(dos.psp()-1);
-        static char name[9];
-        name = mcb.GetFileName();
-        if (!strlen(name)) goto umount;
+        if (mcb.GetFileName().empty()) goto umount;
         LOG_MSG("GUI:Drive %c is being used. Aborted.",i_drive);
         return;
     }

--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -2061,10 +2061,9 @@ std::string MSCDEX_Output(int num) {
 void SetVal(const std::string& secname, const std::string& preval, const std::string& val) {
     if(preval=="keyboardlayout" && !dos_kernel_disabled) {
         DOS_MCB mcb(dos.psp()-1);
-        static char name[9];
-        mcb.GetFileName(name);
-        if (strlen(name)) {
-            LOG_MSG("GUI: Exit %s running in DOSBox-X, and then try again.",name);
+        std::string name = mcb.GetFileName();
+        if (!name.empty()) {
+            LOG_MSG("GUI: Exit %s running in DOSBox-X, and then try again.",name.c_str());
             return;
         }
     }
@@ -2500,7 +2499,7 @@ void UnMount(int i_drive) {
     if(i_drive-'A' == DOS_GetDefaultDrive()) {
         DOS_MCB mcb(dos.psp()-1);
         static char name[9];
-        mcb.GetFileName(name);
+        name = mcb.GetFileName();
         if (!strlen(name)) goto umount;
         LOG_MSG("GUI:Drive %c is being used. Aborted.",i_drive);
         return;

--- a/src/gui/menu_callback.cpp
+++ b/src/gui/menu_callback.cpp
@@ -66,7 +66,7 @@ extern int posx, posy, wheel_key, mbutton, enablelfn, dos_clipboard_device_acces
 extern bool addovl, clearline, pcibus_enable, winrun, window_was_maximized, wheel_guest, clipboard_dosapi, clipboard_biospaste, direct_mouse_clipboard, sync_time, manualtime, pausewithinterrupts_enable, enable_autosave, enable_config_as_shell_commands, noremark_save_state, force_load_state, use_quick_reboot, use_save_file, dpi_aware_enable, pc98_force_ibm_layout, log_int21, log_fileio, x11_on_top, macosx_on_top, rtl, gbk, chinasea, uselangcp;
 extern bool mountfro[26], mountiro[26];
 extern struct BuiltinFileBlob bfb_GLIDE2X_OVL;
-extern const char* RunningProgram;
+extern std::string RunningProgram;
 extern bool video_debug_overlay;
 
 void MSG_Init(void);
@@ -525,7 +525,7 @@ bool drive_saveimg_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * cons
             chdir(Temp_CurrentDir);
             return true;
         }
-    if (dos_kernel_disabled || !strcmp(RunningProgram, "LOADLIN")) return false;
+    if (dos_kernel_disabled || RunningProgram == "LOADLIN") return false;
     Section_prop *sec = static_cast<Section_prop *>(control->GetSection("dosbox"));
     uint32_t freeMB = sec->Get_int("convert fat free space"), timeout = sec->Get_int("convert fat timeout");
     imageDisk *imagedrv = new imageDisk(Drives[drive], drive, freeMB, timeout);
@@ -2216,7 +2216,7 @@ bool clear_screen() {
 }
 
 void show_prompt() {
-    if (!dos_kernel_disabled && !strcmp(RunningProgram, "COMMAND")) {
+    if (!dos_kernel_disabled && RunningProgram == "COMMAND") {
         DOS_Shell temp;
         temp.exit = true;
         temp.ShowPrompt();

--- a/src/gui/menu_callback.cpp
+++ b/src/gui/menu_callback.cpp
@@ -66,7 +66,6 @@ extern int posx, posy, wheel_key, mbutton, enablelfn, dos_clipboard_device_acces
 extern bool addovl, clearline, pcibus_enable, winrun, window_was_maximized, wheel_guest, clipboard_dosapi, clipboard_biospaste, direct_mouse_clipboard, sync_time, manualtime, pausewithinterrupts_enable, enable_autosave, enable_config_as_shell_commands, noremark_save_state, force_load_state, use_quick_reboot, use_save_file, dpi_aware_enable, pc98_force_ibm_layout, log_int21, log_fileio, x11_on_top, macosx_on_top, rtl, gbk, chinasea, uselangcp;
 extern bool mountfro[26], mountiro[26];
 extern struct BuiltinFileBlob bfb_GLIDE2X_OVL;
-extern std::string RunningProgram;
 extern bool video_debug_overlay;
 
 void MSG_Init(void);

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -305,7 +305,7 @@ bool gui_menu_exit(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
 }
 
 extern bool toscale;
-extern const char* RunningProgram;
+extern std::string RunningProgram;
 static GUI::ScreenSDL *UI_Startup(GUI::ScreenSDL *screen) {
     in_gui = true;
 
@@ -325,7 +325,7 @@ static GUI::ScreenSDL *UI_Startup(GUI::ScreenSDL *screen) {
     dos.loaded_codepage = cpbak;
 
     // Comparable to the code of intro.com, but not the same! (the code of intro.com is called from within a com file)
-    shell_idle = !dos_kernel_disabled && strcmp(RunningProgram, "LOADLIN") && first_shell && (DOS_PSP(dos.psp()).GetSegment() == DOS_PSP(dos.psp()).GetParent());
+    shell_idle = !dos_kernel_disabled && RunningProgram != "LOADLIN" && first_shell && (DOS_PSP(dos.psp()).GetSegment() == DOS_PSP(dos.psp()).GetParent());
 
     int sx, sy, sw, sh, scalex, scaley, scale;
     bool fs;
@@ -3113,7 +3113,7 @@ public:
                     temp="-force -t "+temp+" \""+std::string(lTheSaveFileName)+"\"";
                     void runImgmake(const char *str);
                     runImgmake(temp.c_str());
-                    if (!dos_kernel_disabled && strcmp(RunningProgram, "LOADLIN")) {
+                    if (!dos_kernel_disabled && RunningProgram != "LOADLIN") {
                         DOS_Shell shell;
                         shell.ShowPrompt();
                     }

--- a/src/gui/sdl_gui.cpp
+++ b/src/gui/sdl_gui.cpp
@@ -305,7 +305,6 @@ bool gui_menu_exit(DOSBoxMenu * const menu,DOSBoxMenu::item * const menuitem) {
 }
 
 extern bool toscale;
-extern std::string RunningProgram;
 static GUI::ScreenSDL *UI_Startup(GUI::ScreenSDL *screen) {
     in_gui = true;
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -964,7 +964,7 @@ void                        GUI_LoadFonts();
 void                        GUI_Run(bool);
 
 const char*                 titlebar = NULL;
-extern const char*          RunningProgram;
+extern std::string          RunningProgram;
 extern bool                 CPU_CycleAutoAdjust;
 extern                      cpu_cycles_count_t CPU_CyclePercUsed;
 #if !(ENVIRON_INCLUDED)
@@ -1142,8 +1142,8 @@ void GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused) {
     if (showbasic) {
         sprintf(title, "%s%s%s %s", dosbox_title.c_str(), dosbox_title.empty() ? "" : " - ", dosbox_name, VERSION);
 
-        const char *what = RunningProgram;
-        if (what != NULL && *what != 0) {
+        const char *what = RunningProgram.c_str();
+        if (!RunningProgram.empty()) {
             char *p = title + strlen(title); // append to end of string
 
             sprintf(p,": %s - ", what);
@@ -1357,7 +1357,7 @@ bool CheckQuit(void) {
             return systemmessagebox("Quit DOSBox-X warning", MSG_Get("QUIT_CONFIRM"),"yesno", "question", 1);
     } else if (warn == "false")
         return true;
-    if (dos_kernel_disabled&&strcmp(RunningProgram, "DOSBOX-X")) {
+    if (dos_kernel_disabled && RunningProgram != "DOSBOX-X") {
         if (!quit) {
             systemmessagebox("Quit DOSBox-X warning", MSG_Get("QUIT_GUEST_DISABLED"),"ok", "warning", 1);
             return false;
@@ -1374,7 +1374,7 @@ bool CheckQuit(void) {
                     return systemmessagebox("Quit DOSBox-X warning", MSG_Get("QUIT_FILE_OPEN_CONFIRM"),"yesno", "question", 1);
             }
         }
-    else if (RunningProgram&&strcmp(RunningProgram, "DOSBOX-X")&&strcmp(RunningProgram, "COMMAND")&&strcmp(RunningProgram, "4DOS")) {
+    else if (!RunningProgram.empty() && RunningProgram != "DOSBOX-X" && RunningProgram != "COMMAND" && RunningProgram != "4DOS") {
         if (!quit) {
             systemmessagebox("Quit DOSBox-X warning",MSG_Get("QUIT_PROGRAM_DISABLED"),"ok", "warning", 1);
             return false;
@@ -6479,7 +6479,7 @@ void GFX_Events() {
                             GFX_CaptureMouse();
                         SetPriority(sdl.priority.focus);
                         CPU_Disable_SkipAutoAdjust();
-                        if (strcmp(RunningProgram, "LOADLIN") && IsSafeToMemIOOnBehalfOfGuest()) {
+                        if (RunningProgram != "LOADLIN" && IsSafeToMemIOOnBehalfOfGuest()) {
                             BIOS_SynchronizeNumLock();
                             BIOS_SynchronizeCapsLock();
                             BIOS_SynchronizeScrollLock();
@@ -10297,7 +10297,7 @@ fresh_boot:
             dos_kernel_disabled = true;
 
             std::string core(static_cast<Section_prop *>(control->GetSection("cpu"))->Get_string("core"));
-            if (!strcmp(RunningProgram, "LOADLIN") && core == "auto") {
+            if (RunningProgram == "LOADLIN" && core == "auto") {
                 cpudecoder=&CPU_Core_Normal_Run;
                 mainMenu.get_item("mapper_normal").check(true).refresh_item(mainMenu);
 #if (C_DYNAMIC_X86) || (C_DYNREC)

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -128,6 +128,7 @@ char* revert_escape_newlines(const char* aMessage);
 #endif
 
 #include "control.h"
+#include "dos_inc.h"
 #include "dosbox.h"
 #include "menudef.h"
 #include "pic.h"
@@ -964,7 +965,6 @@ void                        GUI_LoadFonts();
 void                        GUI_Run(bool);
 
 const char*                 titlebar = NULL;
-extern std::string          RunningProgram;
 extern bool                 CPU_CycleAutoAdjust;
 extern                      cpu_cycles_count_t CPU_CyclePercUsed;
 #if !(ENVIRON_INCLUDED)

--- a/src/hardware/dma.cpp
+++ b/src/hardware/dma.cpp
@@ -451,10 +451,10 @@ Bitu DmaChannel::Read(Bitu want, uint8_t * buffer) {
     /* You cannot read a DMA channel configured for writing (to memory) */
     if (transfer_mode != DMAT_READ) {
         LOG(LOG_DMACONTROL,LOG_WARN)("BUG: Attempted DMA channel read when DMA channel is configured by guest for writing (to memory)");
-        char psp_name[9];
+        std::string psp_name;
         DOS_MCB psp_mcb(dos.psp()-1);
-        psp_mcb.GetFileName(psp_name);
-        if (strcmp(psp_name, "DIAGNOSE")) // Wengier: Hack for Creative DIAGNOSE.EXE tool for now until the DMA recording function is implemented
+        psp_name = psp_mcb.GetFileName();
+        if (psp_name != "DIAGNOSE") // Wengier: Hack for Creative DIAGNOSE.EXE tool for now until the DMA recording function is implemented
             return 0;
     }
 

--- a/src/hardware/glide.cpp
+++ b/src/hardware/glide.cpp
@@ -56,7 +56,7 @@ using namespace std;
 extern bool OpenGL_using(void);
 extern void GFX_Stop(void);
 extern void GFX_ResetScreen(void);
-extern const char* RunningProgram;
+extern std::string RunningProgram;
 extern bool dpi_aware_enable;
 extern bool DOS_GetMemory_unmapped;
 
@@ -923,8 +923,8 @@ static void process_msg(Bitu value)
 	FP.grFunction0();
 
 	// Enable Tomb Rider displaying shadow
-	if(!strncasecmp(RunningProgram, "Tombub", 6)) tomb = 2;
-	else if(!strncasecmp(RunningProgram, "Tomb", 4)) tomb = 1;
+	if(!strncasecmp(RunningProgram.c_str(), "Tombub", 6)) tomb = 2;
+	else if(!strncasecmp(RunningProgram.c_str(), "Tomb", 4)) tomb = 1;
 	else tomb = 0;
 
 	// Send LFB to the OVL (so it can map it in linear address)

--- a/src/hardware/glide.cpp
+++ b/src/hardware/glide.cpp
@@ -56,7 +56,6 @@ using namespace std;
 extern bool OpenGL_using(void);
 extern void GFX_Stop(void);
 extern void GFX_ResetScreen(void);
-extern std::string RunningProgram;
 extern bool dpi_aware_enable;
 extern bool DOS_GetMemory_unmapped;
 

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -339,7 +339,7 @@ std::string capturedir;
 extern std::string savefilename;
 extern bool showdbcs, use_save_file, noremark_save_state, force_load_state;
 extern unsigned int hostkeyalt, sendkeymap;
-extern const char* RunningProgram;
+extern std::string RunningProgram;
 Bitu CaptureState = 0;
 
 void OPL_SaveRawEvent(bool pressed), SetGameState_Run(int value), ResolvePath(std::string& in);
@@ -549,7 +549,7 @@ std::string GetCaptureFilePath(const char * type,const char * ext) {
 			return {};
 		}
 	}
-	strcpy(file_start,RunningProgram);
+	strcpy(file_start,RunningProgram.c_str());
 	lowcase(file_start);
 	for (char *s=(char*)file_start;*s;s++) *s = filtercapname(*s);
 	strcat(file_start,"_");
@@ -595,7 +595,7 @@ FILE * OpenCaptureFile(const char * type,const char * ext) {
 			return nullptr;
 		}
 	}
-	strcpy(file_start,RunningProgram);
+	strcpy(file_start,RunningProgram.c_str());
 	lowcase(file_start);
 	for (char *s=(char*)file_start;*s;s++) *s = filtercapname(*s);
 	strcat(file_start,"_");
@@ -2332,4 +2332,3 @@ bool capture_fmt_menu_callback(DOSBoxMenu * const menu,DOSBoxMenu::item * const 
 #endif
     return true;
 }
-

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -339,7 +339,6 @@ std::string capturedir;
 extern std::string savefilename;
 extern bool showdbcs, use_save_file, noremark_save_state, force_load_state;
 extern unsigned int hostkeyalt, sendkeymap;
-extern std::string RunningProgram;
 Bitu CaptureState = 0;
 
 void OPL_SaveRawEvent(bool pressed), SetGameState_Run(int value), ResolvePath(std::string& in);

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -3167,9 +3167,9 @@ Bitu SB_INFO::read_sb(Bitu port,Bitu /*iolen*/) {
 				mode = MODE_DMA;
 			}
 
-			extern const char* RunningProgram; // Wengier: Hack for Desert Strike & Jungle Strike
-			if (!IS_PC98_ARCH && port>0x220 && port%0x10==0xE && !dsp.out.used && (!strcmp(RunningProgram, "DESERT") || !strcmp(RunningProgram, "JUNGLE"))) {
-				LOG_MSG("Check status by game: %s\n", RunningProgram);
+			extern std::string RunningProgram; // Wengier: Hack for Desert Strike & Jungle Strike
+			if (!IS_PC98_ARCH && port>0x220 && port%0x10==0xE && !dsp.out.used && (RunningProgram == "DESERT" || RunningProgram == "JUNGLE")) {
+				LOG_MSG("Check status by game: %s\n", RunningProgram.c_str());
 				dsp.out.used++;
 			}
 			if (ess_type == ESS_NONE && (type == SBT_1 || type == SBT_2 || type == SBT_PRO1 || type == SBT_PRO2))

--- a/src/hardware/sblaster.cpp
+++ b/src/hardware/sblaster.cpp
@@ -3167,7 +3167,6 @@ Bitu SB_INFO::read_sb(Bitu port,Bitu /*iolen*/) {
 				mode = MODE_DMA;
 			}
 
-			extern std::string RunningProgram; // Wengier: Hack for Desert Strike & Jungle Strike
 			if (!IS_PC98_ARCH && port>0x220 && port%0x10==0xE && !dsp.out.used && (RunningProgram == "DESERT" || RunningProgram == "JUNGLE")) {
 				LOG_MSG("Check status by game: %s\n", RunningProgram.c_str());
 				dsp.out.used++;

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -277,7 +277,7 @@ extern bool vga_page_flip_occurred;
 extern bool egavga_per_scanline_hpel;
 extern bool vga_enable_hpel_effects;
 extern bool vga_enable_hretrace_effects;
-extern const char* RunningProgram;
+extern std::string RunningProgram;
 extern unsigned int vga_display_start_hretrace;
 extern float hretrace_fx_avg_weight;
 extern bool ignore_vblank_wraparound;
@@ -2610,7 +2610,7 @@ template <const unsigned int card,typename templine_type_t> static inline uint8_
 #if defined(USE_TTF)
                    && dbcs_sbcs
 #endif
-                   && showdbcs) && CurMode && CurMode->type == M_TEXT && !dos_kernel_disabled && strcmp(RunningProgram, "LOADLIN"));
+                   && showdbcs) && CurMode && CurMode->type == M_TEXT && !dos_kernel_disabled && RunningProgram != "LOADLIN");
 
     if (usedbcs && (vga.draw.height < 16u || vga.draw.width < 8u)) return dst;
 
@@ -6531,7 +6531,7 @@ static void VGA_VerticalTimer(Bitu /*val*/) {
 		if (ticksNew-ticksPrev>(unsigned int)autosave_second*1000) {
 			auto_save_state=true;
 			int index=0;
-			for (int i=1; i<10&&i<=autosave_count; i++) if (autosave_name[i].size()&&!strcasecmp(RunningProgram, autosave_name[i].c_str())) index=i;
+			for (int i=1; i<10&&i<=autosave_count; i++) if (autosave_name[i].size()&&!strcasecmp(RunningProgram.c_str(), autosave_name[i].c_str())) index=i;
 			if (autosave_start[index]>=1&&autosave_start[index]<=100) {
 				if (autosave_end[index]>=autosave_start[index]&&autosave_end[index]<=100&&autosave_end[index]>autosave_start[index]) {
 					if (autosave_end[index]>autosave_last[index]&&autosave_last[index]>=autosave_start[index]) autosave_last[index]++;

--- a/src/hardware/vga_draw.cpp
+++ b/src/hardware/vga_draw.cpp
@@ -277,7 +277,6 @@ extern bool vga_page_flip_occurred;
 extern bool egavga_per_scanline_hpel;
 extern bool vga_enable_hpel_effects;
 extern bool vga_enable_hretrace_effects;
-extern std::string RunningProgram;
 extern unsigned int vga_display_start_hretrace;
 extern float hretrace_fx_avg_weight;
 extern bool ignore_vblank_wraparound;

--- a/src/hardware/vga_memory.cpp
+++ b/src/hardware/vga_memory.cpp
@@ -52,7 +52,7 @@ extern bool isa_memory_hole_15mb;
 extern bool vbe_window_size_literal;
 extern unsigned int vbe_window_granularity;
 extern unsigned int vbe_window_size;
-extern const char* RunningProgram;
+extern std::string RunningProgram;
 
 static inline void vga_vram_write_trigger_update(void) {
 	vga.draw.must_complete_frame = true;
@@ -2764,8 +2764,8 @@ void VGA_SetupHandlers(void) {
 	}
 
 	// Workaround for ETen Chinese DOS system (e.g. ET24VA)
-	if ((dos.loaded_codepage == 936 || dos.loaded_codepage == 950 || dos.loaded_codepage == 951) && strlen(RunningProgram) > 3 && !strncmp(RunningProgram, "ET", 2)) enveten = true;
-	runeten = !vga_fill_inactive_ram && enveten && (dos.loaded_codepage == 936 || dos.loaded_codepage == 950 || dos.loaded_codepage == 951) && ((strlen(RunningProgram) > 3 && !strncmp(RunningProgram, "ET", 2)) || !TTF_using());
+	if ((dos.loaded_codepage == 936 || dos.loaded_codepage == 950 || dos.loaded_codepage == 951) && RunningProgram.size() > 3 && !strncmp(RunningProgram.c_str(), "ET", 2)) enveten = true;
+	runeten = !vga_fill_inactive_ram && enveten && (dos.loaded_codepage == 936 || dos.loaded_codepage == 950 || dos.loaded_codepage == 951) && ((RunningProgram.size() > 3 && !strncmp(RunningProgram.c_str(), "ET", 2)) || !TTF_using());
 
 	if (vga.dosboxig.force_A0000) {
 		vgapages.base = VGA_PAGE_A0;

--- a/src/hardware/vga_memory.cpp
+++ b/src/hardware/vga_memory.cpp
@@ -52,8 +52,6 @@ extern bool isa_memory_hole_15mb;
 extern bool vbe_window_size_literal;
 extern unsigned int vbe_window_granularity;
 extern unsigned int vbe_window_size;
-extern std::string RunningProgram;
-
 static inline void vga_vram_write_trigger_update(void) {
 	vga.draw.must_complete_frame = true;
 }

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -11140,7 +11140,7 @@ private:
 #endif
             if (control->opt_fastlaunch) return CBRET_NONE;
         }
-        extern const char* RunningProgram;
+        extern std::string RunningProgram;
         extern void GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused);
         RunningProgram = "DOSBOX-X";
         GFX_SetTitle(-1,-1,-1,false);
@@ -13200,4 +13200,3 @@ void UpdateKeyWithLed(int nVirtKey, int flagAct, int flagLed)
 
 #endif
 }
-

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -11140,7 +11140,6 @@ private:
 #endif
             if (control->opt_fastlaunch) return CBRET_NONE;
         }
-        extern std::string RunningProgram;
         extern void GFX_SetTitle(int32_t cycles, int frameskip, Bits timing, bool paused);
         RunningProgram = "DOSBOX-X";
         GFX_SetTitle(-1,-1,-1,false);

--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -2096,7 +2096,6 @@ public:
 	
 #if !defined(OSFREE)
 static EMS* test = NULL;
-extern std::string RunningProgram;
 void CALLBACK_DeAllocate(Bitu in);
 #endif
 

--- a/src/ints/ems.cpp
+++ b/src/ints/ems.cpp
@@ -2096,7 +2096,7 @@ public:
 	
 #if !defined(OSFREE)
 static EMS* test = NULL;
-extern const char* RunningProgram;
+extern std::string RunningProgram;
 void CALLBACK_DeAllocate(Bitu in);
 #endif
 
@@ -2108,7 +2108,7 @@ RealPt Get_EMS_vm86control() {
 
 #if !defined(OSFREE)
 void EMS_DoShutDown() {
-    if (!strcmp(RunningProgram, "LOADLIN")) {
+    if (RunningProgram == "LOADLIN") {
         test = NULL;
         return;
     }
@@ -2204,4 +2204,3 @@ public:
 } dummy;
 }
 #endif
-

--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -1211,7 +1211,6 @@ void INT10_SetActivePage(uint8_t page) {
     INT10_SetCursorPos(cur_row,cur_col,page);
 }
 
-extern std::string RunningProgram;
 void INT10_SetCursorShape(uint8_t first,uint8_t last) {
     real_writew(BIOSMEM_SEG,BIOSMEM_CURSOR_TYPE,last|(first<<8u));
     if (machine==MCH_CGA || IS_TANDY_ARCH) goto dowrite;

--- a/src/ints/int10_char.cpp
+++ b/src/ints/int10_char.cpp
@@ -1211,7 +1211,7 @@ void INT10_SetActivePage(uint8_t page) {
     INT10_SetCursorPos(cur_row,cur_col,page);
 }
 
-extern const char* RunningProgram;
+extern std::string RunningProgram;
 void INT10_SetCursorShape(uint8_t first,uint8_t last) {
     real_writew(BIOSMEM_SEG,BIOSMEM_CURSOR_TYPE,last|(first<<8u));
     if (machine==MCH_CGA || IS_TANDY_ARCH) goto dowrite;

--- a/src/ints/xms.cpp
+++ b/src/ints/xms.cpp
@@ -1027,8 +1027,6 @@ public:
 };
 
 static XMS* test = NULL;
-extern std::string RunningProgram;
-
 void XMS_DoShutDown() {
 	if (test != NULL) {
 		if (RunningProgram != "LOADLIN") delete test;

--- a/src/ints/xms.cpp
+++ b/src/ints/xms.cpp
@@ -1027,11 +1027,11 @@ public:
 };
 
 static XMS* test = NULL;
-extern const char* RunningProgram;
+extern std::string RunningProgram;
 
 void XMS_DoShutDown() {
 	if (test != NULL) {
-		if (strcmp(RunningProgram, "LOADLIN")) delete test;
+		if (RunningProgram != "LOADLIN") delete test;
 		test = NULL;
 	}
 }

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -52,7 +52,6 @@ std::string langname = "", langnote = "", GetDOSBoxXPath(bool withexe=false);
 extern int lastcp, FileDirExistUTF8(std::string &localname, const char *name), toSetCodePage(DOS_Shell *shell, int newCP, int opt);
 extern bool dos_kernel_disabled, force_conversion, showdbcs, dbcs_sbcs, enableime, tonoime, chinasea, CHCP_changed;
 extern uint16_t GetDefaultCP();
-extern std::string RunningProgram;
 Bitu DOS_ChangeKeyboardLayout(const char* layoutname, int32_t codepage);
 Bitu DOS_ChangeCodepage(int32_t codepage, const char* codepagefile);
 Bitu DOS_LoadKeyboardLayout(const char* layoutname, int32_t codepage, const char* codepagefile);

--- a/src/misc/messages.cpp
+++ b/src/misc/messages.cpp
@@ -52,7 +52,7 @@ std::string langname = "", langnote = "", GetDOSBoxXPath(bool withexe=false);
 extern int lastcp, FileDirExistUTF8(std::string &localname, const char *name), toSetCodePage(DOS_Shell *shell, int newCP, int opt);
 extern bool dos_kernel_disabled, force_conversion, showdbcs, dbcs_sbcs, enableime, tonoime, chinasea, CHCP_changed;
 extern uint16_t GetDefaultCP();
-extern const char * RunningProgram;
+extern std::string RunningProgram;
 Bitu DOS_ChangeKeyboardLayout(const char* layoutname, int32_t codepage);
 Bitu DOS_ChangeCodepage(int32_t codepage, const char* codepagefile);
 Bitu DOS_LoadKeyboardLayout(const char* layoutname, int32_t codepage, const char* codepagefile);

--- a/src/misc/savestates.cpp
+++ b/src/misc/savestates.cpp
@@ -47,7 +47,6 @@ extern unsigned int page;
 extern int autosave_last[10], autosave_count;
 extern std::string autosave_name[10], savefilename;
 extern bool use_save_file, clearline, dos_kernel_disabled;
-extern std::string RunningProgram;
 bool auto_save_state=false;
 bool noremark_save_state = false;
 bool force_load_state = false;
@@ -610,7 +609,6 @@ void SaveState::load(size_t slot) const { //throw (Error)
 #else
         SDL_PauseAudio(0);
 #endif
-	extern std::string RunningProgram;
 	std::string path;
 	int err;
 	bool Get_Custom_SaveDir(std::string& savedir);

--- a/src/misc/savestates.cpp
+++ b/src/misc/savestates.cpp
@@ -47,7 +47,7 @@ extern unsigned int page;
 extern int autosave_last[10], autosave_count;
 extern std::string autosave_name[10], savefilename;
 extern bool use_save_file, clearline, dos_kernel_disabled;
-extern const char* RunningProgram;
+extern std::string RunningProgram;
 bool auto_save_state=false;
 bool noremark_save_state = false;
 bool force_load_state = false;
@@ -246,7 +246,7 @@ namespace
 	void LastAutoSaveSlot(bool pressed) {
 		if (!pressed) return;
 		int index=0;
-		for (int i=1; i<10&&i<=autosave_count; i++) if (autosave_name[i].size()&&!strcasecmp(RunningProgram, autosave_name[i].c_str())) index=i;
+		for (int i=1; i<10&&i<=autosave_count; i++) if (autosave_name[i].size()&&!strcasecmp(RunningProgram.c_str(), autosave_name[i].c_str())) index=i;
 		if (autosave_last[index]<1) return;
 
 		char name[6]="slot0";
@@ -610,7 +610,7 @@ void SaveState::load(size_t slot) const { //throw (Error)
 #else
         SDL_PauseAudio(0);
 #endif
-	extern const char* RunningProgram;
+	extern std::string RunningProgram;
 	std::string path;
 	int err;
 	bool Get_Custom_SaveDir(std::string& savedir);
@@ -696,10 +696,10 @@ void SaveState::load(size_t slot) const { //throw (Error)
 		char buffer[4096];
 		size_t length = (size_t)zis.xsgetn((zip_istreambuf::char_type*)buffer,sizeof(buffer)-1); buffer[length] = 0;
 
-		if (!length||(size_t)length!=strlen(RunningProgram)||strncmp(buffer,RunningProgram,length)) {
+		if (!length||(size_t)length!=RunningProgram.size()||strncmp(buffer,RunningProgram.c_str(),length)) {
 			buffer[length]='\0';
 			loadstate_detail_saved = length ? std::string(buffer) : std::string("(none)");
-			loadstate_detail_current = RunningProgram ? std::string(RunningProgram) : std::string("(none)");
+			loadstate_detail_current = RunningProgram.empty() ? std::string("(none)") : RunningProgram;
 			if(!force_load_state&&!loadstateconfirm(1)) {
 				LOG_MSG("Aborted. Check your program name: %s",buffer);
 				load_err=true;
@@ -947,4 +947,3 @@ std::string SaveState::getName(size_t slot, bool nl) const {
     unzClose(zf);
 	return ret;
 }
-

--- a/src/output/output_gamelink.cpp
+++ b/src/output/output_gamelink.cpp
@@ -23,7 +23,7 @@
 using namespace std;
 
 extern uint32_t RunningProgramHash[4];
-extern const char* RunningProgram;
+extern std::string RunningProgram;
 
 #if !defined(C_SDL2)
 #error "gamelink output requires SDL2"
@@ -262,7 +262,7 @@ void OUTPUT_GAMELINK_Transfer()
     //LOG_MSG("OUTPUT_GAMELINK: Transfer");
     GameLink::Out( (uint16_t)sdl.clip.w+2*sdl.clip.x, (uint16_t)sdl.clip.h+2*sdl.clip.y, render.src.ratio,
         sdl.gamelink.want_mouse,
-        RunningProgram,
+        RunningProgram.c_str(),
         RunningProgramHash,
         (const uint8_t*)sdl.gamelink.framebuf,
         MemBase );

--- a/src/output/output_gamelink.cpp
+++ b/src/output/output_gamelink.cpp
@@ -7,6 +7,7 @@
 #include <math.h>
 
 #include "dosbox.h"
+#include "dos_inc.h"
 #include "logging.h"
 #include "menudef.h"
 #include "sdlmain.h"
@@ -23,8 +24,6 @@
 using namespace std;
 
 extern uint32_t RunningProgramHash[4];
-extern std::string RunningProgram;
-
 #if !defined(C_SDL2)
 #error "gamelink output requires SDL2"
 #endif

--- a/src/output/output_ttf.cpp
+++ b/src/output/output_ttf.cpp
@@ -23,6 +23,7 @@
 #include <math.h>
 
 #include "dosbox.h"
+#include "dos_inc.h"
 #include "logging.h"
 #include "sdlmain.h"
 #include "render.h"
@@ -102,7 +103,6 @@ static unsigned long ttfSize = sizeof(DOSBoxTTFbi), ttfSizeb = 0, ttfSizei = 0, 
 static void * ttfFont = DOSBoxTTFbi, * ttfFontb = NULL, * ttfFonti = NULL, * ttfFontbi = NULL;
 extern int posx, posy, eurAscii, transparency, NonUserResizeCounter;
 extern bool rtl, gbk, chinasea, switchttf, force_conversion, blinking, showdbcs, loadlang, window_was_maximized;
-extern std::string RunningProgram;
 extern uint8_t ccount;
 extern uint16_t cpMap[512], cpMap_PC98[256];
 uint16_t cpMap_copy[256];

--- a/src/output/output_ttf.cpp
+++ b/src/output/output_ttf.cpp
@@ -102,7 +102,7 @@ static unsigned long ttfSize = sizeof(DOSBoxTTFbi), ttfSizeb = 0, ttfSizei = 0, 
 static void * ttfFont = DOSBoxTTFbi, * ttfFontb = NULL, * ttfFonti = NULL, * ttfFontbi = NULL;
 extern int posx, posy, eurAscii, transparency, NonUserResizeCounter;
 extern bool rtl, gbk, chinasea, switchttf, force_conversion, blinking, showdbcs, loadlang, window_was_maximized;
-extern const char* RunningProgram;
+extern std::string RunningProgram;
 extern uint8_t ccount;
 extern uint16_t cpMap[512], cpMap_PC98[256];
 uint16_t cpMap_copy[256];
@@ -555,7 +555,7 @@ int setTTFCodePage() {
 		LOG_MSG("Loaded system codepage: %d\n", cp);
 		int notMapped = setTTFMap(true);
 #if !defined(OSFREE)
-		if (strcmp(RunningProgram, "LOADLIN") && !dos_kernel_disabled)
+		if (RunningProgram != "LOADLIN" && !dos_kernel_disabled)
 			initcodepagefont();
 #endif
 #if defined(WIN32) && !defined(HX_DOS)
@@ -768,8 +768,8 @@ void OUTPUT_TTF_Select(int fsize) {
                 c=80;
                 r=real_readb(0x60,0x113) & 0x01 ? 25 : 20;
             } else {
-                c=strcmp(RunningProgram, "LOADLIN")?real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS):80;
-                r=(uint16_t)(IS_EGAVGA_ARCH&&strcmp(RunningProgram, "LOADLIN")?real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS):24)+1;
+                c=RunningProgram != "LOADLIN" ? real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS) : 80;
+                r=(uint16_t)(IS_EGAVGA_ARCH&&RunningProgram != "LOADLIN"?real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS):24)+1;
             }
             if (ttf.lins<1||ttf.cols<1)	{
                 if (ttf.cols<1)
@@ -805,8 +805,8 @@ void OUTPUT_TTF_Select(int fsize) {
                 c=80;
                 r=real_readb(0x60,0x113) & 0x01 ? 25 : 20;
             } else {
-                c=strcmp(RunningProgram, "LOADLIN")?real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS):80;
-                r=(uint16_t)(IS_EGAVGA_ARCH&&strcmp(RunningProgram, "LOADLIN")?real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS):24)+1;
+                c=RunningProgram != "LOADLIN" ? real_readw(BIOSMEM_SEG,BIOSMEM_NB_COLS) : 80;
+                r=(uint16_t)(IS_EGAVGA_ARCH&&RunningProgram != "LOADLIN"?real_readb(BIOSMEM_SEG,BIOSMEM_NB_ROWS):24)+1;
             }
             ttf.cols=c;
             ttf.lins=r;
@@ -1440,7 +1440,7 @@ void ttf_switch_on(bool ss=true) {
          * protected mode (e.g. a game using a DOS extender). CALLBACK_RunRealInt()
          * would push a real-mode-style frame and corrupt the extender,
          * causing a #GP storm on the handler's IRETD. */
-        if (strcmp(RunningProgram, "LOADLIN") && !cpu.pmode) {
+        if (RunningProgram != "LOADLIN" && !cpu.pmode) {
             uint16_t oldax=reg_ax;
             reg_ax=0x1600;
             CALLBACK_RunRealInt(0x2F);

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -64,7 +64,7 @@ extern bool dos_shell_running_program, mountwarning, winautorun;
 extern bool startcmd, startwait, startquiet, internal_program;
 extern bool addovl, addipx, addne2k, enableime, showdbcs;
 extern bool halfwidthkana, force_conversion, gbk, uselangcp, chinasea;
-extern const char* RunningProgram;
+extern std::string RunningProgram;
 extern int enablelfn, msgcodepage, lastmsgcp;
 extern uint16_t countryNo;
 extern unsigned int dosbox_shell_env_size;
@@ -489,7 +489,7 @@ public:
 		return true;
 	}
 	bool Close() override { return true; }
-	uint16_t GetInformation(void) override { return (strcmp(RunningProgram, "WCLIP") ? DeviceInfoFlags::Device : 0) | DeviceInfoFlags::EofOnInput; }
+	uint16_t GetInformation(void) override { return (RunningProgram == "WCLIP" ? 0 : DeviceInfoFlags::Device) | DeviceInfoFlags::EofOnInput; }
 	bool ReadFromControlChannel(PhysPt bufptr,uint16_t size,uint16_t * retcode) override { (void)bufptr; (void)size; (void)retcode; return false; }
 	bool WriteToControlChannel(PhysPt bufptr,uint16_t size,uint16_t * retcode) override { (void)bufptr; (void)size; (void)retcode; return false; }
 };
@@ -2713,4 +2713,3 @@ void CONFIGSHELL_Run() {
 	}
 #endif
 }
-

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -64,7 +64,6 @@ extern bool dos_shell_running_program, mountwarning, winautorun;
 extern bool startcmd, startwait, startquiet, internal_program;
 extern bool addovl, addipx, addne2k, enableime, showdbcs;
 extern bool halfwidthkana, force_conversion, gbk, uselangcp, chinasea;
-extern std::string RunningProgram;
 extern int enablelfn, msgcodepage, lastmsgcp;
 extern uint16_t countryNo;
 extern unsigned int dosbox_shell_env_size;


### PR DESCRIPTION
This branch refactors DOS MCB handling into a dedicated `dos_mcb.h` helper and updates MCB-related code to use clearer, type-safe APIs. The new helper centralizes filename access, block type checks, segment math, containment checks, and chain traversal, replacing scattered raw 'M'/'Z' comparisons and manual MCB walking with named methods and range-based loops.

It also changes RunningProgram from a raw `const char*` to `std::string`, centralizes its declaration, and updates call sites to use safer string comparisons.