### PR TITLE
Savestates written on Windows cannot be loaded on Linux, and hang the emulator

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,13 @@ NEXT VERSION:
     layout and ownership ordering match expected MCB-chain behavior. (cimarronm)
   - Debugger: fixed disassembler showing 16-bit register names for byte-sized
     operands. (cimarronm)
+  - Fixed savestates written by a Windows build failing to load on Linux
+    builds. The per-drive Opts struct in the DOS component held an unsigned
+    long, which is 4 bytes on Windows and 8 on LP64 hosts, so the saved stream
+    desynchronized and the load ran off the end of the component. Also fixed
+    POD_Load_DOS_Mscdex looping forever on an out-of-range CD drive count, and
+    mounted drive paths keeping their Windows path separators when a state is
+    restored on a non-Windows host. (ozy24)
 
 2026.08.02
   - Debugger: normalize 16-bit segmented offsets for address display/lookup and

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -2440,7 +2440,12 @@ struct Opts {
     int mounttype;
     uint8_t mediaid;
     unsigned char CDROM_drive;
-    unsigned long cdrom_sector_offset;
+    /* NOT `unsigned long`: that is 4 bytes on Windows (LLP64) and 8 on
+     * Linux/macOS (LP64), and this struct is written verbatim by WRITE_POD,
+     * so its size is part of the on-disk savestate format -- widening it
+     * makes a saved state unreadable on the other platform. A CD sector
+     * offset does not need more than 32 bits. */
+    uint32_t cdrom_sector_offset;
     unsigned char floppy_emu_type;
 };
 Opts opts;

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -2670,6 +2670,21 @@ void POD_Load_DOS_Files( std::istream& stream )
             READ_POD( &lalloc, lalloc);
             READ_POD( &oalloc, oalloc);
             READ_POD( &opts, opts);
+#if !defined(WIN32)
+            /* The mount path is stored verbatim, so a state saved on Windows
+             * carries '\' separators. The code below unmounts the current
+             * drive and rebuilds it from this string, so without translation
+             * the new drive's base directory is a name containing a literal
+             * backslash. localDrive does not validate it, so nothing is
+             * logged and the guest simply fails every file access.
+             *
+             * Bounded by sizeof: READ_POD fills these buffers straight from
+             * the file and does not guarantee a terminator. */
+            for (size_t q = 0; q < sizeof(dinfo) && dinfo[q]; q++)
+                if (dinfo[q] == '\\') dinfo[q] = CROSS_FILESPLIT;
+            for (size_t q = 0; q < sizeof(overlaydir) && overlaydir[q]; q++)
+                if (overlaydir[q] == '\\') overlaydir[q] = CROSS_FILESPLIT;
+#endif
             if( Drives[lcv] && strcasecmp(Drives[lcv]->info, dinfo) && (!strncmp(dinfo,"local directory ",16) || !strncmp(dinfo,"CDRom ",6) || !strncmp(dinfo,"PhysFS directory ",17) || !strncmp(dinfo,"PhysFS CDRom ",13) || (!strncmp(dinfo,"isoDrive ",9) || !strncmp(dinfo,"fatDrive ",9))))
                 unmount(lcv);
             if( !Drives[lcv] ) {

--- a/src/dos/dos_mscdex.cpp
+++ b/src/dos/dos_mscdex.cpp
@@ -1802,7 +1802,7 @@ void POD_Save_DOS_Mscdex( std::ostream& stream )
 	if (!dos_kernel_disabled) {
 		uint16_t dnum=GetNumDrives();
 		WRITE_POD( &dnum, dnum);
-		for (uint8_t drive_unit=0; drive_unit<dnum; drive_unit++) {
+		for (uint16_t drive_unit=0; drive_unit<dnum; drive_unit++) {
 			TMSF pos, start, end;
 			bool playing, pause;
 
@@ -1838,7 +1838,15 @@ void POD_Load_DOS_Mscdex( std::istream& stream )
 				}
 			}
 		}
-		for (uint8_t drive_unit=0; drive_unit<dnum; drive_unit++) {
+		/* dnum comes from the savestate and is not trustworthy. It must be
+		 * compared against a counter wide enough to hold it, or a value above
+		 * 255 wraps the uint8_t and the loop never terminates. */
+		if (dnum > MSCDEX_MAX_DRIVES) {
+			LOG_MSG("MSCDEX: savestate declares %u CD drives, more than the %u supported; ignoring",
+				(unsigned)dnum, (unsigned)MSCDEX_MAX_DRIVES);
+			dnum = 0;
+		}
+		for (uint16_t drive_unit=0; drive_unit<dnum; drive_unit++) {
 			TMSF pos, start, end;
 			uint32_t msf_time, play_len;
 			bool playing, pause;


### PR DESCRIPTION
Three related fixes: the first is the defect, the second is why it presents as a
hang rather than an error, the third is the next thing that breaks once the
first is fixed. Same-platform save/load is unaffected, which is presumably why
this has gone unnoticed.

**1. `struct Opts` is not a fixed-size POD (`dos_files.cpp`)**

`Opts::cdrom_sector_offset` is `unsigned long` — 4 bytes on Windows (LLP64), 8
on Linux/macOS (LP64). `POD_Save_DOS_Files` writes the struct verbatim with
`WRITE_POD` once per mounted drive, so `sizeof(Opts)` (32 vs 40) is part of the
on-disk format, and a state written by the MSVC build is unreadable by a Linux
build. Every other member of the struct is already fixed-width. This is the same
class of bug as #6321 (`pic_tickindex_t`), and fixed the same way. On my test
state the `Dos` component was written as 68,773 bytes and the Linux reader
wanted 68,837.

**2. `POD_Load_DOS_Mscdex` loops forever on a bad drive count (`dos_mscdex.cpp`)**

`uint16_t dnum` is read from the file, then compared against a `uint8_t` loop
counter. Any `dnum` over 255 wraps the counter at 256 and the loop never ends.
With bug 1 present I saw `dnum = 14860`: 100% CPU, no video, no input, and no
error, since nothing on that path reports failure. Worth fixing on its own — it
turns any future format mismatch into a visible failure instead of a lockup. The
save-side loop has the same narrow-counter pattern; `dnum` is `GetNumDrives()`
there and cannot exceed the cap today, but it is widened too rather than left as
a trap.

**3. Mount paths keep their Windows separators (`dos_files.cpp`)**

The `Dos` component stores each drive descriptor verbatim, e.g. `local directory
DARKSUN\`. On load the drive is unmounted and rebuilt from that string, so off
Windows the new `localDrive`'s base directory is a name containing a literal
backslash. `localDrive` does not validate `startdir`, so nothing is logged and
the guest just fails every file access. Translated to `CROSS_FILESPLIT` on
non-Windows hosts. The descriptor is restored raw afterwards by
`DOS_Drive::LoadState`, so `Drives[]->info` still shows the Windows text; only
`basedir` — the field `drive_local.cpp` builds real paths from — is corrected.
Relative mounts still need the same working directory as when the state was
saved.

**Verification**

Runtime testing was done on the 2026.07.02 release tree, against savestates
produced by the official Windows build of that version (`machine=svga_s3`,
`memsize=16`, `core=normal`). Loading a Windows-authored state and halting at
the address it was saved at gives guest RAM byte-identical over the whole
0xA0000 to a `MEMDUMPBIN 0:0 A0000` of the same state on the original Windows
machine. Six such states load; before the fix they hung every time. Against
current master these three commits are compile-verified only — the affected code
is unchanged since that tag.

**Not done**

- The image-disk restore path reads a `diskname` that is likely subject to the
  same separator problem as #3. I have not exercised it and left it alone.
- The translation in #3 rewrites every backslash in the stored descriptor. A
  backslash is a legal filename character on Linux, so a Linux-authored state
  whose mount path genuinely contains one would be rewritten too. That seemed
  the better trade against leaving Windows-authored states unloadable, but it
  is a behaviour change for that (rare) case rather than a pure fix.
- I have not audited the remaining savestate structs for other non-fixed-width
  members reached by `WRITE_POD`; `Opts` is simply the one that broke.
- Only tested x86-64 Windows → Linux. macOS is LP64 like Linux, so it should
  be affected and repaired identically, but I have not tested it and have not
  claimed it fixed there.
