### PR TITLE
Fix LOCK prefix handling to raise #UD on invalid instructions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,10 +5,10 @@ Next version:
     start cylinder from the MBR CHS fields (the high bits were not shifted),
     reject malformed CHS/LBA partition entries instead of producing a bad or
     out-of-bounds sector address. (cimarronm)
-  - Fixed the LOCK (0xF0) prefix in the normal and full CPU cores to prefix
-    the following instruction instead of executing as its own no-op, and
-    raise a #UD exception on 80186+ if it precedes an instruction LOCK is
-    not legal on. (cimarronm)
+  - Fixed the LOCK (0xF0) prefix in the normal, full, and dynamic (dyn_x86 and
+    dynrec) CPU cores to prefix the following instruction instead of
+    executing as its own no-op, and raise a #UD exception on 80186+ if it
+    precedes an instruction LOCK is not legal on. (cimarronm)
 
 2026.08.31:
   - Added support for mounting TeleDisk (.td0) floppy image files. (cimarronm)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,10 @@ Next version:
     start cylinder from the MBR CHS fields (the high bits were not shifted),
     reject malformed CHS/LBA partition entries instead of producing a bad or
     out-of-bounds sector address. (cimarronm)
+  - Fixed the LOCK (0xF0) prefix in the normal and full CPU cores to prefix
+    the following instruction instead of executing as its own no-op, and
+    raise a #UD exception on 80186+ if it precedes an instruction LOCK is
+    not legal on. (cimarronm)
 
 2026.08.31:
   - Added support for mounting TeleDisk (.td0) floppy image files. (cimarronm)

--- a/src/cpu/core_dyn_x86/decoder.h
+++ b/src/cpu/core_dyn_x86/decoder.h
@@ -2484,6 +2484,11 @@ static void dyn_larlsl(bool islar) {
 #define dyn_mmx_check() if ((dyn_dh_fpu.dh_fpu_enabled) && (!fpu_used)) {dh_fpu_startup();}
 #endif
 
+#include "lock.h"
+static INLINE uint8_t LockPrefixRead(PhysPt address) {
+	return mem_readb(address);
+}
+
 static CacheBlock * CreateCacheBlock(CodePageHandler * codepage,PhysPt start,Bitu max_opcodes) {
 	Bits i;
 
@@ -3128,6 +3133,9 @@ restart_prefix:
 			dyn_check_bool_exception_al();
 			break;
 		case 0xf0:		//LOCK
+			if (CPU_ArchitectureType >= CPU_ARCHTYPE_80186 &&
+				!CPU_LockPrefixValid(decode.code, LockPrefixRead))
+				goto illegalopcode;
 			goto restart_prefix;
 		case 0xf2:		//REPNE/NZ
 			decode.rep=REP_NZ;

--- a/src/cpu/core_dynrec/decoder.h
+++ b/src/cpu/core_dynrec/decoder.h
@@ -25,6 +25,11 @@
 #include "dyn_fpu.h"
 #include <stddef.h>
 
+#include "lock.h"
+static INLINE uint8_t LockPrefixRead(PhysPt address) {
+	return mem_readb(address);
+}
+
 /*
 	The function CreateCacheBlock translates the instruction stream
 	until either an unhandled instruction is found, the maximum
@@ -286,6 +291,11 @@ restart_prefix:
 
 		case 0x66:decode.big_op=!cpu.code.big;goto restart_prefix;
 		case 0x67:decode.big_addr=!cpu.code.big;goto restart_prefix;
+		case 0xf0:	// lock
+			if (CPU_ArchitectureType >= CPU_ARCHTYPE_80186 &&
+				!CPU_LockPrefixValid(decode.code, LockPrefixRead))
+				goto illegalopcode;
+			goto restart_prefix;
 
 		// 'push imm8/16/32'
 		case 0x68:
@@ -348,7 +358,6 @@ restart_prefix:
 
 		case 0x90:	// nop
 		case 0x9b:	// wait
-		case 0xf0:	// lock
 			break;
 
 		case 0x91:case 0x92:case 0x93:case 0x94:case 0x95:case 0x96:case 0x97:

--- a/src/cpu/core_dynrec/risc_armv8le.h
+++ b/src/cpu/core_dynrec/risc_armv8le.h
@@ -454,6 +454,7 @@ static void gen_mov_qword_to_reg_imm(HostReg dest_reg,uint64_t imm) {
 
 // helper function for gen_mov_word_to_reg
 static void gen_mov_word_to_reg_helper(HostReg dest_reg,void* data,bool dword,HostReg data_reg) {
+	(void)data;
 	if (dword) {
 		cache_addd( LDR_IMM(dest_reg, data_reg, 0) );       // ldr dest_reg, [data_reg]
 	} else {
@@ -530,6 +531,7 @@ static bool gen_mov_memval_from_reg(HostReg src_reg, void *dest, Bitu size) {
 
 // helper function for gen_mov_word_from_reg
 static void gen_mov_word_from_reg_helper(HostReg src_reg,void* dest,bool dword, HostReg data_reg) {
+	(void)dest;
 	if (dword) {
 		cache_addd( STR_IMM(src_reg, data_reg, 0) );        // str src_reg, [data_reg]
 	} else {
@@ -643,7 +645,7 @@ static void gen_add_imm(HostReg reg,uint32_t imm) {
 
 // and a 32bit constant value with a full register
 static void gen_and_imm(HostReg reg,uint32_t imm) {
-	uint32_t imm2, scale;
+	uint32_t imm2;
 
 	imm2 = ~imm;
 	if(!imm2) return;
@@ -774,6 +776,9 @@ template <typename T> static void INLINE gen_call_function_raw(const T func) {
 // note: the parameters are loaded in the architecture specific way
 // using the gen_load_param_ functions below
 template <typename T> static DRC_PTR_SIZE_IM INLINE gen_call_function_setup(const T func,Bitu paramcount,bool fastcall=false) {
+	(void)paramcount;
+	(void)fastcall;
+
     DRC_PTR_SIZE_IM proc_addr = (DRC_PTR_SIZE_IM)cache.pos;
 	gen_call_function_raw(func);
 	return proc_addr;
@@ -847,7 +852,7 @@ static void INLINE gen_fill_branch(DRC_PTR_SIZE_IM data) {
 #if C_DEBUG
 	Bits len=(uint64_t)cache.pos-data;
 	if (len<0) len=-len;
-	if (len>=0x00100000) LOG_MSG("Big jump %d",len);
+	if (len>=0x00100000) LOG_MSG("Big jump %d",(int)len);
 #endif
 	*(uint32_t*)data=( (*(uint32_t*)data) & 0xff00001f ) | ( ( ((uint64_t)cache.pos - data) << 3 ) & 0x00ffffe0 );
 }

--- a/src/cpu/core_full.cpp
+++ b/src/cpu/core_full.cpp
@@ -52,7 +52,10 @@ typedef PhysPt EAPoint;
 #define LoadD(reg) reg
 #define SaveD(reg,val)	reg=val
 
-
+#include "lock.h"
+static INLINE uint8_t LockPrefixRead(PhysPt address) {
+	return mem_readb_inline(address);
+}
 
 #include "core_full/loadwrite.h"
 #include "core_full/support.h"

--- a/src/cpu/core_full/load.h
+++ b/src/cpu/core_full/load.h
@@ -484,11 +484,11 @@ l_M_Ed:
 	case D_WAIT:
 	case D_NOP:
 		goto nextopcode;
-	case D_LOCK: /* FIXME: according to intel, LOCK should raise an exception if it's not followed by one of a small set of instructions;
-			probably doesn't matter for our purposes as it is a pentium prefix anyhow */
-// todo: make an option to show this
-//		LOG(LOG_CPU,LOG_NORMAL)("CPU:LOCK");
-		goto nextopcode;
+	case D_LOCK:
+		if (CPU_ArchitectureType >= CPU_ARCHTYPE_80186 &&
+			!CPU_LockPrefixValid(inst.cseip, LockPrefixRead))
+			EXCEPTION(EXCEPTION_UD);
+		goto restartopcode;
 	case D_ENTERw:
 		{
 			Bitu bytes=Fetchw();
@@ -567,4 +567,3 @@ l_M_Ed:
 		LOG(LOG_CPU,LOG_ERROR)("LOAD:Unhandled code %d opcode %lx",inst.code.load,(unsigned long)inst.entry);
 		goto illegalopcode;
 }
-

--- a/src/cpu/core_normal.cpp
+++ b/src/cpu/core_normal.cpp
@@ -54,6 +54,11 @@ extern bool ignore_opcode_63;
 #define SaveMd(off,val)	mem_writed_inline(off,val)
 #define SaveMq(off,val) {mem_writed_inline(off,((uint32_t)(val))&0xffffffff);mem_writed_inline(off+4,(((uint64_t)(val))>>((uint64_t)32))&0xffffffff);}
 
+#include "lock.h"
+static INLINE uint8_t LockPrefixRead(PhysPt address) {
+	return mem_readb_inline(address);
+}
+
 Bitu cycle_count;
 
 #if C_FPU
@@ -240,4 +245,3 @@ Bits CPU_Core_Normal_Trap_Run(void) {
 void CPU_Core_Normal_Init(void) {
 
 }
-

--- a/src/cpu/core_normal/prefix_none.h
+++ b/src/cpu/core_normal/prefix_none.h
@@ -1325,9 +1325,10 @@
         opcode_f0:
 #endif
 		REMEMBER_PREFIX(MP_NONE);
-// todo: make an option to show this
-//		LOG(LOG_CPU,LOG_NORMAL)("CPU:LOCK"); /* FIXME: see case D_LOCK in core_full/load.h */
-		break;
+		if (CPU_CORE >= CPU_ARCHTYPE_80186 &&
+			!CPU_LockPrefixValid(core.cseip, LockPrefixRead))
+			EXCEPTION(EXCEPTION_UD);
+		goto restart_opcode;
 #if CPU_CORE >= CPU_ARCHTYPE_80186
 	CASE_B(0xf1)												/* ICEBP */
 		CPU_SW_Interrupt_NoIOPLCheck(1,GETIP);
@@ -1596,6 +1597,3 @@
 			break;
 		}
 			
-
-
-

--- a/src/cpu/core_normal/support.h
+++ b/src/cpu/core_normal/support.h
@@ -17,6 +17,7 @@
  */
 
 #include <math.h>
+#include "lock.h"
 
 #define LoadMbs(off) (int8_t)(LoadMb(off))
 #define LoadMws(off) (int16_t)(LoadMw(off))
@@ -855,5 +856,3 @@ typedef PhysPt (*EA_LookupHandler)(void);
 # include "table_ea.h"
 #endif
 #include "../modrm.h"
-
-

--- a/src/cpu/core_normal_286.cpp
+++ b/src/cpu/core_normal_286.cpp
@@ -67,6 +67,10 @@ extern bool mustCompleteInstruction;
 #define SaveMd(off,val)	mem_writed_inline(off,val)
 #define SaveMq(off,val) {mem_writed_inline(off,val&0xffffffff);mem_writed_inline(off+4,(val>>32)&0xffffffff);}
 
+static INLINE uint8_t LockPrefixRead(PhysPt address) {
+	return mem_readb_inline(address);
+}
+
 extern Bitu cycle_count;
 
 #if C_FPU
@@ -261,4 +265,3 @@ Bits CPU_Core286_Normal_Trap_Run(void) {
 void CPU_Core286_Normal_Init(void) {
 
 }
-

--- a/src/cpu/core_normal_8086.cpp
+++ b/src/cpu/core_normal_8086.cpp
@@ -74,6 +74,10 @@ static void SaveMw(Bitu off,Bitu val) {
 
 #define SaveMd(off,val)	mem_writed_inline(off,val)
 
+static INLINE uint8_t LockPrefixRead(PhysPt address) {
+	return mem_readb_inline(address);
+}
+
 extern Bitu cycle_count;
 
 #if C_FPU
@@ -267,4 +271,3 @@ Bits CPU_Core8086_Normal_Trap_Run(void) {
 void CPU_Core8086_Normal_Init(void) {
 
 }
-

--- a/src/cpu/core_prefetch.cpp
+++ b/src/cpu/core_prefetch.cpp
@@ -53,6 +53,10 @@ extern bool ignore_opcode_63;
 #define SaveMd(off,val)	mem_writed_inline(off,val)
 #define SaveMq(off,val) {mem_writed_inline(off,val&0xffffffff);mem_writed_inline(off+4,(val>>32)&0xffffffff);}
 
+static INLINE uint8_t LockPrefixRead(PhysPt address) {
+	return mem_readb_inline(address);
+}
+
 extern Bitu cycle_count;
 
 #if C_FPU
@@ -314,4 +318,3 @@ Bits CPU_Core_Prefetch_Trap_Run(void) {
 void CPU_Core_Prefetch_Init(void) {
 
 }
-

--- a/src/cpu/core_prefetch_286.cpp
+++ b/src/cpu/core_prefetch_286.cpp
@@ -69,6 +69,10 @@ extern bool ignore_opcode_63;
 #define SaveMd(off,val)	mem_writed_inline(off,val)
 #define SaveMq(off,val) {mem_writed_inline(off,val&0xffffffff);mem_writed_inline(off+4,(val>>32)&0xffffffff);}
 
+static INLINE uint8_t LockPrefixRead(PhysPt address) {
+	return mem_readb_inline(address);
+}
+
 extern Bitu cycle_count;
 
 #if C_FPU
@@ -325,4 +329,3 @@ Bits CPU_Core_Prefetch_Trap_Run(void) {
 
 	return ret;
 }
-

--- a/src/cpu/core_prefetch_8086.cpp
+++ b/src/cpu/core_prefetch_8086.cpp
@@ -78,6 +78,10 @@ static void SaveMw(Bitu off,Bitu val) {
 
 #define SaveMd(off,val)	mem_writed_inline(off,val)
 
+static INLINE uint8_t LockPrefixRead(PhysPt address) {
+	return mem_readb_inline(address);
+}
+
 extern Bitu cycle_count;
 
 #if C_FPU
@@ -333,4 +337,3 @@ Bits CPU_Core_Prefetch_Trap_Run(void) {
 
 	return ret;
 }
-

--- a/src/cpu/core_simple.cpp
+++ b/src/cpu/core_simple.cpp
@@ -50,6 +50,11 @@ extern bool ignore_opcode_63;
 #define SaveMd(off,val) mem_writed(off,val)
 #define SaveMq(off,val) {mem_writed(off,val&0xffffffff);mem_writed(off+4,(val>>32)&0xffffffff);}
 
+#include "lock.h"
+static INLINE uint8_t LockPrefixRead(HostPt address) {
+	return *address;
+}
+
 extern Bitu cycle_count;
 
 #if C_FPU

--- a/src/cpu/lock.h
+++ b/src/cpu/lock.h
@@ -1,0 +1,50 @@
+#ifndef DOSBOX_CPU_LOCK_H
+#define DOSBOX_CPU_LOCK_H
+
+/*
+ *  Copyright (C) 2026  The DOSBox-X Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ */
+
+#include <cstdint>
+
+template <typename Address, typename ReadByte>
+static INLINE bool CPU_LockPrefixValid(Address ip, ReadByte read_byte) {
+	uint8_t opcode;
+	do {
+		opcode=read_byte(ip++);
+	} while (opcode==0x26 || opcode==0x2e || opcode==0x36 || opcode==0x3e ||
+			 opcode==0x64 || opcode==0x65 || opcode==0x66 || opcode==0x67);
+
+	if (opcode==0x0f) {
+		opcode=read_byte(ip++);
+		if (opcode==0xba) {
+			const uint8_t modrm=read_byte(ip);
+			return (modrm>>6)!=3 && ((modrm>>3)&7)>=5;
+		}
+
+		if (opcode!=0xa3 && opcode!=0xab && opcode!=0xb0 && opcode!=0xb1 &&
+			opcode!=0xb3 && opcode!=0xbb && opcode!=0xc0 && opcode!=0xc1 &&
+			opcode!=0xc7)
+			return false;
+		const uint8_t modrm=read_byte(ip);
+		return (modrm>>6)!=3 &&
+			(opcode!=0xc7 || ((modrm>>3)&7)==1);
+	}
+
+	const uint8_t modrm=read_byte(ip);
+	if (opcode>=0x80 && opcode<=0x83)
+		return (modrm>>6)!=3;
+	if (opcode==0xfe || opcode==0xff)
+		return (modrm>>6)!=3 && ((modrm>>3)&7)<=1;
+	if (opcode==0xf6 || opcode==0xf7)
+		return (modrm>>6)!=3 &&
+			(((modrm>>3)&7)==2 || ((modrm>>3)&7)==3);
+	return false;
+}
+
+#endif

--- a/src/cpu/lock.h
+++ b/src/cpu/lock.h
@@ -12,6 +12,12 @@
 
 #include <cstdint>
 
+// ModR/M helpers: mod==3 selects a register operand (no memory access,
+// so not a valid LOCK target); reg is the middle 3-bit opcode-extension
+// field used by several instruction groups.
+static INLINE bool ModRmIsMemory(uint8_t modrm) { return (modrm>>6)!=3; }
+static INLINE uint8_t ModRmReg(uint8_t modrm) { return (modrm>>3)&7; }
+
 template <typename Address, typename ReadByte>
 static INLINE bool CPU_LockPrefixValid(Address ip, ReadByte read_byte) {
 	uint8_t opcode;
@@ -22,29 +28,58 @@ static INLINE bool CPU_LockPrefixValid(Address ip, ReadByte read_byte) {
 
 	if (opcode==0x0f) {
 		opcode=read_byte(ip++);
-		if (opcode==0xba) {
-			const uint8_t modrm=read_byte(ip);
-			return (modrm>>6)!=3 && ((modrm>>3)&7)>=5;
+		switch (opcode) {
+			case 0xab: // BTS
+			case 0xb0: case 0xb1: // CMPXCHG
+			case 0xb3: // BTR
+				break;
+			case 0xba: { // BTS/BTR/BTC imm8 (reg>=5; BT itself, reg==4, is excluded)
+				const uint8_t modrm=read_byte(ip);
+				return ModRmIsMemory(modrm) && ModRmReg(modrm)>=5;
+			}
+			case 0xbb: // BTC
+			case 0xc0: case 0xc1: // XADD
+				break;
+			case 0xc7: { // CMPXCHG8B/CMPXCHG16B
+				const uint8_t modrm=read_byte(ip);
+				return ModRmIsMemory(modrm) && ModRmReg(modrm)==1;
+			}
+			default:
+				return false;
 		}
-
-		if (opcode!=0xa3 && opcode!=0xab && opcode!=0xb0 && opcode!=0xb1 &&
-			opcode!=0xb3 && opcode!=0xbb && opcode!=0xc0 && opcode!=0xc1 &&
-			opcode!=0xc7)
-			return false;
 		const uint8_t modrm=read_byte(ip);
-		return (modrm>>6)!=3 &&
-			(opcode!=0xc7 || ((modrm>>3)&7)==1);
+		return ModRmIsMemory(modrm);
 	}
 
-	const uint8_t modrm=read_byte(ip);
-	if (opcode>=0x80 && opcode<=0x83)
-		return (modrm>>6)!=3;
-	if (opcode==0xfe || opcode==0xff)
-		return (modrm>>6)!=3 && ((modrm>>3)&7)<=1;
-	if (opcode==0xf6 || opcode==0xf7)
-		return (modrm>>6)!=3 &&
-			(((modrm>>3)&7)==2 || ((modrm>>3)&7)==3);
-	return false;
+	switch (opcode) {
+		// ADD/OR/ADC/SBB/AND/SUB/XOR Eb/Ev,Gb/Gv (r/m is destination;
+		// CMP's forms 0x38/0x39 are excluded since CMP does not write
+		// its operand)
+		case 0x00: case 0x01: case 0x08: case 0x09:
+		case 0x10: case 0x11: case 0x18: case 0x19:
+		case 0x20: case 0x21: case 0x28: case 0x29:
+		case 0x30: case 0x31:
+		// XCHG Eb/Ev,Gb/Gv
+		case 0x86: case 0x87: {
+			const uint8_t modrm=read_byte(ip);
+			return ModRmIsMemory(modrm);
+		}
+		case 0x80: case 0x81: case 0x82: case 0x83: { // ADD/OR/../XOR imm (excl. CMP)
+			const uint8_t modrm=read_byte(ip);
+			return ModRmIsMemory(modrm) && ModRmReg(modrm)!=7;
+		}
+		case 0xfe: case 0xff: { // INC/DEC
+			const uint8_t modrm=read_byte(ip);
+			return ModRmIsMemory(modrm) && ModRmReg(modrm)<=1;
+		}
+		case 0xf6: case 0xf7: { // NOT/NEG
+			const uint8_t modrm=read_byte(ip);
+			return ModRmIsMemory(modrm) &&
+				(ModRmReg(modrm)==2 || ModRmReg(modrm)==3);
+		}
+		default:
+			return false;
+	}
 }
 
 #endif


### PR DESCRIPTION
Addresses #6535

Previously, the LOCK (0xF0) prefix was treated as a standalone no-op instruction in `core_normal`, `core_full`, and `core_dynrec` instead of prefixing the following instruction. This meant instructions like `LOCK PUSH CX` would execute normally instead of raising a #UD (invalid opcode) exception as real 80186+ hardware does.