### PR TITLE
Fix OpenGL scaling when modeswitch is off

### DIFF
--- a/src/output/output_opengl.cpp
+++ b/src/output/output_opengl.cpp
@@ -196,7 +196,9 @@ retry:
 
     bool isModeswitchSet = vga.draw.modeswitch_set;
 
-    if (((fixedWidth == 0 || fixedHeight == 0)) && !isModeswitchSet )
+    if (isModeswitchSet)
+        fixedHeight = 0;
+    else if (fixedWidth == 0 || fixedHeight == 0)
     {
         Bitu consider_height = menu.maxwindow ? currentWindowHeight : 0;
         Bitu consider_width = menu.maxwindow ? currentWindowWidth : 0;
@@ -206,8 +208,6 @@ retry:
         fixedWidth = final_width;
         fixedHeight = final_height;
     }
-    else
-	fixedHeight = 0;
 
 #if DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW
     /* scale the menu bar if the window is large enough */


### PR DESCRIPTION
## What issue(s) does this PR address?

OpenGL scaling appears to have regressed in the latest 26.08.31 release. Looking into it, it seems it's related to the handling of the new "modeswitch" option. When this option is off, "fixedheight" gets forced to 0 in the else clause, effectively ignoring the user's specified window resolution. I've adjusted the check so that fixedheight is only forced to 0 if modeswitch is on, otherwise the old logic takes over.

There's a lot of logic happening in this function, and I'm not 100% sure what the implications of the modeswitch variable are supposed to be, but this seems to be the intended logic. Feel free to adjust as necessary if it's not.

## Does this PR introduce new feature(s)?

No

## Does this PR introduce any breaking change(s)?

No

## Additional information

It's possible a similar problem exists in other output paths, but I haven't looked into that.