### PR TITLE
Modesetting resolution change exclusive to fullscreen.

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -1913,18 +1913,19 @@ SDL_Window* GFX_SetSDLWindowMode(uint16_t width, uint16_t height, SCREEN_TYPES s
 	/*
 	 * When modeswitching _is_ enabled let's go with sane values.
 	 */
-	bool isModeSwicthSet = vga.draw.modeswitch_set;
+	bool isModeswicthSet = vga.draw.modeswitch_set;
 
-	if(isModeSwicthSet) {
-		flags = SDL_WINDOW_FULLSCREEN;
-		width = vga.draw.width;
-		height = vga.draw.height;
-	}
 #endif
 
     if (GFX_IsFullscreen()) {
         SDL_DisplayMode displayMode;
         SDL_GetWindowDisplayMode(sdl.window, &displayMode);
+
+	if(isModeswicthSet) {
+		flags = SDL_WINDOW_FULLSCREEN;
+		width = vga.draw.width;
+		height = vga.draw.height;
+	}
 
         displayMode.w = width;
         displayMode.h = height;

--- a/src/output/output_opengl.cpp
+++ b/src/output/output_opengl.cpp
@@ -214,7 +214,7 @@ retry:
     /* SDL drawn menus cannot coexist with 3Dfx emulation. In fact, there is a serious
      * bug in SDL1 builds that rapidly expands the vertical size of the menu every frame. */
     
-    if (Voodoo_OGL_GetWidth() != 0 && Voodoo_OGL_GetHeight() != 0 && Voodoo_OGL_Active() && sdl.desktop.prevent_fullscreen && isModeswitchSet) {
+    if (Voodoo_OGL_GetWidth() != 0 && Voodoo_OGL_GetHeight() != 0 && Voodoo_OGL_Active() && sdl.desktop.prevent_fullscreen)  {
     }
     else {
         int cw = fixedWidth, ch = fixedHeight;
@@ -272,7 +272,7 @@ retry:
 #if DOSBOXMENU_TYPE == DOSBOXMENU_SDLDRAW
     if (mainMenu.isVisible() && !sdl.desktop.fullscreen) 
     {
-        if (Voodoo_OGL_GetWidth() != 0 && Voodoo_OGL_GetHeight() != 0 && Voodoo_OGL_Active() && sdl.desktop.prevent_fullscreen && isModeswitchSet ) {
+        if (Voodoo_OGL_GetWidth() != 0 && Voodoo_OGL_GetHeight() != 0 && Voodoo_OGL_Active() && sdl.desktop.prevent_fullscreen) {
         }
         else {
             windowHeight += mainMenu.menuBox.h;


### PR DESCRIPTION
Using the modesetting feature is now exclusive to fullscreen (as it should be) and will not interfere with how the window sizing behaves while DOSBox-X is windowed.

This fixes "Measure is not counting menus. Only the viewport..." mentioned in #6517