### PR TITLE
Fix retrieving version number for Windows setup files

### DIFF
--- a/.github/workflows/vsbuild_xp.yml
+++ b/.github/workflows/vsbuild_xp.yml
@@ -260,7 +260,11 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') 
         shell: bash
         run: |
-          DOSBOX_X_RELEASE=`gh release list -L1 | grep -o "....-..-.." | head -n 1 | sed -e "s/-/./g"`
+          DOSBOX_X_RELEASE=$(echo "${GITHUB_REF##*/}" | sed -nE 's/^dosbox-x-v([0-9]+\.[0-9]+\.[0-9]+)$/\1/p')
+          if [[ -z "$DOSBOX_X_RELEASE" ]]; then
+            DOSBOX_X_RELEASE=$(gh release list -L1 | grep -o "....-..-.." | head -n 1 | sed -e "s/-/./g")
+          fi
+          echo "DOSBOX_X_RELEASE=$DOSBOX_X_RELEASE" >> $GITHUB_ENV
           sed -i "s/^#define MyAppVersion.*/#define MyAppVersion \"$DOSBOX_X_RELEASE\"/" contrib/windows/installer/DOSBox-X-setupXP.iss
       - name: Prepare files
         shell: bash

--- a/.github/workflows/windows-installers.yml
+++ b/.github/workflows/windows-installers.yml
@@ -487,7 +487,11 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') 
         shell: bash
         run: |
-          DOSBOX_X_RELEASE=`gh release list -L1 | grep -o "....-..-.." | head -n 1 | sed -e "s/-/./g"`
+          DOSBOX_X_RELEASE=$(echo "${GITHUB_REF##*/}" | sed -nE 's/^dosbox-x-v([0-9]+\.[0-9]+\.[0-9]+)$/\1/p')
+          if [[ -z "$DOSBOX_X_RELEASE" ]]; then
+            DOSBOX_X_RELEASE=$(gh release list -L1 | grep -o "....-..-.." | head -n 1 | sed -e "s/-/./g")
+          fi
+          echo "DOSBOX_X_RELEASE=$DOSBOX_X_RELEASE" >> $GITHUB_ENV
           sed -i "s/^#define MyAppVersion.*/#define MyAppVersion \"$DOSBOX_X_RELEASE\"/" contrib/windows/installer/DOSBox-X-installer.iss
       - name: Prepare files
         shell: bash


### PR DESCRIPTION
The version number of Windows setup files in the Release builds may slightly differ from what it should be due to the retrieving method.
This PR fixes the retrieving to match the version tag as well as other portable files.
