### PR TITLE
MCP Protocol

### DIFF
--- a/README.debugger
+++ b/README.debugger
@@ -96,7 +96,7 @@ Debugger MCP control protocol
 
 When the debugger is enabled, DOSBox-X also starts a minimal TCP control
 client for external debugger tooling. This is used by the companion
-dosbox-x-mcp-server project.
+[dosbox-x-mcp-server](https://github.com/caiiiycuk/dosbox-x-mcp-server) project.
 
 DOSBox-X connects to:
 

--- a/README.debugger
+++ b/README.debugger
@@ -142,6 +142,10 @@ interactive debugger prompt. For example:
 returns the same CPU state text that the interactive CPU command would write
 to the debugger output window.
 
+Resume commands (`RUN`, `RUNWATCH`, and `VRT`) are acknowledged before
+DOSBox-X leaves the debugger loop. Their response is only a successful
+acceptance of the command, not a post-resume state snapshot.
+
 Output is captured from DEBUG_ShowMsg while an MCP command is running. Paged
 debugger output is not paused for terminal input during this capture, so
 commands such as HELP, GDT, LDT, IDT, and DOS memory listings can be returned

--- a/README.debugger
+++ b/README.debugger
@@ -151,6 +151,11 @@ debugger output is not paused for terminal input during this capture, so
 commands such as HELP, GDT, LDT, IDT, and DOS memory listings can be returned
 to the MCP client without hanging on the debugger pager.
 
+The MCP control queue is polled both from the normal timer path and directly
+from the active debugger loop. This lets MCP clients issue commands after a
+BREAK has stopped emulation in the debugger; concurrent MCP tool calls are
+still serialized by the MCP server before they reach DOSBox-X.
+
 Unknown commands return ERR and include the normal debugger
 "command not recognized" text. Commands behind build options, such as
 C_HEAVY_DEBUG-only commands, may be unavailable in some builds. MCP clients

--- a/README.debugger
+++ b/README.debugger
@@ -91,6 +91,69 @@ DEBUGBOX [command] [options]
 You can also type DEBUGBOX without a parameter to start the
 debugger.
 
+Debugger MCP control protocol
+-----------------------------
+
+When the debugger is enabled, DOSBox-X also starts a minimal TCP control
+client for external debugger tooling. This is used by the companion
+dosbox-x-mcp-server project.
+
+DOSBox-X connects to:
+
+  127.0.0.1:58991
+
+The external MCP server must be started first and listen on that address.
+If the server is not available, DOSBox-X keeps running normally and retries
+the connection in the background. If the connection is lost, DOSBox-X will
+try to reconnect.
+
+The control channel is intentionally line-oriented text, not JSON. The MCP
+server sends one request line:
+
+  REQ <id> PING
+  REQ <id> BREAK
+  REQ <id> EXEC <debugger command>
+
+DOSBox-X replies with:
+
+  BEGIN <id> OK
+  <zero or more output lines>
+  END <id>
+
+or:
+
+  BEGIN <id> ERR
+  <one or more error lines>
+  END <id>
+
+Only one debugger command is expected to be pending at a time. The MCP
+server serializes calls before sending them to DOSBox-X.
+
+PING returns PONG and is used to check the active connection.
+
+BREAK enters the built-in debugger, equivalent to invoking the debugger
+break action.
+
+EXEC runs one existing debugger command through the same parser used by the
+interactive debugger prompt. For example:
+
+  REQ 7 EXEC CPU
+
+returns the same CPU state text that the interactive CPU command would write
+to the debugger output window.
+
+Output is captured from DEBUG_ShowMsg while an MCP command is running. Paged
+debugger output is not paused for terminal input during this capture, so
+commands such as HELP, GDT, LDT, IDT, and DOS memory listings can be returned
+to the MCP client without hanging on the debugger pager.
+
+Unknown commands return ERR and include the normal debugger
+"command not recognized" text. Commands behind build options, such as
+C_HEAVY_DEBUG-only commands, may be unavailable in some builds. MCP clients
+should call HELP for the live command list from the running DOSBox-X build,
+or use their own static command catalog as a hint before falling back to raw
+EXEC.
+
 Debugger keyboard shortcuts
 ---------------------------
 

--- a/README.debugger
+++ b/README.debugger
@@ -94,18 +94,24 @@ debugger.
 Debugger MCP control protocol
 -----------------------------
 
-When the debugger is enabled, DOSBox-X also starts a minimal TCP control
+When the debugger is enabled, DOSBox-X can start a minimal TCP control
 client for external debugger tooling. This is used by the companion
 [dosbox-x-mcp-server](https://github.com/caiiiycuk/dosbox-x-mcp-server) project.
 
+Enable it in the [dosbox] section:
+
+  mcp_server=58991
+
 DOSBox-X connects to:
 
-  127.0.0.1:58991
+  127.0.0.1:<mcp_server>
 
 The external MCP server must be started first and listen on that address.
 If the server is not available, DOSBox-X keeps running normally and retries
 the connection in the background. If the connection is lost, DOSBox-X will
 try to reconnect.
+
+The default value is 0, which disables debugger MCP control.
 
 The control channel is intentionally line-oriented text, not JSON. The MCP
 server sends one request line:

--- a/src/debug/Makefile.am
+++ b/src/debug/Makefile.am
@@ -1,4 +1,4 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include
 
 noinst_LIBRARIES = libdebug.a
-libdebug_a_SOURCES = debug.cpp debug_gui.cpp debug_disasm.cpp debug_inc.h disasm_tables.h debug_win32.cpp
+libdebug_a_SOURCES = debug.cpp debug_gui.cpp debug_disasm.cpp debug_inc.h disasm_tables.h debug_win32.cpp debug_mcp.cpp debug_mcp.h

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -5147,6 +5147,13 @@ void dyn_core_dh_debug_flush (void);
 
 Bitu DEBUG_Loop(void) {
     dosbox_agent::AGENT_BridgePump();
+
+    ControlServer_Poll();
+
+    // MCP commands such as RUN or VRT can switch back to the normal loop.
+    if (DOSBOX_GetLoop() != DEBUG_Loop)
+        return 0;
+
     if (debug_running) {
         Bitu now = SDL_GetTicks();
 

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -56,6 +56,8 @@ using namespace std;
 #include "keyboard.h"
 #include "control.h"
 
+#include "debug_mcp.h"
+
 bool Clear_SYSENTER_Debug();
 bool Toggle_BreakSYSEnter();
 bool Toggle_BreakSYSExit();
@@ -4314,6 +4316,23 @@ bool ParseCommand(char* str) {
 	return false;
 }
 
+bool DEBUG_ExecuteCommand(const char* command)
+{
+	if (command == NULL || *command == 0) {
+		DEBUG_ShowMsg("*** Debugger command not recognized");
+		return false;
+	}
+
+	std::vector<char> buffer(command, command + strlen(command));
+	buffer.push_back(0);
+
+	if (ParseCommand(buffer.data()))
+		return true;
+
+	DEBUG_ShowMsg("*** Debugger command not recognized");
+	return false;
+}
+
 char* AnalyzeInstruction(char* inst, bool saveSelector) {
 	static char result[256];
 
@@ -6061,6 +6080,9 @@ void DEBUG_SetupConsole(void) {
 }
 
 void DEBUG_ShutDown(Section * /*sec*/) {
+	TIMER_DelTickHandler(ControlServer_Poll);
+	ControlServer_Stop();
+
 	CBreakpoint::DeleteAll();
 	CDebugVar::DeleteAll();
 	if (dbg.win_main != NULL) {
@@ -6091,6 +6113,9 @@ void DEBUG_ReinitCallback(void) {
 
 void DEBUG_Init() {
     LOG(LOG_MISC, LOG_DEBUG)("Initializing debug system");
+
+	ControlServer_Start(58991);
+	TIMER_AddTickHandler(ControlServer_Poll);
 
 	/* Reset code overview and input line */
 	memset((void*)&codeViewData,0,sizeof(codeViewData));

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -6121,8 +6121,12 @@ void DEBUG_ReinitCallback(void) {
 void DEBUG_Init() {
     LOG(LOG_MISC, LOG_DEBUG)("Initializing debug system");
 
-	ControlServer_Start(58991);
-	TIMER_AddTickHandler(ControlServer_Poll);
+	Section_prop *section = static_cast<Section_prop *>(control->GetSection("dosbox"));
+	const int mcp_server_port = section != NULL ? section->Get_int("mcp_server") : 0;
+	if (mcp_server_port > 0) {
+		ControlServer_Start(static_cast<uint16_t>(mcp_server_port));
+		TIMER_AddTickHandler(ControlServer_Poll);
+	}
 
 	/* Reset code overview and input line */
 	memset((void*)&codeViewData,0,sizeof(codeViewData));

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -34,6 +34,7 @@
 #include "control.h"
 #include "menu.h"
 #include "debug.h"
+#include "debug_mcp.h"
 #include "debug_inc.h"
 #include "pic.h"
 
@@ -677,8 +678,9 @@ void DEBUG_DrawInput(void);
 
 void DEBUG_BeginPagedContent(void) {
 #if C_DEBUG
-	if (agent_output_capture_active)
+	if (agent_output_capture_active || DEBUG_MCP_IsCapturingOutput())
 		return;
+
 	int maxy, maxx; getmaxyx(dbg.win_out,maxy,maxx);
 
     debugPageCounter = 0;
@@ -688,8 +690,9 @@ void DEBUG_BeginPagedContent(void) {
 
 void DEBUG_EndPagedContent(void) {
 #if C_DEBUG
-	if (agent_output_capture_active)
+	if (agent_output_capture_active || DEBUG_MCP_IsCapturingOutput())
 		return;
+
     debugPageCounter = 0;
     debugPageStopAt = 0;
     DEBUG_DrawInput();
@@ -772,6 +775,8 @@ void DEBUG_ShowMsg(char const* format,...) {
             agent_output_capture += '\n';
         agent_output_capture += buf;
     }
+
+    DEBUG_MCP_CaptureMessage(buf);
 #endif
 
 #if C_DEBUG

--- a/src/debug/debug_mcp.cpp
+++ b/src/debug/debug_mcp.cpp
@@ -106,6 +106,25 @@ std::string SanitizeProtocolLine(std::string line)
     return line;
 }
 
+std::string FirstWordUpper(const std::string& value)
+{
+    const auto begin = value.find_first_not_of(" \t");
+    if (begin == std::string::npos)
+        return {};
+
+    const auto end = value.find_first_of(" \t", begin);
+    if (end == std::string::npos)
+        return UpperAscii(value.substr(begin));
+
+    return UpperAscii(value.substr(begin, end - begin));
+}
+
+bool IsResumeDebuggerCommand(const std::string& command)
+{
+    const auto word = FirstWordUpper(command);
+    return word == "RUN" || word == "RUNWATCH" || word == "VRT";
+}
+
 void BeginCapture()
 {
     std::lock_guard<std::mutex> lock(g_capture_mutex);
@@ -500,6 +519,28 @@ void SendErrorResponse(const std::string& id, const std::string& error)
     SendResponse(id.empty() ? "0" : id, false, {error});
 }
 
+bool OutgoingQueueEmpty()
+{
+    std::lock_guard<std::mutex> lock(g_outgoing_mutex);
+    return g_outgoing.empty();
+}
+
+void WaitForOutgoingDrain()
+{
+    constexpr int max_wait_ms = 250;
+    constexpr int sleep_step_ms = 5;
+
+    for (int elapsed_ms = 0;
+         elapsed_ms < max_wait_ms && g_running.load();
+         elapsed_ms += sleep_step_ms) {
+        if (OutgoingQueueEmpty() || !g_connected.load())
+            return;
+
+        std::this_thread::sleep_for(
+                std::chrono::milliseconds(sleep_step_ms));
+    }
+}
+
 void ProcessControlCommand(const std::string& line)
 {
     ControlRequest request;
@@ -512,6 +553,14 @@ void ProcessControlCommand(const std::string& line)
 
     if (request.command == "PING") {
         SendResponse(request.id, true, {"PONG"});
+        return;
+    }
+
+    if (request.command == "EXEC" &&
+            IsResumeDebuggerCommand(request.payload)) {
+        SendResponse(request.id, true, {"OK"});
+        WaitForOutgoingDrain();
+        DEBUG_ExecuteCommand(request.payload.c_str());
         return;
     }
 

--- a/src/debug/debug_mcp.cpp
+++ b/src/debug/debug_mcp.cpp
@@ -3,7 +3,7 @@
 #include "config.h"
 
 #if defined(C_DEBUG) && C_DEBUG && \
-        ((defined(C_SDL2_NET) && C_SDL2_NET) || (defined(C_SDL_NET) && C_SDL_NET))
+        ((defined(C_SDL2) && C_SDL2) || (defined(C_SDL) && C_SDL))
 
 #include "debug.h"
 

--- a/src/debug/debug_mcp.cpp
+++ b/src/debug/debug_mcp.cpp
@@ -1,0 +1,664 @@
+#include "debug_mcp.h"
+
+#include "config.h"
+
+#if defined(C_DEBUG) && C_DEBUG && \
+        ((defined(C_SDL2_NET) && C_SDL2_NET) || (defined(C_SDL_NET) && C_SDL_NET))
+
+#include "debug.h"
+
+#if defined(C_SDL2_NET) && C_SDL2_NET
+#include <SDL2/SDL_net.h>
+#else
+#include <SDL_net.h>
+#endif
+
+#include <atomic>
+#include <chrono>
+#include <climits>
+#include <cstdio>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+constexpr const char* CONTROL_HOST = "127.0.0.1";
+
+constexpr int SOCKET_POLL_TIMEOUT_MS = 50;
+constexpr int RECONNECT_DELAY_MS = 1000;
+
+constexpr size_t MAX_INCOMING_MESSAGES = 1024;
+constexpr size_t MAX_OUTGOING_MESSAGES = 1024;
+constexpr size_t MAX_CAPTURE_LINES = 16384;
+
+// Protect against a peer continuously sending data without '\n'.
+constexpr size_t MAX_RECEIVE_BUFFER = 1024 * 1024;
+
+std::atomic<bool> g_running{false};
+std::atomic<bool> g_connected{false};
+
+uint16_t g_port = 0;
+
+std::thread g_thread;
+
+std::mutex g_incoming_mutex;
+std::deque<std::string> g_incoming;
+
+std::mutex g_outgoing_mutex;
+std::deque<std::string> g_outgoing;
+
+std::mutex g_capture_mutex;
+bool g_capture_active = false;
+size_t g_capture_discarded = 0;
+std::vector<std::string> g_capture_lines;
+
+//
+// All socket operations happen ONLY in the I/O thread.
+//
+// This is important because SDLNet_TCP_Send/Recv/Close don't
+// have to be synchronized with the DOSBox-X emulation thread.
+//
+
+TCPsocket g_socket = nullptr;
+SDLNet_SocketSet g_socket_set = nullptr;
+
+std::string g_receive_buffer;
+
+struct ControlRequest {
+    std::string id;
+    std::string command;
+    std::string payload;
+};
+
+bool IsSpace(const char c)
+{
+    return c == ' ' || c == '\t';
+}
+
+std::string TrimLeft(std::string value)
+{
+    while (!value.empty() && IsSpace(value.front()))
+        value.erase(value.begin());
+
+    return value;
+}
+
+std::string UpperAscii(std::string value)
+{
+    for (auto& c : value) {
+        if (c >= 'a' && c <= 'z')
+            c = static_cast<char>(c - ('a' - 'A'));
+    }
+
+    return value;
+}
+
+std::string SanitizeProtocolLine(std::string line)
+{
+    for (auto& c : line) {
+        if (c == '\r' || c == '\n')
+            c = ' ';
+    }
+
+    return line;
+}
+
+void BeginCapture()
+{
+    std::lock_guard<std::mutex> lock(g_capture_mutex);
+    g_capture_lines.clear();
+    g_capture_discarded = 0;
+    g_capture_active = true;
+}
+
+std::vector<std::string> EndCapture()
+{
+    std::lock_guard<std::mutex> lock(g_capture_mutex);
+    g_capture_active = false;
+
+    std::vector<std::string> lines;
+    lines.swap(g_capture_lines);
+
+    if (g_capture_discarded > 0) {
+        char message[128];
+        std::snprintf(message,
+                      sizeof(message),
+                      "[%lu debug output lines discarded]",
+                      static_cast<unsigned long>(g_capture_discarded));
+        lines.emplace_back(message);
+        g_capture_discarded = 0;
+    }
+
+    return lines;
+}
+
+void CloseConnection()
+{
+    g_connected.store(false);
+
+    if (g_socket) {
+        if (g_socket_set)
+            SDLNet_TCP_DelSocket(g_socket_set, g_socket);
+
+        SDLNet_TCP_Close(g_socket);
+        g_socket = nullptr;
+    }
+
+    if (g_socket_set) {
+        SDLNet_FreeSocketSet(g_socket_set);
+        g_socket_set = nullptr;
+    }
+
+    g_receive_buffer.clear();
+}
+
+bool Connect()
+{
+    IPaddress address = {};
+
+    if (SDLNet_ResolveHost(&address, CONTROL_HOST, g_port) < 0) {
+        std::fprintf(stderr,
+                     "[ControlClient] SDLNet_ResolveHost failed: %s\n",
+                     SDLNet_GetError());
+
+        return false;
+    }
+
+    std::fprintf(stderr,
+                 "[ControlClient] connecting to %s:%u...\n",
+                 CONTROL_HOST,
+                 static_cast<unsigned>(g_port));
+
+    TCPsocket socket = SDLNet_TCP_Open(&address);
+
+    if (!socket)
+        return false;
+
+    SDLNet_SocketSet socket_set = SDLNet_AllocSocketSet(1);
+
+    if (!socket_set) {
+        std::fprintf(stderr,
+                     "[ControlClient] SDLNet_AllocSocketSet failed: %s\n",
+                     SDLNet_GetError());
+
+        SDLNet_TCP_Close(socket);
+        return false;
+    }
+
+    if (SDLNet_TCP_AddSocket(socket_set, socket) < 0) {
+        std::fprintf(stderr,
+                     "[ControlClient] SDLNet_TCP_AddSocket failed: %s\n",
+                     SDLNet_GetError());
+
+        SDLNet_FreeSocketSet(socket_set);
+        SDLNet_TCP_Close(socket);
+
+        return false;
+    }
+
+    g_socket = socket;
+    g_socket_set = socket_set;
+
+    g_receive_buffer.clear();
+
+    g_connected.store(true);
+
+    std::fprintf(stderr,
+                 "[ControlClient] connected to %s:%u\n",
+                 CONTROL_HOST,
+                 static_cast<unsigned>(g_port));
+
+    return true;
+}
+
+bool SendAll(const std::string& data)
+{
+    if (!g_socket)
+        return false;
+
+    const char* ptr = data.data();
+    size_t remaining = data.size();
+
+    while (remaining > 0) {
+        const int chunk =
+                remaining > static_cast<size_t>(INT_MAX)
+                        ? INT_MAX
+                        : static_cast<int>(remaining);
+
+        const int sent = SDLNet_TCP_Send(
+                g_socket,
+                ptr,
+                chunk);
+
+        if (sent <= 0)
+            return false;
+
+        ptr += sent;
+        remaining -= static_cast<size_t>(sent);
+    }
+
+    return true;
+}
+
+void QueueIncoming(std::string message)
+{
+    std::lock_guard<std::mutex> lock(g_incoming_mutex);
+
+    if (g_incoming.size() >= MAX_INCOMING_MESSAGES)
+        g_incoming.pop_front();
+
+    g_incoming.emplace_back(std::move(message));
+}
+
+bool PopIncoming(std::string& message)
+{
+    std::lock_guard<std::mutex> lock(g_incoming_mutex);
+
+    if (g_incoming.empty())
+        return false;
+
+    message = std::move(g_incoming.front());
+    g_incoming.pop_front();
+    return true;
+}
+
+void ProcessReceiveBuffer()
+{
+    for (;;) {
+        const auto newline = g_receive_buffer.find('\n');
+
+        if (newline == std::string::npos)
+            break;
+
+        std::string line =
+                g_receive_buffer.substr(0, newline);
+
+        g_receive_buffer.erase(0, newline + 1);
+
+        // Support both "\n" and "\r\n".
+        if (!line.empty() && line.back() == '\r')
+            line.pop_back();
+
+        if (line.empty())
+            continue;
+
+        QueueIncoming(std::move(line));
+    }
+}
+
+bool Receive()
+{
+    char buffer[8192];
+
+    const int received =
+            SDLNet_TCP_Recv(
+                    g_socket,
+                    buffer,
+                    sizeof(buffer));
+
+    if (received <= 0)
+        return false;
+
+    g_receive_buffer.append(
+            buffer,
+            static_cast<size_t>(received));
+
+    if (g_receive_buffer.size() > MAX_RECEIVE_BUFFER) {
+        std::fprintf(stderr,
+                     "[ControlClient] receive buffer overflow\n");
+
+        return false;
+    }
+
+    ProcessReceiveBuffer();
+
+    return true;
+}
+
+bool FlushOutgoing()
+{
+    for (;;) {
+        std::string message;
+
+        {
+            std::lock_guard<std::mutex> lock(g_outgoing_mutex);
+
+            if (g_outgoing.empty())
+                return true;
+
+            message = g_outgoing.front();
+        }
+
+        if (!SendAll(message))
+            return false;
+
+        {
+            std::lock_guard<std::mutex> lock(g_outgoing_mutex);
+
+            if (!g_outgoing.empty())
+                g_outgoing.pop_front();
+        }
+    }
+}
+
+void SleepReconnectDelay()
+{
+    //
+    // Do it in short steps so ControlServer_Stop()
+    // doesn't have to wait a full second.
+    //
+
+    constexpr int step_ms = 50;
+
+    for (int elapsed = 0;
+         elapsed < RECONNECT_DELAY_MS && g_running.load();
+         elapsed += step_ms) {
+
+        std::this_thread::sleep_for(
+                std::chrono::milliseconds(step_ms));
+    }
+}
+
+void ThreadMain()
+{
+    while (g_running.load()) {
+
+        //
+        // Connect / reconnect
+        //
+
+        if (!g_socket) {
+            if (!Connect()) {
+                SleepReconnectDelay();
+                continue;
+            }
+        }
+
+        //
+        // Send everything currently queued.
+        //
+
+        if (!FlushOutgoing()) {
+            std::fprintf(stderr,
+                         "[ControlClient] connection lost while sending\n");
+
+            CloseConnection();
+            continue;
+        }
+
+        //
+        // Wait for incoming data.
+        //
+
+        const int ready =
+                SDLNet_CheckSockets(
+                        g_socket_set,
+                        SOCKET_POLL_TIMEOUT_MS);
+
+        if (ready < 0) {
+            std::fprintf(stderr,
+                         "[ControlClient] SDLNet_CheckSockets failed: %s\n",
+                         SDLNet_GetError());
+
+            CloseConnection();
+            continue;
+        }
+
+        if (ready == 0)
+            continue;
+
+        if (g_socket && SDLNet_SocketReady(g_socket)) {
+            if (!Receive()) {
+                std::fprintf(stderr,
+                             "[ControlClient] connection closed\n");
+
+                CloseConnection();
+                continue;
+            }
+        }
+    }
+
+    CloseConnection();
+}
+
+bool ParseControlRequest(const std::string& line,
+                         ControlRequest& request,
+                         std::string& error)
+{
+    if (line.compare(0, 4, "REQ ") != 0) {
+        error = "expected REQ <id> <PING|BREAK|EXEC>";
+        return false;
+    }
+
+    const auto id_begin = line.find_first_not_of(" \t", 4);
+    if (id_begin == std::string::npos) {
+        error = "missing request id";
+        return false;
+    }
+
+    const auto id_end = line.find_first_of(" \t", id_begin);
+    if (id_end == std::string::npos) {
+        error = "missing request command";
+        return false;
+    }
+
+    request.id = line.substr(id_begin, id_end - id_begin);
+
+    const auto command_begin = line.find_first_not_of(" \t", id_end);
+    if (command_begin == std::string::npos) {
+        error = "missing request command";
+        return false;
+    }
+
+    const auto command_end = line.find_first_of(" \t", command_begin);
+    if (command_end == std::string::npos) {
+        request.command = UpperAscii(line.substr(command_begin));
+        request.payload.clear();
+    } else {
+        request.command = UpperAscii(
+                line.substr(command_begin, command_end - command_begin));
+        request.payload = TrimLeft(line.substr(command_end));
+    }
+
+    if (request.command != "PING" &&
+            request.command != "BREAK" &&
+            request.command != "EXEC") {
+        error = "unknown request command";
+        return false;
+    }
+
+    if (request.command == "EXEC" && request.payload.empty()) {
+        error = "missing debugger command";
+        return false;
+    }
+
+    return true;
+}
+
+void SendResponse(const std::string& id,
+                  const bool ok,
+                  const std::vector<std::string>& lines)
+{
+    std::string response = std::string("BEGIN ") + id + (ok ? " OK" : " ERR");
+
+    for (const auto& line : lines) {
+        response.push_back('\n');
+        response += SanitizeProtocolLine(line);
+    }
+
+    response += "\nEND ";
+    response += id;
+
+    ControlServer_Send(std::move(response));
+}
+
+void SendErrorResponse(const std::string& id, const std::string& error)
+{
+    SendResponse(id.empty() ? "0" : id, false, {error});
+}
+
+void ProcessControlCommand(const std::string& line)
+{
+    ControlRequest request;
+    std::string error;
+
+    if (!ParseControlRequest(line, request, error)) {
+        SendErrorResponse(request.id, error);
+        return;
+    }
+
+    if (request.command == "PING") {
+        SendResponse(request.id, true, {"PONG"});
+        return;
+    }
+
+    BeginCapture();
+
+    bool ok = true;
+    if (request.command == "BREAK") {
+        DEBUG_EnableDebugger();
+    } else {
+        ok = DEBUG_ExecuteCommand(request.payload.c_str());
+    }
+
+    auto output = EndCapture();
+    SendResponse(request.id, ok, output);
+}
+
+} // namespace
+
+void ControlServer_Start(const uint16_t port)
+{
+    if (port == 0)
+        return;
+
+    if (g_running.load())
+        return;
+
+    if (SDLNet_Init() < 0) {
+        std::fprintf(stderr,
+                     "[ControlClient] SDLNet_Init failed: %s\n",
+                     SDLNet_GetError());
+
+        return;
+    }
+
+    g_port = port;
+
+    {
+        std::lock_guard<std::mutex> lock(g_incoming_mutex);
+        g_incoming.clear();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(g_outgoing_mutex);
+        g_outgoing.clear();
+    }
+
+    g_running.store(true);
+
+    g_thread = std::thread(ThreadMain);
+}
+
+void ControlServer_Stop()
+{
+    if (!g_running.exchange(false))
+        return;
+
+    if (g_thread.joinable())
+        g_thread.join();
+
+    g_connected.store(false);
+    g_port = 0;
+
+    {
+        std::lock_guard<std::mutex> lock(g_incoming_mutex);
+        g_incoming.clear();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(g_outgoing_mutex);
+        g_outgoing.clear();
+    }
+
+    EndCapture();
+}
+
+bool ControlServer_IsConnected()
+{
+    return g_connected.load();
+}
+
+void ControlServer_Send(std::string message)
+{
+    if (!g_running.load())
+        return;
+
+    message.push_back('\n');
+
+    std::lock_guard<std::mutex> lock(g_outgoing_mutex);
+
+    if (g_outgoing.size() >= MAX_OUTGOING_MESSAGES)
+        g_outgoing.pop_front();
+
+    g_outgoing.emplace_back(std::move(message));
+}
+
+void ControlServer_SendEvent(
+        const std::string& event,
+        const std::string& data)
+{
+    ControlServer_Send(std::string("BEGIN event OK\n") +
+                       SanitizeProtocolLine(event) + " " +
+                       SanitizeProtocolLine(data) +
+                       "\nEND event");
+}
+
+void ControlServer_Poll()
+{
+    std::string command;
+    while (PopIncoming(command)) {
+        std::fprintf(stderr,
+                     "[ControlClient] mcp command %s\n",
+                     command.c_str());
+
+        ProcessControlCommand(command);
+    }
+}
+
+bool DEBUG_MCP_IsCapturingOutput()
+{
+    std::lock_guard<std::mutex> lock(g_capture_mutex);
+    return g_capture_active;
+}
+
+void DEBUG_MCP_CaptureMessage(const char* message)
+{
+    std::lock_guard<std::mutex> lock(g_capture_mutex);
+
+    if (!g_capture_active)
+        return;
+
+    if (g_capture_lines.size() >= MAX_CAPTURE_LINES) {
+        ++g_capture_discarded;
+        return;
+    }
+
+    g_capture_lines.emplace_back(message ? message : "");
+}
+
+#else
+
+void ControlServer_Start(uint16_t) {}
+void ControlServer_Stop() {}
+bool ControlServer_IsConnected() { return false; }
+void ControlServer_Send(std::string) {}
+void ControlServer_SendEvent(const std::string&, const std::string&) {}
+void ControlServer_Poll() {}
+bool DEBUG_MCP_IsCapturingOutput() { return false; }
+void DEBUG_MCP_CaptureMessage(const char*) {}
+
+#endif

--- a/src/debug/debug_mcp.cpp
+++ b/src/debug/debug_mcp.cpp
@@ -3,7 +3,8 @@
 #include "config.h"
 
 #if defined(C_DEBUG) && C_DEBUG && \
-        ((defined(C_SDL2) && C_SDL2) || (defined(C_SDL) && C_SDL))
+        ((defined(C_SDL_NET) && C_SDL_NET) || \
+         (defined(C_SDL2_NET) && C_SDL2_NET))
 
 #include "debug.h"
 

--- a/src/debug/debug_mcp.h
+++ b/src/debug/debug_mcp.h
@@ -1,0 +1,58 @@
+#ifndef DOSBOX_X_DEBUG_MCP_H
+#define DOSBOX_X_DEBUG_MCP_H
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+//
+// Start connection to the external control server.
+//
+// port == 0 means disabled.
+//
+// DOSBox-X acts as a TCP client and connects to:
+//
+//     127.0.0.1:<port>
+//
+// The connection is maintained in a background thread.
+// If the server is unavailable or the connection is lost,
+// reconnection is attempted automatically.
+//
+void ControlServer_Start(uint16_t port);
+
+//
+// Stop background thread and close the connection.
+//
+void ControlServer_Stop();
+
+//
+// Returns true if currently connected.
+//
+bool ControlServer_IsConnected();
+
+// Queue a line-oriented response for the control connection.
+void ControlServer_Send(std::string message);
+
+// Convenience function for asynchronous events.
+void ControlServer_SendEvent(
+        const std::string& event,
+        const std::string& data);
+
+//
+// Retrieve and process all MCP commands
+//
+// IMPORTANT:
+// This function should be called from the DOSBox-X
+// main/emulation thread.
+//
+//
+void ControlServer_Poll();
+
+// Execute one existing debugger command through ParseCommand().
+bool DEBUG_ExecuteCommand(const char* command);
+
+// Capture hook used by DEBUG_ShowMsg while a control request is running.
+bool DEBUG_MCP_IsCapturingOutput();
+void DEBUG_MCP_CaptureMessage(const char* message);
+
+#endif //DOSBOX_X_DEBUG_MCP_H

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -1763,6 +1763,10 @@ void DOSBOX_SetupConfigSections(void) {
     Pbool = secprop->Add_bool("bochs debug port e9",Property::Changeable::WhenIdle,false);
     Pbool->Set_help("If set, emulate Bochs debug port E9h. ASCII text written to this I/O port is assumed to be debug output, and logged.");
 
+    Pint = secprop->Add_int("mcp_server", Property::Changeable::OnlyAtStart, 0);
+    Pint->SetMinMax(0, 65535);
+    Pint->Set_help("TCP port of the external debugger MCP server on 127.0.0.1. Set to 0 to disable debugger MCP control.");
+
     Pstring = secprop->Add_string("machine",Property::Changeable::OnlyAtStart,"svga_s3");
     Pstring->Set_values(machines);
     Pstring->Set_help("The type of machine DOSBox-X tries to emulate.");

--- a/vs/dosbox-x.vcxproj
+++ b/vs/dosbox-x.vcxproj
@@ -1233,6 +1233,7 @@ for /d %%i in ("$(SolutionDir)\..\contrib\translations\*") do copy "%%i\*.lng" "
     <ClCompile Include="..\src\agent\transport\local_transport.cpp" />
     <ClCompile Include="..\src\debug\debug_disasm.cpp" />
     <ClCompile Include="..\src\debug\debug_gui.cpp" />
+    <ClCompile Include="..\src\debug\debug_mcp.cpp" />
     <ClCompile Include="..\src\debug\debug_win32.cpp" />
     <ClCompile Include="..\src\dosbox.cpp" />
     <ClCompile Include="..\src\dos\cdrom.cpp" />
@@ -1883,6 +1884,7 @@ for /d %%i in ("$(SolutionDir)\..\contrib\translations\*") do copy "%%i\*.lng" "
     <ClInclude Include="..\src\cpu\lazyflags.h" />
     <ClInclude Include="..\src\cpu\modrm.h" />
     <ClInclude Include="..\src\debug\debug_inc.h" />
+    <ClInclude Include="..\src\debug\debug_mcp.h" />
     <ClInclude Include="..\src\debug\disasm_tables.h" />
     <ClInclude Include="..\src\dos\cdrom.h" />
     <ClInclude Include="..\src\dos\dev_con.h" />

--- a/vs/dosbox-x.vcxproj.filters
+++ b/vs/dosbox-x.vcxproj.filters
@@ -852,6 +852,9 @@
     <ClCompile Include="..\src\debug\debug_gui.cpp">
       <Filter>Sources\debug</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\debug\debug_mcp.cpp">
+      <Filter>Sources\debug</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\debug\debug_win32.cpp">
       <Filter>Sources\debug</Filter>
     </ClCompile>
@@ -2025,6 +2028,9 @@
       <Filter>Sources\hardware\reSID</Filter>
     </ClInclude>
     <ClInclude Include="..\src\debug\debug_inc.h">
+      <Filter>Sources\debug</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\debug\debug_mcp.h">
       <Filter>Sources\debug</Filter>
     </ClInclude>
     <ClInclude Include="..\src\debug\disasm_tables.h">


### PR DESCRIPTION
## Summary

This adds a small, optional control channel to the built-in debugger so an external
process can drive it: `src/debug/debug_mcp.cpp` (~700 lines) plus three integration
points in `debug.cpp` / `debug_gui.cpp`.

When the debugger starts, DOSBox-X opens an outbound TCP connection to
`127.0.0.1:58991` and speaks a line-oriented text protocol:

```
REQ <id> PING                  ->  BEGIN <id> OK
                                   PONG
                                   END <id>

REQ <id> BREAK                 ->  enters the debugger

REQ <id> EXEC <debugger cmd>   ->  BEGIN <id> OK
                                   <captured debugger output>
                                   END <id>
```

`EXEC` runs the string through the very same `ParseCommand()` used by the
interactive debugger prompt, and the resulting `DEBUG_ShowMsg` output is captured
and returned. 


The counterpart is a separate project, [dosbox-x-mcp-server](https://github.com/caiiiycuk/dosbox-x-mcp-server), which exposes this to LLM agents as MCP tools.

### How to use it

`dosbox-x-mcp-server` is a Rust program that works on all major platforms. Just register it as an MCP server in OpenCode and start a session.

From that point on, whenever you launch DOSBox-X, it automatically connects to the MCP server, allowing you to interact with and control the running DOSBox-X instance directly through OpenCode.

I originally wrote this for the js-dos project to help diagnose and fix issues in games that were difficult to solve manually. It works really well — in my cases, it did exactly what I wanted it to do.

The same approach also works in browser environments.


---

Below, you can read an overview and comparison with the recently merged PR. I think the approaches are very similar, but I don't know Chinese well enough to fully understand how to use that implementation.

Also, for my particular use case, only this PR allows me to control a js-dos instance running in the browser.

I think it makes sense to keep both options.

---

## Design philosophy

The guiding idea is that **the emulator should ship a transport, not an API.**

- **No new debugger semantics.** There is no session model, no state machine, no
  capability negotiation, no schema. Whatever the interactive debugger can do
  today, an MCP server can do today; whatever gets added to the debugger tomorrow
  works over this channel with no changes here. The maintenance cost does not grow
  as the debugger grows.

- **Policy belongs outside the emulator.** Tool descriptions, JSON schemas, retry
  and timeout policy, prompt-facing naming, and everything else that is really
  *LLM tooling* lives in the MCP server. That layer changes on a weekly cadence;
  an emulator does not. Keeping it out of tree means DOSBox-X never has to track
  the churn of the agent ecosystem.

- **Text is a feature, not a shortcoming.** The debugger's output is what a human
  reverse engineer reads, and reading exactly that kind of text is what language
  models are unusually good at. A per-field JSON contract is something a *program*
  needs; a model does not need `AX` in its own key to understand `AX=0000`. Where
  a client does want structure, it can parse on its side, at its own risk, without
  the emulator freezing a format into a public contract.

- **Debuggable by hand.** The wire format is plain lines: `nc 127.0.0.1 58991`
  and you can drive the whole thing manually. No pipes, no framing, no codegen.

- **The emulator connects out; it never listens.** DOSBox-X is the TCP *client*.
  There is no listening socket to firewall, no port to secure, no unauthenticated
  server inside the emulator process. If nothing is listening, DOSBox-X just keeps
  running and retries in the background.

- **Small enough to actually review.** One file, three integration points, all of
  it compiled out unless `C_DEBUG` and SDL_net are both available.

## What changed

| File | Change |
| --- | --- |
| `src/debug/debug_mcp.{cpp,h}` | New. I/O thread, reconnect loop, request parsing, output capture. |
| `src/debug/debug.cpp` | `DEBUG_ExecuteCommand()` wrapper around `ParseCommand()`; start/stop with the debugger; `ControlServer_Poll()` inside `DEBUG_Loop()`. |
| `src/debug/debug_gui.cpp` | Capture hook in `DEBUG_ShowMsg`; pager suppressed while capturing. |
| `README.debugger` | Protocol documentation. |
| `src/debug/Makefile.am`, `vs/dosbox-x.vcxproj*` | Build files. |

Threading: all socket I/O happens on a dedicated thread; commands are only ever
executed on the emulation thread (via a tick handler, and via `DEBUG_Loop()` while
the debugger is stopped). Queues are bounded, the receive buffer is capped, and
`\r`/`\n` are sanitized out of protocol lines.

Suppressing the pager during capture matters in practice: without it, `HELP`,
`GDT`, `LDT`, `IDT` and the DOS memory listings block waiting for a keypress and
hang the channel.

Resume commands (`RUN`, `RUNWATCH`, `VRT`) are acknowledged *before* DOSBox-X
leaves the debugger loop, so the client gets an accepted-response rather than a
timeout. That response is an acknowledgement, not a post-resume state snapshot.

## Relationship to the agent RPC interface (#6512)

#6512 landed a much larger structured interface. The two solve the same problem
from opposite ends, and this section is an honest comparison rather than an
argument that one should replace the other.

**This PR — pros**

- ~700 lines in one file, three integration points; nothing added to `Normal_Loop`,
  the shell, or `control.h`.
- Works everywhere DOSBox-X works: SDL_net is available on every target, and the
  feature compiles out cleanly where it is not.
- Full debugger command surface immediately, including commands added later.
- No listening socket, no new command-line options, no config file format.
- Wire format inspectable with `nc`/`telnet`.

**This PR — cons**

- The client parses human-readable debugger text; that format is not a stable
  contract and can change upstream at any time.
- Port `58991` is hardcoded — no `dosbox.conf` setting or command-line switch yet.
- Synchronous request/response only. There is no operation/`wait` model, no
  timeout negotiation, and no asynchronous breakpoint-hit event (the send-event
  helper exists but is not wired up yet).
- "One request in flight" is a convention the client must honour, not an
  invariant enforced by the code.
- No bundled client library or test suite; the client lives in a separate repo.

**#6512 — pros**

- A real structured contract: registers as an object, `memory.read` reporting a
  failing offset, breakpoint handles, trace pages with cursors and per-step
  register diffs.
- Asynchronous model with `operation_id` + `execution.wait`, and a debugger-stop
  listener, so the client is not polling.
- `EmulationThreadQueue` is a cleaner marshalling primitive than a tick handler.
- Named pipe transport, per-request limits, config file, and a `--agent-self-test`
  mode.
- Ships a Python client, unit tests, integration scripts, and extensive docs.
- Genuinely useful debugger-core additions (`CBreakpoint::DeleteBreakpoint`,
  `ConsumeLastTriggered`, agent step-over, resume-after-terminate).

**#6512 — cons**

- Windows only in practice: `UnixSocketTransport::Start()` returns *"outside the
  Windows v1 scope"*, and `C_DOSBOX_AGENT` is defined only in
  `vs/dosbox-x.vcxproj` — the autotools build compiles `libagent.a` but every
  integration point stays disabled.
- ~10.5k lines across 72 files, with `agent_server.cpp` alone at 3136 lines and a
  hand-rolled JSON parser.
- Wider blast radius: `Normal_Loop`, `shell_cmds.cpp`, `control.h`,
  `include/debug.h`, plus unrelated `PlatformToolset v142 -> v143` bumps in the
  bundled zlib/libpng/SDL/freetype projects.
- Rigid session model: a single session, a fixed stop at entry, DOS-filename-only
  targets, a controlled mount — attaching to an already-running machine is not
  possible.
- `trace.*` requires `C_HEAVY_DEBUG`, and register data still comes from parsing a
  strict textual form of the debugger output.
- Primary documentation is in Chinese, which is a barrier for most reviewers.

## Why the two can coexist

They occupy different layers and different build configurations, and this branch
is already rebased on top of #6512 with both paths live:

- Build flags are independent: the agent interface is gated on `C_DOSBOX_AGENT`
  (MSVC only today), this channel on `C_DEBUG` + SDL_net. Either, both, or neither
  can be enabled.
- The one place they truly overlap is debugger output capture, and both capture
  paths now sit side by side in `DEBUG_ShowMsg`, `DEBUG_BeginPagedContent` and
  `DEBUG_EndPagedContent`.
- In `DEBUG_Loop()`, `AGENT_BridgePump()` runs first, then `ControlServer_Poll()`.
- Neither owns global debugger state exclusively; they are separate transports in
  front of the same debugger.

They also serve different users. The agent interface is the right tool for a
deterministic, scripted, reproducible analysis pipeline on Windows. This channel
is the right tool for an LLM that wants the debugger as a human uses it, on any
platform, with nothing to keep in sync as the debugger evolves.

## Known limitations / possible follow-ups

- Make the port configurable (`dosbox.conf` option and/or a command-line switch),
  with `0` meaning disabled.
- Emit asynchronous events on breakpoint hits, using the existing
  `ControlServer_SendEvent()` helper.
- Optionally reject overlapping requests explicitly instead of relying on client
  discipline.

## Testing

- Builds clean on Linux (autotools, GCC, SDL2 + SDL2_net) with no new warnings.
- Exercised end to end against
  [dosbox-x-mcp-server](https://github.com/caiiiycuk/dosbox-x-mcp-server):
  `PING`, `BREAK`, and `EXEC` of the paged commands (`HELP`, `GDT`, `LDT`, `IDT`),
  plus resume commands (`RUN`, `VRT`) and reconnect after the server restarts.
