### PR TITLE
bios_disk: fix INT 13h CHS decoding for floppies

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,10 @@ NEXT VERSION:
     layout and ownership ordering match expected MCB-chain behavior. (cimarronm)
   - Debugger: fixed disassembler showing 16-bit register names for byte-sized
     operands. (cimarronm)
+  - Fixed INT 13h CHS decoding for floppies, which incorrectly used the hard
+    disk layout (10-bit cylinder / 6-bit sector) instead of the floppy layout
+    (8-bit cylinder in CH / 8-bit sector in CL) on read, write, and get drive
+    parameters. (cimarronm)
 
 2026.08.02
   - Debugger: normalize 16-bit segmented offsets for address display/lookup and

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -1957,6 +1957,7 @@ static Bitu INT13_DiskHandler(void) {
     uint8_t sectbuf[2048/*CD-ROM support*/];
     uint8_t  drivenum;
     Bitu  i,t;
+    uint32_t rd_cyl = 0, rd_sect = 0;
     uint64_t LBA = 0;
     last_drive = reg_dl;
     drivenum = GetDosDriveNumber(reg_dl);
@@ -2070,10 +2071,15 @@ static Bitu INT13_DiskHandler(void) {
             return CBRET_NONE;
         }
 
+        /* Floppies (DL bit 7 clear) use an 8-bit cylinder in CH and an 8-bit sector in CL.
+         * Hard disks (DL bit 7 set) use a 10-bit cylinder (upper 2 bits in CL bits 6-7)
+         * and a 6-bit sector (CL bits 0-5). */
+        rd_cyl  = (reg_dl & 0x80) ? (uint32_t)(reg_ch | ((reg_cl & 0xc0) << 2)) : (uint32_t)reg_ch;
+        rd_sect = (reg_dl & 0x80) ? (uint32_t)(reg_cl & 63) : (uint32_t)reg_cl;
         segat = SegValue(es);
         bufptr = reg_bx;
         for(i=0;i<reg_al;i++) {
-            last_status = imageDiskList[drivenum]->Read_Sector((uint32_t)reg_dh, (uint32_t)(reg_ch | ((reg_cl & 0xc0)<< 2)), (uint32_t)((reg_cl & 63)+i), sectbuf);
+            last_status = imageDiskList[drivenum]->Read_Sector((uint32_t)reg_dh, rd_cyl, rd_sect+i, sectbuf);
 
             if (imageDiskList[drivenum]->class_id == imageDisk::ID_EL_TORITO_FLOPPY)
                 diskio_delay(512);
@@ -2083,7 +2089,7 @@ static Bitu INT13_DiskHandler(void) {
                 diskio_delay(512);
 
             /* IDE emulation: simulate change of IDE state that would occur on a real machine after INT 13h */
-            IDE_EmuINT13DiskReadByBIOS(reg_dl, (uint32_t)(reg_ch | ((reg_cl & 0xc0)<< 2)), (uint32_t)reg_dh, (uint32_t)((reg_cl & 63)+i));
+            IDE_EmuINT13DiskReadByBIOS(reg_dl, rd_cyl, (uint32_t)reg_dh, rd_sect+i);
 
             if((last_status != Int13Status::NoError) || killRead) {
                 LOG_MSG("Error in disk read");
@@ -2122,6 +2128,9 @@ static Bitu INT13_DiskHandler(void) {
             return CBRET_NONE;
         }
 
+        /* See INT 13h AH=02h read: floppies use 8-bit cylinder/8-bit sector, hard disks 10-bit/6-bit. */
+        rd_cyl  = (reg_dl & 0x80) ? (uint32_t)(reg_ch | ((reg_cl & 0xc0) << 2)) : (uint32_t)reg_ch;
+        rd_sect = (reg_dl & 0x80) ? (uint32_t)(reg_cl & 63) : (uint32_t)reg_cl;
         bufptr = reg_bx;
         for(i=0;i<reg_al;i++) {
             for(t=0;t<imageDiskList[drivenum]->getSectSize();t++) {
@@ -2134,7 +2143,7 @@ static Bitu INT13_DiskHandler(void) {
             else
                 diskio_delay(512);
 
-            last_status = imageDiskList[drivenum]->Write_Sector((uint32_t)reg_dh, (uint32_t)(reg_ch | ((reg_cl & 0xc0) << 2)), (uint32_t)((reg_cl & 63) + i), &sectbuf[0]);
+            last_status = imageDiskList[drivenum]->Write_Sector((uint32_t)reg_dh, rd_cyl, rd_sect + i, &sectbuf[0]);
             if(last_status != Int13Status::NoError) {
                 reg_ah = (uint8_t)last_status;
                 CALLBACK_SCF(true);
@@ -2160,7 +2169,7 @@ static Bitu INT13_DiskHandler(void) {
         segat = SegValue(es);
         bufptr = reg_bx;
         for(i=0;i<reg_al;i++) {
-            last_status = imageDiskList[drivenum]->Read_Sector((uint32_t)reg_dh, (uint32_t)(reg_ch | ((reg_cl & 0xc0)<< 2)), (uint32_t)((reg_cl & 63)+i), sectbuf);
+            last_status = imageDiskList[drivenum]->Read_Sector((uint32_t)reg_dh, rd_cyl, rd_sect+i, sectbuf);
             if(last_status != 0x00) {
                 LOG_MSG("Error in disk read");
                 CALLBACK_SCF(true);
@@ -2258,7 +2267,10 @@ static Bitu INT13_DiskHandler(void) {
         }
 
         reg_ch = (uint8_t)(tmpcyl & 0xff);
-        reg_cl = (uint8_t)(((tmpcyl >> 2) & 0xc0) | (tmpsect & 0x3f)); 
+        if (reg_dl & 0x80) /* hard disk: 10-bit cylinder, 6-bit sector */
+            reg_cl = (uint8_t)(((tmpcyl >> 2) & 0xc0) | (tmpsect & 0x3f));
+        else /* floppy: 8-bit cylinder in CH, 8-bit sector in CL */
+            reg_cl = (uint8_t)(tmpsect & 0xff);
         reg_dh = (uint8_t)tmpheads;
         last_status = Int13Status::NoError;
         if (reg_dl&0x80) {  // harddisks

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -16,8 +16,14 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-#include <assert.h>
+#include <cassert>
 #include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "dosbox.h"
 #include "callback.h"
@@ -28,7 +34,6 @@
 #include "mem.h"
 #include "dos_inc.h" /* for Drives[] */
 #include "../dos/drives.h"
-#include "mapper.h"
 #include "ide.h"
 #include "cpu.h"
 
@@ -341,6 +346,13 @@ static const uint8_t hdddiskboot[] = {
     0x12,0x3c,0x04,0x35,0x04,0x24,0x01,0x25,0x00,0x00,
 };
 
+/* The packed on-disk structures (direntry, bootstrap) below are only accessed
+ * through var_read()/var_write(), which do byte-wise unaligned-safe host I/O,
+ * so -Waddress-of-packed-member is a false positive here. */
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
+#endif
 struct fatFromDOSDrive
 {
 	DOS_Drive* drive;
@@ -761,7 +773,7 @@ struct fatFromDOSDrive
             STOREINTELDWORD(&pe.ipl_cyl, 1);
             STOREINTELDWORD(&pe.cyl, 1);
             STOREINTELDWORD(&pe.end_cyl, sasi.cylinders);
-            strncpy(pe.name, "MS-DOS          ", 16);
+            memcpy(pe.name, "MS-DOS          ", 16); // fixed-width, space-padded, not NUL-terminated
             memset(&pt, 0, sizeof(pt));
             memcpy(&pt,&pe,sizeof(pe));
         }
@@ -831,8 +843,8 @@ struct fatFromDOSDrive
 		var_write(&bootsec.fatcopies, 2);
 		var_write(&bootsec.totalsectorcount, 0); // 16 bit field is 0, actual value is in totalsecdword
 		var_write(&bootsec.mediadescriptor, 0xF8); //also in FAT[0]
-		var_write(&bootsec.sectorspertrack, IS_PC98_ARCH ? sasi.sectors : SECTORSPERTRACK);
-		var_write(&bootsec.headcount, IS_PC98_ARCH ? sasi.surfaces : HEADCOUNT);
+		var_write(&bootsec.sectorspertrack, IS_PC98_ARCH ? (uint16_t)sasi.sectors : (uint16_t)SECTORSPERTRACK);
+		var_write(&bootsec.headcount, IS_PC98_ARCH ? (uint16_t)sasi.surfaces : (uint16_t)HEADCOUNT);
 		var_write(&bootsec.hiddensectorcount, IS_PC98_ARCH ? sect_boot_pc98 : SECT_BOOT);
 		var_write(&bootsec.totalsecdword, partSize);
 		bootsec.magic1 = 0x55; bootsec.magic2 = 0xaa;
@@ -1063,6 +1075,9 @@ struct fatFromDOSDrive
             return false;
     }
 };
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 bool saveDiskImage(imageDisk *image, const char *name) {
     return image && image->ffdd && image->ffdd->SaveImage(name);
@@ -1087,7 +1102,7 @@ diskGeo DiskGeometryList[] = {
     {1520, 19, 2, 80, 2, 512, 224, 1, 0xF9, 10},      // IBM PC high density 5.25" double-sided 1.52MB (XDF)
     {1840, 23, 2, 80, 4, 512, 224, 1, 0xF0, 12},      // IBM PC high density 3.5" double-sided 1.84MB (XDF)
 
-    {   0,  0, 0,  0, 0,    0,  0, 0,    0}
+    {   0,  0, 0,  0, 0,    0,  0, 0,    0, 0}
 };
 
 Bitu call_int13 = 0;
@@ -1202,7 +1217,7 @@ void updateFloppyDPT(void) {
             }
             else if (fi == 0) {
                 /* Present it as a 1.44MB drive */
-                uint32_t tmpheads = 2, tmpcyl = 80, tmpsect = 18, tmpsize = 512;
+                uint32_t tmpsect = 18, tmpsize = 512;
 
                 /* taken from a QEMU VM */
                 phys_writeb(tp+0,0xAF);
@@ -1757,6 +1772,12 @@ imageDisk::~imageDisk()
         delete ffdd;
 }
 
+/* var_read() on the packed bootstrap fields below is unaligned-safe by design,
+ * so -Waddress-of-packed-member is a false positive here. */
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
+#endif
 void imageDisk::Set_GeometryForHardDisk()
 {
 	sector_size = 512;
@@ -1787,6 +1808,9 @@ void imageDisk::Set_GeometryForHardDisk()
     LBA = (uint64_t)diskimgsize / sector_size;
     Set_Geometry(16, diskimgsize / (512 * 63 * 16), 63, 512);
 }
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 void imageDisk::Set_Geometry(uint32_t setHeads, uint32_t setCyl, uint32_t setSect, uint32_t setSectSize) {
 


### PR DESCRIPTION
## Summary
- INT 13h AH=02h (read), AH=03h (write), and AH=08h (get drive parameters) incorrectly used the hard-disk CHS layout (10-bit cylinder / 6-bit sector) for floppies. Floppies use an 8-bit cylinder in CH and an 8-bit sector in CL.
- Decoding is now selected by the DL bit-7 fixed-disk flag: floppies get 8-bit cylinder / 8-bit sector; hard disks keep 10-bit / 6-bit.
- AH=08h encodes the CHS result back into CH/CL using the matching layout per drive type.
- Cleaned up compiler warnings and includes in `bios_disk.cpp`
