### PR TITLE
Add /V arg for ver to just the reported version

### DIFF
--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1931,6 +1931,7 @@ void SHELL_MessagesInit() {
 	MSG_Add("SHELL_CMD_VER_HELP_LONG","VER [/R]\n"
 			"VER [SET] number or VER SET [major minor]\n\n"
 			"  /R                 Display DOSBox-X's Git commit version and build date.\n"
+			"  /V                 Display DOSBox-X's reported DOS version.\n"
 			"  [SET] number       Set the specified number as the reported DOS version.\n"
 			"  SET [major minor]  Set the reported DOS version in major and minor format.\n\n"
 			"  \033[0mE.g., \033[37;1mVER 6.0\033[0m or \033[37;1mVER 7.1\033[0m sets the DOS version to 6.0 and 7.1, respectively.\n"

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -3871,11 +3871,18 @@ bool set_ver(char *s);
 void DOS_Shell::CMD_VER(char *args) {
 	HELP("VER");
 	bool optR=ScanCMDBool(args,"R");
+    bool optV=ScanCMDBool(args,"V");
 	if (char* rem = ScanCMDRemain(args)) {
 		WriteOut(MSG_Get("SHELL_ILLEGAL_SWITCH"), rem);
 		return;
 	}
-	if(!optR && args && *args) {
+    if (optV)
+    {
+        WriteOut("%d.%02d\n", dos.version.major, dos.version.minor);
+        if (optR) WriteOut("%s / %s / %d-bit", GIT_COMMIT_HASH, OS_PLATFORM_LONG, OS_BIT_INT);
+        return;
+    }
+	if (!optR && args && *args) {
 		char* word = StripWord(args);
 		if(strcasecmp(word,"set")) {
 			if (*word=='=') word=trim(word+1);


### PR DESCRIPTION
## What issue(s) does this PR address?

N/A

## Does this PR introduce new feature(s)?

Introduce argument to the VER command that displays just the reported DOS version. Includes compatibility with the existing R flag to display a shorthand of the git commit info, sans date.

## Does this PR introduce any breaking change(s)?

No

## Additional information

This is honestly a feature that really only benefits myself and the rare few like me. I like to have my autoexec match a regular dos machine with it's autoexec, and being able to reference ONLY the reported version. /V interop was an afterthought, and most likely unnecessary. I just thought it prudent to integrate with what existed previously.