### PR TITLE
Fix crash on loading lang files (macOS)

### DIFF
--- a/src/gui/menu_macos.mm
+++ b/src/gui/menu_macos.mm
@@ -581,13 +581,13 @@ void sdl_hax_nsMenuItemUpdateFromItem(void *nsMenuItem, DOSBoxMenu::item &item) 
         const std::string &st = item.get_shortcut_text();
         std::string ft;
 
+        int cp = dos.loaded_codepage;
+        InitCodePage();
+
         if (CodePageGuestToHostUTF8(tempstr,it.c_str()))
             ft += tempstr;
         else
             ft += it;
-
-        int cp = dos.loaded_codepage;
-        InitCodePage();
 
         NSMutableAttributedString *titleas;
         {


### PR DESCRIPTION
Fix crash on loading lang files (macOS).

## What issue(s) does this PR address?
Fixes #6434

<img width="592" height="390" alt="image" src="https://github.com/user-attachments/assets/c049686a-cd7c-4be1-ae98-0a05c6991521" />
