### PR TITLE
drive_virtual: fix CHDIR succeeding on a file on drive Z:

### DIFF
--- a/src/dos/drive_virtual.cpp
+++ b/src/dos/drive_virtual.cpp
@@ -679,8 +679,11 @@ bool Virtual_Drive::TestDir(const char* fulldir) {
         LOG_MSG("[DEBUG] Layer %d: Searching for '%s' under parent onpos: %u", (int)depth, dir_name.c_str(), current_onpos);
 #endif
         while(scan) {
-            // Check context parent mapping and match string contents first
-            if(scan->onpos == current_onpos &&
+            // Check context parent mapping and match string contents first.
+            // Only a directory entry can be a path component: every registered
+            // entry owns a slot in vfsnames/vfnames, so the index lookup below
+            // resolves for plain files too and would accept them as directories.
+            if(scan->onpos == current_onpos && scan->isdir &&
                 (case_insensitive_equal(scan->name, dir_name) ||
                     case_insensitive_equal(scan->lname, dir_name))) {
 #if ENABLE_LOGGING

--- a/tests/dos_files_tests.cpp
+++ b/tests/dos_files_tests.cpp
@@ -392,6 +392,28 @@ TEST_F(DOS_FilesTest, DOS_FindFirst_FindFile_Nonexistant)
 	EXPECT_EQ(dos.errorcode, DOSERR_NO_MORE_FILES);
 }
 
+// A file is not a directory. CHDIR onto one has to fail on the Z: drive the
+// same way it does on local and FAT drives, and leave the current directory
+// where it was.
+TEST_F(DOS_FilesTest, DOS_ChangeDir_Rejects_File_As_Directory)
+{
+	char olddir[DOS_PATHLENGTH];
+	safe_strcpy(olddir, Drives[25]->curdir);
+
+	// a directory on Z: is still accepted
+	dos.errorcode = DOSERR_NONE;
+	EXPECT_TRUE(DOS_ChangeDir("Z:\\SYSTEM"));
+	EXPECT_STREQ(Drives[25]->curdir, "SYSTEM");
+
+	// a file on the same drive is not
+	dos.errorcode = DOSERR_NONE;
+	EXPECT_FALSE(DOS_ChangeDir("Z:\\AUTOEXEC.BAT"));
+	EXPECT_EQ(dos.errorcode, DOSERR_PATH_NOT_FOUND);
+	EXPECT_STREQ(Drives[25]->curdir, "SYSTEM");
+
+	safe_strcpy(Drives[25]->curdir, olddir);
+}
+
 // this probably isn't a desirable quality, but figure that out later
 TEST_F(DOS_FilesTest, DOS_DTAExtendName_Mutates_Input)
 {


### PR DESCRIPTION
CHDIR onto a file on drive Z: succeeded and left the current directory pointing at the file, so `CD Z:\AUTOEXEC.BAT` was accepted where `localDrive::TestDir` and `fatDrive::TestDir` both report path not found. `Virtual_Drive::TestDir` resolves each path component to its slot in `vfsnames`/`vfnames` by comparing pointers, and `VFILE_Register` hands every entry such a slot, files as well as directories, so that lookup succeeded for plain files and the entry's `isdir` flag was never consulted. This matches a path component against directory entries only.

## What issue(s) does this PR address?

N/A

## Does this PR introduce new feature(s)?

No.

## Does this PR introduce any breaking change(s)?

No. Directory lookups on drive Z: are unchanged, and only paths whose components name a file now fail, which is what the other drive back ends already do. The same check also makes the leading directory validation in `DOS_FindDevice` and the error code picked by `DOS_MakeDir` and `DOS_RemoveDir` behave as intended.

## Additional information

Covered by a new `DOS_FilesTest.DOS_ChangeDir_Rejects_File_As_Directory` case in `tests/dos_files_tests.cpp`, which fails on master and passes with this change; the whole `dosbox-x -tests` suite is green.
