### PR TITLE
Fix build error of nightly builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1431,6 +1431,16 @@ if test x$enable_ffmpeg = xyes; then
     fi
 fi
 
+dnl FEATURE: RPC debugger agent output support
+AH_TEMPLATE(C_DOSBOX_AGENT,[Define to 1 to use RPC debugger agent support])
+AC_ARG_ENABLE(dosbox_agent,AC_HELP_STRING([--enable-dosbox_agent],[Enable RPC debugger agent support]),enable_dosbox_agent=$enableval,enable_dosbox_agent=no)
+
+dnl FEATURE: RPC debugger agent output support
+if test x$enable_dosbox_agent = xyes; then
+    AC_DEFINE([C_DOSBOX_AGENT], [1])
+    AC_MSG_NOTICE([enabled RPC debugger agent output support])
+fi
+
 dnl FEATURE: Whether to use Direct3D 9 output
 AH_TEMPLATE(HAVE_D3D9_H,[Define to 1 to use Direct3D 9 display output support])
 AC_ARG_ENABLE(d3d9,AC_HELP_STRING([--enable-d3d9],[Enable Direct3D 9 support]),enable_d3d9=$enableval,enable_d3d9=no)

--- a/src/dos/dos_devices.cpp
+++ b/src/dos/dos_devices.cpp
@@ -125,10 +125,10 @@ bool DOS_ExtDevice::Read(uint8_t * data,uint16_t * size) {
 	unsigned int todo = *size;
 	unsigned int done = 0;
 	unsigned int rd;
-
+#if !defined(OSFREE)
 	if (extdev_read_limit && batch_size > extdev_read_limit)
 		batch_size = extdev_read_limit;
-
+#endif
 	const auto inproc = [bufptr, &todo, &done, &rd, &data, this](const unsigned int batch_size) {
 		rd = 0;
 
@@ -176,10 +176,10 @@ bool DOS_ExtDevice::Write(const uint8_t * data,uint16_t * size) {
 	unsigned int todo = *size;
 	unsigned int done = 0;
 	unsigned int wd;
-
+#if !defined(OSFREE)
 	if (extdev_write_limit && batch_size > extdev_write_limit)
 		batch_size = extdev_write_limit;
-
+#endif
 	const auto inproc = [bufptr, &todo, &done, &wd, &data, this](const unsigned int batch_size) {
 		wd = 0;
 

--- a/src/dos/dos_files.cpp
+++ b/src/dos/dos_files.cpp
@@ -228,7 +228,7 @@ void DOS_SetDefaultDrive(uint8_t drive) {
 }
 
 bool DOS_MakeName(char const * const name,char * const fullname,uint8_t * drive) {
-	if(!name || *name == 0 || *name == ' ' || *name == '\n' || *name == ':') {
+    if(!name || *name == 0 || *name == ' ' || *name == '\n' || *name == ':') {
 		/* Both \0 and space are separators and
 		 * empty filenames report file not found */
 		DOS_SetError(DOSERR_FILE_NOT_FOUND);
@@ -298,7 +298,7 @@ bool DOS_MakeName(char const * const name,char * const fullname,uint8_t * drive)
 			else if (c==' ') continue; /* should be separator */
 		}
 		upname[w++]=(char)c;
-        if (((IS_PC98_ARCH && shiftjis_lead_byte(c)) || (isDBCSCP() && isKanji1(c))) && r<DOS_PATHLENGTH) {
+        if(((IS_PC98_ARCH && shiftjis_lead_byte(c)) || (isDBCSCP() && isKanji1(c))) && r < DOS_PATHLENGTH && name_int[r] != 0) {
             /* The trailing byte is NOT ASCII and SHOULD NOT be converted to uppercase like ASCII */
             upname[w++]=name_int[r++];
         }

--- a/tests/agent/agent_architecture_tests.cpp
+++ b/tests/agent/agent_architecture_tests.cpp
@@ -1,3 +1,4 @@
+#if defined(C_DEBUG) && defined(C_DOSBOX_AGENT)
 #include "agent/agent_bridge.h"
 #include "agent/agent_protocol.h"
 #include "agent/agent_server.h"
@@ -284,3 +285,4 @@ TEST(AgentSession, ReusesCompletedRequestResultsAndRejectsConflicts)
 }
 
 } // namespace
+#endif

--- a/tests/agent/agent_parser_tests.cpp
+++ b/tests/agent/agent_parser_tests.cpp
@@ -1,3 +1,4 @@
+#if defined(C_DEBUG) && defined(C_DOSBOX_AGENT)
 #include "agent/debugger_output_parser.h"
 
 #include <gtest/gtest.h>
@@ -39,3 +40,4 @@ TEST(DebuggerOutputParser, RejectsAbnormalSpacingWithoutPartialResult)
 }
 
 } // namespace
+#endif // C_DEBUG && C_DOSBOX_AGENT

--- a/tests/dos_files_tests.cpp
+++ b/tests/dos_files_tests.cpp
@@ -62,12 +62,25 @@ void assert_DTAExtendName(std::string input,
 void assert_DOS_MakeName(char const *const input,
                          bool exp_result,
                          std::string exp_fullname = "",
-                         int exp_drive = 0)
+                         int exp_drive = 0,
+                         size_t input_len = SIZE_MAX)
 {
 	uint8_t drive_result;
-	char fullname_result[DOS_PATHLENGTH];
+    char fullname_result[DOS_PATHLENGTH] = {};
+    if(input_len == SIZE_MAX && input) input_len = strlen(input);
 	bool result = DOS_MakeName(input, fullname_result, &drive_result);
-	EXPECT_EQ(result, exp_result);
+
+    /**
+    printf("DOS_MakeName input:");
+    if(input) {
+        for(size_t i = 0; i < input_len; ++i)
+            printf(" %02X", static_cast<unsigned char>(input[i]));
+    }
+    printf(" exp_result: %s result: %s\n",
+        exp_result ? "true" : "false",
+        result ? "true" : "false");
+    */
+    EXPECT_EQ(result, exp_result);
 	// if we expected success, also test these
 	if (exp_result) {
 		EXPECT_EQ(std::string(fullname_result), exp_fullname);
@@ -290,13 +303,27 @@ TEST_F(DOS_FilesTest, DOS_MakeName_GoodChars)
 				};
 				std::string test_input(reinterpret_cast<char *>(input_array), 3);
 				uselfn = false;
-				assert_DOS_MakeName(test_input.c_str(), true, test_input, 25);
+                assert_DOS_MakeName(test_input.data(), true, test_input, 25, test_input.size());
 				uselfn = true;
-				assert_DOS_MakeName(test_input.c_str(), true, test_input, 25);
+                assert_DOS_MakeName(test_input.data(), true, test_input, 25, test_input.size());
 			}
 		}
 	}
 	uselfn = oldlfn;
+}
+
+TEST_F(DOS_FilesTest, DOS_MakeName_DBCS)
+{
+    // A DBCS lead byte at the end of the input must not consume the
+    // terminating NUL byte as a trailing byte.
+    const char input1[] = { 'Z', '9', static_cast<char>(0x9D), '\0' };
+
+    // A valid DBCS lead/trail byte pair must be preserved as a single DBCS character.
+    const char input2[] = { 'Z', '9', static_cast<char>(0x9D),
+                           static_cast<char>(0xBD), '\0' };
+
+    assert_DOS_MakeName(input1, true, std::string(input1, 3), 25, 3);
+    assert_DOS_MakeName(input2, true, std::string(input2, 4), 25, 4);
 }
 
 TEST_F(DOS_FilesTest, DOS_MakeName_Colon_Illegal_Paths)


### PR DESCRIPTION
This PR fixes a number of build errors of nightly builds
 - Fix build error of OSFREE builds induced by commit 6a00928433e38aa8d184d8a61719aa6f99ad7c69
 - Fix unit testing of DOS_MakeName() when DBCS characters are used
 - Disable unit testing of RPC debbuger agent related functions when the feature is disabled 

Edit: HX-DOS and Windows low-end build is still unsuccessful, but all other platforms are now able to be built. (Currently without RPC agent support) 
