### PR TITLE
Fix redefinition of enums on Macports build

### DIFF
--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -64,6 +64,7 @@ extern const char *dos_clipboard_device_name;
 #include <errno.h>
 #include <time.h>
 
+#ifndef _MACPORTS_TIME_H_
 typedef enum {
     _CLOCK_REALTIME = 0,
 #if !defined(CLOCK_REALTIME)
@@ -178,6 +179,7 @@ int clock_gettime(clockid_t clk_id, struct timespec* tp) {
 #ifdef __cplusplus
 }
 #endif
+#endif // _MACPORTS_TIME_H_
 
 #endif // __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
 

--- a/src/misc/ethernet_slirp.cpp
+++ b/src/misc/ethernet_slirp.cpp
@@ -31,6 +31,8 @@
 extern std::string niclist;
 
 #if __APPLE__ && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
+
+#ifndef _MACPORTS_TIME_H_
 typedef enum {
     _CLOCK_REALTIME = 0,
 #if !defined(CLOCK_REALTIME)
@@ -72,7 +74,8 @@ extern "C" {
 /* clock_gettime() only available in macOS 10.12+ (Sierra) */
 int clock_gettime(clockid_t clk_id, struct timespec *tp);
 }
-#endif
+#endif // _MACPORTS_TIME_H_
+#endif // __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
 
 #ifdef WIN32
 #if _WIN32_WINNT < 0x600


### PR DESCRIPTION
PR #5695 enabled building on old (<= 10.12) macOS by adding some missing functions and definitions.
However, it conflicted with Macports legacy support resulting in a build failure.
This PR removes the added functions and definitions when building on Macports.

```
dos_files.cpp:68:5: error: redefinition of enumerator '_CLOCK_REALTIME'
    _CLOCK_REALTIME = 0,
    ^
/opt/local/include/LegacySupport/time.h:58:1: note: previous definition is here
_CLOCK_REALTIME = 0,
^
```