### PR TITLE
Fix build error of Windows low-end and HX-DOS builds

### DIFF
--- a/src/agent/bridge/agent_bridge.cpp
+++ b/src/agent/bridge/agent_bridge.cpp
@@ -1,3 +1,4 @@
+#if defined(C_DEBUG) && defined(C_DOSBOX_AGENT)
 #include "agent/agent_bridge.h"
 
 #include <atomic>
@@ -259,3 +260,5 @@ bool AGENT_RunQueueSelfTest(std::string* error)
 }
 
 } // namespace dosbox_agent
+
+#endif // defined(C_DEBUG) && defined(C_DOSBOX_AGENT)

--- a/src/agent/debugger/debugger_adapter.cpp
+++ b/src/agent/debugger/debugger_adapter.cpp
@@ -1,3 +1,4 @@
+#if defined(C_DEBUG) && defined(C_DOSBOX_AGENT)
 #include "dosbox.h"
 #include "agent/debugger_adapter.h"
 #include "agent/agent_bridge.h"
@@ -741,3 +742,4 @@ bool DebuggerAdapter::TerminateTarget(std::string* error) const
 }
 
 } // namespace dosbox_agent
+#endif // defined(C_DEBUG) && defined(C_DOSBOX_AGENT)

--- a/src/agent/parser/debugger_output_parser.cpp
+++ b/src/agent/parser/debugger_output_parser.cpp
@@ -1,3 +1,4 @@
+#if defined(C_DEBUG) && defined(C_DOSBOX_AGENT)
 #include "agent/debugger_output_parser.h"
 
 #include <cctype>
@@ -62,3 +63,4 @@ DebuggerOutputParseResult AGENT_ParseDebuggerRegisterOutput(const std::string& o
 }
 
 } // namespace dosbox_agent
+#endif // defined(C_DEBUG) && defined(C_DOSBOX_AGENT)

--- a/src/agent/protocol/agent_protocol.cpp
+++ b/src/agent/protocol/agent_protocol.cpp
@@ -1,3 +1,4 @@
+#if defined(C_DEBUG) && defined(C_DOSBOX_AGENT)
 #include "agent/agent_protocol.h"
 
 #include <cerrno>
@@ -807,3 +808,4 @@ std::string AGENT_MakeJsonRpcError(const JsonValue& id,
 }
 
 } // namespace dosbox_agent
+#endif // defined(C_DEBUG) && defined(C_DOSBOX_AGENT)

--- a/src/agent/server/agent_server.cpp
+++ b/src/agent/server/agent_server.cpp
@@ -1,3 +1,4 @@
+#if defined(C_DEBUG) && defined(C_DOSBOX_AGENT)
 #include "agent/agent_server.h"
 
 #include "agent/agent_bridge.h"
@@ -3135,3 +3136,4 @@ bool AgentServer::RunProtocolSelfTest(std::string* error)
 }
 
 } // namespace dosbox_agent
+#endif // defined(C_DEBUG) && defined(C_DOSBOX_AGENT)

--- a/src/agent/trace/trace_store.cpp
+++ b/src/agent/trace/trace_store.cpp
@@ -1,3 +1,4 @@
+#if defined(C_DEBUG) && defined(C_DOSBOX_AGENT)
 #include "agent/trace_store.h"
 
 #include <iomanip>
@@ -163,3 +164,4 @@ bool TraceStore::Read(const bool has_cursor,
 }
 
 } // namespace dosbox_agent
+#endif // defined(C_DEBUG) && defined(C_DOSBOX_AGENT)

--- a/src/agent/transport/local_transport.cpp
+++ b/src/agent/transport/local_transport.cpp
@@ -1,3 +1,4 @@
+#if defined(C_DEBUG) && defined(C_DOSBOX_AGENT)
 #include "rpc_transport.h"
 
 #include <algorithm>
@@ -329,3 +330,4 @@ std::unique_ptr<IRpcTransport> AGENT_CreateLocalTransport(const AgentTransport t
 }
 
 } // namespace dosbox_agent
+#endif // defined(C_DEBUG) && defined(C_DOSBOX_AGENT)

--- a/src/agent/transport/rpc_transport.h
+++ b/src/agent/transport/rpc_transport.h
@@ -1,6 +1,7 @@
 #ifndef DOSBOX_AGENT_RPC_TRANSPORT_H
 #define DOSBOX_AGENT_RPC_TRANSPORT_H
 
+#if defined(C_DEBUG) && defined(C_DOSBOX_AGENT)
 #include "agent/agent_protocol.h"
 
 #include <functional>
@@ -27,5 +28,5 @@ public:
 std::unique_ptr<IRpcTransport> AGENT_CreateLocalTransport(AgentTransport transport);
 
 } // namespace dosbox_agent
-
+#endif // defined(C_DEBUG) && defined(C_DOSBOX_AGENT)
 #endif

--- a/src/debug/debug.cpp
+++ b/src/debug/debug.cpp
@@ -18,9 +18,6 @@
 
 
 #include "dosbox.h"
-#if defined(C_DOSBOX_AGENT)
-#include "agent/agent_bridge.h"
-#endif
 #if C_DEBUG
 
 #include "../../tests/tests.h"
@@ -37,7 +34,9 @@
 using namespace std;
 
 #include "debug.h"
+#if defined(C_DOSBOX_AGENT)
 #include "agent/agent_bridge.h"
+#endif
 #include "cross.h" //snprintf
 #include "fpu.h"
 #include "bios.h"
@@ -62,7 +61,9 @@ bool Toggle_BreakSYSExit();
 
 #if !defined(OSFREE)
 extern bool debugger_break_on_exec;
+# if defined(C_DOSBOX_AGENT)
 extern unsigned int debugger_box_depth;
+# endif
 #endif
 
 /* [https://github.com/joncampbell123/dosbox-x/issues/1264] ncurses non-ASCII keys are outside ASCII range (start at octal 0400 == hex 0x100) */
@@ -978,9 +979,19 @@ bool CBreakpoint::IsBreakpoint(uint16_t seg, uint32_t off)
 bool CBreakpoint::DeleteBreakpoint(uint16_t seg, uint32_t off)
 {
 	CBreakpoint* bp = FindPhysBreakpoint(seg, off, false);
-	return DeleteBreakpoint(bp);
+#if defined(C_DOSBOX_AGENT)
+    return DeleteBreakpoint(bp);
+#else
+    if(bp) {
+        BPoints.remove(bp);
+        delete bp;
+        return true;
+    }
+    return false;
+#endif
 }
 
+#if defined(C_DOSBOX_AGENT)
 bool CBreakpoint::DeleteBreakpoint(CBreakpoint* breakpoint)
 {
 	if (breakpoint == nullptr)
@@ -1004,7 +1015,7 @@ CBreakpoint* CBreakpoint::ConsumeLastTriggered(void)
 	lastTriggered = nullptr;
 	return result;
 }
-
+#endif // C_DOSBOX_AGENT
 
 void CBreakpoint::ShowList(void)
 {
@@ -1080,6 +1091,7 @@ static bool StepOver()
 	return false;
 }
 
+#if defined(C_DOSBOX_AGENT)
 void DrawRegistersUpdateOld(void);
 int32_t DEBUG_Run(int32_t amount,bool quickexit);
 bool ParseCommand(char* str);
@@ -1217,6 +1229,8 @@ bool DEBUG_AgentStopTrace(uint32_t* event_count);
 bool DEBUG_AgentTraceIsActive(void);
 void DEBUG_AgentCopyTraceEvents(std::vector<DEBUG_AgentTraceEvent>* events);
 #endif
+
+#endif // C_DEBUG && C_DOSBOX_AGENT
 
 bool DEBUG_ExitLoop(void)
 {
@@ -5127,7 +5141,9 @@ void dyn_core_dh_debug_flush (void);
 #endif
 
 Bitu DEBUG_Loop(void) {
+#if defined(C_DOSBOX_AGENT)
     dosbox_agent::AGENT_BridgePump();
+#endif
     if (debug_running) {
         Bitu now = SDL_GetTicks();
 
@@ -5983,18 +5999,21 @@ private:
 void DEBUG_CheckExecuteBreakpoint(uint16_t seg, uint32_t off)
 {
 #if !defined(OSFREE)
-# if C_DEBUG
     if (debugger_break_on_exec) {
-		// The new entry breakpoint is created at the current CS:IP. The
+# if defined(C_DOSBOX_AGENT)
+        // The new entry breakpoint is created at the current CS:IP. The
 		// existing bulk activation intentionally skips that address, so arm
 		// this one explicitly before preserving the other breakpoint state.
 		CBreakpoint* const entry_breakpoint = CBreakpoint::AddBreakpoint(seg,off,true);
 		entry_breakpoint->Activate(true);
         CBreakpoint::ActivateBreakpointsExceptAt(SegPhys(cs)+reg_eip);
 		agent_entry_breakpoint_sequence.fetch_add(1, std::memory_order_relaxed);
+# else
+        CBreakpoint::AddBreakpoint(seg, off, true);
+        CBreakpoint::ActivateBreakpointsExceptAt(SegPhys(cs) + reg_eip);
+# endif
         debugger_break_on_exec = false;
     }
-# endif
 #endif
 #if 0
 	if (pDebugcom && pDebugcom->IsActive()) {
@@ -6408,6 +6427,7 @@ void DEBUG_HeavyLogInstruction(void) {
 	if (++logCount >= LOGCPUMAX) logCount = 0;
 }
 
+#if defined(C_DEBUG) && defined(C_DOSBOX_AGENT)
 bool DEBUG_AgentStartTrace(const uint32_t instruction_count)
 {
 	if (instruction_count == 0 || agent_trace_active)
@@ -6466,6 +6486,7 @@ static void DEBUG_AgentCaptureTraceEvent(void)
 	event.analysis = inst.res;
 	agent_trace_events.push_back(event);
 }
+#endif
 
 void DEBUG_HeavyWriteLogInstruction(void) {
 	if (!logHeavy) return;
@@ -6508,7 +6529,8 @@ void DEBUG_HeavyWriteLogInstruction(void) {
 
 bool DEBUG_HeavyIsBreakpoint(void) {
 	const bool agent_trace_was_active = agent_trace_active;
-	if (agent_trace_active) {
+#if defined(C_DOSBOX_AGENT)
+    if (agent_trace_active) {
 		DEBUG_AgentCaptureTraceEvent();
 		if (--agent_trace_remaining == 0) {
 			agent_trace_active = false;
@@ -6516,6 +6538,7 @@ bool DEBUG_HeavyIsBreakpoint(void) {
 			return true;
 		}
 	}
+#endif
 	if (cpuLog) {
 		if (cpuLogCounter>0) {
 			LogInstruction(SegValue(cs),reg_eip,cpuLogFile);
@@ -6531,7 +6554,11 @@ bool DEBUG_HeavyIsBreakpoint(void) {
 		}
 	}
 	// LogInstruction
-	if (logHeavy && !agent_trace_was_active) DEBUG_HeavyLogInstruction();
+	if (logHeavy
+#if defined(C_DOSBOX_AGENT)
+        && !agent_trace_was_active
+#endif  
+        ) DEBUG_HeavyLogInstruction();
 	if (zeroProtect) {
 		static Bitu zero_count = 0;
 		uint32_t value = 0;

--- a/src/debug/debug_gui.cpp
+++ b/src/debug/debug_gui.cpp
@@ -677,9 +677,11 @@ void DEBUG_DrawInput(void);
 
 void DEBUG_BeginPagedContent(void) {
 #if C_DEBUG
-	if (agent_output_capture_active)
+# if defined(C_DOSBOX_AGENT)
+    if (agent_output_capture_active)
 		return;
-	int maxy, maxx; getmaxyx(dbg.win_out,maxy,maxx);
+#endif
+    int maxy, maxx; getmaxyx(dbg.win_out,maxy,maxx);
 
     debugPageCounter = 0;
     debugPageStopAt = maxy;
@@ -688,8 +690,10 @@ void DEBUG_BeginPagedContent(void) {
 
 void DEBUG_EndPagedContent(void) {
 #if C_DEBUG
-	if (agent_output_capture_active)
+# if defined(C_DOSBOX_AGENT)
+    if (agent_output_capture_active)
 		return;
+# endif
     debugPageCounter = 0;
     debugPageStopAt = 0;
     DEBUG_DrawInput();
@@ -702,7 +706,7 @@ bool in_debug_showmsg = false;
 
 bool IsDebuggerActive(void);
 
-#if C_DEBUG
+#if C_DEBUG && defined(C_DOSBOX_AGENT)
 bool DEBUG_AgentBeginOutputCapture(void)
 {
     if (agent_output_capture_active)
@@ -766,7 +770,7 @@ void DEBUG_ShowMsg(char const* format,...) {
     /* remove newlines if present */
     while (len > 0 && buf[len-1] == '\n') buf[--len] = 0;
 
-#if C_DEBUG
+#if C_DEBUG && defined(C_DOSBOX_AGENT)
     if (agent_output_capture_active) {
         if (!agent_output_capture.empty())
             agent_output_capture += '\n';

--- a/src/dosbox.cpp
+++ b/src/dosbox.cpp
@@ -52,7 +52,9 @@
 #include <ctime>
 #include <unistd.h>
 #include "dosbox.h"
+#if defined(C_DEBUG) && defined(C_DOSBOX_AGENT)
 #include "agent/agent_bridge.h"
+#endif // defined(C_DEBUG) && defined(C_DOSBOX_AGENT)
 #include "debug.h"
 #include "cpu.h"
 #include "logging.h"
@@ -467,7 +469,9 @@ static Bitu Normal_Loop(void) {
 
     try {
         while (1) {
+#if defined(C_DEBUG) && defined(C_DOSBOX_AGENT)
             dosbox_agent::AGENT_BridgePump();
+#endif
             if (PIC_RunQueue()) {
                 /* now is the time to check for the NMI (Non-maskable interrupt) */
                 CPU_Check_NMI();
@@ -739,9 +743,9 @@ volatile int runmachine_recursion = 0;
 
 void DOSBOX_RunMachine(void){
     Bitu ret;
-
+#if defined(C_DEBUG) && defined(C_DOSBOX_AGENT)
     dosbox_agent::AGENT_BridgeAttachToCurrentThread();
-
+#endif
     extern unsigned int last_callback;
     unsigned int p_last_callback = last_callback;
     last_callback = 0;

--- a/src/shell/shell.cpp
+++ b/src/shell/shell.cpp
@@ -77,9 +77,11 @@ uint16_t shell_psp = 0;
 Bitu call_int2e = 0;
 Bitu call_int23 = 0;
 
+#if defined(C_DOSBOX_SGENT)
 uint16_t DOS_ShellGetPSP() {
 	return shell_psp;
 }
+#endif
 
 std::string GetDOSBoxXPath(bool withexe=false);
 const char* DOS_GetLoadedLayout(void);

--- a/src/shell/shell_cmds.cpp
+++ b/src/shell/shell_cmds.cpp
@@ -4239,9 +4239,13 @@ void DOS_Shell::CMD_DEBUGBOX(char * args) {
 		return;
     }
     debugger_break_on_exec = true;
+#if defined(C_DOSBOX_AGENT)
     ++debugger_box_depth;
+#endif
     DoCommand((char *)argv.c_str());
+#if defined(C_DOSBOX_AGENT)
     --debugger_box_depth;
+#endif
     debugger_break_on_exec = false;
 }
 # endif


### PR DESCRIPTION
This PR fixes build errors on Windows Low-end and HX-DOS by preventing RPC agent-related files from being compiled when the feature is disabled.

The RPC agent code introduced in PR #6512 is currently incompatible with these two platforms.

Nightly builds for all platforms are currently built with the RPC agent feature disabled. Re-enabling the feature will be attempted once all platforms are buildable again.
