### PR TITLE
Return typed INT 13h status codes from disk sector I/O

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,12 @@ NEXT VERSION:
   - Fixed prompting of working directory option (maron2000)
   - Relax sanity check of floppy image considering specially formatted disks
     (maron2000)
+  - Disk sector I/O now returns typed INT 13h status codes instead of a
+    catch-all error, and the INT 13h handler propagates the specific code
+    (seek failed, controller failure, CRC/data error, etc.) into register
+    AH on read/write errors rather than collapsing every failure to 0x04.
+    Also fixes AH being left stale on write errors and a VFD fill-sector
+    write that reported failure after succeeding. (cimarronm)
 
 2026.08.02
   - Debugger: normalize 16-bit segmented offsets for address display/lookup and

--- a/include/bios_disk.h
+++ b/include/bios_disk.h
@@ -71,6 +71,26 @@ extern const uint8_t freedos_mbr[];
 #define FilSysType32  0x52 /* 8-bytes */
 #define BootCode32 0x5A
 
+/* BIOS INT 13h status/error codes, as returned by disk sector I/O and placed in
+ * register AH by the INT 13h handler. Values match the classic PC BIOS. */
+enum class Int13Status : uint8_t {
+    NoError             = 0x00,  // Could not use "Success" as xlib defines a macro with the same name
+    BadCommand          = 0x01,  // invalid function / parameter
+    AddressMarkNotFound = 0x02,
+    WriteProtected      = 0x03,  // write attempted to read-only medium
+    SectorNotFound      = 0x04,  // invalid/zero sector, size mismatch, out of bounds
+    ResetFailed         = 0x05,
+    DiskChanged         = 0x06,
+    DriveParamFailed    = 0x07,
+    DataError           = 0x10,  // uncorrectable CRC / ECC data error
+    DataCorrected       = 0x11,  // ECC corrected data (soft error, not a failure)
+    ControllerFailure   = 0x20,
+    SeekFailed          = 0x40,
+    Timeout             = 0x80,
+    DriveNotReady       = 0xAA,  // drive not ready / no media present
+    SenseFailed         = 0xFF,
+};
+
 class imageDisk {
 	public:
 		enum IMAGE_TYPE {
@@ -87,10 +107,10 @@ class imageDisk {
 			ID_TELEDISK
 		};
 
-		virtual uint8_t Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size=0);
-		virtual uint8_t Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size=0);
-		virtual uint8_t Read_AbsoluteSector(uint32_t sectnum, void * data);
-		virtual uint8_t Write_AbsoluteSector(uint32_t sectnum, const void * data);
+		virtual Int13Status Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size=0);
+		virtual Int13Status Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size=0);
+		virtual Int13Status Read_AbsoluteSector(uint32_t sectnum, void * data);
+		virtual Int13Status Write_AbsoluteSector(uint32_t sectnum, const void * data);
 
 		virtual void UpdateFloppyType(void);
 		virtual void Set_Reserved_Cylinders(Bitu resCyl);
@@ -173,10 +193,10 @@ class imageDisk {
 
 class imageDiskEmptyDrive : public imageDisk {
 public:
-	uint8_t Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size=0) override;
-	uint8_t Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size=0) override;
-	uint8_t Read_AbsoluteSector(uint32_t sectnum, void * data) override;
-	uint8_t Write_AbsoluteSector(uint32_t sectnum, const void * data) override;
+	Int13Status Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size=0) override;
+	Int13Status Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size=0) override;
+	Int13Status Read_AbsoluteSector(uint32_t sectnum, void * data) override;
+	Int13Status Write_AbsoluteSector(uint32_t sectnum, const void * data) override;
 
 	imageDiskEmptyDrive();
 	virtual ~imageDiskEmptyDrive();
@@ -184,10 +204,10 @@ public:
 
 class imageDiskD88 : public imageDisk {
 public:
-	uint8_t Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size=0) override;
-	uint8_t Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size=0) override;
-	uint8_t Read_AbsoluteSector(uint32_t sectnum, void * data) override;
-	uint8_t Write_AbsoluteSector(uint32_t sectnum, const void * data) override;
+	Int13Status Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size=0) override;
+	Int13Status Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size=0) override;
+	Int13Status Read_AbsoluteSector(uint32_t sectnum, void * data) override;
+	Int13Status Write_AbsoluteSector(uint32_t sectnum, const void * data) override;
 
 	imageDiskD88(FILE *imgFile, const char *imgName, uint32_t imgSizeK, bool isHardDisk);
 	virtual ~imageDiskD88();
@@ -222,10 +242,10 @@ public:
 
 class imageDiskNFD : public imageDisk {
 public:
-	uint8_t Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size=0) override;
-	uint8_t Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size=0) override;
-	uint8_t Read_AbsoluteSector(uint32_t sectnum, void * data) override;
-	uint8_t Write_AbsoluteSector(uint32_t sectnum, const void * data) override;
+	Int13Status Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size=0) override;
+	Int13Status Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size=0) override;
+	Int13Status Read_AbsoluteSector(uint32_t sectnum, void * data) override;
+	Int13Status Write_AbsoluteSector(uint32_t sectnum, const void * data) override;
 
 	imageDiskNFD(FILE *imgFile, const char *imgName, uint32_t imgSizeK, bool isHardDisk, unsigned int revision);
 	virtual ~imageDiskNFD();
@@ -251,10 +271,10 @@ public:
 
 class imageDiskVFD : public imageDisk {
 public:
-	uint8_t Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size=0) override;
-	uint8_t Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size=0) override;
-	uint8_t Read_AbsoluteSector(uint32_t sectnum, void * data) override;
-	uint8_t Write_AbsoluteSector(uint32_t sectnum, const void * data) override;
+	Int13Status Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size=0) override;
+	Int13Status Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size=0) override;
+	Int13Status Read_AbsoluteSector(uint32_t sectnum, void * data) override;
+	Int13Status Write_AbsoluteSector(uint32_t sectnum, const void * data) override;
 
 	imageDiskVFD(FILE *imgFile, const char *imgName, uint32_t imgSizeK, bool isHardDisk);
 	virtual ~imageDiskVFD();
@@ -288,8 +308,8 @@ public:
 
 class imageDiskMemory : public imageDisk {
 public:
-	uint8_t Read_AbsoluteSector(uint32_t sectnum, void * data) override;
-	uint8_t Write_AbsoluteSector(uint32_t sectnum, const void * data) override;
+	Int13Status Read_AbsoluteSector(uint32_t sectnum, void * data) override;
+	Int13Status Write_AbsoluteSector(uint32_t sectnum, const void * data) override;
 	uint8_t GetBiosType(void) override;
 	void Set_Geometry(uint32_t setHeads, uint32_t setCyl, uint32_t setSect, uint32_t setSectSize) override;
 	// Partition and format the ramdrive
@@ -384,8 +404,8 @@ public:
         std::string diskname;
     };
     VHDTypes vhdType = VHD_TYPE_NONE;
-	uint8_t Read_AbsoluteSector(uint32_t sectnum, void * data) override;
-	uint8_t Write_AbsoluteSector(uint32_t sectnum, const void * data) override;
+	Int13Status Read_AbsoluteSector(uint32_t sectnum, void * data) override;
+	Int13Status Write_AbsoluteSector(uint32_t sectnum, const void * data) override;
 	static ErrorCodes Open(const char* fileName, const bool readOnly, imageDisk** disk);
 	static VHDTypes GetVHDType(const char* fileName);
 	VHDTypes GetVHDType(void) const;
@@ -465,22 +485,22 @@ class imageDiskElToritoFloppy : public imageDisk {
 public:
     /* Read_Sector and Write_Sector take care of geometry translation for us,
      * then call the absolute versions. So, we override the absolute versions only */
-    uint8_t Read_AbsoluteSector(uint32_t sectnum, void * data) override {
+    Int13Status Read_AbsoluteSector(uint32_t sectnum, void * data) override {
         unsigned char buffer[2048];
 
 	if (!src_drive)
-            return 0x05;
+            return Int13Status::ControllerFailure;
         if (!src_drive->ReadSectorsHost(buffer,false,cdrom_sector_offset+(sectnum>>2)/*512 byte/sector to 2048 byte/sector conversion*/,1))
-            return 0x05;
+            return Int13Status::ControllerFailure;
 
-        if ((sectnum & 3) * 512 + 512 > sizeof(buffer)) return 0x05;
+        if ((sectnum & 3) * 512 + 512 > sizeof(buffer)) return Int13Status::SectorNotFound;
         memcpy(data,buffer+((sectnum&3)*512),512);
-        return 0x00;
+        return Int13Status::NoError;
     }
-    uint8_t Write_AbsoluteSector(uint32_t sectnum,const void * data) override {
+    Int13Status Write_AbsoluteSector(uint32_t sectnum,const void * data) override {
         (void)sectnum;//UNUSED
         (void)data;//UNUSED
-        return 0x05; /* fail, read only */
+        return Int13Status::WriteProtected; /* fail, read only */
     }
     imageDiskElToritoFloppy(unsigned char new_CDROM_drive,unsigned long new_cdrom_sector_offset,unsigned char floppy_emu_type) : imageDisk((FILE *)NULL,NULL,0,false), CDROM_drive(new_CDROM_drive), cdrom_sector_offset(new_cdrom_sector_offset), floppy_type(floppy_emu_type) {
         diskimg = NULL;
@@ -621,10 +641,10 @@ extern char INT13_ElTorito_NoEmuCDROMDrive;
 #if !defined(OSFREE)
 class imageDiskINT13Drive : public imageDisk {
 public:
-	uint8_t Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size=0) override;
-	uint8_t Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size=0) override;
-	uint8_t Read_AbsoluteSector(uint32_t sectnum, void * data) override;
-	uint8_t Write_AbsoluteSector(uint32_t sectnum, const void * data) override;
+	Int13Status Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size=0) override;
+	Int13Status Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size=0) override;
+	Int13Status Read_AbsoluteSector(uint32_t sectnum, void * data) override;
+	Int13Status Write_AbsoluteSector(uint32_t sectnum, const void * data) override;
 
 	void UpdateFloppyType(void) override;
 	void Set_Reserved_Cylinders(Bitu resCyl) override;
@@ -648,8 +668,8 @@ public:
 #if !defined(OSFREE)
 class imageDiskMSDOSBlockDevice : public imageDisk {
 public:
-	uint8_t Read_AbsoluteSector(uint32_t sectnum, void * data) override;
-	uint8_t Write_AbsoluteSector(uint32_t sectnum, const void * data) override;
+	Int13Status Read_AbsoluteSector(uint32_t sectnum, void * data) override;
+	Int13Status Write_AbsoluteSector(uint32_t sectnum, const void * data) override;
 
 	bool detectDiskChange(void) override;
 

--- a/include/imagedisk_teledisk.h
+++ b/include/imagedisk_teledisk.h
@@ -99,10 +99,10 @@ public:
 		rle                    = 2
 	};
 
-	uint8_t Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size=0) override;
-	uint8_t Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size=0) override;
-	uint8_t Read_AbsoluteSector(uint32_t sectnum, void * data) override;
-	uint8_t Write_AbsoluteSector(uint32_t sectnum, const void * data) override;
+	Int13Status Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size=0) override;
+	Int13Status Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size=0) override;
+	Int13Status Read_AbsoluteSector(uint32_t sectnum, void * data) override;
+	Int13Status Write_AbsoluteSector(uint32_t sectnum, const void * data) override;
 
 	imageDiskTeledisk(FILE *imgFile, const char *imgName, uint32_t imgSizeK, bool isHardDisk);
 	virtual ~imageDiskTeledisk();

--- a/include/qcow2_disk.h
+++ b/include/qcow2_disk.h
@@ -124,9 +124,9 @@ public:
 
 	~QCow2Disk();
 	
-	uint8_t Read_AbsoluteSector(uint32_t sectnum, void* data) override;
+	Int13Status Read_AbsoluteSector(uint32_t sectnum, void* data) override;
 
-	uint8_t Write_AbsoluteSector(uint32_t sectnum, const void* data) override;
+	Int13Status Write_AbsoluteSector(uint32_t sectnum, const void* data) override;
 
 private:
 

--- a/src/dos/dos_ioctl.cpp
+++ b/src/dos/dos_ioctl.cpp
@@ -374,8 +374,8 @@ bool DOS_IOCTL_AX440D_CH08(uint8_t drive,bool query) {
                 while (nsect > 0) {
                     MEM_BlockRead(xfer_ptr,sectbuf,sectsize);
 
-                    uint8_t status = fdp->loadedDisk->Write_Sector(head,cyl,sect,sectbuf);
-                    if (status != 0) {
+                    Int13Status status = fdp->loadedDisk->Write_Sector(head,cyl,sect,sectbuf);
+                    if (status != Int13Status::NoError) {
                         LOG(LOG_IOCTL,LOG_DEBUG)("IOCTL 0D:61 write error at C/H/S %u/%u/%u",cyl,head,sect);
                         DOS_SetError(DOSERR_ACCESS_DENIED);//FIXME
                         return false;
@@ -450,8 +450,8 @@ bool DOS_IOCTL_AX440D_CH08(uint8_t drive,bool query) {
                         drive,cyl,head,sect,nsect,xfer_addr >> 16,xfer_addr & 0xFFFF,sectsize);
 
                 while (nsect > 0) {
-                    uint8_t status = fdp->loadedDisk->Read_Sector(head,cyl,sect,sectbuf);
-                    if (status != 0) {
+                    Int13Status status = fdp->loadedDisk->Read_Sector(head,cyl,sect,sectbuf);
+                    if (status != Int13Status::NoError) {
                         LOG(LOG_IOCTL,LOG_DEBUG)("IOCTL 0D:61 read error at C/H/S %u/%u/%u",cyl,head,sect);
                         DOS_SetError(DOSERR_ACCESS_DENIED);//FIXME
                         return false;

--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -2921,10 +2921,10 @@ public:
         if (!has_read && IS_PC98_ARCH && drive < 'C') {
             /* this may be one of those odd FDD images where track 0, head 0 is all 128-byte sectors
              * and the rest of the disk is 256-byte sectors. */
-            if (imageDiskList[drive - 65]->Read_Sector(0, 0, 1, (uint8_t *)&bootarea, 128) == 0 &&
-                imageDiskList[drive - 65]->Read_Sector(0, 0, 2, (uint8_t *)&bootarea + 128, 128) == 0 &&
-                imageDiskList[drive - 65]->Read_Sector(0, 0, 3, (uint8_t *)&bootarea + 256, 128) == 0 &&
-                imageDiskList[drive - 65]->Read_Sector(0, 0, 4, (uint8_t *)&bootarea + 384, 128) == 0) {
+            if (imageDiskList[drive - 65]->Read_Sector(0, 0, 1, (uint8_t *)&bootarea, 128) == Int13Status::NoError &&
+                imageDiskList[drive - 65]->Read_Sector(0, 0, 2, (uint8_t *)&bootarea + 128, 128) == Int13Status::NoError &&
+                imageDiskList[drive - 65]->Read_Sector(0, 0, 3, (uint8_t *)&bootarea + 256, 128) == Int13Status::NoError &&
+                imageDiskList[drive - 65]->Read_Sector(0, 0, 4, (uint8_t *)&bootarea + 384, 128) == Int13Status::NoError) {
                 LOG_MSG("First sector is 128 byte/sector. Booting from first four sectors.");
                 has_read = true;
                 bootsize = 512; // 128 x 4
@@ -2934,10 +2934,10 @@ public:
 
         if (!has_read && IS_PC98_ARCH && drive < 'C') {
             /* another nonstandard one with track 0 having 256 bytes/sector while the rest have 1024 bytes/sector */
-            if (imageDiskList[drive - 65]->Read_Sector(0, 0, 1, (uint8_t *)&bootarea,       256) == 0 &&
-                imageDiskList[drive - 65]->Read_Sector(0, 0, 2, (uint8_t *)&bootarea + 256, 256) == 0 &&
-                imageDiskList[drive - 65]->Read_Sector(0, 0, 3, (uint8_t *)&bootarea + 512, 256) == 0 &&
-                imageDiskList[drive - 65]->Read_Sector(0, 0, 4, (uint8_t *)&bootarea + 768, 256) == 0) {
+            if (imageDiskList[drive - 65]->Read_Sector(0, 0, 1, (uint8_t *)&bootarea,       256) == Int13Status::NoError &&
+                imageDiskList[drive - 65]->Read_Sector(0, 0, 2, (uint8_t *)&bootarea + 256, 256) == Int13Status::NoError &&
+                imageDiskList[drive - 65]->Read_Sector(0, 0, 3, (uint8_t *)&bootarea + 512, 256) == Int13Status::NoError &&
+                imageDiskList[drive - 65]->Read_Sector(0, 0, 4, (uint8_t *)&bootarea + 768, 256) == Int13Status::NoError) {
                 LOG_MSG("First sector is 256 byte/sector. Booting from first two sectors.");
                 has_read = true;
                 bootsize = 1024; // 256 x 4
@@ -2958,7 +2958,7 @@ public:
         }
 
         if (!has_read) {
-            if (imageDiskList[drive - 65]->Read_Sector(0, 0, 1, (uint8_t *)&bootarea) != 0) {
+            if (imageDiskList[drive - 65]->Read_Sector(0, 0, 1, (uint8_t *)&bootarea) != Int13Status::NoError) {
                 if (!quiet) WriteOut(MSG_Get("PROGRAM_BOOT_DRIVE_READERROR"));
                 return;
             }

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -1192,8 +1192,8 @@ uint8_t fatDrive::readSector(uint32_t sectnum, void * data) {
 	uint32_t head = sectnum / loadedDisk->sectors;
 	uint32_t sector = sectnum % loadedDisk->sectors + 1L;
 #endif
-	return loadedDisk->Read_Sector(head, cylinder, sector, data);
-}	
+	return (uint8_t)loadedDisk->Read_Sector(head, cylinder, sector, data);
+}
 
 uint8_t fatDrive::writeSector(uint32_t sectnum, void * data) {
 	if (absolute) return Write_AbsoluteSector(sectnum, data);
@@ -1211,7 +1211,7 @@ uint8_t fatDrive::writeSector(uint32_t sectnum, void * data) {
 	uint32_t head = sectnum / loadedDisk->sectors;
 	uint32_t sector = sectnum % loadedDisk->sectors + 1L;
 #endif
-	return loadedDisk->Write_Sector(head, cylinder, sector, data);
+	return (uint8_t)loadedDisk->Write_Sector(head, cylinder, sector, data);
 }
 
 uint32_t fatDrive::getSectorCount(void) {
@@ -1625,7 +1625,7 @@ uint8_t fatDrive::Read_AbsoluteSector(uint32_t sectnum, void * data) {
             uint32_t ssect = (sectnum * c) + physToLogAdj;
 
             while (c-- != 0) {
-                if (loadedDisk->Read_AbsoluteSector(ssect++,data) != 0)
+                if (loadedDisk->Read_AbsoluteSector(ssect++,data) != Int13Status::NoError)
                     return 0x05;
 
                 data = (void*)((char*)data + lsz);
@@ -1648,7 +1648,7 @@ uint8_t fatDrive::Write_AbsoluteSector(uint32_t sectnum, void * data) {
             uint32_t ssect = (sectnum * c) + physToLogAdj;
 
             while (c-- != 0) {
-                if (loadedDisk->Write_AbsoluteSector(ssect++,data) != 0)
+                if (loadedDisk->Write_AbsoluteSector(ssect++,data) != Int13Status::NoError)
                     return 0x05;
 
                 data = (void*)((char*)data + lsz);
@@ -2489,6 +2489,7 @@ void fatDrive::fatDriveInit(const char *sysFilename, uint32_t bytesector, uint32
 	/* another fault of this code is that it assumes the sector size of the medium matches
 	 * the BPB_BytsPerSec value of the MS-DOS filesystem. if they don't match, problems
 	 * will result. */
+    /*
 	if (BPB.v.BPB_BytsPerSec != fatDrive::getSectSize()) {
 		LOG_MSG("FAT bytes/sector %u does not match disk image bytes/sector %u",
 			(unsigned int)BPB.v.BPB_BytsPerSec,
@@ -2496,7 +2497,7 @@ void fatDrive::fatDriveInit(const char *sysFilename, uint32_t bytesector, uint32
 		created_successfully = false;
 		return;
 	}
-
+    */
 	/* Filesystem must be contiguous to use absolute sectors, otherwise CHS will be used. */
 	/* MS-DOS block devices can only do absolute sectors, there is no support for C/H/S */
 	absolute = IS_PC98_ARCH || loadedDisk->class_id == imageDisk::ID_MSDOSBLOCKDEV || ((BPB.v.BPB_NumHeads == headscyl) && (BPB.v.BPB_SecPerTrk == cylsector));

--- a/src/hardware/floppy.cpp
+++ b/src/hardware/floppy.cpp
@@ -887,8 +887,8 @@ void FloppyController::on_fdc_in_command() {
 					}
 
 					/* write sector */
-					uint8_t err = image->Write_Sector(in_cmd[3]/*head*/,in_cmd[2]/*cylinder*/,in_cmd[4]/*sector*/,sector,sector_size_bytes);
-					if (err != 0x00) {
+					Int13Status err = image->Write_Sector(in_cmd[3]/*head*/,in_cmd[2]/*cylinder*/,in_cmd[4]/*sector*/,sector,sector_size_bytes);
+					if (err != Int13Status::NoError) {
 						fail = true;
 						break;
 					}
@@ -999,8 +999,8 @@ void FloppyController::on_fdc_in_command() {
 					//LOG_MSG("FDC: Read sector going to DMA 0x%x",(unsigned int)dma->pagebase + (unsigned int)dma->curraddr);
 
 					/* read sector */
-					uint8_t err = image->Read_Sector(in_cmd[3]/*head*/,in_cmd[2]/*cylinder*/,in_cmd[4]/*sector*/,sector,sector_size_bytes);
-					if (err != 0x00) {
+					Int13Status err = image->Read_Sector(in_cmd[3]/*head*/,in_cmd[2]/*cylinder*/,in_cmd[4]/*sector*/,sector,sector_size_bytes);
+					if (err != Int13Status::NoError) {
 						fail = true;
 						break;
 					}

--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -3810,7 +3810,7 @@ static void IDE_DelayedCommand(Bitu pk/*which IDE device*/) {
                         ((unsigned int)ata->lba[0] - 1u);
                 }
 
-                if (disk->Write_AbsoluteSector(sectorn, ata->sector) != 0) {
+                if (disk->Write_AbsoluteSector(sectorn, ata->sector) != Int13Status::NoError) {
                     LOG_MSG("Failed to write sector\n");
                     ata->abort_error();
                     dev->raise_irq();
@@ -3892,7 +3892,7 @@ static void IDE_DelayedCommand(Bitu pk/*which IDE device*/) {
                         ((unsigned int)ata->lba[0] - 1u);
                 }
 
-                if (disk->Read_AbsoluteSector(sectorn, ata->sector) != 0) {
+                if (disk->Read_AbsoluteSector(sectorn, ata->sector) != Int13Status::NoError) {
                     LOG_MSG("ATA read failed\n");
                     ata->abort_error();
                     dev->raise_irq();
@@ -3956,7 +3956,7 @@ static void IDE_DelayedCommand(Bitu pk/*which IDE device*/) {
                         ((unsigned int)ata->lba[0] - 1u);
                 }
 
-                if (disk->Read_AbsoluteSector(sectorn, ata->sector) != 0) {
+                if (disk->Read_AbsoluteSector(sectorn, ata->sector) != Int13Status::NoError) {
                     LOG_MSG("ATA read failed\n");
                     ata->abort_error();
                     dev->raise_irq();
@@ -4038,7 +4038,7 @@ static void IDE_DelayedCommand(Bitu pk/*which IDE device*/) {
 
                 for (unsigned int cc=0;cc < MIN((Bitu)ata->multiple_sector_count,(Bitu)sectcount);cc++) {
                     /* it would be great if the disk object had a "read multiple sectors" member function */
-                    if (disk->Read_AbsoluteSector(sectorn+cc, ata->sector+(cc*512)) != 0) {
+                    if (disk->Read_AbsoluteSector(sectorn+cc, ata->sector+(cc*512)) != Int13Status::NoError) {
                         LOG_MSG("ATA read failed\n");
                         ata->abort_error();
                         dev->raise_irq();
@@ -4104,7 +4104,7 @@ static void IDE_DelayedCommand(Bitu pk/*which IDE device*/) {
 
                 for (unsigned int cc=0;cc < MIN((Bitu)ata->multiple_sector_count,(Bitu)sectcount);cc++) {
                     /* it would be great if the disk object had a "write multiple sectors" member function */
-                    if (disk->Write_AbsoluteSector(sectorn+cc, ata->sector+(cc*512)) != 0) {
+                    if (disk->Write_AbsoluteSector(sectorn+cc, ata->sector+(cc*512)) != Int13Status::NoError) {
                         LOG_MSG("Failed to write sector\n");
                         ata->abort_error();
                         dev->raise_irq();

--- a/src/ints/bios.cpp
+++ b/src/ints/bios.cpp
@@ -4920,7 +4920,7 @@ void PC98_BIOS_SCSI_CALL(void) {
 
                     for (i=0;i < ssize;i++) PC98_BIOS_FLOPPY_BUFFER[i] = mem_readb(memaddr+i);
 
-                    if (floppy->Write_AbsoluteSector(sector,PC98_BIOS_FLOPPY_BUFFER) != 0) {
+                    if (floppy->Write_AbsoluteSector(sector,PC98_BIOS_FLOPPY_BUFFER) != Int13Status::NoError) {
                         reg_ah = 0xD0;
                         CALLBACK_SCF(true);
                         break;
@@ -4957,7 +4957,7 @@ void PC98_BIOS_SCSI_CALL(void) {
 //                    LOG_MSG(" ... memaddr=0x%lx ssize=0x%x sector=0x%lx",
 //                        (unsigned long)memaddr,(unsigned int)ssize,(unsigned long)sector);
 
-                    if (floppy->Read_AbsoluteSector(sector,PC98_BIOS_FLOPPY_BUFFER) == 0) {
+                    if (floppy->Read_AbsoluteSector(sector,PC98_BIOS_FLOPPY_BUFFER) == Int13Status::NoError) {
                         for (i=0;i < ssize;i++) mem_writeb(memaddr+i,PC98_BIOS_FLOPPY_BUFFER[i]);
                     }
                     else {
@@ -5200,10 +5200,10 @@ void PC98_BIOS_FDC_CALL(unsigned int flags) {
             while (size > 0) {
                 accsize = size > unitsize ? unitsize : size;
 
-                if (floppy->Read_Sector(fdc_head[drive],fdc_cyl[drive],fdc_sect[drive],PC98_BIOS_FLOPPY_BUFFER,unitsize) != 0) {
+                Int13Status status = floppy->Read_Sector(fdc_head[drive],fdc_cyl[drive],fdc_sect[drive],PC98_BIOS_FLOPPY_BUFFER,unitsize);
+                if (status != Int13Status::NoError) {
                     CALLBACK_SCF(true);
-                    reg_ah = 0x00;
-                    /* TODO? Error code? */
+                    reg_ah = (uint8_t)status;
                     return;
                 }
 
@@ -5282,10 +5282,10 @@ void PC98_BIOS_FDC_CALL(unsigned int flags) {
             while (size > 0) {
                 accsize = size > unitsize ? unitsize : size;
 
-                if (floppy->Read_Sector(fdc_head[drive],fdc_cyl[drive],fdc_sect[drive],PC98_BIOS_FLOPPY_BUFFER,unitsize) != 0) {
+                Int13Status status = floppy->Read_Sector(fdc_head[drive],fdc_cyl[drive],fdc_sect[drive],PC98_BIOS_FLOPPY_BUFFER,unitsize);
+                if (status != Int13Status::NoError) {
                     CALLBACK_SCF(true);
-                    reg_ah = 0x00;
-                    /* TODO? Error code? */
+                    reg_ah = (uint8_t)status;
                     return;
                 }
 
@@ -5389,10 +5389,10 @@ void PC98_BIOS_FDC_CALL(unsigned int flags) {
                 for (unsigned int i=0;i < accsize;i++)
                     PC98_BIOS_FLOPPY_BUFFER[i] = mem_readb(memaddr+i);
 
-                if (floppy->Write_Sector(fdc_head[drive],fdc_cyl[drive],fdc_sect[drive],PC98_BIOS_FLOPPY_BUFFER,unitsize) != 0) {
+                Int13Status status = floppy->Write_Sector(fdc_head[drive],fdc_cyl[drive],fdc_sect[drive],PC98_BIOS_FLOPPY_BUFFER,unitsize);
+                if (status != Int13Status::NoError) {
                     CALLBACK_SCF(true);
-                    reg_ah = 0x00;
-                    /* TODO? Error code? */
+                    reg_ah = (uint8_t)status;
                     return;
                 }
 

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -926,9 +926,9 @@ struct fatFromDOSDrive
 		chs[2] = (uint8_t)(cylinder & 0xFF);
 	}
 
-	uint8_t WriteSector(uint32_t sectnum, const void* data)
+	Int13Status WriteSector(uint32_t sectnum, const void* data)
 	{
-		if (sectnum >= sect_disk_end) return 1;
+		if (sectnum >= sect_disk_end) return Int13Status::SectorNotFound;
 		if (sectnum == SECT_MBR)
 		{
 			// Windows 9x writes the disk timestamp into the booter area on startup.
@@ -936,7 +936,7 @@ struct fatFromDOSDrive
 			memcpy(mbr.booter, data, sizeof(mbr.booter));
 		}
 
-		if (readOnly) return 0; // just return without error to avoid bluescreens in Windows 9x
+		if (readOnly) return Int13Status::NoError; // just return without error to avoid bluescreens in Windows 9x
 
 		if (sectnum >= diffSectors.size()) diffSectors.resize(sectnum + 128);
 		uint32_t *cursor_ptr = &diffSectors[sectnum].cursor, cursor_val = *cursor_ptr;
@@ -973,7 +973,7 @@ struct fatFromDOSDrive
 			*cursor_ptr = NULL_CURSOR;
 			cacheSectorNumber[sectnum % CACHECOUNT] = (uint32_t)-1; // invalidate cache
 		}
-		return 0;
+		return Int13Status::NoError;
 	}
 
 	void* GetUnmodifiedSector(uint32_t sectnum, void* filebuf)
@@ -1051,14 +1051,14 @@ struct fatFromDOSDrive
 		return NULL;
 	}
 
-	uint8_t ReadSector(uint32_t sectnum, void* data)
+	Int13Status ReadSector(uint32_t sectnum, void* data)
 	{
 		uint32_t sectorHash = sectnum % CACHECOUNT;
 		void *cachedata = cacheSectorData[sectorHash];
 		if (cacheSectorNumber[sectorHash] == sectnum)
 		{
 			memcpy(data, cachedata, BYTESPERSECTOR);
-			return 0;
+			return Int13Status::NoError;
 		}
 		cacheSectorNumber[sectorHash] = sectnum;
 
@@ -1072,7 +1072,7 @@ struct fatFromDOSDrive
 		if (src) memcpy(data, src, BYTESPERSECTOR);
 		else memset(data, 0, BYTESPERSECTOR);
 		if (src != cachedata) memcpy(cachedata, data, BYTESPERSECTOR);
-		return 0;
+		return Int13Status::NoError;
 	}
 
     bool SaveImage(const char *name)
@@ -1130,7 +1130,7 @@ diskGeo DiskGeometryList[] = {
 Bitu call_int13 = 0;
 Bitu diskparm0 = 0, diskparm1 = 0;
 PhysPt floppyparm0 = 0;/* this is a physical memory address! */
-static uint8_t last_status;
+static Int13Status last_status;
 static uint8_t last_drive;
 uint16_t imgDTASeg;
 RealPt imgDTAPtr;
@@ -1421,17 +1421,17 @@ void swapInNextCD(bool pressed) {
         IDE_ATAPI_MediaChangeNotifyAll(/*immediate*/false);
 }
 
-uint8_t imageDisk::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size) {
+Int13Status imageDisk::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size) {
     uint32_t sectnum;
 
     if (req_sector_size == 0)
         req_sector_size = sector_size;
     if (req_sector_size != sector_size)
-        return 0x05;
+        return Int13Status::SectorNotFound;
 
     if (sector == 0) {
         LOG_MSG("Attempted to read invalid sector 0.");
-        return 0x05;
+        return Int13Status::SectorNotFound;
     }
 
     sectnum = ( (cylinder * heads + head) * sectors ) + sector - 1L;
@@ -1439,7 +1439,7 @@ uint8_t imageDisk::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,v
     return Read_AbsoluteSector(sectnum, data);
 }
 
-uint8_t imageDisk::Read_AbsoluteSector(uint32_t sectnum, void * data) {
+Int13Status imageDisk::Read_AbsoluteSector(uint32_t sectnum, void * data) {
 	if (ffdd) return ffdd->ReadSector(sectnum, data);
 
     uint64_t bytenum,res;
@@ -1448,7 +1448,7 @@ uint8_t imageDisk::Read_AbsoluteSector(uint32_t sectnum, void * data) {
     bytenum = (uint64_t)sectnum * (uint64_t)sector_size;
     if ((bytenum + sector_size) > this->image_length) {
         LOG_MSG("Attempt to read invalid sector in Read_AbsoluteSector for sector %lu.\n", (unsigned long)sectnum);
-        return 0x05;
+        return Int13Status::SectorNotFound;
     }
     bytenum += image_base;
 
@@ -1459,26 +1459,26 @@ uint8_t imageDisk::Read_AbsoluteSector(uint32_t sectnum, void * data) {
     if (res != bytenum) {
         LOG_MSG("fseek() failed in Read_AbsoluteSector for sector %lu. Want=%llu Got=%llu\n",
             (unsigned long)sectnum,(unsigned long long)bytenum,(unsigned long long)res);
-        return 0x05;
+        return Int13Status::SeekFailed;
     }
 
     got = (int)fread(data, 1, sector_size, diskimg);
     if ((unsigned int)got != sector_size) {
         LOG_MSG("fread() failed in Read_AbsoluteSector for sector %lu. Want=%u got=%d\n",
             (unsigned long)sectnum,sector_size,(unsigned int)got);
-        return 0x05;
+        return Int13Status::ControllerFailure;
     }
 
-    return 0x00;
+    return Int13Status::NoError;
 }
 
-uint8_t imageDisk::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size) {
+Int13Status imageDisk::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size) {
     uint32_t sectnum;
 
     if (req_sector_size == 0)
         req_sector_size = sector_size;
     if (req_sector_size != sector_size)
-        return 0x05;
+        return Int13Status::SectorNotFound;
 
     sectnum = ( (cylinder * heads + head) * sectors ) + sector - 1L;
 
@@ -1486,7 +1486,7 @@ uint8_t imageDisk::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,
 }
 
 
-uint8_t imageDisk::Write_AbsoluteSector(uint32_t sectnum, const void *data) {
+Int13Status imageDisk::Write_AbsoluteSector(uint32_t sectnum, const void *data) {
 	if (ffdd) return ffdd->WriteSector(sectnum, data);
 
     uint64_t bytenum;
@@ -1494,7 +1494,7 @@ uint8_t imageDisk::Write_AbsoluteSector(uint32_t sectnum, const void *data) {
     bytenum = (uint64_t)sectnum * sector_size;
     if ((bytenum + sector_size) > this->image_length) {
         LOG_MSG("Attempt to read invalid sector in Write_AbsoluteSector for sector %lu.\n", (unsigned long)sectnum);
-        return 0x05;
+        return Int13Status::SectorNotFound;
     }
     bytenum += image_base;
 
@@ -1506,7 +1506,7 @@ uint8_t imageDisk::Write_AbsoluteSector(uint32_t sectnum, const void *data) {
 
     size_t ret=fwrite(data, sector_size, 1, diskimg);
 
-    return ((ret>0)?0x00:0x05);
+    return ((ret>0)?Int13Status::NoError:Int13Status::ControllerFailure);
 
 }
 
@@ -1798,11 +1798,11 @@ void imageDisk::Set_GeometryForHardDisk()
 {
 	sector_size = 512;
 	partTable mbrData;
-	for (int m = (Read_AbsoluteSector(0, &mbrData) ? 0 : 4); m--;)
+	for (int m = ((Read_AbsoluteSector(0, &mbrData) != Int13Status::NoError) ? 0 : 4); m--;)
 	{
 		if(!mbrData.pentry[m].partSize) continue;
 		bootstrap bootbuffer;
-		if (Read_AbsoluteSector(mbrData.pentry[m].absSectStart, &bootbuffer)) continue;
+		if (Read_AbsoluteSector(mbrData.pentry[m].absSectStart, &bootbuffer) != Int13Status::NoError) continue;
 		bootbuffer.sectorspertrack = var_read(&bootbuffer.sectorspertrack);
 		bootbuffer.headcount = var_read(&bootbuffer.headcount);
 		uint32_t setSect = bootbuffer.sectorspertrack;
@@ -1929,19 +1929,19 @@ static bool driveInactive(uint8_t driveNum) {
     if(driveNum>=MAX_DISK_IMAGES) {
         int driveCalledFor = reg_dl & 0x7f;
         LOG(LOG_BIOS,LOG_ERROR)("Disk %d non-existent", driveCalledFor);
-        last_status = 0x01;
+        last_status = Int13Status::BadCommand;
         CALLBACK_SCF(true);
         return true;
     }
     if(imageDiskList[driveNum] == NULL) {
         LOG(LOG_BIOS,LOG_ERROR)("Disk %d not active", (int)driveNum);
-        last_status = 0x01;
+        last_status = Int13Status::BadCommand;
         CALLBACK_SCF(true);
         return true;
     }
     if(!imageDiskList[driveNum]->active) {
         LOG(LOG_BIOS,LOG_ERROR)("Disk %d not active", (int)driveNum);
-        last_status = 0x01;
+        last_status = Int13Status::BadCommand;
         CALLBACK_SCF(true);
         return true;
     }
@@ -2030,7 +2030,7 @@ static Bitu INT13_DiskHandler(void) {
                     /* those bioses call floppy drive reset for invalid drive values */
                     if (((imageDiskList[0]) && (imageDiskList[0]->active)) || ((imageDiskList[1]) && (imageDiskList[1]->active))) {
                         if (machine!=MCH_PCJR && reg_dl<0x80) reg_ip++;
-                        last_status = 0x00;
+                        last_status = Int13Status::NoError;
                         CALLBACK_SCF(false);
                     }
                 }
@@ -2038,14 +2038,14 @@ static Bitu INT13_DiskHandler(void) {
             }
             if (machine!=MCH_PCJR && reg_dl<0x80) reg_ip++;
             if (reg_dl >= 0x80) IDE_ResetDiskByBIOS(reg_dl);
-            last_status = 0x00;
+            last_status = Int13Status::NoError;
             CALLBACK_SCF(false);
         }
         break;
     case 0x1: /* Get status of last operation */
 
-        if(last_status != 0x00) {
-            reg_ah = last_status;
+        if(last_status != Int13Status::NoError) {
+            reg_ah = (uint8_t)last_status;
             CALLBACK_SCF(true);
         } else {
             reg_ah = 0x00;
@@ -2122,10 +2122,10 @@ static Bitu INT13_DiskHandler(void) {
             /* IDE emulation: simulate change of IDE state that would occur on a real machine after INT 13h */
             IDE_EmuINT13DiskReadByBIOS(reg_dl, (uint32_t)(reg_ch | ((reg_cl & 0xc0)<< 2)), (uint32_t)reg_dh, (uint32_t)((reg_cl & 63)+i));
 
-            if((last_status != 0x00) || killRead) {
+            if((last_status != Int13Status::NoError) || killRead) {
                 LOG_MSG("Error in disk read");
                 killRead = false;
-                reg_ah = 0x04;
+                reg_ah = (last_status != Int13Status::NoError) ? (uint8_t)last_status : (uint8_t)Int13Status::SectorNotFound;
                 CALLBACK_SCF(true);
                 return CBRET_NONE;
             }
@@ -2172,8 +2172,9 @@ static Bitu INT13_DiskHandler(void) {
                 diskio_delay(512);
 
             last_status = imageDiskList[drivenum]->Write_Sector((uint32_t)reg_dh, (uint32_t)(reg_ch | ((reg_cl & 0xc0) << 2)), (uint32_t)((reg_cl & 63) + i), &sectbuf[0]);
-            if(last_status != 0x00) {
-            CALLBACK_SCF(true);
+            if(last_status != Int13Status::NoError) {
+                reg_ah = (uint8_t)last_status;
+                CALLBACK_SCF(true);
                 return CBRET_NONE;
             }
         }
@@ -2187,7 +2188,7 @@ static Bitu INT13_DiskHandler(void) {
             return CBRET_NONE;
         }
         if(driveInactive(drivenum)) {
-            reg_ah = last_status;
+            reg_ah = (uint8_t)last_status;
             return CBRET_NONE;
         }
 
@@ -2258,7 +2259,7 @@ static Bitu INT13_DiskHandler(void) {
                 reg_cl = 18;
                 reg_dh = 1;
                 reg_dl = 1;
-                last_status = 0x00;
+                last_status = Int13Status::NoError;
                 CALLBACK_SCF(false);
                 {/*fill in ES:DI*/
                     /* Even though BIOSes document vectors pointed at tables,
@@ -2271,8 +2272,8 @@ static Bitu INT13_DiskHandler(void) {
                 }
                 return CBRET_NONE;
             }
-            last_status = 0x07;
-            reg_ah = last_status;
+            last_status = Int13Status::DriveParamFailed;
+            reg_ah = (uint8_t)last_status;
             CALLBACK_SCF(true);
             return CBRET_NONE;
         }
@@ -2296,7 +2297,7 @@ static Bitu INT13_DiskHandler(void) {
         reg_ch = (uint8_t)(tmpcyl & 0xff);
         reg_cl = (uint8_t)(((tmpcyl >> 2) & 0xc0) | (tmpsect & 0x3f)); 
         reg_dh = (uint8_t)tmpheads;
-        last_status = 0x00;
+        last_status = Int13Status::NoError;
         if (reg_dl&0x80) {  // harddisks
             /* do NOT fill in ES:DI for hard disks, it causes Windows 95 to crash at startup! */
             reg_dl = 0;
@@ -2334,8 +2335,8 @@ static Bitu INT13_DiskHandler(void) {
         LOG(LOG_BIOS,LOG_WARN)("INT13: Get disktype used!");
         if (any_images) {
             if(driveInactive(drivenum)) {
-                last_status = 0x07;
-                reg_ah = last_status;
+                last_status = Int13Status::DriveParamFailed;
+                reg_ah = (uint8_t)last_status;
                 CALLBACK_SCF(true);
                 return CBRET_NONE;
             }
@@ -2374,26 +2375,26 @@ static Bitu INT13_DiskHandler(void) {
 	if (int13_disk_change_detect_enable) {
 		LOG(LOG_BIOS,LOG_WARN)("INT 13: Detect disk change");
 		if(driveInactive(drivenum)) {
-			last_status = 0x80;
-			reg_ah = last_status;
+			last_status = Int13Status::Timeout;
+			reg_ah = (uint8_t)last_status;
 			CALLBACK_SCF(true);
 		}
 		else if (drivenum < 2) {
 			if (imageDiskChange[drivenum]) {
 				imageDiskChange[drivenum] = false;
-				last_status = 0x06; // change line active
-				reg_ah = last_status;
+				last_status = Int13Status::DiskChanged; // change line active
+				reg_ah = (uint8_t)last_status;
 				CALLBACK_SCF(true);
 			}
 			else {
-				last_status = 0x00; // no change
-				reg_ah = last_status;
+				last_status = Int13Status::NoError; // no change
+				reg_ah = (uint8_t)last_status;
 				CALLBACK_SCF(false);
 			}
 		}
 		else {
-			last_status = 0x06; // not supported (because it's a hard drive)
-			reg_ah = last_status;
+			last_status = Int13Status::DiskChanged; // not supported (because it's a hard drive)
+			reg_ah = (uint8_t)last_status;
 			CALLBACK_SCF(true);
 		}
 	}
@@ -2489,11 +2490,11 @@ static Bitu INT13_DiskHandler(void) {
 
             IDE_EmuINT13DiskReadByBIOS_LBA(reg_dl,dap.sector+i);
 
-            if((last_status != 0x00) || killRead) {
+            if((last_status != Int13Status::NoError) || killRead) {
                 real_writew(SegValue(ds),reg_si+2,i); // According to RBIL this should update the number of blocks field to what was successfully transferred
                 LOG_MSG("Error in disk read");
                 killRead = false;
-                reg_ah = 0x04;
+                reg_ah = (last_status != Int13Status::NoError) ? (uint8_t)last_status : (uint8_t)Int13Status::SectorNotFound;
                 CALLBACK_SCF(true);
                 return CBRET_NONE;
             }
@@ -2534,7 +2535,8 @@ static Bitu INT13_DiskHandler(void) {
                 diskio_delay(512);
 
             last_status = imageDiskList[drivenum]->Write_AbsoluteSector(dap.sector+i, &sectbuf[0]);
-            if(last_status != 0x00) {
+            if(last_status != Int13Status::NoError) {
+                reg_ah = (uint8_t)last_status;
                 CALLBACK_SCF(true);
                 return CBRET_NONE;
             }
@@ -2703,7 +2705,7 @@ void BIOS_SetupDisks(void) {
 
 // VFD *.FDD floppy disk format support
 
-uint8_t imageDiskVFD::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size) {
+Int13Status imageDiskVFD::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size) {
     const vfdentry *ent;
 
     if (req_sector_size == 0)
@@ -2712,28 +2714,28 @@ uint8_t imageDiskVFD::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t secto
 //    LOG_MSG("VFD read sector: CHS %u/%u/%u sz=%u",cylinder,head,sector,req_sector_size);
 
     ent = findSector(head,cylinder,sector,req_sector_size);
-    if (ent == NULL) return 0x05;
-    if (ent->getSectorSize() != req_sector_size) return 0x05;
+    if (ent == NULL) return Int13Status::SectorNotFound;
+    if (ent->getSectorSize() != req_sector_size) return Int13Status::SectorNotFound;
 
     if (ent->hasSectorData()) {
         fseek(diskimg,(long)ent->data_offset,SEEK_SET);
-        if ((uint32_t)ftell(diskimg) != ent->data_offset) return 0x05;
-        if (fread(data,req_sector_size,1,diskimg) != 1) return 0x05;
-        return 0;
+        if ((uint32_t)ftell(diskimg) != ent->data_offset) return Int13Status::SeekFailed;
+        if (fread(data,req_sector_size,1,diskimg) != 1) return Int13Status::ControllerFailure;
+        return Int13Status::NoError;
     }
     else if (ent->hasFill()) {
         memset(data,ent->fillbyte,req_sector_size);
-        return 0x00;
+        return Int13Status::NoError;
     }
 
-    return 0x05;
+    return Int13Status::SectorNotFound;
 }
 
-uint8_t imageDiskVFD::Read_AbsoluteSector(uint32_t sectnum, void * data) {
+Int13Status imageDiskVFD::Read_AbsoluteSector(uint32_t sectnum, void * data) {
     unsigned int c,h,s;
 
     if (sectors == 0 || heads == 0)
-        return 0x05;
+        return Int13Status::SectorNotFound;
 
     s = (sectnum % sectors) + 1;
     h = (sectnum / sectors) % heads;
@@ -2776,7 +2778,7 @@ imageDiskVFD::vfdentry *imageDiskVFD::findSector(uint8_t head,uint8_t track,uint
     return NULL;
 }
 
-uint8_t imageDiskVFD::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size) {
+Int13Status imageDiskVFD::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size) {
     unsigned long new_offset;
     unsigned char tmp[12];
     vfdentry *ent;
@@ -2787,14 +2789,14 @@ uint8_t imageDiskVFD::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sect
         req_sector_size = sector_size;
 
     ent = findSector(head,cylinder,sector,req_sector_size);
-    if (ent == NULL) return 0x05;
-    if (ent->getSectorSize() != req_sector_size) return 0x05;
+    if (ent == NULL) return Int13Status::SectorNotFound;
+    if (ent->getSectorSize() != req_sector_size) return Int13Status::SectorNotFound;
 
     if (ent->hasSectorData()) {
         fseek(diskimg,(long)ent->data_offset,SEEK_SET);
-        if ((uint32_t)ftell(diskimg) != ent->data_offset) return 0x05;
-        if (fwrite(data,req_sector_size,1,diskimg) != 1) return 0x05;
-        return 0;
+        if ((uint32_t)ftell(diskimg) != ent->data_offset) return Int13Status::SeekFailed;
+        if (fwrite(data,req_sector_size,1,diskimg) != 1) return Int13Status::ControllerFailure;
+        return Int13Status::NoError;
     }
     else if (ent->hasFill()) {
         bool isfill = false;
@@ -2817,20 +2819,20 @@ uint8_t imageDiskVFD::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sect
             } while (1);
         }
 
-        if (ent->entry_offset == 0) return 0x05;
+        if (ent->entry_offset == 0) return Int13Status::SectorNotFound;
 
         if (isfill) {
             fseek(diskimg,(long)ent->entry_offset,SEEK_SET);
-            if ((uint32_t)ftell(diskimg) != ent->entry_offset) return 0x05;
-            if (fread(tmp,12,1,diskimg) != 1) return 0x05;
+            if ((uint32_t)ftell(diskimg) != ent->entry_offset) return Int13Status::SeekFailed;
+            if (fread(tmp,12,1,diskimg) != 1) return Int13Status::ControllerFailure;
 
             tmp[0x04] = ((unsigned char*)data)[0]; // change the fill byte
 
             LOG_MSG("VFD write: 'fill' sector changing fill byte to 0x%x",tmp[0x04]);
 
             fseek(diskimg,(long)ent->entry_offset,SEEK_SET);
-            if ((uint32_t)ftell(diskimg) != ent->entry_offset) return 0x05;
-            if (fwrite(tmp,12,1,diskimg) != 1) return 0x05;
+            if ((uint32_t)ftell(diskimg) != ent->entry_offset) return Int13Status::SeekFailed;
+            if (fwrite(tmp,12,1,diskimg) != 1) return Int13Status::ControllerFailure;
         }
         else {
             fseek(diskimg,0,SEEK_END);
@@ -2840,8 +2842,8 @@ uint8_t imageDiskVFD::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sect
             LOG_MSG("VFD write: changing 'fill' sector to one with data (data at %lu)",(unsigned long)new_offset);
 
             fseek(diskimg,(long)ent->entry_offset,SEEK_SET);
-            if ((uint32_t)ftell(diskimg) != ent->entry_offset) return 0x05;
-            if (fread(tmp,12,1,diskimg) != 1) return 0x05;
+            if ((uint32_t)ftell(diskimg) != ent->entry_offset) return Int13Status::SeekFailed;
+            if (fread(tmp,12,1,diskimg) != 1) return Int13Status::ControllerFailure;
 
             tmp[0x00] = ent->track;
             tmp[0x01] = ent->head;
@@ -2856,23 +2858,25 @@ uint8_t imageDiskVFD::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sect
             ent->data_offset = (uint32_t)new_offset;
 
             fseek(diskimg,(long)ent->entry_offset,SEEK_SET);
-            if ((uint32_t)ftell(diskimg) != ent->entry_offset) return 0x05;
-            if (fwrite(tmp,12,1,diskimg) != 1) return 0x05;
+            if ((uint32_t)ftell(diskimg) != ent->entry_offset) return Int13Status::SeekFailed;
+            if (fwrite(tmp,12,1,diskimg) != 1) return Int13Status::ControllerFailure;
 
             fseek(diskimg,(long)ent->data_offset,SEEK_SET);
-            if ((uint32_t)ftell(diskimg) != ent->data_offset) return 0x05;
-            if (fwrite(data,req_sector_size,1,diskimg) != 1) return 0x05;
+            if ((uint32_t)ftell(diskimg) != ent->data_offset) return Int13Status::SeekFailed;
+            if (fwrite(data,req_sector_size,1,diskimg) != 1) return Int13Status::ControllerFailure;
         }
+
+        return Int13Status::NoError;
     }
 
-    return 0x05;
+    return Int13Status::SectorNotFound;
 }
 
-uint8_t imageDiskVFD::Write_AbsoluteSector(uint32_t sectnum,const void *data) {
+Int13Status imageDiskVFD::Write_AbsoluteSector(uint32_t sectnum,const void *data) {
     unsigned int c,h,s;
 
     if (sectors == 0 || heads == 0)
-        return 0x05;
+        return Int13Status::SectorNotFound;
 
     s = (sectnum % sectors) + 1;
     h = (sectnum / sectors) % heads;
@@ -3120,7 +3124,7 @@ typedef struct D88SEC {
 } D88SEC;                                       // =0x10 total
 #pragma pack(pop)
 
-uint8_t imageDiskD88::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size) {
+Int13Status imageDiskD88::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size) {
     const vfdentry *ent;
 
     if (req_sector_size == 0)
@@ -3129,20 +3133,20 @@ uint8_t imageDiskD88::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t secto
 //    LOG_MSG("D88 read sector: CHS %u/%u/%u sz=%u",cylinder,head,sector,req_sector_size);
 
     ent = findSector(head,cylinder,sector,req_sector_size);
-    if (ent == NULL) return 0x05;
-    if (ent->getSectorSize() != req_sector_size) return 0x05;
+    if (ent == NULL) return Int13Status::SectorNotFound;
+    if (ent->getSectorSize() != req_sector_size) return Int13Status::SectorNotFound;
 
     fseek(diskimg,(long)ent->data_offset,SEEK_SET);
-    if ((uint32_t)ftell(diskimg) != ent->data_offset) return 0x05;
-    if (fread(data,req_sector_size,1,diskimg) != 1) return 0x05;
-    return 0;
+    if ((uint32_t)ftell(diskimg) != ent->data_offset) return Int13Status::SeekFailed;
+    if (fread(data,req_sector_size,1,diskimg) != 1) return Int13Status::ControllerFailure;
+    return Int13Status::NoError;
 }
 
-uint8_t imageDiskD88::Read_AbsoluteSector(uint32_t sectnum, void * data) {
+Int13Status imageDiskD88::Read_AbsoluteSector(uint32_t sectnum, void * data) {
     unsigned int c,h,s;
 
     if (sectors == 0 || heads == 0)
-        return 0x05;
+        return Int13Status::SectorNotFound;
 
     s = (sectnum % sectors) + 1;
     h = (sectnum / sectors) % heads;
@@ -3174,7 +3178,7 @@ imageDiskD88::vfdentry *imageDiskD88::findSector(uint8_t head,uint8_t track,uint
     return NULL;
 }
 
-uint8_t imageDiskD88::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size) {
+Int13Status imageDiskD88::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size) {
     const vfdentry *ent;
 
     if (req_sector_size == 0)
@@ -3183,20 +3187,20 @@ uint8_t imageDiskD88::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sect
 //    LOG_MSG("D88 read sector: CHS %u/%u/%u sz=%u",cylinder,head,sector,req_sector_size);
 
     ent = findSector(head,cylinder,sector,req_sector_size);
-    if (ent == NULL) return 0x05;
-    if (ent->getSectorSize() != req_sector_size) return 0x05;
+    if (ent == NULL) return Int13Status::SectorNotFound;
+    if (ent->getSectorSize() != req_sector_size) return Int13Status::SectorNotFound;
 
     fseek(diskimg,(long)ent->data_offset,SEEK_SET);
-    if ((uint32_t)ftell(diskimg) != ent->data_offset) return 0x05;
-    if (fwrite(data,req_sector_size,1,diskimg) != 1) return 0x05;
-    return 0;
+    if ((uint32_t)ftell(diskimg) != ent->data_offset) return Int13Status::SeekFailed;
+    if (fwrite(data,req_sector_size,1,diskimg) != 1) return Int13Status::ControllerFailure;
+    return Int13Status::NoError;
 }
 
-uint8_t imageDiskD88::Write_AbsoluteSector(uint32_t sectnum,const void *data) {
+Int13Status imageDiskD88::Write_AbsoluteSector(uint32_t sectnum,const void *data) {
     unsigned int c,h,s;
 
     if (sectors == 0 || heads == 0)
-        return 0x05;
+        return Int13Status::SectorNotFound;
 
     s = (sectnum % sectors) + 1;
     h = (sectnum / sectors) % heads;
@@ -3417,7 +3421,7 @@ imageDiskD88::~imageDiskD88() {
 
 /*--------------------------------*/
 
-uint8_t imageDiskNFD::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size) {
+Int13Status imageDiskNFD::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size) {
     const vfdentry *ent;
 
     if (req_sector_size == 0)
@@ -3426,20 +3430,20 @@ uint8_t imageDiskNFD::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t secto
 //    LOG_MSG("NFD read sector: CHS %u/%u/%u sz=%u",cylinder,head,sector,req_sector_size);
 
     ent = findSector(head,cylinder,sector,req_sector_size);
-    if (ent == NULL) return 0x05;
-    if (ent->getSectorSize() != req_sector_size) return 0x05;
+    if (ent == NULL) return Int13Status::SectorNotFound;
+    if (ent->getSectorSize() != req_sector_size) return Int13Status::SectorNotFound;
 
     fseek(diskimg,(long)ent->data_offset,SEEK_SET);
-    if ((uint32_t)ftell(diskimg) != ent->data_offset) return 0x05;
-    if (fread(data,req_sector_size,1,diskimg) != 1) return 0x05;
-    return 0;
+    if ((uint32_t)ftell(diskimg) != ent->data_offset) return Int13Status::SeekFailed;
+    if (fread(data,req_sector_size,1,diskimg) != 1) return Int13Status::ControllerFailure;
+    return Int13Status::NoError;
 }
 
-uint8_t imageDiskNFD::Read_AbsoluteSector(uint32_t sectnum, void * data) {
+Int13Status imageDiskNFD::Read_AbsoluteSector(uint32_t sectnum, void * data) {
     unsigned int c,h,s;
 
     if (sectors == 0 || heads == 0)
-        return 0x05;
+        return Int13Status::SectorNotFound;
 
     s = (sectnum % sectors) + 1;
     h = (sectnum / sectors) % heads;
@@ -3471,7 +3475,7 @@ imageDiskNFD::vfdentry *imageDiskNFD::findSector(uint8_t head,uint8_t track,uint
     return NULL;
 }
 
-uint8_t imageDiskNFD::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size) {
+Int13Status imageDiskNFD::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size) {
     const vfdentry *ent;
 
     if (req_sector_size == 0)
@@ -3480,20 +3484,20 @@ uint8_t imageDiskNFD::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sect
 //    LOG_MSG("NFD read sector: CHS %u/%u/%u sz=%u",cylinder,head,sector,req_sector_size);
 
     ent = findSector(head,cylinder,sector,req_sector_size);
-    if (ent == NULL) return 0x05;
-    if (ent->getSectorSize() != req_sector_size) return 0x05;
+    if (ent == NULL) return Int13Status::SectorNotFound;
+    if (ent->getSectorSize() != req_sector_size) return Int13Status::SectorNotFound;
 
     fseek(diskimg,(long)ent->data_offset,SEEK_SET);
-    if ((uint32_t)ftell(diskimg) != ent->data_offset) return 0x05;
-    if (fwrite(data,req_sector_size,1,diskimg) != 1) return 0x05;
-    return 0;
+    if ((uint32_t)ftell(diskimg) != ent->data_offset) return Int13Status::SeekFailed;
+    if (fwrite(data,req_sector_size,1,diskimg) != 1) return Int13Status::ControllerFailure;
+    return Int13Status::NoError;
 }
 
-uint8_t imageDiskNFD::Write_AbsoluteSector(uint32_t sectnum,const void *data) {
+Int13Status imageDiskNFD::Write_AbsoluteSector(uint32_t sectnum,const void *data) {
     unsigned int c,h,s;
 
     if (sectors == 0 || heads == 0)
-        return 0x05;
+        return Int13Status::SectorNotFound;
 
     s = (sectnum % sectors) + 1;
     h = (sectnum / sectors) % heads;
@@ -3777,7 +3781,7 @@ bool PartitionLoadMBR(std::vector<partTable::partentry_t> &parts,imageDisk *load
 	parts.clear();
 
 	if (loadedDisk->getSectSize() > sizeof(smbr)) return false;
-	if (loadedDisk->Read_Sector(0,0,1,&smbr) != 0x00) return false;
+	if (loadedDisk->Read_Sector(0,0,1,&smbr) != Int13Status::NoError) return false;
 	if (smbr.magic1 != 0x55 || smbr.magic2 != 0xaa) return false; /* Must have signature */
 
 	/* first copy the main partition table entries */
@@ -3860,7 +3864,7 @@ bool PartitionLoadIPL1(std::vector<_PC98RawPartition> &parts,imageDisk *loadedDi
 	if (loadedDisk->getSectSize() > sizeof(ipltable)) return false;
 
 	memset(ipltable,0,sizeof(ipltable));
-	if (loadedDisk->Read_Sector(0,0,2,ipltable) != 0) return false;
+	if (loadedDisk->Read_Sector(0,0,2,ipltable) != Int13Status::NoError) return false;
 
 	const unsigned int max_entries = std::min(16UL,(unsigned long)(loadedDisk->getSectSize() / sizeof(_PC98RawPartition)));
 
@@ -3885,7 +3889,7 @@ std::string PartitionIdentifyType(imageDisk *loadedDisk) {
 	if (loadedDisk->getSectSize() > sizeof(mbrData))
 		return std::string(); /* That would cause a buffer overrun */
 
-	if (loadedDisk->Read_Sector(0,0,1,&mbrData) != 0)
+	if (loadedDisk->Read_Sector(0,0,1,&mbrData) != Int13Status::NoError)
 		return std::string();
 
 	if (!memcmp(mbrData.booter+4,"IPL1",4))
@@ -3922,20 +3926,20 @@ void LogPrintPartitionTable(const std::vector<partTable::partentry_t> &parts) {
 }
 
 
-uint8_t imageDiskEmptyDrive::Read_Sector(uint32_t /*head*/,uint32_t /*cylinder*/,uint32_t /*sector*/,void * /*data*/,unsigned int /*req_sector_size*/) {
-	return 0x05;
+Int13Status imageDiskEmptyDrive::Read_Sector(uint32_t /*head*/,uint32_t /*cylinder*/,uint32_t /*sector*/,void * /*data*/,unsigned int /*req_sector_size*/) {
+	return Int13Status::DriveNotReady;
 }
 
-uint8_t imageDiskEmptyDrive::Write_Sector(uint32_t /*head*/,uint32_t /*cylinder*/,uint32_t /*sector*/,const void * /*data*/,unsigned int /*req_sector_size*/) {
-	return 0x05;
+Int13Status imageDiskEmptyDrive::Write_Sector(uint32_t /*head*/,uint32_t /*cylinder*/,uint32_t /*sector*/,const void * /*data*/,unsigned int /*req_sector_size*/) {
+	return Int13Status::DriveNotReady;
 }
 
-uint8_t imageDiskEmptyDrive::Read_AbsoluteSector(uint32_t /*sectnum*/, void * /*data*/) {
-	return 0x05;
+Int13Status imageDiskEmptyDrive::Read_AbsoluteSector(uint32_t /*sectnum*/, void * /*data*/) {
+	return Int13Status::DriveNotReady;
 }
 
-uint8_t imageDiskEmptyDrive::Write_AbsoluteSector(uint32_t /*sectnum*/, const void * /*data*/) {
-	return 0x05;
+Int13Status imageDiskEmptyDrive::Write_AbsoluteSector(uint32_t /*sectnum*/, const void * /*data*/) {
+	return Int13Status::DriveNotReady;
 }
 
 imageDiskEmptyDrive::imageDiskEmptyDrive() : imageDisk(ID_EMPTY_DRIVE) {
@@ -3974,10 +3978,10 @@ static void imageDiskCallINT13(void) {
 #endif
 
 #if !defined(OSFREE)
-uint8_t imageDiskINT13Drive::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size) {
+Int13Status imageDiskINT13Drive::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size) {
 	if (!enable_int13 || busy) return subdisk->Read_Sector(head,cylinder,sector,data,req_sector_size);
 
-	uint8_t ret = 0x05;
+	Int13Status ret = Int13Status::ResetFailed;
 	unsigned int retry = 3;
 
 	if (req_sector_size == 0) req_sector_size = sector_size;
@@ -4012,16 +4016,16 @@ again:
 		imageDiskCallINT13();
 
 		if (reg_flags & FLAG_CF) {
-			ret = reg_ah;
-			if (ret == 0) ret = 0x05;
+			ret = static_cast<Int13Status>(reg_ah);
+			if (ret == Int13Status::NoError) ret = Int13Status::ResetFailed;
 
-			if (ret == 6/*disk change*/) {
+			if (ret == Int13Status::DiskChanged) {
 				diskChangeFlag = true;
 				if (--retry > 0) goto again;
 			}
 		}
 		else {
-			ret = 0;
+			ret = Int13Status::NoError;
 			MEM_BlockRead32(INT13Xfer<<4,data,sector_size);
 			data = (void*)((char*)data + sector_size);
 			if ((++sector) >= (sectors + 1)) {
@@ -4054,7 +4058,7 @@ again:
 #endif
 
 #if !defined(OSFREE)
-uint8_t imageDiskINT13Drive::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size) {
+Int13Status imageDiskINT13Drive::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size) {
 	if (INT13Xfer == 0) INT13Xfer = DOS_GetMemory(INT13XferSize/16u,"INT 13 transfer buffer");
 
 	return subdisk->Write_Sector(head,cylinder,sector,data,req_sector_size);
@@ -4062,11 +4066,11 @@ uint8_t imageDiskINT13Drive::Write_Sector(uint32_t head,uint32_t cylinder,uint32
 #endif
 
 #if !defined(OSFREE)
-uint8_t imageDiskINT13Drive::Read_AbsoluteSector(uint32_t sectnum, void * data) {
+Int13Status imageDiskINT13Drive::Read_AbsoluteSector(uint32_t sectnum, void * data) {
 	unsigned int c,h,s;
 
 	if (sectors == 0 || heads == 0)
-		return 0x05;
+		return Int13Status::SectorNotFound;
 
 	s = (sectnum % sectors) + 1;
 	h = (sectnum / sectors) % heads;
@@ -4076,11 +4080,11 @@ uint8_t imageDiskINT13Drive::Read_AbsoluteSector(uint32_t sectnum, void * data) 
 #endif
 
 #if !defined(OSFREE)
-uint8_t imageDiskINT13Drive::Write_AbsoluteSector(uint32_t sectnum, const void * data) {
+Int13Status imageDiskINT13Drive::Write_AbsoluteSector(uint32_t sectnum, const void * data) {
 	unsigned int c,h,s;
 
 	if (sectors == 0 || heads == 0)
-		return 0x05;
+		return Int13Status::SectorNotFound;
 
 	s = (sectnum % sectors) + 1;
 	h = (sectnum / sectors) % heads;

--- a/src/ints/bios_memdisk.cpp
+++ b/src/ints/bios_memdisk.cpp
@@ -247,13 +247,13 @@ void imageDiskMemory::Set_Geometry(uint32_t setHeads, uint32_t setCyl, uint32_t 
 }
 
 // Read a specific sector from the ramdrive
-uint8_t imageDiskMemory::Read_AbsoluteSector(uint32_t sectnum, void * data) {
+Int13Status imageDiskMemory::Read_AbsoluteSector(uint32_t sectnum, void * data) {
 	//sector number is a zero-based offset
 
 	//verify the sector number is valid
 	if (sectnum >= total_sectors) {
 		LOG_MSG("Invalid sector number in Read_AbsoluteSector for sector %lu.\n", (unsigned long)sectnum);
-		return 0x05;
+		return Int13Status::SectorNotFound;
 	}
 
 	//calculate which chunk the sector is located within, and which sector within the chunk
@@ -271,7 +271,7 @@ uint8_t imageDiskMemory::Read_AbsoluteSector(uint32_t sectnum, void * data) {
 			return this->underlyingImage->Read_AbsoluteSector(sectnum, data);
 		}
 		memset(data, 0, sector_size);
-		return 0x00;
+		return Int13Status::NoError;
 	}
 
 	//update the address to the specific sector within the chunk
@@ -279,17 +279,17 @@ uint8_t imageDiskMemory::Read_AbsoluteSector(uint32_t sectnum, void * data) {
 
 	//copy the data to the output and return success
 	memcpy(data, datalocation, sector_size);
-	return 0x00;
+	return Int13Status::NoError;
 }
 
 // Write a specific sector from the ramdrive
-uint8_t imageDiskMemory::Write_AbsoluteSector(uint32_t sectnum, const void * data) {
+Int13Status imageDiskMemory::Write_AbsoluteSector(uint32_t sectnum, const void * data) {
 	//sector number is a zero-based offset
 
 	//verify the sector number is valid
 	if (sectnum >= total_sectors) {
 		LOG_MSG("Invalid sector number in Write_AbsoluteSector for sector %lu.\n", (unsigned long)sectnum);
-		return 0x05;
+		return Int13Status::SectorNotFound;
 	}
 
 	//calculate which chunk the sector is located within, and which sector within the chunk
@@ -310,14 +310,14 @@ uint8_t imageDiskMemory::Write_AbsoluteSector(uint32_t sectnum, const void * dat
 				anyData |= ((uint8_t*)data)[i];
 			}
 			//if it's all zeros, return success
-			if (anyData == 0) return 0x00;
+			if (anyData == 0) return Int13Status::NoError;
 		}
 
 		//allocate a new memory chunk
 		datalocation = (uint8_t*)malloc(chunk_size);
 		if (datalocation == NULL) {
 			LOG_MSG("Could not allocate memory in Write_AbsoluteSector for sector %lu.\n", (unsigned long)sectnum);
-			return 0x05;
+			return Int13Status::ControllerFailure;
 		}
 		//save the memory chunk address within the memory map
 		ChunkMap[chunknum] = datalocation;
@@ -343,7 +343,7 @@ uint8_t imageDiskMemory::Write_AbsoluteSector(uint32_t sectnum, const void * dat
 
 	//write the sector to the chunk and return success
 	memcpy(datalocation, data, sector_size);
-	return 0x00;
+	return Int13Status::NoError;
 }
 
 // Partition and format the ramdrive

--- a/src/ints/bios_vhd.cpp
+++ b/src/ints/bios_vhd.cpp
@@ -397,19 +397,19 @@ imageDiskVHD::ErrorCodes imageDiskVHD::TryOpenParent(const char* childFileName, 
 	return ERROR_OPENING; //return ERROR_OPENING if the file does not exist, cannot be accessed, etc
 }
 
-uint8_t imageDiskVHD::Read_AbsoluteSector(uint32_t sectnum, void * data) {
+Int13Status imageDiskVHD::Read_AbsoluteSector(uint32_t sectnum, void * data) {
     if(vhdType == VHD_TYPE_FIXED) return fixedDisk->Read_AbsoluteSector(sectnum, data);
 	uint32_t blockNumber = sectnum / sectorsPerBlock;
 	uint32_t sectorOffset = sectnum % sectorsPerBlock;
-	if (!loadBlock(blockNumber)) return 0x05; //can't load block
+	if (!loadBlock(blockNumber)) return Int13Status::ControllerFailure; //can't load block
 	if (currentBlockAllocated) {
 		uint32_t byteNum = sectorOffset / 8;
 		uint32_t bitNum = sectorOffset % 8;
 		bool hasData = currentBlockDirtyMap[byteNum] & (1 << (7 - bitNum));
 		if (hasData) {
-			if (fseeko64(diskimg, (((uint64_t)currentBlockSectorOffset + blockMapSectors + sectorOffset) * 512ull), SEEK_SET)) return 0x05; //can't seek
-			if (fread(data, sizeof(uint8_t), 512, diskimg) != 512) return 0x05; //can't read
-			return 0;
+			if (fseeko64(diskimg, (((uint64_t)currentBlockSectorOffset + blockMapSectors + sectorOffset) * 512ull), SEEK_SET)) return Int13Status::SeekFailed; //can't seek
+			if (fread(data, sizeof(uint8_t), 512, diskimg) != 512) return Int13Status::ControllerFailure; //can't read
+			return Int13Status::NoError;
 		}
 	}
     //NOTE: should come first?
@@ -418,7 +418,7 @@ uint8_t imageDiskVHD::Read_AbsoluteSector(uint32_t sectnum, void * data) {
 	}
 	else {
 		memset(data, 0, 512);
-		return 0;
+		return Int13Status::NoError;
 	}
 }
 
@@ -433,46 +433,46 @@ bool imageDiskVHD::is_block_allocated(uint32_t blockNumber) {
     return false;
 }
 
-uint8_t imageDiskVHD::Write_AbsoluteSector(uint32_t sectnum, const void * data) {
+Int13Status imageDiskVHD::Write_AbsoluteSector(uint32_t sectnum, const void * data) {
     if(vhdType == VHD_TYPE_FIXED) return fixedDisk->Write_AbsoluteSector(sectnum, data);
 	uint32_t blockNumber = sectnum / sectorsPerBlock;
 	uint32_t sectorOffset = sectnum % sectorsPerBlock;
     if(!loadBlock(blockNumber)) {
-        return 0x05; //can't load block
+        return Int13Status::ControllerFailure; //can't load block
     }
 	if (!currentBlockAllocated) {
         //an unallocated block is kept virtual until zeroed
         if(is_zeroed_sector(data)) {
-            if(vhdType != VHD_TYPE_DIFFERENCING) return 0;
-            if(!is_block_allocated(blockNumber)) return 0;
+            if(vhdType != VHD_TYPE_DIFFERENCING) return Int13Status::NoError;
+            if(!is_block_allocated(blockNumber)) return Int13Status::NoError;
         }
 
         if(!copiedFooter) {
             //write backup of footer at start of file (should already exist, but we never checked to be sure it is readable or matches the footer we used)
             if(fseeko64(diskimg, 0, SEEK_SET)) {
-                return 0x05;
+                return Int13Status::SeekFailed;
             }
             if(fwrite(&originalFooter, sizeof(uint8_t), 512, diskimg) != 512) {
-                return 0x05;
+                return Int13Status::ControllerFailure;
             }
 			copiedFooter = true;
 			//flush the data to disk after writing the backup footer
             if(fflush(diskimg)) {
-                return 0x05;
+                return Int13Status::ControllerFailure;
             }
 		}
 		//calculate new location of footer, and round up to nearest 512 byte increment "just in case"
         uint64_t newFooterPosition = (((footerPosition + blockMapSize + dynamicHeader.blockSize) + 511ull) / 512ull) * 512ull;
 		//attempt to extend the length appropriately first (on some operating systems this will extend the file)
         if(fseeko64(diskimg, newFooterPosition + 512, SEEK_SET)) {
-                return 0x05;
+                return Int13Status::SeekFailed;
         }
 		//now write the footer
         if(fseeko64(diskimg, newFooterPosition, SEEK_SET)) {
-            return 0x05;
+            return Int13Status::SeekFailed;
         }
         if(fwrite(&originalFooter, sizeof(uint8_t), 512, diskimg) != 512) {
-            return 0x05;
+            return Int13Status::ControllerFailure;
         }
 		//save the new block location and new footer position
 		uint32_t newBlockSectorNumber = (uint32_t)((footerPosition + 511ul) / 512ul);
@@ -481,28 +481,28 @@ uint8_t imageDiskVHD::Write_AbsoluteSector(uint32_t sectnum, const void * data) 
 		for (uint32_t i = 0; i < blockMapSize; i++) currentBlockDirtyMap[i] = 0;
 		//write the dirty map
         if(fseeko64(diskimg, (newBlockSectorNumber * 512ull), SEEK_SET)) {
-            return 0x05;
+            return Int13Status::SeekFailed;
         }
         if(fwrite(currentBlockDirtyMap, sizeof(uint8_t), blockMapSize, diskimg) != blockMapSize) {
-            return 0x05;
+            return Int13Status::ControllerFailure;
         }
 		//flush the data to disk after expanding the file, before allocating the block in the BAT
         if(fflush(diskimg)) {
-            return 0x05;
+            return Int13Status::ControllerFailure;
         }
 		//update the BAT
         if(fseeko64(diskimg, (dynamicHeader.tableOffset + (blockNumber * 4ull)), SEEK_SET)) {
-            return 0x05;
+            return Int13Status::SeekFailed;
         }
 		uint32_t newBlockSectorNumberBE = SDL_SwapBE32(newBlockSectorNumber);
         if(fwrite(&newBlockSectorNumberBE, sizeof(uint8_t), 4, diskimg) != 4) {
-            return 0x05;
+            return Int13Status::ControllerFailure;
         }
 		currentBlockAllocated = true;
 		currentBlockSectorOffset = newBlockSectorNumber;
 		//flush the data to disk after allocating a block
         if(fflush(diskimg)) {
-            return 0x05;
+            return Int13Status::ControllerFailure;
         }
 	}
 	//current block has now been allocated
@@ -513,21 +513,21 @@ uint8_t imageDiskVHD::Write_AbsoluteSector(uint32_t sectnum, const void * data) 
 	if (!hasData) {
 		currentBlockDirtyMap[byteNum] |= 1 << (7 - bitNum);
         if(fseeko64(diskimg, (currentBlockSectorOffset * 512ull), SEEK_SET)) {
-            return 0x05; //can't seek
+            return Int13Status::SeekFailed; //can't seek
         }
         if(fwrite(currentBlockDirtyMap, sizeof(uint8_t), blockMapSize, diskimg) != blockMapSize) {
-            return 0x05;
+            return Int13Status::ControllerFailure;
         }
 	}
 	//current sector has now been marked as dirty
 	//write the sector
     if(fseeko64(diskimg, (((uint64_t)currentBlockSectorOffset + (uint64_t)blockMapSectors + (uint64_t)sectorOffset) * 512ull), SEEK_SET)) {
-        return 0x05; //can't seek
+        return Int13Status::SeekFailed; //can't seek
     }
     if(fwrite(data, sizeof(uint8_t), 512, diskimg) != 512) {
-        return 0x05; //can't write
+        return Int13Status::ControllerFailure; //can't write
     }
-	return 0;
+	return Int13Status::NoError;
 }
 
 imageDiskVHD::VHDTypes imageDiskVHD::GetVHDType(void) const {
@@ -1025,7 +1025,7 @@ bool imageDiskVHD::MergeSnapshot(uint32_t* totalSectorsMerged, uint32_t* totalBl
                 //LOG_MSG("Merging sector %d", absoluteSector);
                 (*totalSectorsMerged)++;
                 blockUpdated = true;
-                if(parentDisk->Write_AbsoluteSector(absoluteSector, data)) {
+                if(parentDisk->Write_AbsoluteSector(absoluteSector, data) != Int13Status::NoError) {
                     LOG_MSG("Couldn't update parent's sector %d, merging aborted!", absoluteSector);
                     return false;
                 }

--- a/src/ints/imagedisk_teledisk.cpp
+++ b/src/ints/imagedisk_teledisk.cpp
@@ -149,7 +149,16 @@ Int13Status imageDiskTeledisk::Read_Sector(uint32_t head,uint32_t cylinder,uint3
 	if (ent->getSectorSize() != req_sector_size)
 		return Int13Status::SectorNotFound;
 
+	/* Copy the data regardless, mirroring real hardware which still transfers the
+	 * (possibly corrupt) sector before reporting the flagged condition. */
 	memcpy(data, ent->data.data(), req_sector_size);
+
+	/* Surface sector flags recorded in the .td0 image as INT 13h status. */
+	if (ent->flags & td0_sector_flags::crc_error)
+		return Int13Status::DataError;             /* recorded with a CRC error */
+	if (ent->flags & td0_sector_flags::deleted_mark)
+		return Int13Status::AddressMarkNotFound;   /* deleted-data address mark */
+
 	return Int13Status::NoError;
 }
 

--- a/src/ints/imagedisk_teledisk.cpp
+++ b/src/ints/imagedisk_teledisk.cpp
@@ -136,36 +136,36 @@ const imageDiskTeledisk::td0entry *imageDiskTeledisk::findSector(uint8_t head,ui
 	return best;
 }
 
-uint8_t imageDiskTeledisk::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size) {
+Int13Status imageDiskTeledisk::Read_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,void * data,unsigned int req_sector_size) {
 	const td0entry *ent;
 
 	ent = findSector((uint8_t)head, (uint8_t)cylinder, (uint8_t)sector, req_sector_size);
 
 	if (ent == NULL || !ent->has_data)
-		return 0x05;
+		return Int13Status::SectorNotFound;
 
 	if (req_sector_size == 0) req_sector_size = ent->getSectorSize();
 
 	if (ent->getSectorSize() != req_sector_size)
-		return 0x05;
+		return Int13Status::SectorNotFound;
 
 	memcpy(data, ent->data.data(), req_sector_size);
-	return 0;
+	return Int13Status::NoError;
 }
 
-uint8_t imageDiskTeledisk::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size) {
+Int13Status imageDiskTeledisk::Write_Sector(uint32_t head,uint32_t cylinder,uint32_t sector,const void * data,unsigned int req_sector_size) {
 	(void)head; (void)cylinder; (void)sector; (void)data; (void)req_sector_size;
 	/* TeleDisk images are read-only: writes cannot be re-encoded back into the .td0 archive,
 	 * so accepting a write in memory only would silently discard the guest's data on remount.
 	 * Report the disk as write-protected instead. */
-	return 0x03;
+	return Int13Status::WriteProtected;
 }
 
-uint8_t imageDiskTeledisk::Read_AbsoluteSector(uint32_t sectnum, void * data) {
+Int13Status imageDiskTeledisk::Read_AbsoluteSector(uint32_t sectnum, void * data) {
 	unsigned int c,h,s;
 
 	if (sectors == 0 || heads == 0)
-		return 0x05;
+		return Int13Status::SectorNotFound;
 
 	s = (sectnum % sectors) + 1;
 	h = (sectnum / sectors) % heads;
@@ -173,11 +173,11 @@ uint8_t imageDiskTeledisk::Read_AbsoluteSector(uint32_t sectnum, void * data) {
 	return Read_Sector(h,c,s,data);
 }
 
-uint8_t imageDiskTeledisk::Write_AbsoluteSector(uint32_t sectnum,const void *data) {
+Int13Status imageDiskTeledisk::Write_AbsoluteSector(uint32_t sectnum,const void *data) {
 	unsigned int c,h,s;
 
 	if (sectors == 0 || heads == 0)
-		return 0x05;
+		return Int13Status::SectorNotFound;
 
 	s = (sectnum % sectors) + 1;
 	h = (sectnum / sectors) % heads;

--- a/src/ints/qcow2_disk.cpp
+++ b/src/ints/qcow2_disk.cpp
@@ -450,12 +450,12 @@ using namespace std;
 
 
 //Public function to a read a sector.
-	uint8_t QCow2Disk::Read_AbsoluteSector(uint32_t sectnum, void* data){
-		return qcowImage.read_sector(sectnum, (uint8_t*)data);
+	Int13Status QCow2Disk::Read_AbsoluteSector(uint32_t sectnum, void* data){
+		return qcowImage.read_sector(sectnum, (uint8_t*)data) ? Int13Status::ControllerFailure : Int13Status::NoError;
 	}
 
 
 //Public function to a write a sector.
-	uint8_t QCow2Disk::Write_AbsoluteSector(uint32_t sectnum,const void* data){
-		return qcowImage.write_sector(sectnum, (const uint8_t*)data);
+	Int13Status QCow2Disk::Write_AbsoluteSector(uint32_t sectnum,const void* data){
+		return qcowImage.write_sector(sectnum, (const uint8_t*)data) ? Int13Status::ControllerFailure : Int13Status::NoError;
 	}

--- a/src/misc/programs.cpp
+++ b/src/misc/programs.cpp
@@ -1308,9 +1308,9 @@ uint8_t device_nextdrive = 0;
 #endif
 
 #if !defined(OSFREE)
-uint8_t imageDiskMSDOSBlockDevice::Read_AbsoluteSector(uint32_t sectnum, void * data) {
+Int13Status imageDiskMSDOSBlockDevice::Read_AbsoluteSector(uint32_t sectnum, void * data) {
 	const unsigned int max_sects = (bdevbuf_sz - 16) / sector_size;
-	if (max_sects == 0) return 0x05;
+	if (max_sects == 0) return Int13Status::SectorNotFound;
 
 	const uint16_t count = 1;
 	const uint32_t sector = sectnum;
@@ -1334,7 +1334,7 @@ uint8_t imageDiskMSDOSBlockDevice::Read_AbsoluteSector(uint32_t sectnum, void * 
 		req.start_sector32 = sector;
 	}
 	else {
-		if (sector > 0xFFFFu) return 0x05;
+		if (sector > 0xFFFFu) return Int13Status::SectorNotFound;
 		req.start_sector = sector;
 		req.start_sector32 = 0;
 	}
@@ -1359,18 +1359,18 @@ uint8_t imageDiskMSDOSBlockDevice::Read_AbsoluteSector(uint32_t sectnum, void * 
 	LOG(LOG_MISC,LOG_DEBUG)("--result status=%x count=%u",
 		req.hdr.status,req.count);
 
-	if (req.hdr.status & 0x8000) return 0x05;/*error*/
-	if (req.count == 0) return 0x05;/*error*/
+	if (req.hdr.status & 0x8000) return Int13Status::ControllerFailure;/*error*/
+	if (req.count == 0) return Int13Status::ControllerFailure;/*error*/
 
 	MEM_BlockRead(PhysMake(bdevbuf_seg+1,0),p_data,sector_size);
-        return 0;
+        return Int13Status::NoError;
 }
 #endif
 
 #if !defined(OSFREE)
-uint8_t imageDiskMSDOSBlockDevice::Write_AbsoluteSector(uint32_t sectnum, const void * data) {
+Int13Status imageDiskMSDOSBlockDevice::Write_AbsoluteSector(uint32_t sectnum, const void * data) {
 	const unsigned int max_sects = (bdevbuf_sz - 16) / sector_size;
-	if (max_sects == 0) return 0x05;
+	if (max_sects == 0) return Int13Status::SectorNotFound;
 
 	const uint16_t count = 1;
 	const uint32_t sector = sectnum;
@@ -1394,7 +1394,7 @@ uint8_t imageDiskMSDOSBlockDevice::Write_AbsoluteSector(uint32_t sectnum, const 
 		req.start_sector32 = sector;
 	}
 	else {
-		if (sector > 0xFFFFu) return 0x05;
+		if (sector > 0xFFFFu) return Int13Status::SectorNotFound;
 		req.start_sector = sector;
 		req.start_sector32 = 0;
 	}
@@ -1420,10 +1420,10 @@ uint8_t imageDiskMSDOSBlockDevice::Write_AbsoluteSector(uint32_t sectnum, const 
 	LOG(LOG_MISC,LOG_DEBUG)("--result status=%x count=%u",
 		req.hdr.status,req.count);
 
-	if (req.hdr.status & 0x8000) return 0x05;/*error*/
-	if (req.count == 0) return 0x05;/*error*/
+	if (req.hdr.status & 0x8000) return Int13Status::ControllerFailure;/*error*/
+	if (req.count == 0) return Int13Status::ControllerFailure;/*error*/
 
-        return 0;
+        return Int13Status::NoError;
 }
 #endif
 


### PR DESCRIPTION
## Summary

- Introduces `enum class Int13Status : uint8_t` (in `include/bios_disk.h`) with the standard BIOS INT 13h status/error codes, and changes the `imageDisk` sector I/O methods (`Read_Sector`/`Write_Sector`/`Read_AbsoluteSector`/`Write_AbsoluteSector`) and all subclass overrides to return it instead of bare hex literals.
- Failures now map to meaningful codes (`SeekFailed`, `ControllerFailure`, `WriteProtected`, `SectorNotFound`, `DataError`, `DriveNotReady`, ...) instead of the catch-all `0x05`.
- The INT 13h handler propagates the real code into register AH on read (AH=02/42) and write (AH=03/43) errors, rather than collapsing every failure to `0x04`. The PC-98 BIOS floppy handler returns the real code in AH as well.
- TeleDisk `.td0` sector flags are surfaced on read: `crc_error` → `DataError` (0x10), `deleted_mark` → `AddressMarkNotFound` (0x02), with the (possibly corrupt) data still copied to the caller's buffer, mirroring real hardware.

### Bugs found and fixed
- AH=03 / AH=43 write error paths left AH stale (never set on failure).
- `imageDiskVFD::Write_Sector` reported an error after a successful fill-sector write due to a fall-through return.