### PR TITLE
PIT: Fix Mode 0/4 counter wrap on ARM, gate pause calculation, and Mode 2/3 gate triggers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,10 @@ Next version:
     dynrec) CPU cores to prefix the following instruction instead of
     executing as its own no-op, and raise a #UD exception on 80186+ if it
     precedes an instruction LOCK is not legal on. (cimarronm)
+  - Fixed PIT timer emulation: prevented float-to-unsigned saturation on ARM
+    architectures when Mode 0/4 counts past terminal count, fixed gate pause
+    delay calculation for Mode 0/4, and unified Mode 2/3 gate trigger handling
+    per 8253/8254 specification. (cimarronm)
 
 2026.08.31:
   - Added support for mounting TeleDisk (.td0) floppy image files. (cimarronm)

--- a/src/hardware/timer.cpp
+++ b/src/hardware/timer.cpp
@@ -162,6 +162,8 @@ struct PIT_Block {
         /* NTS: Remember, the counter counts DOWN, not up, so the delay is how long it takes to get there */
         if (mode == 2)
             c_delay = ((pic_tickindex_t)(1000ull * (0xFFFFu - counter))) / PIT_TICK_RATE; /* counts down to ONE, not ZERO */
+        else if (mode == 0 || mode == 4)
+            c_delay = ((pic_tickindex_t)(1000ull * ((uint16_t)(cntr_cur - counter)))) / PIT_TICK_RATE;
         else
             c_delay = ((pic_tickindex_t)(1000ull * (0x10000u - counter))) / PIT_TICK_RATE;
 
@@ -235,25 +237,16 @@ struct PIT_Block {
                     /* TODO */
                     break;
                 case 2:     /* Rate Generator */
+                case 3:     /* Square Wave Mode */
                     /* output goes HIGH immediately */
                     if (on) {
                         reset_count_at(now);
                         latch_next_counter();
+                        set_output(true);
                     }
                     else {
                         set_output(true);
                     }
-                    /* TODO */
-                    break;
-                case 3:     /* Square Wave Mode */
-                    if (on) {
-                        reset_count_at(now);
-                        latch_next_counter();
-                    }
-                    else {
-                        set_output(true);
-                    }
-                    /* TODO */
                     break;
                 case 5:     /* Hardware Triggered Strobe */
                     if (on) {
@@ -335,24 +328,18 @@ struct PIT_Block {
         read_counter_result ret;
 
         switch (mode) {
-            case 4:		/* Software Triggered Strobe */
             case 0:		/* Interrupt on Terminal Count */
+            case 4:		/* Software Triggered Strobe */
                 {
-                    pic_tickindex_t tmp;
-
                     /* Counter keeps on counting after passing terminal count */
-                    if (bcd) {
-                        tmp = pic_tickfmod(index,((pic_tickindex_t)(1000ul *   10000ul)) / PIT_TICK_RATE);
-                        ret.counter = (uint16_t)(((unsigned long)(cntr_cur - ((tmp * PIT_TICK_RATE) / 1000.0))) %   10000ul);
-                    } else {
-                        tmp = pic_tickfmod(index,((pic_tickindex_t)(1000ul * 0x10000ul)) / PIT_TICK_RATE);
-                        ret.counter = (uint16_t)(((unsigned long)(cntr_cur - ((tmp * PIT_TICK_RATE) / 1000.0))) % 0x10000ul);
-                    }
+                    const uint64_t elapsed_ticks = (uint64_t)((index * PIT_TICK_RATE) / 1000.0);
 
-                    if (index > delay)
-                        ret.cycle = 1;
+                    if (bcd)
+                        ret.counter = (uint16_t)((cntr_cur - (elapsed_ticks % 10000ul) + 10000ul) % 10000ul);
                     else
-                        ret.cycle = 0;
+                        ret.counter = (uint16_t)(cntr_cur - elapsed_ticks);
+
+                    ret.cycle = index > delay ? 1 : 0;
                 }
                 break;
             case 5:     /* Hardware Triggered Strobe */


### PR DESCRIPTION
### Summary of Changes

1. **Mode 0/4 Counter Wraparound Underflow on ARM Architectures**:
   - In `read_counter()` for Modes 0 and 4, when the counter passed terminal count, `(unsigned long)(cntr_cur - elapsed)` converted a negative float to `unsigned long`.
   - On ARM architectures, converting negative floating-point numbers to unsigned integers saturates to `0`, causing `read_counter()` to return `0x0000` indefinitely instead of wrapping around through `0xFFFF`.
   - Replaced the floating-point calculation with direct integer subtraction and modulo arithmetic.

2. **Mode 0/4 Gate Pause Calculation**:
   - In `restart_counter_at()`, Modes 0 and 4 were computing delay from `0x10000` rather than `cntr_cur`.
   - Corrected elapsed delay calculation against `cntr_cur` so raising GATE properly resumes countdown from the paused counter value per Intel 8253/8254 specifications.

3. **Mode 2 and Mode 3 Gate Trigger Handling**:
   - Unified Mode 2 and Mode 3 gate handling in `set_gate()` so both modes reload counters and set OUT high immediately on GATE rising edge per the 8253/8254 datasheet.