### PR TITLE
IMGMOUNT: Fix loading IMGMAKE.IMG if no image specified

### DIFF
--- a/src/dos/dos_programs.cpp
+++ b/src/dos/dos_programs.cpp
@@ -6306,12 +6306,15 @@ class IMGMOUNT : public Program {
 		bool ParseFiles(std::string &commandLine, std::vector<std::string> &paths, bool nodef) {
 			char drive=commandLine[0];
 			bool nocont=false;
-			while (!nocont&&cmd->ExistsCommand(1)) {
+            if(!isalpha(drive) && !isdigit(drive)) return false;
+
+			while (!nocont) {
 				bool usedef=false;
 				if (!cmd->FindCommand(1, commandLine)) {
 					if (!nodef && !paths.size()) {
 						commandLine="IMGMAKE.IMG";
 						usedef=true;
+                        LOG_MSG("IMGMOUNT: No file specified, using default 'IMGMAKE.IMG'");
 					}
 					else {
 						break;
@@ -6425,6 +6428,7 @@ class IMGMOUNT : public Program {
 					return false;
 				}
 				paths.push_back(commandLine);
+                if(usedef) break;
 			}
 			return false;
 		}


### PR DESCRIPTION
Fix IMGMOUNT didn't mount IMGMAKE.IMG if no image was specified.

## What issue(s) does this PR address?
Fixes #6464

<img width="713" height="496" alt="image" src="https://github.com/user-attachments/assets/f1878587-4b72-4dd3-bae0-24caf2751c3f" />
