### PR TITLE
Experimental: Pre-compiled .deb package for Ubuntu 24.04/26.04

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -159,7 +159,7 @@ jobs:
 
           cat "$pkg/DEBIAN/control"
 
-          deb="$top/dosbox-x_${{ env.timestamp }}nightly_amd64.deb"
+          deb="$top/dosbox-x_Ubuntu24.04_${{ env.timestamp }}nightly_amd64.deb"
           rm -f "$deb"
 
           ls -la "$pkg/usr/bin/"
@@ -173,12 +173,18 @@ jobs:
           echo Test installation
           sudo apt install "$deb"
 
+          cd "$top"
+          package="$top/ubuntu-package"
+          rm -rf "$package"
+          mkdir -p "$package"
+          cp "$deb" "$package/"
+          cp "$top/contrib/linux/instructions.md" "$package/"
 
       - name: Upload Ubuntu package
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: dosbox-x-ubuntu24.04-x86_64-${{ env.timestamp }}_nightly
-          path: ${{ github.workspace }}/dosbox-x_${{ env.timestamp }}nightly_amd64.deb
+          name: dosbox-x-ubuntu24.04-x86_64-${{ env.timestamp }}_nightly_deb
+          path: ${{ github.workspace }}/ubuntu-package/
           
   Test_Linux_Preview:
     permissions:
@@ -327,7 +333,7 @@ jobs:
 
           cat "$pkg/DEBIAN/control"
 
-          deb="$top/dosbox-x_${{ env.timestamp }}nightly_amd64.deb"
+          deb="$top/dosbox-x_Ubuntu26.04_${{ env.timestamp }}nightly_amd64.deb"
           rm -f "$deb"
 
           ls -la "$pkg/usr/bin/"
@@ -341,8 +347,15 @@ jobs:
           echo Test installation
           sudo apt install "$deb"
 
+          cd "$top"
+          package="$top/ubuntu-package"
+          rm -rf "$package"
+          mkdir -p "$package"
+          cp "$deb" "$package/"
+          cp "$top/contrib/linux/instructions.md" "$package/"
+
       - name: Upload Ubuntu package
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: dosbox-x-ubuntu26.04-x86_64-${{ env.timestamp }}_nightly
-          path: ${{ github.workspace }}/dosbox-x_${{ env.timestamp }}nightly_amd64.deb
+          name: dosbox-x-ubuntu26.04-x86_64-${{ env.timestamp }}_nightly_deb
+          path: ${{ github.workspace }}/ubuntu-package/

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install libraries
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y nasm fluidsynth libfluidsynth-dev libpcap-dev libslirp-dev libsdl-net1.2-dev libsdl2-net-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev libpng-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libavdevice-dev libavcodec-extra
+          sudo apt-get install -y nasm fluidsynth libfluidsynth-dev libpcap-dev libslirp-dev libsdl-net1.2-dev libsdl2-net-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev libpng-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libavdevice-dev libavcodec-extra dpkg-dev
           mkdir src/bin
       - name: Update build info
         shell: bash
@@ -94,6 +94,92 @@ jobs:
         with:
           name: dosbox-x-linux-x86_64-${{ env.timestamp }}
           path: ${{ github.workspace }}/src/bin/
+      - name: Create deb package
+        run: |
+          top=`pwd`
+          pkg="$top/deb"
+          rm -rf "$pkg"
+          mkdir -p "$pkg/DEBIAN"
+          mkdir -p "$pkg/usr/bin"
+          mkdir -p "$pkg/usr/share/dosbox-x/drivez"
+          mkdir -p "$pkg/usr/share/dosbox-x/glshaders"
+          mkdir -p "$pkg/usr/share/dosbox-x/languages"
+
+          cp "$top/src/bin/dosbox-x-sdl1" "$pkg/usr/bin/dosbox-x-sdl1"
+          cp "$top/src/bin/dosbox-x-sdl2" "$pkg/usr/bin/dosbox-x-sdl2"
+          ln -s dosbox-x-sdl2 "$pkg/usr/bin/dosbox-x"
+          cp "$top/CHANGELOG" "$pkg/usr/share/dosbox-x/CHANGELOG.txt"
+          cp "$top/dosbox-x.reference.conf" "$pkg/usr/share/dosbox-x/dosbox-x.reference.conf"
+          cp "$top/dosbox-x.reference.full.conf" "$pkg/usr/share/dosbox-x/dosbox-x.reference.full.conf"
+          cp "$top/contrib/fonts/FREECG98.BMP" "$pkg/usr/share/dosbox-x/FREECG98.BMP"
+          cp "$top/contrib/fonts/"wqy_1?pt.bdf "$pkg/usr/share/dosbox-x/"
+          cp "$top/contrib/fonts/Nouveau_IBM.ttf" "$pkg/usr/share/dosbox-x/Nouveau_IBM.ttf"
+          cp "$top/contrib/fonts/SarasaGothicFixed.ttf" "$pkg/usr/share/dosbox-x/SarasaGothicFixed.ttf"
+          cp "$top/contrib/windows/installer/drivez_readme.txt" "$pkg/usr/share/dosbox-x/drivez/readme.txt"
+          cp "$top/contrib/glshaders/"* "$pkg/usr/share/dosbox-x/glshaders/"
+          cp "$top/contrib/translations/"*/*.lng "$pkg/usr/share/dosbox-x/languages/"
+
+          cat > "$pkg/DEBIAN/control" <<EOF
+          Package: dosbox-x
+          Version: ${{ env.timestamp }}
+          Section: otherosfs
+          Priority: optional
+          Architecture: amd64
+          Depends: \${shlibs:Depends}
+          Maintainer: DOSBox-X Team
+          Description: DOS emulator with extended features
+           DOSBox-X is a DOS emulator with extended features.
+          EOF
+
+          # Needs $top/debian/control file to run dpkg-shlibdeps
+          mkdir -p "$top/debian"
+          cat > "$top/debian/control" <<EOF
+          Source: dosbox-x
+          Section: otherosfs
+          Priority: optional
+          Maintainer: DOSBox-X Team
+          Build-Depends: debhelper
+
+          Package: dosbox-x
+          Architecture: amd64
+          Depends: \${shlibs:Depends}
+          Description: DOS emulator with extended features
+           DOSBox-X is a DOS emulator with extended features.
+          EOF
+
+          dpkg-shlibdeps \
+            -T"$top/debian/substvars" \
+            "$pkg/usr/bin/dosbox-x-sdl1" \
+            "$pkg/usr/bin/dosbox-x-sdl2"
+
+          deps=$(sed -n 's/^shlibs:Depends=//p' "$top/debian/substvars")
+          sed -i "s|^Depends:.*|Depends: $deps|" "$pkg/DEBIAN/control"
+
+          rm -rf "$top/debian"
+
+          cat "$pkg/DEBIAN/control"
+
+          deb="$top/dosbox-x_${{ env.timestamp }}nightly_amd64.deb"
+          rm -f "$deb"
+
+          ls -la "$pkg/usr/bin/"
+
+          dpkg-deb --build "$pkg" "$deb"
+
+          dpkg-deb --info "$deb"
+          dpkg-deb --contents "$deb"
+          dpkg-deb --field "$deb" Package Version Architecture Depends
+
+          echo Test installation
+          sudo apt install "$deb"
+
+
+      - name: Upload Ubuntu package
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: dosbox-x-ubuntu24.04-x86_64-${{ env.timestamp }}_nightly
+          path: ${{ github.workspace }}/dosbox-x_${{ env.timestamp }}nightly_amd64.deb
+          
   Test_Linux_Preview:
     permissions:
       actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
@@ -112,8 +198,30 @@ jobs:
       - name: Install libraries
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y nasm fluidsynth libfluidsynth-dev libpcap-dev libslirp-dev libsdl-net1.2-dev libsdl2-net-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev libpng-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libavdevice-dev libavcodec-extra
+          sudo apt-get install -y nasm fluidsynth libfluidsynth-dev libpcap-dev libslirp-dev libsdl-net1.2-dev libsdl2-net-dev libglu1-mesa-dev freeglut3-dev mesa-common-dev libpng-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libavdevice-dev libavcodec-extra dpkg-dev
           mkdir src/bin
+      - name: Update build info
+        shell: bash
+        run: |
+          echo "timestamp=`git show -s --format=%at | xargs -I# date -d @# +%Y%m%d%H%M%S`" >> $GITHUB_ENV
+          export shortsha=`echo ${GITHUB_SHA} | cut -c1-7`
+          export copyrightyear=`git show -s --format=%at | xargs -I# date -d @# +'%Y'`
+          export updatestr=`git show -s --format=%at | xargs -I# date -d @# +'%b %d, %Y %I:%M:%S%P'`
+          echo '/* auto generated */' > include/build_timestamp.h
+          echo "#define UPDATED_STR \"${updatestr}\"" >> include/build_timestamp.h
+          echo "#define GIT_COMMIT_HASH \"${shortsha}\""  >> include/build_timestamp.h
+          echo "#define COPYRIGHT_END_YEAR \"${copyrightyear}\"" >> include/build_timestamp.h
+          cat include/build_timestamp.h
+      - name: Detect OSFREE build
+        id: osfree
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_NAME}" == "main-osfree" ]] || \
+             grep -q '^#define C_OSFREE 1' vs/config_package.h 2>/dev/null; then
+            echo "osfree=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "osfree=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Build Linux SDL1
         run: |
           top=`pwd`
@@ -127,6 +235,7 @@ jobs:
           strip -s $top/src/dosbox-x
           cp $top/src/dosbox-x $top/src/bin/dosbox-x-sdl2
       - name: Unit testing
+        if: steps.osfree.outputs.osfree != 'true'
         run: |
           top=`pwd`
           chmod +x $top/src/bin/dosbox-x-sdl1 $top/src/bin/dosbox-x-sdl2
@@ -153,3 +262,87 @@ jobs:
         with:
           name: dosbox-x-linux-x86_64-26.04LTS_${{ env.timestamp }}
           path: ${{ github.workspace }}/src/bin/
+      - name: Create deb package
+        run: |
+          top=`pwd`
+          pkg="$top/deb"
+          rm -rf "$pkg"
+          mkdir -p "$pkg/DEBIAN"
+          mkdir -p "$pkg/usr/bin"
+          mkdir -p "$pkg/usr/share/dosbox-x/drivez"
+          mkdir -p "$pkg/usr/share/dosbox-x/glshaders"
+          mkdir -p "$pkg/usr/share/dosbox-x/languages"
+
+          cp "$top/src/bin/dosbox-x-sdl1" "$pkg/usr/bin/dosbox-x-sdl1"
+          cp "$top/src/bin/dosbox-x-sdl2" "$pkg/usr/bin/dosbox-x-sdl2"
+          ln -s dosbox-x-sdl2 "$pkg/usr/bin/dosbox-x"
+          cp "$top/CHANGELOG" "$pkg/usr/share/dosbox-x/CHANGELOG.txt"
+          cp "$top/dosbox-x.reference.conf" "$pkg/usr/share/dosbox-x/dosbox-x.reference.conf"
+          cp "$top/dosbox-x.reference.full.conf" "$pkg/usr/share/dosbox-x/dosbox-x.reference.full.conf"
+          cp "$top/contrib/fonts/FREECG98.BMP" "$pkg/usr/share/dosbox-x/FREECG98.BMP"
+          cp "$top/contrib/fonts/"wqy_1?pt.bdf "$pkg/usr/share/dosbox-x/"
+          cp "$top/contrib/fonts/Nouveau_IBM.ttf" "$pkg/usr/share/dosbox-x/Nouveau_IBM.ttf"
+          cp "$top/contrib/fonts/SarasaGothicFixed.ttf" "$pkg/usr/share/dosbox-x/SarasaGothicFixed.ttf"
+          cp "$top/contrib/windows/installer/drivez_readme.txt" "$pkg/usr/share/dosbox-x/drivez/readme.txt"
+          cp "$top/contrib/glshaders/"* "$pkg/usr/share/dosbox-x/glshaders/"
+          cp "$top/contrib/translations/"*/*.lng "$pkg/usr/share/dosbox-x/languages/"
+          
+          cat > "$pkg/DEBIAN/control" <<EOF
+          Package: dosbox-x
+          Version: ${{ env.timestamp }}
+          Section: otherosfs
+          Priority: optional
+          Architecture: amd64
+          Depends: \${shlibs:Depends}
+          Maintainer: DOSBox-X Team
+          Description: DOS emulator with extended features
+           DOSBox-X is a DOS emulator with extended features.
+          EOF
+
+          # Needs $top/debian/control file to run dpkg-shlibdeps
+          mkdir -p "$top/debian"
+          cat > "$top/debian/control" <<EOF
+          Source: dosbox-x
+          Section: otherosfs
+          Priority: optional
+          Maintainer: DOSBox-X Team
+          Build-Depends: debhelper
+
+          Package: dosbox-x
+          Architecture: amd64
+          Depends: \${shlibs:Depends}
+          Description: DOS emulator with extended features
+           DOSBox-X is a DOS emulator with extended features.
+          EOF
+
+          dpkg-shlibdeps \
+            -T"$top/debian/substvars" \
+            "$pkg/usr/bin/dosbox-x-sdl1" \
+            "$pkg/usr/bin/dosbox-x-sdl2"
+
+          deps=$(sed -n 's/^shlibs:Depends=//p' "$top/debian/substvars")
+          sed -i "s|^Depends:.*|Depends: $deps|" "$pkg/DEBIAN/control"
+
+          rm -rf "$top/debian"
+
+          cat "$pkg/DEBIAN/control"
+
+          deb="$top/dosbox-x_${{ env.timestamp }}nightly_amd64.deb"
+          rm -f "$deb"
+
+          ls -la "$pkg/usr/bin/"
+
+          dpkg-deb --build "$pkg" "$deb"
+
+          dpkg-deb --info "$deb"
+          dpkg-deb --contents "$deb"
+          dpkg-deb --field "$deb" Package Version Architecture Depends
+
+          echo Test installation
+          sudo apt install "$deb"
+
+      - name: Upload Ubuntu package
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: dosbox-x-ubuntu26.04-x86_64-${{ env.timestamp }}_nightly
+          path: ${{ github.workspace }}/dosbox-x_${{ env.timestamp }}nightly_amd64.deb

--- a/contrib/linux/instructions.md
+++ b/contrib/linux/instructions.md
@@ -1,0 +1,55 @@
+# DOSBox-X Ubuntu Package Installation
+
+1. Update the package information:
+
+   sudo apt-get update
+
+2. Install the DOSBox-X Debian package:
+
+   sudo apt-get install ./dosbox-x_<version>nightly_amd64.deb
+
+Replace `<version>` with the version of the downloaded package.
+
+For example:
+
+```
+sudo apt-get install ./dosbox-x_20260910nightly_amd64.deb
+```
+
+APT will automatically install any required dependencies.
+
+3. DOSBox-X provides two executables:
+
+   dosbox-x-sdl1
+   dosbox-x-sdl2
+
+`dosbox-x-sdl2` is the SDL2 version and is the default version launched by the `dosbox-x` command.
+
+`dosbox-x-sdl1` is the SDL1 version. It can be useful on older systems or in environments where SDL2 is not available or does not work properly.
+
+4. Start the default SDL2 version:
+
+   dosbox-x
+
+5. To make `dosbox-x` launch the SDL1 version instead, replace the symbolic link:
+
+   sudo ln -sf dosbox-x-sdl1 /usr/bin/dosbox-x
+
+After this, running:
+
+```
+dosbox-x
+```
+
+will launch the SDL1 version.
+
+6. To switch back to the SDL2 version:
+
+   sudo ln -sf dosbox-x-sdl2 /usr/bin/dosbox-x
+
+The installed executables can also be launched directly:
+
+```
+dosbox-x-sdl1
+dosbox-x-sdl2
+```


### PR DESCRIPTION
The nightly builds for Linux does not attach the required dependencies, so may not work even on Ubuntu (aka build environment of nightly builds).
This PR builds .deb packages for Ubuntu 24.04/26.04 for test purposes, which can be more useful at least for Ubuntu users.

<img width="1045" height="703" alt="image" src="https://github.com/user-attachments/assets/717d22bb-ba6c-4637-9dcf-94458cb95d14" />
