### PR TITLE
macOS CI builds: Use macos-15 runner

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -152,7 +152,7 @@ jobs:
       actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
       contents: write # for actions/checkout to fetch code and softprops/action-gh-release
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.13.1


### PR DESCRIPTION
Change CI runner for macOS from macos-14 to macos-15 due to end of its life.

