### PR TITLE
bios_disk: fix chs_write packing high cylinder bits into the sector field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,6 +32,9 @@ NEXT VERSION:
     POD_Load_DOS_Mscdex looping forever on an out-of-range CD drive count, and
     mounted drive paths keeping their Windows path separators when a state is
     restored on a non-Windows host. (ozy24)
+  - Fixed chs_write packing the high cylinder bits into the sector field of the
+    synthesized MBR partition table, which corrupted the end-CHS entry for disks
+    with an end cylinder above 255. (cimarronm)
 
 2026.08.02
   - Debugger: normalize 16-bit segmented offsets for address display/lookup and

--- a/src/ints/bios_disk.cpp
+++ b/src/ints/bios_disk.cpp
@@ -885,7 +885,7 @@ struct fatFromDOSDrive
 		if (head > 0xFF || sector > 0x3F || cylinder > 0x3FF)
             LOG_MSG("Warning: Invalid CHS data - %X, %X, %X\n", head, sector, cylinder);
 		chs[0] = (uint8_t)(head & 0xFF);
-		chs[1] = (uint8_t)((sector & 0x3F) | ((cylinder >> 8) & 0x3));
+		chs[1] = (uint8_t)((sector & 0x3F) | ((cylinder >> 2) & 0xC0));
 		chs[2] = (uint8_t)(cylinder & 0xFF);
 	}
 


### PR DESCRIPTION
`chs_write` in `src/ints/bios_disk.cpp` placed cylinder bits 8–9 into bits 0–1 of the second CHS byte (`(cylinder >> 8) & 0x3`), corrupting the sector field and dropping the high cylinder bits.
