### PR TITLE
Fix build error of XP VS builds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ Next version
     (maron2000)
   - Fixed window resizing (OpenGL, SDL2) (misty7666)
   - Updated Nuked-OPL3-fast to v1.8-fast.3 (tgies)
+  - Added support for nested subdirectories in Z drive (maron2000)
 
 2026.07.02
   - Prepare for release. This time release OSFREE first so that the normal

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -21,6 +21,8 @@
 #include <string.h>
 #include <time.h>
 #include <vector>
+#include <cctype>
+#include <algorithm>
 
 #include "dosbox.h"
 #include "dos_inc.h"


### PR DESCRIPTION
Fix build error of XP Visual Studio builds, since PR #6411.
The builds are successful for all other platforms.