### PR TITLE
Fixed the show function of the NEC mouse driver for the PC-9801

### DIFF
--- a/src/ints/mouse.cpp
+++ b/src/ints/mouse.cpp
@@ -1626,6 +1626,7 @@ static Bitu INT33_Handler(void) {
         goto software_reset;
     case 0x01:  /* MS MOUSE v1.0+ - SHOW MOUSE CURSOR */
         if (mouse.hidden) mouse.hidden--;
+        if(pc98_nec_mouse) mouse.hidden = 0;
         mouse.updateRegion_y[1] = -1; //offscreen
         DrawCursor();
         if(!mouse.hidden) Mouse_Used();


### PR DESCRIPTION
NEC mouse drivers do not maintain an internal display counter.
The mouse cursor is displayed even if int 33h ah=01h is called after multiple calls to int 33h ah=02h.
