### PR TITLE
Fix a out-of-bounds array access bug in drive_virtual.cpp

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -49,6 +49,7 @@
   - Fixed FAT volume labels being displayed as 8.3 filenames. (cimarronm)
   - Fixed crash of Win9x lowend build at launch due to use of AttachConsole()
     function (maron2000)
+  - Fixed a out-of-bounds array access bug in drive_virtual.cpp (maron2000)
 
 2026.08.02
   - Debugger: normalize 16-bit segmented offsets for address display/lookup and

--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -345,15 +345,15 @@ void VFILE_Register(const char* name, uint8_t* data, uint32_t size, const char* 
 
     // Safely register its own information to the global arrays only after the parent has been successfully resolved.
     unsigned int assigned_index = vfpos;
-    if(trimmed_name.size() >= CROSS_LEN || trimmed_sname.size() >= CROSS_LEN) {
+    if(trimmed_name.size() >= CROSS_LEN || trimmed_sname.size() >= DOS_NAMELENGTH_ASCII) {
         return; // Reject malformed overly long paths safely
     }
 
     // Safely assign data to structural boundaries
-    strncpy(vfnames[assigned_index], name, CROSS_LEN - 1);
+    strncpy(vfnames[assigned_index], trimmed_name.c_str(), CROSS_LEN - 1);
     vfnames[assigned_index][CROSS_LEN - 1] = '\0';
-    strncpy(vfsnames[assigned_index], sname.c_str(), CROSS_LEN - 1);
-    vfsnames[assigned_index][CROSS_LEN - 1] = '\0';
+    strncpy(vfsnames[assigned_index], trimmed_sname.c_str(), DOS_NAMELENGTH_ASCII - 1);
+    vfsnames[assigned_index][DOS_NAMELENGTH_ASCII - 1] = '\0';
 
     VFILE_Block* new_file = new VFILE_Block;
     new_file->name = vfsnames[assigned_index];


### PR DESCRIPTION
Correct vfsnames buffer size handling to use DOS_NAMELENGTH_ASCII instead of CROSS_LEN, preventing an out-of-bounds array access.

Edit: gcc warned this code as follows
```c++
drive_virtual.cpp:356:5: warning: array index 511 is past the end of the array (that has type 'char[13]') [-Warray-bounds]
  356 |     vfsnames[assigned_index][CROSS_LEN - 1] = '\0';
      |     ^                        ~~~~~~~~~~~~~
drive_virtual.cpp:55:1: note: array 'vfsnames' declared here
   55 | char sfn[DOS_NAMELENGTH_ASCII],vfnames[MAX_VFILES][CROSS_LEN],vfsnames[MAX_VFILES][DOS_NAMELENGTH_ASCII];
      | ^
```