### PR TITLE
Add TeleDisk (.td0) image support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 NEXT VERSION:
-  - 
+  - Added support for mounting TeleDisk (.td0) floppy image files. (cimarronm)
 
 2026.08.02
   - Debugger: normalize 16-bit segmented offsets for address display/lookup and

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -83,7 +83,8 @@ class imageDisk {
 			ID_NFD,
 			ID_EMPTY_DRIVE,
 			ID_INT13,
-			ID_MSDOSBLOCKDEV
+			ID_MSDOSBLOCKDEV,
+			ID_TELEDISK
 		};
 
 		virtual uint8_t Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size=0);

--- a/include/imagedisk_teledisk.h
+++ b/include/imagedisk_teledisk.h
@@ -1,0 +1,128 @@
+/*
+ *  Copyright (C) 2026 The DOSBox-X Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#ifndef DOSBOX_IMAGE_DISK_TELEDISK_H
+#define DOSBOX_IMAGE_DISK_TELEDISK_H
+
+#include "bios_disk.h"
+
+/* TeleDisk sector flags (sector header, spec section 6.5). Values are OR-combined. */
+enum class td0_sector_flags : uint8_t {
+	none          = 0x00,
+	duplicate     = 0x01, /* sector duplicated within a track */
+	crc_error     = 0x02, /* sector was read with a CRC error */
+	deleted_mark  = 0x04, /* deleted-data address mark */
+	dos_skipped   = 0x10, /* skipped via DOS allocation; NO data block follows */
+	id_no_data    = 0x20, /* had ID field but no data; NO data block follows */
+	data_no_id    = 0x40  /* had data but no ID field (bogus header) */
+};
+
+static inline bool operator&(td0_sector_flags lhs, td0_sector_flags rhs) {
+	return (static_cast<uint8_t>(lhs) & static_cast<uint8_t>(rhs)) != 0;
+}
+
+#pragma pack(push,1)
+/* On-disk TeleDisk (.TD0) structures. All multi-byte fields are little-endian;
+ * read them through the td0_read_u16le() helper rather than dereferencing directly. */
+struct td0_image_header {
+	uint8_t  signature[2];    /* "TD" normal, "td" advanced compression */
+	uint8_t  sequence;        /* 0 for first/only volume */
+	uint8_t  check_sequence;
+	uint8_t  version;         /* high.low nibble, e.g. 0x15 == 1.5 */
+	uint8_t  data_rate;
+	uint8_t  drive_type;
+	uint8_t  stepping;        /* bit 7 set => optional comment block present */
+	uint8_t  dos_alloc_flag;
+	uint8_t  sides;           /* 1 == one side, otherwise two */
+	uint8_t  crc[2];
+};
+
+struct td0_comment_header {
+	uint8_t  crc[2];
+	uint8_t  length[2];       /* size of comment data block that follows */
+	uint8_t  year;            /* years since 1900 */
+	uint8_t  month;           /* 0 == January */
+	uint8_t  day;
+	uint8_t  hour;
+	uint8_t  minute;
+	uint8_t  second;
+};
+
+struct td0_track_header {
+	uint8_t  num_sectors;     /* 0xFF marks end of image */
+	uint8_t  cylinder;        /* physical cylinder */
+	uint8_t  head;            /* bit 0 == side; bit 7 == single-density */
+	uint8_t  crc;
+};
+
+struct td0_sector_header {
+	uint8_t          cylinder;        /* logical cylinder in the sector ID field */
+	uint8_t          head;            /* logical side/head */
+	uint8_t          sector;          /* logical sector number */
+	uint8_t          size_code;       /* sector size = 128 << size_code */
+	td0_sector_flags flags;
+	uint8_t          crc;
+};
+
+struct td0_data_header {
+	uint8_t  block_size[2];   /* size of data block including the method byte */
+	uint8_t  method;          /* sector_encoding_method */
+};
+#pragma pack(pop)
+
+static_assert(sizeof(td0_image_header)   == 12, "td0_image_header must match on-disk layout");
+static_assert(sizeof(td0_comment_header) == 10, "td0_comment_header must match on-disk layout");
+static_assert(sizeof(td0_track_header)   ==  4, "td0_track_header must match on-disk layout");
+static_assert(sizeof(td0_sector_header)  ==  6, "td0_sector_header must match on-disk layout");
+static_assert(sizeof(td0_data_header)    ==  3, "td0_data_header must match on-disk layout");
+
+class imageDiskTeledisk : public imageDisk {
+public:
+	enum class sector_encoding_method : uint8_t {
+		raw                    = 0,
+		repeated_2byte_pattern = 1,
+		rle                    = 2
+	};
+
+	uint8_t Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size=0) override;
+	uint8_t Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size=0) override;
+	uint8_t Read_AbsoluteSector(uint32_t sectnum, void * data) override;
+	uint8_t Write_AbsoluteSector(uint32_t sectnum, const void * data) override;
+
+	imageDiskTeledisk(FILE *imgFile, const char *imgName, uint32_t imgSizeK, bool isHardDisk);
+	virtual ~imageDiskTeledisk();
+
+	struct td0entry {
+		uint8_t phys_track = 0, phys_head = 0, phys_sector = 0;
+		uint8_t logical_track = 0, logical_head = 0;
+		uint16_t sector_size = 0;
+		td0_sector_flags flags = td0_sector_flags::none;
+		bool has_data = false;
+		std::vector<uint8_t> data;
+
+		td0entry() {}
+		uint16_t getSectorSize(void) const { return sector_size; }
+	};
+
+	td0entry *findSector(uint8_t head,uint8_t track,uint8_t sector,unsigned int req_sector_size=0);
+	const td0entry *findSector(uint8_t head,uint8_t track,uint8_t sector,unsigned int req_sector_size=0) const;
+
+	std::vector<td0entry> dents;
+};
+
+#endif

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -45,6 +45,7 @@
 #include "cdrom.h"
 #include "builtin.h"
 #include "bios_disk.h"
+#include "imagedisk_teledisk.h"
 #include "dos_system.h"
 #include "dos_inc.h"
 #include "bios.h"
@@ -654,8 +655,8 @@ void MenuBrowseFDImage(char drive, int num, int type) {
 	getcwd(Temp_CurrentDir, 512);
 	char const * lTheOpenFileName;
 	std::string files="", fname="";
-	const char *lFilterPatterns[] = {"*.ima","*.img","*.xdf","*.fdi","*.hdm","*.nfd","*.d88","*.IMA","*.IMG","*.XDF","*.FDI","*.HDM","*.NFD","*.D88"};
-	const char *lFilterDescription = "Floppy image files (*.ima, *.img, *.xdf, *.fdi, *.hdm, *.nfd, *.d88)";
+	const char *lFilterPatterns[] = {"*.ima","*.img","*.xdf","*.fdi","*.hdm","*.nfd","*.d88","*.td0","*.IMA","*.IMG","*.XDF","*.FDI","*.HDM","*.NFD","*.D88","*.TD0"};
+	const char *lFilterDescription = "Floppy image files (*.ima, *.img, *.xdf, *.fdi, *.hdm, *.nfd, *.d88, *.td0)";
 	lTheOpenFileName = tinyfd_openFileDialog("Select a floppy image file","",sizeof(lFilterPatterns)/sizeof(lFilterPatterns[0]), lFilterPatterns, lFilterDescription, 0);
 
 #if !defined(OSFREE)
@@ -740,7 +741,7 @@ void MenuBrowseImageFile(char drive, bool arc, bool boot, bool multiple, const s
 			paths.push_back(lTheOpenFileName);
 		}
 	} else {
-		const char *lFilterPatterns[] = {"*.ima","*.img","*.vhd","*.fdi","*.hdi","*.nfd","*.nhd","*.d88","*.hdm","*.xdf","*.iso","*.cue","*.bin","*.chd","*.mdf","*.gog","*.ins","*.ccd","*.inst","*.IMA","*.IMG","*.VHD","*.FDI","*.HDI","*.NFD","*.NHD","*.D88","*.HDM","*.XDF","*.ISO","*.CUE","*.BIN","*.CHD","*.MDF","*.GOG","*.INS","*.CCD","*.INST"};
+		const char *lFilterPatterns[] = {"*.ima","*.img","*.vhd","*.fdi","*.hdi","*.nfd","*.nhd","*.d88","*.td0","*.hdm","*.xdf","*.iso","*.cue","*.bin","*.chd","*.mdf","*.gog","*.ins","*.ccd","*.inst","*.IMA","*.IMG","*.VHD","*.FDI","*.HDI","*.NFD","*.NHD","*.D88","*.TD0","*.HDM","*.XDF","*.ISO","*.CUE","*.BIN","*.CHD","*.MDF","*.GOG","*.INS","*.CCD","*.INST"};
 		const char *lFilterDescription = "Disk/CD image files";
 		lTheOpenFileName = tinyfd_openFileDialog(((multiple?"Select image file(s) for Drive ":"Select an image file for Drive ")+str+":").c_str(),"", sizeof(lFilterPatterns) / sizeof(lFilterPatterns[0]),lFilterPatterns,lFilterDescription,multiple?1:0);
 		if (lTheOpenFileName) {
@@ -2644,6 +2645,8 @@ public:
 
             if(ext && !strcasecmp(ext, ".d88"))
                 newDiskSwap[index] = new imageDiskD88(usefile, fname, floppysize, false);
+            else if(!memcmp(hdr, "TD\0", 3))
+                newDiskSwap[index] = new imageDiskTeledisk(usefile, fname, floppysize, false);
             else if(!memcmp(hdr, "VFD1.", 5))
                 newDiskSwap[index] = new imageDiskVFD(usefile, fname, floppysize, false);
             else if(!memcmp(hdr, "T98FDDIMAGE.R0\0\0", 16))
@@ -6162,9 +6165,10 @@ class IMGMOUNT : public Program {
 							if (!paths.empty()) {
 								const char *ext = strrchr(paths[0].c_str(), '.');
 								if (ext != NULL) {
-									if ((!IS_PC98_ARCH && strcasecmp(ext,".img") && strcasecmp(ext,".ima") && strcasecmp(ext,".vhd") && strcasecmp(ext,".qcow2")) ||
+									if ((!IS_PC98_ARCH && strcasecmp(ext,".img") && strcasecmp(ext,".ima") && strcasecmp(ext,".vhd") && strcasecmp(ext,".qcow2") && strcasecmp(ext,".td0")) ||
 											(IS_PC98_ARCH && strcasecmp(ext,".hdi") && strcasecmp(ext,".nhd") && strcasecmp(ext,".img") && strcasecmp(ext,".ima"))){
 										WriteOut(MSG_Get("PROGRAM_MOUNT_UNSUPPORTED_EXT"), ext);
+                                        LOG_MSG("IMGMOUNT: Warning: Unsupported extension '%s' for image file '%s'", ext, paths[0].c_str());
 									}
 								}
 							}
@@ -7691,6 +7695,13 @@ class IMGMOUNT : public Program {
 					imagesize = (uint32_t)(sectors / 2); /* orig. code wants it in KBs */
 					setbuf(newDisk, NULL);
 					newImage = new imageDiskD88(newDisk, fname, (uint32_t)imagesize, false/*this is a FLOPPY image format*/);
+				}
+				else if (!memcmp(tmp, "TD\0", 3)) {
+					fseeko64(newDisk, 0L, SEEK_END);
+					sectors = (uint64_t)ftello64(newDisk) / (uint64_t)sizes[0];
+					imagesize = (uint32_t)(sectors / 2); /* orig. code wants it in KBs */
+					setbuf(newDisk, NULL);
+					newImage = new imageDiskTeledisk(newDisk, fname, (uint32_t)imagesize, false/*this is a FLOPPY image format*/);
 				}
 				else if (!memcmp(tmp, "VFD1.", 5)) { /* FDD files */
 					fseeko64(newDisk, 0L, SEEK_END);

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -53,6 +53,7 @@
 #include "cross.h"
 #include "bios.h"
 #include "bios_disk.h"
+#include "imagedisk_teledisk.h"
 #include "qcow2_disk.h"
 #include "bitop.h"
 #include "callback.h"
@@ -1564,6 +1565,8 @@ fatDrive::fatDrive(const char* sysFilename, uint32_t bytesector, uint32_t cylsec
 
 		if (ext != NULL && !strcasecmp(ext, ".d88"))
 			loadedDisk = new imageDiskD88(diskfile, fname, (uint32_t)filesize, false);
+		else if (!memcmp(bootcode, "TD\0", 3))
+			loadedDisk = new imageDiskTeledisk(diskfile, fname, (uint32_t)filesize, false);
 		else if (!memcmp(bootcode,"VFD1.",5)) /* FDD files */
 			loadedDisk = new imageDiskVFD(diskfile, fname, (uint32_t)filesize, false);
 		else if (!memcmp(bootcode,"T98FDDIMAGE.R0\0\0",16))
@@ -2198,8 +2201,10 @@ void fatDrive::fatDriveInit(const char *sysFilename, uint32_t bytesector, uint32
                 bootbuffer.magic1 = 0x55;	// to silence warning
                 bootbuffer.magic2 = 0xaa;
             }
-            else if(!IS_PC98_ARCH && loadedDisk->diskSizeK <= 360) {
-                /* Read media descriptor in FAT */
+            else if(!IS_PC98_ARCH) {
+                /* Before DOS 2.0 there was no BPB. DOS 1.x identified the floppy format
+                 * solely by the media descriptor byte at the start of the FAT. Read it and
+                 * build the BPB from that (done before matching against DiskGeometryList). */
                 uint8_t sectorBuffer[512];
                 loadedDisk->Read_AbsoluteSector(1, &sectorBuffer);
                 uint8_t mdesc = sectorBuffer[0];

--- a/src/ints/Makefile.am
+++ b/src/ints/Makefile.am
@@ -4,4 +4,5 @@ noinst_LIBRARIES = libints.a
 libints_a_SOURCES = mouse.cpp xms.cpp xms.h ems.cpp int_dosv.cpp \
                     int10.cpp int10.h int10_char.cpp int10_memory.cpp int10_misc.cpp int10_modes.cpp \
                     int10_vesa.cpp int10_pal.cpp int10_put_pixel.cpp int10_video_state.cpp int10_vptable.cpp \
-                    bios.cpp bios_disk.cpp bios_vhd.cpp bios_keyboard.cpp qcow2_disk.cpp bios_memdisk.cpp pc98_lio.cpp
+                    bios.cpp bios_disk.cpp bios_vhd.cpp bios_keyboard.cpp qcow2_disk.cpp bios_memdisk.cpp pc98_lio.cpp \
+                    imagedisk_teledisk.cpp

--- a/src/ints/imagedisk_teledisk.cpp
+++ b/src/ints/imagedisk_teledisk.cpp
@@ -1,0 +1,400 @@
+/*
+ *  Copyright (C) 2026 The DOSBox-X Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "dosbox.h"
+#include "bios_disk.h"
+#include "imagedisk_teledisk.h"
+
+static inline uint16_t td0_read_u16le(const uint8_t *p) {
+	return (uint16_t)p[0] | ((uint16_t)p[1] << 8U);
+}
+
+static bool td0_decode_method_raw(const std::vector<uint8_t> &encoded, const uint16_t sector_size, std::vector<uint8_t> &decoded) {
+	if (encoded.size() != sector_size)
+		return false;
+	decoded = encoded;
+	return true;
+}
+
+static bool td0_decode_method_repeated_2byte_pattern(const std::vector<uint8_t> &encoded, const uint16_t sector_size, std::vector<uint8_t> &decoded) {
+	decoded.clear();
+	decoded.reserve(sector_size);
+
+	size_t pos = 0;
+	while (decoded.size() < sector_size) {
+		if ((pos + 4U) > encoded.size())
+			return false;
+
+		const uint16_t count = td0_read_u16le(&encoded[pos]); pos += 2;
+		const uint8_t b0 = encoded[pos++];
+		const uint8_t b1 = encoded[pos++];
+
+		for (uint16_t i = 0; i < count && decoded.size() < sector_size; i++) {
+			decoded.push_back(b0);
+			if (decoded.size() >= sector_size)
+				break;
+			decoded.push_back(b1);
+		}
+	}
+
+	return decoded.size() == sector_size;
+}
+
+static bool td0_decode_method_rle(const std::vector<uint8_t> &encoded, const uint16_t sector_size, std::vector<uint8_t> &decoded) {
+	decoded.clear();
+	decoded.reserve(sector_size);
+
+	size_t pos = 0;
+	while (decoded.size() < sector_size) {
+		if (pos >= encoded.size())
+			return false;
+
+		const uint8_t token = encoded[pos++];
+		if (token == 0) {
+			if (pos >= encoded.size())
+				return false;
+
+			const uint8_t n = encoded[pos++];
+			if ((pos + n) > encoded.size())
+				return false;
+
+			for (uint8_t i = 0; i < n && decoded.size() < sector_size; i++)
+				decoded.push_back(encoded[pos++]);
+		}
+		else {
+			const size_t block_len = (size_t)token * 2U;
+			if (pos >= encoded.size())
+				return false;
+			const uint8_t repeat_count = encoded[pos++];
+			if ((pos + block_len) > encoded.size())
+				return false;
+
+			std::vector<uint8_t> block(block_len);
+			memcpy(&block[0], &encoded[pos], block_len);
+			pos += block_len;
+
+			for (uint8_t r = 0; r < repeat_count && decoded.size() < sector_size; r++) {
+				for (size_t i = 0; i < block_len && decoded.size() < sector_size; i++)
+					decoded.push_back(block[i]);
+			}
+		}
+	}
+
+	return decoded.size() == sector_size;
+}
+
+static bool td0_decode_sector_data(imageDiskTeledisk::sector_encoding_method method, const std::vector<uint8_t> &encoded, const uint16_t sector_size, std::vector<uint8_t> &decoded) {
+	switch (method) {
+	case imageDiskTeledisk::sector_encoding_method::raw:
+		return td0_decode_method_raw(encoded, sector_size, decoded);
+	case imageDiskTeledisk::sector_encoding_method::repeated_2byte_pattern:
+		return td0_decode_method_repeated_2byte_pattern(encoded, sector_size, decoded);
+	case imageDiskTeledisk::sector_encoding_method::rle:
+		return td0_decode_method_rle(encoded, sector_size, decoded);
+	default:
+		return false;
+	}
+}
+
+imageDiskTeledisk::td0entry *imageDiskTeledisk::findSector(uint8_t head,uint8_t track,uint8_t sector,unsigned int req_sector_size) {
+	/* Delegate to the const overload; safe to cast away const because this object is non-const here. */
+	const imageDiskTeledisk *self = this;
+	return const_cast<td0entry *>(self->findSector(head, track, sector, req_sector_size));
+}
+
+const imageDiskTeledisk::td0entry *imageDiskTeledisk::findSector(uint8_t head,uint8_t track,uint8_t sector,unsigned int req_sector_size) const {
+	const td0entry *best = NULL;
+
+	for (const auto &entry : dents) {
+		if (entry.phys_head != head || entry.phys_track != track || entry.phys_sector != sector)
+			continue;
+		if (req_sector_size != ~0U && req_sector_size != 0 && entry.sector_size != req_sector_size)
+			continue;
+		if (best == NULL || (!best->has_data && entry.has_data))
+			best = &entry;
+	}
+
+	return best;
+}
+
+uint8_t imageDiskTeledisk::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size) {
+	const td0entry *ent;
+
+	ent = findSector((uint8_t)head, (uint8_t)cylinder, (uint8_t)sector, req_sector_size);
+
+	if (ent == NULL || !ent->has_data)
+		return 0x05;
+
+	if (req_sector_size == 0) req_sector_size = ent->getSectorSize();
+
+	if (ent->getSectorSize() != req_sector_size)
+		return 0x05;
+
+	memcpy(data, ent->data.data(), req_sector_size);
+	return 0;
+}
+
+uint8_t imageDiskTeledisk::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size) {
+	(void)head; (void)cylinder; (void)sector; (void)data; (void)req_sector_size;
+	/* TeleDisk images are read-only: writes cannot be re-encoded back into the .td0 archive,
+	 * so accepting a write in memory only would silently discard the guest's data on remount.
+	 * Report the disk as write-protected instead. */
+	return 0x03;
+}
+
+uint8_t imageDiskTeledisk::Read_AbsoluteSector(uint32_t sectnum, void * data) {
+	unsigned int c,h,s;
+
+	if (sectors == 0 || heads == 0)
+		return 0x05;
+
+	s = (sectnum % sectors) + 1;
+	h = (sectnum / sectors) % heads;
+	c = (sectnum / sectors / heads);
+	return Read_Sector(h,c,s,data);
+}
+
+uint8_t imageDiskTeledisk::Write_AbsoluteSector(uint32_t sectnum,const void *data) {
+	unsigned int c,h,s;
+
+	if (sectors == 0 || heads == 0)
+		return 0x05;
+
+	s = (sectnum % sectors) + 1;
+	h = (sectnum / sectors) % heads;
+	c = (sectnum / sectors / heads);
+	return Write_Sector(h,c,s,data);
+}
+
+imageDiskTeledisk::imageDiskTeledisk(FILE *imgFile, const char *imgName, uint32_t imgSizeK, bool isHardDisk) : imageDisk(ID_TELEDISK) {
+	(void)isHardDisk;//UNUSED
+	(void)imgSizeK;//UNUSED
+	td0_image_header header;
+
+	heads = 1;
+	cylinders = 0;
+	image_base = 0;
+	sectors = 0;
+	active = false;
+	sector_size = 0;
+	reserved_cylinders = 0;
+	diskSizeK = 0;
+	diskimg = imgFile;
+
+	if (imgName != NULL)
+		diskname = imgName;
+
+	if (diskimg == NULL)
+		return;
+
+	fseek(diskimg,0,SEEK_SET);
+	if (fread(&header,1,sizeof(header),diskimg) != sizeof(header))
+		return;
+
+	/* Only support "TD" (normal compression), not "td" advanced compression */
+	if (header.signature[0] != 'T' || header.signature[1] != 'D')
+		return;
+
+	/* Optional comment block, flagged by the high bit of the stepping field */
+	if (header.stepping & 0x80U) {
+		td0_comment_header comment;
+		if (fread(&comment,1,sizeof(comment),diskimg) != sizeof(comment))
+			return;
+
+		const uint16_t comment_len = td0_read_u16le(comment.length);
+		if (fseek(diskimg, (long)comment_len, SEEK_CUR) != 0)
+			return;
+	}
+
+	bool parse_ok = false;
+	for (;;) {
+		td0_track_header track_header;
+		if (fread(&track_header,1,sizeof(track_header),diskimg) != sizeof(track_header))
+			return;
+
+		const uint8_t num_sectors = track_header.num_sectors;
+		if (num_sectors == 0xFFU) {
+			parse_ok = true;
+			break;
+		}
+
+		const uint8_t phys_track = track_header.cylinder;
+		const uint8_t phys_head = track_header.head & 1U;
+
+		for (uint8_t i = 0; i < num_sectors; i++) {
+			td0_sector_header sector_header;
+			if (fread(&sector_header,1,sizeof(sector_header),diskimg) != sizeof(sector_header))
+				return;
+
+			td0entry ent;
+			const uint8_t size_code = (sector_header.size_code > 6U) ? 0U : sector_header.size_code;
+
+			ent.phys_track = phys_track;
+			ent.phys_head = phys_head;
+			ent.phys_sector = sector_header.sector;
+			ent.logical_track = sector_header.cylinder;
+			ent.logical_head = sector_header.head;
+			ent.sector_size = (uint16_t)(128U << size_code);
+			ent.flags = sector_header.flags;
+
+			if ((ent.flags & td0_sector_flags::id_no_data) || (sector_header.size_code & 0xF8U)) {
+				ent.has_data = false;
+				ent.data.assign(ent.sector_size, 0);
+			}
+			else if (ent.flags & td0_sector_flags::dos_skipped) {
+				ent.has_data = true;
+				ent.data.assign(ent.sector_size, 0);
+			}
+			else {
+				td0_data_header data_header;
+				const long data_header_offset = ftell(diskimg);
+				if (fread(&data_header,1,sizeof(data_header),diskimg) != sizeof(data_header))
+					return;
+
+				const uint16_t data_block_size = td0_read_u16le(data_header.block_size);
+				if (data_block_size < 1U)
+					return;
+
+				const uint16_t encoded_size = (uint16_t)(data_block_size - 1U);
+				std::vector<uint8_t> encoded(encoded_size);
+				if (encoded_size != 0 && fread(&encoded[0],1,encoded_size,diskimg) != encoded_size)
+					return;
+
+				const imageDiskTeledisk::sector_encoding_method method =
+					static_cast<imageDiskTeledisk::sector_encoding_method>(data_header.method);
+
+				ent.has_data = td0_decode_sector_data(method, encoded, ent.sector_size, ent.data);
+				if (!ent.has_data) {
+					LOG_MSG("TD0: failed to decode sector C/H/S=%u/%u/%u method=%u file_ofs=%ld",
+						(unsigned int)ent.phys_track,
+						(unsigned int)ent.phys_head,
+						(unsigned int)ent.phys_sector,
+						(unsigned int)method,
+						data_header_offset);
+					ent.data.assign(ent.sector_size, 0);
+				}
+			}
+
+			dents.push_back(ent);
+			diskSizeK += ent.sector_size;
+		}
+	}
+
+	diskSizeK /= 1024;
+
+	if (parse_ok && !dents.empty()) {
+		bool founddisk = false;
+		const td0entry *ent;
+
+		ent = findSector(0,0,1,~0U);
+		if (ent != NULL && ent->getSectorSize() <= 1024)
+			sector_size = ent->getSectorSize();
+
+		if (sector_size != 0 && sector_size < 512) {
+			ent = findSector(0,1,1,~0U);
+			if (ent != NULL && ent->getSectorSize() <= 1024) {
+				const unsigned int nsz = ent->getSectorSize();
+				if (sector_size < nsz)
+					sector_size = (uint16_t)nsz;
+			}
+		}
+
+		if (sector_size != 0) {
+			unsigned int i = 0;
+			while (DiskGeometryList[i].ksize != 0) {
+				const diskGeo &diskent = DiskGeometryList[i];
+
+				if (diskent.bytespersect == sector_size) {
+					ent = findSector(0,0,(uint8_t)diskent.secttrack,sector_size);
+					if (ent != NULL && sectors < diskent.secttrack)
+						sectors = diskent.secttrack;
+				}
+
+				i++;
+			}
+		}
+
+		if (sector_size != 0 && sectors != 0) {
+			unsigned int i = 0;
+			while (DiskGeometryList[i].ksize != 0) {
+				const diskGeo &diskent = DiskGeometryList[i];
+
+				if (diskent.bytespersect == sector_size && diskent.secttrack >= sectors) {
+					ent = findSector(0,(uint8_t)(diskent.cylcount-1),(uint8_t)sectors,sector_size);
+					if (ent != NULL && cylinders < diskent.cylcount)
+						cylinders = diskent.cylcount;
+				}
+
+				i++;
+			}
+		}
+
+		if (sector_size != 0 && sectors != 0 && cylinders != 0) {
+			ent = findSector(1,0,(uint8_t)sectors,sector_size);
+			if (ent != NULL)
+				heads = 2;
+		}
+
+		if (sector_size != 0 && sectors != 0 && cylinders != 0 && heads != 0)
+			founddisk = true;
+
+		/* Fallback for nonstandard geometries */
+		if (!founddisk) {
+			uint16_t max_sector = 0, max_cyl = 0, max_head = 0, max_ss = 0;
+			for (const auto &entry : dents) {
+				if (entry.sector_size > max_ss)
+					max_ss = entry.sector_size;
+				if (entry.phys_sector > max_sector)
+					max_sector = entry.phys_sector;
+				if (entry.phys_track > max_cyl)
+					max_cyl = entry.phys_track;
+				if (entry.phys_head > max_head)
+					max_head = entry.phys_head;
+			}
+
+			if (max_sector != 0 && max_ss != 0) {
+				sector_size = max_ss;
+				sectors = max_sector;
+				cylinders = max_cyl + 1;
+				heads = max_head + 1;
+				founddisk = (sectors != 0 && cylinders != 0 && heads != 0);
+			}
+		}
+
+		LOG_MSG("TD0 geometry detection: C/H/S %u/%u/%u %u bytes/sector entries=%u",
+			cylinders, heads, sectors, sector_size, (unsigned int)dents.size());
+
+		/* active stays false (as initialized) unless we resolved a usable geometry */
+		if (founddisk) {
+			active = true;
+			incrementFDD();
+			updateFloppyDPT();
+		}
+	}
+}
+
+imageDiskTeledisk::~imageDiskTeledisk() {
+	if(diskimg != NULL) {
+		fclose(diskimg);
+		diskimg=NULL;
+	}
+}

--- a/vs/dosbox-x.vcxproj
+++ b/vs/dosbox-x.vcxproj
@@ -1527,6 +1527,7 @@ for /d %%i in ("$(SolutionDir)\..\contrib\translations\*") do copy "%%i\*.lng" "
     <ClCompile Include="..\src\hardware\glide.cpp" />
     <ClCompile Include="..\src\ints\bios.cpp" />
     <ClCompile Include="..\src\ints\bios_disk.cpp" />
+    <ClCompile Include="..\src\ints\imagedisk_teledisk.cpp" />
     <ClCompile Include="..\src\ints\bios_keyboard.cpp" />
     <ClCompile Include="..\src\ints\ems.cpp" />
     <ClCompile Include="..\src\ints\int10.cpp" />

--- a/vs/dosbox-x.vcxproj.filters
+++ b/vs/dosbox-x.vcxproj.filters
@@ -603,6 +603,9 @@
     <ClCompile Include="..\src\ints\bios_disk.cpp">
       <Filter>Sources\ints</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\ints\imagedisk_teledisk.cpp">
+      <Filter>Sources\ints</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\ints\bios_keyboard.cpp">
       <Filter>Sources\ints</Filter>
     </ClCompile>


### PR DESCRIPTION
## Summary
- Adds a new `imageDiskTeledisk` image type that reads TeleDisk (`.td0`) floppy images.
- Wires `.td0` detection (via the `TD` file signature) into the image-mounting paths in `IMGMOUNT`, the floppy swap list, and `fatDrive`, and adds `.td0`/`.TD0` to the file-open dialog filters.
- Improves DOS 1.x floppy detection in `fatDriveInit` to build the BPB from the FAT media descriptor byte (pre-DOS 2.0 floppies have no BPB), and logs a warning on unsupported IMGMOUNT extensions.

## Why TeleDisk?
TeleDisk (`.td0`) is a widely-used archival format for preserving copy-protected and non-standard floppy disks. Unlike a flat sector image, it records per-track/per-sector geometry and metadata, so it can faithfully capture disks with mixed sector sizes, unusual layouts, and other quirks common in vintage software. Supporting it lets DOSBox-X mount a large body of preserved floppy images directly.