### PR TITLE
fix6404-sdl2resize

### DIFF
--- a/src/gui/menu.cpp
+++ b/src/gui/menu.cpp
@@ -2184,11 +2184,17 @@ void DOSBox_NoMenu(void) {
 #endif
 #if DOSBOXMENU_TYPE == DOSBOXMENU_HMENU
     if(!menu.gui) return;
+
+    HMENU pMenu = GetMenu(GetHWND());
+
     menu.toggle=false;
-    NonUserResizeCounter=1;
     SDL1_hax_SetMenu(NULL);
     mainMenu.get_item("mapper_togmenu").check(!menu.toggle).refresh_item(mainMenu);
     RENDER_CallBack( GFX_CallBackReset );
+
+    if(pMenu != NULL)
+        NonUserResizeCounter = 1;
+
 #endif
 #if defined(USE_TTF)
     if (ttf.inUse) resetFontSize();


### PR DESCRIPTION
Add a summary of the change(s) brought by this PR here.

## What issue(s) does this PR address?

Fixes #6404

## Does this PR introduce new feature(s)?

No.
This PR only corrects existing resize logic and does not introduce new features.

## Does this PR introduce any breaking change(s)?

This fix addresses only the issue regarding resizing the OpenGL window without a menu bar.

## Additional information

Only menu.cpp is modified.
The change ensures consistent behavior between SDL2 and non‑SDL2 builds regarding window resize events.
