### PR TITLE
Fix build error on FFmpeg 9

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,9 @@ NEXT VERSION:
   - On non-MSC, only define MIN/MAX if not already defined (skitt)
   - Fixed FreeDOS XCOPY failed to copy files when destination directory was
     not specified (maron2000)
+  - IMGMOUNT: Fixed a regression that didn't try loading IMGMAKE.IMG if no 
+    image was specified (maron2000)
+  - Fixed a build error when FFmpeg is upgraded to FFmpeg 9 (maron2000)
 
 2026.08.02
   - Debugger: normalize 16-bit segmented offsets for address display/lookup and

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -1288,10 +1288,27 @@ skip_shot:
 			#else
 			ffmpeg_aud_ctx->ch_layout = AV_CHANNEL_LAYOUT_STEREO;
 			#endif
-
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(61, 13, 100)
+            // Legacy support for FFmpeg not supporting avcodec_get_supported_config()
 			if (ffmpeg_aud_codec->sample_fmts != NULL)
 				ffmpeg_aud_ctx->sample_fmt = (ffmpeg_aud_codec->sample_fmts)[0];
-			else
+#else
+            // For FFmpeg supporting avcodec_get_supported_config()
+            const enum AVSampleFormat* formats = NULL;
+
+            const int ret = avcodec_get_supported_config(
+                NULL,
+                ffmpeg_aud_codec,
+                AV_CODEC_CONFIG_SAMPLE_FORMAT,
+                0,
+                reinterpret_cast<const void**>(&formats),
+                NULL
+            );
+
+            if(ret >= 0 && formats != NULL)
+                ffmpeg_aud_ctx->sample_fmt = formats[0];
+#endif
+            else
 				ffmpeg_aud_ctx->sample_fmt = AV_SAMPLE_FMT_FLT;
 
 			if (avcodec_open2(ffmpeg_aud_ctx,ffmpeg_aud_codec,NULL) < 0) {


### PR DESCRIPTION
Fix build error when FFmpeg version is upgraded to FFmpeg 9 which has removed `sample_fmts`.
Confirmed build successful on Ubuntu 24.04 with FFmpeg 6.1 and Ubuntu 26.04 with FFmpeg 8.0.1.

## What issue(s) does this PR address?
Fixes #6446
