### PR TITLE
Fix an exception in drive_virtual.cpp

### DIFF
--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -232,7 +232,7 @@ void VFILE_Register(const char* name, uint8_t* data, uint32_t size, const char* 
     static unsigned int last_resolved_onpos = 0;
 
     std::string current_normalized_dir = dir_str;
-    if(current_normalized_dir.front() == '/' || current_normalized_dir.front() == '\\') current_normalized_dir.erase(0, 1);
+    if(!current_normalized_dir.empty() && (current_normalized_dir.front() == '/' || current_normalized_dir.front() == '\\')) current_normalized_dir.erase(0, 1);
     if(!current_normalized_dir.empty() && (current_normalized_dir.back() == '/' || current_normalized_dir.back() == '\\')) current_normalized_dir.pop_back();
 
     // Improvement: To avoid catching its own name during the search, the global arrays (vfnames/vfsnames) 


### PR DESCRIPTION
我很困惑， 为什么第236行在对current_normalized_dir的尾部取值前进行了空字符串的判断，而在第235行中对头部进行取值时却没有判断空字符串？？

我在首次测试中就遇到此处触发的异常。由于DEBUG版在遇到此异常时无法继续，所以我添加了空字符串的判断。