### PR TITLE
Fix capture and savestate saved to user config directory

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ NEXT VERSION:
   - IMGMOUNT: Fixed a regression that didn't try loading IMGMAKE.IMG if no 
     image was specified (maron2000)
   - Fixed a build error when FFmpeg is upgraded to FFmpeg 9 (maron2000)
+  - Fixed capture and savestate directory locations (maron2000)
 
 2026.08.02
   - Debugger: normalize 16-bit segmented offsets for address display/lookup and

--- a/include/cross.h
+++ b/include/cross.h
@@ -73,6 +73,7 @@ public:
 	static void ResolveHomedir(std::string & temp_line);
 	static void CreateDir(std::string const& in);
 	static bool IsPathAbsolute(std::string const& in);
+    static std::string GetCurDir(void);
 };
 
 

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -10701,8 +10701,14 @@ bool TTF_using(void) {
 }
 
 bool Get_Custom_SaveDir(std::string& savedir) {
-    if (custom_savedir.length() != 0) {
-        savedir=custom_savedir;
+    if(custom_savedir.length() != 0) {
+        if(Cross::IsPathAbsolute(custom_savedir)) {
+            savedir = custom_savedir; // use the absolute path as is
+        }
+        else {
+            savedir = working_dir + CROSS_FILESPLIT + custom_savedir;
+        }
+        LOG(LOG_MISC, LOG_DEBUG)("savestate: Set custom save directory to: %s", savedir);
         return true;
     }
     return false;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -206,6 +206,8 @@ void OUTPUT_Metal_Shutdown();
 void OUTPUT_Metal_CheckSourceResolution();
 #endif
 
+std::string working_dir = ""; // Store working directory 
+
 #if defined(WIN32)
 #include "resource.h"
 #if !defined(HX_DOS)
@@ -9259,9 +9261,10 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 
         {
             std::unique_ptr<char[]> cwd(new char[PATH_MAX]);
-            if(getcwd(cwd.get(), PATH_MAX))
-                LOG_MSG("DOSBox-X's working directory: %s\n", cwd.get());
-            else
+            if(getcwd(cwd.get(), PATH_MAX)){
+                working_dir = cwd.get();
+                LOG_MSG("DOSBox-X's working directory: %s\n", working_dir.c_str());
+            } else
                 LOG(LOG_GUI, LOG_ERROR)("sdlmain.cpp main() failed to get the current working directory.");
         }
     const char *imestr = section->Get_string("ime");

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -10708,7 +10708,7 @@ bool Get_Custom_SaveDir(std::string& savedir) {
         else {
             savedir = working_dir + CROSS_FILESPLIT + custom_savedir;
         }
-        LOG(LOG_MISC, LOG_DEBUG)("savestate: Set custom save directory to: %s", savedir);
+        LOG(LOG_MISC, LOG_DEBUG)("savestate: Set custom save directory to: %s", savedir.c_str());
         return true;
     }
     return false;

--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -8586,16 +8586,33 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         control->configfiles.clear();
     }
 
-    if (!control->opt_defaultconf && control->config_file_list.empty()) {
-        /* load the global config file first */
+    if(!control->opt_defaultconf) {
+        if(control->opt_userconf) {
+            control->ParseConfigFile(config_combined.c_str()); // Load the userconfig file if -userconf option is specified on the command line
+            if(control->configfiles.size()) configfile = config_combined;
+        }
 
-        /* -- Parse configuration files */
-        /* First search the current directory */
-        control->ParseConfigFile("dosbox-x.conf");
-        if(control->configfiles.size()) configfile = "dosbox-x.conf";
-        else {
-            control->ParseConfigFile("dosbox.conf");
-            if(control->configfiles.size()) configfile = "dosbox.conf";
+        if(control->config_file_list.size()) {
+            for(size_t si = 0; si < control->config_file_list.size(); si++) {
+                std::string configfile_path = control->config_file_list[si]; // use config files specified by -conf option on the command line
+                if(!control->config_file_list[si].empty()) control->ParseConfigFile(configfile_path.c_str());
+                if(control->configfiles.size()) configfile = configfile_path;
+            }
+        }
+
+        /* -- Search for configuration files */
+        if(!control->configfiles.size()) {
+            /* First search the current directory */
+            control->ParseConfigFile("dosbox-x.conf");
+            if(control->configfiles.size()) configfile = "dosbox-x.conf";
+            else {
+                control->ParseConfigFile("dosbox.conf");
+                if(control->configfiles.size()) configfile = "dosbox.conf";
+            }
+            if(control->configfiles.size()) {
+                std::string cur_dir = Cross::GetCurDir();
+                configfile = cur_dir + configfile;
+            }
         }
 
         /* If conf file not found, search the directory where the executable exists */
@@ -8625,20 +8642,20 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
             control->ParseConfigFile(config_combined.c_str());
             if(control->configfiles.size()) configfile = config_combined;
         }
+    }
 
-        if(configfile.size()) {
-            Section_prop* section = static_cast<Section_prop*>(control->GetSection("dosbox"));
-            workdiropt = section->Get_string("working directory option");
-            workdirdef = section->Get_path("working directory default")->realpath;
-            std::string resolvestr = section->Get_string("resolve config path");
-            resolveopt = resolvestr == "true" || resolvestr == "1" ? 1 : (resolvestr == "dosvar" ? 2 : (resolvestr == "tilde" ? 3 : 0));
-            void ResolvePath(std::string & in);
-            ResolvePath(workdirdef);
+    if(control->configfiles.size()) {
+        Section_prop* section = static_cast<Section_prop*>(control->GetSection("dosbox"));
+        workdiropt = section->Get_string("working directory option");
+        workdirdef = section->Get_path("working directory default")->realpath;
+        std::string resolvestr = section->Get_string("resolve config path");
+        resolveopt = resolvestr == "true" || resolvestr == "1" ? 1 : (resolvestr == "dosvar" ? 2 : (resolvestr == "tilde" ? 3 : 0));
+        void ResolvePath(std::string & in);
+        ResolvePath(workdirdef);
 
-            control->ClearExtraData();
-            control->configfiles.clear();
-            // LOG_MSG("working directory default=%s, working directory option=%s", workdiropt.c_str(), workdirdef.c_str());
-        }
+        control->ClearExtraData();
+        control->configfiles.clear();
+        // LOG_MSG("working directory default=%s, working directory option=%s", workdiropt.c_str(), workdirdef.c_str());
     }
 
     if (workdiropt == "prompt" && control->opt_promptfolder < 0) control->opt_promptfolder = 1;
@@ -8673,8 +8690,8 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         usecfgdir = true;
     }
 
-    /* default do not prompt if -set, -conf, -userconf, -defaultconf, or -defaultdir is used */
-    if (control->opt_promptfolder < 0 && (!control->config_file_list.empty() || !control->opt_set.empty() || control->opt_userconf || control->opt_defaultconf || control->opt_used_defaultdir || control->opt_fastlaunch || control->opt_test || workdiropt == "noprompt")) {
+    /* default do not prompt if -set, -defaultconf, or -defaultdir is used */
+    if (control->opt_promptfolder < 0 && (!control->opt_set.empty() || control->opt_defaultconf || control->opt_used_defaultdir || control->opt_fastlaunch || control->opt_test || workdiropt == "noprompt")) {
         control->opt_promptfolder = 0;
     }
 
@@ -8860,7 +8877,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 
         tmp = Cross::GetPlatformConfigName();
         config_combined = config_path + tmp;
-        /* -- -- first the user config file */
+        /* -- -- first handle the -userconf option */
         if (control->opt_userconf || workdirsave>0) {
             LOG(LOG_MISC,LOG_DEBUG)("Loading config file according to -userconf from %s",config_combined.c_str());
             control->ParseConfigFile(config_combined.c_str());
@@ -8910,15 +8927,10 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
         }
 
     if (!control->opt_defaultconf) {
-        /* -- -- if none found, use dosbox-x.conf or dosbox.conf */
-        std::string cur_dir;
-        std::unique_ptr<char[]> cwd(new char[PATH_MAX]);
-        if(getcwd(cwd.get(), PATH_MAX) != nullptr) {
-            cur_dir = std::string(cwd.get()) + CROSS_FILESPLIT;
-        }
-        else {
-            cur_dir.clear();
-        }
+        /* -- -- if -userconf and -conf option not found, search for conf files */
+        /* Current directory -> Program directory -> User config directory      */
+
+        std::string cur_dir = Cross::GetCurDir();
         const std::string config_paths[] = {
             cur_dir + "dosbox-x.conf",
             cur_dir + "dosbox.conf",
@@ -8926,6 +8938,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
             exepath.empty() ? "" : exepath + "dosbox.conf",
             res_path.empty() ? "": res_path + "dosbox-x.conf", /* resource level conf */
             config_path.empty() ? "" : config_path + "dosbox-x.conf", /* user level conf */
+            config_path.empty() ? "" : config_path + "dosbox.conf", /* user level conf */
             config_combined /* user level conf (default name)*/
         };
 
@@ -9228,6 +9241,7 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
 		}
 
     {
+        /**
         Section_prop *section = static_cast<Section_prop *>(control->GetSection("dosbox"));
         workdiropt = section->Get_string("working directory option");
         workdirdef = section->Get_path("working directory default")->realpath;
@@ -9258,37 +9272,36 @@ int main(int argc, char* argv[]) SDL_MAIN_NOEXCEPT {
                 }
             }
         }
+        */
+        working_dir = Cross::GetCurDir();
+        if(working_dir.empty())
+            LOG(LOG_GUI, LOG_ERROR)("sdlmain.cpp main() failed to get the current working directory.");
+        else
+            LOG_MSG("DOSBox-X's working directory: %s\n", working_dir.c_str());
 
-        {
-            std::unique_ptr<char[]> cwd(new char[PATH_MAX]);
-            if(getcwd(cwd.get(), PATH_MAX)){
-                working_dir = cwd.get();
-                LOG_MSG("DOSBox-X's working directory: %s\n", working_dir.c_str());
-            } else
-                LOG(LOG_GUI, LOG_ERROR)("sdlmain.cpp main() failed to get the current working directory.");
-        }
-    const char *imestr = section->Get_string("ime");
-    enableime = !strcasecmp(imestr, "true") || !strcasecmp(imestr, "1");
-    if (!strcasecmp(imestr, "auto")) {
-        const char *machine = section->Get_string("machine");
-        if (!strcasecmp(machine, "pc98") || !strcasecmp(machine, "pc9801") || !strcasecmp(machine, "pc9821") || !strcasecmp(machine, "jega") || strcasecmp(static_cast<Section_prop *>(control->GetSection("dosv"))->Get_string("dosv"), "off")) enableime = true;
-        else {
-            force_conversion = true;
-            int cp=dos.loaded_codepage;
-            if (InitCodePage() && isDBCSCP()) enableime = true;
-            else if (control->opt_langcp) tonoime = true;
-            force_conversion = false;
-            dos.loaded_codepage=cp;
+        Section_prop* section = static_cast<Section_prop*>(control->GetSection("dosbox"));
+        const char *imestr = section->Get_string("ime");
+        enableime = !strcasecmp(imestr, "true") || !strcasecmp(imestr, "1");
+        if (!strcasecmp(imestr, "auto")) {
+            const char *machine = section->Get_string("machine");
+            if (!strcasecmp(machine, "pc98") || !strcasecmp(machine, "pc9801") || !strcasecmp(machine, "pc9821") || !strcasecmp(machine, "jega") || strcasecmp(static_cast<Section_prop *>(control->GetSection("dosv"))->Get_string("dosv"), "off")) enableime = true;
+            else {
+                force_conversion = true;
+                int cp=dos.loaded_codepage;
+                if (InitCodePage() && isDBCSCP()) enableime = true;
+                else if (control->opt_langcp) tonoime = true;
+                force_conversion = false;
+                dos.loaded_codepage=cp;
 #if defined (WIN32)
-            if (!enableime&&!tonoime) {
-                const Section_prop* section = static_cast<Section_prop*>(control->GetSection("dos"));
-                const char * layoutname=section->Get_string("keyboardlayout");
-                WORD cur_kb_layout = LOWORD(GetKeyboardLayout(0));
-                if (!strcmp(layoutname, "jp") || !strcmp(layoutname, "ko") || !strcmp(layoutname, "cn") || !strcmp(layoutname, "tw") || !strcmp(layoutname, "hk") || !strcmp(layoutname, "zh") || !strcmp(layoutname, "zhs") || !strcmp(layoutname, "zht") || (!strcmp(layoutname, "auto") && (cur_kb_layout == 1028 || cur_kb_layout == 1041 || cur_kb_layout == 1042 || cur_kb_layout == 2052 || cur_kb_layout == 3076))) enableime = true;
-            }
+                if (!enableime&&!tonoime) {
+                    const Section_prop* section = static_cast<Section_prop*>(control->GetSection("dos"));
+                    const char * layoutname=section->Get_string("keyboardlayout");
+                    WORD cur_kb_layout = LOWORD(GetKeyboardLayout(0));
+                    if (!strcmp(layoutname, "jp") || !strcmp(layoutname, "ko") || !strcmp(layoutname, "cn") || !strcmp(layoutname, "tw") || !strcmp(layoutname, "hk") || !strcmp(layoutname, "zh") || !strcmp(layoutname, "zhs") || !strcmp(layoutname, "zht") || (!strcmp(layoutname, "auto") && (cur_kb_layout == 1028 || cur_kb_layout == 1041 || cur_kb_layout == 1042 || cur_kb_layout == 2052 || cur_kb_layout == 3076))) enableime = true;
+                }
 #endif
+            }
         }
-    }
 #if defined(WIN32) && !defined(HX_DOS) && !defined(_WIN32_WINDOWS)
         if (!enableime&&!tonoime) ImmDisableIME((DWORD)(-1));
 #endif

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -2167,7 +2167,7 @@ void CAPTURE_Init() {
 	// grab and store capture path
 	Prop_path *proppath = section->Get_path("captures");
 	assert(proppath != NULL);
-    std::string captures_value = proppath->GetValue();
+    std::string captures_value = proppath->GetValue().ToString();
     if(captures_value.empty()) {
         LOG_MSG("HARDWARE: CAPTURE_Init(): Capture path is empty, using working directory.");
         capturedir = working_dir;

--- a/src/hardware/hardware.cpp
+++ b/src/hardware/hardware.cpp
@@ -73,6 +73,7 @@ bool video_debug_overlay = false;
 bool skip_encoding_unchanged_frames = false, show_recorded_filename = true;
 std::string pathvid = "", pathwav = "", pathmtw = "", pathmid = "", pathopl = "", pathscr = "", pathprt = "", pathpcap = "";
 bool systemmessagebox(char const * aTitle, char const * aMessage, char const * aDialogType, char const * aIconType, int aDefaultButton);
+extern std::string working_dir;
 
 FILE* pcap_fp = NULL;
 
@@ -2158,7 +2159,7 @@ void ParseAutoSaveArg(std::string arg) {
 void CAPTURE_Init() {
 	DOSBoxMenu::item *item;
 
-	LOG(LOG_MISC,LOG_DEBUG)("Initializing screenshot and A/V capture system");
+	LOG(LOG_MISC,LOG_DEBUG)("HARDWARE: Initializing screenshot and A/V capture system");
 
 	Section_prop *section = static_cast<Section_prop *>(control->GetSection("dosbox"));
 	assert(section != NULL);
@@ -2166,7 +2167,19 @@ void CAPTURE_Init() {
 	// grab and store capture path
 	Prop_path *proppath = section->Get_path("captures");
 	assert(proppath != NULL);
-	capturedir = proppath->realpath;
+    std::string captures_value = proppath->GetValue();
+    if(captures_value.empty()) {
+        LOG_MSG("HARDWARE: CAPTURE_Init(): Capture path is empty, using working directory.");
+        capturedir = working_dir;
+    }
+    else if(Cross::IsPathAbsolute(captures_value)) {
+         capturedir = captures_value; // use the absolute path as is
+    }
+    else {
+         capturedir = working_dir + CROSS_FILESPLIT + captures_value;
+    }
+    LOG(LOG_MISC, LOG_DEBUG)("HARDWARE: Capture directory set to %s", capturedir.c_str());
+
     SetGameState_Run(section->Get_int("saveslot")-1);
     noremark_save_state = !section->Get_bool("saveremark");
     video_debug_overlay = section->Get_bool("video debug at startup");

--- a/src/misc/cross.cpp
+++ b/src/misc/cross.cpp
@@ -55,6 +55,14 @@ bool isKanji1_gbk(uint8_t chr), CodePageHostToGuestUTF16(char *d/*CROSS_LEN*/,co
 #define _mkdir(x) mkdir(x)
 #endif
 
+#ifndef PATH_MAX
+#if defined(WIN32)
+#define PATH_MAX MAX_PATH
+#else
+#define PATH_MAX 4096 /* LINUX sets to 4096, while this varies from 260 to 4096 depending on platforms */
+#endif
+#endif
+
 int resolveopt = 1;
 void autoExpandEnvironmentVariables(std::string & text, bool dosvar) {
     static std::regex env(dosvar?"\\%([^%]+)%":"\\$\\{([^}]+)\\}");
@@ -296,6 +304,18 @@ bool Cross::IsPathAbsolute(std::string const& in) {
 	if (in.size() > 1 && in[0] == '/' ) return true;
 #endif
 	return false;
+}
+
+std::string Cross::GetCurDir(void) {
+    std::string cur_dir;
+    std::unique_ptr<char[]> cwd(new char[PATH_MAX]);
+    if(getcwd(cwd.get(), PATH_MAX) != nullptr) {
+        cur_dir = std::string(cwd.get()) + CROSS_FILESPLIT;
+    }
+    else {
+        cur_dir.clear();
+    }
+    return cur_dir;
 }
 
 #if defined (WIN32)

--- a/src/misc/savestates.cpp
+++ b/src/misc/savestates.cpp
@@ -54,6 +54,7 @@ std::string saveloaderr="";
 void refresh_slots(void);
 void GFX_LosingFocus(void), GFX_ReleaseMouse(void), MAPPER_ReleaseAllKeys(void), resetFontSize(void);
 bool systemmessagebox(char const * aTitle, char const * aMessage, char const * aDialogType, char const * aIconType, int aDefaultButton);
+extern std::string working_dir;
 
 namespace
 {
@@ -465,21 +466,11 @@ void SaveState::save(size_t slot) { //throw (Error)
 	int errclose;
 	std::string path;
 	bool Get_Custom_SaveDir(std::string& savedir);
-	if(Get_Custom_SaveDir(path)) {
-		path+=CROSS_FILESPLIT;
-	} else {
-		extern std::string capturedir;
-		const size_t last_slash_idx = capturedir.find_last_of("\\/");
-		if (std::string::npos != last_slash_idx) {
-			path = capturedir.substr(0, last_slash_idx);
-		} else {
-			path = ".";
-		}
-		path+=CROSS_FILESPLIT;
-		path+="save";
-		Cross::CreateDir(path);
-		path+=CROSS_FILESPLIT;
-	}
+	if(!Get_Custom_SaveDir(path)) {
+        path = working_dir + CROSS_FILESPLIT + "save";
+        Cross::CreateDir(path);
+    }
+    path += CROSS_FILESPLIT;
 
 	std::string temp, save2;
 	std::stringstream slotname;
@@ -616,20 +607,11 @@ void SaveState::load(size_t slot) const { //throw (Error)
 	std::string path;
 	int err;
 	bool Get_Custom_SaveDir(std::string& savedir);
-	if(Get_Custom_SaveDir(path)) {
-		path+=CROSS_FILESPLIT;
-	} else {
-		extern std::string capturedir;
-		const size_t last_slash_idx = capturedir.find_last_of("\\/");
-		if (std::string::npos != last_slash_idx) {
-			path = capturedir.substr(0, last_slash_idx);
-		} else {
-			path = ".";
-		}
-		path += CROSS_FILESPLIT;
-		path +="save";
-		path += CROSS_FILESPLIT;
-	}
+	if(!Get_Custom_SaveDir(path)) {
+        path = working_dir + CROSS_FILESPLIT + "save";
+    }
+    path += CROSS_FILESPLIT;
+
 	std::string temp;
 	temp = path;
 	std::stringstream slotname;

--- a/src/misc/savestates.cpp
+++ b/src/misc/savestates.cpp
@@ -178,7 +178,7 @@ namespace
 
 		try
 		{
-			LOG_MSG("Saving state to slot: %d", (int)currentSlot + 1);
+			//LOG_MSG("Saving state to slot: %d", (int)currentSlot + 1);
 			SaveState::instance().save(currentSlot);
 			if (page!=GetGameState()/SaveState::SLOT_COUNT)
 				SetGameState((int)currentSlot);
@@ -203,7 +203,7 @@ namespace
 
 		try
 		{
-			LOG_MSG("Loading state from slot: %d", (int)currentSlot + 1);
+			//LOG_MSG("Loading state from slot: %d", (int)currentSlot + 1);
 			SaveState::instance().load(currentSlot);
 #if defined(USE_TTF)
 			if (ttf.inUse) resetFontSize();
@@ -477,6 +477,7 @@ void SaveState::save(size_t slot) { //throw (Error)
 	slotname << slot+1;
 	temp=path;
 	std::string save=use_save_file&&savefilename.size()?savefilename:temp+slotname.str()+".sav";
+    LOG_MSG("Saving state to slot: %d (%s)", (int)slot + 1, save.c_str());
 
 	zipFile zf;
 	{
@@ -626,6 +627,7 @@ void SaveState::load(size_t slot) const { //throw (Error)
 		return;
 	}
 	check_slot.close();
+    LOG_MSG("Loading state from slot: %d (%s)", (int)slot + 1, save.c_str());
 
 	unz_file_info64 file_info;
 	unzFile zf;


### PR DESCRIPTION
It was reported that capture and savestate directory was occasionally set to the user config directory.
This PR sets the directories relative to the `working directory`.

## What issue(s) does this PR address?
Fixes #6470 

<img width="715" height="537" alt="image" src="https://github.com/user-attachments/assets/d89ca0d9-54fa-4fa2-bc7b-966e55475c61" />
