### PR TITLE
Fix parsing of command-line executable arguments

### DIFF
--- a/src/gui/sdlmain.cpp
+++ b/src/gui/sdlmain.cpp
@@ -7759,22 +7759,65 @@ bool DOSBOX_parse_argv() {
         control->cmdline->GetCurrentArgv(tmp);
         trim(tmp);
         localname = tmp;
-        int rescp = FileDirExistCP(tmp.c_str()), resutf8 = rescp||!tmp.size()?0:FileDirExistUTF8(localname, tmp.c_str());
+        std::string args;
+        size_t argpos = std::string::npos;
+        size_t p = 0;
+        while((p = tmp.find('.', p)) != std::string::npos) {
+            size_t end = p + 4;
+            if((end == tmp.size() || tmp[end] == ' ') &&
+                (!strcasecmp(tmp.substr(p, 4).c_str(), ".bat") ||
+                    !strcasecmp(tmp.substr(p, 4).c_str(), ".exe") ||
+                    !strcasecmp(tmp.substr(p, 4).c_str(), ".com"))) {
+                argpos = end;
+            }
+            p = end;
+        }
+        if(argpos != std::string::npos && argpos < tmp.size()) {
+            args = tmp.substr(argpos);
+            trim(args);
+            localname = tmp.substr(0, argpos);
+            trim(localname);
+            
+        }
+        int rescp = FileDirExistCP(localname.c_str()), resutf8 = rescp || !localname.size() ? 0 : FileDirExistUTF8(localname, localname.c_str());
         if (!rescp && resutf8) {
             tmp = localname;
             rescp = resutf8;
         }
         const char *ext = strrchr(tmp.c_str(),'.'); /* if it looks like a file... with an extension */
+        if(ext != NULL && (!strcasecmp(ext, ".bat") || !strcasecmp(ext, ".exe") || !strcasecmp(ext, ".com"))) {
+                        /* no arguments */
+        }
+        else if(ext != NULL) {
+            const char* space = strchr(ext, ' ');
+            if(space != NULL && (size_t)(space - ext) == 4) {
+                localname = tmp.substr(0, space - tmp.c_str());
+                ext = strrchr(localname.c_str(), '.');
+            }
+        }
         if (rescp) {
             if (rescp == 2 || (ext != NULL && rescp == 1 && (!strcasecmp(ext,".zip") || !strcasecmp(ext,".7z")))) {
                 control->auto_bat_additional.push_back("@mount c: \""+tmp+"\" -nl");
                 control->cmdline->EatCurrentArgv();
                 continue;
             } else if (ext != NULL && rescp == 1 && (!strcasecmp(ext,".bat") || !strcasecmp(ext,".exe") || !strcasecmp(ext,".com"))) { /* .BAT files given on the command line trigger automounting C: to run it */
+                // FIX_ME: Should we mount the directory of the executable to C:? (Code currently disabled)
+                /**
+                std::string mountpath = ".";
+                size_t pos = tmp.find_last_of("\\/");
+                if(pos != std::string::npos) {
+                    mountpath = tmp.substr(0, pos);
+                    if(mountpath.empty()) mountpath = "\\";
+                }
+                control->auto_bat_additional.push_back("@mount c: \"" + mountpath + "\" -nl"); // mount the directory of the executable to C:
+                */
                 control->auto_bat_additional.push_back(tmp);
                 control->cmdline->EatCurrentArgv();
                 continue;
             }
+        }
+        else if(ext != NULL && (!strcasecmp(ext, ".bat") || !strcasecmp(ext, ".exe") || !strcasecmp(ext, ".com"))) {
+            LOG_MSG("WARNING: Executable specified on the command line was not found and ignored: %s\n", localname.c_str());
         }
 
         control->cmdline->NextArgv();

--- a/src/misc/setup.cpp
+++ b/src/misc/setup.cpp
@@ -1426,13 +1426,13 @@ bool CommandLine::FindStringFullBegin(char const* const begin,std::string & valu
             if (remove) cmds.erase(it);
             if (q) {
                 std::string str=value;
-                if (str.back()==c)
+                if (str.size() && str.back()==c)
                     value.pop_back();
                 else while (str.size()&&++it!=cmds.end()) {
                     str=(*it);
                     if (remove) cmds.erase(it);
                     value+=" "+str;
-                    if (str.back()==c) {
+                    if (str.size()&&str.back()==c) {
                         value.pop_back();
                         break;
                     }

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -1342,10 +1342,32 @@ public:
                     cmd += "@if not '%CONFIG%'=='' %CONFIG%";
                 } else {
                     std::string batname;
+                    std::string batargs;
                     //LOG_MSG("auto_bat_additional %s\n", str.c_str());
 
-                    std::replace(str.begin(),str.end(),'/','\\');
                     size_t pos = std::string::npos;
+                    size_t argpos = std::string::npos;
+                    size_t extpos = std::string::npos;
+                    const char* exts[] = { ".bat", ".exe", ".com" };
+                    for(size_t p = 0; p + 4 <= str.size() && extpos == std::string::npos; p++) {
+                        if(str[p] == '.') {
+                            size_t end = p + 4;
+                            for(size_t i = 0; i < 3; i++) {
+                                if(!strcasecmp(str.substr(p, 4).c_str(), exts[i]) &&
+                                    (end == str.size() || str[end] == ' ')) {
+                                    extpos = p;
+                                    argpos = end;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if(argpos != std::string::npos && argpos < str.size()) {
+                        batargs = str.substr(argpos);
+                        trim(batargs);
+                        str.erase(argpos);
+                    }
+                    std::replace(str.begin(), str.end(), '/', '\\');
                     bool lead = false;
                     for (unsigned int j=0; j<str.size(); j++) {
                         if (lead) lead = false;
@@ -1375,7 +1397,11 @@ public:
 #endif
                     cmd += "@CALL \"";
                     cmd += batname;
-                    cmd += "\"" + opt + "\n";
+                    cmd += "\"";
+                    if(!batargs.empty()) {
+                        cmd += " " + batargs;
+                    }
+                    cmd += opt + "\n";
                     if (templfn) cmd += "@config -set lfn=" + std::string(enablelfn==-1?"auto":"autostart") + "\n";
 #if defined(WIN32) && !defined(HX_DOS)
                     if (!winautorun) cmd += "@config -set startcmd=false\n";


### PR DESCRIPTION
This PR fixes an bug that DOS executable specified in command line didn't launch at startup.
```
DOSBox-X version 2026.08.31 SDL2, copyright 2011-2026 The DOSBox-X Team.
DOSBox-X project maintainer: joncampbell123 (The Great Codeholio)

dosbox-x [name] [options]
```
Also, handle executable arguments separately from DOSBox-X command-line options by quoting them.
e.g.
```
dosbox-x "zmap.com u" -console -set output=default
```

<img width="722" height="452" alt="image" src="https://github.com/user-attachments/assets/531463a4-79a7-42bf-9490-c0ce0a9ca4e3" />


## What issue(s) does this PR address?
Fixes #6520