### PR TITLE
Fix IDE CHS cylinder carry handling

### DIFF
--- a/src/hardware/ide.cpp
+++ b/src/hardware/ide.cpp
@@ -52,6 +52,10 @@
 # pragma warning(disable:4065) /* switch statement no case labels */
 #endif
 
+static inline unsigned int ide_chs_cylinder(const uint16_t lba[3]) {
+    return ((unsigned int)lba[1] & 0xffu) | (((unsigned int)lba[2] & 0xffu) << 8u);
+}
+
 struct IDEEventPack {
 #if defined(HX_DOS) || (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
 	IDEEventPack() = default;
@@ -1799,7 +1803,9 @@ bool IDEATADevice::increment_current_address(Bitu count) {
                     if (heads == 16) drivehead -= 0x10;
                     /* increment cylinder */
                     if (((++lba[1])&0xFF) == 0x00) {
+                        lba[1] = 0x00;
                         if (((++lba[2])&0xFF) == 0x00) {
+                            lba[2] = 0x00;
                             return false;
                         }
                     }
@@ -3792,9 +3798,9 @@ static void IDE_DelayedCommand(Bitu pk/*which IDE device*/) {
                     }
                     else if ((unsigned int)(ata->drivehead & 0xFu) >= (unsigned int)ata->heads ||
                         (unsigned int)ata->lba[0] > (unsigned int)ata->sects ||
-                        (unsigned int)(ata->lba[1] | (ata->lba[2] << 8u)) >= (unsigned int)ata->cyls) {
+                        ide_chs_cylinder(ata->lba) >= (unsigned int)ata->cyls) {
                         LOG_MSG("C/H/S %u/%u/%u out of bounds %u/%u/%u\n",
-                            (unsigned int)(ata->lba[1] | (ata->lba[2] << 8u)),
+                            ide_chs_cylinder(ata->lba),
                             (unsigned int)(ata->drivehead&0xFu),
                             (unsigned int)(ata->lba[0]),
                             (unsigned int)ata->cyls,
@@ -3806,7 +3812,7 @@ static void IDE_DelayedCommand(Bitu pk/*which IDE device*/) {
                     }
 
                     sectorn = ((ata->drivehead & 0xF) * ata->sects) +
-                        (((unsigned int)ata->lba[1] | ((unsigned int)ata->lba[2] << 8u)) * ata->sects * ata->heads) +
+                        (ide_chs_cylinder(ata->lba) * ata->sects * ata->heads) +
                         ((unsigned int)ata->lba[0] - 1u);
                 }
 
@@ -3874,9 +3880,9 @@ static void IDE_DelayedCommand(Bitu pk/*which IDE device*/) {
                     }
                     else if ((unsigned int)(ata->drivehead & 0xF) >= (unsigned int)ata->heads ||
                         (unsigned int)ata->lba[0] > (unsigned int)ata->sects ||
-                        (unsigned int)(ata->lba[1] | ((unsigned int)ata->lba[2] << 8u)) >= (unsigned int)ata->cyls) {
+                        ide_chs_cylinder(ata->lba) >= (unsigned int)ata->cyls) {
                         LOG_MSG("C/H/S %u/%u/%u out of bounds %u/%u/%u\n",
-                            (unsigned int)(ata->lba[1] | ((unsigned int)ata->lba[2] << 8u)),
+                            ide_chs_cylinder(ata->lba),
                             (unsigned int)(ata->drivehead&0xF),
                             (unsigned int)ata->lba[0],
                             (unsigned int)ata->cyls,
@@ -3888,7 +3894,7 @@ static void IDE_DelayedCommand(Bitu pk/*which IDE device*/) {
                     }
 
                     sectorn = ((ata->drivehead & 0xFu) * ata->sects) +
-                        (((unsigned int)ata->lba[1] | ((unsigned int)ata->lba[2] << 8u)) * ata->sects * ata->heads) +
+                        (ide_chs_cylinder(ata->lba) * ata->sects * ata->heads) +
                         ((unsigned int)ata->lba[0] - 1u);
                 }
 
@@ -3938,9 +3944,9 @@ static void IDE_DelayedCommand(Bitu pk/*which IDE device*/) {
                     }
                     else if ((unsigned int)(ata->drivehead & 0xF) >= (unsigned int)ata->heads ||
                         (unsigned int)ata->lba[0] > (unsigned int)ata->sects ||
-                        (unsigned int)(ata->lba[1] | ((unsigned int)ata->lba[2] << 8u)) >= (unsigned int)ata->cyls) {
+                        ide_chs_cylinder(ata->lba) >= (unsigned int)ata->cyls) {
                         LOG_MSG("C/H/S %u/%u/%u out of bounds %u/%u/%u\n",
-                            (unsigned int)(ata->lba[1] | ((unsigned int)ata->lba[2] << 8u)),
+                            ide_chs_cylinder(ata->lba),
                             (unsigned int)(ata->drivehead&0xFu),
                             (unsigned int)ata->lba[0],
                             (unsigned int)ata->cyls,
@@ -3952,7 +3958,7 @@ static void IDE_DelayedCommand(Bitu pk/*which IDE device*/) {
                     }
 
                     sectorn = (((unsigned int)ata->drivehead & 0xFu) * ata->sects) +
-                        (((unsigned int)ata->lba[1] | ((unsigned int)ata->lba[2] << 8u)) * ata->sects * ata->heads) +
+                        (ide_chs_cylinder(ata->lba) * ata->sects * ata->heads) +
                         ((unsigned int)ata->lba[0] - 1u);
                 }
 
@@ -4015,9 +4021,9 @@ static void IDE_DelayedCommand(Bitu pk/*which IDE device*/) {
                     }
                     else if ((unsigned int)(ata->drivehead & 0xF) >= (unsigned int)ata->heads ||
                         (unsigned int)ata->lba[0] > (unsigned int)ata->sects ||
-                        (unsigned int)(ata->lba[1] | ((unsigned int)ata->lba[2] << 8u)) >= (unsigned int)ata->cyls) {
+                        ide_chs_cylinder(ata->lba) >= (unsigned int)ata->cyls) {
                         LOG_MSG("C/H/S %u/%u/%u out of bounds %u/%u/%u\n",
-                            (unsigned int)(ata->lba[1] | ((unsigned int)ata->lba[2] << 8u)),
+                            ide_chs_cylinder(ata->lba),
                             (unsigned int)(ata->drivehead&0xF),
                             (unsigned int)ata->lba[0],
                             (unsigned int)ata->cyls,
@@ -4029,7 +4035,7 @@ static void IDE_DelayedCommand(Bitu pk/*which IDE device*/) {
                     }
 
                     sectorn = ((ata->drivehead & 0xF) * ata->sects) +
-                        (((unsigned int)ata->lba[1] | ((unsigned int)ata->lba[2] << 8u)) * ata->sects * ata->heads) +
+                        (ide_chs_cylinder(ata->lba) * ata->sects * ata->heads) +
                         ((unsigned int)ata->lba[0] - 1);
                 }
 
@@ -4084,9 +4090,9 @@ static void IDE_DelayedCommand(Bitu pk/*which IDE device*/) {
                     }
                     else if ((unsigned int)(ata->drivehead & 0xF) >= (unsigned int)ata->heads ||
                         (unsigned int)ata->lba[0] > (unsigned int)ata->sects ||
-                        (unsigned int)(ata->lba[1] | ((unsigned int)ata->lba[2] << 8)) >= (unsigned int)ata->cyls) {
+                        ide_chs_cylinder(ata->lba) >= (unsigned int)ata->cyls) {
                         LOG_MSG("C/H/S %u/%u/%u out of bounds %u/%u/%u\n",
-                            (unsigned int)(ata->lba[1] | ((unsigned int)ata->lba[2] << 8)),
+                            ide_chs_cylinder(ata->lba),
                             (unsigned int)(ata->drivehead&0xF),
                             (unsigned int)ata->lba[0],
                             (unsigned int)ata->cyls,
@@ -4098,7 +4104,7 @@ static void IDE_DelayedCommand(Bitu pk/*which IDE device*/) {
                     }
 
                     sectorn = ((unsigned int)(ata->drivehead & 0xF) * ata->sects) +
-                        (((unsigned int)ata->lba[1] | ((unsigned int)ata->lba[2] << 8)) * ata->sects * ata->heads) +
+                        (ide_chs_cylinder(ata->lba) * ata->sects * ata->heads) +
                         ((unsigned int)ata->lba[0] - 1);
                 }
 


### PR DESCRIPTION
This fixes CHS address advancement in IDE ATA emulation.

IDEATADevice::increment_current_address() stores IDE sector/cylinder registers in lba[], where lba[1] is the cylinder-low register and lba[2] is cylinder-high. In CHS mode, when cylinder-low wrapped past 0xff, the code detected the wrap with & 0xff but did not reset lba[1] back to 0x00.

Because later CHS-to-linear calculations used lba[1] without masking, lba[1] == 0x0100 could be interpreted as an extra 256 cylinders. With geometry 16/63, this caused reads to jump by 256 * 16 * 63 = 258048 sectors.

This could make guest OS disk reads land on unrelated/free sectors and return zero-filled data.

Changes:
- Reset lba[1] to 0x00 when the CHS cylinder-low byte wraps.
- Reset lba[2] to 0x00 when the cylinder-high byte wraps.
- Add ide_chs_cylinder() and use it in CHS bounds checks and CHS-to-linear conversions so only the emulated 8-bit cylinder registers are used.
Validation:
- Reproduced the bad sequence before the fix: read stream jumped from 1032191 to 1290240.
- After the fix, the stream correctly continues from 1032191 to 1032192.
- The affected sectors are read as allocated non-zero data and delivered through IDE PIO unchanged.
- The observed https://github.com/caiiiycuk/js-dos/issues/390 no longer reproduces. 