### PR TITLE
On non-MSC, only define MIN/MAX if not already defined

### DIFF
--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -1425,8 +1425,12 @@ bool DOS_Canonicalize(char const * const name,char * const big) {
 # define MIN(a,b) ((a) < (b) ? (a) : (b))
 # define MAX(a,b) ((a) > (b) ? (a) : (b))
 #else
-# define MIN(a,b) std::min(a,b)
-# define MAX(a,b) std::max(a,b)
+# ifndef MIN
+#  define MIN(a,b) std::min(a,b)
+# endif
+# ifndef MAX
+#  define MAX(a,b) std::max(a,b)
+# endif
 #endif
 
 /* Common routine to take larger allocation information (such as FAT32) and convert it to values

--- a/src/dos/drive_fat.cpp
+++ b/src/dos/drive_fat.cpp
@@ -2592,8 +2592,12 @@ void fatDrive::fatDriveInit(const char *sysFilename, uint32_t bytesector, uint32
 # define MIN(a,b) ((a) < (b) ? (a) : (b))
 # define MAX(a,b) ((a) > (b) ? (a) : (b))
 #else
-# define MIN(a,b) std::min(a,b)
-# define MAX(a,b) std::max(a,b)
+# ifndef MIN
+#  define MIN(a,b) std::min(a,b)
+# endif
+# ifndef MAX
+#  define MAX(a,b) std::max(a,b)
+# endif
 #endif
 
 bool fatDrive::AllocationInfo32(uint32_t * _bytes_sector,uint32_t * _sectors_cluster,uint32_t * _total_clusters,uint32_t * _free_clusters) {


### PR DESCRIPTION
## What issue(s) does this PR address?

On current versions of Debian, DOSBox-X 2026.08.02 fails to build with an error caused by the redefinition of `MIN` and `MAX` in `drive_fat.cpp` and `dos_files.cpp`. `MIN` and `MAX` are already defined in `<sys/param.h>` in Unix-style systems, and it ends up included in those files.

This checks that MIN and MAX are undefined before defining them. An alternative would be to explicitly include <sys/param.h> if available, but that's more complicated.

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

No.

## Additional information

There are similar definitions of `MIN`/`MAX` elsewhere, I can update them too if that seems useful.