### PR TITLE
Fix crash of Win9x lowend build at launch

### DIFF
--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -595,9 +595,14 @@ void DBGUI_StartUp(void) {
 	/* Start the main window */
 
 #ifdef WIN32
-    if(!AttachConsole(ATTACH_PARENT_PROCESS)) { // Make sure console window is opened
+    typedef BOOL(WINAPI* AttachConsoleProc)(DWORD);
+
+    HMODULE kernel = GetModuleHandle(TEXT("kernel32.dll"));
+    AttachConsoleProc pAttachConsole =
+        (AttachConsoleProc)GetProcAddress(kernel, "AttachConsole");
+
+    if(!pAttachConsole || !pAttachConsole(ATTACH_PARENT_PROCESS))
         AllocConsole();
-    }
     freopen("CONIN$", "r", stdin);
     freopen("CONOUT$", "w", stdout);
     freopen("CONOUT$", "w", stderr);


### PR DESCRIPTION
Remove usage of AttachConsole() on Win9x builds to avoid crashes.

## What issue(s) does this PR address?
Fixes #6432
Fixes #6488
