### PR TITLE
dos_execute: fix potential non-null-terminated string passed to SetFileName()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,6 +42,7 @@ NEXT VERSION:
   - Floppy INT 13h sector reads/writes now honor the bytes-per-sector code from
     the disk base table pointed to by INT 1Eh instead of assuming 512, allowing
     guests that reprogram INT 1Eh to access non-512 media. (cimarronm)
+  - Simplified the MCB filename-stripping logic in DOS_Execute(). (cimarronm)
 
 2026.08.02
   - Debugger: normalize 16-bit segmented offsets for address display/lookup and

--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -17,8 +17,11 @@
  */
 
 
-#include <string.h>
-#include <ctype.h>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <cstring>
+#include <string>
 
 #include "dosbox.h"
 #include "logging.h"
@@ -293,7 +296,11 @@ static void SetupCMDLine(uint16_t pspseg, const DOS_ParamBlock& block) {
 bool DOS_Execute(const char* name, PhysPt block_pt, uint16_t flags) {
 	EXE_Header head;Bitu i;
 	uint16_t fhandle;uint16_t len;uint32_t pos;
-	uint16_t pspseg,envseg,loadseg,memsize=0xffff,readsize;
+	uint16_t pspseg;
+	uint16_t envseg = 0;
+	uint16_t loadseg;
+	uint16_t memsize=0xffff;
+	uint16_t readsize;
 	uint16_t maxsize,maxfree=0xffff;
 	PhysPt loadaddress;RealPt relocpt;
 	uint32_t headersize = 0, imagesize = 0,memimagesize = 0;

--- a/src/dos/dos_execute.cpp
+++ b/src/dos/dos_execute.cpp
@@ -885,22 +885,16 @@ bool DOS_Execute(const char* name, PhysPt block_pt, uint16_t flags) {
 		if ( (d2>=DOS_DRIVES) || !Drives[d2] ) reg_bh = 0xFF; else reg_bh = 0;
 
 		/* Write filename in new program MCB */
-		char stripname[8]= { 0 };Bitu index=0;
-		while (char chr=*name++) {
-			switch (chr) {
-			case ':':case '\\':case '/':index=0;break;
-			default:if (index<8) stripname[index++]=(char)toupper(chr);
-			}
-		}
-		index=0;
-		while (index<8) {
-			if (stripname[index]=='.') break;
-			if (!stripname[index]) break;	
-			index++;
-		}
-		memset(&stripname[index],0,8-index);
+		const char *base = name;
+		for (const char *p = name; *p; p++)
+			if (*p == ':' || *p == '\\' || *p == '/') base = p + 1;
+
+		std::array<char, 9> stripname = {};
+		size_t index = 0;
+		for (; index < stripname.size() - 1 && base[index] && base[index] != '.'; index++)
+			stripname[index] = (char)toupper(base[index]);
 		DOS_MCB pspmcb(dos.psp()-1);
-		pspmcb.SetFileName(stripname);
+		pspmcb.SetFileName(stripname.data());
 		DOS_UpdatePSPName();
 		RunningProgramHash[0] = head.checksum;
 		RunningProgramHash[1] = checksum_bytes;
@@ -913,7 +907,7 @@ bool DOS_Execute(const char* name, PhysPt block_pt, uint16_t flags) {
 			if (s != 0) {
 				DOS_MCB envmcb(s-1);
 				envmcb.SetPSPSeg(dos.psp());
-				envmcb.SetFileName(stripname);
+				envmcb.SetFileName(stripname.data());
 			}
 		}
 	}


### PR DESCRIPTION
Fixes a bug in DOS_Execute() where the 8-character MCB filename buffer (stripname) was not guaranteed to be null-terminated: if the stripped name was exactly 8 characters with no '.' or embedded null, memset(&stripname[index], 0, 8-index) was a no-op, leaving the buffer without a terminator. DOS_MCB::SetFileName() takes a const char * and calls strlen() on it, so this could read past the end of the 8-byte stack buffer into adjacent stack memory.